### PR TITLE
Add softailure for soundtouch module

### DIFF
--- a/tests/console/soundtouch.pm
+++ b/tests/console/soundtouch.pm
@@ -51,7 +51,7 @@ sub run {
 
     start_audiocapture;
     assert_script_run 'aplay soundtouch/1d5d9dD_rate.wav soundtouch/1d5d9dD_tempo-and-pitch.wav soundtouch/bar_bpm.wav';
-    assert_recorded_sound 'soundtouch';
+    record_soft_failure 'bsc#1048271' unless assert_recorded_sound 'soundtouch';
     assert_script_run 'rm -rf soundtouch';
     # unregister SDK
     if (is_sle) {


### PR DESCRIPTION
Due to bsc#1048271 we cannot run this test safely, so we want at least
a soft failure in case it fails


- Related ticket: https://progress.opensuse.org/issues/55958
- Verification run: tbd