### PR TITLE
Increase timeout for wait inst-bootmenu needle

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -33,7 +33,7 @@ sub handle_installer_medium_bootup {
     my ($self) = @_;
 
     return unless (check_var("BOOTFROM", "d") || (get_var('UEFI') && get_var('USBBOOT')));
-    assert_screen 'inst-bootmenu';
+    assert_screen 'inst-bootmenu', 60;
 
     if (check_var("BOOTFROM", "d") && check_var("AUTOUPGRADE") && check_var("PATCH")) {
         assert_screen 'grub2';


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/61016
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/3724727
