### PR TITLE
Add declarative schedule for multipath image creation

### DIFF
--- a/schedule/kernel/create_hdd_multipath_lvm_encrypt_textmode.yaml
+++ b/schedule/kernel/create_hdd_multipath_lvm_encrypt_textmode.yaml
@@ -1,0 +1,43 @@
+name:           multipath
+description:    >
+    Prepare image with multipath, lvm and encryption enabled for kernel
+    testing.
+vars:
+    DESKTOP: textmode
+    MULTIPATH: 1
+    LVM: 1
+    ENCRYPT: 1
+    HDDMODEL: scsi-hd
+    SEPARATE_HOME: 0
+    INSTALLONLY: 1
+schedule:
+    - installation/bootloader_start
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/multipath
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning/encrypt_lvm
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/hostname_inst
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/grub_test
+    - installation/first_boot
+    - console/sle15_workarounds
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/kernel/create_hdd_multipath_lvm_textmode.yaml
+++ b/schedule/kernel/create_hdd_multipath_lvm_textmode.yaml
@@ -1,0 +1,41 @@
+name:           multipath
+description:    >
+    Prepare image with multipath and lvm enabled for kernel testing.
+vars:
+    DESKTOP: textmode
+    MULTIPATH: 1
+    LVM: 1
+    HDDMODEL: scsi-hd
+    SEPARATE_HOME: 0
+    INSTALLONLY: 1
+schedule:
+    - installation/bootloader_start
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/multipath
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning/lvm_no_separate_home
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/hostname_inst
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/grub_test
+    - installation/first_boot
+    - console/sle15_workarounds
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/kernel/create_hdd_multipath_textmode.yaml
+++ b/schedule/kernel/create_hdd_multipath_textmode.yaml
@@ -1,0 +1,40 @@
+name:           multipath
+description:    >
+    Prepare image with multipath enabled for kernel testing.
+vars:
+    DESKTOP: textmode
+    MULTIPATH: 1
+    HDDMODEL: scsi-hd
+    SEPARATE_HOME: 0
+    INSTALLONLY: 1
+schedule:
+    - installation/bootloader_start
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/multipath
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning/no_separate_home
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/hostname_inst
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/grub_test
+    - installation/first_boot
+    - console/sle15_workarounds
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown


### PR DESCRIPTION
Fix poo#60326: Multipath image creation for kernel testing was
implemented inside main.pm. Logic was moved to yaml declarative schedule.

- Related ticket: https://progress.opensuse.org/issues/60326
- Needles: none
- Verification run:
create_hdd_multipath_textmode: http://10.100.12.105/tests/360
create_hdd_multipath_lvm_textmode http://10.100.12.105/tests/3607
create_hdd_multipath_lvm_encryp_textmode http://10.100.12.105/tests/3606 (failure expected)
