### PR TITLE
Do not test Overview tab in yast2 lan with NetworkManager

### DIFF
--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -56,9 +56,11 @@ sub run {
         type_string(get_var('DISTRI') . '-host') if get_var("DISTRI") =~ /(sle|opensuse)/;
     }
     # Overview tab
-    send_key $cmd{overview_tab};
-    assert_screen 'yast2-network-settings_overview';
+    # When controlled by NM we cannot edit anything in the UI and in latest version
+    # it's not even possible to open the tab and warning will be shown, so skip this tab completely
     unless (is_network_manager_default) {
+        send_key $cmd{overview_tab};
+        assert_screen 'yast2-network-settings_overview';
         send_key $cmd{add_device};
         # Older than 15-SP2 versions require two steps to select device type: expand the list and then select the option.
         # On 15-SP2 it is a list of radio buttons, so only one step with selecting the radio is needed.


### PR DESCRIPTION
When network is controlled by NM, we were not able to edit anything in
the tab. Now in TW we got a change that we are not even able to open
this tab, so skip this part of the test.

See [poo#57737](https://progress.opensuse.org/issues/57737).
- [Verification run](http://d27.suse.de/tests/289)
