### PR TITLE
LTP: Remove workaround for missing NIC configuration

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -106,26 +106,6 @@ sub run {
     script_run('aa-enabled; aa-status');
 
     if ($is_network) {
-        # poo#18762: Sometimes there is physical NIC which is not configured.
-        # One of the reasons can be renaming by udev rule in
-        # /etc/udev/rules.d/70-persistent-net.rules. This breaks some tests
-        # (even net namespace based ones).
-        # Workaround: configure physical NIS (if needed).
-        my $conf_nic_script = << 'EOF';
-dir=/sys/class/net
-ifaces="`basename -a $dir/* | grep -v -e ^lo -e ^tun -e ^virbr -e ^vnet`"
-for iface in $ifaces; do
-    config=/etc/sysconfig/network/ifcfg-$iface
-    if [ "`cat $dir/$iface/operstate`" = "down" ] && [ ! -e $config ]; then
-        echo "WARNING: create config '$config'"
-        printf "BOOTPROTO='dhcp'\nSTARTMODE='auto'\nDHCLIENT_SET_DEFAULT_ROUTE='yes'\n" > $config
-        systemctl restart network
-        sleep 1
-    fi
-done
-EOF
-        script_output($conf_nic_script);
-
         # emulate $LTPROOT/testscripts/network.sh
         assert_script_run('curl ' . data_url("ltp/net.sh") . ' -o net.sh', 60);
         assert_script_run('chmod 755 net.sh');


### PR DESCRIPTION
Sometimes LTP tests (and maybe other) get NIC eth1, which is not
configured.  Although previous job which created qcow2
(create_hdd_minimal_base+sdk) had eth0,
/etc/udev/rules.d/70-persistent-net.rules somehow fails to detect it's
the same NIC and creates eth1 (udev problem).

Removing `/etc/udev/rules.d/70-persistent-net.rules` (with
`DROP_PERSISTENT_NET_RULES=1`) at the end of create_hdd_minimal_base+sdk
solves the problem, so we don't need to keep this workaround.

If this solution is ever needed, it should be added to some common place
to be reusable by other tests (lib/network_utils.pm or lib/mm_network.pm),
like it was in original PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9078.

- Related ticket: poo#60245, bsc#1157896, poo#18762
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3671129 (install_ltp+sle+Online@aarch64-virtio) which uses image from https://openqa.suse.de/tests/3666119 (create_hdd_minimal_base+sdk@aarch64-virtio) cloned with `DROP_PERSISTENT_NET_RULES=1`.