### PR TITLE
Add 'fsid=0' with nfs v4 as is supported there

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -72,7 +72,7 @@ sub yast_handle_firewall {
 }
 
 sub add_shares {
-    my ($rw, $ro) = @_;
+    my ($rw, $ro, $version) = @_;
 
     # Add rw share
     send_key 'alt-d';
@@ -84,11 +84,13 @@ sub add_shares {
     assert_screen 'nfs-share-host';
     send_key 'tab';
     # Change 'ro,root_squash' to 'rw,no_root_squash,...'
+    # For nfs4 also add fsid=0
     send_key 'home';
     send_key 'delete';
     send_key 'delete';
     send_key 'delete';
-    type_string "rw,no_";
+    my $options = "rw," . ($version eq '4' ? "fsid=0," : '') . 'no_';
+    type_string $options;
     send_key 'alt-o';
 
     # Saved

--- a/tests/console/yast2_nfs4_server.pm
+++ b/tests/console/yast2_nfs4_server.pm
@@ -61,8 +61,8 @@ sub run {
     send_key 'alt-n';
 
     assert_screen 'nfs-overview';
-
-    add_shares($rw, $ro);
+    # Add nfs v4 share
+    add_shares($rw, $ro, '4');
 
     send_key 'alt-f';
     wait_serial("$module_name-0") or die "'yast2 $module_name' didn't finish";


### PR DESCRIPTION
In #8852 I have removed this option for all nfs shares, as is not
recommended even for NFSv4 where is supported, but it breaks QAM tests,
so changing it to old behavior for v4 and investigate the failure in
parallel, as it seems to be a bug in the product.

- [Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%238891&distri=sle)
