### PR TITLE
sles4sap: Update Docker version used for Hawk tests

### DIFF
--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -21,7 +21,7 @@ use x11utils;
 use version_utils 'is_desktop_installed';
 
 sub install_docker {
-    my $docker_url = "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.2.tgz";
+    my $docker_url = "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.5.tgz";
 
     assert_script_run "curl -s $docker_url | tar zxf - --strip-components 1 -C /usr/bin", 120;
     # Allow the user to run docker. We can't add him to the docker group without restarting X.


### PR DESCRIPTION
Update the Docker minor version used for the Hawk tests to remove these warnings about Docker Iptables chains in newer kernels:

https://openqa.suse.de/tests/3688314#step/hawk_gui/8

From the [Docker Changelog](https://docs.docker.com/engine/release-notes/)

> Rollback libnetwork changes to fix DOCKER-USER iptables chain issue. docker/engine#404
