### PR TITLE
Workarounds for cluster migrations without support server

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -43,6 +43,7 @@ sub run {
             barrier_create("BARRIER_HA_NFS_SUPPORT_DIR_SETUP_$cluster_name", $num_nodes);
             barrier_create("BARRIER_HA_HOSTS_FILES_READY_$cluster_name",     $num_nodes);
             barrier_create("BARRIER_HA_LUNS_FILES_READY_$cluster_name",      $num_nodes);
+            barrier_create("BARRIER_HA_NONSS_FILES_SYNCED_$cluster_name",    $num_nodes);
         }
         else {
             barrier_create("BARRIER_HA_$cluster_name", $num_nodes + 1);


### PR DESCRIPTION
When not using the name resolution provided by a Support Server in a SLES+HA MM cluster migration test, where the original cluster was setup in unicast mode, migrated cluster will fail to properly start if the VMs receive different IP addresses to the ones used during the setup of the cluster in the original systems.

This PR introduces a workaround to such an scenario by:

1. Stopping pacemaker.
2. Determining the old IP addresses configured in corosync.conf
3. Determining the new IP addresses of the working VMs
4. Replacing the old IP addresses with the new ones in corosync.conf and drbd_passive.res files.
5. Restarting pacemaker.

- Related ticket: N/A
- Needles: N/A
- Verification runs: [node1](http://mango.suse.de/tests/1935) & [node2](http://mango.suse.de/tests/1936)
