### PR TITLE
Mount the boot/efi in modify_existing_partition

### DIFF
--- a/lib/Installation/Partitioner/FormattingOptionsPage.pm
+++ b/lib/Installation/Partitioner/FormattingOptionsPage.pm
@@ -48,7 +48,8 @@ sub select_do_not_format_device_radiobutton {
 }
 
 sub select_format_device_radiobutton {
-    my ($self) = @_;
+    my ($self, $skip) = @_;
+    return if $skip;
     assert_screen(FORMATTING_OPTIONS_PAGE);
     send_key($self->{format_shortcut});
 }
@@ -82,10 +83,13 @@ sub select_partition_id {
 }
 
 sub select_filesystem {
-    my ($self, $filesystem) = @_;
+    my ($self, $filesystem, $skip) = @_;
+    return if $skip;
     assert_screen(FORMATTING_OPTIONS_PAGE);
     send_key($self->{filesystem_shortcut});
-    send_key 'end';
+    wait_screen_change(sub {
+            send_key 'end';
+    }, 20);
     if ($filesystem eq 'swap') {
         send_key_until_needlematch(FILESYSTEM_SWAP, 'up');
     }

--- a/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
@@ -114,8 +114,8 @@ sub edit_partition_on_gpt_disk {
     $self->get_expert_partitioner_page()->expand_item_in_system_view_table();
     $self->get_expert_partitioner_page()->select_item_in_system_view_table($args->{existing_partition});
     $self->get_expert_partitioner_page()->press_edit_partition_button();
-    $self->get_edit_formatting_options_page()->select_format_device_radiobutton();
-    $self->get_edit_formatting_options_page()->select_filesystem($args->{fs_type});
+    $self->get_edit_formatting_options_page()->select_format_device_radiobutton($args->{skip});
+    $self->get_edit_formatting_options_page()->select_filesystem($args->{fs_type}, $args->{skip});
     $self->get_edit_formatting_options_page()->select_mount_device_radiobutton();
     $self->get_edit_formatting_options_page()->fill_in_mount_point_field($args->{mount_point});
     $self->get_edit_formatting_options_page()->press_next();

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -28,6 +28,7 @@ schedule:
   - console/validate_modify_existing_partition
 
 test_data:
+  root:
     disk: 'vda'
     existing_partition: 'vda2'
     mount_point: '/'
@@ -37,7 +38,14 @@ test_data:
     # part_size is the size we input in partitioner, lsblk_expected_size_output is what we'll use for validation.
     part_size: '11GiB'
     lsblk_expected_size_output: '11G'
-
+  boot-uefi:
+    disk: 'vda'
+    existing_partition: 'vda1'
+    mount_point: '/boot/efi'
+    fs_type: 'fat'
+    skip: 1
+    part_size: '256MiB'
+    lsblk_expected_size_output: '256M'
 conditional_schedule:
   reconnect_mgmt_console:
     ARCH:

--- a/tests/console/validate_modify_existing_partition.pm
+++ b/tests/console/validate_modify_existing_partition.pm
@@ -22,13 +22,15 @@ sub run {
 
     select_console "root-console";
 
-    record_info("Check $test_data->{fs_type}", "Verify that the partition filesystem is $test_data->{fs_type}");
-    my $fstype = script_output("df -PT $test_data->{mount_point} | grep -v \"Filesystem\" | awk '{print \$2}'");
-    assert_equals($test_data->{fs_type}, $fstype);
+    foreach my $part (keys %$test_data) {
+        record_info("Check $test_data->{fs_type}", "Verify that the partition filesystem is $test_data->{$part}->{fs_type}");
+        my $fstype = script_output("df -PT $test_data->{$part}->{mount_point} | grep -v \"Filesystem\" | awk '{print \$2}'");
+        assert_matches(qr/$test_data->{$part}->{fs_type}/, $fstype, "$test_data->{$part}->{fs_type} does not match with $fstype");
 
-    record_info("Check size", "Verify that the partition size is $test_data->{part_size}");
-    my $partsize = script_output("lsblk | grep $test_data->{existing_partition} | awk '{print \$4}'");
-    assert_equals($test_data->{lsblk_expected_size_output}, $partsize);
+        record_info("Check size", "Verify that the partition size is $test_data->{$part}->{part_size}");
+        my $partsize = script_output("lsblk | grep $test_data->{$part}->{existing_partition} | awk '{print \$4}'");
+        assert_equals($test_data->{$part}->{lsblk_expected_size_output}, $partsize);
+    }
 }
 
 1;

--- a/tests/installation/partitioning/modify_existing_partition.pm
+++ b/tests/installation/partitioning/modify_existing_partition.pm
@@ -12,7 +12,7 @@
 
 use strict;
 use warnings;
-use parent 'installbasetest';
+use parent 'y2_installbase';
 use testapi;
 use version_utils ':VERSION';
 use scheduler 'get_test_data';
@@ -21,8 +21,11 @@ sub run {
     my $test_data   = get_test_data();
     my $partitioner = $testapi::distri->get_expert_partitioner();
     $partitioner->run_expert_partitioner();
-    $partitioner->resize_partition_on_gpt_disk($test_data);
-    $partitioner->edit_partition_on_gpt_disk($test_data);
+    $partitioner->resize_partition_on_gpt_disk($test_data->{root});
+    for my $part (keys %$test_data) {
+        record_info("modify $part", "$$test_data{$part}->{existing_partition}");
+        $partitioner->edit_partition_on_gpt_disk($$test_data{$part});
+    }
     $partitioner->accept_changes();
 }
 


### PR DESCRIPTION
- fix post_fail_hook
- modify sda1 to use fat and mount /boot/efi in arch
- fix validation

The **v4/ExpertPartitionerController.pm** 's _select_filesystem()_ can take an extra argument which helps to avoid to edit the filesystem. this is because functions like _edit_partition_on_gpt_disk_ can be used to make a change but a filesystem doesnt need to be modified. So in this particular case the test_data for boot partition contain a skip=1 which passed to the _select_filesystem_ and such the only call is the one which mount the partition in _edit_partition_on_gpt_disk._ 

Note that the test_data defines fs == 'fat' but the system defines it as vfat. Thats why the use of assert_matches. i just dont know if this is of any concern for our test_data.

I wrapped the send_key 'end' with wait_screen_change as there was weird behavior that illustrated [here](http://aquarius.suse.cz/tests/1033). this helps somehow but still can occur. That might a problem with the way i use needles or something, as i can see that it matches partitioning_raid-fat_format-selected but the maybe too early.

y2_installbase is used which fixes the logs' gathering.

- Related ticket: https://progress.opensuse.org/issues/59900
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1260
- Verification run: http://aquarius.suse.cz/tests/1038
BREAKING_CHANGES_VR: https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%239024&distri=sle&version=15-SP2