### PR TITLE
Install btrfs-progs from zypper repository

### DIFF
--- a/data/btrfs-progs/install.sh
+++ b/data/btrfs-progs/install.sh
@@ -9,7 +9,6 @@ btrfs-find-root
 btrfs-image
 btrfs-select-super
 btrfstune
-btrfs-corrupt-block
 mkfs.btrfs
 Documentation
 '
@@ -23,9 +22,3 @@ make testsuite
 mkdir -p $2
 tar zxf tests/btrfs-progs-tests.tar.gz -C $2
 cp -r $btrfs_bin /sbin/
-cp tests/clean-tests.sh $2
-if [ "$3" == "misc" ];then
-    sed -ie '/check_min_kernel_version/,+2 s/^/#/' $2/misc-tests/034*/test.sh
-    umount /home
-fi
-

--- a/tests/btrfs-progs/install.pm
+++ b/tests/btrfs-progs/install.pm
@@ -48,7 +48,7 @@ sub run {
     install_dependencies;
     assert_script_run 'wget ' . autoinst_url('/data/btrfs-progs/install.sh');
     assert_script_run 'chmod a+x install.sh';
-    assert_script_run './install.sh ' . GIT_URL . " " . INST_DIR . " " . get_var('CATEGORY'), timeout => 1200;
+    assert_script_run './install.sh ' . GIT_URL . " " . INST_DIR, timeout => 1200;
     assert_script_run 'cd ' . INST_DIR;
 
     # Create log file


### PR DESCRIPTION
Add a new method to install btrfs-progs from zypper repository

- Related ticket: https://progress.opensuse.org/issues/59410
- Verification run: 
http://10.67.133.10/tests/49  (install from repository)
http://10.67.133.10/tests/50  (install from git hub)