### PR TITLE
Workaround of bug 1158898 to set a random hostname for sles15sp2 host

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -65,6 +65,12 @@ sub run {
     # turn on debug for libvirtd & enable journal with previous reboot
     enable_debug_logging if is_x86_64;
 
+    # work around missing hostname issue for guest migration tests on sles15sp2
+    if (is_sle('=15-SP2') && (get_var('VIRT_NEW_GUEST_MIGRATION_SOURCE') || get_var('VIRT_NEW_GUEST_MIGRATION_DESTINATION'))) {
+        assert_script_run 'echo "suse$RANDOM" > /etc/hostname';    # need reboot to take effect
+        script_run 'cat /etc/hostname';
+        script_run 'echo "change the hostname to `cat /etc/hostname` and it need reboot to take effect!"';
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
hostname is set to 'localhost' on sles15sp2, which leads to various network communication failures. The bug has not gotten fixed and is not expected to be fixed today. The workaround is to set a hostname randomly to verify another bug bsc#1157149 in build#105.4.

@alice-suse @xguo @waynechen55

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1158898
- Verification run: http://10.67.18.253/tests/1593#
