### PR TITLE
Test autoyast installation with multi-device Btrfs

### DIFF
--- a/data/autoyast_opensuse/autoyast_multi_btrfs.xml
+++ b/data/autoyast_opensuse/autoyast_multi_btrfs.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+    </general>
+    <login_settings>
+        <autologin_user>bernhard</autologin_user>
+    </login_settings>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <install_recommended config:type="boolean">true</install_recommended>
+        <products config:type="list">
+            <product>openSUSE</product>
+        </products>
+        <patterns config:type="list">
+            <pattern>apparmor</pattern>
+            <pattern>base</pattern>
+            <pattern>gnome</pattern>
+        </patterns>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">true</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <partitioning config:type="list">
+        <drive>
+            <device>/dev/vda</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <format config:type="boolean">false</format>
+                    <partition_id config:type="integer">263</partition_id>
+                    <partition_nr config:type="integer">1</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>8388608</size>
+                </partition>
+                <partition>
+                    <btrfs_name>btrfs_57</btrfs_name>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">true</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <format config:type="boolean">true</format>
+                    <label>root_multi_btrfs</label>
+                    <mount>/</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <partition_id config:type="integer">131</partition_id>
+                    <partition_nr config:type="integer">2</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>19992150016</size>
+                    <subvolumes config:type="list">
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>root</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>srv</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>home</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">false</copy_on_write>
+                            <path>var</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>opt</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
+                </partition>
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <filesystem config:type="symbol">swap</filesystem>
+                    <format config:type="boolean">true</format>
+                    <mount>swap</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <partition_id config:type="integer">130</partition_id>
+                    <partition_nr config:type="integer">3</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>1473232384</size>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <device>/dev/vdb</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <btrfs_name>btrfs_57</btrfs_name>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">true</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <format config:type="boolean">true</format>
+                    <label>root_multi_btrfs</label>
+                    <mount>/</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <partition_id config:type="integer">131</partition_id>
+                    <partition_nr config:type="integer">1</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>21463302144</size>
+                    <subvolumes config:type="list">
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>root</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>srv</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>home</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">false</copy_on_write>
+                            <path>var</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>opt</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <device>/dev/vdc</device>
+            <disklabel>none</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <btrfs_name>btrfs_79</btrfs_name>
+                    <create config:type="boolean">false</create>
+                    <create_subvolumes config:type="boolean">false</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <format config:type="boolean">false</format>
+                    <label>test_multi_btrfs</label>
+                    <mount>/test</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <resize config:type="boolean">false</resize>
+                    <subvolumes config:type="list"/>
+                    <subvolumes_prefix><![CDATA[]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <device>/dev/vdd</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <btrfs_name>btrfs_79</btrfs_name>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">false</create_subvolumes>
+                    <crypt_fs config:type="boolean">true</crypt_fs>
+                    <crypt_key>nots3cr3t</crypt_key>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <format config:type="boolean">true</format>
+                    <label>test_multi_btrfs</label>
+                    <loop_fs config:type="boolean">true</loop_fs>
+                    <mount>/test</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <partition_id config:type="integer">131</partition_id>
+                    <partition_nr config:type="integer">1</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>21463302144</size>
+                    <subvolumes config:type="list"/>
+                    <subvolumes_prefix><![CDATA[]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <btrfs_options>
+                <data_raid_level>raid0</data_raid_level>
+                <metadata_raid_level>raid1</metadata_raid_level>
+            </btrfs_options>
+            <device>btrfs_57</device>
+            <disklabel>none</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">true</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <label>root_multi_btrfs</label>
+                    <mount>/</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <resize config:type="boolean">false</resize>
+                    <subvolumes config:type="list">
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>root</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>srv</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>home</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">false</copy_on_write>
+                            <path>var</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>opt</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_BTRFS</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <btrfs_options>
+                <data_raid_level>raid0</data_raid_level>
+                <metadata_raid_level>raid1</metadata_raid_level>
+            </btrfs_options>
+            <device>btrfs_79</device>
+            <disklabel>none</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">false</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <label>test_multi_btrfs</label>
+                    <mount>/test</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <resize config:type="boolean">false</resize>
+                    <subvolumes config:type="list"/>
+                    <subvolumes_prefix><![CDATA[]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_BTRFS</type>
+            <use>all</use>
+        </drive>
+    </partitioning>
+</profile>

--- a/data/autoyast_sle15/autoyast_multi_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_multi_btrfs.xml
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons config:type="list">
+            <addon>
+                <name>sle-module-server-applications</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+            <addon>
+                <name>sle-module-desktop-applications</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+    </general>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+    <keyboard>
+        <keyboard_values>
+            <delay/>
+            <discaps config:type="boolean">false</discaps>
+            <numlock>bios</numlock>
+            <rate/>
+        </keyboard_values>
+        <keymap>english-us</keymap>
+    </keyboard>
+    <language>
+        <language>en_US</language>
+        <languages/>
+    </language>
+    <ntp-client>
+        <ntp_policy>auto</ntp_policy>
+    </ntp-client>
+    <software>
+        <packages config:type="list">
+            <package>grub2</package>
+            <package>sles-release</package>
+        </packages>
+        <patterns config:type="list">
+            <pattern>apparmor</pattern>
+            <pattern>base</pattern>
+            <pattern>basesystem</pattern>
+            <pattern>documentation</pattern>
+            <pattern>enhanced_base</pattern>
+            <pattern>gnome_basic</pattern>
+            <pattern>gnome_basis</pattern>
+            <pattern>minimal_base</pattern>
+            <pattern>x11</pattern>
+            <pattern>x11_enhanced</pattern>
+        </patterns>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <networking>
+        <interfaces config:type="list">
+            <interface>
+                <bootproto>dhcp</bootproto>
+                <device>eth0</device>
+                <dhclient_set_default_route>yes</dhclient_set_default_route>
+                <startmode>auto</startmode>
+            </interface>
+        </interfaces>
+    </networking>
+    <firewall>
+        <enable_firewall config:type="boolean">true</enable_firewall>
+        <start_firewall config:type="boolean">true</start_firewall>
+    </firewall>
+    <timezone>
+        <hwclock>UTC</hwclock>
+        <timezone>Europe/Berlin</timezone>
+    </timezone>
+    <users config:type="list">
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <gid>100</gid>
+            <home>/home/bernhard</home>
+            <password_settings>
+                <expire/>
+                <flag/>
+                <inact>-1</inact>
+                <max>99999</max>
+                <min>0</min>
+                <warn>7</warn>
+            </password_settings>
+            <shell>/bin/bash</shell>
+            <uid>1000</uid>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <fullname>root</fullname>
+            <gid>0</gid>
+            <home>/root</home>
+            <password_settings>
+                <expire/>
+                <flag/>
+                <inact/>
+                <max/>
+                <min/>
+                <warn/>
+            </password_settings>
+            <shell>/bin/bash</shell>
+            <uid>0</uid>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <partitioning config:type="list">
+        <drive>
+            <device>/dev/vda</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <format config:type="boolean">false</format>
+                    <partition_id config:type="integer">263</partition_id>
+                    <partition_nr config:type="integer">1</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>8388608</size>
+                </partition>
+                <partition>
+                    <btrfs_name>btrfs_57</btrfs_name>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">true</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <format config:type="boolean">true</format>
+                    <label>root_multi_btrfs</label>
+                    <mount>/</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <partition_id config:type="integer">131</partition_id>
+                    <partition_nr config:type="integer">2</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>19992150016</size>
+                    <subvolumes config:type="list">
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>root</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>srv</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>home</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">false</copy_on_write>
+                            <path>var</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>opt</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
+                </partition>
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <filesystem config:type="symbol">swap</filesystem>
+                    <format config:type="boolean">true</format>
+                    <mount>swap</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <partition_id config:type="integer">130</partition_id>
+                    <partition_nr config:type="integer">3</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>1473232384</size>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <device>/dev/vdb</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <btrfs_name>btrfs_57</btrfs_name>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">true</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <format config:type="boolean">true</format>
+                    <label>root_multi_btrfs</label>
+                    <mount>/</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <partition_id config:type="integer">131</partition_id>
+                    <partition_nr config:type="integer">1</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>21463302144</size>
+                    <subvolumes config:type="list">
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>root</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>srv</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>home</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">false</copy_on_write>
+                            <path>var</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>opt</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <device>/dev/vdc</device>
+            <disklabel>none</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <btrfs_name>btrfs_79</btrfs_name>
+                    <create config:type="boolean">false</create>
+                    <create_subvolumes config:type="boolean">false</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <format config:type="boolean">false</format>
+                    <label>test_multi_btrfs</label>
+                    <mount>/test</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <resize config:type="boolean">false</resize>
+                    <subvolumes config:type="list"/>
+                    <subvolumes_prefix><![CDATA[]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <device>/dev/vdd</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <btrfs_name>btrfs_79</btrfs_name>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">false</create_subvolumes>
+                    <crypt_fs config:type="boolean">true</crypt_fs>
+                    <crypt_key>nots3cr3t</crypt_key>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <format config:type="boolean">true</format>
+                    <label>test_multi_btrfs</label>
+                    <loop_fs config:type="boolean">true</loop_fs>
+                    <mount>/test</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <partition_id config:type="integer">131</partition_id>
+                    <partition_nr config:type="integer">1</partition_nr>
+                    <resize config:type="boolean">false</resize>
+                    <size>21463302144</size>
+                    <subvolumes config:type="list"/>
+                    <subvolumes_prefix><![CDATA[]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <btrfs_options>
+                <data_raid_level>raid0</data_raid_level>
+                <metadata_raid_level>raid1</metadata_raid_level>
+            </btrfs_options>
+            <device>btrfs_57</device>
+            <disklabel>none</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">true</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <label>root_multi_btrfs</label>
+                    <mount>/</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <resize config:type="boolean">false</resize>
+                    <subvolumes config:type="list">
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>root</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>srv</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>home</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">false</copy_on_write>
+                            <path>var</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>opt</path>
+                        </subvolume>
+                        <subvolume>
+                            <copy_on_write config:type="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_BTRFS</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <btrfs_options>
+                <data_raid_level>raid0</data_raid_level>
+                <metadata_raid_level>raid1</metadata_raid_level>
+            </btrfs_options>
+            <device>btrfs_79</device>
+            <disklabel>none</disklabel>
+            <enable_snapshots config:type="boolean">false</enable_snapshots>
+            <initialize config:type="boolean">false</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <create_subvolumes config:type="boolean">false</create_subvolumes>
+                    <filesystem config:type="symbol">btrfs</filesystem>
+                    <label>test_multi_btrfs</label>
+                    <mount>/test</mount>
+                    <mountby config:type="symbol">uuid</mountby>
+                    <resize config:type="boolean">false</resize>
+                    <subvolumes config:type="list"/>
+                    <subvolumes_prefix><![CDATA[]]></subvolumes_prefix>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_BTRFS</type>
+            <use>all</use>
+        </drive>
+    </partitioning>
+</profile>

--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -1,0 +1,29 @@
+name:           autoyast_multi_btrfs
+description:    >
+  Test autoyast installation, while using multi-device Btrfs filesystem
+vars:
+  ENCRYPT: 1
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/validate_multi_btrfs_partitioning
+  - console/validate_encrypt
+test_data:
+  multi_devices:
+    - mount_point: /
+      label: root_multi_btrfs
+      devices:
+        - /dev/vda2
+        - /dev/vdb1
+    - mount_point: /test
+      label: test_multi_btrfs
+      devices:
+        - /dev/vdc
+        - /dev/mapper/cr_vdd1
+  crypttab:
+    num_devices_encrypted: 1
+  !include: test_data/yast/encryption/default_enc.yaml

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -323,6 +323,10 @@ sub run {
             # if we matched bios-boot tag during stage1 we may get grub menu, legacy behavior
             # keep it as a fallback if grub timeout is disabled
             send_key 'ret';
+            # Finish the current module execution if encrypted disks are used.
+            # Delegate entering the encryption passphrase and boot validation to the
+            # next test modules.
+            return if (get_var('ENCRYPT'));
         }
         elsif (match_has_tag('prague-pxe-menu') || match_has_tag('qa-net-selection')) {
             last;    # we missed reboot-after-installation, wait for boot is in autoyast/console

--- a/tests/console/validate_multi_btrfs_partitioning.pm
+++ b/tests/console/validate_multi_btrfs_partitioning.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Data-driven validation module to check multi-device Btrfs setup.
+# Test data must be specified in the corresponding yaml file.
+# Scenarios covered:
+# - Verify labels for all the mount points provided from test data (e.g. "/", "/test");
+# - Verify the number of devices used for multi-device Btrfs filesystems;
+# - Verify devices that are used in multi-device Btrfs filesystems.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_data';
+use Test::Assert ':all';
+
+sub run {
+
+    my $test_data     = get_test_data();
+    my @multi_devices = @{$test_data->{multi_devices}};
+
+    select_console 'root-console';
+
+    foreach (@multi_devices) {
+        my $mount_point              = $_->{mount_point};
+        my $btrfs_multidevice_output = script_output("btrfs filesystem show $mount_point");
+
+        record_info("Label", "Verify label for \"$mount_point\" mount point");
+        assert_true($btrfs_multidevice_output =~ $_->{label},
+            "Wrong label is shown for multi-device Btrfs with \"$mount_point\" mount point");
+
+        record_info("Number of devices", "Verify the number of devices used for multi-device Btrfs with \"$mount_point\" mount point corresponds to the expected");
+        my @partitions_count = ($btrfs_multidevice_output =~ /devid/g);
+        assert_equals(scalar @{$_->{devices}}, @partitions_count,
+            "Multi-device Btrfs with \"$mount_point\" mount point contains wrong number of devices");
+
+        foreach (@{$_->{devices}}) {
+            record_info("$_", "Verify the device \"$_\" is used in multi-device Btrfs with \"$mount_point\" mount point");
+            assert_true($btrfs_multidevice_output =~ $_,
+                "Multi-device Btrfs with \"$mount_point\" mount point does not contain the expected device \"$_\"");
+        }
+    }
+}
+
+1;


### PR DESCRIPTION
**Please, merge also needles before merging this PR.**

The commit adds the appropriate Autoyast control file for Tumbleweed
and SLE15 installation and adds validation module to check that the partitioning
was made correctly.

Also, it adds the appropriate YAML scheduling file.

NOTE: The appropriate test suite has to be created on openQA:

**autoyast_multi_btrfs:**

DESKTOP=gnome
NUMDISKS=4
YAML_SCHEDULE=schedule/yast/autoyast_multi_btrfs.yaml

for Tumbleweed:
AUTOYAST=autoyast_opensuse/autoyast_multi_btrfs.xml

for sle15:
AUTOYAST=autoyast_sle15/autoyast_multi_btrfs.xml

- Related ticket: [poo#57668](https://progress.opensuse.org/issues/57668)
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/609
- Verification runs: 
   - Sle15: http://10.160.65.138/tests/1147
   - Tumbleweed: http://10.160.65.138/tests/1144