### PR TITLE
Register addons at the beginning of Public Cloud QAM scenario

### DIFF
--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -43,8 +43,6 @@ sub run {
     if (is_sle('=12-SP5') && is_aarch64()) {
         register_product;
         add_suseconnect_product 'sle-sdk';
-    } elsif (get_var('PUBLIC_CLOUD')) {
-        add_suseconnect_product(get_addon_fullname('sdk'));
     }
     zypper_call('in gcc glibc-devel gdb');    #Install test depedencies.
 

--- a/tests/console/zziplib.pm
+++ b/tests/console/zziplib.pm
@@ -36,7 +36,7 @@ sub run {
         zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", name => 'SDK';
     }
     # maintenance updates are registered with sdk module
-    elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
+    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
         cleanup_registration;
         register_product;
         add_suseconnect_product('sle-module-desktop-applications');
@@ -73,7 +73,7 @@ sub run {
     if (get_var('BETA')) {
         zypper_call "rr SDK";
     }
-    elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
+    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
         remove_suseconnect_product(get_addon_fullname('sdk'));
     }
 }

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -20,9 +20,16 @@ use utils;
 
 sub run {
     my ($self, $args) = @_;
+
+    my @addons = split(/,/, get_var('SCC_ADDONS', ''));
+
     select_console 'tunnel-console';
 
     $args->{my_instance}->run_ssh_command(cmd => "sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'), timeout => 180) unless (get_var('FLAVOR') =~ 'On-Demand');
+
+    for my $addon (@addons) {
+        ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon)) unless ($addon eq '');
+    }
 
     assert_script_run("rsync -va -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");


### PR DESCRIPTION
Register all the addons just after the system in `transfer_repos.pm` and do not remove those in following tests.

- Related ticket: [poo#54842](https://progress.opensuse.org/issues/54842)
- Needles: No need
- Verification run: [12sp4@ec2](http://pdostal-server.suse.cz/tests/5864) [12sp4@gce](http://pdostal-server.suse.cz/tests/5863) [15sp1@ec2](http://pdostal-server.suse.cz/tests/5860) [15sp1@gce](http://pdostal-server.suse.cz/tests/5862)
