### PR TITLE
[WIP] Disable bootloader_start for aarch64

### DIFF
--- a/schedule/yast/nfs/yast2_nfs_v3_client.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v3_client.yaml
@@ -3,6 +3,11 @@ name:          yast2_nfs_v3_client
 description:    >
   Multimachine nfs v3 test, client side. Configures an export with the yast module, and validates that the exported FS is working. Maintainer jrivrain@suse.com.
 schedule:
-  - installation/bootloader_start
+  - {{bootloader_start}}
   - boot/boot_to_desktop
   - console/yast2_nfs_client
+conditional_schedule:
+  reconnect_mgmt_console:
+    ARCH:
+      s390x:
+        - installation/bootloader_start


### PR DESCRIPTION
I see that yast2_cmd directly starts witj boot_to_desktop.
- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
