### PR TITLE
gnuhealth: Fix tests for new gnuhealth 3.6 in Tumbleweed

### DIFF
--- a/tests/gnuhealth/gnuhealth_client_first_time.pm
+++ b/tests/gnuhealth/gnuhealth_client_first_time.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,30 +14,39 @@ use base 'x11test';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_leap is_tumbleweed);
+use version_utils 'is_leap';
 
 sub run {
-    my $gnuhealth = get_var('GNUHEALTH_CLIENT', 'gnuhealth-client');
-    if (is_tumbleweed || is_leap('42.3+')) {
-        wait_screen_change { send_key 'tab' };
-        send_key 'ret';
-        assert_screen "$gnuhealth-login_password";
-    }
-    else {
-        send_key_until_needlematch "gnuhealth-login_password", 'tab';
-    }
+    my $gnuhealth    = get_var('GNUHEALTH_CLIENT', 'gnuhealth-client');
+    my $gnuhealth_34 = is_leap('<=15.2');
+    wait_screen_change { send_key 'tab' };
+    send_key 'ret';
+    assert_screen "$gnuhealth-login_password";
     type_string "susetesting\n";
     assert_screen "$gnuhealth-module_configuration_wizard_start";
-    send_key 'ret';
+    send_key $gnuhealth_34 ? 'ret' : 'alt-o';
     assert_screen "$gnuhealth-module_configuration_wizard-add_users-welcome";
-    send_key 'ret';
+    send_key $gnuhealth_34 ? 'ret' : 'alt-o';
     assert_screen "$gnuhealth-module_configuration_wizard-add_users_dialog";
     # let's not add a user for now
-    send_key 'alt-e';
+    if ($gnuhealth_34) {
+        send_key 'alt-e';
+    }
+    else {
+        # newer versions have ambiguous hotkeys, need to select over two
+        # different fields with "E" for hotkey. Let's hope the second button
+        # is "End" and confirm it
+        send_key 'alt-e';
+        send_key 'alt-e';
+        save_screenshot;
+        send_key 'ret';
+    }
     assert_screen "$gnuhealth-module_configuration_wizard-next_step";
     send_key 'alt-n';
-    assert_screen "$gnuhealth-module_configuration_wizard-configuration_done";
-    send_key 'alt-o';
+    if ($gnuhealth_34) {
+        assert_screen "$gnuhealth-module_configuration_wizard-configuration_done";
+        send_key 'alt-o';
+    }
     assert_screen "$gnuhealth-admin_view", 300;
 }
 

--- a/tests/gnuhealth/gnuhealth_client_preconfigure.pm
+++ b/tests/gnuhealth/gnuhealth_client_preconfigure.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,7 +14,7 @@ use base 'x11test';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_leap is_tumbleweed);
+use version_utils 'is_leap';
 
 sub run {
     my $gnuhealth = get_var('GNUHEALTH_CLIENT', 'gnuhealth-client');
@@ -27,28 +27,8 @@ sub run {
     send_key_until_needlematch "$gnuhealth-manage_profiles-host_textfield_selected", 'tab';
     type_string 'localhost';
     send_key 'tab';
-    if (is_tumbleweed || is_leap('42.3+')) {
-        assert_screen "$gnuhealth-manage_profiles-database_selected";
-        type_string 'admin';
-    }
-    else {
-        # button 'create' should appear, weird GUI behaviour
-        assert_and_click "$gnuhealth-manage_profiles-create_database";
-        # tryton server password
-        type_string 'susetesting';
-        send_key 'tab';
-        # database name
-        type_string 'gnuhealth_demo';
-        send_key 'tab';
-        send_key 'tab';
-        # admin password
-        type_string 'susetesting';
-        send_key 'tab';
-        type_string 'susetesting';
-        # wait for create button to be active
-        assert_and_click "$gnuhealth-manage_profiles-create_database-create";
-
-    }
+    assert_screen "$gnuhealth-manage_profiles-database_selected";
+    type_string 'admin';
     # back to profiles menue
     assert_screen "$gnuhealth-manage_profiles-add", 300;
     send_key 'ret';

--- a/tests/gnuhealth/gnuhealth_setup.pm
+++ b/tests/gnuhealth/gnuhealth_setup.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,7 +14,7 @@ use base 'x11test';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_leap is_tumbleweed);
+use version_utils 'is_leap';
 use utils 'systemctl';
 
 sub run() {
@@ -24,12 +24,15 @@ sub run() {
     systemctl 'start postgresql';
     wait_screen_change { script_run 'su postgres', 0 };
     script_run 'sed -i -e \'s/\(\(local\|host\).*all.*all.*\)\(md5\|ident\)/\1trust/g\' /var/lib/pgsql/data/pg_hba.conf', 0;
-    script_run 'psql -c "CREATE USER tryton WITH CREATEDB;"',                                                             0;
-    script_run 'createdb gnuhealth --encoding=\'UTF8\' --owner=tryton',                                                   0;
-    script_run 'exit',                                                                                                    0;
+
+    script_run 'psql -c "CREATE USER tryton WITH CREATEDB;"',           0;
+    script_run 'createdb gnuhealth --encoding=\'UTF8\' --owner=tryton', 0;
+    script_run 'exit',                                                  0;
     systemctl 'restart postgresql';
     assert_script_run 'echo susetesting > /tmp/pw';
-    assert_script_run 'sudo -u tryton env TRYTONPASSFILE=/tmp/pw trytond-admin -c /etc/tryton/trytond.conf --all -d gnuhealth --password', 600;
+    my $cmd = 'sudo -u tryton env TRYTONPASSFILE=/tmp/pw trytond-admin -c /etc/tryton/trytond.conf --all -d gnuhealth --password';
+    $cmd .= ' --email root' unless is_leap('<=15.2');
+    assert_script_run $cmd, 600;
     systemctl 'start gnuhealth';
     # exit from root session
     send_key 'ctrl-d';


### PR DESCRIPTION
This also removes obsolete support for gnuhealth in openSUSE Leap 42.3
and earlier.

Verification run: http://lord.arch.suse.de/tests/2772
    
Related needle change:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/623

Related progress issue: https://progress.opensuse.org/issues/60740