### PR TITLE
Wait till apparmor is closed before cleaning the console

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -202,6 +202,11 @@ sub run {
         send_key 'alt-o';
         assert_screen 'yast2_apparmor_profile_for_top_generated';
         send_key 'alt-f';
+        #confirm profile generation
+        assert_screen 'yast2_apparmor_profile_generated';
+        send_key 'alt-o';
+        #wait till app is closed
+        wait_serial("$module_name-0", 200) || die "'yast2 apparmor' didn't finish";
         #cleaning the console
         type_string "reset\n";
         return;


### PR DESCRIPTION
See [poo#58433](https://progress.opensuse.org/issues/58433).

Needles are created using webui.

## Verification runs
[openSUSE](https://openqa.opensuse.org/tests/overview?version=Tumbleweed&distri=opensuse&build=rwx788%2Fos-autoinst-distri-opensuse%238956).
[SLE](https://openqa.suse.de/tests/overview?distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%238956&version=15-SP2).