### PR TITLE
[IGNORE] Adjust addon_products_sle to workaround Full Flavor

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -863,7 +863,7 @@ sub load_inst_tests {
     }
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
-        loadtest "installation/scc_registration";
+        loadtest "installation/scc_registration" unless check_var('FLAVOR', 'Full');
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }

--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -1,0 +1,26 @@
+---
+name:           offline_install+skip_registration
+description:    >
+  Offline installation. Skipping registration for SLE 15, as requires network connection.
+  This is default behavior for SLE 12.
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/network_configuration
+  - installation/addon_products_sle
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot

--- a/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
@@ -1,0 +1,20 @@
+---
+name:           releasenotes_origin+unregistered
+description:    >
+  Test fate#323273 - Check the origin (rpm or url) of the showed release notes.
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/releasenotes_origin
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -1,0 +1,35 @@
+---
+name:           skip_registration
+description:    >
+  Like a standard scenario with explicit skipping of SCC registration
+  in case where we register by default, e.g. for SLE >= 15
+  See https://progress.opensuse.org/issues/25264 for details.
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -78,8 +78,16 @@ sub handle_all_packages_medium {
     for my $i (@addons) {
         push @addons_license_tags, "addon-license-$i" if grep(/^$i$/, @addons_with_license);
         send_key 'home';
-        send_key_until_needlematch "addon-products-all_packages-$i-highlighted", 'down', 30;
-        send_key 'spc';
+        # soft_fail when it tries to match needle for sles15 product
+        # https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-install.html#sec-yast-install-modules-offline
+        # implies that the product selection is mandatory
+        if ($i =~ $sle_prod) {
+            record_soft_failure "$i is missing. bsc#1156568";
+        }
+        else {
+            send_key_until_needlematch "addon-products-all_packages-$i-highlighted", 'down', 30;
+            send_key 'spc';
+        }
     }
     send_key $cmd{next};
     # Check the addon license agreement
@@ -149,48 +157,53 @@ sub run {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
-    if ($self->process_unsigned_files([qw(inst-addon addon-products)])) {
-        assert_screen_with_soft_timeout(
-            [qw(inst-addon addon-products)],
-            timeout      => 60,
-            soft_timeout => 30,
-            bugref       => 'bsc#1123963');
+    unless (check_var('FLAVOR', 'Full')) {
+        if ($self->process_unsigned_files([qw(inst-addon addon-products)])) {
+            assert_screen_with_soft_timeout(
+                [qw(inst-addon addon-products)],
+                timeout      => 60,
+                soft_timeout => 30,
+                bugref       => 'bsc#1123963');
+        }
     }
+    record_info('inst-addon out');
     if (get_var("ADDONS")) {
         send_key match_has_tag('inst-addon') ? 'alt-k' : 'alt-a';
         # the ISO_X variables must match the ADDONS list
         my $sr_number = 0;
         for my $addon (split(/,/, get_var('ADDONS'))) {
             $sr_number++ unless (is_sle('15+') && $sr_number == 1);
-            assert_screen 'addon-menu-active';
-            wait_screen_change { send_key 'alt-d' };    # DVD
-            send_key $cmd{next};
-            assert_screen 'dvd-selector';
-            send_key_until_needlematch 'addon-dvd-list',         'tab',  5;     # jump into addon list
-            send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 10;    # select addon in list
-            send_key 'alt-o';                                                   # continue
+            unless (check_var('FLAVOR', 'Full')) {
+                assert_screen 'addon-menu-active';
+                wait_screen_change { send_key 'alt-d' };    # DVD
+                send_key $cmd{next};
+                assert_screen 'dvd-selector';
+                send_key_until_needlematch 'addon-dvd-list',         'tab',  5;     # jump into addon list
+                send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 10;    # select addon in list
+                send_key 'alt-o';                                                   # continue
+            }
             handle_addon($addon);
-            if ((split(/,/, get_var('ADDONS')))[-1] ne $addon) {                # if $addon is not first from all ADDONS
-                send_key 'alt-a';                                               # add another add-on
+            if ((split(/,/, get_var('ADDONS')))[-1] ne $addon) {                    # if $addon is not first from all ADDONS
+                send_key 'alt-a';                                                   # add another add-on
             }
         }
     }
     test_addonurl if is_sle('>=15') && get_var('ADDONURL');
     if (get_var("ADDONURL")) {
         if (match_has_tag('inst-addon')) {
-            send_key 'alt-k';                                                   # install with addons
+            send_key 'alt-k';                                                       # install with addons
         }
         else {
             send_key 'alt-a';
         }
         for my $addon (split(/,/, get_var('ADDONURL'))) {
             assert_screen 'addon-menu-active';
-            my $uc_addon = uc $addon;                                           # varibale name is upper case
-            send_key 'alt-u';                                                   # specify url
+            my $uc_addon = uc $addon;                                               # varibale name is upper case
+            send_key 'alt-u';                                                       # specify url
             send_key $cmd{next};
             assert_screen 'addonurl-entry';
-            send_key 'alt-u';                                                   # select URL field
-            type_string get_required_var("ADDONURL_$uc_addon");                 # repo URL
+            send_key 'alt-u';                                                       # select URL field
+            type_string get_required_var("ADDONURL_$uc_addon");                     # repo URL
             send_key $cmd{next};
             wait_still_screen;    # wait after key is pressed, e.g. 'addon-products' can apper shortly before initialization
             my @tags = ('addon-products', "addon-betawarning-$addon", "addon-license-$addon", 'import-untrusted-gpg-key');


### PR DESCRIPTION
- create schedulers and remove scc_registration
- throw a soft_failure for bsc#1156568
- no handling for second betawarning, leaving to fail

ADDONS=all-packages should be set for that group of test suites

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
