### PR TITLE
Do not expect a display manager when AUTOLOGIN is active

### DIFF
--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -58,9 +58,9 @@ sub logout_and_login {
 sub reboot_system {
     my ($self) = @_;
     reboot_x11;
-    $self->{await_reboot} = 1;
-    $self->wait_boot(nologin => 1);
     if (check_var('NOAUTOLOGIN', 1)) {
+        $self->{await_reboot} = 1;
+        $self->wait_boot(nologin => 1);
         assert_screen "displaymanager", 200;
         $self->{await_reboot} = 0;
         # The keyboard focus is different between SLE15 and SLE12
@@ -68,6 +68,8 @@ sub reboot_system {
         send_key "ret";
         wait_still_screen;
         type_string "$newpwd\n";
+    } else {
+        $self->wait_boot();
     }
     assert_screen "generic-desktop";
 }


### PR DESCRIPTION
If either NOAUTOLOGIN or nologin are set, wait_boot expects the display
manager to appear, otherwise it expects a generic desktop.

The override has to happen in case NOAUTOLOGIN is set as wait_boot would
use the old password, for NOAUTOLOGIN=0 the default handling is fine.

- Related ticket: https://progress.opensuse.org/issues/60575
- Verification run: https://openqa.opensuse.org/tests/1107990