### PR TITLE
Add test suite for phub module

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-base+phub.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-base+phub.yaml
@@ -1,0 +1,19 @@
+---
+description: 'Test suite verifies functionality of packages present in Package Hub (phub) module'
+name: 'jeos-base+phub'
+schedule:
+  - installation/bootloader_hyperv
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/machinery
+  - sysauth/sssd
+  - console/orphaned_packages_check
+  - console/repo_orphaned_packages_check
+  - console/coredump_collect

--- a/schedule/jeos/sle/hyperv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-extratest.yaml
@@ -41,7 +41,6 @@ schedule:
   - console/ca_certificates_mozilla
   - console/unzip
   - console/salt
-  - console/machinery
   - console/gpg
   - console/rsync
   - console/shells
@@ -51,5 +50,4 @@ schedule:
   - console/docker_runc
   - console/docker_image
   - console/zypper_docker
-  - sysauth/sssd
   - console/kdump_and_crash

--- a/schedule/jeos/sle/kvm/jeos-base+phub.yaml
+++ b/schedule/jeos/sle/kvm/jeos-base+phub.yaml
@@ -1,0 +1,18 @@
+---
+description: 'Test suite verifies functionality of packages present in Package Hub (phub) module'
+name: 'jeos-base+phub'
+schedule:
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/machinery
+  - sysauth/sssd
+  - console/orphaned_packages_check
+  - console/repo_orphaned_packages_check
+  - console/coredump_collect

--- a/schedule/jeos/sle/kvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/kvm/jeos-extratest.yaml
@@ -39,7 +39,6 @@ schedule:
   - console/ca_certificates_mozilla
   - console/unzip
   - console/salt
-  - console/machinery
   - console/gpg
   - console/rsync
   - console/shells
@@ -50,5 +49,4 @@ schedule:
   - console/docker_runc
   - console/docker_image
   - console/zypper_docker
-  - sysauth/sssd
   - console/kdump_and_crash

--- a/schedule/jeos/sle/xen/hvm/jeos-base+phub.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-base+phub.yaml
@@ -1,0 +1,19 @@
+---
+description: 'Test suite verifies functionality of packages present in Package Hub (phub) module'
+name: 'jeos-base+phub'
+schedule:
+  - installation/bootloader_svirt
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/machinery
+  - sysauth/sssd
+  - console/orphaned_packages_check
+  - console/repo_orphaned_packages_check
+  - console/coredump_collect

--- a/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
@@ -41,7 +41,6 @@ schedule:
   - console/ca_certificates_mozilla
   - console/unzip
   - console/salt
-  - console/machinery
   - console/gpg
   - console/rsync
   - console/shells
@@ -52,5 +51,4 @@ schedule:
   - console/docker_runc
   - console/docker_image
   - console/zypper_docker
-  - sysauth/sssd
   - console/kdump_and_crash

--- a/schedule/jeos/sle/xen/pv/jeos-base+phub.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-base+phub.yaml
@@ -1,0 +1,18 @@
+---
+description: 'Test suite verifies functionality of packages present in Package Hub (phub) module'
+name: 'jeos-base+phub'
+schedule:
+  - installation/bootloader_svirt
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/machinery
+  - sysauth/sssd
+  - console/orphaned_packages_check
+  - console/repo_orphaned_packages_check
+  - console/coredump_collect

--- a/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
@@ -40,7 +40,6 @@ schedule:
   - console/ca_certificates_mozilla
   - console/unzip
   - console/salt
-  - console/machinery
   - console/gpg
   - console/rsync
   - console/shells
@@ -50,5 +49,4 @@ schedule:
   - console/docker
   - console/docker_runc
   - console/docker_image
-  - sysauth/sssd
   - console/zypper_docker


### PR DESCRIPTION
PackageHub modules are enabled as one of the last modules in the development cycle.
It would be more convenient to separate test cases in a stand-alone test suite.

[Example from QsF](https://openqa.suse.de/tests/3658812) and [Bug 1151373 - [SLE15-SP2 Build 38.5] openQA test fails in machinery - Missing or broken repository after registering module PackageHub](https://bugzilla.suse.com/show_bug.cgi?id=1151373)

- Related ticket: [[sle][jeos] test fails in machinery and sssd - missing phub registration](https://progress.opensuse.org/issues/60563)

