### PR TITLE
KLP: install kernel-devel if not already installed

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -25,6 +25,11 @@ sub run {
         record_info("Azure don't have kGraft/LP infrastructure");
         return;
     }
+
+    if (script_run('[ -d /lib/modules/$(uname -r)/build ]') != 0) {
+        zypper_call('in -l kernel-devel');
+    }
+
     my $git_repo = get_required_var('QA_TEST_KLP_REPO');
     my ($test_type) = $git_repo =~ /qa_test_(\w+).git/;
 


### PR DESCRIPTION
This fixes KLP for QA jobs, (which don't use QAM incidents repository)

Fixes: 8dad5d2a8 Install kernel-devel package in install_ltp

It fixes https://openqa.suse.de/tests/3666121/file/serial_terminal.txt
```
[05:36:53] Test Case 3: Patch under pressure
[05:36:53] *** Compiling kernel live patch
[05:36:53] make: *** /usr/src/linux-5.3.13-1-obj/x86_64/default: No such file or directory.  Stop.
```
Verification run
- http://quasar.suse.cz/tests/4220 (sle-15-SP2-Online-x86_64-Build101.1-kernel-live-patching@64bit)