### PR TITLE
LTP: Respect LTP_RUNTEST_TAG

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -264,12 +264,15 @@ sub is_kernel_test {
 
 sub get_ltp_tag {
     my $tag = get_var('LTP_RUNTEST_TAG');
-    if (!defined $tag && defined get_var('HDD_1')) {
-        $tag = get_var('PUBLISH_HDD_1');
-        $tag = get_var('HDD_1') if (!defined $tag);
-        $tag = basename($tag);
-    } else {
-        $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
+
+    if (!defined $tag) {
+        if (defined get_var('HDD_1')) {
+            $tag = get_var('PUBLISH_HDD_1');
+            $tag = get_var('HDD_1') if (!defined $tag);
+            $tag = basename($tag);
+        } else {
+            $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
+        }
     }
     $tag =~ s/[^a-zA-Z0-9_@]+/-/g;
     return $tag . '.txt';

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -428,7 +428,7 @@ E.g.: key=value,key2="value with spaces",key3='another value with spaces'
 
 The runtest asset files are appended with git or pkg depending on how LTP was
 installed. By default the runtest files from the git installation will be
-uesd, but setting this variable to pkg allows that behavior to be overridden.
+used, but setting this variable to pkg allows that behavior to be overridden.
 
 =cut
 


### PR DESCRIPTION
LTP_RUNTEST_TAG was overwritten with bare metal tests version

Fixes: 5d4e80ac2 ("LTP: Fix get_ltp_tag() for non-master branches")

Verification run:
* LTP_RUNTEST_TAG=foo.N => files needs to contain: foo-N
http://quasar.suse.cz/tests/4069#downloads
http://quasar.suse.cz/tests/4070#downloads
http://quasar.suse.cz/tests/4074#downloads
* default
http://quasar.suse.cz/tests/4073#downloads
http://quasar.suse.cz/tests/4072#downloads
http://quasar.suse.cz/tests/4071#downloads