### PR TITLE
Increase timeout for yast2 installer to get loading system completed

### DIFF
--- a/lib/bootloader_spvm.pm
+++ b/lib/bootloader_spvm.pm
@@ -140,7 +140,7 @@ sub boot_spvm {
     save_screenshot;
 
     assert_screen("novalink-successful-first-boot", 120);
-    assert_screen("run-yast-ssh",                   60);
+    assert_screen("run-yast-ssh",                   120);
 
     # Delete partition table before starting installation
     select_console('install-shell');


### PR DESCRIPTION
yast2 installer has sporadic issue with loading system files.
This could be network issue or spvm host itself. Increase timeout
from 60 to 120 seconds.
see https://progress.opensuse.org/issues/57212
verification runs:
https://openqa.suse.de/tests/3610350#next_previous
