### PR TITLE
Close beta warning for each enabled module

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -90,7 +90,7 @@ sub handle_all_packages_medium {
     my $counter           = 2 + (scalar @addons_license_tags);
     my $addon_license_num = 0;
     while ($counter--) {
-        assert_screen([qw(addon-products-nonempty sle-product-license-agreement)], 180);
+        assert_screen([qw(addon-products-nonempty sle-product-license-agreement inst-betawarning)], 180);
         last if (match_has_tag 'addon-products-nonempty');
         if (match_has_tag 'sle-product-license-agreement') {
             if (@addons_license_tags && check_screen(\@addons_license_tags, 30)) {
@@ -98,6 +98,12 @@ sub handle_all_packages_medium {
             }
             wait_screen_change { send_key 'alt-a' };
             wait_screen_change { send_key 'alt-n' };
+        }
+        elsif (match_has_tag('inst-betawarning')) {
+            record_soft_failure('bsc#1156629 - beta warning appears twice during the installation');
+            foreach (@addons) {
+                wait_screen_change { send_key 'alt-o' };
+            }
         }
     }
     record_info "Error", "License agreement not shown for some addons", result => 'fail'


### PR DESCRIPTION
Workaround. See bsc#1156629

- Related ticket: https://progress.opensuse.org/issues/60041
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/1948#step/addon_products_sle/26
