### PR TITLE
New test: installation on remote multipathed disk

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -429,6 +429,12 @@ sub load_boot_tests {
 sub load_reboot_tests {
     return if check_var("IPXE", "1");
 
+    # Special case: our disk and boot config is on the supportserver
+    # PXE reboot to be handled by module boot_to_desktop
+    if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL')) {
+        loadtest "boot/boot_to_desktop";
+        return;
+    }
     # there is encryption passphrase prompt which is handled in installation/boot_encrypt
     if ((is_s390x && !get_var('ENCRYPT')) || uses_qa_net_hardware() || is_spvm) {
         loadtest "boot/reconnect_mgmt_console";

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -478,13 +478,14 @@ sub select_first_hard_disk {
     else {
         assert_and_click 'hard-disk-dev-sdb-selected' if match_has_tag('hard-disk-dev-sdb-selected');
         if (match_has_tag('hard-disk-dev-non-sda-selected')) {
-            foreach my $tag (grep { $_ =~ /hard-disk-dev-(sd[a-z]|pmem[0-9])/ } @{$matched_needle->{needle}->{tags}}) {
+            foreach my $tag (grep { $_ =~ /hard-disk-dev-([sv]d[a-z]|pmem[0-9])/ } @{$matched_needle->{needle}->{tags}}) {
                 assert_and_click "$tag-selected";
             }
         }
     }
     assert_screen [qw(select-hard-disks-one-selected hard-disk-dev-sda-not-selected)];
     assert_and_click 'hard-disk-dev-sda-not-selected' if match_has_tag('hard-disk-dev-sda-not-selected');
+    save_screenshot;
     send_key $cmd{next};
 }
 
@@ -615,6 +616,7 @@ sub take_first_disk {
         }
         send_key $cmd{next};
     }
+    save_screenshot;
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -677,10 +677,11 @@ elsif (get_var("SUPPORT_SERVER")) {
         loadtest "remote/remote_controller";
         load_inst_tests();
     }
-    loadtest "ha/barrier_init"               if get_var("HA_CLUSTER");
-    loadtest "hpc/barrier_init"              if get_var("HPC");
-    loadtest "support_server/custom_pxeboot" if (get_var("SUPPORT_SERVER_PXE_CUSTOMKERNEL"));
-    loadtest "support_server/flaky_mp_iscsi" if (get_var("ISCSI_MULTIPATH_FLAKY"));
+    loadtest "ha/barrier_init"                  if get_var("HA_CLUSTER");
+    loadtest "hpc/barrier_init"                 if get_var("HPC");
+    loadtest "support_server/meddle_multipaths" if (get_var("SUPPORT_SERVER_TEST_INSTDISK_MULTIPATH"));
+    loadtest "support_server/custom_pxeboot"    if (get_var("SUPPORT_SERVER_PXE_CUSTOMKERNEL"));
+    loadtest "support_server/flaky_mp_iscsi"    if (get_var("ISCSI_MULTIPATH_FLAKY"));
     unless (load_slenkins_tests()) {
         loadtest "support_server/wait_children";
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -679,6 +679,7 @@ elsif (get_var("SUPPORT_SERVER")) {
     }
     loadtest "ha/barrier_init"               if get_var("HA_CLUSTER");
     loadtest "hpc/barrier_init"              if get_var("HPC");
+    loadtest "support_server/custom_pxeboot" if (get_var("SUPPORT_SERVER_PXE_CUSTOMKERNEL"));
     loadtest "support_server/flaky_mp_iscsi" if (get_var("ISCSI_MULTIPATH_FLAKY"));
     unless (load_slenkins_tests()) {
         loadtest "support_server/wait_children";

--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -50,6 +50,7 @@ use warnings;
 use base 'y2_installbase';
 use testapi;
 use lockapi;
+use mmapi;
 use utils;
 use version_utils qw(:VERSION :BACKEND);
 use ipmi_backend_utils;
@@ -182,6 +183,13 @@ sub run {
             next;
         }
         last;
+    }
+
+    if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_REPORT_PKGINSTALL')) {
+        my $jobid_server = (get_parents())->[0] or die "USE_SUPPORT_SERVER_REPORT_PKGINSTALL set, but no parent supportserver job found";
+        # notify the supportserver about current status (e.g.: meddle_multipaths.pm)
+        mutex_create("client_pkginstall_done", $jobid_server);
+        record_info("Disk I/O", "Mutex \"client_pkginstall_done\" created");
     }
 
     # Stop reboot countdown where necessary for e.g. uploading logs

--- a/tests/installation/disk_activation_iscsi.pm
+++ b/tests/installation/disk_activation_iscsi.pm
@@ -37,7 +37,8 @@ sub run {
     send_key "alt-i";    # go to initiator name field
     wait_still_screen(2, 10);
     type_string "$iscsi_iqn";
-    wait_still_screen(2, 10);
+    wait_still_screen(5, 30);
+    save_screenshot;
     send_key "alt-n";    # "Connected Targets" tab, empty list
     assert_screen 'iscsi-initiator-connected-targets-none-fs';
     send_key $cmd{add};    # go to "iSCSI Initiator Discovery" screen
@@ -45,12 +46,18 @@ sub run {
     send_key "alt-i";      # go to IP address field
     wait_still_screen(2, 10);
     type_string "$iscsi_server_ip";
+    wait_still_screen(5, 30);
+    save_screenshot;
     send_key "alt-n";      # iSCSI Initiator Discovery: discovered targets list, first one is selected
+    wait_still_screen(2, 10);
+    save_screenshot;
     send_key "alt-o";      # press Connect button
     wait_still_screen(2, 10);
     assert_screen 'iscsi-initiator-startup-and-authentication';
-    send_key "alt-s";       # startup mode. Selection list: *manual onboot automatic
-    send_key "down";        # Wanted: onboot
+    send_key "alt-s";      # startup mode. Selection list: *manual onboot automatic
+    send_key "down";       # Wanted: onboot. Show resulting setting.
+    wait_still_screen(2, 10);
+    save_screenshot;
     send_key $cmd{next};    # Now connect
     assert_screen 'iscsi-client-target-connected-fs';
     send_key $cmd{next};

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -37,6 +37,12 @@ sub run {
         # to reboot from this disk after downloading the bootconfig via PXE.
 
         my $jobid_server = (get_parents())->[0] or die "Unexpectedly no parent job found";
+        if (get_var('USE_SUPPORT_SERVER_TEST_INSTDISK_MULTIPATH')) {
+            # A multipath robustness test was in progress during package installation:
+            # wait until the supportserver reports the tidy-up of all multipaths
+            # (reference: meddle_multipaths.pm)
+            mutex_wait("multipathed_iscsi_export_clean", $jobid_server);
+        }
         # "supportserver: you have my system disk; please prepare a PXE menu entry with my new bootconfig"
         mutex_create("custom_pxe_client_ready", $jobid_server);
         # Await server's response "OK, done" (custom_pxeboot.pm)

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -17,8 +17,10 @@
 use base 'y2_installbase';
 use strict;
 use warnings;
+use lockapi;
 use testapi;
 use utils;
+use mmapi;
 use power_action_utils 'power_action';
 use Utils::Backends 'has_ttys';
 
@@ -30,7 +32,18 @@ sub run {
         my $svirt = console('svirt');
         $svirt->change_domain_element(os => boot => {dev => 'hd'});
     }
+    if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL')) {
+        # we installed on a remote disk provided by a supportserver job and want
+        # to reboot from this disk after downloading the bootconfig via PXE.
+
+        my $jobid_server = (get_parents())->[0] or die "Unexpectedly no parent job found";
+        # "supportserver: you have my system disk; please prepare a PXE menu entry with my new bootconfig"
+        mutex_create("custom_pxe_client_ready", $jobid_server);
+        # Await server's response "OK, done" (custom_pxeboot.pm)
+        mutex_wait("custom_pxe_ready", $jobid_server);
+    }
     # Reboot
+    # alt-o is the "OK" button in popup "the system will reboot in X seconds..."
     if (has_ttys) {
         my $count = 0;
         while (!wait_screen_change(sub { send_key 'alt-o' }, undef, similarity_level => 20)) {
@@ -44,7 +57,47 @@ sub run {
         # socket end
         send_key 'alt-o';
     }
-    power_action('reboot', observe => 1, keepconsole => 1, first_reboot => 1);
+    if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL')) {
+        # "Press ESC for boot menu"
+        # Expected: match in about 5 seconds
+        assert_screen("initboot_ESC_prompt", 10);
+        send_key "esc";
+
+        # Expected: the BIOS boot menu featuring a netboot entry
+        # This boot menu appears very quickly after ESC: within 1 s:
+        #
+        # Select boot device:
+        #
+        # 1. DVD/CD ...
+        # ...
+        # 4. iPXE ...
+        # ...
+        #
+        # WARNING: the PXE entry number is _volatile_!
+
+        assert_screen("bios_bootmenu", 10);
+        # Since we don't know which entry is the iPXE entry, each case needs
+        # a dedicated needle with distinct secondary tag.
+        # Most likely: 4, then 5
+        my $pxe_found = "";
+        foreach (4, 5, 3, 2, 1) {
+            if (match_has_tag("bios_bootmenu_pxe_is_$_")) {
+                $pxe_found = $_;
+                send_key "$pxe_found";
+                last;
+            }
+        }
+        die "BIOS boot menu: unable to detect PXE entry. Giving up." unless $pxe_found;
+        #
+        # Expected now: the PXE boot menu with a "Custom kernel" menu entry.
+        # Continuation controlled by variable 'USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL': see
+        #    lib/main_common.pm, sub load_reboot_tests(): loadtest "boot/boot_to_desktop"
+        #    -->  boot/boot_to_desktop.pm:                $self->wait_boot(...
+        #    -->  lib/opensusebasetest.pm:                $self->handle_pxeboot(...
+    }
+    else {
+        power_action('reboot', observe => 1, keepconsole => 1, first_reboot => 1);
+    }
 }
 
 1;

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -21,7 +21,9 @@
 use base 'y2_installbase';
 use strict;
 use warnings;
+use lockapi;
 use testapi;
+use mmapi;
 use version_utils qw(is_sle is_upgrade);
 
 sub run {
@@ -126,6 +128,12 @@ sub run {
                 assert_screen 'x11-imagesused', 500;
             }
         }
+    }
+    if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_REPORT_PKGINSTALL')) {
+        my $jobid_server = (get_parents())->[0] or die "USE_SUPPORT_SERVER_REPORT_PKGINSTALL set, but no parent supportserver job found";
+        # notify the supportserver about current status (e.g.: meddle_multipaths.pm)
+        mutex_create("client_pkginstall_start", $jobid_server);
+        record_info("Disk I/O", "Mutex \"client_pkginstall_start\" created");
     }
 }
 

--- a/tests/support_server/meddle_multipaths.pm
+++ b/tests/support_server/meddle_multipaths.pm
@@ -1,0 +1,85 @@
+# Copyright (C) 2019 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: A test for the supportserver in the role of (iSCSI)
+# system disk provider for the SUT.
+#
+# During initial installation, while the client is installing its
+# packages: run a disk access robustness test by meddling with
+# the LUNs of this system disk (the client will see non-fatal
+# fails of the corresponding multipaths).
+#
+# Expected effect: no harm. The client installation is supposed
+# to proceed completely undisturbed (multipath robustness).
+#
+# Maintainer: Klaus G. Wagner <kgw@suse.com>
+
+use strict;
+use warnings;
+use base 'basetest';
+use lockapi;
+use testapi;    # sub autoinst_url()
+use mmapi;
+
+sub run {
+    my $self = shift;
+
+    if (!get_var('SUPPORT_SERVER')) {
+        $self->result('ok');
+        return 1;
+    }
+
+    if (get_var('SUPPORT_SERVER_TEST_INSTDISK_MULTIPATH')) {
+        my $jobid_client = get_children();
+        # the SUT job
+        $jobid_client = (keys %$jobid_client)[0] or die "supportserver: no client job found";
+        # reference: multipath_flaky_luns.sh
+        my $meddler_pidfile = "/tmp/multipath_flaky_luns.pid";
+        my $meddler_pid;
+
+        # Wait until client reports that, after it properly got its system
+        # disk, heavy I/O is now about to begin (see start_install.pm).
+        mutex_wait("client_pkginstall_start", $jobid_client);
+        assert_script_run("/usr/local/bin/multipath_flaky_luns.sh", 30);
+        $meddler_pid = script_output("/bin/cat \"$meddler_pidfile\"", 30);
+        record_info("Meddling", "Client system disk: LUN meddling started. PID: $meddler_pid");
+
+        # Keep going until client reports that it is through package
+        # installation and is about to reboot (see await_install.pm)
+        mutex_wait("client_pkginstall_done", $jobid_client);
+
+        # Restore the multipaths and report (cf. support_server/flaky_mp_iscsi.pm)
+        script_run("kill -INT $meddler_pid");
+        record_info("SIGINT", "LUN meddling SIGINTed. PID: $meddler_pid");
+        assert_script_run("until ! [ -e \"$meddler_pidfile\" ] ; do sleep 5; done", 90);
+        script_run("/usr/local/bin/multipath_flaky_luns.sh -l", 30);
+
+        # Notify client that that all paths are now restored
+        # (reference: reboot_after_installation.pm)
+        mutex_create("multipathed_iscsi_export_clean", $jobid_client);
+        record_info("MP clean", "Mutex \"multipathed_iscsi_export_clean\" set");
+    }
+    else {
+        record_info("No action", "SUPPORT_SERVER_TEST_INSTDISK_MULTIPATH is not set");
+    }
+    $self->result('ok');
+}
+
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
During initial installation the SUT imports a multipathed iSCSI target disk
from a parallel supportserver job and proceeds to install onto it (the
testsuite must set `SELECT_FIRST_DISK` for this).

Once the initial installation is complete and the client is ready to reboot
the supportserver adds the new kernel and initrd to its PXE server
configuration (custom_pxeboot.pm).  After this the client is supposed
to boot this kernel and initrd via PXE.  The initrd would then re-import
the remote multipathed system disk and proceed from there.

_Note:_  For client installations >= SLE-15 (or equivalent) the supportserver
also needs to be SLE-15 or newer, since older supportservers are unable to
properly access the client's new (btrfs) rootfs and kernel/initrd.
Cf. [PR#8982: New SLES-15 SP1 supportserver](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8982).

_Note 2:_ Beginning with commit 6f1fc8e the test has been enhanced so as to allow the supportserver to run a multipath robustness test while the client is busy installing packages.
Expected result is that the client's disk access remains completely unaffected.

- Related ticket: https://progress.opensuse.org/issues/50144
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1230

## Verification runs
See also  [PR#8983: supportserver: extensions to the TFTP/PXE service](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8983)
### [New SLES-15 SP1 supportserver, PR#8982](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8982)
-  [client (SLES-15 SP1)](http://polya.suse.de/tests/651), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/650)
-  [client (SLES-15 GA)](http://polya.suse.de/tests/645), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/644)
-  [client (SLES-12 SP4)](http://polya.suse.de/tests/657), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/656)
-  [client (SLES-12 SP3 LTSS)](http://polya.suse.de/tests/659), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/658)
-  [client (SLES-12 SP2 LTSS)](http://polya.suse.de/tests/660), [supportserver (SLES-15 SP1) ](http://polya.suse.de/tests/661)
### [Existing openqa_support_server_sles12sp3_multipath.x86_64.qcow2](https://openqa.suse.de/tests/3627373/asset/hdd/openqa_support_server_sles12sp3_multipath.x86_64.qcow2)
-  [client (SLES-12 SP4)](http://polya.suse.de/tests/649), [supportserver (SLES-12 SP3) ](http://polya.suse.de/tests/648)
-  [client (SLES-12 SP3 LTSS)](http://polya.suse.de/tests/653), [supportserver (SLES-12 SP3) ](http://polya.suse.de/tests/652)
-  [client (SLES-12 SP2 LTSS)](http://polya.suse.de/tests/655), [supportserver (SLES-12 SP3) ](http://polya.suse.de/tests/654)
