### PR TITLE
Fix git registration's yaml

### DIFF
--- a/schedule/yast/skip_registration/skip_registration@s390x-zVM.yaml
+++ b/schedule/yast/skip_registration/skip_registration@s390x-zVM.yaml
@@ -9,8 +9,8 @@ schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
-  - installation/scc_registration
   - installation/disk_activation
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning


### PR DESCRIPTION
Wrong order in the schedule, breaks skip_registration for zVM: https://openqa.suse.de/tests/3698918#
The skip registration step is here, but after disk activation.
