### PR TITLE
Add RDP remote desktop cases to TW (TW as server)

### DIFF
--- a/tests/x11/remote_desktop/windows_client_remotelogin.pm
+++ b/tests/x11/remote_desktop/windows_client_remotelogin.pm
@@ -16,7 +16,7 @@ use warnings;
 use base 'x11test';
 use testapi;
 use lockapi;
-use version_utils 'is_sles4sap';
+use version_utils qw(is_sles4sap is_tumbleweed);
 
 sub run {
     my $self = shift;
@@ -41,7 +41,8 @@ sub run {
     send_key "ret";
 
     assert_screen "xrdp-sharing-activate", 120;
-    if (is_sles4sap) {
+
+    if (is_sles4sap || is_tumbleweed) {
         x11_start_program('gnome-session-quit --logout --force', valid => 0);
     }
     else {

--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -21,7 +21,7 @@ use mm_tests;
 use base 'opensusebasetest';
 use utils qw(systemctl zypper_call);
 use x11utils qw(handle_login turn_off_gnome_screensaver);
-use version_utils qw(is_sle is_sles4sap);
+use version_utils qw(is_sle is_sles4sap is_tumbleweed);
 
 sub run {
     my ($self) = @_;
@@ -33,7 +33,12 @@ sub run {
     become_root;
 
     # Setup static NETWORK
-    configure_static_network('10.0.2.17/24');
+    if (is_tumbleweed) {
+        $self->configure_static_ip_nm('10.0.2.17/24');
+    }
+    else {
+        configure_static_network('10.0.2.17/24');
+    }
 
     if (is_sles4sap) {
         # xrdp should already be installed in SLES4SAP
@@ -78,10 +83,12 @@ sub run {
     mouse_click if get_var('OFW');
     send_key_until_needlematch 'displaymanager', 'esc';
 
-    if (is_sles4sap) {
-        # We don't have to test the reconnection and reboot part in SLES4SAP
+    if (is_sles4sap || is_tumbleweed) {
+        # We don't have to test the reconnection and reboot part in SLES4SAP and TW
+        send_key "tab" if is_tumbleweed;
         handle_login;
     }
+
     else {
         send_key 'ret';
         assert_screen "displaymanager-password-prompt";
@@ -98,6 +105,7 @@ sub run {
         if (match_has_tag('other-users-logged-in-2users')) {
             record_soft_failure 'bsc#1116281 GDM didnt behave correctly when the error message Multiple logins are not supported. is triggered';
         }
+
         assert_and_click "force-restart";
         type_password;
         send_key "ret";


### PR DESCRIPTION
This pair of tests covered TW as the server and windows as the client
Reconnection and reboot part is not covered

- Related ticket: 
  https://progress.opensuse.org/issues/59010
- Needles: 
  https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/621
- Verification run: 
  http://10.67.19.11/tests/1539
  http://10.67.19.11/tests/1538
