### PR TITLE
wicked:  enable cleanup_before_shutdown

### DIFF
--- a/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
@@ -63,7 +63,6 @@
             sed -i 's/splash=silent\ quiet//' /etc/default/grub
             sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
             grub2-mkconfig -o /boot/grub2/grub.cfg
-            systemctl enable serial-getty@hvc1
             ]]>
         </source>
       </script>

--- a/schedule/create_hdd_autoyast_wicked.yaml
+++ b/schedule/create_hdd_autoyast_wicked.yaml
@@ -9,4 +9,5 @@ schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
+  - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -67,8 +67,12 @@ END_SCRIPT
             systemctl 'stop wickedd.service';
             assert_script_run('ls /var/lib/wicked/');
             save_screenshot;
-            assert_script_run('rm -f /var/lib/wicked/*.xml');
+            script_run('rm -f /var/lib/wicked/*.xml');
+            script_run('rm -f /var/run/wicked/extension/hostname');
+            script_run('rm -f /var/run/wicked/extension/hostname');
+            script_run('rm -f /var/run/wicked/*');
         }
+        script_run('rm -f /etc/hostname');
     }
     # Make some information available on common systems to help debug shutdown issues.
     if (get_var('DESKTOP', '') =~ qr/gnome|kde/) {


### PR DESCRIPTION
Previous approach from starting hvc1 in AutoYaST profile
specific for wicked was shortterm solution because it was solving
problem exclusively for wicked. This patch is moving to use
generic approach which suppose to be used by everyone who face with
problem of no ability to login to PowerKVM via serial terminal