### PR TITLE
serial_terminal: Skip update of securetty

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -43,9 +43,9 @@ service and start it. It requires selecting root console before.
 =cut
 sub add_serial_console {
     my ($console) = @_;
-    my $service   = 'serial-getty@' . $console;
-    my $config    = '/etc/securetty';
-    script_run(qq{grep -q "^$console\$" $config || echo '$console' >> $config; systemctl enable $service; systemctl start $service});
+    my $service = 'serial-getty@' . $console;
+    script_run(qq{grep -q "^$console\$" /etc/securetty || echo '$console' >> /etc/securetty;}) if (is_sle('<12-sp2'));
+    script_run("systemctl enable $service; systemctl start $service");
 }
 
 =head2 get_login_message


### PR DESCRIPTION
In versions greater than SLE 12 SP1 file /etc/securetty is
ignored anyway so no point to update it when adding another
serial device