### PR TITLE
HPC: save slurmctld specific logs

### DIFF
--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -58,7 +58,7 @@ sub post_fail_hook {
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');
     $self->upload_service_log('slurmctld');
-    upload_logs('/var/log/slurmctld.log');
+    upload_logs('/var/log/slurmctld.log', failok => 1);
 }
 
 1;

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -58,6 +58,7 @@ sub post_fail_hook {
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');
     $self->upload_service_log('slurmctld');
+    upload_logs('/var/log/slurmctld.log');
 }
 
 1;

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -55,8 +55,7 @@ sub post_fail_hook {
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');
     $self->upload_service_log('slurmctld');
-    upload_logs('/var/log/slurmctld.log');
+    upload_logs('/var/log/slurmctld.log', failok => 1);
 }
 
 1;
-

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -55,6 +55,7 @@ sub post_fail_hook {
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');
     $self->upload_service_log('slurmctld');
+    upload_logs('/var/log/slurmctld.log');
 }
 
 1;


### PR DESCRIPTION
In some scenarios, we have slurmctl secondary node, and there is
a need of saving slurmctl logs from that controller

- Verification run: as this is super trivial, I do not prepare test run.
