### PR TITLE
WIP wicked: enable cleanup_before_shutdown

### DIFF
--- a/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
@@ -63,7 +63,6 @@
             sed -i 's/splash=silent\ quiet//' /etc/default/grub
             sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
             grub2-mkconfig -o /boot/grub2/grub.cfg
-            systemctl enable serial-getty@hvc1
             ]]>
         </source>
       </script>

--- a/schedule/create_hdd_autoyast_wicked.yaml
+++ b/schedule/create_hdd_autoyast_wicked.yaml
@@ -9,4 +9,5 @@ schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
+  - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -48,7 +48,7 @@ END_SCRIPT
     # Configure serial consoles for virtio support
     # poo#18860 Enable console on hvc0 on SLES < 12-SP2
     # poo#44699 Enable console on hvc1 to fix login issues on ppc64le
-    if (!check_var('VIRTIO_CONSOLE', 0)) {
+    if (check_var('VIRTIO_CONSOLE', 1)) {
         if (is_sle('<12-SP2') && !check_var('ARCH', 's390x')) {
             add_serial_console('hvc0');
         }
@@ -59,7 +59,7 @@ END_SCRIPT
     # Proceed with dhcp cleanup on qemu backend only.
     # Cleanup is made, because if same hdd image used in multimachine scenario
     # on several nodes, the dhcp clients use same id and cause conflicts on dhcpd server.
-    if (check_var('BACKEND', 'qemu')) {
+    if (check_var('BACKEND', 'qemu') && !check_var('EXTRATEST','wicked')) {
         my $network_status = script_output('systemctl status network');
         # Do dhcp cleanup for wicked
         if ($network_status =~ /wicked/) {


### PR DESCRIPTION
Previous approach from starting hvc1 in AutoYaST profile
specific for wicked was shortterm solution because it was solving
problem exclusively for wicked. This patch is moving to use
generic approach which suppose to be used by everyone who face with
problem of no ability to login to PowerKVM via serial terminal