### PR TITLE
[WIP] Fix patch_sle swith to tty6

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -715,7 +715,8 @@ sub activate_console {
             # case the system is still booting (https://bugzilla.novell.com/show_bug.cgi?id=895602)
             # or when using remote consoles which can take some seconds, e.g.
             # just after ssh login
-            wait_still_screen 1;    # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet
+            # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet
+            wait_still_screen 6, 180;
             assert_screen \@tags, 60;
             if (match_has_tag("tty$nr-selected")) {
                 type_string "$user\n";


### PR DESCRIPTION
In patch_sle after we booted into desktop, sometime we can't switch into tty_6. we need to wait for 
longer for wait_still_screen.

- Related ticket: https://progress.opensuse.org/issues/57281
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3569898
                            https://openqa.suse.de/tests/3570051
                           snapper_rollback
                           failed: https://openqa.suse.de/tests/3577604
                           fixed : https://openqa.suse.de/tests/3577707
                           In sles15sp2 migration:
                           failed: https://openqa.suse.de/tests/3627740
                           fixed:  https://openqa.suse.de/tests/3635337