### PR TITLE
Fix HANA cluster installation

### DIFF
--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -23,7 +23,7 @@ sub run {
     my $instance_id  = get_required_var('INSTANCE_ID');
     my $sid          = get_required_var('INSTANCE_SID');
     my $cluster_name = get_cluster_name;
-    my ($virtual_ip, $virtual_netmask) = split '/', get_required_var('VIRTUAL_IP_CIDR');
+    my ($virtual_ip, $virtual_netmask) = split '/', get_required_var('INSTANCE_IP_CIDR');
 
     # Set SAP variables
     my $pscmd  = $self->set_ps_cmd("HDB");

--- a/tests/sles4sap/netweaver_cluster.pm
+++ b/tests/sles4sap/netweaver_cluster.pm
@@ -26,7 +26,7 @@ sub run {
     my $alias        = get_required_var('INSTANCE_ALIAS');
     my $lun          = get_required_var('INSTANCE_LUN');
     my $cluster_name = get_cluster_name;
-    my ($ip, $netmask) = split '/', get_required_var('INSTANCE_IP');
+    my ($ip, $netmask) = split '/', get_required_var('INSTANCE_IP_CIDR');
 
     # Set SAP variables
     my $pscmd  = $self->set_ps_cmd("$type");

--- a/tests/sles4sap/netweaver_network.pm
+++ b/tests/sles4sap/netweaver_network.pm
@@ -21,7 +21,7 @@ sub run {
     my ($self)        = @_;
     my $cluster_name  = get_cluster_name;
     my $instance_type = get_required_var('INSTANCE_TYPE');
-    my ($ip, $netmask) = split '/', get_required_var('INSTANCE_IP');
+    my ($ip, $netmask) = split '/', get_required_var('INSTANCE_IP_CIDR');
     my $sid   = get_required_var('INSTANCE_SID');
     my $alias = lc("sap$sid" . substr($instance_type, 0, 2));
 


### PR DESCRIPTION
Replace `VIRTUAL_IP_CIDR` variable by the already existing and set `INSTANCE_IP` variable.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/3702840#step/hana_cluster/2
- Verification run: Not needed, issue is clearly identified
