### PR TITLE
Revert changes related to skip registration step for Full medium

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -866,7 +866,7 @@ sub load_inst_tests {
     }
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
-        loadtest "installation/scc_registration" unless check_var('FLAVOR', 'Full');
+        loadtest "installation/scc_registration";
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }

--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -8,6 +8,7 @@ schedule:
   - installation/welcome
   - installation/accept_license
   - installation/network_configuration
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/partitioning
   - installation/partitioning_finish

--- a/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
@@ -6,6 +6,7 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/releasenotes_origin
   - installation/partitioning

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -9,6 +9,7 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning

--- a/schedule/yast/skip_registration/skip_registration@s390x-zVM.yaml
+++ b/schedule/yast/skip_registration/skip_registration@s390x-zVM.yaml
@@ -9,6 +9,7 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/scc_registration
   - installation/disk_activation
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/skip_registration/skip_registration@s390x.yaml
+++ b/schedule/yast/skip_registration/skip_registration@s390x.yaml
@@ -9,6 +9,7 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -34,4 +35,3 @@ schedule:
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
   - shutdown/svirt_upload_assets
-  

--- a/schedule/yast/skip_registration/skip_registration@svirt-hyperv.yaml
+++ b/schedule/yast/skip_registration/skip_registration@svirt-hyperv.yaml
@@ -9,6 +9,7 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -32,4 +33,3 @@ schedule:
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
   - shutdown/hyperv_upload_assets
-  

--- a/schedule/yast/skip_registration/skip_registration@svirt-xen-hvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration@svirt-xen-hvm.yaml
@@ -9,6 +9,7 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -32,4 +33,3 @@ schedule:
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
   - shutdown/svirt_upload_assets
-

--- a/schedule/yast/skip_registration/skip_registration@svirt-xen-pv.yaml
+++ b/schedule/yast/skip_registration/skip_registration@svirt-xen-pv.yaml
@@ -9,6 +9,7 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning

--- a/schedule/yast/skip_registration/skip_registration@uefi.yaml
+++ b/schedule/yast/skip_registration/skip_registration@uefi.yaml
@@ -9,6 +9,7 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/scc_registration  
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning


### PR DESCRIPTION
 We got registration back to full medium and many of the adjustments we
did are not necessary anymore.
Complex part is that we also have some adjustments which are necessary,
like not selecting DVD source anymore.

- [Verification runs](https://openqa.suse.de/tests/overview?build=rwx788_full_medium&distri=sle)
