### PR TITLE
JeOS hyperV images mounts by UUID

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -15,10 +15,11 @@ use strict;
 use warnings;
 use testapi;
 use version_utils qw(is_sle is_tumbleweed is_leap);
+use Utils::Backends 'is_hyperv';
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);
 
 sub expect_mount_by_uuid {
-    return (is_sle('>=15-sp2') || is_tumbleweed || is_leap('>=15.2'));
+    return (is_hyperv || is_sle('>=15-sp2') || is_tumbleweed || is_leap('>=15.2'));
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
- Motivation: https://bugzilla.suse.com/show_bug.cgi?id=1156394
- Verification runs:
   * [sle-12-SP5-JeOS-for-MS-HyperV-x86_64-Build4.131-jeos-fs_stress_hyperv@svirt-hyperv-uefi](http://eris.suse.cz/tests/2513#step/firstrun/53) 
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.131-jeos-fs_stress@64bit-virtio-vga](http://eris.suse.cz/tests/2515#)
