### PR TITLE
Suport Server: Do not install pre-installed rpms

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -527,7 +527,6 @@ sub setup_nfs_server {
         $nfs_permissions = get_required_var("NFS_PERMISSIONS");
     }
 
-    zypper_call('in rpcbind nfs-kernel-server');
     systemctl("start rpcbind");
     systemctl("start nfs-server");
     assert_script_run("nfsstat –s");


### PR DESCRIPTION
As the support server is started from the pre-created image, there
is no real need of attempting rpms which are there. Having that step
might cause various problems with repositories etc.

This change should be considered an intermediate one while support
server gets some more maintenance.
