### PR TITLE
[WIP] Increase period to check screen during stage 1 and 2

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -47,7 +47,7 @@ use x11utils 'untick_welcome_on_next_startup';
 my $confirmed_licenses = 0;
 my $stage              = 'stage1';
 my $maxtime            = 2000 * get_var('TIMEOUT_SCALE', 1);    #Max waiting time for stage 1
-my $check_time         = 50;                                    #Period to check screen during stage 1 and 2
+my $check_time         = 100;                                   #Period to check screen during stage 1 and 2
 
 # Downloading updates takes long time
 $maxtime = 5500 if is_caasp('qam');


### PR DESCRIPTION
to avoid to timeout too early on slow workers (poo#60092)

- Related ticket: https://progress.opensuse.org/issues/60092
- Verification run: https://openqa.opensuse.org/t1096177
