### PR TITLE
yast2-storage-ng: remove deprecated code

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1427,7 +1427,7 @@ sub load_extra_tests_y2uitest_gui {
     # On openSUSE, the scheduling happens in schedule/yast2_gui.yaml
     if (get_var("QAM_YAST2UI")) {
         loadtest "yast2_gui/yast2_bootloader" if is_sle("12-SP2+");
-        loadtest "yast2_gui/yast2_storage_ng" if is_sle("15+");
+        loadtest "yast2_gui/yast2_storage_ng" if is_sle("15+") || is_leap("15.0+") || is_tumbleweed;
         loadtest "yast2_gui/yast2_security"   if is_sle("12-SP2+");
         loadtest "yast2_gui/yast2_keyboard"   if is_sle("12-SP2+");
     }

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -45,7 +45,7 @@ sub add_logical_volume {
     wait_screen_change { type_string "$lvname" };
     wait_screen_change { send_key "alt-n" };
     # custom size
-    send_key(is_sle('<=12-sp4') ? "alt-c" : "alt-t");
+    send_key("alt-t");
     wait_still_screen 1;
     send_key "alt-s";
     wait_screen_change { type_string "400MiB" };
@@ -56,7 +56,7 @@ sub add_logical_volume {
 
 sub encrypt_partition {
     wait_still_screen 1;
-    send_key(is_sle('<=12-sp4') ? "alt-c" : "alt-y");
+    send_key("alt-y");
     wait_still_screen 2;
     send_key "alt-n";
     wait_still_screen 2;
@@ -64,17 +64,13 @@ sub encrypt_partition {
     wait_screen_change { type_string "susetesting" };
     send_key "alt-v";
     wait_screen_change { type_string "susetesting" };
-    send_key(is_sle('<=12-sp4') ? "alt-f" : "alt-n");
+    send_key("alt-n");
     wait_still_screen 2;
 }
 
 sub select_vdb {
-    if (is_sle('<=12-sp4')) {
-        assert_and_dclick "yast2_storage_ng-select-vdb";
-    } else {
-        assert_and_click "yast2_storage_ng-select-vdb";
-        wait_screen_change { send_key "alt-p" } if is_opensuse || is_sle("15-sp1+");
-    }
+    assert_and_click "yast2_storage_ng-select-vdb";
+    wait_screen_change { send_key "alt-p" } if is_opensuse || is_sle("15-sp1+");
 }
 
 sub start_y2sn {
@@ -97,14 +93,8 @@ sub run {
     ### ADD PARTITION ###
     # /dev/vdb is unpartitioned, now we have to add a new partition
     wait_screen_change { send_key "alt-a" };
-    if (is_sle('<=12-sp4')) {
-        wait_screen_change { send_key "alt-n" };
-        # custom size
-        send_key "alt-c";
-    } else {
-        # custom size
-        send_key "alt-o";
-    }
+    # custom size
+    send_key "alt-o";
     wait_still_screen 1;
     # select entry and type partition size
     send_key "alt-s";
@@ -120,13 +110,7 @@ sub run {
     send_key_until_needlematch("yast2_storage_ng-ext4", "up");
     send_key "ret";
     wait_still_screen 2;
-    # on SLE 12.x it's not possible to resize an ext4 encrypted filesystem,
-    if (is_sle("<=12-sp4")) {
-        send_key "alt-f";
-        wait_still_screen 2;
-    } else {
-        encrypt_partition;
-    }
+    encrypt_partition;
     assert_screen "yast2_storage_ng-partition-created";
     send_key "alt-n";
     wait_still_screen 2;
@@ -164,7 +148,7 @@ sub run {
     # select entry and type partition size
     send_key "alt-s";
     wait_screen_change { type_string "170MiB" };
-    wait_screen_change { send_key(is_sle('<=12-sp4') ? "alt-o" : "alt-n") };
+    wait_screen_change { send_key("alt-n") };
 
     assert_screen "yast2_storage_ng-partition-resized";
     wait_screen_change { send_key "alt-n" };
@@ -201,13 +185,13 @@ sub run {
     wait_screen_change { type_string "vgtest" };
     assert_and_click "yast2_storage_ng-vg-select-device";
     send_key "alt-a";
-    wait_screen_change { send_key(is_sle('<=12-sp4') ? "alt-f" : "alt-n") };
+    wait_screen_change { send_key("alt-n") };
 
     #  go to system view
     send_key "alt-s";
     assert_and_dclick "yast2_storage_ng-select-vgtest";
 
-    my $fs_page_shortcut = is_sle("<=12-sp4") ? "alt-f" : "alt-n";
+    my $fs_page_shortcut = "alt-n";
     wait_screen_change { send_key "alt-i" } if is_opensuse || is_sle("15-sp1+");
 
     # XFS, non encrypted
@@ -227,17 +211,10 @@ sub run {
     send_key_until_needlematch("yast2_storage_ng-btrfs", "up");
     send_key "ret";
     # BtrFS encryption fails on SLE 12.x, therefore we skip it
-    if (is_sle("<=12-sp4")) {
-        wait_screen_change { send_key $fs_page_shortcut };
-    } else {
-        encrypt_partition;
-    }
+    encrypt_partition;
 
     # Raw, non encrypted
-    my $raw_shortcut = is_sle("<=12-sp4") ? "alt-a" : "alt-r";
-    add_logical_volume "lv4", $raw_shortcut;
-    # on SLE 12.x the alt-a shortcut doesn't seem to work reliably, so here we 'force' the raw format
-    send_key "alt-d" if is_sle("<=12-sp4");
+    add_logical_volume "lv4", "alt-r";
     wait_still_screen 1;
     wait_screen_change { send_key $fs_page_shortcut };
 


### PR DESCRIPTION
yast2-storage-ng is not present in SLE 12.x but only on 15.x and greater even though the yast2 module has the same name (`storage`) on both major versions.

- Related ticket: https://progress.opensuse.org/issues/60860
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1279
- Verification runs:
  - 15sp1: http://d250.qam.suse.de/tests/2368 :heavy_check_mark: 
  - 15sp0: http://d250.qam.suse.de/tests/2370 :heavy_check_mark: 