### PR TITLE
Skip phub for Full and Online media

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   registration_bootloader_params
   yast_scc_registration
   skip_registration
+  skip_package_hub_if_necessary
   scc_deregistration
   scc_version
   get_addon_fullname
@@ -366,6 +367,18 @@ sub _yast_scc_addons_handler {
     }
 }
 
+sub skip_package_hub_if_necessary {
+    my ($addon) = @_;
+    if (is_sle('15-SP2+') && $addon eq 'phub') {
+        if (check_var('FLAVOR', 'Online')) {
+            record_soft_failure('bsc#1151373 - Missing or broken repository after registering module PackageHub');
+        } elsif (check_var('FLAVOR', 'Full')) {
+            record_info('Full media: no PHUB', 'Skipping Package Hub, it is not available on offline scenarios - bsc#1157659');
+        }
+        next;
+    }
+}
+
 sub process_scc_register_addons {
     # The value of SCC_ADDONS is a list of abbreviation of addons/modules
     # Following are abbreviations defined for modules and some addons
@@ -407,6 +420,7 @@ sub process_scc_register_addons {
         @scc_addons = grep { $_ ne '' } @scc_addons;
 
         for my $addon (@scc_addons) {
+            skip_package_hub_if_necessary($addon);
             if (check_var('VIDEOMODE', 'text') || check_var('SCC_REGISTER', 'console')) {
                 # The actions of selecting scc addons have been changed on SP2 or later in textmode
                 # For online migration, we have to do registration on pre-created HDD, set a flag

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -18,7 +18,7 @@ use testapi;
 use utils qw(addon_license handle_untrusted_gpg_key assert_screen_with_soft_timeout);
 use version_utils 'is_sle';
 use qam 'advance_installer_window';
-use registration qw(%SLE15_DEFAULT_MODULES rename_scc_addons @SLE15_ADDONS_WITHOUT_LICENSE);
+use registration qw(%SLE15_DEFAULT_MODULES rename_scc_addons @SLE15_ADDONS_WITHOUT_LICENSE skip_package_hub_if_necessary);
 use LWP::Simple 'head';
 
 sub handle_all_packages_medium {
@@ -78,6 +78,7 @@ sub handle_all_packages_medium {
     my @addons_with_license = qw(ha we);
     my @addons_license_tags = ();
     for my $i (@addons) {
+        skip_package_hub_if_necessary($i);
         push @addons_license_tags, "addon-license-$i" if grep(/^$i$/, @addons_with_license);
         send_key 'home';
         send_key_until_needlematch "addon-products-all_packages-$i-highlighted", 'down', 30;
@@ -111,6 +112,7 @@ sub handle_all_packages_medium {
     assert_screen "addon-products-nonempty";
     # Confirm all required addons are properly added
     foreach (@addons) {
+        skip_package_hub_if_necessary($_);
         send_key 'home';
         send_key_until_needlematch "addon-products-$_", 'down';
     }


### PR DESCRIPTION
## Observation
- Full media doesn't use SCC, not internet connection. Not possible to
get packages from that module.
- Online media fails to add package hub repository because it is missing
for SLE15-SP2.

## Related tickets
- https://bugzilla.suse.com/show_bug.cgi?id=1157659
- https://bugzilla.suse.com/show_bug.cgi?id=1151373
- https://progress.opensuse.org/issues/60041

## Verification runs
- Online: http://openqa.slindomansilla-vm.qa.suse.de/tests/1998#step/scc_registration/20
- Full: http://openqa.slindomansilla-vm.qa.suse.de/tests/1999#step/addon_products_sle/51