### PR TITLE
Move activate existing encrypted partitions to yaml

### DIFF
--- a/schedule/yast/encryption/cryptlvm+activate_existing+force_recompute.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing+force_recompute.yaml
@@ -1,0 +1,35 @@
+---
+description: >
+  Conduct installation activating encrypted partitions, but creating encrypted
+  lvm setup from scratch. Using pre-partitioned disk image to validate encrypted
+  partitions activation and that we can re-ecnrypt the disk.
+name: cryptlvm+activate_existing+force_recompute
+vars:
+    ENCRYPT: 1
+    ENCRYPT_ACTIVATE_EXISTING: 1
+    ENCRYPT_FORCE_RECOMPUTE: 1
+    LVM: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/encrypted_volume_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm_ignore_existing
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm+activate_existing+import_users.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing+import_users.yaml
@@ -1,37 +1,32 @@
 ---
 description: >
-  Conduct installation trying to reuse encryoted partitions (bsc#993247). Using
-  pre-partitioned disk image to validate encrypted partitions activation.
-  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
-  module is scheduled and OPT_KERNEL_PARAMS variable is set.
-name: cryptlvm+activate_existing
+  Conduct installation activating encrypted partitions and importing users created
+  in that installation. Using pre-partitioned disk image to validate encrypted
+  partitions activation and that we can re-ecnrypt the disk.
+name: cryptlvm+activate_existing+import_users
 vars:
-    OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
-    DESKTOP: textmode
     ENCRYPT_ACTIVATE_EXISTING: 1
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
-  - installation/encrypted_volume_activation
   - installation/scc_registration
+  - installation/encrypted_volume_activation
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
   - installation/partitioning/encrypt_lvm_reuse_existing
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/user_settings
+  - installation/hostname_inst
+  - installation/user_import
   - installation/user_settings_root
-  - installation/resolve_dependency_issues
   - installation/installation_overview
-  - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm+activate_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing.yaml
@@ -1,0 +1,31 @@
+---
+description: >
+  Conduct installation trying to reuse encrypted partitions (bsc#993247). Using
+  pre-partitioned disk image to validate encrypted partitions activation.
+name: cryptlvm+activate_existing
+vars:
+    ENCRYPT_ACTIVATE_EXISTING: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/encrypted_volume_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm_reuse_existing
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm+activate_existing_dasd.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing_dasd.yaml
@@ -1,0 +1,34 @@
+---
+description: >
+  Conduct installation trying to reuse encrypted partitions (bsc#993247). Using
+  pre-partitioned disk image to validate encrypted partitions activation.
+  For zVM we activate DASD disk which we format in from of the installation and
+  create encrypted partition on it, similarly to powerVM.
+name: cryptlvm+activate_existing
+vars:
+    ENCRYPT_ACTIVATE_EXISTING: 1
+    FORMAT_DASD: pre_install
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/disk_activation
+  - installation/scc_registration
+  - installation/encrypted_volume_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm_reuse_existing
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/boot_encrypt
+  - boot/reconnect_mgmt_console
+  - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm+activate_existing_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing_spvm.yaml
@@ -1,0 +1,37 @@
+---
+description: >
+  Conduct installation trying to reuse encrypted partitions (bsc#993247). Using
+  pre-partitioned disk image to validate encrypted partitions activation.
+  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+name: cryptlvm+activate_existing
+vars:
+    OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+    DESKTOP: textmode
+    ENCRYPT_ACTIVATE_EXISTING: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/encrypted_volume_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm_reuse_existing
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -1,0 +1,35 @@
+---
+description: >
+  Conduct installation cancelling encrypted partitions activation, and
+  creating encrypted lvm setup from scratch.
+  Using pre-partitioned disk image to validate encrypted
+  partitions activation and that we can re-ecnrypt the disk.
+name: cryptlvm+activate_existing
+vars:
+    ENCRYPT: 1
+    ENCRYPT_CANCEL_EXISTING: 1
+    LVM: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/encrypted_volume_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm_ignore_existing
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -1,0 +1,34 @@
+---
+description: >
+  Conduct installation cancelling encrypted partitions activation, and
+  creating non-encrypted lvm setup from scratch.
+  Using pre-partitioned disk image to validate encrypted
+  partitions activation and that we can re-ecnrypt the disk.
+name: cryptlvm+activate_existing
+vars:
+    ENCRYPT_CANCEL_EXISTING: 1
+    LVM: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/encrypted_volume_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/lvm_ignore_existing
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot

--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -70,6 +70,11 @@ sub run {
             return;
         }
     }
+    # Wrapped call for powerVM
+    if (check_var('BACKEND', 'spvm')) {
+        $self->bootloader::run();
+        return;
+    }
 }
 
 1;

--- a/tests/installation/encrypted_volume_activation.pm
+++ b/tests/installation/encrypted_volume_activation.pm
@@ -27,7 +27,7 @@ use version_utils 'is_storage_ng';
 my $after_cancel_tags = [
     qw(
       enable-multipath scc-registration
-      inst-instmode
+      inst-instmode addon-products
       )];
 
 sub run {


### PR DESCRIPTION
We have disk activation step after registration, so moving these
scenarios to yaml and do additional adjustments to make it work.

NOTE: This PR requires changes in the test suites: [MR](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/merge_requests/85).

Fix for 17 jobs.

[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=rwx788%2Fos-autoinst-distri-opensuse%238996)
