### PR TITLE
Disable kvm module in qemu test for ppc64le

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1578,7 +1578,7 @@ sub load_extra_tests_opensuse {
 sub load_extra_tests_qemu {
     loadtest "qemu/info";
     loadtest "qemu/qemu";
-    loadtest "qemu/kvm" unless is_aarch64;    # nested kvm is not yet supported on ARM
+    loadtest "qemu/kvm" unless (is_aarch64 || is_ppc64le);    # nested kvm is not yet implemented on ARM and kvm not supported on ppc64le
     loadtest "qemu/user" if is_opensuse;
 }
 


### PR DESCRIPTION
Ticket: https://bugzilla.suse.com/show_bug.cgi?id=1153543
Verification: https://openqa.suse.de/t3587881