### PR TITLE
Handle issue with type_string in select_patterns_and_packages.pm

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -24,6 +24,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use utils 'type_string_slow';
 
 sub accept3rdparty {
     #Third party licenses sometimes appear
@@ -116,11 +117,10 @@ sub gotodetails {
             assert_and_click 'packages-search-field-selected';
             wait_screen_change { send_key 'ctrl-a' };
             wait_screen_change { send_key 'delete' };
-            type_string "$p";
+            type_string_slow "$p";
             send_key 'alt-s';    # search button
         }
-        send_key_until_needlematch "packages-$p-selected", 'down', 60;
-        wait_screen_change { send_key "$operation" };
+        assert_and_click "packages-$p-selected";
         wait_still_screen 2;
         save_screenshot;
     }


### PR DESCRIPTION
on some slow workers we have problem with type_string and send_key.
use type_string_slow instead type_string, use assert_and_click
instead of send_key.
see https://progress.opensuse.org/issues/59049
verification test run:
https://openqa.suse.de/tests/3583227