### PR TITLE
Increase ready_time for wait_boot in SAP tests

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -393,16 +393,17 @@ sub check_instance_state {
 }
 
 sub reboot {
-    my ($self) = @_;
+    my ($self, %args) = @_;
+    my $ready_time = $args{ready_time} // 500;
 
     if (check_var('BACKEND', 'ipmi')) {
         power_action('reboot', textmode => 1, keepconsole => 1);
         switch_from_ssh_to_sol_console;
-        $self->wait_boot(textmode => 1);
+        $self->wait_boot(textmode => 1, ready_time => $ready_time);
     }
     else {
         power_action('reboot', textmode => 1);
-        $self->wait_boot;
+        $self->wait_boot(ready_time => $ready_time);
     }
     $self->select_serial_terminal;
 }


### PR DESCRIPTION
Add the ability to modify `ready_time` for reboot during `mr_test` tests and increase the default value from '300' to '500' because of sporadic timeout issue than can occur (mainly on ppc64le architecture).

- Related ticket: N/A
- Needles: N/A
- Verification run: TO_BE_DONE
