### PR TITLE
add "yast_ftp_server" to support SLE12sp5

### DIFF
--- a/tests/yast2_cmd/yast_ftp_server.pm
+++ b/tests/yast2_cmd/yast_ftp_server.pm
@@ -110,7 +110,7 @@ sub run {
     if (is_sle('15+')) {
         assert_script_run 'yast ftp-server startup socket';
     }
-    if (is_sle('<=12-sp4')) {
+    if (is_sle('<=12-sp5')) {
         assert_script_run 'yast ftp-server startup xinetd';
     }
 
@@ -153,7 +153,7 @@ sub run {
     if (is_sle('15+')) {
         assert_script_run 'yast ftp-server startup socket';
     }
-    if (is_sle('<=12-sp4')) {
+    if (is_sle('<=12-sp5')) {
         assert_script_run 'yast ftp-server startup xinetd';
     }
     assert_script_run 'echo "hello world" > /srv/ftp/tmp.txt';


### PR DESCRIPTION
This module is a suite of tests for yast ftp server, this update fixed the lack support of SLE12sp5.

- Related ticket: https://progress.opensuse.org/issues/59028
    Needles: no
    Verification run:
- SLE12SP2: http://10.67.19.78/tests/1240
- SLE12SP3: http://10.67.19.78/tests/1239
- SLE12SP4: http://10.67.19.78/tests/1243
- SLE12SP5: http://10.67.19.78/tests/1237
- SLE15 : http://10.67.19.78/tests/1241
- SLE15SP1: http://10.67.19.78/tests/1242