### PR TITLE
HPC: Fix migration tests with pre patch installation

### DIFF
--- a/tests/hpc/hpc_migration.pm
+++ b/tests/hpc/hpc_migration.pm
@@ -46,6 +46,7 @@ sub run {
     zypper_call('in zypper-migration-plugin');
 
     #list available migration targets
+    script_run('zypper  --no-refresh patch --updatestack-only -y');
     my $migration_query = script_run('zypper migration --query');
     if ($migration_query != 0) {
         $self->migration_err();


### PR DESCRIPTION
The command 'zypper migration --query' performs a zypper
patch-check and will ask the user to install recommended
patches. Since the migration --query command doesn't provide
automatic answer, we need to call the patch command before
with auto answer '-y'.

- Failed run: https://openqa.suse.de/tests/3583087#step/hpc_migration/37
- Verification run: http://fromm.arch.suse.de/tests/244
