### PR TITLE
Schedule storage-ng only on QAM 15+

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1427,7 +1427,7 @@ sub load_extra_tests_y2uitest_gui {
     # On openSUSE, the scheduling happens in schedule/yast2_gui.yaml
     if (get_var("QAM_YAST2UI")) {
         loadtest "yast2_gui/yast2_bootloader" if is_sle("12-SP2+");
-        loadtest "yast2_gui/yast2_storage_ng" if is_sle("12-SP2+");
+        loadtest "yast2_gui/yast2_storage_ng" if is_sle("15+");
         loadtest "yast2_gui/yast2_security"   if is_sle("12-SP2+");
         loadtest "yast2_gui/yast2_keyboard"   if is_sle("12-SP2+");
     }


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3675215#step/yast2_storage_ng/32