### PR TITLE
Allow multiple addons one-by-one in 15-SP2 Full medium

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -145,11 +145,9 @@ sub handle_addon {
     wait_still_screen 2;
     send_key_until_needlematch "addon-products-$addon", 'down', 30;
     # modules like SES or RT that are not part of Packages ISO don't have this step
-    if (is_sle('15+') && $addon !~ /^ses$|^rt$/) {
-        send_key 'spc';
-        wait_screen_change { send_key $cmd{next} };
-        assert_screen 'addon-product-installation';
-    }
+    send_key 'spc' if (is_sle('15+') && $addon !~ /^ses$|^rt$/);
+    # Return to top of the page
+    for (1 .. 15) { send_key 'pgup' }
 }
 
 sub test_addonurl {
@@ -184,47 +182,41 @@ sub run {
     if (get_var("ADDONS")) {
         send_key match_has_tag('inst-addon') ? 'alt-k' : 'alt-a';
         # the ISO_X variables must match the ADDONS list
-        my $sr_number       = 0;
-        my $first_iteration = 1;
+        my $sr_number = 0;
         for my $addon (split(/,/, get_var('ADDONS'))) {
             $sr_number++ unless (is_sle('15+') && $sr_number == 1);
             # in full_installer the dialog to choose the installation media
-            # does not appear at first, thus we have to skip it. It does appear
-            # when cycling to add more ADDONS
-            unless (((check_var('FLAVOR', 'Full')) || ((is_sle('15-SP2+') && get_var('MEDIA_UPGRADE')))) && $first_iteration) {
+            # does not appear, thus we have to skip it
+            unless ((check_var('FLAVOR', 'Full')) || ((is_sle('15-SP2+') && get_var('MEDIA_UPGRADE')))) {
                 assert_screen 'addon-menu-active';
                 wait_screen_change { send_key 'alt-d' };    # DVD
                 send_key $cmd{next};
                 assert_screen 'dvd-selector';
-                if (get_var('ISO_1') or get_var('ISO_2')) {    # Skip DVD selection if only Full medium is attached
-                    send_key_until_needlematch 'addon-dvd-list',         'tab',  5;     # jump into addon list
-                    send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 10;    # select addon in list
-                }
-                send_key 'alt-o';                                                       # continue
+                send_key_until_needlematch 'addon-dvd-list',         'tab',  5;     # jump into addon list
+                send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 10;    # select addon in list
+                send_key 'alt-o';                                                   # continue
             }
-            $first_iteration = 0;
             handle_addon($addon);
-            if ((split(/,/, get_var('ADDONS')))[-1] ne $addon) {                        # if $addon is not first from all ADDONS
-                send_key 'alt-a';                                                       # add another add-on
-            }
         }
+        wait_screen_change { send_key $cmd{next} };
+        assert_screen 'addon-product-installation';
     }
     test_addonurl if is_sle('>=15') && get_var('ADDONURL');
     if (get_var("ADDONURL")) {
         if (match_has_tag('inst-addon')) {
-            send_key 'alt-k';                                                           # install with addons
+            send_key 'alt-k';                                                       # install with addons
         }
         else {
             send_key 'alt-a';
         }
         for my $addon (split(/,/, get_var('ADDONURL'))) {
             assert_screen 'addon-menu-active';
-            my $uc_addon = uc $addon;                                                   # varibale name is upper case
-            send_key 'alt-u';                                                           # specify url
+            my $uc_addon = uc $addon;                                               # varibale name is upper case
+            send_key 'alt-u';                                                       # specify url
             send_key $cmd{next};
             assert_screen 'addonurl-entry';
-            send_key 'alt-u';                                                           # select URL field
-            type_string get_required_var("ADDONURL_$uc_addon");                         # repo URL
+            send_key 'alt-u';                                                       # select URL field
+            type_string get_required_var("ADDONURL_$uc_addon");                     # repo URL
             send_key $cmd{next};
             wait_still_screen;    # wait after key is pressed, e.g. 'addon-products' can apper shortly before initialization
             my @tags = ('addon-products', "addon-betawarning-$addon", "addon-license-$addon", 'import-untrusted-gpg-key');


### PR DESCRIPTION
6f1a3650f8ca05946ea25b84742eb65a03bbad62 and 0e1862612 introduced changes to skip the Add On Product screen (addon-menu-active) when using SLES 15-SP2's Full medium, as the installer goes straight to the Extension and Module Selection screen during installations. However, while this screen is not shown initially to select the addons present in the Full medium, if one adds each addon one by one (for example, with ADDONS=base,serverapp,desktopapp,ha), the Add On Product screen is shown in each successive iteration. This PR introduces a workaround for such cases.

- Related ticket: N/A
- Failing tests: [x86_64](https://openqa.suse.de/tests/3666150), [s390x](https://openqa.suse.de/tests/3658071), [ppc64le](https://openqa.suse.de/tests/3658034) & [aarch64](https://openqa.suse.de/tests/3658014)
- Needles: N/A
- Verification run: [x86_64](http://mango.suse.de/tests/1951), [aarch64](https://openqa.suse.de/t3672036), [ppc64le](https://openqa.suse.de/t3672001) (failure in verification run is unrelated to this PR)
