### PR TITLE
Fix ready_time variable for SAP

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -818,7 +818,7 @@ sub wait_boot_past_bootloader {
     # On SLES4SAP upgrade tests with desktop, only check for a DM screen with the SAP System
     # Administrator user listed but do not attempt to login
     if (get_var('HDDVERSION') and is_desktop_installed() and is_upgrade() and is_sles4sap()) {
-        assert_screen 'displaymanager-sapadm', $$ready_time;
+        assert_screen 'displaymanager-sapadm', $ready_time;
         return;
     }
 


### PR DESCRIPTION
Fix a small regression added in PR#9035.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/3651670#step/boot_to_desktop/5
- Verification run: Not needed
