### PR TITLE
Fix scheduling for multipath installation on zfcp

### DIFF
--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -1,0 +1,30 @@
+name:           zfcp
+description:    >
+  Test installation on machine with zfcp multipath disk.
+  Only tests succesful detection of multipath and installation.
+  No functional testing of multipath itself.
+vars:
+  DESKTOP: gnome
+  MULTIPATH: 1
+schedule:
+  -installation/bootloader_start
+  -installation/welcome
+  -installation/accept_license
+  -installation/disk_activation
+  -installation/scc_registration
+  -installation/multipath
+  -installation/addon_products_sle
+  -installation/system_role
+  -installation/partitioning
+  -installation/partitioning_finish
+  -installation/installer_timezone
+  -installation/user_settings
+  -installation/user_settings_root
+  -installation/installation_overview
+  -installation/disable_grub_timeout
+  -installation/start_install
+  -installation/await_install
+  -installation/logs_from_installation_system
+  -installation/reboot_after_installation
+  -boot/reconnect_mgmt_console
+  -installation/first_boot


### PR DESCRIPTION
Similarly to multipath test in qemu, we now get multipath detection
after registration step. Adjusting the schedule for it.

See [poo#59247](https://progress.opensuse.org/issues/59247).

[Verification run](https://openqa.suse.de/tests/overview?distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%238936&version=15-SP2)
