### PR TITLE
Enable post_fail_hook for kontact

### DIFF
--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -55,4 +55,8 @@ sub run {
     x11_start_program('killall kontact', valid => 0);
 }
 
+sub post_fail_hook {
+    my $self = shift;
+    $self->SUPER::post_fail_hook();
+}
 1;


### PR DESCRIPTION
we have sporadic issue when kontact starts up. We can investigate
at least when the logs are avalable.
see https://progress.opensuse.org/issues/54488
verification run: http://f40.suse.de/tests/5535#step/kontact