### PR TITLE
Accept HA license when registering after install

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -139,7 +139,7 @@ sub accept_addons_license {
     # HA and WE have licenses when calling yast2 scc
     push @addons_with_license, @SLE15_ADDONS_WITH_LICENSE_NOINSTALL if (is_sle('15+') and get_var('IN_PATCH_SLE'));
     # HA does not show EULA when doing migration to 12-SP5
-    @addons_with_license = grep { $_ ne 'ha' } @addons_with_license if (is_sle('12-sp5+') && get_var('UPGRADE'));
+    @addons_with_license = grep { $_ ne 'ha' } @addons_with_license if (is_sle('12-sp5+') && get_var('UPGRADE') && !get_var('IN_PATCH_SLE'));
 
     for my $addon (@scc_addons) {
         # most modules don't have license, skip them
@@ -299,7 +299,7 @@ sub register_addons {
         # WE doesn't need code on SLED
         push @addons_with_code, 'we' unless (check_var('SLE_PRODUCT', 'sled'));
         # HA doesn't need code on SLES4SAP or in migrations to 12-SP5
-        push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap') || (is_sle('12-sp5+') && get_var('UPGRADE')));
+        push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap') || (is_sle('12-sp5+') && get_var('UPGRADE') && !get_var('IN_PATCH_SLE')));
         if ((my $regcode = get_var("SCC_REGCODE_$uc_addon")) or ($addon eq "ltss")) {
             # skip addons which doesn't need to input scc code
             next unless grep { $addon eq $_ } @addons_with_code;


### PR DESCRIPTION
HA license has to be accepted when registering system after installation and HA regcode must be typed as well.

- Failed test: https://openqa.suse.de/tests/3635662#step/patch_sle/34
- Related ticket: N/A
- Needles: N/A
- Verification run: http://1a102.qa.suse.de/tests/1604
