### PR TITLE
Do not send alt-f4 since the qt window closes itself (poo#58763)

### DIFF
--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -64,7 +64,6 @@ sub run {
     assert_script_run 'qmake-qt5';
     assert_script_run 'make';
     assert_script_run './libqt5-qtbase';
-    wait_screen_change { send_key 'alt-f4' };
     type_string "exit\n";
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/58763
- Verification run: 
  * x86_64: https://openqa.opensuse.org/t1101801
  * aarch64: https://openqa.opensuse.org/t1101802