### PR TITLE
Delete unused code pre_bootmenu_setup

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -31,7 +31,6 @@ our @EXPORT = qw(
   compare_bootparams
   create_encrypted_part
   parse_bootparams_in_serial
-  pre_bootmenu_setup
   select_bootmenu_more
   select_bootmenu_option
   uefi_bootmenu_params
@@ -240,15 +239,6 @@ sub boot_into_snapshot {
     # avoid timeout for booting to HDD
     save_screenshot;
     send_key 'ret';
-}
-
-sub pre_bootmenu_setup {
-    if (get_var("IPXE")) {
-        sleep 60;
-        return 3;
-    }
-    return 3 if get_var('BOOT_HDD_IMAGE');
-    return 0;
 }
 
 sub select_bootmenu_option {

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -247,18 +247,6 @@ sub pre_bootmenu_setup {
         sleep 60;
         return 3;
     }
-
-    # After version 12 the USB storage is set as the default boot device using
-    # bootindex. Before 12 it needs to be selected in the BIOS.
-    if (isotovideo::get_version() < 12 && get_var("USBBOOT")) {
-        assert_screen "boot-menu", 5;
-        # support multiple versions of seabios, does not harm to press
-        # multiple keys here: seabios<1.9: f12, seabios=>1.9: esc
-        send_key((match_has_tag 'boot-menu-esc') ? 'esc' : 'f12');
-        assert_screen "boot-menu-usb", 4;
-        send_key(2 + get_var("NUMDISKS"));
-    }
-
     return 3 if get_var('BOOT_HDD_IMAGE');
     return 0;
 }

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -43,7 +43,7 @@ use Utils::Backends 'is_spvm';
 # hint: press shift-f10 trice for highest debug level
 sub run {
     return boot_spvm if is_spvm;
-    return           if pre_bootmenu_setup == 3;
+    return           if get_var('BOOT_HDD_IMAGE');
     return           if select_bootmenu_option == 3;
     # the default loader is isolinux on openSUSE/SLE products with product-builder
     my $boot_cmd = 'ret';

--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,17 +15,11 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use bootloader_setup qw(ensure_shim_import pre_bootmenu_setup select_bootmenu_more);
+use bootloader_setup qw(ensure_shim_import select_bootmenu_more);
 
 sub run {
     my $self       = shift;
     my $iterations = 0;
-
-    # handle mediacheck for usb boot if non-uefi
-    if (!get_var("UEFI")) {
-        return if pre_bootmenu_setup == 3;
-    }
-
     ensure_shim_import;
     select_bootmenu_more('inst-onmediacheck', 1);
 


### PR DESCRIPTION
I checked tests on both o3 and osd and could not find the combination of
IPXE with bootloader or mediacheck. IPXE is used in special, different
test setups which does not rely on pre_bootmenu_setup at all. Only the
combination of the bootloader module together with BOOT_HDD_IMAGE might
be used so this commit moves that check directly into the bootloader
code. Obviously mediacheck is also not used with BOOT_HDD_IMAGE and
!UEFI and I would doubt this could even work.

Verification runs:
`openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8972 https://openqa.suse.de/tests/3576649 && openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8972 https://openqa.suse.de/tests/3614138 && openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8972 https://openqa.suse.de/tests/3614192 && openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8972 https://openqa.opensuse.org/tests/1091616 INCLUDE_MODULES=bootloader,welcome && openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8972 https://openqa.opensuse.org/tests/1091065 && openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8972 https://openqa.opensuse.org/tests/1091051 INCLUDE_MODULES=bootloader_uefi,welcome`
Created job #3619321: sle-12-SP5-Server-DVD-x86_64-Build0372-mediacheck@64bit -> https://openqa.suse.de/t3619321
Created job #3619322: sle-15-SP2-Online-x86_64-Build92.1-USBinstall@64bit -> https://openqa.suse.de/t3619322
Created job #3619323: sle-15-SP2-Online-x86_64-Build92.1-mediacheck@64bit -> https://openqa.suse.de/t3619323
Created job #1091896: opensuse-Tumbleweed-DVD-x86_64-Build20191120-gnome@64bit -> https://openqa.opensuse.org/t1091896
Created job #1091897: opensuse-Tumbleweed-DVD-x86_64-Build20191120-mediacheck@64bit -> https://openqa.opensuse.org/t1091897
Created job #1091898: opensuse-Tumbleweed-DVD-x86_64-Build20191120-uefi@64bit -> https://openqa.opensuse.org/t1091898
