### PR TITLE
Increase timout for SLE registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -221,7 +221,7 @@ sub cleanup_registration {
 Wrapper for SUSEConnect -r <regcode>. Requires SCC_REGCODE variable.
 =cut
 sub register_product {
-    assert_script_run 'SUSEConnect -r ' . get_required_var('SCC_REGCODE');
+    assert_script_run('SUSEConnect -r ' . get_required_var('SCC_REGCODE'), 200);
 }
 
 sub register_addons_cmd {


### PR DESCRIPTION
Especially 15+ registration is registring multiple modules which takes more than 90 seconds

- Fail: https://openqa.suse.de/tests/3582626#step/apache2_changehat/10
- Verification run: http://10.100.12.155/tests/13751