### PR TITLE
Fix some boot issues with GDM

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -829,6 +829,7 @@ sub wait_boot_past_bootloader {
     # Administrator user listed but do not attempt to login
     if (get_var('HDDVERSION') and is_desktop_installed() and is_upgrade() and is_sles4sap()) {
         assert_screen 'displaymanager-sapadm', $ready_time;
+        wait_still_screen;    # We need to ensure that we are in a stable state
         return;
     }
 

--- a/tests/migration/sle12_online_migration/post_migration.pm
+++ b/tests/migration/sle12_online_migration/post_migration.pm
@@ -27,7 +27,8 @@ sub run {
 
     add_maintenance_repos() if (get_var('MAINT_TEST_REPO'));
 
-    if (is_desktop_installed && (!is_sles4sap || is_sle('15+'))) {
+    # we need to ensure that desktop is unlocked on SLE15+ but not on any SLES4SAP
+    if (is_desktop_installed && !is_sles4sap && is_sle('15+')) {
         select_console 'x11', await_console => 0;
         ensure_unlocked_desktop;
         mouse_hide(1);


### PR DESCRIPTION
We can saw sporadic issues with GDM when we try to select `root-console` in `online_migration_setup.pm` or `zypper_patch.pm`, this seems to be an issue in `wait_boot_past_bootloader`.

This commit fixes this.

- Related ticket: N/A
- Needles: N/A
- Failing tests: https://openqa.suse.de/tests/3716372#step/online_migration_setup/4 or https://openqa.suse.de/tests/3721172#step/zypper_patch/11, https://openqa.suse.de/tests/3721161#step/mr_test/107
- Verification run: [migration_online+zypper_sles4sap15sp1](https://openqa.suse.de/tests/3722974), [migration_offline+dvd_sles4sap15sp1](https://openqa.suse.de/tests/3725459), [sles4sap_gnome_saptune_v2_note_2578899](https://openqa.suse.de/tests/3725156)
- Regression test: [online_sled15sp1_pscc_basesys_desk_we_dev_py2_all_full_y](https://openqa.suse.de/tests/3725102), [offline_sled15sp1_media_basesys-desk-we-dev-py2_all_full](https://openqa.suse.de/tests/3725104), [migration_offline+scc_sles4sap12sp4](https://openqa.suse.de/tests/3725107)

**Note:** failures of verification/regression tests are not because of this PR, but because of *others-non-yet-resolved* issues.