### PR TITLE
Update bug references for yast investigation and exclude yast_sysconfig from execution on s390x

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -218,17 +218,17 @@ sub investigate_yast2_failure {
     }
     # Hash with critical errors in YaST2 and bug reference if any
     my %y2log_errors = (
-        "<3>.*Cannot parse the data from server"     => 'bsc#1126045',
-        "No textdomain configured"                   => 'bsc#1127756',    # Detecting missing translations
-                                                                          # Detecting specifi errors proposed by the YaST dev team
-        "nothing provides"                           => undef,            # Detecting missing required packages
-        "but this requirement cannot be provided"    => undef,            # Detecting package conflicts
-        "Could not load icon|Couldn't load pixmap"   => undef,            # Detecting missing icons
-        "Internal error. Please report a bug report" => undef,            # Detecting internal errors
+        "No textdomain configured"                   => undef,    # Detecting missing translations
+                                                                  # Detecting specifi errors proposed by the YaST dev team
+        "nothing provides"                           => undef,    # Detecting missing required packages
+        "but this requirement cannot be provided"    => undef,    # Detecting package conflicts
+        "Could not load icon|Couldn't load pixmap"   => undef,    # Detecting missing icons
+        "Internal error. Please report a bug report" => undef,    # Detecting internal errors
     );
     # Hash with known errors which we don't want to track in each postfail hook
     my %y2log_known_errors = (
-        "<3>.*no[t]? mount" => 'bsc#1092088',                             # Detect not mounted partition
+        "<3>.*no[t]? mount"   => 'bsc#1092088',                   # Detect not mounted partition
+        "<3>.*lib/cheetah.rb" => 'bsc#1153749',
 
         # The error below will be cleaned up, see https://trello.com/c/5qTQZKH3/2918-sp2-logs-cleanup
         # Adding reference to trello, detect those in single scenario

--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -15,12 +15,15 @@ conditional_schedule:
         - yast2_cmd/yast_ftp_server
         - yast2_cmd/yast_users
         - yast2_cmd/yast_keyboard
+        - yast2_cmd/yast_sysconfig
       x86_64:
         - yast2_cmd/yast_ftp_server
         - yast2_cmd/yast_users
         - yast2_cmd/yast_keyboard
+        - yast2_cmd/yast_sysconfig
       aarch64:
         - yast2_cmd/yast_keyboard
+        - yast2_cmd/yast_sysconfig
       s390x:
         - yast2_cmd/yast_lan
         - yast2_cmd/yast_ftp_server
@@ -33,7 +36,6 @@ schedule:
      - yast2_cmd/yast_rdp
      - yast2_cmd/yast_timezone
      - yast2_cmd/yast_tftp_server
-     - yast2_cmd/yast_sysconfig
      - yast2_cmd/yast_nfs_server
      - yast2_cmd/yast_nfs_client
      - {{under_issues_investigation}}


### PR DESCRIPTION
Multiple hot patches for SLE 15 SP2.

Excluding fixed entry, failing in case of missing translations and add
new soft-failure for cheetah errors in the logs.

- [Verification run](https://openqa.suse.de/tests/overview?version=15-SP2&build=rwx788%2Fos-autoinst-distri-opensuse%238898&distri=sle)

Also, new test in `yast2_cmd` started to fail on s390x, will be investigated in https://progress.opensuse.org/issues/58742
