### PR TITLE
Fix schedule for multipath test suite on SLE 15 SP2

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -425,10 +425,12 @@ sub process_scc_register_addons {
         }
         # start addons/modules registration, it needs longer time if select multiple or all addons/modules
         my $counter = ADDONS_COUNT;
+        my @needles = qw(import-untrusted-gpg-key nvidia-validation-failed yast_scc-pkgtoinstall yast-scc-emptypkg inst-addon contacting-registration-server refreshing-repository);
+        # In SLE 15 SP2 multipath detection happens directly after registration, so using it to detect that all pop-up are processed
+        push @needles, 'enable-multipath' if is_sle('15-SP2+') && get_var('MULTIPATH');
         while ($counter--) {
             die 'Addon registration repeated too much. Check if SCC is down.' if ($counter eq 1);
-            assert_screen [
-                qw(import-untrusted-gpg-key nvidia-validation-failed yast_scc-pkgtoinstall yast-scc-emptypkg inst-addon contacting-registration-server refreshing-repository)];
+            assert_screen [@needles];
             if (match_has_tag('import-untrusted-gpg-key')) {
                 handle_untrusted_gpg_key;
                 next;
@@ -472,7 +474,7 @@ sub process_scc_register_addons {
                 sleep 5;
                 next;
             }
-            elsif (match_has_tag('inst-addon')) {
+            elsif (match_has_tag('inst-addon') || match_has_tag('enable-multipath')) {
                 # it would show Add On Product screen if scc registration correctly during installation
                 # it would show software install dialog if scc registration correctly by yast2 scc
                 last;

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -1,0 +1,31 @@
+name:           multipath
+description:    >
+  Test installation on machine with virtual multipath hardware.
+  Only tests succesful detection of multipath and installation.
+  No functional testing of multipath itself.
+vars:
+  DESKTOP: gnome
+  MULTIPATH: 1
+schedule:
+  -installation/bootloader_start
+  -installation/welcome
+  -installation/accept_license
+  -installation/scc_registration
+  -installation/multipath
+  -installation/addon_products_sle
+  -installation/system_role
+  -installation/partitioning
+  -installation/partitioning_finish
+  -installation/installer_timezone
+  -installation/hostname_inst
+  -installation/user_settings
+  -installation/user_settings_root
+  -installation/resolve_dependency_issues
+  -installation/installation_overview
+  -installation/disable_grub_timeout
+  -installation/start_install
+  -installation/await_install
+  -installation/logs_from_installation_system
+  -installation/reboot_after_installation
+  -installation/grub_test
+  -installation/first_boot


### PR DESCRIPTION
Screen with multipath detection is now after the registration.
We use this moment to move this test suite to yaml.

I will provide MR to add the setting to the test suite.

See [poo#59247](https://progress.opensuse.org/issues/59247).

[Verification runs](http://d27.suse.de/tests/overview?version=15-SP2&build=89.1&distri=sle)
