### PR TITLE
wicked: Enable hvc1 serial console for PowerKVM

### DIFF
--- a/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
@@ -63,6 +63,7 @@
             sed -i 's/splash=silent\ quiet//' /etc/default/grub
             sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
             grub2-mkconfig -o /boot/grub2/grub.cfg
+            systemctl enable serial-getty@hvc1
             ]]>
         </source>
       </script>

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -583,7 +583,10 @@ sub pre_run_hook {
     type_string($coninfo);
     wait_serial($coninfo, undef, 0, no_regex => 1);
     type_string("\n");
-    add_serial_console('hvc1') if ($self->{name} eq 'before_test' && get_var('VIRTIO_CONSOLE_NUM', 1) > 1);
+    if ($self->{name} eq 'before_test' && get_var('VIRTIO_CONSOLE_NUM', 1) > 1) {
+        my $serial_terminal = check_var('ARCH', 'ppc64le') ? 'hvc2' : 'hvc1';
+        add_serial_console($serial_terminal);
+    }
     if ($self->{name} ne 'before_test' && get_var('WICKED_TCPDUMP')) {
         script_run('tcpdump -s0 -U -w /tmp/tcpdump' . $self->{name} . '.pcap >& /dev/null & export CHECK_TCPDUMP_PID=$!');
         set_var('WICKED_TCPDUMP_PID', script_output('echo $CHECK_TCPDUMP_PID'));


### PR DESCRIPTION
It appears that hvc0 used by default on other architectures
can not be used in case of Power. So we need to enable hvc1
systemd service to be able to run tests with VIRTIO_CONSOLE=1

VR: 
https://openqa.suse.de/tests/3685246 - create hdd job with modified profile
https://openqa.suse.de/tests/3685332 - tests running with image created by 3685246 and VIRTIO_CONSOLE=1 