### PR TITLE
Increase timout for korean keyboard summary

### DIFF
--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -40,7 +40,7 @@ sub run {
     zypper_call("in yast2-country", timeout => 480);
     assert_script_run("yast keyboard list");
     assert_script_run("yast keyboard set layout=korean");
-    validate_script_output("yast keyboard summary 2>&1", sub { m/korean/ });
+    validate_script_output("yast keyboard summary 2>&1", sub { m/korean/ }, timeout => 90);
 
     # Set keyboard layout to german.
     assert_script_run("yast keyboard set layout=german");


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3578057#step/yast_keyboard/15
- Verification run:
http://10.100.12.155/tests/13771#step/yast_keyboard/10
https://openqa.suse.de/tests/3586539
