### PR TITLE
publiccloud: Add missing quotes in use statement

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -13,7 +13,7 @@
 
 package publiccloud::instance;
 use testapi;
-use Carp croak;
+use Carp 'croak';
 use Mojo::Base -base;
 use Mojo::Util 'trim';
 use File::Basename;


### PR DESCRIPTION
This fix following warning:
```
  Unquoted string "croak" may clash with future reserved word at
```