### PR TITLE
Adjust uefi_bootmenu_params to deal with usual grub2 config on JeOS

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -17,7 +17,7 @@ use File::Basename 'basename';
 use Time::HiRes 'sleep';
 use testapi;
 use utils;
-use version_utils qw(is_caasp is_jeos is_leap is_sle);
+use version_utils qw(is_caasp is_jeos is_leap is_sle is_tumbleweed);
 use mm_network;
 
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_CONSOLE_DEFAULT_DEVICE SERIAL_CONSOLE_DEFAULT_PORT);
@@ -320,21 +320,37 @@ sub uefi_bootmenu_params {
     #send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5);
     (is_jeos) ? send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5)
       :         send_key 'e';
-    for (1 .. 2) { send_key "down"; }
-    send_key "end";
-    # delete "keep" word
-    for (1 .. 4) { send_key "backspace"; }
-    # hardcoded the value of gfxpayload to 1024x768
-    type_string "1024x768";
-    assert_screen "gfxpayload_changed", 10;
-    # back to the entry position
-    send_key "home";
-    for (1 .. 2) { send_key "up"; }
-    if (is_jeos) {
-        send_key "up";
+    # Kiwi in TW uses grub2-mkconfig instead of the custom kiwi config
+    if (is_jeos && is_tumbleweed) {
+        for (1 .. 3) { send_key "down"; }
+        send_key "end";
+        # delete "keep" word
+        for (1 .. 4) { send_key "backspace"; }
+        # hardcoded the value of gfxpayload to 1024x768
+        type_string "1024x768";
+        assert_screen "gfxpayload_changed", 10;
+        # back to the entry position
+        send_key "home";
+        for (1 .. 10) { send_key "down"; }
     }
-    sleep 5;
-    for (1 .. 4) { send_key "down"; }
+    else {
+        for (1 .. 2) { send_key "down"; }
+        send_key "end";
+        # delete "keep" word
+        for (1 .. 4) { send_key "backspace"; }
+        # hardcoded the value of gfxpayload to 1024x768
+        type_string "1024x768";
+        assert_screen "gfxpayload_changed", 10;
+        # back to the entry position
+        send_key "home";
+        for (1 .. 2) { send_key "up"; }
+        if (is_jeos) {
+            send_key "up";
+        }
+        sleep 5;
+        for (1 .. 4) { send_key "down"; }
+    }
+
     send_key "end";
 
     if (get_var("NETBOOT")) {


### PR DESCRIPTION
New kiwi in Tumbleweed uses grub2-mkconfig now, so the key sequence to change
settings there has to be adjusted.

Verification run: http://10.160.67.86/tests/614
