### PR TITLE
[WIP] Disable bootloader_start for aarch64

### DIFF
--- a/schedule/yast/nfs/yast2_nfs_v3_client.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v3_client.yaml
@@ -6,3 +6,11 @@ schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
   - console/yast2_nfs_client
+<<<<<<< HEAD
+conditional_schedule:
+  bootloader_start:
+    ARCH:
+      s390x:
+        - installation/bootloader_start
+=======
+>>>>>>> parent of fc9689342... Disable bootloader_start for aarch64


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
