### PR TITLE
[WIP] Add orphaned packages check before and after migration

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -35,6 +35,7 @@ use services::rpcbind;
 use autofs_utils;
 use services::postfix;
 use kdump_utils;
+use services::orphaned_packages_check;
 
 our @EXPORT = qw(
   $hdd_base_version
@@ -157,6 +158,12 @@ our $default_services = {
         srv_proc_name      => 'kdump',
         support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1',
         service_check_func => \&full_kdump_check
+    },
+    orphaned_packages_check => {
+        srv_pkg_name       => 'orphaned_package',
+        srv_proc_name      => 'orphaned_package',
+        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1',
+        service_check_func => \&services::orphaned_packages_check::orphaned_packages_list
     },
 };
 

--- a/lib/services/orphaned_packages_check.pm
+++ b/lib/services/orphaned_packages_check.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Check for any orphaned packages. There should be none in fully
+# supported systems
+# Maintainer: Oliver Kurz <okurz@suse.com>
+# Tags: poo#19606
+
+package services::orphaned_packages_check;
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use version_utils 'is_upgrade';
+
+sub orphaned_packages_list {
+    my $cmd = 'zypper pa --orphaned | grep -v "\(release-DVD\|release-dvd\|openSUSE-release\|skelcd\)" | (! grep "@System")';
+    # there are orphans on older, unsupported openSUSE versions which we
+    # upgrade from. They will most likely never be fixed
+    my $expect_failure = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
+    set_var('ZYPPER_ORPHANED_CHECK_ONLY', get_var('ZYPPER_ORPHANED_CHECK_ONLY', $expect_failure));
+    if (get_var('ZYPPER_ORPHANED_CHECK_ONLY')) {
+        script_run($cmd);
+    }
+    else {
+        assert_script_run($cmd, fail_message => "Orphaned packages found, set 'ZYPPER_ORPHANED_CHECK_ONLY' to only check and not fail the test");
+    }
+}
+
+1;
+

--- a/tests/console/orphaned_packages_check.pm
+++ b/tests/console/orphaned_packages_check.pm
@@ -18,20 +18,11 @@ use warnings;
 use testapi;
 use utils 'zypper_call';
 use version_utils 'is_upgrade';
+use services::orphaned_packages_check;
 
 sub run {
     select_console 'root-console';
-    my $cmd = 'zypper pa --orphaned | grep -v "\(release-DVD\|release-dvd\|openSUSE-release\|skelcd\)" | (! grep "@System")';
-    # there are orphans on older, unsupported openSUSE versions which we
-    # upgrade from. They will most likely never be fixed
-    my $expect_failure = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
-    set_var('ZYPPER_ORPHANED_CHECK_ONLY', get_var('ZYPPER_ORPHANED_CHECK_ONLY', $expect_failure));
-    if (get_var('ZYPPER_ORPHANED_CHECK_ONLY')) {
-        script_run($cmd);
-    }
-    else {
-        assert_script_run($cmd, fail_message => "Orphaned packages found, set 'ZYPPER_ORPHANED_CHECK_ONLY' to only check and not fail the test");
-    }
+    services::orphaned_packages_check::orphaned_packages_list;
 }
 
 1;


### PR DESCRIPTION
Check for any orphaned packages before and after migration. There should be none in fully supported systems. If there are some orphaned packages, fail the case.
- Related ticket: https://progress.opensuse.org/issues/47333
- Needles:  N/A
- Verification run: 
Migration group cases
http://openqa.suse.de/tests/3724809#step/orphaned_packages_check/10
http://openqa.suse.de/tests/3724810#step/orphaned_packages_check/10
http://openqa.suse.de/tests/3724765#step/orphaned_packages_check/10
Migration regression cases
http://openqa.suse.de/tests/3724764#step/install_service/394
