### PR TITLE
Fix failures on SuSEfirewall2 shutdown introduced with 2308ed9b2

### DIFF
--- a/lib/Utils/Systemd.pm
+++ b/lib/Utils/Systemd.pm
@@ -50,9 +50,9 @@ sub disable_and_stop_service {
 
     my $cmd = $args{mask_service} ? 'mask' : 'disable';
     if (is_sle('<12-sp3')) {
-        map { systemctl("$_ $service_name") } ($cmd, 'stop');
+        map { systemctl("$_ $service_name", %args) } ($cmd, 'stop');
     } else {
-        systemctl("$cmd --now $service_name");
+        systemctl("$cmd --now $service_name", %args);
     }
 }
 

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -289,7 +289,7 @@ sub setup_network {
         }
     }
 
-    disable_and_stop_service(opensusebasetest::firewall);
+    disable_and_stop_service(opensusebasetest::firewall, ignore_failure => 1);
 }
 
 sub run {

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -28,8 +28,9 @@ sub run {
     assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');
     assert_script_run('echo "10.0.2.102 client minion" >> /etc/hosts');
 
-    # Configure static network, disable firewall
-    disable_and_stop_service($self->firewall);
+    # Configure static network, disable firewall, ignore failure which can
+    # happen for SuSEfirewall2
+    disable_and_stop_service($self->firewall, ignore_failure => 1);
 
     # Configure the internal network an  try it
     if ($hostname =~ /server|master/) {


### PR DESCRIPTION
The systemd service SuSEfirewall2 internally references
SuSEfirewall2_setup which fails to stop after the according symlinks
have been removed by systemctl already.

See https://openqa.suse.de/tests/3692944#step/install_ltp/159