### PR TITLE
Increase 'zypper ref' and temporaly allow sshd pwd

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -25,16 +25,17 @@ use warnings;
 use base "consoletest";
 use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
-use utils qw(systemctl exec_and_insert_password zypper_call);
+use utils qw(systemctl exec_and_insert_password zypper_call random_string);
 use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap);
 
 sub run {
     my $self = shift;
+    select_console 'root-console';
+
     # new user to test sshd
     my $ssh_testman        = "sshboy";
-    my $ssh_testman_passwd = "let3me2in1";
-
-    select_console 'root-console';
+    my $ssh_testman_passwd = get_var('PUBLIC_CLOUD') ? random_string(8) : 'let3me2in1';
+    assert_script_run('echo -e "Match User ' . $ssh_testman . '\n\tPasswordAuthentication yes" >> /etc/ssh/sshd_config') if (get_var('PUBLIC_CLOUD'));
 
     # 'nc' is not installed by default on JeOS
     if (script_run("which nc")) {

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -22,7 +22,7 @@ sub run {
     my ($self, $args) = @_;
     select_console 'tunnel-console';
 
-    $args->{my_instance}->run_ssh_command(cmd => "sudo zypper ref");
+    $args->{my_instance}->run_ssh_command(cmd => "sudo zypper ref", timeout => 360);
     ssh_fully_patch_system($args->{my_instance}->public_ip);
     $args->{my_instance}->softreboot();
 }


### PR DESCRIPTION
1) Increate 'zypper ref' timeout in public_cloud/patch_and_reboot.pm
2) Temporaly enable PasswordAuthentication for Public Cloud in console/sshd.pm

- Related ticket: [poo#54842](https://progress.opensuse.org/issues/54842)
- Needles: No need
- Verification run: [pdostal-server.suse.cz](http://pdostal-server.suse.cz/tests/5821#)
