### PR TITLE
reboot_gnome: Increase aarch64 timeout further

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -28,7 +28,8 @@ sub run {
     # In 88388900d2dfe267230972c6905b3cc18fb288cf the wait timeout was
     # bumped, due to tianocore being a bit slower, this brings this module
     # in sync
-    my $bootloader_timeout = (is_boot_encrypted || check_var('ARCH', 'aarch64')) ? 400 : 300;
+    # 12/2019: Increasing from 400 to 600 since more seems to be required.
+    my $bootloader_timeout = (is_boot_encrypted || check_var('ARCH', 'aarch64')) ? 600 : 300;
 
     $self->wait_boot(bootloader_time => $bootloader_timeout);
 }


### PR DESCRIPTION
Without this one still got Stall detected and Failed during cryptlvm.

- Related ticket: https://progress.opensuse.org/issues/60287
- Verification run: https://openqa.suse.de/tests/3693243
(with openqa-clone-custom-git-refspec using this branch)

Before this change, three similar failures:
https://openqa.suse.de/tests/3628341
https://openqa.suse.de/tests/3644979
https://openqa.suse.de/tests/3677218
