### PR TITLE
Don't run livecd_network_settings on TW anymore

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -874,8 +874,8 @@ sub load_inst_tests {
         loadtest 'installation/releasenotes_origin' if get_var('CHECK_RELEASENOTES_ORIGIN');
     }
     if (noupdatestep_is_applicable()) {
-        # Krypton/Argon disable the network configuration stage
-        if (get_var("LIVECD") && !is_krypton_argon) {
+        # On TW Lives and Argon there is no network configuration stage
+        if (get_var("LIVECD") && is_leap && !is_krypton_argon) {
             loadtest "installation/livecd_network_settings";
         }
         # See https://github.com/yast/yast-packager/pull/385


### PR DESCRIPTION
Latest YaST skips this module by default now.

Verification run: http://10.160.67.86/tests/621
Fixes https://progress.opensuse.org/issues/60109