### PR TITLE
Add additional schedulers to skip_registration

### DIFF
--- a/schedule/yast/skip_registration/skip_registration@s390x-zVM.yaml
+++ b/schedule/yast/skip_registration/skip_registration@s390x-zVM.yaml
@@ -1,0 +1,35 @@
+---
+name:           skip_registration@s390x-zVM
+description:    >
+  Like a standard scenario with explicit skipping of SCC registration
+  in case where we register by default, e.g. for SLE >= 15
+  See https://progress.opensuse.org/issues/25264 for details.
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/disk_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/yast/skip_registration/skip_registration@s390x.yaml
+++ b/schedule/yast/skip_registration/skip_registration@s390x.yaml
@@ -1,0 +1,37 @@
+---
+name:           skip_registration@s390x
+description:    >
+  Like a standard scenario with explicit skipping of SCC registration
+  in case where we register by default, e.g. for SLE >= 15
+  See https://progress.opensuse.org/issues/25264 for details.
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/reconnect_mgmt_console
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+  - shutdown/svirt_upload_assets
+  

--- a/schedule/yast/skip_registration/skip_registration@svirt-hyperv.yaml
+++ b/schedule/yast/skip_registration/skip_registration@svirt-hyperv.yaml
@@ -1,0 +1,35 @@
+---
+name:           skip_registration@svirt-hyperv
+description:    >
+  Like a standard scenario with explicit skipping of SCC registration
+  in case where we register by default, e.g. for SLE >= 15
+  See https://progress.opensuse.org/issues/25264 for details.
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/integration_services
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+  - shutdown/hyperv_upload_assets
+  

--- a/schedule/yast/skip_registration/skip_registration@svirt-xen-hvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration@svirt-xen-hvm.yaml
@@ -1,0 +1,35 @@
+---
+name:           skip_registration@svirt-xen-hvm
+description:    >
+  Like a standard scenario with explicit skipping of SCC registration
+  in case where we register by default, e.g. for SLE >= 15
+  See https://progress.opensuse.org/issues/25264 for details.
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+  - shutdown/svirt_upload_assets
+

--- a/schedule/yast/skip_registration/skip_registration@svirt-xen-pv.yaml
+++ b/schedule/yast/skip_registration/skip_registration@svirt-xen-pv.yaml
@@ -1,0 +1,32 @@
+---
+name:           skip_registration@svirt-xen-pv
+description:    >
+  Like a standard scenario with explicit skipping of SCC registration
+  in case where we register by default, e.g. for SLE >= 15
+  See https://progress.opensuse.org/issues/25264 for details.
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+  - shutdown/svirt_upload_assets

--- a/schedule/yast/skip_registration/skip_registration@uefi.yaml
+++ b/schedule/yast/skip_registration/skip_registration@uefi.yaml
@@ -1,0 +1,35 @@
+---
+name:           skip_registration@uefi
+description:    >
+  Like a standard scenario with explicit skipping of SCC registration
+  in case where we register by default, e.g. for SLE >= 15
+  See https://progress.opensuse.org/issues/25264 for details.
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
Add schedulers for:
s390x
svirt-hyperv
svirt-hyperv-uefi
svirt-xen-hvm
svirt-xen-pv
uefi

- Related ticket: https://progress.opensuse.org/issues/58691
- Needles: 
- Verification run: 

[skip_registration](https://openqa.suse.de/tests/overview?version=15-SP2&build=b10n1k%2Fos-autoinst-distri-opensuse%238929&distri=sle)