### PR TITLE
Wrapper for using runltp-ng on baremetal

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -248,7 +248,8 @@ sub packagekit_available {
 
 sub is_ltp_test {
     return (get_var('INSTALL_LTP')
-          || get_var('LTP_COMMAND_FILE'));
+          || get_var('LTP_COMMAND_FILE')
+          || get_var('LTP_RUNLTP_SUPPORT'));
 }
 
 sub is_kernel_test {

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -188,6 +188,9 @@ sub load_kernel_tests {
         boot_hdd_image();
         loadtest 'numa_irqbalance';
     }
+    elsif (get_var('LTP_RUNLTP_SUPPORT')) {
+        loadtest 'runltp_support';
+    }
 
     if (check_var('BACKEND', 'svirt') && get_var('PUBLISH_HDD_1')) {
         loadtest '../shutdown/svirt_upload_assets';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -628,7 +628,7 @@ if (is_jeos) {
 
 # load the tests in the right order
 if (is_kernel_test()) {
-    if (get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) {
+    if ((get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) || get_var('LTP_RUNLTP_SUPPORT')) {
         load_baremetal_tests();
     }
     load_kernel_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -628,7 +628,7 @@ if (is_jeos) {
 
 # load the tests in the right order
 if (is_kernel_test()) {
-    if ((get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) || get_var('LTP_RUNLTP_SUPPORT')) {
+    if (get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) {
         load_baremetal_tests();
     }
     load_kernel_tests();

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Wrap runltp-ng, should be run on baremetal workers
+#
+# Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use power_action_utils 'power_action';
+use lockapi;
+use ipmi_backend_utils;
+
+sub run {
+    my $self = shift;
+
+    $self->select_serial_terminal;
+
+    zypper_call('in git-core qemu squashfs xz');
+
+    assert_script_run('git clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git');
+    assert_script_run('cd runltp-support && curl -OL https://openqa.suse.de/assets/iso/' . get_var('ISO'));
+    assert_script_run('./install-setup-run-syzkaller.sh ' . get_var('SCC_REGCODE') . ' ' . get_var('ISO'),
+        timeout => 3600);
+    assert_script_run('cd runltp-ng && tar -c syzkaller* | xz -T 8 > results.tar.xz');
+    upload_logs('results.tar.xz');
+}
+
+1;

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -20,20 +20,62 @@ use power_action_utils 'power_action';
 use lockapi;
 use ipmi_backend_utils;
 
+sub ipmitool {
+    my ($cmd) = @_;
+
+    my @cmd = ('ipmitool', '-I', 'lanplus', '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
+    push(@cmd, split(/ /, $cmd));
+
+    my ($stdin, $stdout, $stderr, $ret);
+    print @cmd;
+    $ret = IPC::Run::run(\@cmd, \$stdin, \$stdout, \$stderr);
+    chomp $stdout;
+    chomp $stderr;
+
+    die join(' ', @cmd) . ": $stderr" unless ($ret);
+    bmwqemu::diag("IPMI: $stdout");
+    return $stdout;
+}
+
+sub poweroff_host {
+    ipmitool("chassis power off");
+    while (1) {
+        sleep(3);
+        my $stdout = ipmitool('chassis power status');
+        last if $stdout =~ m/is off/;
+        ipmitool('chassis power off');
+    }
+}
+
+sub poweron_host {
+    ipmitool("chassis power on");
+    while (1) {
+        sleep(3);
+        my $stdout = ipmitool('chassis power status');
+        last if $stdout =~ m/is on/;
+        ipmitool('chassis power on');
+    }
+}
+
 sub run {
     my $self = shift;
 
+    poweron_host;
+    select_console 'sol', await_console => 0;
+    assert_screen('linux-login', 1800);
     $self->select_serial_terminal;
 
-    zypper_call('in git-core qemu squashfs xz');
+    zypper_call('in git-core');
 
     assert_script_run('mount /dev/nvme0n1p2 /mnt && cd /mnt/var/tmp');
     assert_script_run('git clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git');
-    assert_script_run('cd runltp-support && curl -OL https://openqa.suse.de/assets/iso/' . get_var('ISO'));
+    assert_script_run('cd runltp-support && ./host-install.sh');
     assert_script_run('./install-setup-run-syzkaller.sh ' . get_var('SCC_REGCODE') . ' ' . get_var('ISO'),
         timeout => 3600);
     assert_script_run('./tar-up-results.sh');
     upload_logs('runltp-ng/results.tar.xz');
+
+    power_action('poweroff');
 }
 
 1;

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -67,8 +67,8 @@ sub run {
     zypper_call('in git-core');
 
     assert_script_run('mount /dev/nvme0n1p2 /mnt && cd /mnt/var/tmp');
-    script_run('git clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git');
-    assert_script_run('cd runltp-support && git pull --recurse-submodules && ./host-install.sh');
+    assert_script_run('git -c http.sslVerify=false clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git || git -C runltp-support -c http.sslVerify=false pull --recurse-submodules');
+    assert_script_run('cd runltp-support && ./host-install.sh');
     assert_script_run("./install-setup-run-syzkaller.sh $scc $iso", timeout => 10800);
     assert_script_run('./tar-up-results.sh');
     upload_logs('runltp-ng/results.tar.xz');

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -27,12 +27,13 @@ sub run {
 
     zypper_call('in git-core qemu squashfs xz');
 
+    assert_script_run('mount /dev/nvme0n1p2 /mnt && cd /mnt/var/tmp');
     assert_script_run('git clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git');
     assert_script_run('cd runltp-support && curl -OL https://openqa.suse.de/assets/iso/' . get_var('ISO'));
     assert_script_run('./install-setup-run-syzkaller.sh ' . get_var('SCC_REGCODE') . ' ' . get_var('ISO'),
         timeout => 3600);
-    assert_script_run('cd runltp-ng && tar -c syzkaller* | xz -T 8 > results.tar.xz');
-    upload_logs('results.tar.xz');
+    assert_script_run('./tar-up-results.sh');
+    upload_logs('runltp-ng/results.tar.xz');
 }
 
 1;

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -68,8 +68,8 @@ sub run {
     zypper_call('in git-core');
 
     assert_script_run('mount /dev/nvme0n1p2 /mnt && cd /mnt/var/tmp');
-    assert_script_run('git clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git');
-    assert_script_run('cd runltp-support && ./host-install.sh');
+    script_run('git clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git');
+    assert_script_run('cd runltp-support && git pull --recurse-submodules && ./host-install.sh');
     assert_script_run('./install-setup-run-syzkaller.sh ' . get_var('SCC_REGCODE') . ' ' . get_var('ISO'),
         timeout => 3600);
     assert_script_run('./tar-up-results.sh');

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -69,7 +69,7 @@ sub run {
     assert_script_run('mount /dev/nvme0n1p2 /mnt && cd /mnt/var/tmp');
     script_run('git clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git');
     assert_script_run('cd runltp-support && git pull --recurse-submodules && ./host-install.sh');
-    assert_script_run("./install-setup-run-syzkaller.sh $scc $iso", timeout => 3600);
+    assert_script_run("./install-setup-run-syzkaller.sh $scc $iso", timeout => 10800);
     assert_script_run('./tar-up-results.sh');
     upload_logs('runltp-ng/results.tar.xz');
 

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -70,6 +70,7 @@ sub run {
     assert_script_run('git -c http.sslVerify=false clone --recurse-submodules https://gitlab.suse.de/kernel-qa/runltp-support.git || git -C runltp-support -c http.sslVerify=false pull --recurse-submodules');
     assert_script_run('cd runltp-support && ./host-install.sh');
     assert_script_run("./install-setup-run-syzkaller.sh $scc $iso", timeout => 10800);
+    type_string("\n"); # Clear any characters which were somehow passed to the shell
     assert_script_run('./tar-up-results.sh');
     upload_logs('runltp-ng/results.tar.xz');
 

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -56,8 +56,8 @@ sub poweron_host {
 
 sub run {
     my $self = shift;
-    my $iso = basename(get_var('ISO'));
-    my $scc = get_var('SCC_REGCODE');
+    my $iso  = basename(get_var('ISO'));
+    my $scc  = get_var('SCC_REGCODE');
 
     poweron_host;
     select_console 'sol', await_console => 0;

--- a/tests/kernel/runltp_support.pm
+++ b/tests/kernel/runltp_support.pm
@@ -37,7 +37,6 @@ sub ipmitool {
 }
 
 sub poweroff_host {
-    ipmitool("chassis power off");
     while (1) {
         sleep(3);
         my $stdout = ipmitool('chassis power status');
@@ -47,7 +46,6 @@ sub poweroff_host {
 }
 
 sub poweron_host {
-    ipmitool("chassis power on");
     while (1) {
         sleep(3);
         my $stdout = ipmitool('chassis power status');


### PR DESCRIPTION
Minimal OpenQA test module for running the runltp-support scripts which
in-turn wrap runltp-ng and expect. To begin with this just targets the
syzkaller reproducers as most LTP tests run fine in OpenQA, however the
reproducers can crash the host (worker) in addition to the VM being tested.

Also there are 1000's of them and OpenQA struggles to handle logging this many
tests. For the same reason the OpenPOSIX tests will benefit from being run
like this, but they are not supported yet.

- Related ticket: https://progress.opensuse.org/issues/58604

