### PR TITLE
Fips_setup: Increase bootloader_time to avoid timeout after GNOME upgrade

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -70,7 +70,7 @@ sub run {
     }
 
     power_action('reboot', textmode => 1);
-    $self->wait_boot;
+    $self->wait_boot(bootloader_time => 200);
 
     # Workaround to resolve console switch issue
     select_console 'root-console';


### PR DESCRIPTION
1. Increase bootloader_time to 200 in fips_setup wait_boot
2. Avoid timeout error during wait_boot after GNOME upgrade

- Related ticket: https://progress.opensuse.org/issues/60551
- Needles: NA
- Verification run: 
http://10.100.210.39/tests/516 (crypt_core)
http://10.100.210.39/tests/514 (crypt_web)
http://10.100.210.39/tests/513 (crypt_tool)
http://10.100.210.39/tests/515 (crypt_x11)