### PR TITLE
Increate default timeout in ssh_add_suseconnect_product()

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -204,6 +204,7 @@ sub ssh_add_suseconnect_product {
     $arch    //= '${CPU}';
     $params  //= '';
     $retry   //= 0;                 # run SUSEConnect a 2nd time to workaround the gpg error due to missing repo key on 1st run
+    $timeout //= 180;
 
     my $result = script_run("ssh $remote sudo SUSEConnect -p $name/$version/$arch $params", $timeout);
     if ($result != 0 && $retry) {


### PR DESCRIPTION
Hello,

I noticed the mru-extratests are often timeouting while the system registration.
This increases the `$timeout` from standard value to `180` perhaps the instance is remote.

- Related ticket: None
- Needles: None
- Verification run: [pdostal-server.suse.cz](http://pdostal-server.suse.cz/tests/5870)
- Timeouted run: [openqa.suse.de](https://openqa.suse.de/tests/3631135#step/transfer_repos/18)
