### PR TITLE
Add workaround missing NIC configuration

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -22,6 +22,7 @@ use utils;
 use bootloader_setup qw(add_custom_grub_entries add_grub_cmdline_settings);
 use main_common 'get_ltp_tag';
 use main_ltp 'loadtest_from_runtest_file';
+use network_utils 'fix_missing_nic_config';
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
 use serial_terminal 'add_serial_console';
@@ -313,6 +314,7 @@ sub run {
     }
 
     $self->select_serial_terminal;
+    fix_missing_nic_config;
 
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
         script_run('echo 1 > /sys/module/printk/parameters/time');


### PR DESCRIPTION
Move old fix from LTP to place where it can be used by more tests.
Enhancement: add soft failure, debug before and after with ip link; ip addr.

Use it for all LTP tests (it was used only for LTP network tests,
now it's used for install_ltp and all tests).

NOTE: this is just a workaround, better would be to force QEMU to always use eth0.

Broken https://openqa.suse.de/tests/3661934
Fixed https://openqa.suse.de/tests/3665979

 Related ticket: poo#60245, bsc#1157896
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3665979 (install_ltp+sle+Online@aarch64-virtio)
(also tested on other 15sp2 and 12sp5 archs; intel on openSUSE Tumbleweed)

