### PR TITLE
Increase boot timeout for encrypted systems

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -605,7 +605,7 @@ sub wait_grub {
     elsif (match_has_tag('encrypted-disk-password-prompt')) {
         # unlock encrypted disk before grub
         workaround_type_encrypted_passphrase;
-        assert_screen "grub2", 15;
+        assert_screen "grub2", 90;
     }
     mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');
 }

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -27,8 +27,10 @@ sub run {
     # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
     my $timeout = get_var('UEFI') ? 140 : 80;
     # Add additional 60 seconds if the test suite is migration as reboot from
-    # pre-migration system may take an additional time.
+    # pre-migration system may take an additional time. Booting of encrypted disk
+    # needs additional time too.
     $timeout += 60 if get_var('PATCH') || get_var('ONLINE_MIGRATION');
+    $timeout += 60 if get_var('ENCRYPT');
     # Do not attempt to log into the desktop of a system installed with SLES4SAP
     # being prepared for upgrade, as it does not have an unprivileged user to test
     # with other than the SAP Administrator


### PR DESCRIPTION
Fix poo#60746: Boot needs more time on slow systems when is disk
encryption enabled.

- Related ticket: https://progress.opensuse.org/issues/60746
- Needles: none
- Verification run: 
aarch64: https://openqa.suse.de/t3672041 (system booted fine)