### PR TITLE
Fix textmode SAP product selection in Installer

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,9 +69,11 @@ sub get_product_shortcuts {
             : is_aarch64() ? 's'
             : 'i',
             sled     => 'x',
-            sles4sap => get_var('OFW') ? 'i' : 'p',
-            hpc      => is_x86_64() ? 'g' : 'u',
-            rt       => is_x86_64() ? 't' : undef
+            sles4sap => get_var('OFW') ? 'i'
+            : (is_sle('=15-SP2') && is_x86_64()) ? 't'
+            : 'p',
+            hpc => is_x86_64() ? 'g' : 'u',
+            rt  => is_x86_64() ? 't' : undef
         );
     }
     # Else return old shortcuts


### PR DESCRIPTION
As Real Time Product is not part of 15-SP2 on x86_64, the shortcut key for SAP Product has changed since Build93.1.

This commit fix this.

NOTE: this change on Real Time Product is for 15-SP2 only, nothing planned yet for 15-SP3, so the fix is limited to 15-SP2.

- Related ticket: N/A
- Needles: already created (welcome-select-product-sles4sap-20191125)
- Failing test: https://openqa.suse.de/tests/3628210#step/welcome/6
- Verification run: [x86_64](https://openqa.suse.de/t3628500)
- Regression run: [ppc64le](https://openqa.suse.de/t3628499), [standard SLE](https://openqa.suse.de/t3628497)

**Note on verification/regression runs:** failure is done of other reasons, mainly missing needles because of System Roles screen changes.