### PR TITLE
Update yast_lan test module due to changes in product

### DIFF
--- a/tests/yast2_cmd/yast_lan.pm
+++ b/tests/yast2_cmd/yast_lan.pm
@@ -28,10 +28,10 @@ sub run {
     select_console 'root-console';
     zypper_call "in yast2-network";
     my $type = is_sle('>15') ? 'type=vlan' : '';
-    validate_script_output "yast lan add name=vlan50 ethdevice=eth0 $type 2>&1", sub { m/Virtual/ };
+    validate_script_output "yast lan add name=vlan50 ethdevice=eth0 $type 2>&1", sub { m/Virtual/ || m/vlan50/ };
     validate_script_output 'yast lan show id=1 2>&1',                            sub { m/vlan50/ };
-    validate_script_output 'yast lan edit id=1 bootproto=dhcp 2>&1',             sub { m/IP address assigned using DHCP/ }, 60;
-    validate_script_output 'yast lan delete id=1 2>&1',                          sub { m/deleted/ };
-    validate_script_output 'yast lan list 2>&1',                                 sub { !m/Virtual/ };
+    validate_script_output 'yast lan edit id=1 bootproto=dhcp 2>&1', sub { m/IP address assigned using DHCP/ || m/Configured with dhcp/ }, 60;
+    assert_script_run 'yast lan delete id=1 2>&1';
+    validate_script_output 'yast lan list 2>&1', sub { !m/Virtual/ && !m/vlan50/ };
 }
 1;


### PR DESCRIPTION
Output format of 'yast lan' command is changed. The commit updates the
test module in accordance with the changes.

The old regexes are remained to still allow testing on previous product
versions.

- Verification run: ttps://openqa.suse.de/tests/3633177