### PR TITLE
publiccloud: Install ec2uploadimg from pip

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -54,9 +54,12 @@ sub run {
         }
         assert_script_run('aws --version');
     }
-    zypper_call('-q in python-ec2uploadimg');
-    assert_script_run("curl " . data_url('publiccloud/ec2utils.conf') . " -o /root/.ec2utils.conf");
     record_info('EC2', script_output('aws --version'));
+
+    # Install ec2imgutils
+    assert_script_run('pip3 install ec2imgutils');
+    assert_script_run("curl " . data_url('publiccloud/ec2utils.conf') . " -o /root/.ec2utils.conf");
+    record_info('ec2imgutils', 'ec2uploadimg:' . script_output('ec2uploadimg --version'));
 
     # Install Azure cli
     assert_script_run("pip3 install -q --ignore-installed azure-cli", 240);


### PR DESCRIPTION
We need version 7.0.7 with commit
https://github.com/SUSE-Enceladus/ec2imgutils/commit/ff85aa00fcd3e1672d370343d2308aa2bd5e3dc9
but package isn't updated till now, so move to pip version.

- Related ticket: https://progress.opensuse.org/issues/57524
- Verification run: https://openqa.suse.de/t3636435
