### PR TITLE
Fix dns entry in multipath autoyast profile

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -144,8 +144,7 @@ pre init scripts feature. See poo#20818.
       <hostname>vtest3</hostname>
       <domain>suse.de</domain>
       <nameservers config:type="list">
-        <nameserver>8.8.8.8</nameserver>
-        <nameserver></nameserver>
+        <nameserver>10.0.2.3</nameserver>
       </nameservers>
       <searchlist config:type="list">
       </searchlist>


### PR DESCRIPTION
Google's DNS doesn't resolve openqa.suse.de, which is expected.

[Verification run](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23ay&distri=sle&version=15-SP2).
