### PR TITLE
Remove check for confirmation pop-up in expert partitioner

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -203,10 +203,7 @@ sub start_partitioner {
     }
     assert_screen 'yast2_control-center-partitioner_expert', timeout => 60;
     send_key 'alt-f';
-    if (is_storage_ng) {
-        assert_screen 'expert-partitioner-modify-confirmation';
-        wait_screen_change { send_key 'alt-o' };    #Continue
-    }
+
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
 


### PR DESCRIPTION
We don't get pop-up to confirm any actions in yast2 control center
anymore. So, removing this check.
This worked before, because is_storage_ng used variable before and now
check sle version too.

Doesn't affect openSUSE, because `is_storage_ng` uses `is_sle` only.

- [Verification run](https://openqa.suse.de/tests/3674558#).
