### PR TITLE
Import is_node function from hacluster lib

### DIFF
--- a/tests/ha/check_hawk.pm
+++ b/tests/ha/check_hawk.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use lockapi;
-use hacluster 'get_cluster_name';
+use hacluster qw(get_cluster_name is_node);
 use utils 'systemctl';
 use version_utils 'is_sle';
 


### PR DESCRIPTION
Fix missing library import, can be related to #9149.
- Failed [test](https://openqa.suse.de/tests/3702468)
- Related ticket: N/A
- Needles: N/A
- Verification run: [node1](http://1a102.qa.suse.de/tests/1829) [node2](http://1a102.qa.suse.de/tests/1830)
