### PR TITLE
fix tests failures in sle15sp2 staging of gnome-3.34 upgrade

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -788,7 +788,7 @@ sub wait_boot {
             #assert_screen "dm-password-input", 10;
             elsif (check_var('DESKTOP', 'gnome')) {
                 # In GNOME/gdm, we do not have to enter a username, but we have to select it
-                if (is_tumbleweed) {
+                if (is_tumbleweed || is_sle('>=15-sp2')) {
                     send_key 'tab';
                 }
                 send_key 'ret';

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -25,7 +25,7 @@ use base 'bootbasetest';
 use testapi;
 use utils 'handle_emergency';
 use version_utils qw(is_sle is_leap is_desktop_installed is_upgrade is_sles4sap);
-use x11utils 'handle_login';
+use x11utils qw(handle_login ensure_unlocked_desktop);
 use main_common 'opensuse_welcome_applicable';
 
 sub run {
@@ -62,6 +62,15 @@ sub run {
         assert_screen [qw(displaymanager emergency-shell emergency-mode)], $boot_timeout;
         handle_emergency if (match_has_tag('emergency-shell') or match_has_tag('emergency-mode'));
         handle_login;
+    }
+
+    if (is_sle('>=15-SP2') && get_var("STAGING")) {
+        # quick workaround for poo#60332
+        record_soft_failure 'poo#60332 - deal with additional polkit windows';
+        wait_still_screen;
+        ensure_unlocked_desktop;
+        sleep(20);
+        ensure_unlocked_desktop;
     }
 
     my @tags = qw(generic-desktop);


### PR DESCRIPTION
This is an emergency PR to fix test errors in sle15sp2 staging project.

The problem is there are 2 unexpected polkit window during first login.  So I use `ensure_unlocked_desktop` to handle that.

Another change in `lib/opensusebasetest.pm` is for poo#60335, after reboot, the logic for selecting user is changed to the same as Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/60332
https://progress.opensuse.org/issues/60335
- Needles: none
- Verification run: https://openqa.nue.suse.com/tests/3636438 (with CASEDIR)
