### PR TITLE
install_ltp: enable kernel log to serial console

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -296,7 +296,7 @@ sub run {
     my $self     = shift;
     my $inst_ltp = get_var 'INSTALL_LTP';
     my $tag      = get_ltp_tag();
-    my $grub_param;
+    my $grub_param = 'ignore_loglevel';
 
     if ($inst_ltp !~ /(repo|git)/i) {
         die 'INSTALL_LTP must contain "git" or "repo"';
@@ -316,7 +316,7 @@ sub run {
 
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
         script_run('echo 1 > /sys/module/printk/parameters/time');
-        $grub_param = 'printk.time=1';
+        $grub_param .= ' printk.time=1';
     }
 
     # check kGraft if KGRAFT=1
@@ -346,7 +346,7 @@ sub run {
     $grub_param .= ' console=hvc0'     if (get_var('ARCH') eq 'ppc64le');
     $grub_param .= ' console=ttysclp0' if (get_var('ARCH') eq 's390x');
     if (defined $grub_param) {
-        add_grub_cmdline_settings($grub_param);
+        add_grub_cmdline_settings($grub_param, update_grub => 1);
     }
 
     add_custom_grub_entries if (is_sle('12+') || is_opensuse) && !is_jeos;


### PR DESCRIPTION
Add 'ignore_loglevel' kernel command line argument to enable kernel log output (dmesg) to serial console. This will prevent loss of kernel logs due to VM snapshot reload after system crash.

Also make sure that Grub config file gets regenerated even if there are no custom Grub menu entries to create.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - 12SP1@x86_64: https://openqa.suse.de/tests/3698317
  - 12SP4@PPC64LE: https://openqa.suse.de/tests/3698318
  - 12SP5@x86_64: https://openqa.suse.de/tests/3698319
  - 15SP1@x86_64: https://openqa.suse.de/tests/3698320

Look for OOM killer messages in serial0.txt