### PR TITLE
autofs service check not work

### DIFF
--- a/lib/autofs_utils.pm
+++ b/lib/autofs_utils.pm
@@ -5,6 +5,7 @@ C<autofs_utils> - Functions for setup autofs server and check autofs service
 =cut
 package autofs_utils;
 
+use Exporter 'import';
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION
With the removing of the ISA from autofs_util.pm, we need to use Exporter 'import' to call full_autofs_check.

- Related ticket: https://progress.opensuse.org/issues/60965
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/3720670
https://openqa.suse.de/tests/3720695