### PR TITLE
Don't run plasma_browser_integration on live tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1295,7 +1295,9 @@ sub load_x11tests {
         }
     }
     if (kdestep_is_applicable()) {
-        loadtest "x11/plasma_browser_integration" if (is_tumbleweed || is_leap("15.1+"));
+        if((is_tumbleweed || is_leap("15.1+")) && !get_var('LIVECD')) {
+            loadtest "x11/plasma_browser_integration";
+        }
         loadtest "x11/khelpcenter";
         if (get_var("PLASMA5")) {
             loadtest "x11/systemsettings5";

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1295,7 +1295,7 @@ sub load_x11tests {
         }
     }
     if (kdestep_is_applicable()) {
-        if((is_tumbleweed || is_leap("15.1+")) && !get_var('LIVECD')) {
+        if ((is_tumbleweed || is_leap("15.1+")) && !get_var('LIVECD')) {
             loadtest "x11/plasma_browser_integration";
         }
         loadtest "x11/khelpcenter";


### PR DESCRIPTION
It's incredibly unreliable, probably because the browser cache (so also the video data) ends up in the ramdisk.

Fixes poo#59867

~~No verification run as I don't have access to a local openQA instance...~~

Verification run: http://10.160.67.86/tests/620
