### PR TITLE
Stabilize reboot after installation by disabling timeout

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -419,6 +419,8 @@ sub bootmenu_default_params {
         push @params, get_extra_boot_params();
     }
 
+    push @params, 'reboot_timeout=' . get_var('REBOOT_TIMEOUT', 0) unless (is_leap('<15.2') || is_sle('<15-SP2'));
+
     # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
     # Default namescheme 'by-id' for devices is broken on Hyper-V (bsc#1029303),
     # we have to use something else.

--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -42,10 +42,7 @@
 #     - Send 'alt-i'
 #   - If needle matches 'package-update-found'
 #     - Send 'alt-n'
-#   - Unless REMOTE_CONTROLLER is set or is_caasp
-#     - Start a countdown, send 'alt-s' and print 'workaround', "While trying to stop countdown
-#     we saw a screen change, retrying up to $counter times more" on each
-#     iteration, while trying to match screens with 55% similarity.
+#   - Stop reboot timeout where necessary
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;
@@ -187,8 +184,8 @@ sub run {
         last;
     }
 
-    # Stop reboot countdown for e.g. uploading logs
-    unless (get_var("REMOTE_CONTROLLER") || is_caasp) {
+    # Stop reboot countdown where necessary for e.g. uploading logs
+    unless (check_var('REBOOT_TIMEOUT', 0) || get_var("REMOTE_CONTROLLER") || is_caasp) {
         # Depending on the used backend the initial key press to stop the
         # countdown might not be evaluated correctly or in time. In these
         # cases we keep hitting the keys until the countdown stops.

--- a/variables.md
+++ b/variables.md
@@ -96,6 +96,7 @@ PKGMGR_ACTION_AT_EXIT | string | "" | Set the default behavior of the package ma
 PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
 QA_TESTSUITE | string | | Comma or semicolon separated a list of the automation cases' name, and these cases will be installed and triggered if you call "start_testrun" function from qa_run.pm
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
+REBOOT_TIMEOUT | integer | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
 REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.
 REMOTE_REPOINST | boolean | | Use linuxrc features to install OS from specified repository (install) while booting installer from DVD (instsys)
 REPO_* | string | | Url pointing to the mirrored repo. REPO_0 contains installation iso.


### PR DESCRIPTION
By default the YaST installer has a timeout for the interactive dialog
at the end of installation  Our test code tries to stop the reboot timer
to be able to collect logs and further data before explicitly confirming
the reboot. In some cases our tests failed to step the timeout despite
multiple retries. With yast2-installation >= 4.2.24 and yast2 >= 4.2.32
the installer system accepts a parameter "reboot_timeout" to configure
the timeout and disable it with the value "0" which we do in tests now
to have all the time we need before explicitly confirming the reboot.

Verification run: https://openqa.opensuse.org/tests/1114648#step/await_install/12

Related progress issue: https://progress.opensuse.org/issues/50615