### PR TITLE
[WIP] xfstests: Use root-console on svirt backend

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -42,7 +42,8 @@ sub collect_version {
 
 sub run {
     my $self = shift;
-    $self->select_serial_terminal;
+    # Use root-console for installation on svirt instead of root-sut-serial
+    check_var('BACKEND', 'svirt') ? select_console('root-console') : $self->select_serial_terminal;
 
     # Disable PackageKit
     # This is done by the previous module (enable_kdump) only if NO_KDUMP is not set


### PR DESCRIPTION
Use root-console on svirt backend. This PR to solve the problem[1] when login to svirt.
[1] http://openqa.suse.de/tests/3616068#step/install/1

- Related Ticket: https://progress.opensuse.org/issues/60106
- Verification run: http://openqa.suse.de/tests/3616075
