### PR TITLE
Set DM_NEEDS_USERNAME correctly

### DIFF
--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -43,7 +43,7 @@ sub run {
     # Setup DM_NEEDS_USERNAME for SLE15 KDE migration case
     # In SLES15 KDE has been drop, after migration the default desktop is XDM
     # KDE has moved to Package Hub, it will stay install with SLES15 if added PackageHub
-    set_var('DM_NEEDS_USERNAME', '1') if (get_var('DESKTOP', 'KDE') && is_sle('15+') && (get_var('ADDONURL', '') !~ /phub/));
+    set_var('DM_NEEDS_USERNAME', '1') if (check_var('DESKTOP', 'KDE') && is_sle('15+') && (get_var('ADDONURL', '') !~ /phub/));
 
     record_info('Version', 'VERSION=' . get_var('VERSION'));
     reset_consoles_tty;


### PR DESCRIPTION
The judgment with get_var in version_switch_upgrade_target.pm cause DM_NEEDS_USERNAME=1 unexpected, we need change the judgment to check_var.

- Related ticket: https://progress.opensuse.org/issues/60503
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3661008
