### PR TITLE
Use human readable dmesg timestamp

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -392,7 +392,7 @@ Example:
 =cut
 sub assert_shutdown_with_soft_timeout {
     my ($args) = @_;
-    $args->{timeout}      //= check_var('ARCH', 's390x') ? 600 : 60;
+    $args->{timeout}      //= check_var('ARCH', 's390x') ? 600 : get_var('DEBUG_SHUTDOWN') ? 180 : 60;
     $args->{soft_timeout} //= 0;
     $args->{bugref}       //= "No bugref specified";
     if ($args->{soft_timeout}) {

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -276,6 +276,9 @@ sub power_action {
     }
     my $soft_fail_data;
     my $shutdown_timeout = 60;
+    if (is_sle('15-sp1+') && check_var('DESKTOP', 'textmode') && ($action eq 'poweroff')) {
+        $soft_fail_data = {bugref => 'bsc#1158145', soft_timeout => 60, timeout => $shutdown_timeout *= 3};
+    }
     # Shutdown takes longer than 60 seconds on SLE12 SP4 and SLE 15
     if (is_sle('12+') && check_var('DESKTOP', 'gnome') && ($action eq 'poweroff')) {
         $soft_fail_data = {bugref => 'bsc#1055462', soft_timeout => 60, timeout => $shutdown_timeout *= 3};

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -35,7 +35,7 @@ sub run {
         my $script = << "END_SCRIPT";
              echo -e '#!/bin/sh
              echo --- dmesg log ---  > /dev/$serialdev
-             dmesg  >> /dev/$serialdev
+             dmesg -T >> /dev/$serialdev
              echo --- journactl log ---  >> /dev/$serialdev 
              journalctl >> /dev/$serialdev'  > /usr/lib/systemd/system-shutdown/debug.sh \\
 END_SCRIPT


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3636623#step/shutdown/2
- Verification run:
https://openqa.suse.de/tests/3644852 15sp1 with DEBUG_SHUTDOWN
https://openqa.suse.de/tests/3646242 15sp1
https://openqa.suse.de/tests/3646241 15sp2
https://openqa.opensuse.org/tests/1098161