### PR TITLE
Rename sub get_test_data to avoid name conflicts

### DIFF
--- a/declarative-schedule-doc.md
+++ b/declarative-schedule-doc.md
@@ -115,9 +115,9 @@ to indicate that the module or modules executed at this position is conditional 
 #### test_data
 As vars.json has quite limited capabilities due to the design, in the yaml files
 it's possible to define any structure, which can be described using plain yaml
-format. This data can be accessed when calling `get_test_data()`
+format. This data can be accessed when calling `get_test_suite_data()`
 method from `lib/scheduler.pm`. This feature is designed to store test related
-date for data driven tests and provide better structure for the test suite settings.
+data for data driven tests and provide better structure for the test suite settings.
 
 The whole section is parsed with perl structures, so in case you have following
 settings:
@@ -135,7 +135,7 @@ test_data:
 Your test code will look like:
 ```
 sub run {
-    my $test_data = get_test_data();
+    my $test_data = get_test_suite_data();
     foreach my $item (@{$test_data->{list}}) {
         diag $item;
     }

--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -27,9 +27,9 @@ use main_common 'loadtest';
 use YAML::Tiny;
 use Data::Dumper;
 
-our @EXPORT = qw(load_yaml_schedule get_test_data);
+our @EXPORT = qw(load_yaml_schedule get_test_suite_data);
 
-my $test_data;
+my $test_suite_data;
 my $include_tag = "!include";
 
 sub parse_vars {
@@ -60,26 +60,26 @@ sub parse_schedule {
     return @scheduled;
 }
 
-=head2 get_test_data
+=head2 get_test_suite_data
 
 Returns test data parsed from the yaml file.
 
 =cut
 
-sub get_test_data {
-    return $test_data;
+sub get_test_suite_data {
+    return $test_suite_data;
 }
 
-=head2 parse_test_data
+=head2 parse_test_suite_data
 
 Parse test data from the yaml file which contains data used in the tests which could be located
 in the same file than the schedule or in a dedicated file only for data.
 
 =cut
 
-sub parse_test_data {
+sub parse_test_suite_data {
     my ($schedule) = shift;
-    $test_data = {};
+    $test_suite_data = {};
 
     # if test_data section is defined in schedule file
     if (exists $schedule->{test_data}) {
@@ -87,7 +87,7 @@ sub parse_test_data {
         _import_test_data_included($schedule->{test_data});
 
         # test_data from schedule file has priority over included data
-        $test_data = {%$test_data, %{$schedule->{test_data}}};
+        $test_suite_data = {%$test_suite_data, %{$schedule->{test_data}}};
     }
 
     # import test data directly from data file
@@ -95,7 +95,7 @@ sub parse_test_data {
         # test data from data file has priority over test_data from schedule
         _import_test_data_from_yaml(path => $yamlfile, allow_included => 1);
     }
-    diag(Dumper($test_data));
+    diag(Dumper($test_suite_data));
 }
 
 =head2 load_yaml_schedule
@@ -110,7 +110,7 @@ sub load_yaml_schedule {
         my %schedule_vars = parse_vars($schedule);
         while (my ($var, $value) = each %schedule_vars) { set_var($var, $value) }
         my @schedule_modules = parse_schedule($schedule);
-        parse_test_data($schedule);
+        parse_test_suite_data($schedule);
         loadtest($_) for (@schedule_modules);
         return 1;
     }
@@ -152,7 +152,7 @@ sub _import_test_data_from_yaml {
     }
     _ensure_include_not_present($include_yaml);
     # latest included data has priority over previous included data
-    $test_data = {%$test_data, %{$include_yaml}};
+    $test_suite_data = {%$test_suite_data, %{$include_yaml}};
 }
 
 1;

--- a/t/02_yaml_schedule.t
+++ b/t/02_yaml_schedule.t
@@ -17,8 +17,8 @@ subtest 'parse_yaml_test_data_single_import' => sub {
     use scheduler;
     # compare versions if possible
     my $schedule = YAML::Tiny::LoadFile(dirname(__FILE__) . '/data/test_schedule_single_import.yaml');
-    scheduler::parse_test_data($schedule);
-    my $testdata = scheduler::get_test_data();
+    scheduler::parse_test_suite_data($schedule);
+    my $testdata = scheduler::get_test_suite_data();
     ok $testdata->{test_in_yaml_schedule} eq 'test_in_yaml_schedule_value', "Value from schedule file was overwritten by yaml import";
     ok $testdata->{test_in_yaml_import_1} eq 'test_in_yaml_import_value_1', "Value from single imported yaml were not parsed properly";
 
@@ -28,8 +28,8 @@ subtest 'parse_yaml_test_data_multiple_imports' => sub {
     use scheduler;
     # compare versions if possible
     my $schedule = YAML::Tiny::LoadFile(dirname(__FILE__) . '/data/test_schedule_multi_imports.yaml');
-    scheduler::parse_test_data($schedule);
-    my $testdata = scheduler::get_test_data();
+    scheduler::parse_test_suite_data($schedule);
+    my $testdata = scheduler::get_test_suite_data();
     ok $testdata->{test_in_yaml_schedule} eq 'test_in_yaml_schedule_value', "Value from schedule file was overwritten by yaml import";
     ok $testdata->{test_in_yaml_import_1} eq 'test_in_yaml_import_value_1', "Value from the first imported yaml were not parsed properly";
     ok $testdata->{test_in_yaml_import_2} eq 'test_in_yaml_import_value_2', "Value from the second imported yaml were not parsed properly";
@@ -38,7 +38,7 @@ subtest 'parse_yaml_test_data_multiple_imports' => sub {
 
 subtest 'do_not_allow_nested_imports' => sub {
     my $schedule = YAML::Tiny::LoadFile(dirname(__FILE__) . '/data/test_schedule_nested_import.yaml');
-    dies_ok { scheduler::parse_test_data($schedule) } "Error: test_data can only be defined in a dedicated file for data\n";
+    dies_ok { scheduler::parse_test_suite_data($schedule) } "Error: test_data can only be defined in a dedicated file for data\n";
 };
 
 subtest 'parse_yaml_test_data_using_yaml_data_setting' => sub {
@@ -48,8 +48,8 @@ subtest 'parse_yaml_test_data_using_yaml_data_setting' => sub {
     set_var('YAML_TEST_DATA', 't/data/test_data_yaml_data_setting.yaml');
     # compare versions if possible
     my $schedule = YAML::Tiny::LoadFile(dirname(__FILE__) . '/data/test_schedule_yaml_data_setting.yaml');
-    scheduler::parse_test_data($schedule);
-    my $testdata = scheduler::get_test_data();
+    scheduler::parse_test_suite_data($schedule);
+    my $testdata = scheduler::get_test_suite_data();
     ok $testdata->{test_in_yaml_data} eq 'test_in_yaml_data',               "Value from data file was overwritten by value from schedule or other imports";
     ok $testdata->{test_in_yaml_import_3} eq 'test_in_yaml_import_value_3', "Value in data file was overwritten by value in schedule file";
 };

--- a/tests/autoyast/verify_disk_as_md_member.pm
+++ b/tests/autoyast/verify_disk_as_md_member.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 use testapi;
 use base 'basetest';
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 
 sub collect_disk_data {
@@ -29,7 +29,7 @@ sub collect_disk_data {
 }
 
 sub run {
-    my $test_data = get_test_data();
+    my $test_data = get_test_suite_data();
     my $disk_data = collect_disk_data($test_data->{disk});
 
     my @partitions = ($disk_data =~ /$test_data->{type_part}/g);

--- a/tests/autoyast/verify_disk_as_md_member_clone.pm
+++ b/tests/autoyast/verify_disk_as_md_member_clone.pm
@@ -16,12 +16,12 @@ use warnings;
 use base 'basetest';
 use testapi;
 use xml_utils;
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 use autoyast 'init_autoyast_profile';
 
 sub run {
-    my $test_data = get_test_data();                     # get test data from scheduling yaml file
+    my $test_data = get_test_suite_data();               # get test data from scheduling yaml file
     my $xpc       = get_xpc(init_autoyast_profile());    # get XPathContext
 
     record_info('RAID level', 'Verify that raid level in the generated autoyast profile corresponds to the expected one.');

--- a/tests/autoyast/verify_imported_users.pm
+++ b/tests/autoyast/verify_imported_users.pm
@@ -15,10 +15,10 @@ use strict;
 use warnings;
 use base 'consoletest';
 use testapi;
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 
 sub run {
-    my $test_data = get_test_data();
+    my $test_data = get_test_suite_data();
     my $errors;
     foreach my $path (@{$test_data->{paths}}) {
         if (!script_run("test -f $path")) {

--- a/tests/console/validate_encrypt.pm
+++ b/tests/console/validate_encrypt.pm
@@ -20,7 +20,7 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 use Test::Assert ':all';
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use Data::Dumper;
 use Utils::Backends 'is_spvm';
 
@@ -100,7 +100,7 @@ sub verify_cryptsetup_luks {
 
 sub run {
     select_console 'root-console' unless is_spvm;
-    my $test_data = get_test_data();
+    my $test_data = get_test_suite_data();
     my $crypttab  = parse_crypttab();
     verify_crypttab(num_devices => $test_data->{crypttab}->{num_devices_encrypted},
         crypttab => $crypttab);

--- a/tests/console/validate_file_system.pm
+++ b/tests/console/validate_file_system.pm
@@ -17,11 +17,11 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 
 sub run {
-    my $test_data  = get_test_data();
+    my $test_data  = get_test_suite_data();
     my %partitions = %{$test_data->{file_system}};
 
     foreach (keys %partitions) {

--- a/tests/console/validate_lvm_raid1.pm
+++ b/tests/console/validate_lvm_raid1.pm
@@ -16,7 +16,7 @@ use base "y2_module_consoletest";
 use testapi;
 use utils;
 use Test::Assert ':all';
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use version_utils "is_sle";
 use power_action_utils 'power_action';
 
@@ -25,7 +25,7 @@ sub run {
 
     select_console 'root-console';
 
-    my $config = get_test_data();
+    my $config = get_test_suite_data();
     $config->{expected_num_devs} = scalar @{$config->{disks}};
     # actual_num_devs is used to get the number of the disks in raid
     # as we move in and out a disk during the test. This is because

--- a/tests/console/validate_modify_existing_partition.pm
+++ b/tests/console/validate_modify_existing_partition.pm
@@ -14,11 +14,11 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 
 sub run {
-    my $test_data = get_test_data();
+    my $test_data = get_test_suite_data();
 
     select_console "root-console";
 

--- a/tests/console/validate_multi_btrfs_partitioning.pm
+++ b/tests/console/validate_multi_btrfs_partitioning.pm
@@ -19,12 +19,12 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 
 sub run {
 
-    my $test_data     = get_test_data();
+    my $test_data     = get_test_suite_data();
     my @multi_devices = @{$test_data->{multi_devices}};
 
     select_console 'root-console';

--- a/tests/console/validate_no_cow_attribute.pm
+++ b/tests/console/validate_no_cow_attribute.pm
@@ -23,11 +23,11 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 
 sub run {
-    my $test_data = get_test_data();
+    my $test_data = get_test_suite_data();
 
     select_console('root-console');
 

--- a/tests/installation/partitioning/modify_existing_partition.pm
+++ b/tests/installation/partitioning/modify_existing_partition.pm
@@ -15,10 +15,10 @@ use warnings;
 use parent 'installbasetest';
 use testapi;
 use version_utils ':VERSION';
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 
 sub run {
-    my $test_data   = get_test_data();
+    my $test_data   = get_test_suite_data();
     my $partitioner = $testapi::distri->get_expert_partitioner();
     $partitioner->run_expert_partitioner();
     $partitioner->resize_partition_on_gpt_disk($test_data);

--- a/tests/installation/partitioning/raid_gpt.pm
+++ b/tests/installation/partitioning/raid_gpt.pm
@@ -17,10 +17,10 @@ use warnings;
 use parent 'installbasetest';
 use testapi;
 use version_utils ':VERSION';
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 
 sub run {
-    my $test_data = get_test_data();
+    my $test_data = get_test_suite_data();
 
     my $partitioner = $testapi::distri->get_expert_partitioner();
     $partitioner->run_expert_partitioner();

--- a/tests/installation/partitioning/raid_msdos.pm
+++ b/tests/installation/partitioning/raid_msdos.pm
@@ -17,10 +17,10 @@ use warnings;
 use parent 'installbasetest';
 use testapi;
 use version_utils ':VERSION';
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 
 sub run {
-    my $test_data = get_test_data();
+    my $test_data = get_test_suite_data();
 
     my $partitioner = $testapi::distri->get_expert_partitioner();
     $partitioner->run_expert_partitioner();

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -28,12 +28,12 @@ use lockapi qw(mutex_create mutex_wait);
 use version_utils qw(is_sle is_leap);
 use yast2_widget_utils 'change_service_configuration';
 use utils qw(systemctl type_string_slow_extended);
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use y2_mm_common 'prepare_xterm_and_setup_static_network';
 
 # load expected test data from yaml
 # common for both iscsi MM modules
-my $test_data = get_test_data();
+my $test_data = get_test_suite_data();
 
 sub initiator_service_tab {
     unless (is_sle('<15') || is_leap('<15.1')) {

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -30,12 +30,12 @@ use version_utils qw(is_sle is_leap);
 use mmapi qw(get_children wait_for_children);
 use utils qw(zypper_call systemctl type_string_slow_extended);
 use yast2_widget_utils 'change_service_configuration';
-use scheduler 'get_test_data';
+use scheduler 'get_test_suite_data';
 use y2_mm_common 'prepare_xterm_and_setup_static_network';
 
 # load expected test data from yaml
 # common for both iscsi MM modules
-my $test_data = get_test_data();
+my $test_data = get_test_suite_data();
 
 sub create_fileio {
     if (defined($test_data->{target_conf}->{backstore})) {


### PR DESCRIPTION
Two different functions with the same name 'get_test_data' were
implemented in both os-autoinst's testapi and in tests' scheduler. Also,
both of them were used with Exporter and that caused name-collision
warning, that potentially may lead to unexpected results while calling
one or another function.

The commit renames the function and all the related functions and
variables.

- Related ticket: [poo#60356](https://progress.opensuse.org/issues/60356)
- Verification runs: https://openqa.suse.de/tests/3639818