### PR TITLE
Increase timeout for plasma-browser-integration-install

### DIFF
--- a/tests/x11/plasma_browser_integration.pm
+++ b/tests/x11/plasma_browser_integration.pm
@@ -35,7 +35,7 @@ sub run {
     # Click on the reminder, it might take a while to appear
     assert_and_click('plasma-browser-integration-reminder', 30);
     # Click "Add to Firefox". Longer timeout as loading can take a while
-    assert_and_click('plasma-browser-integration-install', 60);
+    assert_and_click('plasma-browser-integration-install', 90);
     # Confirm installation
     assert_and_click('plasma-browser-integration-install-confirm');
     # Ack the "has been added" popup


### PR DESCRIPTION
as current value may be a bit short in some cases (kde-wayland on aarch64).