### PR TITLE
autoyast_smoke: fix ethernet name list for aarch64

### DIFF
--- a/tests/console/autoyast_smoke.pm
+++ b/tests/console/autoyast_smoke.pm
@@ -37,7 +37,7 @@ sub run {
         assert_script_run qq{systemctl is-enabled $service | grep disabled};
 
         record_info('INFO', 'Verify networking');
-        assert_script_run "ip link show | grep -E \"(ens|eth)[0-9]\" | grep UP";
+        assert_script_run "ip link show | grep -E \"(ens|enp|eth)[0-9]\" | grep UP";
     }
     else {
         record_info('INFO', 'Check firewall is enabled and running');


### PR DESCRIPTION
as ethernet device is named enpXsY on aarch64 Tumbleweed.

This will fix autoyast_gnome@aarch64 on Tumbleweed: https://openqa.opensuse.org/tests/1083280#step/autoyast_smoke/37
