### PR TITLE
Add missing bootloader_zkvm to mau-extratests on s390

### DIFF
--- a/schedule/qam/12-SP4/mau-extratests.yaml
+++ b/schedule/qam/12-SP4/mau-extratests.yaml
@@ -1,6 +1,7 @@
 ---
 name: mau-extratests
 schedule:
+- {{zkvm_boot}}
 - boot/boot_to_desktop
 - console/prepare_test_data
 - console/consoletest_setup
@@ -60,4 +61,9 @@ schedule:
 - console/osinfo_db
 - console/libgcrypt
 - console/coredump_collect
+conditional_schedule:
+  zkvm_boot:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
 ...

--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -1,6 +1,7 @@
 ---
 name: mau-extratests
 schedule:
+- {{zkvm_boot}}
 - boot/boot_to_desktop
 - console/prepare_test_data
 - console/consoletest_setup
@@ -60,4 +61,9 @@ schedule:
 - console/osinfo_db
 - console/libgcrypt
 - console/coredump_collect
+conditional_schedule:
+  zkvm_boot:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
 ...


### PR DESCRIPTION
mau-extratests is failing on s390x due to missing bootloader test module. Add it to schedule.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - 12SP4: https://openqa.suse.de/tests/3666223
  - 12SP5: https://openqa.suse.de/tests/3666224