### PR TITLE
Scroll down to further check dependency warning msg

### DIFF
--- a/tests/installation/resolve_dependency_issues.pm
+++ b/tests/installation/resolve_dependency_issues.pm
@@ -26,6 +26,12 @@ sub run {
 
     if (check_screen('manual-intervention', 0)) {
         $self->deal_with_dependency_issues;
+    } elsif (check_screen('installation-settings-overview-loaded-scrollbar')) {
+        # We still need further check if we find scrollbar
+        assert_and_click "installation-settings-overview-loaded-scrollbar-down";
+        if (check_screen('manual-intervention', 0)) {
+            $self->deal_with_dependency_issues;
+        }
     }
 }
 


### PR DESCRIPTION
The dependency warning msg can not be captured since too many content occupy the full screen, so we need add scroll down  action.
- Related ticket: https://progress.opensuse.org/issues/60665
- Needles: 
- Verification run: http://openqa.suse.de/tests/3680914#
