### PR TITLE
Change OPENQA_URL with OPENQA_FTP_URL

### DIFF
--- a/tests/console/wavpack.pm
+++ b/tests/console/wavpack.pm
@@ -33,18 +33,11 @@ sub run {
     # setup
     select_console 'root-console';
     # development module needed for dependencies, released products are tested with sdk module
-    if (is_sle) {
-        if (get_var('BETA')) {
-            my $sdk_repo = is_sle('15+') ? get_var('REPO_SLE_MODULE_DEVELOPMENT_TOOLS') : get_var('REPO_SLE_SDK');
-            zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", name => "SDK";
-        }
-        # maintenance updates are registered with sdk module
-        elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
-            cleanup_registration;
-            register_product;
-            add_suseconnect_product('sle-module-desktop-applications');
-            add_suseconnect_product(get_addon_fullname('sdk'));
-        }
+    if (is_sle() && !main_common::is_updates_tests()) {
+        cleanup_registration;
+        register_product;
+        add_suseconnect_product('sle-module-desktop-applications');
+        add_suseconnect_product(get_addon_fullname('sdk'));
     }
     zypper_call 'in alsa alsa-utils wavpack';
     assert_script_run("cp /usr/share/sounds/alsa/Noise.wav .");
@@ -70,13 +63,8 @@ sub run {
     assert_script_run("wvgain -s Noise.wv 2>&1 | grep -Pzo \"replaygain_track_gain = \\+11.06 dB(.|\\n)*replaygain_track_peak = 0.126251\"");
 
     # unregister SDK
-    if (is_sle) {
-        if (get_var('BETA')) {
-            zypper_call "rr SDK";
-        }
-        elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
-            remove_suseconnect_product(get_addon_fullname('sdk'));
-        }
+    if (is_sle() && !main_common::is_updates_tests()) {
+        remove_suseconnect_product(get_addon_fullname('sdk'));
     }
 }
 

--- a/tests/console/zziplib.pm
+++ b/tests/console/zziplib.pm
@@ -31,12 +31,7 @@ sub run {
     my $filezip = "files.zip";
     select_console "root-console";
     # development module needed for dependencies, released products are tested with sdk module
-    if (get_var('BETA')) {
-        my $sdk_repo = is_sle('15+') ? get_var('REPO_SLE_MODULE_DEVELOPMENT_TOOLS') : get_var('REPO_SLE_SDK');
-        zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", name => 'SDK';
-    }
-    # maintenance updates are registered with sdk module
-    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+    if (!main_common::is_updates_tests()) {
         cleanup_registration;
         register_product;
         add_suseconnect_product('sle-module-desktop-applications');
@@ -70,10 +65,7 @@ sub run {
     #Clean files used:
     assert_script_run "cd ; rm -rf /tmp/zip ; rm /tmp/$filezip";
     # unregister SDK
-    if (get_var('BETA')) {
-        zypper_call "rr SDK";
-    }
-    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+    if (!main_common::is_updates_tests()) {
         remove_suseconnect_product(get_addon_fullname('sdk'));
     }
 }


### PR DESCRIPTION
Usage of OPENQA_URL cause failures in jobs cloned to
private openQA instances, because only openqa.suse.de has
clones of repositories. OPENQA_FTP_URL not depending on
exact hostname of openQA on which job is running