### PR TITLE
Public Cloud: Adapt TF files to new Terraform version

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -39,9 +39,9 @@ variable "storage-account" {
 }
 
 resource "random_id" "service" {
-    count = "${var.instance_count}"
+    count = var.instance_count
     keepers = {
-        name = "${var.name}"
+        name = var.name
     }
     byte_length = 8
 }
@@ -49,10 +49,10 @@ resource "random_id" "service" {
 
 resource "azurerm_resource_group" "openqa-group" {
     name     = "${var.name}-${element(random_id.service.*.hex, 0)}"
-    location = "${var.region}"
+    location = var.region
 
     tags = {
-        openqa_created_by = "${var.name}"
+        openqa_created_by = var.name
         openqa_created_date = "${timestamp()}"
         openqa_created_id = "${element(random_id.service.*.hex, 0)}"
     }
@@ -61,29 +61,29 @@ resource "azurerm_resource_group" "openqa-group" {
 resource "azurerm_virtual_network" "openqa-network" {
     name                = "${azurerm_resource_group.openqa-group.name}-vnet"
     address_space       = ["10.0.0.0/16"]
-    location            = "${var.region}"
-    resource_group_name = "${azurerm_resource_group.openqa-group.name}"
+    location            = var.region
+    resource_group_name = azurerm_resource_group.openqa-group.name
 }
 
 resource "azurerm_subnet" "openqa-subnet" {
     name                 = "${azurerm_resource_group.openqa-group.name}-subnet"
-    resource_group_name  = "${azurerm_resource_group.openqa-group.name}"
-    virtual_network_name = "${azurerm_virtual_network.openqa-network.name}"
+    resource_group_name  = azurerm_resource_group.openqa-group.name
+    virtual_network_name = azurerm_virtual_network.openqa-network.name
     address_prefix       = "10.0.1.0/24"
 }
 
 resource "azurerm_public_ip" "openqa-publicip" {
     name                         = "${var.name}-${element(random_id.service.*.hex, count.index)}-public-ip"
-    location                     = "${var.region}"
-    resource_group_name          = "${azurerm_resource_group.openqa-group.name}"
+    location                     = var.region
+    resource_group_name          = azurerm_resource_group.openqa-group.name
     allocation_method            = "Dynamic"
-    count                        = "${var.instance_count}"
+    count                        = var.instance_count
 }
 
 resource "azurerm_network_security_group" "openqa-nsg" {
     name                = "${azurerm_resource_group.openqa-group.name}-nsg"
-    location            = "${var.region}"
-    resource_group_name = "${azurerm_resource_group.openqa-group.name}"
+    location            = var.region
+    resource_group_name = azurerm_resource_group.openqa-group.name
 
     security_rule {
         name                       = "SSH"
@@ -100,23 +100,23 @@ resource "azurerm_network_security_group" "openqa-nsg" {
 
 resource "azurerm_network_interface" "openqa-nic" {
     name                      = "${var.name}-${element(random_id.service.*.hex, count.index)}-nic"
-    location                  = "${var.region}"
-    resource_group_name       = "${azurerm_resource_group.openqa-group.name}"
-    network_security_group_id = "${azurerm_network_security_group.openqa-nsg.id}"
-    count                     = "${var.instance_count}"
+    location                  = var.region
+    resource_group_name       = azurerm_resource_group.openqa-group.name
+    network_security_group_id = azurerm_network_security_group.openqa-nsg.id
+    count                     = var.instance_count
 
     ip_configuration {
         name                          = "${element(random_id.service.*.hex, count.index)}-nic-config"
-        subnet_id                     = "${azurerm_subnet.openqa-subnet.id}"
+        subnet_id                     = azurerm_subnet.openqa-subnet.id
         private_ip_address_allocation = "dynamic"
-        public_ip_address_id          = "${element(azurerm_public_ip.openqa-publicip.*.id, count.index)}"
+        public_ip_address_id          = element(azurerm_public_ip.openqa-publicip.*.id, count.index)
     }
 }
 
 resource "azurerm_image" "image" {
     name                      = "${azurerm_resource_group.openqa-group.name}-disk1"
-    location                  = "${var.region}"
-    resource_group_name       = "${azurerm_resource_group.openqa-group.name}"
+    location                  = var.region
+    resource_group_name       = azurerm_resource_group.openqa-group.name
 
     os_disk {
         os_type = "Linux"
@@ -128,14 +128,14 @@ resource "azurerm_image" "image" {
 
 resource "azurerm_virtual_machine" "openqa-vm" {
     name                  = "${var.name}-${element(random_id.service.*.hex, count.index)}"
-    location              = "${var.region}"
-    resource_group_name   = "${azurerm_resource_group.openqa-group.name}"
+    location              = var.region
+    resource_group_name   = azurerm_resource_group.openqa-group.name
     network_interface_ids = ["${azurerm_network_interface.openqa-nic[count.index].id}"]
-    vm_size               = "${var.type}"
-    count                 = "${var.instance_count}"
+    vm_size               = var.type
+    count                 = var.instance_count
 
     storage_image_reference {
-        id = "${azurerm_image.image.id}"
+        id = azurerm_image.image.id
     }
 
     storage_os_disk {
@@ -154,12 +154,12 @@ resource "azurerm_virtual_machine" "openqa-vm" {
         disable_password_authentication = true
         ssh_keys {
             path     = "/home/azureuser/.ssh/authorized_keys"
-            key_data = "${file("/root/.ssh/id_rsa.pub")}"
+            key_data = file("/root/.ssh/id_rsa.pub")
         }
     }
 
     tags = {
-        openqa_created_by = "${var.name}"
+        openqa_created_by = var.name
         openqa_created_date = "${timestamp()}"
         openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
     }
@@ -171,21 +171,21 @@ resource "azurerm_virtual_machine" "openqa-vm" {
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "default" {
-    count              = "${var.create-extra-disk ? var.instance_count: 0}"
-    managed_disk_id    = "${element(azurerm_managed_disk.ssd_disk.*.id, count.index)}"
-    virtual_machine_id = "${element(azurerm_virtual_machine.openqa-vm.*.id, count.index)}"
+    count              = var.create-extra-disk ? var.instance_count: 0
+    managed_disk_id    = element(azurerm_managed_disk.ssd_disk.*.id, count.index)
+    virtual_machine_id = element(azurerm_virtual_machine.openqa-vm.*.id, count.index)
     lun                = "1"
     caching            = "ReadWrite"
 }
 
 resource "azurerm_managed_disk" "ssd_disk" {
-  count                = "${var.create-extra-disk ? var.instance_count: 0}"
+  count                = var.create-extra-disk ? var.instance_count: 0
   name                 = "ssd-disk-${element(random_id.service.*.hex, count.index)}"
-  location             = "${azurerm_resource_group.openqa-group.location}"
-  resource_group_name  = "${azurerm_resource_group.openqa-group.name}"
-  storage_account_type = "${var.extra-disk-type}"
+  location             = azurerm_resource_group.openqa-group.location
+  resource_group_name  = azurerm_resource_group.openqa-group.name
+  storage_account_type = var.extra-disk-type
   create_option        = "Empty"
-  disk_size_gb         = "${var.extra-disk-size}"
+  disk_size_gb         = var.extra-disk-size
 }
 
 
@@ -196,7 +196,7 @@ output "vm_name" {
 data "azurerm_public_ip" "openqa-publicip" {
     name                = "${azurerm_public_ip.openqa-publicip[count.index].name}"
     resource_group_name = "${azurerm_virtual_machine.openqa-vm.0.resource_group_name}"
-    count               = "${var.instance_count}"
+    count               = var.instance_count
 }
 
 output "public_ip" {


### PR DESCRIPTION
After Terraform update to v0.12.16, we have a lot of
warning messages of the type:
`Warning: Interpolation-only expressions are deprecated`

GCE:
before:  http://fromm.arch.suse.de/tests/349/file/serial_terminal.txt
after: http://fromm.arch.suse.de/tests/351/file/serial_terminal.txt

EC2:
before: http://fromm.arch.suse.de/tests/353/file/serial_terminal.txt
after: http://fromm.arch.suse.de/tests/355/file/serial_terminal.txt

Azure:
before: http://fromm.arch.suse.de/tests/356/file/serial_terminal.txt
after: http://fromm.arch.suse.de/tests/357/file/serial_terminal.txt
