### PR TITLE
Fix libqt5_qtbase for 12SP5

### DIFF
--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -28,8 +28,8 @@ sub run {
 
     # Install required packages
     # designer-qt5 is in package libqt5-qttools, yast release notes in yast2-installation
-    # SDK needs to be added for 12-SP3
-    if (is_sle('<12-SP4')) {
+    # SDK needs to be added for 12
+    if (is_sle('<=12-SP5')) {
         select_console 'root-console';
         cleanup_registration;
         register_product;


### PR DESCRIPTION
Do not limit adding the SDK to just earlier 12 versions, 12SP5 requires it too.

- Related ticket: https://progress.opensuse.org/issues/58745
- Verification run:
12 SP5 on s390x: https://openqa.suse.de/tests/3610289
(failing one without the fix at https://openqa.suse.de/tests/3576429)
12 SP4 still works: http://d432.qam.suse.de/tests/249#step/libqt5_qtbase/40
