### PR TITLE
Enable minimal autoyast installation on spvm

### DIFF
--- a/data/autoyast_sle15/mini_remote.xml
+++ b/data/autoyast_sle15/mini_remote.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- minimal autoyast profile with sshd service explicitly enabled for the remote installation -->
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons config:type="list">
+            <addon>
+                <name>sle-module-basesystem</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <services-manager>
+        <default_target>multi-user</default_target>
+        <services>
+            <enable config:type="list">
+                <service>sshd</service>
+            </enable>
+            <on_demand config:type="list"/>
+        </services>
+    </services-manager>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+</profile>

--- a/schedule/yast/autoyast_mini_spvm.yaml
+++ b/schedule/yast/autoyast_mini_spvm.yaml
@@ -1,0 +1,22 @@
+name:           autoyast_mini
+description:    >
+    Parent job produces autoyast profile after successful completion.
+    This test uses generated profile to do autoyast installation.
+vars:
+    AUTOYAST: autoyast_sle15/mini_remote.xml
+    AUTOYAST_CONFIRM: 1
+    DESKTOP: textmode
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot


### PR DESCRIPTION
Backend required some tricks to enable autoyast tests on it. Also, minimal profile doesn't enable sshd by default, so that we had to have one thing more in the minimal profile.

See [poo#60044](https://progress.opensuse.org/issues/60044).

- [Verification run](https://openqa.suse.de/tests/3655580#).
