### PR TITLE
DRY wait_boot/first_boot

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -699,25 +699,9 @@ sub handle_emergency_if_needed {
 
 sub handle_displaymanager_login {
     my ($self, %args) = @_;
-    diag("handle_displaymanager_login: \$ready_time: $args{ready_time}, \$nologin: $args{nologin}");
     assert_screen [qw(displaymanager emergency-shell emergency-mode)], $args{ready_time};
     handle_emergency_if_needed;
-    return if $args{nologin};
-    # SLE11 SP4 kde desktop do not need type username
-    if (get_var('DM_NEEDS_USERNAME')) {
-        type_string "$username\n";
-    }
-    # log in
-    elsif (check_var('DESKTOP', 'gnome')) {
-        # In GNOME/gdm, we do not have to enter a username, but we have to select it
-        unless (is_sle('<=15-sp1') || is_leap('<=15.1')) {
-            send_key 'tab';
-        }
-        send_key 'ret';
-    }
-
-    assert_screen 'displaymanager-password-prompt', no_wait => 1;
-    type_password $password. "\n";
+    handle_login unless $args{nologin};
 }
 
 sub handle_grub {
@@ -818,7 +802,6 @@ sub wait_boot_past_bootloader {
     my $ready_time   = $args{ready_time} // (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 500 : 300;
     my $nologin      = $args{nologin};
     my $forcenologin = $args{forcenologin};
-    diag("wait_boot_past_bootloader: \$textmode: $textmode, \$ready_time: $ready_time, \$nologin: $nologin, \$forcenologin: $forcenologin");
 
     # On IPMI, when selecting x11 console, we are connecting to the VNC server on the SUT.
     # select_console('x11'); also performs a login, so we should be at generic-desktop.

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -167,7 +167,6 @@ sub handle_login {
     save_screenshot();
     # wait for DM, avoid screensaver and try to login
     send_key_until_needlematch('displaymanager', 'esc', 30, 3);
-    wait_still_screen;
     if (get_var('ROOTONLY')) {
         if (check_screen 'displaymanager-username-notlisted', 10) {
             record_soft_failure 'bgo#731320/boo#1047262 "not listed" Login screen for root user is not intuitive';
@@ -194,7 +193,7 @@ sub handle_login {
         wait_screen_change { assert_and_click 'displaymanager-password-prompt' };
     }
     type_password;
-    send_key "ret";
+    send_key 'ret';
 }
 
 =head2 handle_logout

--- a/schedule/boot_to_snapshot.yaml
+++ b/schedule/boot_to_snapshot.yaml
@@ -6,4 +6,3 @@ vars:
 schedule:
     - installation/grub_test
     - installation/boot_into_snapshot
-    - installation/first_boot

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -39,14 +39,6 @@ sub run {
         select_console('x11');
     }
     my $boot_timeout = (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 450 : 200;
-    if (check_var('WORKER_CLASS', 'hornet')) {
-        # hornet does not show the console output
-        diag "waiting $boot_timeout seconds to let hornet boot and finish initial script";
-        sleep $boot_timeout;
-        reset_consoles;
-        select_console 'root-ssh';
-        return;
-    }
     elsif ((get_var('DESKTOP', '') =~ /textmode|serverro/) || get_var('BOOT_TO_SNAPSHOT')) {
         assert_screen('linux-login', $boot_timeout) unless check_var('ARCH', 's390x');
         return;

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -12,95 +12,17 @@
 #          the installation has been completed (either find the desktop after
 #          auto-login or handle the login screen to reach the desktop)
 # - Wait for login screen
-# - Select console type, x11 or ssh
 # - Handle displaymanager
 # - Handle login screen
 # - Check if generic-desktop was reached
-# - Disable wayland
 # Maintainer: Max Lin <mlin@suse.com>
 
 use strict;
 use warnings;
 use base 'bootbasetest';
-use testapi;
-use utils 'handle_emergency';
-use version_utils qw(is_sle is_leap is_desktop_installed is_upgrade is_sles4sap);
-use x11utils qw(ensure_unlocked_desktop handle_login);
-use main_common 'opensuse_welcome_applicable';
 
 sub run {
-    my ($self) = @_;
-    # On IPMI, when selecting x11 console, we are connecting to the VNC server on the SUT.
-    # select_console('x11'); also performs a login, so we should be at generic-desktop.
-    my $gnome_ipmi = (check_var('BACKEND', 'ipmi') && check_var('DESKTOP', 'gnome'));
-    if ($gnome_ipmi) {
-        # first boot takes sometimes quite long time, ensure that it reaches login prompt
-        $self->wait_boot(textmode => 1);
-        select_console('x11');
-    }
-    my $boot_timeout = (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 450 : 200;
-    elsif ((get_var('DESKTOP', '') =~ /textmode|serverro/) || get_var('BOOT_TO_SNAPSHOT')) {
-        assert_screen('linux-login', $boot_timeout) unless check_var('ARCH', 's390x');
-        return;
-    }
-    # On SLES4SAP upgrade tests with desktop, only check for a DM screen with the SAP System
-    # Administrator user listed but do not attempt to login
-    if (get_var('HDDVERSION') and is_desktop_installed() and is_upgrade() and is_sles4sap()) {
-        assert_screen 'displaymanager-sapadm', $boot_timeout;
-        return;
-    }
-    # On IPMI, when selecting x11 console, we are already logged in.
-    if ((get_var("NOAUTOLOGIN") || get_var("IMPORT_USER_DATA")) && !$gnome_ipmi) {
-        assert_screen [qw(displaymanager emergency-shell emergency-mode)], $boot_timeout;
-        handle_emergency if (match_has_tag('emergency-shell') or match_has_tag('emergency-mode'));
-        handle_login;
-    }
-
-    my @tags = qw(generic-desktop);
-    push(@tags, qw(opensuse-welcome)) if opensuse_welcome_applicable;
-    # boo#1102563 - autologin fails on aarch64 with GNOME on current Tumbleweed
-    if (!is_sle('<=15') && !is_leap('<=15.0') && check_var('ARCH', 'aarch64') && check_var('DESKTOP', 'gnome')) {
-        push(@tags, 'displaymanager');
-    }
-    # bsc#1157928 - deal with additional polkit windows
-    if (is_sle && !is_sle('<=15-SP1')) {
-        push(@tags, 'authentication-required-user-settings');
-    }
-
-    # GNOME and KDE get into screenlock after 5 minutes without activities.
-    # using multiple check intervals here then we can get the wrong desktop
-    # screenshot at least in case desktop screenshot changed, otherwise we get
-    # the screenlock screenshot.
-    my $timeout        = 600;
-    my $check_interval = 30;
-    while ($timeout > $check_interval) {
-        my $ret = check_screen \@tags, $check_interval;
-        last if $ret;
-        $timeout -= $check_interval;
-    }
-    # the last check after previous intervals must be fatal
-    assert_screen \@tags, $check_interval;
-    if (match_has_tag('displaymanager')) {
-        record_soft_failure 'boo#1102563 - GNOME autologin broken. Handle login and disable Wayland for login page to make it work next time';
-        handle_login;
-        assert_screen 'generic-desktop';
-        # Force the login screen to use Xorg to get autologin working
-        # (needed for additional tests using boot_to_desktop)
-        x11_start_program('xterm');
-        wait_still_screen;
-        script_sudo('sed -i s/#WaylandEnable=false/WaylandEnable=false/ /etc/gdm/custom.conf');
-        wait_screen_change { send_key 'alt-f4' };
-    }
-    if (match_has_tag('authentication-required-user-settings')) {
-        record_soft_failure 'bsc#1157928 - deal with additional polkit windows';
-        wait_still_screen(3);
-        ensure_unlocked_desktop;
-        # deal with potential followup authentication window which is not
-        # actually a login screen but polkit asking for modification to system
-        # repositories
-        wait_still_screen(3);
-        ensure_unlocked_desktop;
-    }
+    shift->wait_boot_past_bootloader;
 }
 
 sub test_flags {


### PR DESCRIPTION
* Merge 'first_boot' and 'wait_boot' as much as possible
* wait_boot: Simplify by extracting methods
* first_boot: Remove obsolete temporary workaround for machine "hornet"
* Remove redundant module "first_boot" from "boot_to_snapshot" schedule

Verification runs:
* [opensuse-Tumbleweed-DVD-x86_64-extra_tests_on_kde_okurz_only_multi-users-dm@64bit](https://openqa.opensuse.org/tests/1099140)
* [gnome-gdm](https://openqa.opensuse.org/tests/1099076)
* [cryptlvm-uefi](https://openqa.opensuse.org/tests/1099077)
* [sle-15-SP2-create_hdd_sles4sap_textmode](https://openqa.suse.de/tests/3644110)
* [sle-12-SP5-SAP-DVD-x86_64-create_hdd_sles4sap_textmode](https://openqa.suse.de/tests/3644087)
* [sle-12-SP5-Server-DVD-x86_64-autologin_yast@64bit](https://openqa.suse.de/tests/3644089)
* [sle-12-SP5-Server-DVD-ppc64le-cryptlvm@ppc64le](https://openqa.suse.de/tests/3644091)
* [sle-12-SP5-Server-DVD-aarch64-cryptlvm@aarch64](https://openqa.suse.de/tests/3644092)
* [sle-12-SP5-Server-DVD-s390x-xfs@s390x-kvm-sle12](https://openqa.suse.de/tests/3644093)
* [sle-12-SP5-Server-DVD-s390x-xfs@s390x-zVM-vswitch-l2](https://openqa.suse.de/tests/3644094)
* [sle-12-SP4-Desktop-DVD-Updates-x86_64-qam-gnome@64bit](https://openqa.suse.de/tests/3644095)
* [sle-12-SP4-Server-DVD-Updates-x86_64-qam-textmode@64bit](https://openqa.suse.de/tests/3644096)
* [sle-15-Server-DVD-Updates-x86_64-mru-install-minimal-with-addons@64bit](https://openqa.suse.de/tests/3644097)
* [sle-15-Server-DVD-Updates-x86_64-qam-gnome@64bit](https://openqa.suse.de/tests/3644098)
* [opensuse-Tumbleweed-DVD-x86_64-boot_to_snapshot@64bit](https://openqa.opensuse.org/tests/1099074)
* [opensuse-Tumbleweed-DVD-x86_64-gnome@64bit](https://openqa.opensuse.org/tests/1098513)
* [opensuse-Tumbleweed-DVD-x86_64-kde@64bit](https://openqa.opensuse.org/tests/1098471)
* [opensuse-Tumbleweed-DVD-x86_64-minimalx@64bit](https://openqa.opensuse.org/tests/1098472)
* [opensuse-Tumbleweed-DVD-x86_64-textmode@64bit](https://openqa.opensuse.org/tests/1098473)
* [opensuse-Tumbleweed-DVD-x86_64-upgrade_Leap_15.1_gnome@64bit](https://openqa.opensuse.org/tests/1099143)
* [opensuse-Tumbleweed-DVD-x86_64-extra_tests_on_kde@64bit](https://openqa.opensuse.org/tests/1099141)
* [opensuse-Tumbleweed-DVD-x86_64-extra_tests_on_gnome@64bit](https://openqa.opensuse.org/tests/1099142)
* [opensuse-Tumbleweed-DVD-x86_64-extra_tests_in_textmode_okurz@64bit](https://openqa.opensuse.org/tests/1099075)

Related progress issue: https://progress.opensuse.org/issues/60401