### PR TITLE
Fix boot on encrypted disk for SLE15+

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -356,7 +356,7 @@ sub is_staging {
 Returns true if storage_ng is used
 =cut
 sub is_storage_ng {
-    return get_var('STORAGE_NG');
+    return get_var('STORAGE_NG') || is_sle('15+');
 }
 
 =head2 is_upgrade


### PR DESCRIPTION
Fix poo#60083: Disk on SLE15+ is fully encrypted. Condition
was not matching this situation properly and password request to
unlock the disk was skipped.

- Related ticket: https://progress.opensuse.org/issues/60083
- Needles: none
- Verification run: 
x86_64:
SLE15: http://10.100.12.105/tests/3611
SLE12: http://10.100.12.105/tests/3612
aarch64:
SLE15: https://openqa.suse.de/t3644735
SLE12: not applicable
ppc64le:
SLE15: https://openqa.suse.de/tests/3644727
SLE12: https://openqa.suse.de/tests/3644728

Installation tests:
SLE15: http://10.100.12.105/tests/3619
SLE12: http://10.100.12.105/tests/3621