### PR TITLE
LTP: Add debug_pagealloc=on kernel cmdline arg

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -314,9 +314,12 @@ sub run {
 
     $self->select_serial_terminal;
 
+    # jsc#SLE-9743
+    $grub_param = 'debug_pagealloc=on';
+
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
         script_run('echo 1 > /sys/module/printk/parameters/time');
-        $grub_param = 'printk.time=1';
+        $grub_param .= ' printk.time=1';
     }
 
     # check kGraft if KGRAFT=1


### PR DESCRIPTION
See: jsc#SLE-9743

Verification runs: running some tests on both SLE and Tumbleweed with this option, after it was added via install_ltp
- http://quasar.suse.cz/tests/4296/file/serial_terminal.txt (sle-12-SP5-Server-DVD-x86_64-Build0372-ltp_ima@64bit)
- http://quasar.suse.cz/tests/4287/file/serial_terminal.txt (sle-12-SP5-Server-DVD-x86_64-Build0372-ltp_syscalls@64bit)
- http://quasar.suse.cz/tests/4285/file/serial_terminal.txt (Tumbleweed-DVD-x86_64-Build20191207-ltp_syscalls@64bit)