### PR TITLE
Add test data for modify_existing_partition

### DIFF
--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -38,14 +38,6 @@ test_data:
     # part_size is the size we input in partitioner, lsblk_expected_size_output is what we'll use for validation.
     part_size: '11GiB'
     lsblk_expected_size_output: '11G'
-  boot-uefi:
-    disk: 'vda'
-    existing_partition: 'vda1'
-    mount_point: '/boot/efi'
-    fs_type: 'fat'
-    skip: 1
-    part_size: '256MiB'
-    lsblk_expected_size_output: '256M'
 conditional_schedule:
   reconnect_mgmt_console:
     ARCH:

--- a/test_data/yast/modify_existing_partition@aarch.yaml
+++ b/test_data/yast/modify_existing_partition@aarch.yaml
@@ -1,0 +1,9 @@
+---
+boot-uefi:
+  disk: 'vda'
+  existing_partition: 'vda1'
+  mount_point: '/boot/efi'
+  fs_type: 'fat'
+  skip: 1
+  part_size: '256MiB'
+  lsblk_expected_size_output: '256M'


### PR DESCRIPTION
Should fix modify_existing_partition after https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9065. 
Obsoletes this other PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9071

- Related ticket: https://progress.opensuse.org/issues/59900
- Verification runs:
aarch64 https://openqa.suse.de/tests/3672045
ppc64le https://openqa.suse.de/tests/3672047
x86_64 http://waaa-amazing.suse.cz/tests/10530

