### PR TITLE
Move version_switch_origin_system to beginning of online migration test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -449,7 +449,6 @@ sub load_online_migration_tests {
     # switch VERSION to ensure migrate to expected target for online migration
     set_var('ORIGIN_SYSTEM_VERSION', get_var('HDDVERSION'));
     set_var('UPGRADE_TARGET_VERSION', get_var('VERSION')) if (!get_var('UPGRADE_TARGET_VERSION'));
-    loadtest "migration/version_switch_origin_system";
 
     loadtest "migration/sle12_online_migration/register_system";
     # do full/minimal update before migration
@@ -1107,6 +1106,7 @@ else {
         load_zdup_tests();
     }
     elsif (get_var("ONLINE_MIGRATION")) {
+        loadtest "migration/version_switch_origin_system";
         load_boot_tests();
         load_online_migration_tests();
     }


### PR DESCRIPTION
We need set the correct VERSION on base system for online migration test, so move version_switch_origin_system to the beginning of online migration test.

- Related ticket: https://progress.opensuse.org/issues/60428
- Needles: N/A
- Verification run: http://10.161.8.44/tests/737#
