### PR TITLE
Only hit return when the "remote access" control panel has been found

### DIFF
--- a/tests/x11/remote_desktop/windows_server_setup.pm
+++ b/tests/x11/remote_desktop/windows_server_setup.pm
@@ -22,7 +22,9 @@ sub run {
     my $self = shift;
 
     assert_and_click "start";
-    type_string "remote access\n";
+    type_string "remote access";
+    assert_screen "start_menu-remote_access-controlpanel";
+    send_key "ret";
 
     assert_and_click "allow-remote-connections";
     assert_screen "allow-connections-with-nla-enabled";


### PR DESCRIPTION
There is a small time frame where the search results show "Search the
Web". Wait until the control panel is found.

- Related ticket: https://progress.opensuse.org/issues/60917
- Verification run: https://openqa.opensuse.org/tests/1110751#step/windows_server_setup/2
