### PR TITLE
x11test: Fix evolution_mail_imap by properly syncing key presses

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -364,19 +364,15 @@ sub evolution_add_self_signed_ca {
     my ($self, $account) = @_;
     # add self-signed CA with internal account
     if ($account =~ m/internal/) {
-        assert_and_click "evolution_wizard-receiving-checkauthtype";
-        assert_screen "evolution_mail_meeting_trust_ca";
-        send_key "alt-a";
-        wait_screen_change {
-            send_key $self->{next};
-            send_key "ret";
-        }
+        assert_and_click 'evolution_wizard-receiving-checkauthtype';
+        assert_screen 'evolution_mail_meeting_trust_ca';
+        send_key 'alt-a';
+        assert_screen 'evolution_wizard-receiving';
+        wait_screen_change { send_key $self->{next} };    # select "Next" key
+        send_key 'ret';                                   # Go to next page (previous key just selected the key)
     }
     else {
         send_key $self->{next};
-    }
-    if (is_sle('12-SP2+')) {
-        send_key "ret";    #only need in SP2 or later
     }
 }
 
@@ -436,7 +432,6 @@ sub setup_mail_account {
         send_key "ret";
     };
     $self->evolution_add_self_signed_ca($account);
-    save_screenshot;
     assert_screen [qw(evolution_wizard-receiving-opts evolution_wizard-receiving-not-focused)];
     if (match_has_tag 'evolution_wizard-receiving-not-focused') {
         record_info('workaround', "evolution window not focused, sending key");


### PR DESCRIPTION
Multiple failures have occurred in the test module evolution_mail_imap
coinciding with the deployment of
https://github.com/os-autoinst/os-autoinst/pull/1260 which made hotkeys
more stable (by making them a bit "slower"). There are multiple key
presses in the method "evolution_add_self_signed_ca" in sequence without
any syncing in between, e.g. no "assert_screen" call and there was a
redundant "ret" key.
It could be more likely that the hotkeys are now actually received by
the system due to more stable key event handling so the keys can be
assumed to all be interpreted. Both, the missing syncing and the
additional "ret" call can cause different symptoms of either staying on
the previous screen or stepping over the next expected screen.

This commit fixes this with proper syncing, no duplicate "ret" and no
other redundant commands.

Verification runs:

* [sle12sp4](https://openqa.suse.de/tests/3600078)
* [sle15sp1](https://openqa.suse.de/tests/3600079)

On Tumbleweed the scenario is not cared about anyway, see [1](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=desktopapps-message-x11&version=Tumbleweed) as it seems but the change should improve it regardless.

Related progress issue: https://progress.opensuse.org/issues/59882