### PR TITLE
KLP: Use run.sh if available

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -16,7 +16,6 @@ use base 'opensusebasetest';
 use testapi;
 use utils;
 use registration;
-use repo_tools 'add_qa_head_repo';
 use version_utils 'is_sle';
 
 sub run {
@@ -30,16 +29,12 @@ sub run {
     my ($test_type) = $git_repo =~ /qa_test_(\w+).git/;
 
     (is_sle(">12-sp1") || !is_sle) ? $self->select_serial_terminal() : select_console('root-console');
-    add_qa_head_repo;
-    zypper_call('in -l bats hiworkload', exitcode => [0, 106, 107]);
 
     add_suseconnect_product("sle-sdk") if (is_sle('<12-SP5'));
-
     zypper_call('in -l git gcc make');
 
     assert_script_run('git clone ' . $git_repo);
-
-    assert_script_run("cd qa_test_$test_type;bats $test_type.bats", 2760);
+    assert_script_run("cd qa_test_$test_type; ./run.sh", 2760);
 }
 
 1;


### PR DESCRIPTION
KLP: Remove hiworkload and bats

These aren't available for o3 as they're in qa_head repository,
which is not reachable on o3.

This needs to temporarily use my fork
QA_TEST_KLP_REPO=https://github.com/pevik/qa_test_klp.git
until this PR is merged:
https://github.com/lpechacek/qa_test_klp/pull/4

NOTE: we could use previous code on osd, but I think it's better
to have the same code for both osd and o3.

- Needles: N/A
- Verification run:
NOTE: All these are correctly failing, because there is currently kernel bug on klp
  - http://quasar.suse.cz/tests/4002 (opensuse-Tumbleweed-DVD-x86_64-Build20191116-kernel-live-patching)
  - http://quasar.suse.cz/tests/4003 (sle-15-SP2-Installer-DVD-x86_64-Build89.1-kernel-live-patching)
  - https://openqa.suse.de/tests/3607193 (sle-15-SP2-Installer-DVD-x86_64-Buildpevik_os-autoinst-distri-opensuse_8947-kernel-live-patching@pevik_os-autoinst-distri-opensuse_klp_remove-hiworkload@64bit)
