### PR TITLE
Remove excessive sudo call in root console

### DIFF
--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -52,7 +52,7 @@ sub run {
 
     if (check_var("ARCH", "x86_64")) {
         assert_script_run('curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64', 240);
-        assert_script_run('chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff');
+        assert_script_run('chmod +x container-diff-linux-amd64 && mv container-diff-linux-amd64 /usr/local/bin/container-diff');
     }
 
     for my $i (0 .. $#$image_names) {


### PR DESCRIPTION
- Related ticket: [[JeOS][sle] test fails in docker_image - remove spare sudo call](https://progress.opensuse.org/issues/57200)
- Verification run: 
   * [docker_image](http://eris.suse.cz/tests/2600#step/docker_image/28)
