### PR TITLE
Add a test to grep for "resume" in /proc/cmdline

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -35,6 +35,7 @@ schedule:
   # Called on BACKEND: qemu
   - {{grub_test}}
   - installation/first_boot
+  - {{check_resume}}
   - console/validate_no_cow_attribute
   # On all the backends except s390x, /home is located on a separate partition
   - {{validate_home_partition}}
@@ -55,6 +56,10 @@ conditional_schedule:
         - boot/reconnect_mgmt_console
       ipmi:
         - boot/reconnect_mgmt_console
+  check_resume:
+    ARCH:
+      s390x:
+        - console/check_resume
   grub_test:
     BACKEND:
       qemu:

--- a/schedule/yast/skip_registration/skip_registration@s390x-zVM.yaml
+++ b/schedule/yast/skip_registration/skip_registration@s390x-zVM.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/check_resume
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare

--- a/schedule/yast/skip_registration/skip_registration@s390x.yaml
+++ b/schedule/yast/skip_registration/skip_registration@s390x.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/check_resume
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare

--- a/tests/console/check_resume.pm
+++ b/tests/console/check_resume.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that "resume=" kernel parameter is absent in the list of default parameters on Sle15-SP2
+# for s390 see https://jira.suse.com/browse/SLE-6926
+# Only for s390.
+
+# Maintainer: Jonathan Rivrain <jrivrain@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+    assert_script_run("grep -v 'resume=' /proc/cmdline", fail_message => "resume parameter found in /proc/cmdline");
+}
+
+1;


### PR DESCRIPTION
 -   Verify that "resume=" kernel parameter does not exist among the list of default parameters on s390.

- Related ticket: https://progress.opensuse.org/issues/53888
- Needles: N/A
- Verification run: 
zkvm: https://openqa.suse.de/tests/3838961
zVM: https://openqa.suse.de/tests/3838953