### PR TITLE
Pass if the wanted system role is selected

### DIFF
--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -37,11 +37,13 @@ sub change_system_role {
             send_key_until_needlematch "system-role-$system_role-selected", 'spc';     # enable role
         }
         else {
-            # scroll down in case role is not visible straight away
-            send_key_until_needlematch "system-role-$system_role", 'down', 5, 1;
-            assert_and_click "system-role-$system_role";
-            # after role is selected, we get top of the list shown, so might need to scroll again
-            send_key_until_needlematch "system-role-$system_role-selected", 'down', 5, 1;
+            if (!check_screen("system-role-$system_role-selected")) {
+                # scroll down in case role is not visible straight away
+                send_key_until_needlematch "system-role-$system_role", 'down', 5, 1;
+                assert_and_click "system-role-$system_role";
+                # after role is selected, we get top of the list shown, so might need to scroll again
+                send_key_until_needlematch "system-role-$system_role-selected", 'down', 5, 1;
+            }
         }
     }
     else {


### PR DESCRIPTION
For some reason the new Yast panel unselect the default option during
the handling. This change will avoid any key press and mouse click when
the wanted system role is already automatically selected.

- Failing tests: http://openqa.slindomansilla-vm.qa.suse.de/tests/1977#step/system_role/4
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1253
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/1978
