### PR TITLE
Wait before activating console on 15+

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -715,7 +715,10 @@ sub activate_console {
             # case the system is still booting (https://bugzilla.novell.com/show_bug.cgi?id=895602)
             # or when using remote consoles which can take some seconds, e.g.
             # just after ssh login
-            wait_still_screen 1;    # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet
+            # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet,
+            # or premature typing of credentials on sle15+
+            my $stilltime = is_sle('15+') ? 3 : 1;
+            wait_still_screen $stilltime;
             assert_screen \@tags, 60;
             if (match_has_tag("tty$nr-selected")) {
                 type_string "$user\n";

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -711,14 +711,14 @@ sub activate_console {
             # s390 zkvm uses a remote ssh session which is root by default so
             # search for that and su to user later if necessary
             push(@tags, 'text-logged-in-root') if get_var('S390_ZKVM');
+            # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet,
+            # or premature typing of credentials on sle15+
+            my $stilltime = is_sle('15+') ? 5 : 1;
+            wait_still_screen $stilltime;
             # we need to wait more than five seconds here to pass the idle timeout in
             # case the system is still booting (https://bugzilla.novell.com/show_bug.cgi?id=895602)
             # or when using remote consoles which can take some seconds, e.g.
             # just after ssh login
-            # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet,
-            # or premature typing of credentials on sle15+
-            my $stilltime = is_sle('15+') ? 3 : 1;
-            wait_still_screen $stilltime;
             assert_screen \@tags, 60;
             if (match_has_tag("tty$nr-selected")) {
                 type_string "$user\n";


### PR DESCRIPTION
select_console is failing very often after snapshot is created

- Fail: https://openqa.suse.de/tests/3671753#step/x11_setup/3
- Verification run:
SLED15
https://openqa.suse.de/tests/3674242
https://openqa.suse.de/tests/3674243
https://openqa.suse.de/tests/3674244
https://openqa.suse.de/tests/3674123
https://openqa.suse.de/tests/3674137
https://openqa.suse.de/tests/3674245
https://openqa.suse.de/tests/3674246
https://openqa.suse.de/tests/3674247
https://openqa.suse.de/tests/3674248
https://openqa.suse.de/tests/3674249
SLED15sp1
https://openqa.suse.de/tests/3676006
https://openqa.suse.de/tests/3676007
https://openqa.suse.de/tests/3676008
https://openqa.suse.de/tests/3676009
https://openqa.suse.de/tests/3676010