### PR TITLE
Remove new krb5 test from main_common

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1637,7 +1637,6 @@ sub load_extra_tests_console {
     loadtest "console/perf" if is_sle('<15-sp1');
     loadtest "console/sysctl";
     loadtest "console/sysstat";
-    loadtest "console/krb5";
     loadtest "console/curl_ipv6" unless get_var('PUBLIC_CLOUD');
     loadtest "console/wget_ipv6";
     loadtest "console/ca_certificates_mozilla";


### PR DESCRIPTION
Test will be added back after it's fixed in yaml form

- Fail: https://openqa.suse.de/tests/3632885#step/krb5/55
