### PR TITLE
Arm can swap disk labels

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -26,7 +26,7 @@ sub set_playground_disk {
         assert_script_run 'parted --script --machine -l';
         my $output = script_output 'parted --script --machine -l';
         # Parse playground disk
-        $output =~ m|(?<disk>/dev/$vd[bc]):.*unknown.*| || die "Failed to parse playground disk, got following output:\n$output";
+        $output =~ m|(?<disk>/dev/$vd[ab]):.*unknown.*| || die "Failed to parse playground disk, got following output:\n$output";
         set_var('PLAYGROUNDDISK', $+{disk});
     }
 }


### PR DESCRIPTION
- Related tickets: 
   * [[jeos][oS] test fails in snapper_thin_lvm on aarch64](https://progress.opensuse.org/issues/59345)
   * [[jeos] test fails in btrfs_qgroups on aarch64](https://progress.opensuse.org/issues/59342)
- Verification runs:
   * cannot download assets from o3 nor download.opensuse.org