### PR TITLE
[WIP] use alt_x for expert_partitioner if needed

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -500,7 +500,13 @@ sub check_warnings {
 sub enter_partitioning {
     # create partitioning
     if (is_storage_ng) {
-        send_key $cmd{expertpartitioner};
+        if (check_screen 'expert_partitioner_x_shortcut', 2) {
+            # pas per poo#59876
+            send_key 'alt-x';
+        }
+        else {
+            send_key $cmd{expertpartitioner};
+        }
         save_screenshot;
         rescan_devices;
     }


### PR DESCRIPTION
use alt_x for expert_partitioner if needed
expect new 'expert_partitioner_x_shortcut' new needle already added in DB.
to solve issue https://progress.opensuse.org/issues/59876


