### PR TITLE
Remove match_typed in vlc test

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -23,7 +23,7 @@ use testapi;
 
 sub run {
     ensure_installed('vlc');
-    x11_start_program('vlc --no-autoscale', target_match => 'vlc-first-time-wizard', match_typed => 'target_match_vlc');
+    x11_start_program('vlc --no-autoscale', target_match => 'vlc-first-time-wizard');
     assert_and_click "vlc-first-time-wizard";
     assert_screen "vlc-main-window";
     send_key "ctrl-l";


### PR DESCRIPTION
To avoid waiting for no reason

- Related ticket: https://progress.opensuse.org/issues/47039
- Verification run: tbd
