### PR TITLE
Disable gnome lockscreen and suspend for HANA tests

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -35,6 +35,7 @@ our @EXPORT = qw(
   turn_off_kde_screensaver
   turn_off_gnome_screensaver
   turn_off_gnome_suspend
+  turn_off_gnome_lockscreen
   untick_welcome_on_next_startup
 );
 
@@ -295,6 +296,17 @@ Disable suspend in gnome. To be called from a command prompt, for example an xte
 =cut
 sub turn_off_gnome_suspend {
     script_run 'gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type \'nothing\'';
+}
+
+=head2 turn_off_gnome_lockscreen
+
+  turn_off_gnome_lockscreen()
+
+Disable lock screen in gnome. To be called from a command prompt, for example an xterm window.
+
+=cut
+sub turn_off_gnome_lockscreen {
+    script_run 'gsettings set org.gnome.desktop.lockdown disable-lock-screen true';
 }
 
 =head2 untick_welcome_on_next_startup

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use x11utils 'turn_off_gnome_screensaver';
+use x11utils qw(turn_off_gnome_screensaver turn_off_gnome_lockscreen turn_off_gnome_suspend);
 
 sub run {
     my ($self) = @_;
@@ -50,6 +50,8 @@ sub run {
 
     x11_start_program('xterm');
     turn_off_gnome_screensaver;
+    turn_off_gnome_lockscreen;
+    turn_off_gnome_suspend;
     type_string "killall xterm\n";
     assert_screen 'generic-desktop';
     x11_start_program('yast2 sap-installation-wizard', target_match => 'sap-installation-wizard');


### PR DESCRIPTION
Disable gnome lockscreen and suspend for HANA tests on SLES4SAP.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3694936