### PR TITLE
Save time by not setting custom prompt in shell sessions anymore

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -382,7 +382,7 @@ skip the entire routine.
 =cut
 sub set_standard_prompt {
     my ($self, $user, %args) = @_;
-    return if $args{skip_set_standard_prompt} || get_var('SKIP_SET_STANDARD_PROMPT');
+    return if $args{skip_set_standard_prompt} || !get_var('SET_CUSTOM_PROMPT');
     $user ||= $testapi::username;
     my $os_type     = $args{os_type} // 'linux';
     my $prompt_sign = $user eq 'root' ? '#' : '$';

--- a/variables.md
+++ b/variables.md
@@ -107,7 +107,7 @@ SELECT_FIRST_DISK | boolean | false | Enables test module to select first disk f
 SEPARATE_HOME | three-state | undef | Used for scheduling the test module where separate `/home` partition should be explicitly enabled (if `1` is set) or disabled (if `0` is set). If not specified, the test module is skipped.
 SES5_CEPH_QA_HEALTH_OK | string | | URL for repo containing ceph-qa-health-ok package.
 SKIP_CERT_VALIDATION | boolean | false | Enables linuxrc parameter to skip certificate validation of the remote source, e.g. when using self-signed https url.
-SKIP_SET_STANDARD_PROMPT | boolean | false | Skips setting the standard prompt in shells. Can save time.
+SET_CUSTOM_PROMPT | boolean | false | Set a custom, shorter prompt in shells. Saves screen space but can take time to set repeatedly in all shell sessions.
 SLE_PRODUCT | string | | Defines SLE product. Possible values: `sles`, `sled`, `sles4sap`. Is mainly used for SLE 15 installation flow.
 SOFTFAIL_BSC1063638 | boolean | false | Enable bsc#1063638 detection.
 STAGING | boolean | false | Indicates staging environment.


### PR DESCRIPTION
Some years ago when tests were requiring more screen checks even for
basic operations we set a different prompt to make needles easy to
maintain. By now this should not be necessary anymore but has the
disadvantage of taking time to redo whenever we enter a new shell
session so we should not do this by default anymore.

Verification runs:

```
env MARKDOWN=1 local/os-autoinst/openQA/script/openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9100 https://openqa.opensuse.org/tests/1105660,https://openqa.opensuse.org/tests/1105386,https://openqa.opensuse.org/tests/1105605,https://openqa.opensuse.org/tests/1105370,https://openqa.opensuse.org/tests/1105365,https://openqa.opensuse.org/tests/1105379,https://openqa.opensuse.org/tests/1105663,https://openqa.opensuse.org/tests/1105674,https://openqa.suse.de/tests/3677094,https://openqa.suse.de/tests/3676594,https://openqa.suse.de/tests/3677102,https://openqa.suse.de/tests/3676622,https://openqa.suse.de/tests/3676628,https://openqa.suse.de/tests/3676658,https://openqa.suse.de/tests/3676702 EXCLUDE_MODULES=rails,firefox,check_os_release,clamav
```

* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-kde-wayland@64bit_virtio](https://openqa.opensuse.org/t1106628)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-extra_tests_on_kde@64bit](https://openqa.opensuse.org/t1106034)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-extra_tests_in_textmode@64bit](https://openqa.opensuse.org/t1106549)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-gnome@64bit](https://openqa.opensuse.org/t1106550)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-textmode@64bit](https://openqa.opensuse.org/t1106551)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-upgrade_13.1-gnome@64bit](https://openqa.opensuse.org/t1106631)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-upgrade_Leap_42.3_cryptlvm@uefi](https://openqa.opensuse.org/t1106623)
* [opensuse-Tumbleweed-KDE-Live-x86_64-Build20191206-kde-live-wayland@64bit_virtio-3G](https://openqa.opensuse.org/t1106036)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20191207-1-qam-minimal+base@64bit](https://openqa.suse.de/t3679397)
* [sle-12-SP4-Desktop-DVD-Updates-x86_64-Build20191207-1-qam-regression-gnome@64bit](https://openqa.suse.de/t3678492)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20191207-1-qam-textmode+sle15@64bit](https://openqa.suse.de/t3679376)
* [sle-12-SP1-Server-DVD-Updates-x86_64-Build20191207-1-qam-textmode@64bit](https://openqa.suse.de/t3679377)
* [sle-12-SP1-Server-DVD-Updates-x86_64-Build20191207-1-mau-extratests@64bit](https://openqa.suse.de/t3678506)
* [sle-12-SP2-Server-DVD-Updates-x86_64-Build20191207-1-qam-minimal+base@64bit](https://openqa.suse.de/t3679378)
* [sle-12-SP3-Server-DVD-Updates-x86_64-Build20191207-1-qam-minimal+base@64bit](https://openqa.suse.de/t3679379)


Related progress issue: https://progress.opensuse.org/issues/55223