### PR TITLE
Add workaround to select first item in module list 

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -77,6 +77,12 @@ sub handle_all_packages_medium {
     # Also record the addons which require license agreement
     my @addons_with_license = qw(ha we);
     my @addons_license_tags = ();
+    # The workaround is added, because needle containing description is the only
+    # way to ensure the certain module is selected on s390x.
+    record_soft_failure('bsc#1157780 - Module description is not appeared when
+    "Basesystem Module" is selected for the first time');
+    send_key 'down';
+    send_key 'end';
     for my $i (@addons) {
         push @addons_license_tags, "addon-license-$i" if grep(/^$i$/, @addons_with_license);
         send_key 'home';


### PR DESCRIPTION
The workaround is added because description for "Basesystem Module"
is not appeared when the module is selected for the first time.

On s390x the only way to ensure the module is selected is to use
description for needle match, because item highlighting is not
recognized by openQA. The same needle matches in both cases - when
item is highlighted and not.

- Related ticket: [poo#59939](https://progress.opensuse.org/issues/59939)
- Verification run: https://openqa.suse.de/tests/3632935