### PR TITLE
Use default NFS version in nis_client

### DIFF
--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -64,8 +64,14 @@ sub nfs_shares_tab {
     assert_screen 'nis-client-nfs-client-shares-conf';
     send_key 'alt-a';          # add
     assert_screen 'nis-client-add-nfs-share';
-    send_key 'alt-v';          # NFSV4 share checkbox (selectable box for newer products)
-    assert_screen 'nis-client-nfsv4-share';
+    # On 15-SP2 "Any (Highest Available)" is selected by default, just keep it.
+    if (is_sle('>=15-SP2')) {
+        assert_screen 'nis-client-default-nfs-version';
+    }
+    else {
+        send_key 'alt-v';      # NFSV4 share checkbox (selectable box for newer products)
+        assert_screen 'nis-client-nfsv4-share';
+    }
     send_key 'alt-s';          # choose NFS server button
     assert_screen 'nis-client-nfs-server';
     send_key 'alt-o';          # OK


### PR DESCRIPTION
On 15-SP2 "Any (Highest Available)" NFS Version is selected by default.

The commit checks the selected value and keeps it as is.

For the previous product versions, the behavior remains the same, so
keep selecting the version explicitly.

- Related ticket: [poo#59142](https://progress.opensuse.org/issues/59142)
- Verification run: https://openqa.suse.de/tests/3635499
https://openqa.suse.de/tests/3635543
