### PR TITLE
Increase timeout for cmd 'aa-autodep -d  /usr/bin/pam*'

### DIFF
--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -57,7 +57,7 @@ sub run {
                 key    => 'c',
             },
         ],
-        30
+        60
     );
 
     # Output generated profiles list to serial console


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3626226#step/aa_autodep/17
- Verification run: complicated to schedule, because prepare tests are scheduled based on test name