### PR TITLE
Do not use name node in the bug-879147_autoinst AY profile

### DIFF
--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -134,7 +134,6 @@
         <bootproto>dhcp</bootproto>
         <device>eth0</device>
         <dhclient_set_default_route>yes</dhclient_set_default_route>
-        <name>Ethernet Card 0</name>
         <startmode>auto</startmode>
       </interface>
       <interface>


### PR DESCRIPTION
Documentation doesn't not describe what this node should do and for the
interface name <device> key is used. So removing it to make the test
work.

- [Verification run](https://openqa.suse.de/tests/3655919#).
