### PR TITLE
Add space to avoid image path to be polluted by 'plymouth.enable' parameter

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -113,9 +113,9 @@ sub run {
         send_key "tab";
     }
     if (check_var('BACKEND', 'ipmi')) {
-        $image_path .= " ipv6.disable=1 "        if get_var('LINUX_BOOT_IPV6_DISABLE');
-        $image_path .= "ifcfg=$interface=dhcp4 " if (!get_var('NETWORK_INIT_PARAM') && !get_var('SUT_NETDEVICE_SKIPPED'));
-        $image_path .= 'plymouth.enable=0 ';
+        $image_path .= " ipv6.disable=1 "         if get_var('LINUX_BOOT_IPV6_DISABLE');
+        $image_path .= " ifcfg=$interface=dhcp4 " if (!get_var('NETWORK_INIT_PARAM') && !get_var('SUT_NETDEVICE_SKIPPED'));
+        $image_path .= ' plymouth.enable=0 ';
     }
     # Execute installation command on pxe management cmd console
     type_string_slow ${image_path} . " ";


### PR DESCRIPTION
Under certain circumstances, plymouth.enable=0 can be appended onto image path directly without space being inserted in between which may lead to wrong URL.

Also prepend space before ifcfg option to avoid similar problem that may happen to other secnairos.


- Related ticket: n/a
- Needles: n/a
- Verification run: http://openqa.qa2.suse.asia/tests/1291#step/boot_from_pxe/8
