### PR TITLE
Update params for 11-sp4

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -696,7 +696,12 @@ sub remote_install_bootmenu_params {
         $params .= " ssh=1 ";    # trigger ssh-text installation
     }
     else {
-        $params .= " sshd=1 VNC=1 VNCSize=1024x768 VNCPassword=$testapi::password ";
+        if (is_sle('=11-sp4')) {
+            #11-SP4 only support ssh=1
+            $params .= " ssh=1 VNC=1 VNCSize=1024x768 VNCPassword=$testapi::password ";
+        } else {
+            $params .= " sshd=1 VNC=1 VNCSize=1024x768 VNCPassword=$testapi::password ";
+        }
     }
 
     $params .= "sshpassword=$testapi::password ";


### PR DESCRIPTION
For 11sp4 only support ssh=1, so update the params.

- Related ticket: https://progress.opensuse.org/issues/60851
- Needles: 
- Verification run: http://10.161.8.32/tests/85#step/bootloader_s390/24
