### PR TITLE
Give more time to ha/check_hawk to finish in first node

### DIFF
--- a/tests/ha/check_hawk.pm
+++ b/tests/ha/check_hawk.pm
@@ -56,6 +56,11 @@ sub run {
         barrier_wait("HAWK_GUI_INIT_$cluster_name");
         barrier_wait("HAWK_GUI_CHECKED_$cluster_name");
     }
+
+    # This module is the last one scheduled in cluster verification migration tests. Since node one
+    # handles the barriers when not using support server, we need to give it more time for the other
+    # nodes to finish
+    sleep bmwqemu::scale_timeout(10) if (is_node(1) and get_var('TEST') =~ /verify/ and !get_var('USE_SUPPORT_SERVER'));
 }
 
 # Specific test_flags for this test module


### PR DESCRIPTION
On HA cluster verifications after a migration (verification jobs) when not using a support server, the barriers are created and handled by the first node. If this node finishes while the rest of the nodes are still working, this can lead to the remaining jobs to fail in `barrier_wait()` calls.

Such a problem can occur even when the rest of the job was successful, leading to false positives such as:

1. [node1](https://openqa.suse.de/tests/3696956) & [node2](https://openqa.suse.de/tests/3696933#step/check_hawk/13)
2. [node1](https://openqa.suse.de/tests/3696932) & [node2](https://openqa.suse.de/tests/3696957#step/check_hawk/13)

This PR introduces a small non-mutex wait after the last `barrier_wait()` to handle this problem.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
