### PR TITLE
No unregistered system warning message for media upgrade on full installation image

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -52,8 +52,11 @@ sub run {
     # Select migration target in sle15 upgrade
     if (is_sle '15+') {
         if (get_var('MEDIA_UPGRADE')) {
-            assert_screen 'upgrade-unregistered-system';
-            send_key $cmd{ok};
+            # No 'unregistered system' warning message shown when using Full installation image on SLE15SP2
+            if (is_sle('<15-SP2')) {
+                assert_screen 'upgrade-unregistered-system';
+                send_key $cmd{ok};
+            }
         }
         else {
             # Ensure we are in 'Select the Migration Target' page


### PR DESCRIPTION
From bsc#1157633, "When the Full installation image is used for upgrading an unregistered system that warning is not displayed". So we shouldn't wait the unregistered system warning message for SLE15SP2.

- Related ticket: https://progress.opensuse.org/issues/60248
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3638034
