### PR TITLE
Workaround for update_package conflict on sles15sp2 XEN

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -19,6 +19,7 @@ use virt_utils;
 use ipmi_backend_utils;
 use Utils::Backends 'is_remote_backend';
 use Utils::Architectures;
+use version_utils 'is_sle';
 
 sub update_package {
     my $self           = shift;
@@ -50,7 +51,7 @@ sub update_package {
 
 sub run {
     my $self = shift;
-    $self->update_package();
+    $self->update_package() unless (is_sle('=15-SP2') && (check_var("HOST_HYPERVISOR", "xen") || check_var("SYSTEM_ROLE", "xen")));
     if (!check_var('ARCH', 's390x')) {
         set_serial_console_on_vh('', '', 'xen') if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
         set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));


### PR DESCRIPTION
Not update package on sles15sp2 xen for Beta1 testing to get around of the bug listed below. When the bug is fixed, we should revert this commit.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1158038
- Verification run: 
gi-guest_developing-on-host_developing-kvm  => update package
http://10.67.18.253/tests/1553

gi-guest_developing-on-host_developing-xen => NOT update package
http://10.67.18.253/tests/1551

gi-guest_developing-on-host_sles12sp5-xen => update package
http://10.67.18.253/tests/1552

@alice-suse @xguo @waynechen55