### PR TITLE
Soft fail when ghostview will fail on wayland

### DIFF
--- a/tests/x11/ghostscript.pm
+++ b/tests/x11/ghostscript.pm
@@ -77,6 +77,10 @@ sub run {
     if (!$gv_missing) {
         script_run "gv $reference", 0;
         assert_screen "ghostview_alphabet";
+        if (match_has_tag('bsc1158907')) {
+            send_key 'alt-f4';
+            wait_still_screen 1;
+        }
 
         # close gv
         send_key "alt-f4";


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1158907
- Verification run:
http://10.100.12.155/tests/14016#step/ghostscript/43
https://openqa.suse.de/tests/3686600
