### PR TITLE
Remove bootloader_start from nfs mm tests

### DIFF
--- a/schedule/yast/nfs/yast2_nfs_v3_client.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v3_client.yaml
@@ -3,6 +3,5 @@ name:          yast2_nfs_v3_client
 description:    >
   Multimachine nfs v3 test, client side. Configures an export with the yast module, and validates that the exported FS is working. Maintainer jrivrain@suse.com.
 schedule:
-  - installation/bootloader_start
   - boot/boot_to_desktop
   - console/yast2_nfs_client

--- a/schedule/yast/nfs/yast2_nfs_v3_server.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v3_server.yaml
@@ -3,6 +3,5 @@ name:          yast2_nfs_v3_server
 description:    >
   Multimachine nfs v3 test, server side. Configures an export with the yast module, and validates that the exported FS is working. Maintainer jrivrain@suse.com.
 schedule:
-  - installation/bootloader_start
   - boot/boot_to_desktop
   - console/yast2_nfs_server

--- a/schedule/yast/nfs/yast2_nfs_v4_client.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v4_client.yaml
@@ -3,6 +3,5 @@ name:          yast2_nfs_v4_client
 description:    >
   Multimachine nfs v4 test, client side. Configures an export with the yast module, and validates that the exported FS is working. Maintainer jrivrain@suse.com.
 schedule:
-  - installation/bootloader_start
   - boot/boot_to_desktop
   - console/yast2_nfs4_client

--- a/schedule/yast/nfs/yast2_nfs_v4_server.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v4_server.yaml
@@ -3,6 +3,5 @@ name:          yast2_nfs_v4_server
 description:    >
   Multimachine nfs v4 test, server side. Configures an export with the yast module, and validates that the exported FS is working.  Maintainer jrivrain@suse.com.
 schedule:
-  - installation/bootloader_start
   - boot/boot_to_desktop
   - console/yast2_nfs4_server


### PR DESCRIPTION
bootloader_start does not seem to help, in the contrary, on aarch64 the VM boots without it, and fails with it:
success: https://openqa.suse.de/tests/3663504
fail: https://openqa.suse.de/tests/3663443#
The script only launches uefi_bootmenu if UEFI=1, and fails for some reason. I disabled the test suite for s390, so now there's really no reason to use it anywhere

- Related ticket: https://progress.opensuse.org/issues/53855
