### PR TITLE
Add nfs MM from QAM in yast group

### DIFF
--- a/schedule/yast/nfs/yast2_nfs_v3_client.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v3_client.yaml
@@ -1,0 +1,8 @@
+---
+name:          yast2_nfs_v3_client
+description:    >
+  Multimachine nfs v3 test, client side. Configures an export with the yast module, and validates that the exported FS is working. Maintainer jrivrain@suse.com.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/yast2_nfs_client

--- a/schedule/yast/nfs/yast2_nfs_v3_server.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v3_server.yaml
@@ -1,0 +1,8 @@
+---
+name:          yast2_nfs_v3_server
+description:    >
+  Multimachine nfs v3 test, server side. Configures an export with the yast module, and validates that the exported FS is working. Maintainer jrivrain@suse.com.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/yast2_nfs_server

--- a/schedule/yast/nfs/yast2_nfs_v4_client.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v4_client.yaml
@@ -1,0 +1,8 @@
+---
+name:          yast2_nfs_v4_client
+description:    >
+  Multimachine nfs v4 test, client side. Configures an export with the yast module, and validates that the exported FS is working. Maintainer jrivrain@suse.com.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/yast2_nfs4_client

--- a/schedule/yast/nfs/yast2_nfs_v4_server.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v4_server.yaml
@@ -1,0 +1,8 @@
+---
+name:          yast2_nfs_v4_server
+description:    >
+  Multimachine nfs v4 test, server side. Configures an export with the yast module, and validates that the exported FS is working.  Maintainer jrivrain@suse.com.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/yast2_nfs4_server

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -25,8 +25,8 @@ use strict;
 use warnings;
 use testapi;
 use lockapi;
-use utils qw(clear_console zypper_call systemctl script_retry);
-use mm_network;
+use utils qw(zypper_call systemctl script_retry);
+use mm_network 'setup_static_mm_network';
 use nfs_common;
 
 sub run {
@@ -38,10 +38,8 @@ sub run {
     # NFSCLIENT defines if the test should be run on multi-machine setup.
     # Otherwise, configure server and client on the single machine.
     if (get_var('NFSCLIENT')) {
-        # Configure static IP for client/server test
-        configure_default_gateway;
-        configure_static_ip('10.0.2.102/24');
-        configure_static_dns(get_host_resolv_conf());
+
+        setup_static_mm_network('10.0.2.102/24');
 
         zypper_call('in yast2-nfs-client nfs-client', timeout => 480, exitcode => [0, 106, 107]);
 
@@ -91,11 +89,7 @@ sub run {
     wait_screen_change { send_key 'alt-o' };
     sleep 1;
     save_screenshot;
-    # Exit YaST
-    wait_screen_change { send_key 'alt-o' };
-
-    wait_serial("$module_name-0") or die "'yast2 $module_name' didn't finish";
-    clear_console;
+    yast2_client_exit($module_name);
 
     #
     # Check the result


### PR DESCRIPTION
Add nfs multi-machine from QAM in yast group. We already have nfs tests, but not in MM.

- Related ticket: https://progress.opensuse.org/issues/53855
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/618
- Verification run:
x86_64:
[sle-server-nfs3](http://waaa-amazing.suse.cz/tests/10433), [sle-client-nfs3](http://waaa-amazing.suse.cz/tests/10434), [sle-server-nfs4](http://waaa-amazing.suse.cz/tests/10429), [sle-client-nfs4](http://waaa-amazing.suse.cz/tests/10430)
[TW-server-v3](http://waaa-amazing.suse.cz/tests/10427), [TW-client-v3](http://waaa-amazing.suse.cz/tests/10428) [TW-client-v4](http://waaa-amazing.suse.cz/tests/10506) <- now OK, bug reported earlier was already fixed.
SLE/ppc64le:
[v4-server](https://openqa.suse.de/tests/3636730), [v4-client](https://openqa.suse.de/tests/3636731)
SLE/aarch64, not tested yet
s390x tests won't start for some reason.

