### PR TITLE
Create a less generic tcsh user and improve user match on /etc/passwd to fix a problem on leap15.2 ppc64le 

### DIFF
--- a/tests/console/shells.pm
+++ b/tests/console/shells.pm
@@ -46,13 +46,13 @@ sub run() {
 #tcsh specializated test for bsc#1154877 && poo#59354:
 sub tcsh_extra_tests {
     select_console 'root-console';
-    script_run 'useradd -s /usr/bin/tcsh -d /home/tux -m tux';
-    script_run 'su - tux', 0;
+    script_run 'useradd -s /usr/bin/tcsh -d /home/tcsh_user -m tcsh_user';
+    script_run 'su - tcsh_user', 0;
 
     #Generate some outputs for the new created user:
     type_string "echo \"echo Sourced!\" >> ~/.tcsh\n";
 
-    type_string "grep tux /etc/passwd > /tmp/tcsh\n";
+    type_string "grep tcsh_user /etc/passwd > /tmp/tcsh\n";
     type_string "echo \$SHELL >> /tmp/tcsh\n";
     type_string "echo ~ >> /tmp/tcsh\n";
     type_string "source ~/.tcsh >> /tmp/tcsh\n";
@@ -61,15 +61,15 @@ sub tcsh_extra_tests {
     #Go back to root/openqa and do the validations:
     script_run 'logout', 0;
 
-    validate_script_output 'grep -c tux:x:1001:100::/home/tux:/usr/bin/tcsh /tmp/tcsh', sub { /1/ };
-    validate_script_output 'grep -c ^/usr/bin/tcsh /tmp/tcsh',                          sub { /1/ };
-    validate_script_output 'grep -c ^/home/tux /tmp/tcsh',                              sub { /1/ };
-    validate_script_output 'grep -c Sourced! /tmp/tcsh',                                sub { /1/ };
-    validate_script_output 'grep 12 /tmp/tcsh',                                         sub { /12/ };
+    validate_script_output 'grep -c /home/tcsh_user:/usr/bin/tcsh /tmp/tcsh', sub { /1/ };
+    validate_script_output 'grep -c ^/usr/bin/tcsh /tmp/tcsh',                sub { /1/ };
+    validate_script_output 'grep -c ^/home/tcsh_user /tmp/tcsh',              sub { /1/ };
+    validate_script_output 'grep -c Sourced! /tmp/tcsh',                      sub { /1/ };
+    validate_script_output 'grep 12 /tmp/tcsh',                               sub { /12/ };
 
     #cleanup:
     script_run 'rm /tmp/tcsh ~/.tcsh';
-    script_run 'userdel tux';
+    script_run 'userdel tcsh_user';
 }
 
 1;


### PR DESCRIPTION
Fixes: https://openqa.opensuse.org/tests/1085853#step/shells/20

grep needs an improvement, it currently matches a user ID 1001, but user id changes accordingly to added system users.
Also change user tux to something like tcsh_user to be less generic.
- Related ticket:https://progress.opensuse.org/issues/59354
- Needles: None
- Verification run: 
PASSES on all SLES;
Tumbleweed run: http://deathstar.suse.cz/tests/2082

Problem reported in the former PR: 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8924
