### PR TITLE
Add post fail hook a replace root console with serial terminal

### DIFF
--- a/tests/rt/rt_is_realtime.pm
+++ b/tests/rt/rt_is_realtime.pm
@@ -16,7 +16,6 @@ use warnings;
 use testapi;
 
 sub run {
-    select_console 'root-console';
     # check booted kernel, expected RT
     validate_script_output("uname -v", sub { m/\s{1}PREEMPT\s{1}RT\s{1}/ });
     # display running RT processes, expected to see FF - SCHED_FIFO or RR - SCHED_RR processes
@@ -35,7 +34,16 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 0};
+    return {fatal => 1};
+}
+
+sub post_fail_hook {
+    my $self = shift;
+
+    select_console 'log-console';
+
+    $self->export_logs_basic;
+    $self->upload_coredumps;
 }
 
 

--- a/tests/rt/rt_peak_pci.pm
+++ b/tests/rt/rt_peak_pci.pm
@@ -17,7 +17,6 @@ use testapi;
 
 # https://fate.suse.com/317131
 sub run {
-    select_console 'root-console';
     assert_script_run "modprobe peak_pci";
     assert_script_run "lsmod | grep ^peak_pci";
 }

--- a/tests/rt/rt_preempt_test.pm
+++ b/tests/rt/rt_preempt_test.pm
@@ -17,7 +17,6 @@ use testapi;
 
 # Run preempt test
 sub run {
-    select_console 'root-console';
     script_run "zypper -q ar http://download.suse.de/ibs/Devel:/RTE:/SLE12SP1/standard/Devel:RTE:SLE12SP1.repo";
     script_run "zypper -q --gpg-auto-import-keys refresh";
     script_run "zypper -q --non-interactive install preempt-test";

--- a/tests/rt/rt_tests.pm
+++ b/tests/rt/rt_tests.pm
@@ -20,7 +20,6 @@ use testapi;
 use utils 'zypper_call';
 
 sub run {
-    select_console 'root-console';
     zypper_call("in rt-tests ibmrtpkgs", log => 'rt_tests_zypper.log');
     assert_script_run "cyclictest -a -t -p 99 -l 100 -v";
     assert_script_run "hackbench -l 100";


### PR DESCRIPTION
- Related ticket: [[slert12sp5] test fails in rt_is_realtime - add post fail hook a replace root console with serial terminal](https://progress.opensuse.org/issues/61028)
- Verification run: http://eris.suse.cz/tests/3006#