### PR TITLE
Code adaptation for 12SP2 QAM

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -322,8 +322,13 @@ sub check_cluster_state {
     assert_script_run "$crm_mon_cmd";
     assert_script_run "$crm_mon_cmd | grep -i 'no inactive resources'" if is_sle '12-sp3+';
     assert_script_run 'crm_mon -1 | grep \'partition with quorum\'';
-    assert_script_run q/crm_mon -s | grep "$(crm node list | grep -c ': member').*nodes online"/;
-    record_soft_failure 'bsc#1158180, regression in crm_mon -s output' if is_sle('>=15-sp2');
+    if (is_sle('=12-sp2')) {
+        assert_script_run q/crm_mon -s | grep "$(crm node list | wc -l).*nodes online"/;
+    }
+    else {
+        assert_script_run q/crm_mon -s | grep "$(crm node list | grep -c ': member').*nodes online"/;
+        record_soft_failure 'bsc#1158180, regression in crm_mon -s output' if is_sle('>=15-sp2');
+    }
     # As some options may be deprecated, test shouldn't die on 'crm_verify'
     if (get_var('HDDVERSION')) {
         script_run 'crm_verify -LV';

--- a/tests/ha/remove_node.pm
+++ b/tests/ha/remove_node.pm
@@ -16,11 +16,12 @@ use warnings;
 use testapi;
 use lockapi;
 use hacluster;
+use version_utils 'is_sle';
 
 sub remove_state_join {
     my ($method, $cluster_name, $node_01, $node_02) = @_;
-    my $remove_cmd = 'crm cluster remove -y -c';
-    my $join_cmd   = 'crm cluster join -y -w /dev/watchdog -i ' . get_var('SUT_NETDEVICE', 'eth0') . ' -c';
+    my $remove_cmd = 'ha-cluster-remove -y -c';
+    my $join_cmd   = 'ha-cluster-join -y -i ' . get_var('SUT_NETDEVICE', 'eth0') . ' -c';
     my $timer      = bmwqemu::scale_timeout(5);
 
     # Waiting for the other nodes to be ready
@@ -61,7 +62,7 @@ sub run {
     remove_state_join('HOST', $cluster_name, $node_01_host, $node_02_host);
 
     # Both remove and join the second node by its IP address
-    remove_state_join('IP', $cluster_name, $node_01_ip, $node_02_ip);
+    remove_state_join('IP', $cluster_name, $node_01_ip, $node_02_ip) unless is_sle('=12-sp2');
 
     # Synchronize all the nodes and save cluster status
     barrier_wait("REMOVE_NODE_FINAL_JOIN_$cluster_name");


### PR DESCRIPTION
Code needs to be adapted for 12SP2 QAM tests.

- [Failed test](https://openqa.suse.de/tests/3681247#step/fencing/9)
- Related ticket: N/A
- Needles: N/A
- Verification run: 12SP2 [node1](http://1a102.qa.suse.de/tests/1768) [node2](http://1a102.qa.suse.de/tests/1769)
- Regression tests: 15SP1 [node1](http://1a102.qa.suse.de/tests/1771) [node2](http://1a102.qa.suse.de/tests/1772)
