### PR TITLE
Fix disabling firewall in install_ltp on SLE-11

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -286,7 +286,14 @@ sub setup_network {
         }
     }
 
-    disable_and_stop_service(opensusebasetest::firewall);
+    if (is_sle('<12')) {
+        script_run('chkconfig -d SuSEfirewall2_init');
+        script_run('chkconfig -d SuSEfirewall2_setup');
+        script_run('/etc/init.d/SuSEfirewall2_setup stop');
+    }
+    else {
+        disable_and_stop_service(opensusebasetest::firewall);
+    }
 }
 
 sub run {


### PR DESCRIPTION
Code for disabling firewall in `install_ltp` from PR #8868 doesn't work on SLE-11 because this release doesn't use SystemD. However, we still need to run tests on this release. Check SLE version and use `chkconfig` instead if necessary.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-11SP3: https://openqa.suse.de/tests/3604118
  - SLE-12SP1: https://openqa.suse.de/tests/3604060