### PR TITLE
Add softfailure for crm_mon -s regression

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -322,7 +322,8 @@ sub check_cluster_state {
     assert_script_run "$crm_mon_cmd";
     assert_script_run "$crm_mon_cmd | grep -i 'no inactive resources'" if is_sle '12-sp3+';
     assert_script_run 'crm_mon -1 | grep \'partition with quorum\'';
-    assert_script_run q/crm_mon -s | grep "$(crm node list | grep -c ': member') nodes online"/;
+    assert_script_run q/crm_mon -s | grep "$(crm node list | grep -c ': member').*nodes online"/;
+    record_soft_failure 'bsc#1158180, regression in crm_mon -s output' if is_sle('>=15-sp2');
     # As some options may be deprecated, test shouldn't die on 'crm_verify'
     if (get_var('HDDVERSION')) {
         script_run 'crm_verify -LV';


### PR DESCRIPTION
Add a record_soft_failure in 15sp2 for crm_mon -s.
Output has changed and developer told me it's a regression (bsc#1158180)

- Related ticket: N/A
- Needles: N/A
- Verification run: 
15SP2: [Node1](http://1a102.qa.suse.de/tests/1633) [Node2](http://1a102.qa.suse.de/tests/1634)
12SP5 (regression test): [Node1](http://1a102.qa.suse.de/tests/1639) [Node2](http://1a102.qa.suse.de/tests/1640)
