### PR TITLE
[WIP] Fix: Apply separate test_data for aarch

### DIFF
--- a/schedule/yast/modify_existing_partition_sle_aarch.yaml
+++ b/schedule/yast/modify_existing_partition_sle_aarch.yaml
@@ -1,9 +1,9 @@
 ---
-name:           modify_existing_partition
+name:           modify_existing_partition@aarch64
 description:    >
   Installation where we modify some pre-existing partitions. Must depend on some create_hdd test suite.
 test_data:
-  !include: yast/modify_existing_partition_sle.yaml
+  !include: test_data/yast/modify_existing_partition_sle_aarch.yaml
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -24,18 +24,8 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - {{reconnect_mgmt_console}}
-  - {{grub_test}}
+  - installation/grub_test
   - installation/first_boot
   - console/validate_modify_existing_partition
 
-conditional_schedule:
-  reconnect_mgmt_console:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-
+        

--- a/test_data/yast/modify_existing_partition.yaml
+++ b/test_data/yast/modify_existing_partition.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  disk: 'vda'
+  existing_partition: 'vda2'
+  mount_point: '/'
+  fs_type: 'ext4'
+  # Sizes should be preferably expressed in human readable binary units (eg GiB) for this test suite:
+  # we use lsblk in validation modules, wich uses human readable binary unit (*ibits).
+  # part_size is the size we input in partitioner, lsblk_expected_size_output is what we'll use for validation.
+  part_size: '11GiB'
+  lsblk_expected_size_output: '11G'

--- a/test_data/yast/modify_existing_partition@aarch.yaml
+++ b/test_data/yast/modify_existing_partition@aarch.yaml
@@ -1,0 +1,19 @@
+---
+root:
+  disk: 'vda'
+  existing_partition: 'vda2'
+  mount_point: '/'
+  fs_type: 'ext4'
+  # Sizes should be preferably expressed in human readable binary units (eg GiB) for this test suite:
+  # we use lsblk in validation modules, wich uses human readable binary unit (*ibits).
+  # part_size is the size we input in partitioner, lsblk_expected_size_output is what we'll use for validation.
+  part_size: '11GiB'
+  lsblk_expected_size_output: '11G'
+boot-uefi:
+  disk: 'vda'
+  existing_partition: 'vda1'
+  mount_point: '/boot/efi'
+  fs_type: 'fat'
+  skip: 1
+  part_size: '256MiB'
+  lsblk_expected_size_output: '256M'


### PR DESCRIPTION
The changes from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9065
doesnt work for x86_94 and s390x. Trying to address the problem with the boot partition
for aarch we affected the other archs as well.

So with this PR we separate the test_data of aarch from the others

DONOTFORGET: adjast jobGroup settings

- Related ticket: https://progress.opensuse.org/issues/59900
- Needles: 
- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP2&build=b10n1k%2Fos-autoinst-distri-opensuse%239071&distri=sle
