### PR TITLE
 Enable all yast2_cmd tests on all architectures 

### DIFF
--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -1,41 +1,21 @@
 name:           yast2_cmd
 description:    >
-    Yast2 cmd interface tests.
-
+    YaST2 cmd interface tests.
 conditional_schedule:
   bootloader_zkvm:
     ARCH:
       s390x:
         - installation/bootloader_zkvm
-  # The test modules are failed on s390x and aarch64 and excluded to do investigations
-  under_issues_investigation:
-    ARCH:
-      ppc64le:
-        - yast2_cmd/yast_lan
-        - yast2_cmd/yast_ftp_server
-        - yast2_cmd/yast_users
-        - yast2_cmd/yast_keyboard
-        - yast2_cmd/yast_sysconfig
-      x86_64:
-        - yast2_cmd/yast_ftp_server
-        - yast2_cmd/yast_users
-        - yast2_cmd/yast_keyboard
-        - yast2_cmd/yast_sysconfig
-      aarch64:
-        - yast2_cmd/yast_keyboard
-        - yast2_cmd/yast_sysconfig
-      s390x:
-        - yast2_cmd/yast_lan
-        - yast2_cmd/yast_ftp_server
-        - yast2_cmd/yast_users
-
 schedule:
-     # Called on ARCH: s390x
-     - {{bootloader_zkvm}}
-     - boot/boot_to_desktop
-     - yast2_cmd/yast_rdp
-     - yast2_cmd/yast_timezone
-     - yast2_cmd/yast_tftp_server
-     - yast2_cmd/yast_nfs_server
-     - yast2_cmd/yast_nfs_client
-     - {{under_issues_investigation}}
+  - {{bootloader_zkvm}}
+  - boot/boot_to_desktop
+  - yast2_cmd/yast_rdp
+  - yast2_cmd/yast_timezone
+  - yast2_cmd/yast_ftp_server
+  - yast2_cmd/yast_nfs_server
+  - yast2_cmd/yast_nfs_client
+  - yast2_cmd/yast_tftp_server
+  - yast2_cmd/yast_lan
+  - yast2_cmd/yast_users
+  - yast2_cmd/yast_keyboard
+  - yast2_cmd/yast_sysconfig


### PR DESCRIPTION
Increase timeouts for slower archs in yast2 cmd. x3 should be a good value to try as default due to when I tried to increase manually timeout for each function I ended up with 60s and 90s.
x3 seems to work for all except arch which failed with: [x3](https://openqa.suse.de/tests/3604902#step/yast_ftp_server/7), [x5](https://openqa.suse.de/tests/3607058#step/yast_ftp_server/6). aarch seems to work with x8 (which I cannot judge if it is ok...)
- Related ticket: https://progress.opensuse.org/issues/58742
- Changes in Job Group: [sle-15](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/merge_requests/80)
- Verification run: [yast_cmd](https://openqa.suse.de/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%238928&distri=sle&version=15-SP2)
