### PR TITLE
Workaround license insert disc issue

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -110,6 +110,10 @@ sub is_module {
 sub accept_addons_license {
     my (@scc_addons) = @_;
 
+    # Trap the 'missing license file on media' issue
+    # Needle is configured as a workaround, so a soft-fail will be shown
+    send_key 'alt-s' if check_screen('license-insert-disc-issue', 30);
+
     # To check the current state of licenses in the product one can conduct
     # the following steps, e.g. for SLE15:
     #   isc co SUSE:SLE-15:GA 000product

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -151,6 +151,9 @@ sub run {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
+    # Trap the 'missing license file on media' issue
+    # Needle is configured as a workaround, so a soft-fail will be shown
+    send_key 'alt-s' if check_screen('license-insert-disc-issue', 30);
     # Full_installer jumps to the Select extension and modules dialog and this
     # makes the tests fail as it doesnt find anything to match
     unless (check_var('FLAVOR', 'Full')) {


### PR DESCRIPTION
On SLE15-SP2 [bsc#1153326](https://bugzilla.suse.com/show_bug.cgi?id=1153326) can appears with some modules/extensions/products on Online-DVD.

This commit workaround this issue and add a softfailure in the test.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1247
- Verification run: [for HA Product in textmode on x86_64](http://1b210.qa.suse.de/tests/6116), [for HA Product in textmode on aarch64](http://1b210.qa.suse.de/tests/6117), [for SLES4SAP](http://1b210.qa.suse.de/tests/6113) and [for BCL Product](http://1b210.qa.suse.de/tests/6115#)
