### PR TITLE
Register addons properly in YaST addon module

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -47,6 +47,7 @@ our @EXPORT = qw(
   verify_scc
   investigate_log_empty_license
   register_addons_cmd
+  register_addons
   %SLE15_MODULES
   %SLE15_DEFAULT_MODULES
   %ADDONS_REGCODE

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -23,21 +23,21 @@ use x11utils 'turn_off_gnome_screensaver';
 Define proxy SCC. For SLE 15 we need to clean existing registration
 =cut
 sub test_setup {
-    select_console 'root-console';
-    if (is_sle('>=15')) {
-        cleanup_registration();
-    }
-    elsif (get_var('SCC_ADDONS')) {
-        # Add every used addon to regurl for proxy SCC
-        my @addon_proxy = ("url: http://server-" . get_var('BUILD_SLE'));
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver;
+    become_root;
+
+    my @addon_proxy = ('url: http://' . (is_sle('<15') ? 'server-' : 'all-') . get_var('BUILD_SLE'));
+    # Add every used addon to regurl for proxy SCC, sle12 addons can have different build numbers
+    if (get_var('SCC_ADDONS') && is_sle('<15')) {
         for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
             my $uc_addon = uc $addon;    # change to uppercase to match variable
             push(@addon_proxy, "\b.$addon-" . get_var("BUILD_$uc_addon"));
         }
-        assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";    # Define proxy SCC
     }
-    turn_off_gnome_screensaver;
-    select_console 'x11';
+
+    assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";    # Define proxy SCC
+    wait_screen_change(sub { type_string "exit\n" }, 5) for (1 .. 2);
 }
 
 sub run {
@@ -58,6 +58,11 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
     verify_scc;
     investigate_log_empty_license;
+}
+
+sub test_flags {
+    # add milestone flag to save setup in lastgood VM snapshot
+    return {fatal => 1, milestone => 1};
 }
 
 1;

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -15,13 +15,35 @@ use base qw(y2_installbase y2_module_guitest);
 use strict;
 use warnings;
 use testapi;
+use version_utils 'is_sle';
 use power_action_utils 'reboot_x11';
-use registration qw(fill_in_registration_data skip_registration);
+use x11utils 'turn_off_gnome_screensaver';
+use registration qw(fill_in_registration_data skip_registration register_addons);
+use List::MoreUtils 'firstidx';
+
+sub test_setup {
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver;
+    become_root;
+
+    my @addon_proxy = ('url: http://' . (is_sle('<15') ? 'server-' : 'all-') . get_var('BUILD_SLE'));
+    # Add every used addon to regurl for proxy SCC, sle12 addons can have different build numbers
+    if (get_var('ADDONS') && is_sle('<15')) {
+        for my $addon (split(/,/, get_var('ADDONS', ''))) {
+            my $uc_addon = uc $addon;    # change to uppercase to match variable
+            push(@addon_proxy, "\b.$addon-" . get_var("BUILD_$uc_addon"));
+        }
+    }
+
+    assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";    # Define proxy SCC
+    wait_screen_change(sub { type_string "exit\n" }, 5) for (1 .. 2);
+}
 
 sub run {
     my ($self) = @_;
     my ($addon, $uc_addon);
     my $perform_reboot;
+    test_setup;
     $self->launch_yast2_module_x11('add-on', target_match => [qw(addon-products packagekit-warning)]);
     if (match_has_tag 'packagekit-warning') {
         send_key 'alt-y';
@@ -64,18 +86,21 @@ sub run {
             else {
                 assert_screen "addon-license-$addon";
             }
-            wait_screen_change { send_key 'alt-a' };                                # yes, agree
+            # accept addon license and move to patterns selection
+            wait_screen_change { send_key 'alt-a' };    # yes, agree
             send_key $cmd{next};
             assert_screen 'addon-yast2-patterns';
             send_key_until_needlematch 'addon-yast2-view-selected', 'alt-v', 10;
-            send_key 'spc';                                                         # open view menu
+            send_key 'spc';                             # open view menu
             wait_screen_change { send_key 'alt-r' };
-            wait_screen_change { send_key 'alt-r' };                                # go to repositories
-            send_key 'ret';                                                         # open repositories tab
+            wait_screen_change { send_key 'alt-r' };    # go to repositories
+            send_key 'ret';                             # open repositories tab
             assert_screen "addon-yast2-repo-$addon";
-            send_key 'alt-a';                                                       # accept
+            # accept repositories
+            send_key 'alt-a';
+            # confirm and continue with automatic changes proposal
             assert_screen 'automatic-changes';
-            send_key 'alt-o';                                                       # OK
+            send_key 'alt-o';
             my @needles = qw(unsupported-package addon-installation-pop-up addon-installation-report);
             do {
                 assert_screen \@needles, 300;
@@ -84,28 +109,22 @@ sub run {
                     send_key 'alt-o';
                 }
                 if (match_has_tag('addon-installation-pop-up')) {
+                    # Handle reboot reminder pop up to activate new kernel ( pop up in case of RT extention )
                     $perform_reboot = 1;
                     send_key 'alt-o';
+                    # Avoid to match the pop up more than once
+                    my $needle_index = firstidx { $_ eq 'addon-installation-pop-up' } @needles;
+                    splice(@needles, $needle_index, 1) unless ($needle_index == -1);
                 }
             } until (match_has_tag('addon-installation-report'));
-            wait_screen_change { send_key 'alt-f'; }    # finish
-            send_key 'alt-a';                           # accept
+            # Installation report, hit Finish button and proceed to SCC registartion
+            send_key 'alt-f';
             assert_screen 'scc-registration';
+            # This part of code should handle registration of the base system and the added extention or module
+            # In case of RT testing, registration is not mandatory in test suite(s) executing *YaST2 add-on*
             if (get_var('SCC_REGISTER')) {
                 fill_in_registration_data;
-                if ($addon ne 'sdk') {                  # sdk doesn't ask for code
-                    my $regcode = get_var("SCC_REGCODE_$uc_addon");
-                    assert_screen "addon-reg-code";
-                    send_key 'tab';                     # jump to code field
-                    type_string $regcode;
-                    sleep 1;
-                    save_screenshot;
-                    send_key $cmd{next};
-                }
-                assert_screen 'addon-products', 60;
-                wait_screen_change { send_key "tab" };    # select addon-products-$addon
-                send_key "pgup",                                    1;
-                send_key_until_needlematch "addon-products-$addon", 'down';
+                register_addons;
             }
             else {
                 skip_registration;
@@ -131,7 +150,8 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 1, milestone => 1};                            # add milestone flag to save setup in lastgood VM snapshot
+    # add milestone flag to save setup in lastgood VM snapshot
+    return {fatal => 1, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [[slert12sp5] test fails in addon_products_yast2 - possible change in workflow](https://progress.opensuse.org/issues/60773)
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1275
- Verification runs:
[addon_products_yast2](http://eris.suse.cz/tests/3069) 
[full blown schedule of addon_products_yast2 test suite](http://eris.suse.cz/tests/3072)

[addon_products_via_SCC_yast2](http://eris.suse.cz/tests/3045) blocked by [[Build0174][slert12sp5] missing license when registering via YaST scc module](https://bugzilla.suse.com/show_bug.cgi?id=1158687)