### PR TITLE
Enable test suites for powerVM on SLE 15 SP2 which we have for SLE 12

### DIFF
--- a/schedule/yast/allmodules+allpatterns/allmodules+allpatterns_spvm.yaml
+++ b/schedule/yast/allmodules+allpatterns/allmodules+allpatterns_spvm.yaml
@@ -1,0 +1,36 @@
+---
+name:           allmodules+allpatterns
+description:    >
+  Perform an installation enabling all modules and selecting all patterns.
+  This test suite always registers to have access to all modules.
+  On spvm we can test in textmode only.
+  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  PATTERNS: all
+  ENABLE_ALL_SCC_MODULES: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/select_patterns_and_packages
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot

--- a/schedule/yast/btrfs/btrfs_sle_libstorage.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage.yaml
@@ -79,28 +79,4 @@ conditional_schedule:
         - console/verify_separate_home
         - console/validate_file_system
 test_data:
-  subvolume:
-    cow:
-      - /opt
-      - /srv
-      - /tmp
-      - /usr/local
-      - /var/cache
-      - /var/crash
-      - /var/lib/machines
-      - /var/lib/mailman
-      - /var/lib/named
-      - /var/opt
-      - /var/spool
-      - /var/tmp
-      - /.snapshots
-    no_cow:
-      - /var/lib/libvirt/images
-      - /var/lib/mariadb
-      - /var/lib/mysql
-      - /var/lib/pgsql
-      - /var/log
-  file_system:
-     /home: xfs
-     /: btrfs
-     
+  !include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -1,0 +1,36 @@
+name:           btrfs_libstorage
+description:    >
+  Validate default installation with btrfs and Libstorage.
+  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  FILESYSTEM: btrfs
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - console/verify_separate_home
+  - console/validate_file_system
+test_data:
+  !include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -1,0 +1,33 @@
+---
+name:           ext4@yast
+description:    >
+  Test for ext4 filesystem. On spvm we can test in textmode only.
+  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  FILESYSTEM: ext4
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot

--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -1,0 +1,34 @@
+---
+name:           xfs
+description:    >
+  Test for the installation with xfs filesystem for the root partition.
+  On spvm we can test in textmode only.
+  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  FILESYSTEM: xfs
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot

--- a/test_data/yast/btrfs/btrfs_sle_libstorage.yaml
+++ b/test_data/yast/btrfs/btrfs_sle_libstorage.yaml
@@ -1,0 +1,24 @@
+subvolume:
+cow:
+  - /opt
+  - /srv
+  - /tmp
+  - /usr/local
+  - /var/cache
+  - /var/crash
+  - /var/lib/machines
+  - /var/lib/mailman
+  - /var/lib/named
+  - /var/opt
+  - /var/spool
+  - /var/tmp
+  - /.snapshots
+no_cow:
+  - /var/lib/libvirt/images
+  - /var/lib/mariadb
+  - /var/lib/mysql
+  - /var/lib/pgsql
+  - /var/log
+file_system:
+ /home: xfs
+ /: btrfs


### PR DESCRIPTION
Somehow we had this test enabled for SLE 12 only, so moving to yaml
schedule and enable in the job group.

NOTE: requires: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/merge_requests/87

- [Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%239010&distri=sle&version=15-SP2)
