### PR TITLE
Fix gnome login for gnome-3.34 upgrade in SLE

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -788,7 +788,7 @@ sub wait_boot {
             #assert_screen "dm-password-input", 10;
             elsif (check_var('DESKTOP', 'gnome')) {
                 # In GNOME/gdm, we do not have to enter a username, but we have to select it
-                if (is_tumbleweed) {
+                unless (is_sle('<=15-sp1') || is_leap('<=15.1')) {
                     send_key 'tab';
                 }
                 send_key 'ret';


### PR DESCRIPTION
* Add workaround for additional polkit authentication windows in SLE gnome >= 3.34
* Fix different handling for gdm password depending on product version

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9021 https://openqa.suse.de/tests/3636718
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9021 https://openqa.suse.de/tests/3636736
```

* sle-15-SP2-Online-C-Staging-x86_64-BuildC.121.1-gnome@64bit -> https://openqa.suse.de/t3638216
* sle-15-SP2-Online-x86_64-Build93.1-gnome@64bit -> https://openqa.suse.de/t3638223