### PR TITLE
Drop livecd_network_settings on Leap 15.2 now as well

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -877,8 +877,8 @@ sub load_inst_tests {
         loadtest 'installation/releasenotes_origin' if get_var('CHECK_RELEASENOTES_ORIGIN');
     }
     if (noupdatestep_is_applicable()) {
-        # On TW Lives and Argon there is no network configuration stage
-        if (get_var("LIVECD") && is_leap && !is_krypton_argon) {
+        # On Leap 15.2/TW Lives and Argon there is no network configuration stage
+        if (get_var("LIVECD") && is_leap("<=15.1") && !is_krypton_argon) {
             loadtest "installation/livecd_network_settings";
         }
         # See https://github.com/yast/yast-packager/pull/385


### PR DESCRIPTION
The YaST change also ended up there now.

Verification run: http://10.160.67.86/tests/623
