### PR TITLE
Add wait_still_screen to wait until snapper module is closed

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -53,6 +53,7 @@ sub y2snapper_close_snapper_module {
     else {
         assert_and_click 'yast2_snapper-close';
     }
+    wait_still_screen 3;
 }
 
 =head2 y2snapper_adding_new_snapper_conf


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3616748#step/yast2_snapper/47
- Verification run: https://openqa.suse.de/tests/3622542
