### PR TITLE
Verify lvm partitions are created with lvm lvscan

### DIFF
--- a/tests/autoyast/verify_disk_as_pv.pm
+++ b/tests/autoyast/verify_disk_as_pv.pm
@@ -43,8 +43,9 @@ sub validate_vg_partitions {
     if ($lmv_disk_scan !~ '1 LVM physical volume whole disk') {
         $errors .= "Disk is not detected as physical volume, but expected to be LVM PV\n";
     }
+    my $lvm_lvscan = script_output('lvm lvscan');
     for my $partition (qw(swap home)) {
-        if ($lmv_disk_scan !~ "/dev/system/$partition") {
+        if ($lvm_lvscan !~ "/dev/system/$partition") {
             $errors .= "$partition partition is not created as expected, expected /dev/system/$partition LV\n";
         }
     }


### PR DESCRIPTION
lvmdiskscan does not show lvm partitions anymore. The test is changed to
use 'lvm lvscan' command to show which partitions are used in LVM.

- Related ticket: [poo#59873](https://progress.opensuse.org/issues/59873)
- Verification run: http://10.160.65.138/tests/1155
