### PR TITLE
Update Security maintainer in test modules

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 # Summary: Base module for AppArmor test cases
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 
 =head1 Apparmor Tests
 

--- a/lib/krb5crypt.pm
+++ b/lib/krb5crypt.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Public variables and functions for krb5 cryptographic testing
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 package krb5crypt;
 

--- a/lib/openscaptest.pm
+++ b/lib/openscaptest.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 # Summary: Base module for openSCAP test cases
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#37006
 
 package openscaptest;

--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -9,7 +9,7 @@
 
 # Summary: Enable SSL module on Apache2 server
 # - calls setup_apache2 with mode = SSL (lib/apachetest.pm)
-# Maintainer: Qingming Su <qingming.su@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use testapi;

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -14,8 +14,7 @@
 # - check that clamscan is able to recognize a fake vim virus
 # - check that clamscan is able to recognize an EICAR virus pdf, txt and zip format
 # - check that clamdscan is able to recognize an EICAR virus pdf, txt and zip format
-# Author: Wei Jiang <wjiang@suse.com>
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: TC1595169, poo#46880
 
 use base "consoletest";

--- a/tests/console/cryptsetup.pm
+++ b/tests/console/cryptsetup.pm
@@ -9,7 +9,7 @@
 
 # Summary: FIPS: cryptsetup
 #    This case is verify the command of cryptsetup whether can be work in FIPS mode
-# Maintainer: dehai <dhkong@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: tc#1528909
 
 

--- a/tests/console/dovecot_ssl.pm
+++ b/tests/console/dovecot_ssl.pm
@@ -11,7 +11,7 @@
 # Note: The test case can be run separately for dovecot sanity test,
 #       or run as stand-alone mail server (together with postfix)
 #       in multi-machine test scenario if MAIL_SERVER var set.
-# Maintainer: Qingming Su <qmsu@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/fetchmail_ssl.pm
+++ b/tests/console/fetchmail_ssl.pm
@@ -11,7 +11,7 @@
 # Note: fetchmail connects to a remote mail server (running dovecot)
 #   and fetch mails to localhost, then deliver mails (by postfix) to
 #   local mailbox.
-# Maintainer: Qingming Su <qmsu@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -18,8 +18,7 @@
 # - Sign test file
 # - Check test file signature
 # - Cleanup
-# Maintainer: Petr Cervinka <pcervinka@suse.com>, Dehai Kong <dhkong@suse.com>
-#             wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Petr Cervinka <pcervinka@suse.com>, Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/ipsec_tools_h2h.pm
+++ b/tests/console/ipsec_tools_h2h.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Test Racoon host-to-host scenario
-# Maintainer: Jiawei Sun <jiawei.sun@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use strict;
 use warnings;

--- a/tests/console/journald_fss.pm
+++ b/tests/console/journald_fss.pm
@@ -14,7 +14,7 @@
 #    It is only needed to test journald's key generation and verification function
 #    Verify key should be generated,as well as a QR code
 #    No failed messages output
-# Maintainer: dehai <dhkong@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/libmicrohttpd.pm
+++ b/tests/console/libmicrohttpd.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Case 1525263 - Verify libmicrohttpd via Greenbone Security Assistant
-# Maintainer: Wei Jiang <wjiang@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/mailx_ssl.pm
+++ b/tests/console/mailx_ssl.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Test mailx send/reveive mails with SSL enabled
-# Maintainer: Qingming Su <qmsu@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/mariadb.pm
+++ b/tests/console/mariadb.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: client part of mariadb ssl connection test
-# Maintainer: Wei Jiang <wjiang@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: TC1595192
 
 use base "consoletest";

--- a/tests/console/mutt_ssl.pm
+++ b/tests/console/mutt_ssl.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Test mutt mail agent with SSL enabled
-# Maintainer: Qingming Su <qmsu@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/openvswitch_ssl.pm
+++ b/tests/console/openvswitch_ssl.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: The test to connect openvswitch to openflow with SSL enabled
-# Maintainer: Wei Jiang <wjiang@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: TC1595181
 
 use base "consoletest";

--- a/tests/console/postfix_tls.pm
+++ b/tests/console/postfix_tls.pm
@@ -11,7 +11,7 @@
 # Note: The test case can be run separately for postfix sanity test,
 #       or run as stand-alone mail server (together with dovecot)
 #       in multi-machine test scenario if MAIL_SERVER var set.
-# Maintainer: Qingming Su <qmsu@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/ssh_pubkey.pm
+++ b/tests/console/ssh_pubkey.pm
@@ -18,7 +18,7 @@
 #    openssh will refuse to work with any non-approved
 #    algorithm in fips mode, just like blowfish cipher
 #    or MD5 hash.
-# Maintainer: Qingming Su <qingming.su@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/console/wget_https.pm
+++ b/tests/console/wget_https.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: FIPS: wget
-# Maintainer: dehai <dhkong@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: tc#1461937
 
 

--- a/tests/feature/feature_console/zypper_crit_sec_fix_only.pm
+++ b/tests/feature/feature_console/zypper_crit_sec_fix_only.pm
@@ -9,7 +9,7 @@
 
 # Summary: Test zypper can update critical security fixes only
 # Tags: fate#318760, tc#1480288
-# Maintainer: Qingming Su <qingming.su@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/fips/curl_fips_rc4_seed.pm
+++ b/tests/fips/curl_fips_rc4_seed.pm
@@ -12,7 +12,7 @@
 #    Both RC4 and SEED are not approved cipher by FIPS140-2.
 #    In a fips enabled system, it will get a failed result if run curl command
 #    with RC4 and SEED ciphers.
-# Maintainer: Jiawei Sun <JiaWei.Sun@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use testapi;

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -17,7 +17,7 @@
 #          Installation check - verify the setup of FIPS installation
 #          ENV mode - selected by FIPS_ENV_MODE
 #          Global mode - setup fips=1 in kernel command line
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: poo#39071
 
 use strict;

--- a/tests/fips/mozilla_nss/apache_nssfips.pm
+++ b/tests/fips/mozilla_nss/apache_nssfips.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Enable NSS module for Apache2 server with NSSFips on
-# Maintainer: Qingming Su <qingming.su@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use strict;
 use warnings;

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -10,8 +10,7 @@
 # Case #1560076 - FIPS: Firefox Mozilla NSS
 
 # Summary: FIPS mozilla-nss test for firefox
-# Maintainer: mitiao <mitiao@gmail.com>,
-#             wnereiz <wnereiz@fsf.member.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tag: poo#47018
 
 use base "x11test";

--- a/tests/fips/openssh/openssh_fips.pm
+++ b/tests/fips/openssh/openssh_fips.pm
@@ -16,7 +16,7 @@
 #    openssh will refuse to work with any non-approved
 #    algorithm in fips mode, just like blowfish cipher
 #    or MD5 hash.
-# Maintainer: Qingming Su <qingming.su@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: tc#1525228
 
 use base "consoletest";

--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -10,7 +10,6 @@
 # Summary: FIPS : openssl should only list FIPS approved cryptographic functions
 #                 while system is working in fips mode
 #
-# Original Author: Qingming Su <qingming.su@suse.com>
 # Maintainer: Ben Chou <bchou@suse.com>
 # Tags: poo#44831
 

--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -10,7 +10,6 @@
 # Summary: FIPS: In fips mode, openssl only works with the FIPS
 #          approved Cihper algorithms: AES and DES3
 #
-# Original Author: Qingming Su <qingming.su@suse.com>
 # Maintainer: Ben Chou <bchou@suse.com>
 # Tags: poo#44837
 

--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -15,7 +15,6 @@
 #          test cases for fips verificaton when FIPS_ENABLED is set, like
 #          the cases to verify opessl hash, cipher, or public key algorithms
 #
-# Original Author: Qingming Su <qingming.su@suse.com>
 # Maintainer: Ben Chou <bchou@suse.com>
 # Tags: poo#44834
 

--- a/tests/fips/openssl/openssl_pubkey_dsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_dsa.pm
@@ -21,7 +21,6 @@
 #
 #          According to openssl wiki, "dss1" digest method is not available in openssl-1.1-x any more
 #
-# Original Author: Qingming Su <qingming.su@suse.com>
 # Maintainer: Ben Chou <bchou@suse.com>
 # Tags: poo#47471, poo#48020
 

--- a/tests/fips/openssl/openssl_pubkey_rsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_rsa.pm
@@ -17,7 +17,7 @@
 #
 #    For DSA public key, test 1024/2048/3072 bits key pair generation,
 #    and message signing/verification.
-# Maintainer: Qingming Su <qingming.su@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use testapi;

--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -22,7 +22,7 @@
 # - Output created pam profile to serial output
 # - Disable temporarily created nscd profile
 # - Cleanup temporary profiles
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36889, poo#45803
 
 use base 'apparmortest';

--- a/tests/security/apparmor/aa_complain.pm
+++ b/tests/security/apparmor/aa_complain.pm
@@ -20,7 +20,7 @@
 # validates output of command and take a screenshot of each command
 # - Put nscd back in enforce mode
 # - Cleanup temporary directories
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36880, tc#1621142
 
 use strict;

--- a/tests/security/apparmor/aa_easyprof.pm
+++ b/tests/security/apparmor/aa_easyprof.pm
@@ -19,7 +19,7 @@
 # json. Capture the output of the command in a log file
 # - Upload the logfile
 # - Check the logfile for a specific set of values
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36895, tc#1621144
 
 use strict;

--- a/tests/security/apparmor/aa_enforce.pm
+++ b/tests/security/apparmor/aa_enforce.pm
@@ -19,7 +19,7 @@
 # - use aa-status to check if nscd is really disabled
 # - runs aa-enforce on /usr/bin/nscd to enforce mode and check output
 # - runs aa-status and check if nscd is on enforce mode.
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36877, tc#1621145
 
 use strict;

--- a/tests/security/apparmor/aa_genprof.pm
+++ b/tests/security/apparmor/aa_genprof.pm
@@ -24,7 +24,7 @@
 # - Run function "aa_tmp_prof_verify" (check if program is able to start using
 # the temporary profiles)
 # - Clean the temporary profiles directory
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36886, poo#45803
 
 use strict;

--- a/tests/security/apparmor/aa_logprof.pm
+++ b/tests/security/apparmor/aa_logprof.pm
@@ -24,7 +24,7 @@
 # - Check /tmp/apparmor.d/usr.sbin.nscd" for '/usr.*nscd mrix' and 'nscd\.conf'
 # - Check if nscd could start with the temporary apparmor profiles
 # - Cleanup temporary directory
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36892, poo#45803
 
 use base "apparmortest";

--- a/tests/security/apparmor/aa_notify.pm
+++ b/tests/security/apparmor/aa_notify.pm
@@ -26,7 +26,7 @@
 # - Check the errors from "aa-notify -l -v"
 # - Disable temporary profile, put nscd back in enforce mode, restart nscd
 # - Cleanup temporary profiles
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36883, tc#1621139
 
 use strict;

--- a/tests/security/apparmor/aa_status.pm
+++ b/tests/security/apparmor/aa_status.pm
@@ -18,7 +18,7 @@
 # - Check if apparmor is active
 # - Run aa-status, check the output for strings about modules/profiles/processes
 # and strings enforced, complain, unconfined and loaded.
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36874, poo#44912
 
 use base "consoletest";

--- a/tests/security/dm_crypt.pm
+++ b/tests/security/dm_crypt.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Test dm-crypt cipher support with cryptsetup tool. Make sure
 #          unsafe algorithms are not applicable in FIPS or non-FIPS mode.
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: poo#39071
 
 use strict;

--- a/tests/security/ima/evm_protection_digital_signatures.pm
+++ b/tests/security/ima/evm_protection_digital_signatures.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Test EVM protection using digital signatures
 # Note: This case should come after 'evm_protection_hmacs'
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#53582
 
 use base "opensusebasetest";

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Test EVM protection using HMACs
 # Note: This case should come after 'evm_setup'
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#53579
 
 use base "opensusebasetest";

--- a/tests/security/ima/evm_setup.pm
+++ b/tests/security/ima/evm_setup.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Setup environment for EVM protection testing
 # Note: This case should come after 'ima_setup'
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#53579
 
 use base "opensusebasetest";

--- a/tests/security/ima/evm_verify.pm
+++ b/tests/security/ima/evm_verify.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test EVM verify function provided by evmctl
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#53585
 
 use base "opensusebasetest";

--- a/tests/security/ima/evmctl_ima_sign.pm
+++ b/tests/security/ima/evmctl_ima_sign.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Test evmctl ima_sign options
 # Note: This case should come after 'ima_apprasial_digital_signatures'
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#50333
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_appraisal_audit.pm
+++ b/tests/security/ima/ima_appraisal_audit.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Test audit function for IMA appraisal
 # Note: This case should come after 'ima_appraisal_digital_signatures'
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#49568
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_appraisal_digital_signatures.pm
+++ b/tests/security/ima/ima_appraisal_digital_signatures.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test IMA appraisal using digital signatures
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#49154
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_appraisal_hashes.pm
+++ b/tests/security/ima/ima_appraisal_hashes.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test IMA appraisal using hashes
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#49151
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_kernel_cmdline_hash.pm
+++ b/tests/security/ima/ima_kernel_cmdline_hash.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test IMA kernel command line for IMA hash
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#48932
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_kernel_cmdline_template.pm
+++ b/tests/security/ima/ima_kernel_cmdline_template.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test IMA kernel command line for IMA template
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#48929
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_measurement.pm
+++ b/tests/security/ima/ima_measurement.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test IMA measurement function
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#48374
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_measurement_audit.pm
+++ b/tests/security/ima/ima_measurement_audit.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test audit function for IMA measurement
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#48926
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_setup.pm
+++ b/tests/security/ima/ima_setup.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Setup environmnet for IMA & EVM testing - import MOK cert,
 #          setup grub boot menu and install necessary ima tools
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#45662
 
 use base "opensusebasetest";

--- a/tests/security/ima/ima_verify.pm
+++ b/tests/security/ima/ima_verify.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Test IMA verify function provided by evmctl
 # Note: This case should come after 'ima_apprasial_digital_signatures'
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#49562
 
 use base "opensusebasetest";

--- a/tests/security/krb5/krb5_crypt_nfs_client.pm
+++ b/tests/security/krb5/krb5_crypt_nfs_client.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test NFS with krb5 authentication and GSS API - client
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Ticket: poo#51560, poo#52388
 
 use base "consoletest";

--- a/tests/security/krb5/krb5_crypt_nfs_server.pm
+++ b/tests/security/krb5/krb5_crypt_nfs_server.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test NFS with krb5 authentication and GSS API - server
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Ticket: poo#51560, poo#52388
 
 use base "consoletest";

--- a/tests/security/krb5/krb5_crypt_prepare.pm
+++ b/tests/security/krb5/krb5_crypt_prepare.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Prepare environment for cryptographic function testing of krb5
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Ticket: poo#51560
 
 use base "consoletest";

--- a/tests/security/krb5/krb5_crypt_setup_client.pm
+++ b/tests/security/krb5/krb5_crypt_setup_client.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Setup client system for krb5 cryptographic testing
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Ticket: poo#51560, poo#51569
 
 use base "consoletest";

--- a/tests/security/krb5/krb5_crypt_setup_kdc.pm
+++ b/tests/security/krb5/krb5_crypt_setup_kdc.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Setup KDC service for krb5 cryptographic testing
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Ticket: poo#51560, poo#51563
 
 use base "consoletest";

--- a/tests/security/krb5/krb5_crypt_setup_server.pm
+++ b/tests/security/krb5/krb5_crypt_setup_server.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Setup server machine for krb5 cryptographic testing
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Ticket: poo#51560, poo#51566
 
 use base "consoletest";

--- a/tests/security/krb5/krb5_crypt_ssh_client.pm
+++ b/tests/security/krb5/krb5_crypt_ssh_client.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test ssh with krb5 authentication - client
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Ticket: poo#51560, poo#51569
 
 use base "consoletest";

--- a/tests/security/krb5/krb5_crypt_ssh_server.pm
+++ b/tests/security/krb5/krb5_crypt_ssh_server.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test ssh with krb5 authentication - server
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Ticket: poo#51560, poo#51566
 
 use base "consoletest";

--- a/tests/security/mokutil_sign.pm
+++ b/tests/security/mokutil_sign.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Test mokutil signing function - Create necessary key pairs,
 #          sign the kernel, import cert and boot with signed kernel.
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#45701
 
 use base "consoletest";

--- a/tests/security/nproc_limits.pm
+++ b/tests/security/nproc_limits.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Make sure the nproc limits are not set in limits.conf
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#43724
 
 use base "opensusebasetest";

--- a/tests/security/openscap/oscap_generating_fix.pm
+++ b/tests/security/openscap/oscap_generating_fix.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Generate  a script that shall bring the system to a state of
 #          compliance with given XCCDF Benchmark
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36916, tc#1621174
 
 use base "consoletest";

--- a/tests/security/openscap/oscap_generating_report.pm
+++ b/tests/security/openscap/oscap_generating_report.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Generate document - security guide or report - form XCCDF file
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36925, tc#1621177
 
 use base 'consoletest';

--- a/tests/security/openscap/oscap_info.pm
+++ b/tests/security/openscap/oscap_info.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Determine type and print information about a openscap source file
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36901, tc#1621169
 
 use base 'consoletest';

--- a/tests/security/openscap/oscap_oval_scanning.pm
+++ b/tests/security/openscap/oscap_oval_scanning.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Perform evaluation of oval (Open Vulnerability and Assessment
 #          Language) file
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36904, tc#1621170
 
 use base 'consoletest';

--- a/tests/security/openscap/oscap_remediating_offline.pm
+++ b/tests/security/openscap/oscap_remediating_offline.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Post-scan remediation test - offline
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36919, tc#1621175
 
 use base "consoletest";

--- a/tests/security/openscap/oscap_remediating_online.pm
+++ b/tests/security/openscap/oscap_remediating_online.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Post-scan remediation test - online
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36916, tc#1621174
 
 use base "consoletest";

--- a/tests/security/openscap/oscap_result_datastream.pm
+++ b/tests/security/openscap/oscap_result_datastream.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test SCAP result data stream
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36913, tc#1621173
 
 use base 'consoletest';

--- a/tests/security/openscap/oscap_setup.pm
+++ b/tests/security/openscap/oscap_setup.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Setup environment for openscap test
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#37006
 
 use base 'consoletest';

--- a/tests/security/openscap/oscap_source_datastream.pm
+++ b/tests/security/openscap/oscap_source_datastream.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test SCAP source data stream
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36910, tc#1621172
 
 use base 'consoletest';

--- a/tests/security/openscap/oscap_validating.pm
+++ b/tests/security/openscap/oscap_validating.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Validate given OVAL and XCCDF file against a XML schema
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36928, tc#1626472
 
 use base 'consoletest';

--- a/tests/security/openscap/oscap_xccdf_scanning.pm
+++ b/tests/security/openscap/oscap_xccdf_scanning.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Perform evaluation of XCCDF (The eXtensible Configuration
 #          Checklist Description Format) file
-# Maintainer: Wes <whdu@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#36907, tc#1621171
 
 use base 'consoletest';

--- a/tests/security/test_repo_setup.pm
+++ b/tests/security/test_repo_setup.pm
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Setup online repos or dvd images for further testing
-# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Maintainer: Ben Chou <bchou@suse.com>
 # Tags: poo#52808
 
 use strict;

--- a/tests/x11/libcamgm.pm
+++ b/tests/x11/libcamgm.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Test libcamgm via Yast2 CA management module(yast2 ca_mgm)
-# Maintainer: Dehai Kong <dhkong@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "x11test";
 use strict;


### PR DESCRIPTION
Update Security maintainer in test modules.

- Related ticket: https://progress.opensuse.org/issues/60809
- Needles: NA
- Verification run: NA