### PR TITLE
Fix SLES4SAP 11-SP4 upgrade + add SCC registration on SLE11

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -827,7 +827,7 @@ sub wait_boot_past_bootloader {
 
     # On SLES4SAP upgrade tests with desktop, only check for a DM screen with the SAP System
     # Administrator user listed but do not attempt to login
-    if (get_var('HDDVERSION') and is_desktop_installed() and is_upgrade() and is_sles4sap()) {
+    if (!is_sle('<=11-SP4') && get_var('HDDVERSION') && is_desktop_installed && is_upgrade && is_sles4sap) {
         assert_screen 'displaymanager-sapadm', $ready_time;
         return;
     }

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -259,6 +259,14 @@ sub sle_register {
                 assert_script_run("echo y | ./$setup_script $smt_url/center/regsvc");
                 assert_script_run("suse_register -n");
             }
+            # NCC can be replaced by SCC even for SLE 11
+            # Needed to workaround a bug with NCC and LTSS module in some cases, see bsc#1158950
+            elsif (get_var('SLE11_USE_SCC')) {
+                my $reg_code = get_required_var('NCC_REGCODE');
+                my $reg_mail = get_var('NCC_MAIL');               # email address is not mandatory for SCC
+                assert_script_run("sed -i '/^url[[:space:]]*/s|.*|url = https://scc.suse.com/ncc/center/regsvc|' /etc/suseRegister.conf");
+                assert_script_run("suse_register -a email=$reg_mail -a regcode-sles=$reg_code", 300);
+            }
             # Otherwise, register SLE 11 to NCC server
             else {
                 my $reg_code = get_required_var("NCC_REGCODE");


### PR DESCRIPTION
- SLES4SAP 11 doesn't need a specific code to handle user connection on GDM like SLE12+.
- Add `SLE11_USE_SCC` variable to be able to register a SLE11 on SCC rather than NCC, this is useful to workaround an issue with LTSS module (see bsc#1158950). In a near future NCC will be replaced by  SCC anyway, so this should be the default sooner.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://1b210.qa.suse.de/tests/6208
- Regression tests: [offline_sles11sp4_ltss_sle15sp2_media_base_def_full](https://openqa.suse.de/t3705200), [migration_offline+dvd_sles4sap15](https://openqa.suse.de/t3705202)