### PR TITLE
Allow the mozilla plasma browser integration installation page to load longer

### DIFF
--- a/tests/x11/plasma_browser_integration.pm
+++ b/tests/x11/plasma_browser_integration.pm
@@ -34,8 +34,8 @@ sub run {
 
     # Click on the reminder, it might take a while to appear
     assert_and_click('plasma-browser-integration-reminder', 30);
-    # Click "Add to Firefox"
-    assert_and_click('plasma-browser-integration-install');
+    # Click "Add to Firefox". Longer timeout as loading can take a while
+    assert_and_click('plasma-browser-integration-install', 60);
     # Confirm installation
     assert_and_click('plasma-browser-integration-install-confirm');
     # Ack the "has been added" popup


### PR DESCRIPTION
The page has to load fully, otherwise there is a weird
"allow addons.mozilla.org to install extensions?" dialog.
In some testruns that can take a while, especially as it depends on an external
webpage.

Fixes poo#59867

Verification run (running): http://10.160.67.86/tests/617