### PR TITLE
Stop corosync in HA workarounds if not using Support Server

### DIFF
--- a/tests/ha/setup_hosts_and_luns.pm
+++ b/tests/ha/setup_hosts_and_luns.pm
@@ -68,7 +68,7 @@ sub run {
     # Special tasks to do in upgrades
     if (get_var('HDDVERSION', '')) {
         # Ensure cluster is not running
-        systemctl 'stop pacemaker';
+        systemctl 'stop pacemaker corosync';
 
         # Get IP adresses configured in /etc/corosync.conf
         my %addr_changes = ();
@@ -83,7 +83,7 @@ sub run {
 
         # Finish early if no ring0 addresses were found in corosync.conf.
         if ($count == 0) {
-            systemctl 'start pacemaker';
+            systemctl 'start corosync pacemaker';
             return;
         }
 
@@ -108,7 +108,7 @@ sub run {
 
         # Restart cluster
         barrier_wait("BARRIER_HA_NONSS_FILES_SYNCED_$cluster_name");
-        systemctl 'start pacemaker';
+        systemctl 'start corosync pacemaker';
         return;    # Skip LUN setup in upgrades
     }
 


### PR DESCRIPTION
On SLES+HA test migration scenarios when the migrated systems receive a new IP address and there is no reverse name resolution available in the test scenario, a workaround was introduced in 3f11a8f8a4cf101e6522d1baf1a81e44e1c99bd9 to stop the cluster services and update the addresses in the configuration files before restarting the cluster.

While this works for migrations to 12-SP5, migrations to 15-SP2 from 15-GM and 15-SP1 seem to have problems, as it seems the corosync service remains active in nodes which got one of the IP addresses originally configured in corosync.conf, and does not load the changes edited into corosync.conf.

This PR ensures that the corosync service is down while editing the configuration files.

- Related ticket: N/A
- Failed tests: https://openqa.suse.de/tests/3658760 & https://openqa.suse.de/tests/3658761
- Needles: N/A
- Verification run: N/A
