### PR TITLE
Change to use full installer for sles15sp2

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -89,8 +89,8 @@ sub repl_repo_in_sourcefile {
         }
         my $soucefile = "/usr/share/qa/virtautolib/data/" . "sources." . "$location";
         my $newrepo   = "http://openqa.suse.de/assets/repo/" . get_var("REPO_0");
-        # for sles15sp2, install host with Online installer, while install guest with Full installer
-        $newrepo =~ s/-Online-/-Full-/ if is_sle("15-sp2+");
+        # for sles15sp2+, install host with Online installer, while install guest with Full installer
+        $newrepo =~ s/-Online-/-Full-/ if ($verorig =~ /15-sp[2-9]/i);
         my $shell_cmd
           = "if grep $veritem $soucefile >> /dev/null;then sed -i \"s#^$veritem=.*#$veritem=$newrepo#\" $soucefile;else echo \"$veritem=$newrepo\" >> $soucefile;fi";
         if (check_var('ARCH', 's390x')) {
@@ -119,7 +119,15 @@ sub repl_module_in_sourcefile {
     my $replaced_item = get_required_var('ARCH') . ".$replaced_orig";
     $version =~ s/-sp0//;
     $version = uc($version);
-    my $daily_build_module = "http://openqa.suse.de/assets/repo/SLE-${version}-Module-\\2-POOL-" . get_required_var('ARCH') . "-Build" . get_required_var('BUILD') . "-Media1/";
+    my $daily_build_module = "http://openqa.suse.de/assets/repo/";
+    # for sles15sp2+, install host with Online installer, while install guest with Full installer
+    if ($version =~ /15-SP[2-9]/) {
+        $daily_build_module .= get_var("REPO_0") . "/Module-\\2/";
+        $daily_build_module =~ s/-Online-/-Full-/;
+    }
+    else {
+        $daily_build_module .= "SLE-${version}-Module-\\2-POOL-" . get_required_var('ARCH') . "-Build" . get_required_var('BUILD') . "-Media1/";
+    }
     my $source_file = "/usr/share/qa/virtautolib/data/sources.*";
     my $command     = "sed -ri 's#^(${replaced_item}).*\$#\\1$daily_build_module#g' $source_file";
     print "Debug: the command to execute is:\n$command \n";

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -89,6 +89,8 @@ sub repl_repo_in_sourcefile {
         }
         my $soucefile = "/usr/share/qa/virtautolib/data/" . "sources." . "$location";
         my $newrepo   = "http://openqa.suse.de/assets/repo/" . get_var("REPO_0");
+        # for sles15sp2, install host with Online installer, while install guest with Full installer
+        $newrepo =~ s/-Online-/-Full-/ if is_sle("15-sp2+");
         my $shell_cmd
           = "if grep $veritem $soucefile >> /dev/null;then sed -i \"s#^$veritem=.*#$veritem=$newrepo#\" $soucefile;else echo \"$veritem=$newrepo\" >> $soucefile;fi";
         if (check_var('ARCH', 's390x')) {


### PR DESCRIPTION
we used <repo_0> repo for both host installation and guest installation prior to sles15sp1. But since sles15sp2, there are two type of installation. we use online image for host installation and full image for guest installation. So we change to use full installer repo.

the link of installer and modules both to be modified to use full installation.

@alice-suse @xguo @waynechen55

- Failing tests: https://openqa.nue.suse.com/tests/3638054
- Verification run for replacing the repos for installer and modules:
gi-guest_sles12sp5-on-host_developing-kvm   http://10.67.18.253/tests/1538
gi-guest_developing-on-host_sles12sp5-kvm   http://10.67.18.253/tests/1539#