### PR TITLE
Increase the timeout for opening lowriter in live CD on uefi-usb

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -956,8 +956,9 @@ sub check_desktop_runner {
 # Start one of the libreoffice components, close any first-run dialogs
 sub libreoffice_start_program {
     my ($self, $program) = @_;
-
-    x11_start_program($program);
+    my %start_program_args;
+    $start_program_args{timeout} = 100 if get_var('LIVECD') && check_var('MACHINE', 'uefi-usb');
+    x11_start_program($program, %start_program_args);
     if (match_has_tag('ooffice-tip-of-the-day')) {
         # Unselect "_S_how tips on startup", select "_O_k"
         send_key "alt-s";


### PR DESCRIPTION
see https://progress.opensuse.org/issues/52739
verification test:
http://f40.suse.de/tests/5676#step/ooffice/9
