### PR TITLE
schedule: Fix non-existing test module file for skip_registration@s390x

### DIFF
--- a/schedule/yast/skip_registration/skip_registration@s390x.yaml
+++ b/schedule/yast/skip_registration/skip_registration@s390x.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/reconnect_mgmt_console
+  - boot/reconnect_mgmt_console
   - installation/first_boot
   - console/sle15_workarounds
   - console/hostname


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/60635