### PR TITLE
Fix a mistake in add_grub_cmdline_settings

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1035,7 +1035,7 @@ sub add_grub_cmdline_settings {
             add         => $add,
             update_grub => 0,
             search      => get_cmdline_var(),
-        }, ['add', 'update_grub', 'search'], @_);
+        }, ['update_grub', 'search'], @_);
 
     change_grub_config('"$', " $add\"", $args{search}, "g", $args{update_grub});
 }
@@ -1069,7 +1069,7 @@ sub replace_grub_cmdline_settings {
             new         => $new,
             update_grub => 0,
             search      => get_cmdline_var(),
-        }, ['old', 'new', 'update_grub', 'search'], @_);
+        }, ['update_grub', 'search'], @_);
     change_grub_config($old, $new, $args{search}, "g", $args{update_grub});
 }
 


### PR DESCRIPTION
This is a bug, it is introduced by me. 
    'Add' is redundant here. Because it has been shifted in line22.
    so '@_' only has the rest of cmdline if they exist.


- Verification run:
http://mitigations.qa2.suse.asia/tests/5406/modules/xen_mitigations/steps/1/src