### PR TITLE
Adopt to new API of baremetal support service

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -73,7 +73,7 @@ sub set_bootscript {
     my $host        = get_required_var('SUT_IP');
     my $ip          = inet_ntoa(inet_aton($host));
     my $http_server = get_required_var('IPXE_HTTPSERVER');
-    my $url         = "$http_server/$ip/script.ipxe";
+    my $url         = "$http_server/v1/bootscript/script.ipxe/$ip";
 
     my $autoyast = get_required_var('AUTOYAST');
 


### PR DESCRIPTION
The baremetal support service introduced a new API, which is more
structured and especially versioned. The old API is deprecated and will
go away in the next version.

https://openqa.suse.de/tests/3610296#step/ipxe_install/1 