### PR TITLE
Fix create_hdd_multipath_lvm_encrypt_textmode schedule

### DIFF
--- a/schedule/kernel/create_hdd_multipath_lvm_encrypt_textmode.yaml
+++ b/schedule/kernel/create_hdd_multipath_lvm_encrypt_textmode.yaml
@@ -33,6 +33,7 @@ schedule:
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
     - installation/grub_test
+    - installation/boot_encrypt
     - installation/first_boot
     - console/sle15_workarounds
     - console/hostname


### PR DESCRIPTION
Fix create_hdd_multipath_lvm_encrypt_textmode schedule, boot_encrypt was missing.
Failure: https://openqa.suse.de/tests/3644600

- Related ticket: https://progress.opensuse.org/issues/60326 
- Needles: none
- Verification run:
http://10.100.12.105/tests/3609

