### PR TITLE
Fix bad server response at publiccloud/download_repos

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -28,10 +28,14 @@ sub run {
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) unless get_var('MAINT_TEST_REPO');
     my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
 
+    my $ret = 0;
     for my $maintrepo (@repos) {
         my ($parent) = $maintrepo =~ 'https?://(.*)$';
         my ($domain) = $parent    =~ '^([a-zA-Z.]*)';
-        assert_script_run("wget --no-clobber -r -R 'robots.txt,*.ico,*.png,*.gif,*.css,*.js,*.htm*' --domains $domain --no-parent $parent $maintrepo", timeout => 600);
+        $ret = script_run "wget --no-clobber -r -R 'robots.txt,*.ico,*.png,*.gif,*.css,*.js,*.htm*' --domains $domain --no-parent $parent $maintrepo", timeout => 600;
+        if ($ret !~ /0|8/) {
+            die "wget error: The $maintrepo download failed with $ret return code.";
+        }
         assert_script_run("echo -en '# $maintrepo:\\n\\n' >> /tmp/repos.list.txt");
         assert_script_run("find $parent >> /tmp/repos.list.txt");
     }


### PR DESCRIPTION
While downloading the repositories the server may return bad response. This does not effect the files we need but causes `curl` to return code `8` instead of `0` and that's what this patch address.

- Related ticket: None
- Needles: None
- Verification run: [SLES15SP1@EC2](http://pdostal-server.suse.cz/tests/6352#)
