### PR TITLE
Workaround issue with serial output for checking string

### DIFF
--- a/tests/console/php7.pm
+++ b/tests/console/php7.pm
@@ -23,6 +23,7 @@ use apachetest;
 sub run {
     select_console 'root-console';
     setup_apache2(mode => 'PHP7');
-    validate_script_output('curl http://localhost/index.php', sub { /PHP Version 7/ });
+    assert_script_run('curl http://localhost/index.php | tee /tmp/tests-console-php7.txt');
+    assert_script_run('grep "PHP Version 7" /tmp/tests-console-php7.txt');
 }
 1;


### PR DESCRIPTION
we have problem with passing long string to serial.
use assert_script_run and grep to workaround this issue.

see https://progress.opensuse.org/issues/59030
verificattion test run:
https://openqa.suse.de/tests/3593575#step/php7/36