### PR TITLE
Revert "Add test suite extra_tests_package_hub"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1687,11 +1687,6 @@ sub load_extra_tests_console {
     loadtest "console/orphaned_packages_check";
 }
 
-sub load_extra_tests_phub {
-    loadtest 'console/machinery';
-    loadtest 'sysauth/sssd';
-}
-
 sub load_extra_tests_sdk {
     loadtest 'console/gdb';
 }


### PR DESCRIPTION
This reverts commit 83596599555534d810113cfd9dfdc2242b7493ee.

Because this test suite is now handled in YAML schedule: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9098/files

- Related ticket: https://progress.opensuse.org/issues/57290
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2041
