### PR TITLE
cleanup install_service warning

### DIFF
--- a/lib/autofs_utils.pm
+++ b/lib/autofs_utils.pm
@@ -11,7 +11,6 @@ use testapi;
 use utils qw(systemctl zypper_call);
 use version_utils qw(is_sle is_jeos);
 
-our @ISA    = qw(Exporter);
 our @EXPORT = qw(setup_autofs_server check_autofs_service
   install_service enable_service start_service
   check_service configure_service full_autofs_check);

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -19,11 +19,9 @@ use power_action_utils 'power_action';
 use version_utils qw(is_sle is_jeos is_leap is_tumbleweed is_opensuse);
 
 
-our @ISA    = qw(Exporter);
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump
   activate_kdump activate_kdump_without_yast kdump_is_active
-  do_kdump install_service configure_service
-  check_function full_kdump_check);
+  do_kdump configure_service check_function full_kdump_check);
 
 sub install_kernel_debuginfo {
     zypper_call 'ref';


### PR DESCRIPTION
Cleanup install service redefines waring during the test startup.

In our code, we use some 'old' code which use @ISA, we shouldn't manipulate @ISA directly, we
can use parent 'Exporter' instead.

- Related ticket: https://progress.opensuse.org/issues/60965
- Needles: N/A
- Verification run: 
regression run
http://10.161.8.44/tests/901/
https://openqa.suse.de/tests/3702365/file/autoinst-log.txt
https://openqa.suse.de/tests/3709825/file/autoinst-log.txt

kdump_and_crash
https://openqa.suse.de/tests/3709811/file/autoinst-log.txt
