### PR TITLE
Add REMOVE_KGRAFT variable to update_kernel test module

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -46,6 +46,7 @@ our @EXPORT = qw(
   fully_patch_system
   ssh_fully_patch_system
   minimal_patch_system
+  zypper_search
   workaround_type_encrypted_passphrase
   is_boot_encrypted
   is_bridged_networking
@@ -643,6 +644,39 @@ sub minimal_patch_system {
     else {
         zypper_call('patch --with-interactive -l', exitcode => [0, 102, 103], timeout => 3000, log => 'minimal_patch.log');
     }
+}
+
+=head2 zypper_search
+
+ zypper_search($search_params);
+
+Run zypper search with given command line arguments and parse the output into
+an array of hashes.
+
+=cut
+
+sub zypper_search {
+    my $params = shift;
+    my @fields = ('status', 'name', 'type', 'version', 'arch', 'repository');
+    my @ret;
+
+    my $output = script_output("zypper -n se $params");
+
+    for my $line (split /\n/, $output) {
+        my @tokens = split /\s*\|\s*/, $line;
+        next if $#tokens < $#fields;
+        my %tmp;
+
+        for (my $i = 0; $i < scalar @fields; $i++) {
+            $tmp{$fields[$i]} = $tokens[$i];
+        }
+
+        push @ret, \%tmp;
+    }
+
+    # Remove header from package list
+    shift @ret;
+    return \@ret;
 }
 
 =head2 workaround_type_encrypted_passphrase

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -57,7 +57,7 @@ sub run {
     }
 
     # check kGraft patch if KGRAFT=1
-    if (check_var('KGRAFT', '1')) {
+    if (check_var('KGRAFT', '1') && !check_var('REMOVE_KGRAFT', '1')) {
         assert_script_run("uname -v| grep -E '(/kGraft-|/lp-)'");
     }
 

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -320,7 +320,7 @@ sub run {
     }
 
     # check kGraft if KGRAFT=1
-    if (check_var("KGRAFT", '1')) {
+    if (check_var("KGRAFT", '1') && !check_var('REMOVE_KGRAFT', '1')) {
         assert_script_run("uname -v | grep -E '(/kGraft-|/lp-)'");
     }
 

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -76,18 +76,26 @@ sub kgraft_state {
     if (is_sle('<=12-SP1')) {
         script_run("lsinitrd /boot/initrd-$kver-xen | grep patch");
         save_screenshot;
-        script_run("lsinitrd /boot/initrd-$kver-xen | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}' > /dev/$serialdev", 0);
-        ($module) = wait_serial(qr/lib*/) =~ /(^.*ko)\s+/;
+        $module = script_output("lsinitrd /boot/initrd-$kver-xen | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}' > /dev/$serialdev");
 
-        mod_rpm_info($module);
+        if (check_var('REMOVE_KGRAFT', '1')) {
+            die 'Kgraft module exists when it should have been removed' if $module;
+        }
+        else {
+            mod_rpm_info($module);
+        }
     }
 
     script_run("lsinitrd /boot/initrd-$kver-default | grep patch");
     save_screenshot;
-    script_run("lsinitrd /boot/initrd-$kver-default | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}' > /dev/$serialdev", 0);
-    ($module) = wait_serial(qr/lib*/) =~ /(^.*ko)\s+/;
+    $module = script_output("lsinitrd /boot/initrd-$kver-default | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}' > /dev/$serialdev");
 
-    mod_rpm_info($module);
+    if (check_var('REMOVE_KGRAFT', '1')) {
+        die 'Kgraft module exists when it should have been removed' if $module;
+    }
+    else {
+        mod_rpm_info($module);
+    }
 
     script_run("uname -a");
     save_screenshot;
@@ -178,8 +186,9 @@ sub prepare_kgraft {
     while (my ($i, $val) = each(@repos)) {
         zypper_call("ar $val kgraft-test-repo-$i");
 
-        my $kversion = script_output(q(zypper -n se -s kernel-default));
-        my $pversion = script_output("zypper -n se -s -r kgraft-test-repo-$i");
+        my $kversion = zypper_search(q(-s -x kernel-default));
+        my $pversion = zypper_search("-s -t package -r kgraft-test-repo-$i");
+        $pversion = join(' ', map { $$_{name} } @$pversion);
 
         #disable kgraf-test-repo for while
         zypper_call("mr -d kgraft-test-repo-$i");
@@ -187,7 +196,12 @@ sub prepare_kgraft {
         my $wanted_version = right_kversion($kversion, $pversion);
         fully_patch_system;
         install_lock_kernel($wanted_version);
+
+        if (check_var('REMOVE_KGRAFT', '1')) {
+            zypper_call("rm " . $pversion);
+        }
     }
+
     power_action('reboot', textmode => 1);
 }
 
@@ -195,9 +209,12 @@ sub right_kversion {
     my ($kversion, $pversion) = @_;
     my ($kver_fragment) = $pversion =~ qr/(?:kgraft-|kernel-live)patch-(\d+_\d+_\d+-\d+_*\d*_*\d*)-default/;
     $kver_fragment =~ s/_/\\\./g;
-    my ($real_version) = $kversion =~ qr/($kver_fragment\.+\d+)/;
 
-    return $real_version;
+    for my $item (@$kversion) {
+        return $$item{version} if $$item{version} =~ qr/^$kver_fragment\./;
+    }
+
+    die "Kernel $kver_fragment not found in repositories.";
 }
 
 sub update_kgraft {
@@ -289,21 +306,24 @@ sub run {
         prepare_kgraft($repo, $incident_id);
         boot_to_console($self);
 
-        # dependencies for heavy load script
-        if (!$wk_ker) {
-            add_qa_head_repo;
-            zypper_call("in qa_lib_ctcs2 qa_test_ltp qa_test_newburn");
-        }
-        # update kgraft patch under heavy load
-        update_kgraft($repo, $incident_id);
+        if (!check_var('REMOVE_KGRAFT', '1')) {
+            # dependencies for heavy load script
+            if (!$wk_ker) {
+                add_qa_head_repo;
+                zypper_call("in qa_lib_ctcs2 qa_test_ltp qa_test_newburn");
+            }
 
-        if (!$wk_ker) {
-            zypper_call("rr qa-head");
-            zypper_call("rm qa_lib_ctcs2 qa_test_ltp qa_test_newburn");
-        }
-        power_action('reboot', textmode => 1);
+            # update kgraft patch under heavy load
+            update_kgraft($repo, $incident_id);
 
-        boot_to_console($self);
+            if (!$wk_ker) {
+                zypper_call("rr qa-head");
+                zypper_call("rm qa_lib_ctcs2 qa_test_ltp qa_test_newburn");
+            }
+            power_action('reboot', textmode => 1);
+
+            boot_to_console($self);
+        }
 
         kgraft_state;
     }


### PR DESCRIPTION
The REMOVE_KGRAFT job variable allows re-running kgraft tests with unpatched SLE kernel. This makes it easier to tell apart kgraft regressions from kernel bugs which were present in the original kernel package.

- Related ticket: N/A
- Needles: N/A

## Verification runs:
12SP2u33
- patched x86_64: https://openqa.suse.de/tests/3688320
- patched ppc64le: https://openqa.suse.de/tests/3688329
- unpatched x86_64: https://openqa.suse.de/tests/3688327
- unpatched ppc64le: https://openqa.suse.de/tests/3688330

12SP4u8
- patched x86_64: https://openqa.suse.de/tests/3688331
- patched ppc64le: https://openqa.suse.de/tests/3688333
- unpatched x86_64: https://openqa.suse.de/tests/3688332
- unpatched ppc64le: https://openqa.suse.de/tests/3688334

15SP1u1
- patched x86_64: https://openqa.suse.de/tests/3688335
- patched ppc64le: https://openqa.suse.de/tests/3692772
- unpatched x86_64: https://openqa.suse.de/tests/3688336
- unpatched ppc64le: https://openqa.suse.de/tests/3688339

12SP2 KOTD
- x86_64: https://openqa.suse.de/tests/3688340
- ppc64le: https://openqa.suse.de/tests/3688341
- s390x: https://openqa.suse.de/tests/3688342

12SP4 KOTD
- x86_64: https://openqa.suse.de/tests/3688343
- ppc64le: https://openqa.suse.de/tests/3688344
- s390x: https://openqa.suse.de/tests/3692774
- aarch64: https://openqa.suse.de/tests/3688346

15SP1 KOTD
- x86_64: https://openqa.suse.de/tests/3688347
- ppc64le: https://openqa.suse.de/tests/3688356
- s390x: https://openqa.suse.de/tests/3688357
- aarch64: https://openqa.suse.de/tests/3688358

12SP4 kernel-ec2:
- x86_64: https://openqa.suse.de/tests/3692786
- ppc64le: https://openqa.suse.de/tests/3688359
- s390x: https://openqa.suse.de/tests/3688360
- aarch64: https://openqa.suse.de/tests/3688361

12SP4 kernel-azure:
- x86_64: https://openqa.suse.de/tests/3688362

15GA kernel-azure:
- x86_64: https://openqa.suse.de/tests/3688363

15SP1 dtb-aarch64:
- x86_64: https://openqa.suse.de/tests/3689384
- ppc64le: https://openqa.suse.de/tests/3688364
- s390x: https://openqa.suse.de/tests/3692809
- aarch64: https://openqa.suse.de/tests/3688365