### PR TITLE
Update generalhw handling to handle ssh (no VNC) version

### DIFF
--- a/data/generalhw_scripts/flash_usb_otg.sh
+++ b/data/generalhw_scripts/flash_usb_otg.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Print commands
+set -ex
+
+# You need to copy ssh pub keys to the flasher for root and geekotest user if this is not the openQA worker
+# ssh-copy-id -i ~/.ssh/id_rsa.pub root@192.168.0.35
+# ssh-copy-id -i ~/.ssh/id_rsa.pub geekotest@192.168.0.35
+
+# Get parameters
+# Image: *.raw.xz or *.iso file
+image_to_flash=$1
+# Destination: <IP_or_hostname>:/storage/
+destination=$2
+# Size to resize (optionnal, default to 24G)
+size=${3:-24G}
+# user
+username=$(whoami)
+
+
+if [ -z "$1" ] || [ -z "$2" ]
+  then
+    echo "Please provide <image to flash> and <destination> as arguments. Optionnaly, <size> to resize the image, if needed (default is 24G)."
+    exit 1;
+fi
+
+# Extract IP/hostanme from $destination
+IFS=: read -r flasher_ip destination_folder <<< "$destination"
+image_to_flash_full_path="$destination_folder/$(basename $image_to_flash)"
+
+image_to_flash_extension="${image_to_flash##*.}"
+uncompressed_filename=$(basename $image_to_flash_full_path .xz)
+
+umount_previous_image="modprobe -r g_mass_storage || true"
+mount_current_image="modprobe g_mass_storage file=$destination_folder/$uncompressed_filename removable=1 || true"
+
+
+echo "Flash script start...";
+
+# Disconnect previous image, if any
+ssh root@$flasher_ip $umount_previous_image
+echo "** USB disk disconnected"
+
+# Cleanup target folder
+ssh $username@$flasher_ip rm -f $destination_folder/*.{raw,xz,iso}
+
+# Copy current image
+scp $image_to_flash $username@$destination
+# Extract compressed image, if needed
+if [[ "$image_to_flash_extension" == "xz" ]]; then
+	ssh $username@$flasher_ip unxz $image_to_flash_full_path
+	echo "**** xz image uncompressed"
+	# Resize *.raw image
+	ssh $username@$flasher_ip qemu-img resize $destination_folder/$uncompressed_filename $size
+	echo "**** raw image resized to $size"
+fi
+echo "** USB disk flashed"
+
+
+# Mount current image
+ssh root@$flasher_ip $mount_current_image
+echo "** USB disk connected"
+
+echo "Flash script done!";

--- a/data/generalhw_scripts/get_sol_ttyUSB0.sh
+++ b/data/generalhw_scripts/get_sol_ttyUSB0.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# exit when any command fails
+# set -e
+
+device=/dev/ttyUSB0
+speed=115200
+
+# Set up device
+stty -F $device $speed
+
+# Read the device $device in the background
+# tail -f $device &
+cat < $device &
+
+# Capture PID of background process so it is possible to terminate it when done
+bgPid=$!
+
+trap cleanup SIGINT SIGTERM SIGKILL
+
+cleanup()
+{
+  # Terminate background read process
+  kill $bgPid
+  exit 1
+}
+
+# Read commands from user, send them to device $device
+while read cmd
+do
+   echo "$cmd" 
+done > $device
+
+cleanup;

--- a/data/generalhw_scripts/power_off_tenma.sh
+++ b/data/generalhw_scripts/power_off_tenma.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Powering OFF"
+
+# Update path where https://github.com/kxtells/tenma-serial is cloned
+tool_path=/tmp/tenma-serial/tenma
+device=/dev/ttyACM0
+
+pushd $tool_path/
+python tenmaControl.py --off $device
+popd

--- a/data/generalhw_scripts/power_on_tenma.sh
+++ b/data/generalhw_scripts/power_on_tenma.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+echo "Powering ON"
+
+# Update path where https://github.com/kxtells/tenma-serial is cloned
+tool_path=/tmp/tenma-serial/tenma
+device=/dev/ttyACM0
+
+current_ma=3100 # 3.1A
+voltage_mv=5000 # 5V
+
+pushd $tool_path/
+python tenmaControl.py -c $current_ma -v $voltage_mv --verbose  $device # Set voltage and max current
+python tenmaControl.py --on $device # Switch ON
+popd

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -35,6 +35,7 @@ use constant {
         qw(
           is_remote_backend
           has_ttys
+          has_serial_over_ssh
           is_hyperv
           is_hyperv_in_gui
           is_svirt_except_s390x
@@ -106,6 +107,16 @@ Returns true if the current instance is using ttys for: ipmi, s390x, spvm, excep
 
 sub has_ttys {
     return ((get_var('BACKEND', '') !~ /ipmi|s390x|spvm/) && !get_var('S390_ZKVM'));
+}
+
+=head2 has_serial_over_ssh
+
+Returns true if the current instance is using a serial through ssh
+
+=cut
+
+sub has_serial_over_ssh {
+    return ((get_var('BACKEND', '') =~ /^(ikvm|ipmi|spvm|generalhw)/) && !defined(get_var('GENERAL_HW_VNC_IP')) && !defined(get_var('GENERAL_HW_SOL_CMD')));
 }
 
 =head2 is_hyperv

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -6,6 +6,7 @@ use testapi;
 use strict;
 use warnings;
 use utils;
+use Utils::Backends 'has_serial_over_ssh';
 use lockapi 'mutex_wait';
 use serial_terminal 'get_login_message';
 use version_utils qw(is_sle is_leap is_upgrade is_aarch64_uefi_boot_hdd is_tumbleweed is_jeos is_sles4sap is_desktop_installed);
@@ -1014,11 +1015,13 @@ sub select_serial_terminal {
         } else {
             $console = $root ? 'root-sut-serial' : 'sut-serial';
         }
-    } elsif ($backend =~ /^(ikvm|ipmi|spvm)$/) {
+    } elsif (has_serial_over_ssh) {
         $console = 'root-ssh';
+    } elsif ($backend eq 'generalhw' && !has_serial_over_ssh) {
+        $console = $root ? 'root-console' : 'user-console';
     }
 
-    die "No support for backend '$backend', add it" if ($console eq '');
+    die "No support for backend '$backend', add it" if (!defined $console) || ($console eq '');
     select_console($console);
 }
 

--- a/tests/jeos/prepare_firstboot.pm
+++ b/tests/jeos/prepare_firstboot.pm
@@ -17,23 +17,55 @@ use testapi;
 use utils 'zypper_call';
 
 sub run {
-    # Login with default credentials (root:linux)
-    assert_screen('linux-login', 300);
-    type_string("root\n",  wait_still_screen => 5);
-    type_string("linux\n", wait_still_screen => 5);
+    my ($self) = @_;
 
-    # Ensure YaST2-Firstboot is disabled, as we use jeos-firstboot in openQA
-    assert_script_run("systemctl disable YaST2-Firstboot");
+    my $default_password          = 'linux';
+    my $distripassword            = $testapi::password;
+    my $reboot_for_jeos_firstboot = 1;
+
+    my $is_generalhw_via_ssh = check_var('BACKEND', 'generalhw') && !defined(get_var('GENERAL_HW_VNC_IP'));
+
+    if ($is_generalhw_via_ssh) {
+        # Run jeos-firstboot manually and do not reboot as we use SSH
+        $reboot_for_jeos_firstboot = 0;
+
+        # Handle default credentials for ssh login
+        $testapi::password = $default_password;
+        $self->select_serial_terminal;
+    }
+    else {
+        # Login with default credentials (root:linux)
+        assert_screen('linux-login', 300);
+        type_string("root\n",              wait_still_screen => 5);
+        type_string("$default_password\n", wait_still_screen => 5);
+    }
 
     # Install and enable jeos-firstboot
     zypper_call('in jeos-firstboot');
-    assert_script_run("touch /var/lib/YaST2/reconfig_system");
-    assert_script_run("systemctl enable jeos-firstboot");
 
+    if ($is_generalhw_via_ssh) {
+        # Do not set eth0 down as we are connected through ssh!
+        assert_script_run("sed -i 's/ip link set down \"\$d\" #/if [ \"eth0\" != \"\$d\" ]; then ip link set down \"\$d\"; fi; #/' /usr/lib/jeos-firstboot");
+    }
     # Remove current root password
     assert_script_run("sed -i 's/^root:[^:]*:/root:*:/' /etc/shadow", 600);
 
-    type_string("reboot\n");
+    # Restore expected password, to be used by jeos-firstboot
+    $testapi::password = $distripassword;
+
+    if ($reboot_for_jeos_firstboot) {
+        # Ensure YaST2-Firstboot is disabled, as we use jeos-firstboot in openQA
+        assert_script_run("systemctl disable YaST2-Firstboot");
+        assert_script_run("systemctl enable jeos-firstboot");
+
+        assert_script_run("touch /var/lib/YaST2/reconfig_system");
+
+        type_string("reboot\n");
+    }
+    else {
+        type_string("/usr/lib/jeos-firstboot\n");
+    }
+
 }
 
 1;


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/60518
Requires https://github.com/os-autoinst/os-autoinst/pull/1304 (merged)
Verification runs:
* locally with generalhw via ssh (no VNC) with a RPi3 B (requires `EXCLUDE_MODULES=bootloader_uefi`)
* check that aarch64 JeOS test on qemu is not broken: https://openqa.opensuse.org/tests/1116650
