### PR TITLE
Fix 'mr_test' execution in textmode

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -400,11 +400,11 @@ sub reboot {
     if (check_var('BACKEND', 'ipmi')) {
         power_action('reboot', textmode => 1, keepconsole => 1);
         switch_from_ssh_to_sol_console;
-        $self->wait_boot(textmode => 1);
+        $self->wait_boot(textmode => 1, nologin => 1);
     }
     else {
         power_action('reboot', textmode => 1);
-        $self->wait_boot;
+        $self->wait_boot(nologin => 1);
     }
     $self->select_serial_terminal;
 }

--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -25,8 +25,8 @@ sub setup {
     $self->select_serial_terminal;
     # Disable packagekit
     pkcon_quit;
-    # saptune is not installed by default on SLES4SAP 12 on ppc64le
-    zypper_call "-n in saptune" if (get_var('OFW') and is_sle('<15'));
+    # saptune is not installed by default on SLES4SAP 12 on ppc64le and in textmode profile
+    zypper_call "-n in saptune" if ((get_var('OFW') and is_sle('<15')) or check_var('DESKTOP', 'textmode'));
     # Install mr_test dependencies
     zypper_call "-n in python3-rpm";
     # Download mr_test and extract it to $HOME
@@ -35,7 +35,7 @@ sub setup {
     assert_script_run "echo 'export PATH=\$PATH:\$HOME' >> /root/.bashrc";
     # Remove any configuration set by sapconf
     assert_script_run "sed -i.bak '/^@/,\$d' /etc/security/limits.conf";
-    assert_script_run 'mv /etc/systemd/logind.conf.d/sap.conf{,.bak}';
+    assert_script_run "mv /etc/systemd/logind.conf.d/sap.conf{,.bak}" unless check_var('DESKTOP', 'textmode');
     assert_script_run 'saptune daemon start';
     if (check_var('BACKEND', 'qemu')) {
         # Ignore disk_elevator on VM's


### PR DESCRIPTION
This commit adapt `mr_test` test to be able to run it in textmode.

This is used to workaround a sporadic issue that can occurs during switch between Gnome and tty screens.

- Related ticket: N/A
- Needles: N/A
- Failing test: http://1b210.qa.suse.de/tests/6142#step/mr_test/102
- Verification run: http://1b210.qa.suse.de/tests/6147

**Note:** the failure in the verification run is due to another issue with the test that needs to be investigate further, but this is not related to this change.