### PR TITLE
Wicked: Remove tracepath from basic suite t08

### DIFF
--- a/tests/wicked/basic/ref/t08_setup_second_card.pm
+++ b/tests/wicked/basic/ref/t08_setup_second_card.pm
@@ -28,8 +28,6 @@ sub run {
     $self->get_from_data('wicked/dhcp/dhcpd_2nics.conf', '/etc/dhcpd.conf');
     systemctl 'start dhcpd.service';
     $self->wait_for_dhcpd();
-    # Enable forwarding to reach the gateway from SUT
-    assert_script_run('sysctl -w net.ipv4.ip_forward=1');
     die("Create mutex failed") unless mutex_create('t08_dhcpd_setup_complete');
 }
 

--- a/tests/wicked/basic/sut/t08_setup_second_card.pm
+++ b/tests/wicked/basic/sut/t08_setup_second_card.pm
@@ -41,9 +41,8 @@ sub run {
     die("Unexpected IP $ip_iface1 on " . $ctx->iface()) unless ($ip_iface1 =~ /$dhcp_ip_sut/);
     die("Unexpected IP $ip_iface2 on " . $ctx->iface2()) unless ($ip_iface2 eq $static_ip_sut);
 
-    $self->ping_with_timeout(type => 'dhcp_2nic', interface => $ctx->iface());
-
-    validate_script_output('tracepath -n ' . $self->get_ip(type => 'gateway'), sub { index($_, $static_ip_ref) != -1 });
+    $self->ping_with_timeout(type => 'dhcp_2nic',   interface => $ctx->iface());
+    $self->ping_with_timeout(type => 'second_card', interface => $ctx->iface2());
 }
 
 sub test_flags {


### PR DESCRIPTION
This tracepath makes sense when we have a setup similar
to the legacy test suite:
https://github.com/openSUSE/wicked-testsuite/blob/master/README.setup#L6

We have a different setup in OpenQA and we would need to force REF
as a router to forward packets to the "outside" world. After talking
to Wicked team, the aim of this test is just to verify that Wicked
can configure 2 interfaces, so there is no need to test routing here.

VR: http://fromm.arch.suse.de/tests/237
[poo#59235](https://progress.opensuse.org/issues/59235)

