### PR TITLE
Increase the timeout for security password check

### DIFF
--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -17,6 +17,7 @@ use warnings;
 use testapi;
 use version_utils 'is_sle';
 use utils 'type_string_slow';
+use Utils::Architectures qw(is_ppc64le is_s390x);
 
 our @EXPORT = qw(type_password_and_verification await_password_check enter_userinfo enter_rootinfo);
 
@@ -29,10 +30,10 @@ sub type_password_and_verification {
 sub await_password_check {
     # PW too easy (cracklib)
     # bsc#937012 is resolved in > SLE 12, skip if VERSION=12
-    return if (is_sle('=12') && check_var('ARCH', 's390x'));
-    assert_screen 'inst-userpasswdtoosimple';
+    return if (is_sle('=12') && is_s390x);
+    my $timeout = (is_ppc64le) ? 90 : 30;
+    assert_screen 'inst-userpasswdtoosimple', $timeout;
     send_key 'ret';
-
 }
 
 sub enter_userinfo {


### PR DESCRIPTION
Password security check can take longer on power

See: https://openqa.suse.de/tests/3694810#step/user_settings/5
VR: https://openqa.suse.de/t3695004