### PR TITLE
x11: fix gedit_about by enabling new code path for SLE15SP2+

### DIFF
--- a/tests/x11/gedit/gedit_about.pm
+++ b/tests/x11/gedit/gedit_about.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -27,7 +27,7 @@ sub run {
     x11_start_program('gedit', target_match => 'gedit-options-icon');
 
     # check about window
-    if (is_tumbleweed) {
+    if (!is_sle('<15-sp2') && !is_leap('<15.2')) {
         assert_and_click 'gedit-menu-icon';
         assert_and_click 'gedit-menu-about';
     }


### PR DESCRIPTION
This test was fixed in Tumbleweed, now enabling this new code path for SLE15SP2+ as well.

- Related ticket: https://progress.opensuse.org/issues/60671
- Needles: none
- Verification run: https://openqa.suse.de/tests/3709830
