### PR TITLE
wicked: add devel tools module to AutoYaST profile for SLE 15

### DIFF
--- a/data/autoyast_sle15/autoyast_wicked_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_wicked_x86_64.xml
@@ -14,6 +14,11 @@
         <arch>{{ARCH}}</arch>
       </addon>
       <addon>
+        <name>sle-module-development-tools</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
         <name>sle-module-server-applications</name>
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
@@ -73,6 +78,18 @@
     <products config:type="list">
       <product>SLES</product>
     </products>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <packages config:type="list">
+      <package>iputils</package>
+      <package>sles-release</package>
+      <package>sle-module-server-applications-release</package>
+      <package>sle-module-development-tools-release</package>
+      <package>sle-module-basesystem-release</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>minimal_base</pattern>
+    </patterns>
   </software>
   <users config:type="list">
     <user>

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -64,8 +64,7 @@ sub run {
     } else {
         # Common SUT Configuration
         if (get_var('WICKED_SOURCES')) {
-            zypper_call('--quiet in -t pattern Basis-Devel');
-            zypper_call('--quiet in automake autoconf libtool libnl-devel libnl3-devel libiw-devel dbus-1-devel pkg-config libgcrypt-devel systemd-devel git');
+            zypper_call('--quiet in automake autoconf libtool libnl-devel libnl3-devel libiw-devel dbus-1-devel pkg-config libgcrypt-devel systemd-devel git make gcc');
             my $repo_url = get_var('WICKED_SOURCES');
             my ($folderName) = $repo_url =~ /.*\/(.*)\.git/;
             if ($repo_url =~ /\#/) {


### PR DESCRIPTION
To be able to install wicked from sources we need to install
pattern Basis-Devel . Current AutoYaST profile do not have all
needed modules enabled