### PR TITLE
Add powerVM over HMC backend

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -39,7 +39,7 @@ use constant {
           is_hyperv
           is_hyperv_in_gui
           is_svirt_except_s390x
-          is_spvm
+          is_pvm
           )
     ],
     CONSOLES => [
@@ -92,7 +92,7 @@ Returns true if the current instance is running as remote backend
 
 sub is_remote_backend {
     # s390x uses only remote repos
-    return check_var('ARCH', 's390x') || (get_var('BACKEND', '') =~ /ipmi|svirt/) || is_spvm();
+    return check_var('ARCH', 's390x') || (get_var('BACKEND', '') =~ /ipmi|svirt/) || is_pvm();
 }
 
 # In some cases we are using a VNC connection provided by the hypervisor that
@@ -151,13 +151,13 @@ sub is_svirt_except_s390x {
     return !get_var('S390_ZKVM') && check_var('BACKEND', 'svirt');
 }
 
-=head2 is_spvm
+=head2 is_pvm
 
-Returns true if the current instance is running as PowerVM backend 'spvm'
+Returns true if the current instance is running as PowerVM backend 'spvm' or 'hmc_pvm'
 
 =cut
 
-sub is_spvm {
+sub is_pvm {
     return check_var('BACKEND', 'spvm') || check_var('BACKEND', 'pvm_hmc');
 }
 

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -158,7 +158,7 @@ Returns true if the current instance is running as PowerVM backend 'spvm'
 =cut
 
 sub is_spvm {
-    return check_var('BACKEND', 'spvm');
+    return check_var('BACKEND', 'spvm') || check_var('BACKEND', 'pvm_hmc');
 }
 
 1;

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -101,12 +101,12 @@ sub is_remote_backend {
 
 =head2 has_ttys
 
-Returns true if the current instance is using ttys for: ipmi, s390x, spvm, except S390_ZKVM
+Returns true if the current instance is using ttys for: ipmi, s390x, spvm, pvm_hmc, except S390_ZKVM
 
 =cut
 
 sub has_ttys {
-    return ((get_var('BACKEND', '') !~ /ipmi|s390x|spvm/) && !get_var('S390_ZKVM'));
+    return ((get_var('BACKEND', '') !~ /ipmi|s390x|spvm|pvm_hmc/) && !get_var('S390_ZKVM'));
 }
 
 =head2 has_serial_over_ssh
@@ -116,7 +116,7 @@ Returns true if the current instance is using a serial through ssh
 =cut
 
 sub has_serial_over_ssh {
-    return ((get_var('BACKEND', '') =~ /^(ikvm|ipmi|spvm|generalhw)/) && !defined(get_var('GENERAL_HW_VNC_IP')) && !defined(get_var('GENERAL_HW_SOL_CMD')));
+    return ((get_var('BACKEND', '') =~ /^(ikvm|ipmi|spvm|pvm_hmc|generalhw)/) && !defined(get_var('GENERAL_HW_VNC_IP')) && !defined(get_var('GENERAL_HW_SOL_CMD')));
 }
 
 =head2 is_hyperv

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -1,4 +1,4 @@
-=head1 bootloader_spvm
+=head1 bootloader_pvm
 
 Library for spvm and pvm_hmc backend to boot and install SLES
 
@@ -12,7 +12,7 @@ Library for spvm and pvm_hmc backend to boot and install SLES
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-package bootloader_spvm;
+package bootloader_pvm;
 
 use base Exporter;
 use Exporter;
@@ -77,8 +77,8 @@ sub boot_pvm {
 
 sub boot_hmc_pvm {
     my $hmc_machine_name = get_required_var('HMC_MACHINE_NAME');
-    my $lpar_id  = get_required_var('LPAR_ID');
-    my $hmc = select_console 'powerhmc-ssh';
+    my $lpar_id          = get_required_var('LPAR_ID');
+    my $hmc              = select_console 'powerhmc-ssh';
 
     # detach possibly attached terminals - might be left over
     type_string "rmvterm -m $hmc_machine_name --id $lpar_id && echo 'DONE'\n";

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -95,6 +95,7 @@ sub boot_hmc_pvm {
 
     # don't wait for it, otherwise we miss the menu
     type_string "mkvterm -m $hmc_machine_name --id $lpar_id\n";
+    return if get_var('BOOT_HDD_IMAGE');
     get_into_net_boot;
 
     # the grub on powerVM has a rather strange feature that it will boot

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -67,37 +67,14 @@ sub get_into_net_boot {
     assert_screen ["pvm-grub", "novalink-failed-first-boot"];
 }
 
-sub boot_pvm {
-    if (check_var('BACKEND', 'spvm')) {
-        boot_spvm();
-    } elsif (check_var('BACKEND', 'pvm_hmc')) {
-        boot_hmc_pvm();
-    }
-}
+=head2 prepare_pvm_installation
 
-sub boot_hmc_pvm {
-    my $hmc_machine_name = get_required_var('HMC_MACHINE_NAME');
-    my $lpar_id          = get_required_var('LPAR_ID');
-    my $hmc              = select_console 'powerhmc-ssh';
+ prepare_pvm_installation();
 
-    # detach possibly attached terminals - might be left over
-    type_string "rmvterm -m $hmc_machine_name --id $lpar_id && echo 'DONE'\n";
-    assert_screen 'pvm-vterm-closed';
+Handle the boot and installation preperation process of PVM LPARs after the hypervisor specific actions to power them on is done
 
-    # power off the machine if it's still running - and don't give it a 2nd chance
-    type_string "chsysstate -r lpar -m $hmc_machine_name -o shutdown --immed --id $lpar_id && echo 'LPAR SUCCESSFULLY SHUT DOWN'\n";
-    assert_screen [qw(pvm-poweroff-successful pvm-poweroff-not-running)], 180;
-
-    # proceed with normal boot if is system already installed, use sms boot for installation
-    my $bootmode = get_var('BOOT_HDD_IMAGE') ? "norm" : "sms";
-    type_string "chsysstate -r lpar -m $hmc_machine_name -o on -b ${bootmode} --id $lpar_id && echo 'LPAR SUCCESSFULLY BOOTED'\n";
-    assert_screen "pvm-poweron-successful";
-
-    # don't wait for it, otherwise we miss the menu
-    type_string "mkvterm -m $hmc_machine_name --id $lpar_id\n";
-    return if get_var('BOOT_HDD_IMAGE');
-    get_into_net_boot;
-
+=cut
+sub prepare_pvm_installation {
     # the grub on powerVM has a rather strange feature that it will boot
     # into the firmware if the lpar was reconfigured in between and the
     # first menu entry was used to enter the command line. So we need to
@@ -150,6 +127,40 @@ sub boot_hmc_pvm {
     # We need to start installer only if it's pure ssh installation
     type_string("yast.ssh\n") if get_var('VIDEOMODE', '') =~ /ssh-x|text/;
     wait_still_screen;
+}
+
+sub boot_pvm {
+    if (check_var('BACKEND', 'spvm')) {
+        boot_spvm();
+    } elsif (check_var('BACKEND', 'pvm_hmc')) {
+        boot_hmc_pvm();
+    }
+}
+
+sub boot_hmc_pvm {
+    my $hmc_machine_name = get_required_var('HMC_MACHINE_NAME');
+    my $lpar_id          = get_required_var('LPAR_ID');
+    my $hmc              = select_console 'powerhmc-ssh';
+
+    # detach possibly attached terminals - might be left over
+    type_string "rmvterm -m $hmc_machine_name --id $lpar_id && echo 'DONE'\n";
+    assert_screen 'pvm-vterm-closed';
+
+    # power off the machine if it's still running - and don't give it a 2nd chance
+    type_string "chsysstate -r lpar -m $hmc_machine_name -o shutdown --immed --id $lpar_id && echo 'LPAR SUCCESSFULLY SHUT DOWN'\n";
+    assert_screen [qw(pvm-poweroff-successful pvm-poweroff-not-running)], 180;
+
+    # proceed with normal boot if is system already installed, use sms boot for installation
+    my $bootmode = get_var('BOOT_HDD_IMAGE') ? "norm" : "sms";
+    type_string "chsysstate -r lpar -m $hmc_machine_name -o on -b ${bootmode} --id $lpar_id && echo 'LPAR SUCCESSFULLY BOOTED'\n";
+    assert_screen "pvm-poweron-successful";
+
+    # don't wait for it, otherwise we miss the menu
+    type_string "mkvterm -m $hmc_machine_name --id $lpar_id\n";
+    # skip further preperations if system is already installed
+    return if get_var('BOOT_HDD_IMAGE');
+    get_into_net_boot;
+    prepare_pvm_installation;
 }
 
 =head2 boot_spvm
@@ -183,62 +194,10 @@ sub boot_spvm {
 
     # don't wait for it, otherwise we miss the menu
     type_string " mkvterm --id $lpar_id\n";
-    # skip installation if is system already installed
+    # skip further preperations if system is already installed
     return if get_var('BOOT_HDD_IMAGE');
     get_into_net_boot;
-
-    # the grub on powerVM has a rather strange feature that it will boot
-    # into the firmware if the lpar was reconfigured in between and the
-    # first menu entry was used to enter the command line. So we need to
-    # reset the LPAR manually
-    if (match_has_tag('novalink-failed-first-boot')) {
-        type_string "set-default ibm,fw-nbr-reboots\n";
-        type_string "reset-all\n";
-        assert_screen 'pvm-firmware-prompt';
-        send_key '1';
-        get_into_net_boot;
-    }
-    # try 3 times but wait a long time in between - if we're too eager
-    # we end with ccc in the prompt
-    send_key_until_needlematch('pvm-grub-command-line', 'c', 3, 5);
-
-    # clear the prompt (and create an error) in case the above went wrong
-    type_string "\n";
-
-    my $repo     = get_required_var('REPO_0');
-    my $mirror   = get_netboot_mirror;
-    my $mntpoint = "mnt/openqa/repo/$repo/boot/ppc64le";
-    assert_screen "pvm-grub-command-line-fresh-prompt", no_wait => 1;
-    type_string_slow "linux $mntpoint/linux vga=normal install=$mirror ";
-    bootmenu_default_params;
-    bootmenu_network_source;
-    specific_bootmenu_params;
-    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
-    type_string_slow remote_install_bootmenu_params;
-    type_string_slow "\n";
-
-    assert_screen "pvm-grub-command-line-fresh-prompt", 180, no_wait => 1;    # kernel is downloaded while waiting
-    type_string_slow "initrd $mntpoint/initrd\n";
-
-    assert_screen "pvm-grub-command-line-fresh-prompt", 180, no_wait => 1;    # initrd is downloaded while waiting
-    type_string "boot\n";
-    save_screenshot;
-
-    assert_screen("novalink-successful-first-boot", 120);
-    assert_screen("run-yast-ssh",                   120);
-
-    # Delete partition table before starting installation
-    select_console('install-shell');
-    foreach my $disk (split(',', get_var('DISK_DEVICES', 'sda'))) {
-        script_run("wipefs -a /dev/$disk");
-        # For cryptlvm+activate existing scenario, create empty enrypted partition
-        create_encrypted_part("$disk") if get_var('ENCRYPT_ACTIVATE_EXISTING');
-    }
-    # Switch to installation console (ssh or vnc)
-    select_console('installation');
-    # We need to start installer only if it's pure ssh installation
-    type_string("yast.ssh\n") if get_var('VIDEOMODE', '') =~ /ssh-x|text/;
-    wait_still_screen;
+    prepare_pvm_installation;
 }
 
 1;

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -303,7 +303,7 @@ sub get_bootmenu_console_params {
 
     # See bsc#1011815, last console set as boot parameter is linked to /dev/console
     # and doesn't work if set to serial device. Don't want this on some backends.
-    push @params, "console=tty" unless (get_var('BACKEND', '') =~ /ipmi|spvm/);
+    push @params, "console=tty" unless (get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/);
     return @params;
 }
 

--- a/lib/bootloader_spvm.pm
+++ b/lib/bootloader_spvm.pm
@@ -1,6 +1,6 @@
 =head1 bootloader_spvm
 
-Library for spvm backend to boot and install SLES
+Library for spvm and pvm_hmc backend to boot and install SLES
 
 =cut
 # SUSE's openQA tests

--- a/lib/bootloader_spvm.pm
+++ b/lib/bootloader_spvm.pm
@@ -26,7 +26,7 @@ use registration 'registration_bootloader_params';
 use utils qw(get_netboot_mirror type_string_slow);
 
 our @EXPORT = qw(
-  boot_spvm
+  boot_pvm
 );
 
 =head2 get_into_net_boot
@@ -65,6 +65,90 @@ sub get_into_net_boot {
 
     type_string "1\n";
     assert_screen ["pvm-grub", "novalink-failed-first-boot"];
+}
+
+sub boot_pvm {
+    if (check_var('BACKEND', 'spvm')) {
+        boot_spvm();
+    } elsif (check_var('BACKEND', 'pvm_hmc')) {
+        boot_hmc_pvm();
+    }
+}
+
+sub boot_hmc_pvm {
+    my $hmc_machine_name = get_required_var('HMC_MACHINE_NAME');
+    my $lpar_id  = get_required_var('LPAR_ID');
+    my $hmc = select_console 'powerhmc-ssh';
+
+    # detach possibly attached terminals - might be left over
+    type_string "rmvterm -m $hmc_machine_name --id $lpar_id && echo 'DONE'\n";
+    assert_screen 'pvm-vterm-closed';
+
+    # power off the machine if it's still running - and don't give it a 2nd chance
+    type_string "chsysstate -r lpar -m $hmc_machine_name -o shutdown --immed --id $lpar_id && echo 'LPAR SUCCESSFULLY SHUT DOWN'\n";
+    assert_screen [qw(pvm-poweroff-successful pvm-poweroff-not-running)], 180;
+
+    # proceed with normal boot if is system already installed, use sms boot for installation
+    my $bootmode = get_var('BOOT_HDD_IMAGE') ? "norm" : "sms";
+    type_string "chsysstate -r lpar -m $hmc_machine_name -o on -b ${bootmode} --id $lpar_id && echo 'LPAR SUCCESSFULLY BOOTED'\n";
+    assert_screen "pvm-poweron-successful";
+
+    # don't wait for it, otherwise we miss the menu
+    type_string "mkvterm -m $hmc_machine_name --id $lpar_id\n";
+    get_into_net_boot;
+
+    # the grub on powerVM has a rather strange feature that it will boot
+    # into the firmware if the lpar was reconfigured in between and the
+    # first menu entry was used to enter the command line. So we need to
+    # reset the LPAR manually
+    if (match_has_tag('novalink-failed-first-boot')) {
+        type_string "set-default ibm,fw-nbr-reboots\n";
+        type_string "reset-all\n";
+        assert_screen 'pvm-firmware-prompt';
+        send_key '1';
+        get_into_net_boot;
+    }
+    # try 3 times but wait a long time in between - if we're too eager
+    # we end with ccc in the prompt
+    send_key_until_needlematch('pvm-grub-command-line', 'c', 3, 5);
+
+    # clear the prompt (and create an error) in case the above went wrong
+    type_string "\n";
+
+    my $repo     = get_required_var('REPO_0');
+    my $mirror   = get_netboot_mirror;
+    my $mntpoint = "mnt/openqa/repo/$repo/boot/ppc64le";
+    assert_screen "pvm-grub-command-line-fresh-prompt", no_wait => 1;
+    type_string_slow "linux $mntpoint/linux vga=normal install=$mirror ";
+    bootmenu_default_params;
+    bootmenu_network_source;
+    specific_bootmenu_params;
+    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
+    type_string_slow remote_install_bootmenu_params;
+    type_string_slow "\n";
+
+    assert_screen "pvm-grub-command-line-fresh-prompt", 180, no_wait => 1;    # kernel is downloaded while waiting
+    type_string_slow "initrd $mntpoint/initrd\n";
+
+    assert_screen "pvm-grub-command-line-fresh-prompt", 180, no_wait => 1;    # initrd is downloaded while waiting
+    type_string "boot\n";
+    save_screenshot;
+
+    assert_screen("novalink-successful-first-boot", 120);
+    assert_screen("run-yast-ssh",                   120);
+
+    # Delete partition table before starting installation
+    select_console('install-shell');
+    foreach my $disk (split(',', get_var('DISK_DEVICES', 'sda'))) {
+        script_run("wipefs -a /dev/$disk");
+        # For cryptlvm+activate existing scenario, create empty enrypted partition
+        create_encrypted_part("$disk") if get_var('ENCRYPT_ACTIVATE_EXISTING');
+    }
+    # Switch to installation console (ssh or vnc)
+    select_console('installation');
+    # We need to start installer only if it's pure ssh installation
+    type_string("yast.ssh\n") if get_var('VIDEOMODE', '') =~ /ssh-x|text/;
+    wait_still_screen;
 }
 
 =head2 boot_spvm

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -14,7 +14,7 @@ use warnings;
 use testapi;
 use utils;
 use registration;
-use Utils::Backends 'is_spvm';
+use Utils::Backends 'is_pvm';
 use power_action_utils 'power_action';
 use version_utils qw(is_sle is_jeos is_leap is_tumbleweed is_opensuse);
 
@@ -209,8 +209,8 @@ sub configure_service {
     activate_kdump;
 
     # restart to activate kdump
-    power_action('reboot', keepconsole => is_spvm);
-    reconnect_mgmt_console if is_spvm;
+    power_action('reboot', keepconsole => is_pvm);
+    reconnect_mgmt_console if is_pvm;
     $self->wait_boot;
 
     select_console 'root-console';
@@ -247,7 +247,7 @@ sub check_function {
         assert_screen 'grub2', 180;
         wait_screen_change { send_key 'ret' };
     }
-    elsif (is_spvm) {
+    elsif (is_pvm) {
         reconnect_mgmt_console;
     }
     else {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -22,7 +22,7 @@ use utils;
 use wicked::TestContext;
 use Utils::Architectures ':ARCH';
 use version_utils qw(:VERSION :BACKEND :SCENARIO);
-use Utils::Backends qw(is_remote_backend is_hyperv is_hyperv_in_gui is_svirt_except_s390x is_spvm);
+use Utils::Backends qw(is_remote_backend is_hyperv is_hyperv_in_gui is_svirt_except_s390x is_pvm);
 use data_integrity_utils 'verify_checksum';
 use bmwqemu ();
 use lockapi 'barrier_create';
@@ -440,7 +440,7 @@ sub load_reboot_tests {
         return;
     }
     # there is encryption passphrase prompt which is handled in installation/boot_encrypt
-    if ((is_s390x && !get_var('ENCRYPT')) || uses_qa_net_hardware() || is_spvm) {
+    if ((is_s390x && !get_var('ENCRYPT')) || uses_qa_net_hardware() || is_pvm) {
         loadtest "boot/reconnect_mgmt_console";
     }
     if (installyaststep_is_applicable()) {
@@ -570,7 +570,7 @@ sub load_system_role_tests {
             loadtest "installation/setup_online_repos";
         }
         # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
-        if ((!get_var('BACKEND', 'ipmi') || !is_spvm) && !is_hyperv_in_gui && !get_var("LIVECD")) {
+        if ((!get_var('BACKEND', 'ipmi') || !is_pvm) && !is_hyperv_in_gui && !get_var("LIVECD")) {
             loadtest "installation/logpackages";
         }
     }
@@ -809,7 +809,7 @@ sub boot_hdd_image {
     if (get_var('UEFI') && (get_var('BOOTFROM') || get_var('BOOT_HDD_IMAGE'))) {
         loadtest 'boot/uefi_bootmenu';
     }
-    loadtest 'installation/bootloader' if is_spvm;
+    loadtest 'installation/bootloader' if is_pvm;
     loadtest 'boot/boot_to_desktop';
 }
 
@@ -983,7 +983,7 @@ sub load_inst_tests {
             and !is_hyperv_in_gui
             and !is_bridged_networking
             and (get_var('BACKEND', '') !~ /ipmi|s390x/)
-            and !is_spvm
+            and !is_pvm
             and is_sle('12-SP2+'))
         {
             loadtest "installation/hostname_inst";

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -25,7 +25,7 @@ use LTP::TestInfo 'testinfo';
 use File::Basename 'basename';
 use main_common qw(load_bootloader_s390x boot_hdd_image get_ltp_tag load_boot_tests load_inst_tests load_reboot_tests);
 use 5.018;
-use Utils::Backends 'is_spvm';
+use Utils::Backends 'is_pvm';
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
 # use warnings;
 
@@ -120,7 +120,7 @@ sub stress_snapshots {
 
 sub load_kernel_tests {
     load_bootloader_s390x();
-    loadtest "../installation/bootloader" if is_spvm;
+    loadtest "../installation/bootloader" if is_pvm;
 
     if (get_var('INSTALL_LTP')) {
         if (get_var('INSTALL_KOTD')) {

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1043,7 +1043,7 @@ of the default {root-,}virtio-terminal)
 C<SERIAL_CONSOLE>=0 disables serial console (use {root,user}-console instead
 of the default {root-,}sut-serial)
 
-On ikvm|ipmi|spvm it's expected, that use_ssh_serial_console() has been called
+On ikvm|ipmi|spvm|pvm_hmc it's expected, that use_ssh_serial_console() has been called
 (done via activate_console()) therefore SERIALDEV has been set and we can
 use root-ssh console directly.
 =cut

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -39,7 +39,7 @@ our @EXPORT = qw(
 
  prepare_system_shutdown();
 
-Need to kill ssh connection with backends like ipmi, spvm, s390x.
+Need to kill ssh connection with backends like ipmi, spvm, pvm_hmc, s390x.
 
 For s390_zkvm or xen, assign console($vnc_console) with C<disable_vnc_stalls> 
 and assign console('svirt') with C<stop_serial_grab>. 
@@ -49,7 +49,7 @@ $vnc_console get required variable 'SVIRT_VNC_CONSOLE' before assignment.
 =cut
 sub prepare_system_shutdown {
     # kill the ssh connection before triggering reboot
-    console('root-ssh')->kill_ssh if get_var('BACKEND', '') =~ /ipmi|spvm/;
+    console('root-ssh')->kill_ssh if get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/;
 
     if (check_var('ARCH', 's390x')) {
         if (check_var('BACKEND', 's390x')) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -381,7 +381,7 @@ that.
 =cut
 sub check_console_font {
     # Does not make sense on ssh-based consoles
-    return if get_var('BACKEND', '') =~ /ipmi|spvm/;
+    return if get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/;
     # we do not await the console here, as we have to expect the font to be broken
     # for the needle to match
     select_console('root-console', await_console => 0);

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1338,6 +1338,8 @@ sub reconnect_mgmt_console {
     elsif (check_var('ARCH', 'ppc64le')) {
         if (check_var('BACKEND', 'spvm')) {
             select_console 'novalink-ssh', await_console => 0;
+        } elsif (check_var('BACKEND', 'pvm_hmc')) {
+            select_console 'powerhmc-ssh', await_console => 0;
         }
     }
     elsif (check_var('ARCH', 'x86_64')) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -22,7 +22,7 @@ use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
 use scheduler 'load_yaml_schedule';
-use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_spvm);
+use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_pvm);
 use Utils::Architectures;
 use DistributionProvider;
 
@@ -732,7 +732,7 @@ elsif (get_var("QA_TESTSUITE")) {
 }
 elsif (get_var('XFSTESTS')) {
     prepare_target;
-    if (is_spvm || check_var('ARCH', 's390x')) {
+    if (is_pvm || check_var('ARCH', 's390x')) {
         loadtest 'xfstests/install';
         loadtest 'xfstests/partition';
         loadtest 'xfstests/run';

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -43,7 +43,7 @@ use power_action_utils 'prepare_system_shutdown';
 use version_utils qw(is_sle is_caasp is_released);
 use main_common 'opensuse_welcome_applicable';
 use x11utils 'untick_welcome_on_next_startup';
-use Utils::Backends 'is_spvm';
+use Utils::Backends 'is_pvm';
 
 my $confirmed_licenses = 0;
 my $stage              = 'stage1';
@@ -138,7 +138,7 @@ sub run {
     push @needles, 'linux-login-casp' if is_caasp;
     # Autoyast reboot automatically without confirmation, usually assert 'bios-boot' that is not existing on zVM
     # So push a needle to check upcoming reboot on zVM that is a way to indicate the stage done
-    push @needles, 'autoyast-stage1-reboot-upcoming' if check_var('ARCH', 's390x') || is_spvm;
+    push @needles, 'autoyast-stage1-reboot-upcoming' if check_var('ARCH', 's390x') || is_pvm;
     # Similar situation over IPMI backend, we can check against PXE menu
     push @needles, qw(prague-pxe-menu qa-net-selection) if check_var('BACKEND', 'ipmi');
     # Import untrusted certification for SMT
@@ -293,7 +293,7 @@ sub run {
         return;
     }
     # For powerVM need to switch to mgmt console to handle the reboot properly
-    if (is_spvm()) {
+    if (is_pvm()) {
         prepare_system_shutdown;
         reconnect_mgmt_console(timeout => 500);
     }
@@ -357,7 +357,7 @@ sub run {
         }
     }
     # ssh console was activated at this point of time, so need to reset
-    reset_consoles if is_spvm;
+    reset_consoles if is_pvm;
     my $expect_errors = get_var('AUTOYAST_EXPECT_ERRORS') // 0;
     die 'exceeded expected autoyast errors' if $num_errors != $expect_errors;
 }

--- a/tests/console/validate_encrypt.pm
+++ b/tests/console/validate_encrypt.pm
@@ -22,7 +22,7 @@ use testapi;
 use Test::Assert ':all';
 use scheduler 'get_test_suite_data';
 use Data::Dumper;
-use Utils::Backends 'is_spvm';
+use Utils::Backends 'is_pvm';
 
 # Check https://www.freedesktop.org/software/systemd/man/crypttab.html for more info about parsing
 sub parse_crypttab {
@@ -99,7 +99,7 @@ sub verify_cryptsetup_luks {
 }
 
 sub run {
-    select_console 'root-console' unless is_spvm;
+    select_console 'root-console' unless is_pvm;
     my $test_data = get_test_suite_data();
     my $crypttab  = parse_crypttab();
     verify_crypttab(num_devices => $test_data->{crypttab}->{num_devices_encrypted},

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -34,7 +34,7 @@ use warnings;
 use testapi;
 use lockapi 'mutex_wait';
 use bootloader_setup;
-use bootloader_spvm;
+use bootloader_pvm;
 use registration;
 use version_utils qw(:VERSION :SCENARIO);
 use utils;
@@ -43,8 +43,8 @@ use Utils::Backends 'is_pvm';
 # hint: press shift-f10 trice for highest debug level
 sub run {
     return boot_pvm if is_pvm;
-    return           if get_var('BOOT_HDD_IMAGE');
-    return           if select_bootmenu_option == 3;
+    return          if get_var('BOOT_HDD_IMAGE');
+    return          if select_bootmenu_option == 3;
     # the default loader is isolinux on openSUSE/SLE products with product-builder
     my $boot_cmd = 'ret';
     # Tumbleweed livecd has been switched to grub with kiwi 9.17.41 except 32bit

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -38,11 +38,11 @@ use bootloader_spvm;
 use registration;
 use version_utils qw(:VERSION :SCENARIO);
 use utils;
-use Utils::Backends 'is_spvm';
+use Utils::Backends 'is_pvm';
 
 # hint: press shift-f10 trice for highest debug level
 sub run {
-    return boot_pvm if is_spvm;
+    return boot_pvm if is_pvm;
     return           if get_var('BOOT_HDD_IMAGE');
     return           if select_bootmenu_option == 3;
     # the default loader is isolinux on openSUSE/SLE products with product-builder

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -42,7 +42,7 @@ use Utils::Backends 'is_spvm';
 
 # hint: press shift-f10 trice for highest debug level
 sub run {
-    return boot_spvm if is_spvm;
+    return boot_pvm if is_spvm;
     return           if get_var('BOOT_HDD_IMAGE');
     return           if select_bootmenu_option == 3;
     # the default loader is isolinux on openSUSE/SLE products with product-builder

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -42,7 +42,7 @@ sub run {
     }
     # while technically SUT has a different network than the BMC
     # we require ssh installation anyway
-    if (get_var('BACKEND', '') =~ /ipmi|spvm/) {
+    if (get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/) {
         use_ssh_serial_console;
         # set serial console for xen
         set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN')                      || check_var('HOST_HYPERVISOR', 'xen'));


### PR DESCRIPTION
This is a follow up for https://github.com/os-autoinst/os-autoinst/pull/1278 to support tests on Power9 machines which are managed within an HMC. You can see a first test completing here: http://openqa.glados.qa.suse.de/tests/128

Things left to do:
 1. Cross-check if the refactor/deduplication of code did not break the existing spvm backend
 2. Deduplicate even more code as suggested in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9016#discussion_r353156340