### PR TITLE
Fix SAP Staging:S group

### DIFF
--- a/schedule/staging/sles4sap_offline_gnome@64bit-staging.yaml
+++ b/schedule/staging/sles4sap_offline_gnome@64bit-staging.yaml
@@ -5,22 +5,12 @@ description:    >
   SCC registration. Boot into Gnome.
   Test SLES for SAP specific applications.
 vars:
-  APPTESTS: sles4sap/patterns,sles4sap/sapconf,sles4sap/saptune
   DM_NEEDS_USERNAME: 1
   HDDSIZEGB: 60
   ROOTONLY: 1
-  SCC_REGISTER: never
-  SCC_URL:
   SHUTDOWN_NEEDS_AUTH: 0
   SLES4SAP_MODE: sles4sap
   SLE_PRODUCT: sles4sap
-  SYSTEM_ROLE: default
-  ADDONURL: base,desktop,sapapp,serverapp,ha
-  ADDONURL_BASE: ftp://openqa.suse.de/%REPO_SLE_MODULE_BASESYSTEM%
-  ADDONURL_DESKTOP: ftp://openqa.suse.de/%REPO_SLE_MODULE_DESKTOP_APPLICATIONS%
-  ADDONURL_SERVERAPP: ftp://openqa.suse.de/%REPO_SLE_MODULE_SERVER_APPLICATIONS%
-  ADDONURL_SAPAPP: ftp://openqa.suse.de/%REPO_SLE_MODULE_SAP_APPLICATIONS%
-  ADDONURL_HA: ftp://openqa.suse.de/%REPO_SLE_PRODUCT_HA%
 schedule:
   - installation/bootloader_start
   - installation/welcome


### PR DESCRIPTION
This commit fixes SAP staging group tests because they have to be adapted to use the new Online-DVD media and so SCC Proxy is now needed.

This commit also remove some unneeded variables in these tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: Not possible easily (staging part)
