### PR TITLE
[wip] [yast2-apparmor tweak] Give reset-console command a second to execute before exiting conditional.

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -195,11 +195,15 @@ sub run {
         type_string "/usr/bin/top\n";
     } else {
         type_string "top\n";
+        wait_still_screen 1;
         send_key 'alt-o';
         assert_screen 'yast2_apparmor_profile_for_top_generated';
         send_key 'alt-f';
+
         #cleaning the console
         type_string "reset\n";
+        wait_still_screen 1;
+
         return;
     }
 


### PR DESCRIPTION
This is to cover a very rare circumstance, probably related to load on which sometimes return is triggered before the type string fully finishes. script_run 'reset' should be an alternative but as this fully resets the terminal the test may understand it as a fail(it logs read for that step but the fully test logs green). This just gives it a 1 sec. cool-down.

- Related ticket: https://progress.opensuse.org/issues/59348
- Needles: None
- Verification run: 
12.2 http://deathstar.suse.cz/tests/1928
12.3 http://deathstar.suse.cz/tests/1929
12.4 http://deathstar.suse.cz/tests/1930
12.5 http://deathstar.suse.cz/tests/1931

15.0 http://deathstar.suse.cz/tests/1943
15.1 http://deathstar.suse.cz/tests/1942

Leap 15.1 http://deathstar.suse.cz/tests/1935
TW http://deathstar.suse.cz/tests/1932