### PR TITLE
New SLES-15 SP1 supportserver

### DIFF
--- a/data/supportserver/autoyast_supportserver_x86_sle15.sh
+++ b/data/supportserver/autoyast_supportserver_x86_sle15.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+#  Thu Oct 31 11:14:59 CET 2019:
+#  The current official supportserver is SLES-12 SP3. This is too old
+#  for purposes like mounting/umounting disk partitions hosting a SLE15 btrfs.
+#
+#  This script creates a new SLES-15 SP1 supportserver disk image.
+#
+#  Excerpt from reference:
+#  https://github.com/os-autoinst/openQA/blob/master/docs/WritingTests.asciidoc
+#
+#	=== Support Server based tests
+#	
+#	The idea is to have a dedicated "helper server" to allow advanced network
+#	based testing.
+#
+#       ....
+#	
+#	==== Preparing the supportserver
+#	
+#	
+#	The support server image is created by calling a special test, based on the autoyast test:
+#	
+#	[source,sh]
+#	--------------------------------------------------------------------------------
+
+
+
+# Settings changes and problems: DISTRI VERSION ISO adapted in the obvious way.
+# Substantial updates are needed for the autoyast file:
+#
+#    /var/lib/openqa/share/tests/os-autoinst-distri-opensuse/data/supportserver/autoyast_supportserver_x86.xml
+#
+# This autoyast file is hardly dependent on the product to install.
+# All the same it is not usable for a SLES-15 SP1 installation.
+#
+# The tentative autoyast_supportserver_x86_sle15.xml specifies
+# all repositories explicitly. Also, the package list needed
+# adaptations:
+#
+#    -  mc      is no longer official, alas. Need to add an appropriate
+#               inofficial PackageHub repo.
+#    -  atftp   is no longer available on SLE-15. Need to switch to tftp.
+#
+#    -  tftp    Latest version 5.2-3.22 is fatally affected by bsc#1153625!
+#               An error in its systemd service description file keeps the
+#               service from starting.
+#
+#               Workaround: bug is fixed in tftp-5.2-5.3.1 from update candidate
+#               S:M:12899. 
+#               The usual method of setting OS_TEST_ISSUES and OS_TEST_TEMPLATE
+#               does not work: the supportserver_generator test ignores this silently.
+#
+#               Therefore: added the corresponding internal repo explicitly
+#               to the autoyast file.
+#
+#               FIXME: this is no longer necessary once S:M:12899 (or an equivalent)
+#               is released as an official update.
+#
+#
+#    In the command below, BUILD is set according to file media.1/media
+#    on the ISO medium. Expected job result: a new image file
+#
+#    /var/lib/openqa/share/factory/hdd/openqa_support_server_sles15sp1.x86_64.qcow2
+#
+/usr/share/openqa/script/client \
+	--host $URL_of_your_openQA_host \
+	--verbose \
+	jobs post \
+	DISTRI=sle \
+	VERSION="15-SP1" \
+        BUILD="228.2" \
+        BUILD_SLE="228.2" \
+	ISO=SLE-15-SP1-Installer-DVD-x86_64-GM-DVD1.iso \
+	ARCH=x86_64 \
+	FLAVOR=Server-DVD \
+	TEST=supportserver_generator \
+	MACHINE=64bit \
+	DESKTOP=textmode \
+	INSTALLONLY=1 \
+	AUTOYAST=supportserver/autoyast_supportserver_x86_sle15.xml \
+	SUPPORT_SERVER_GENERATOR=1 \
+	PUBLISH_HDD_1=openqa_support_server_sles15sp1.x86_64.qcow2
+
+
+
+#  Excerpt (continued) from reference:
+#  /usr/local/src/openQA-gitrepo/openQA/docs/WritingTests.asciidoc
+#
+#	This produces QEMU image 'supportserver.qcow2' that contains the
+#	supportserver. The 'autoyast_supportserver.xml' should define correct user
+#	and password, as well as packages and the common configuration.
+#	
+#	More specific role the supportserver should take is then selected when the
+#	server is run in the actual test scenario.
+#	
+#	==== Using the supportserver
+#	....

--- a/data/supportserver/autoyast_supportserver_x86_sle15.xml
+++ b/data/supportserver/autoyast_supportserver_x86_sle15.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_halt config:type="boolean">false</final_halt>
+      <final_reboot config:type="boolean">false</final_reboot>
+      <halt config:type="boolean">false</halt>
+      <second_stage config:type="boolean">true</second_stage>
+    </mode>
+    <proposals config:type="list"/>
+    <!-- The PackageHub repos feature an unknown gpg key. We want to both trust it and import it. -->
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">false</accept_file_without_checksum>
+      <!-- autoyast docu says: ... accept known keys you have not yet trusted . Not enough here. -->
+      <accept_non_trusted_gpg_key config:type="boolean">false</accept_non_trusted_gpg_key>
+      <!-- autoyast docu says: ... new GPG keys of the installation sources... Supposedly needed. -->
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <!-- autoyast docu says: ... accept and import new GPG keys ... in its database. Supposedly also needed. -->
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/</media_url>
+        <product>sle-module-basesystem</product>
+        <alias>sle-module-basesystem:15.1::pool</alias>
+        <name>sle-module-basesystem:15.1::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <!-- SLE15SP1 AutoYaST docu sec. 4.9.3 Installing Additional/Customized Packages or Products example 4.24
+             "true" <==> Users are asked whether to add such a product. If so, then
+             selected: defines the default state of pre-selected state of packages -->
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/</media_url>
+        <alias>sle-module-basesystem:15.1::update</alias>
+        <name>sle-module-basesystem:15.1::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/</media_url>
+        <product>sle-module-development-tools</product>
+        <alias>sle-module-development-tools:15.1::pool</alias>
+        <name>sle-module-development-tools:15.1::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <alias>sle-module-development-tools:15.1::update</alias>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/</media_url>
+        <name>sle-module-development-tools:15.1::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/</media_url>
+        <product>sle-module-server-applications</product>
+        <alias>sle-module-server-applications:15.1::pool</alias>
+        <name>sle-module-server-applications:15.1::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <alias>sle-module-server-applications:15.1::update</alias>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/</media_url>
+        <name>sle-module-server-applications:15.1::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/</media_url>
+        <product>SLES</product>
+        <alias>SLES:15.1::pool</alias>
+        <name>SLES:15.1::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <!-- SLE15SP1 AutoYaST docu sec. 4.9.2 Package Selection with Patterns and Packages Sections
+             "true" here triggers a "confirm license" dialog rather than auto-accepting the license. Unwanted. -->
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <alias>SLES:15.1::update</alias>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/</media_url>
+        <name>SLES:15.1::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Backports/SLE-15-SP1_x86_64/product/</media_url>
+        <alias>PackageHub:15.1::product</alias>
+        <name>PackageHub:15.1::product</name>
+        <priority config:type="integer">20</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Backports/SLE-15-SP1_x86_64/standard/standard</media_url>
+        <!-- NFS: /mounts/mirror/SuSE/build.suse.de/SUSE/Backports/SLE-15-SP1_x86_64/standard/standard
+             NOTE: *four* RPM subdirs: noarch{,_GA}, x86_64{,_GA}. Looks like both GA pool and updates.
+             CAVEAT: there is  also the .../SLE-15-SP1_x86_64/standard repo which looks alike but is just a bit older... -->
+        <alias>PackageHub:15.1::pool</alias>
+        <name>PackageHub:15.1::pool</name>
+        <priority config:type="integer">20</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+  </bootloader>
+  <networking>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>onboot</startmode>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">false</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+  <software>
+    <image/>
+    <instsource/>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+    <packages config:type="list">
+      <package>vim</package>
+      <package>apache2</package>
+      <package>dhcp-server</package>
+      <package>mc</package>
+      <package>syslinux</package>
+      <package>openssh</package>
+      <package>less</package>
+      <package>nfs-client</package>
+      <package>autofs</package>
+      <package>bind</package>
+      <package>tftp</package>
+      <package>yast2-iscsi-lio-server</package>
+      <package>tgt</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>enhanced_base</pattern>
+    </patterns>
+  </software>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <username>root</username>
+      <user_password>nots3cr3t</user_password>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <username>bernhard</username>
+      <user_password>nots3cr3t</user_password>
+    </user>
+  </users>
+  <services-manager>
+  <!-- SLE15SP1 AutoYaST docu sec. 4.11: Services and Targets-->
+    <default_target>multi-user</default_target>
+    <!-- We don't want much by default. For testing of this autoyast let's tmp. enable sshd
+         FIXME: don't forget to comment this part out later. The real supportserver won't need it. -->
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+    <!-- END  enabling sshd service -->
+  </services-manager>
+</profile>


### PR DESCRIPTION
The currently available openQA supportserver is SLES-12 SP3. This is an old
product. E.g. it was found to be unable to properly mount/umount SLE-15
btrfs: this ability is needed for the upcoming installation test of
a SLES-15 client on a (remote) supportserver disk.

The available documentation/config on supportserver generation does not
really provide much assistance on how to proceed for SLE-15 and newer.
Therefore this PR provides a generator script and a tentative autoyast file
from which a SLES-15 SP1 supportserver disk image may be generated in a
one-time job run.

**FIXME**  The autoyast file specifies *internal* SUSE repositories. At the time of
this PR this is actually inevitable since the needed crucial `tftp` fix [S:M:12899](http://merkur.qam.suse.de/incident/12899/) for [bsc#1153625](https://bugzilla.suse.com/show_bug.cgi?id=1153625)
has not yet been released. In order to later utilize the official repositories the autoyast file
would have to include sections for the needed registrations.

- Related ticket:  https://progress.opensuse.org/issues/50144
- Needles: (none)
## Verification runs:

### [SLES-15 SP1 supportserver generation job](http://polya.suse.de/tests/617)
Resulting [disk image](http://polya.suse.de/tests/617/asset/hdd/openqa_support_server_sles15sp1.x86_64.qcow2)

### Regression tests: existing testsuites qa{,m}_kernel_multipath_flakyserver

-   [client (SLES-15 SP1)](http://polya.suse.de/tests/699), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/698)
-   [client (SLES-15 GA)](http://polya.suse.de/tests/719), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/718)
-   [client (SLES-12 SP4)](http://polya.suse.de/tests/714), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/713)

### Regression tests: Existing testsuites qa{,m}_kernel_multipath
-  [client (SLES-15 SP1)](http://polya.suse.de/tests/743), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/742)
-  [client (SLES-15 SP1)](http://polya.suse.de/tests/734), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/733)

### Validation tests: upcoming testsuite "install and boot remote multipathed system disk"
See [PR#8984](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8984).
-  [client (SLES-15 SP1)](http://polya.suse.de/tests/651), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/650)
-  [client (SLES-15 GA)](http://polya.suse.de/tests/645), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/644)
-  [client (SLES-12 SP4)](http://polya.suse.de/tests/657), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/656)
-  [client (SLES-12 SP3 LTSS)](http://polya.suse.de/tests/659), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/658)
-  [client (SLES-12 SP2 LTSS)](http://polya.suse.de/tests/660), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/661)
