### PR TITLE
orphaned_packages_check: Convert to automatic test failing on any orphans

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -488,6 +488,7 @@ sub load_zdup_tests {
     loadtest 'boot/boot_to_desktop';
     loadtest "installation/opensuse_welcome"  if opensuse_welcome_applicable();
     loadtest 'console/check_upgraded_service' if !is_desktop;
+    loadtest 'console/orphaned_packages_check';
 }
 
 sub load_autoyast_tests {
@@ -1227,7 +1228,7 @@ sub load_consoletests {
     if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && is_sle('<15') && !get_var("MEDIA_UPGRADE")) {
         loadtest "feature/feature_console/deregister";
     }
-    loadtest 'console/orphaned_packages_check' if is_jeos || get_var('UPGRADE') || is_sle('>=12-SP4');
+    loadtest 'console/orphaned_packages_check' if is_jeos || get_var('UPGRADE') || get_var('ZDUP') || !is_sle('<12-SP4');
     loadtest "console/consoletest_finish";
 }
 
@@ -1683,6 +1684,7 @@ sub load_extra_tests_console {
     loadtest 'console/libgpiod' if (is_leap('15.1+') || is_tumbleweed) && !(is_jeos && is_x86_64);
     loadtest 'console/osinfo_db' if (is_sle('12-SP3+') && !is_jeos);
     loadtest 'console/libgcrypt' if ((is_sle(">=12-SP4") && (check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk'))) || is_opensuse);
+    loadtest "console/orphaned_packages_check";
 }
 
 sub load_extra_tests_phub {

--- a/tests/console/orphaned_packages_check.pm
+++ b/tests/console/orphaned_packages_check.pm
@@ -1,16 +1,15 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Check and output orphaned packages
-# - Run "zypper packages --orphaned"
-# - Save screenshot
-# Maintainer: Lemon <leli@suse.com>
+# Summary: Check for any orphaned packages. There should be none in fully
+#   supported systems
+# Maintainer: Oliver Kurz <okurz@suse.de>
 # Tags: poo#19606
 
 use base "consoletest";
@@ -18,17 +17,21 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
+use version_utils 'is_upgrade';
 
 sub run {
     select_console 'root-console';
-
-    #No orphaned packages list to compare currently, so we simply output the result
-    zypper_call('packages --orphaned', log => 'orphaned.log');
-    save_screenshot;
-}
-
-sub test_flags {
-    return {fatal => 1};
+    my $cmd = 'zypper pa --orphaned | grep -v "\(release-DVD\|release-dvd\)" | (! grep "@System")';
+    # there are orphans on older, unsupported openSUSE versions which we
+    # upgrade from. They will most likely never be fixed
+    my $expect_failure = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
+    set_var('ZYPPER_ORPHANED_CHECK_ONLY', get_var('ZYPPER_ORPHANED_CHECK_ONLY', $expect_failure));
+    if (get_var('ZYPPER_ORPHANED_CHECK_ONLY')) {
+        script_run($cmd);
+    }
+    else {
+        assert_script_run($cmd, fail_message => "Orphaned packages found, set 'ZYPPER_ORPHANED_CHECK_ONLY' to only check and not fail the test");
+    }
 }
 
 1;

--- a/variables.md
+++ b/variables.md
@@ -137,3 +137,4 @@ YAST2_FIRSTBOOT_USERNAME | string | | Defines username for the user to be create
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Comma separated list of repositories to be added/used for zypper dup call, defaults to SUSEMIRROR or attached media, e.g. ISO.
 LINUXRC_BOOT | boolean | true | To be used only in scenarios where we are booting an installed system from the installer medium (for example, a DVD) with the menu option "Boot Linux System" (not "boot From Hard Disk"). This option uses linuxrc.
+ZYPPER_ORPHANED_CHECK_ONLY | boolean | false | Within tests/console/orphaned_packages_check.pm only check for orphaned packages, do not fail if any are found.


### PR DESCRIPTION
In fully supported systems there should be no orphaned packages.
Exceptions can still be introduced with `record_soft_failure`.

Verification runs:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9148 https://openqa.suse.de/tests/3687791,https://openqa.suse.de/tests/3694570,https://openqa.suse.de/tests/3688460,https://openqa.suse.de/tests/3687327,https://openqa.suse.de/tests/3687480,https://openqa.suse.de/tests/3688112,https://openqa.suse.de/tests/3688119,https://openqa.suse.de/tests/3687934,https://openqa.suse.de/tests/3695950,https://openqa.suse.de/tests/3695955,https://openqa.suse.de/tests/3695908,https://openqa.suse.de/tests/3695910,https://openqa.suse.de/tests/3696347,https://openqa.suse.de/tests/3696150,https://openqa.suse.de/tests/3691124,https://openqa.suse.de/tests/3575719,https://openqa.opensuse.org/tests/1109703,https://openqa.opensuse.org/tests/1109721,https://openqa.opensuse.org/tests/1110774,https://openqa.opensuse.org/tests/1110773,https://openqa.opensuse.org/tests/1110605,https://openqa.opensuse.org/tests/1110641 EXCLUDE_MODULES=soundtouch,suse_module_tools,check_os_release
```

* [sle-15-SP2-Online-x86_64-Build104.1-minimal+base_yast@64bit](https://openqa.suse.de/t3697359)
* [sle-15-SP2-Online-s390x-Build104.1-minimal+base_yast@s390x-kvm-sle12](https://openqa.suse.de/t3697360)
* [sle-15-SP2-Online-s390x-Build104.1-default@s390x-kvm-sle12](https://openqa.suse.de/t3697362)
* [sle-15-SP2-Online-x86_64-Build104.1-default@64bit](https://openqa.suse.de/t3697358)
* [sle-15-SP2-Migration-from-SLE15-SPX-to-SLE15-SP2-s390x-Build104.1-online_sles15sp1_pscc_basesys-srv_def_full_zdup@s390x-kvm-sle15](https://openqa.suse.de/tests/3697372) -> fails with many orphaned packages, either product bug or test issue because of disabled SLE modules
* [sle-15-SP2-Migration-from-SLE15-SPX-to-SLE15-SP2-s390x-Build104.1-online_sles15sp1_pscc_all_minimal@s390x-kvm-sle15](https://openqa.suse.de/t3697368) -> same as previous
* [sle-15-SP2-Online-x86_64-Build104.1-migration_zypper_sle15_ha_alpha_node01@64bit](https://openqa.suse.de/t3697369) -> shows orphaned packages but does not fail the test, using ZYPPER_ORPHANED_CHECK_ONLY
* [sle-12-SP3-Server-DVD-Updates-x86_64-Build20191212-1-qam-textmode@64bit](https://openqa.suse.de/t3702359)
* [sle-12-SP3-Server-DVD-Updates-x86_64-Build20191212-1-qam-minimal+base@64bit](https://openqa.suse.de/t3702360)
* [sle-12-SP2-Server-DVD-Updates-x86_64-Build20191212-1-qam-textmode@64bit](https://openqa.suse.de/t3700801)
* [sle-12-SP2-Server-DVD-Updates-x86_64-Build20191212-1-qam-minimal+base@64bit](https://openqa.suse.de/t3700802)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20191212-1-qam-minimal+base@64bit](https://openqa.suse.de/t3700803)
* [sle-12-SP5-Server-DVD-Updates-x86_64-Build20191212-1-qam-textmode@64bit](https://openqa.suse.de/t3696971)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20191211-1-qam-textmode+sle15@64bit](https://openqa.suse.de/t3696972)
* [sle-12-SP5-SAP-DVD-x86_64-Build0344-migration_online+zypper_sles4sap12sp4@64bit-2gbram](https://openqa.suse.de/t3700804) -> fails as expected as there are unhandled orphan packages after migration
* [opensuse-Tumbleweed-NET-x86_64-Build20191210-zdup-Leap-42.3-kde@64bit_cirrus](https://openqa.opensuse.org/t1111398)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191210-zdup-Leap-15.1-kde@64bit](https://openqa.opensuse.org/t1111397)
* [opensuse-15.2-DVD-x86_64-Build537.3-extra_tests_in_textmode@64bit](https://openqa.opensuse.org/t1111396)
* [opensuse-15.2-DVD-x86_64-Build537.3-upgrade_Leap_42.3_gnome@64bit](https://openqa.opensuse.org/t1112282)
* [opensuse-15.2-NET-x86_64-Build537.3-textmode@64bit](https://openqa.opensuse.org/t1110905)
* [opensuse-15.1-DVD-Updates-x86_64-Build20191212-1-textmode@64bit](https://openqa.opensuse.org/t1110861)

Related progress issue: https://progress.opensuse.org/issues/47333