### PR TITLE
Fix the modify_existing_partition for opensuse

### DIFF
--- a/schedule/yast/modify_existing_partition_opensuse.yaml
+++ b/schedule/yast/modify_existing_partition_opensuse.yaml
@@ -27,6 +27,7 @@ schedule:
   - console/validate_modify_existing_partition
 
 test_data:
+  root:
     disk: 'vda'
     existing_partition: 'vda2'
     mount_point: '/'
@@ -36,3 +37,4 @@ test_data:
     # part_size is the size we input in partitioner, lsblk_expected_size_output is what we'll use for validation.
     part_size: '10GiB'
     lsblk_expected_size_output: '10G'
+


### PR DESCRIPTION
I neglected to verify https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9024
against opensuse which makes it break. One of the problems was the test_data format.
I dont cover the boot in this fix (do we need to?) as we did for sle for now.


- Related ticket: https://progress.opensuse.org/issues/59900
- Needles: Not as far as we do not use boot partition for test_data
- Verification run: http://aquarius.suse.cz/tests/1052
