### PR TITLE
Print disk usage in shutdown_ltp

### DIFF
--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -35,6 +35,8 @@ sub run {
         export_to_json($tinfo->test_result_export);
     }
 
+    script_run('df -h');
+
     if (get_var('LTP_COMMAND_FILE')) {
         my $ver_linux_log = '/tmp/ver_linux_after.txt';
         script_run("\$LTPROOT/ver_linux > $ver_linux_log 2>&1");


### PR DESCRIPTION
Call `df -h` in `shutdown_ltp`. This can help debug test failures due to lack of free space on VM image.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3681064
