### PR TITLE
virtman_view: reuse send_key 'alt-v' since send_key have been fixed

### DIFF
--- a/tests/virtualization/virtman_view.pm
+++ b/tests/virtualization/virtman_view.pm
@@ -50,11 +50,8 @@ sub run {
     assert_screen 'virt-manager';
 
     # go to view now
-    # decompose alt-v - poo#54056
-    hold_key 'alt';
-    send_key 'v';
-    sleep(1);
-    release_key 'alt';
+    send_key 'alt-v';
+    assert_screen 'virtman-viewmenu';
     send_key 'right';
     assert_screen 'virtman-viewmenu-graph';
     # activate everything


### PR DESCRIPTION
This is an update of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8862
since https://github.com/os-autoinst/os-autoinst/pull/1260 has been merged and deployed.

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/f0156991a75f0024dfcfcc903c658c829356d237
- Verification run:  https://openqa.opensuse.org/tests/1083336