### PR TITLE
Replace y2lan_restart_devices with the 3 separate test modules

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -18,6 +18,7 @@ use warnings FATAL => 'all';
 use parent 'susedistribution';
 use Installation::Partitioner::LibstorageNG::GuidedSetupController;
 use Installation::Partitioner::LibstorageNG::v4::ExpertPartitionerController;
+use YaST::NetworkSettings::v4::NetworkSettingsController;
 
 sub get_partitioner {
     return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
@@ -25,6 +26,10 @@ sub get_partitioner {
 
 sub get_expert_partitioner {
     return Installation::Partitioner::LibstorageNG::v4::ExpertPartitionerController->new();
+}
+
+sub get_network_settings {
+    return YaST::NetworkSettings::v4::NetworkSettingsController->new();
 }
 
 1;

--- a/lib/Distribution/Sle/12.pm
+++ b/lib/Distribution/Sle/12.pm
@@ -21,6 +21,7 @@ use warnings FATAL => 'all';
 use parent 'Distribution::Opensuse::Tumbleweed';
 use Installation::Partitioner::Libstorage::EditProposalSettingsController;
 use Installation::Partitioner::Libstorage::ExpertPartitionerController;
+use YaST::NetworkSettings::v3::NetworkSettingsController;
 
 sub get_partitioner {
     return Installation::Partitioner::Libstorage::EditProposalSettingsController->new();
@@ -28,6 +29,10 @@ sub get_partitioner {
 
 sub get_expert_partitioner {
     return Installation::Partitioner::Libstorage::ExpertPartitionerController->new();
+}
+
+sub get_network_settings {
+    return YaST::NetworkSettings::v3::NetworkSettingsController->new();
 }
 
 1;

--- a/lib/Distribution/Sle/15sp0.pm
+++ b/lib/Distribution/Sle/15sp0.pm
@@ -18,6 +18,7 @@ package Distribution::Sle::15sp0;
 use strict;
 use warnings;
 use Installation::Partitioner::LibstorageNG::v3::ExpertPartitionerController;
+use YaST::NetworkSettings::v3::NetworkSettingsController;
 use parent 'Distribution::Sle::15_current';
 
 # override
@@ -25,5 +26,9 @@ sub get_expert_partitioner {
     return Installation::Partitioner::LibstorageNG::v3::ExpertPartitionerController->new();
 }
 
+# override
+sub get_network_settings {
+    return YaST::NetworkSettings::v3::NetworkSettingsController->new();
+}
 
 1;

--- a/lib/YaST/NetworkSettings/AbstractNetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/AbstractNetworkSettingsController.pm
@@ -1,0 +1,156 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The abstract class introduces interface to business actions and
+# common actions for all the Network Settings Controllers.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::AbstractNetworkSettingsController;
+use strict;
+use warnings;
+use YaST::NetworkSettings::OverviewTab;
+use YaST::NetworkSettings::NetworkCardSetup::AddressTab;
+use YaST::NetworkSettings::NetworkCardSetup::GeneralTab;
+use YaST::NetworkSettings::NetworkCardSetup::VLANAddressTab;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        OverviewTab    => YaST::NetworkSettings::OverviewTab->new(),
+        AddressTab     => YaST::NetworkSettings::NetworkCardSetup::AddressTab->new(),
+        GeneralTab     => YaST::NetworkSettings::NetworkCardSetup::GeneralTab->new(),
+        VLANAddressTab => YaST::NetworkSettings::NetworkCardSetup::VLANAddressTab->new()
+    }, $class;
+}
+
+sub get_overview_tab {
+    my ($self) = @_;
+    return $self->{OverviewTab};
+}
+
+sub get_address_tab {
+    my ($self) = @_;
+    return $self->{AddressTab};
+}
+
+sub get_general_tab {
+    my ($self) = @_;
+    return $self->{GeneralTab};
+}
+
+sub get_vlan_address_tab {
+    my ($self) = @_;
+    return $self->{VLANAddressTab};
+}
+
+=head2 add_bridged_device
+
+  add_bridged_device();
+
+Add Bridged Device using Network Settings Dialog.
+
+The function just adds the device, but does not save the changes by closing
+Network Settings Dialog.
+
+=cut
+sub add_bridged_device();
+
+=head2 add_bond_slave
+
+  add_bond_slave();
+
+Add Bond Slave Device using Network Settings Dialog.
+
+The function just adds the device, but does not save the changes by closing
+Network Settings Dialog.
+
+=cut
+sub add_bond_slave();
+
+=head2 add_vlan_device
+
+  add_vlan_device();
+
+Add VLAN Device using Network Settings Dialog.
+
+The function just adds the device, but does not save the changes by closing
+Network Settings Dialog.
+
+=cut
+sub add_vlan_device();
+
+=head2 view_bridged_device_without_editing
+
+  view_bridged_device_without_editing();
+
+Open already created Bridged Device for editing, view its settings, do not
+change any settings and close the Edit Dialog.
+
+=cut
+sub view_bridged_device_without_editing();
+
+=head2 view_bond_slave_without_editing
+
+  view_bond_slave_without_editing();
+
+Open already created Bond Slave Device for editing, view its settings, do not
+change any settings and close the Edit Dialog.
+
+=cut
+sub view_bond_slave_without_editing();
+
+sub delete_bridged_device {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('bridge');
+    $self->get_overview_tab()->press_delete();
+}
+
+sub delete_bond_device {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('bond');
+    $self->get_overview_tab()->press_delete();
+}
+
+sub delete_vlan_device {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('vlan');
+    $self->get_overview_tab()->press_delete();
+}
+
+sub select_no_link_and_ip_for_ethernet {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('eth');
+    $self->get_overview_tab()->press_edit();
+    $self->get_address_tab()->select_no_link_and_ip_setup();
+    $self->get_address_tab()->press_next();
+}
+
+sub select_dynamic_address_for_ethernet {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('eth');
+    $self->get_overview_tab()->press_edit();
+    $self->get_address_tab()->select_dynamic_address();
+    $self->get_address_tab()->press_next();
+}
+
+sub view_vlan_device_without_editing {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('vlan');
+    $self->get_overview_tab()->press_edit();
+    $self->get_vlan_address_tab()->press_next();
+}
+
+sub save_changes {
+    my ($self) = @_;
+    $self->get_overview_tab()->press_ok();
+}
+
+
+
+1;

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/AddressTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/AddressTab.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Address Tab in YaST2
+# lan module dialog.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::NetworkCardSetup::AddressTab;
+use strict;
+use warnings;
+use testapi;
+use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+
+use constant {
+    ADDRESS_TAB => 'yast2_lan_address_tab_selected'
+};
+
+sub select_dynamic_address {
+    assert_screen(ADDRESS_TAB);
+    send_key('alt-y');
+}
+
+sub select_no_link_and_ip_setup {
+    assert_screen(ADDRESS_TAB);
+    send_key('alt-k');
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->SUPER::press_next(ADDRESS_TAB);
+}
+
+1;

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Bond Slaves Tab in
+# YaST2 lan module dialog.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab;
+use strict;
+use warnings;
+use testapi;
+use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+
+use constant {
+    NETWORK_CARD_SETUP                   => 'yast2_lan_network_card_setup',
+    BOND_SLAVES_TAB                      => 'yast2_lan_bond_slave_tab_selected',
+    ALREADY_CONFIGURED_DEVICE_POPUP      => 'yast2_lan_select_already_configured_device',
+    BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED => 'yast2_lan_checkbox_unchecked'
+};
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        tab_shortcut => $args->{tab_shortcut}
+    }, $class;
+}
+
+sub select_tab {
+    my ($self) = @_;
+    assert_screen(NETWORK_CARD_SETUP);
+    send_key($self->{tab_shortcut});
+}
+
+sub select_bond_slave_in_list {
+    assert_screen(BOND_SLAVES_TAB);
+    assert_and_click(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED);
+}
+
+sub select_continue_in_popup {
+    assert_screen(ALREADY_CONFIGURED_DEVICE_POPUP);
+    send_key 'alt-o';
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->SUPER::press_next(BOND_SLAVES_TAB);
+}
+
+1;

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Bridged Devices Tab in
+#  YaST2 lan module dialog.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab;
+use strict;
+use warnings;
+use testapi;
+use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+
+use constant {
+    NETWORK_CARD_SETUP                => 'yast2_lan_network_card_setup',
+    BRIDGED_DEVICES_TAB               => 'yast2_lan_bridged_devices_tab_selected',
+    ALREADY_CONFIGURED_DEVICE_POPUP   => 'yast2_lan_select_already_configured_device',
+    BRIDGED_DEVICE_CHECKBOX_UNCHECKED => 'yast2_lan_checkbox_unchecked'
+};
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        tab_shortcut             => $args->{tab_shortcut},
+        bridged_devices_shortcut => $args->{bridged_devices_shortcut}
+    }, $class;
+}
+
+sub select_tab {
+    my ($self) = @_;
+    assert_screen(NETWORK_CARD_SETUP);
+    send_key($self->{tab_shortcut});
+}
+
+sub select_bridged_device_in_list {
+    assert_screen(BRIDGED_DEVICES_TAB);
+    assert_and_click(BRIDGED_DEVICE_CHECKBOX_UNCHECKED);
+}
+
+sub select_continue_in_popup {
+    assert_screen(ALREADY_CONFIGURED_DEVICE_POPUP);
+    send_key 'alt-o';
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->SUPER::press_next(BRIDGED_DEVICES_TAB);
+}
+
+1;

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Device Type Dialog in
+# YaST2 lan module dialog.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::NetworkCardSetup::DeviceTypeDialog;
+use strict;
+use warnings;
+use testapi;
+use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+
+use constant {
+    DEVICE_TYPE_DIALOG => 'yast2_lan_device_type_dialog'
+};
+
+sub select_device_type {
+    my ($self, $device) = @_;
+    # Specify device type shortcut, depending on device name provided with
+    # $device method parameter.
+    my $shortcut = {
+        bridge => 'alt-b',
+        bond   => 'alt-o',
+        vlan   => 'alt-v'
+    };
+    assert_screen(DEVICE_TYPE_DIALOG);
+    send_key $shortcut->{$device};
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->SUPER::press_next(DEVICE_TYPE_DIALOG);
+}
+
+
+1;

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/GeneralTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/GeneralTab.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for General Tab in YaST2
+# lan module dialog.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::NetworkCardSetup::GeneralTab;
+use strict;
+use warnings;
+use testapi;
+use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+
+use constant {
+    NETWORK_CARD_SETUP => 'yast2_lan_network_card_setup'
+};
+
+sub select_tab {
+    assert_screen(NETWORK_CARD_SETUP);
+    send_key('alt-g');
+}
+
+1;

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/HardwareDialog.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/HardwareDialog.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Hardware Dialog in
+# YaST2 lan module dialog.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::NetworkCardSetup::HardwareDialog;
+use strict;
+use warnings;
+use testapi;
+use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+
+use constant {
+    HARDWARE_DIALOG           => 'yast2_lan_hardware_dialog',
+    BRIDGE_DEVICE_IN_DROPDOWN => 'yast2_lan_device_type_bridge',
+    BOND_DEVICE_IN_DROPDOWN   => 'yast2_lan_device_type_bond',
+    VLAN_DEVICE_IN_DROPDOWN   => 'yast2_lan_device_type_VLAN'
+};
+
+sub select_device_type {
+    my ($self, $device) = @_;
+    assert_screen(HARDWARE_DIALOG);
+    send_key 'alt-d';    # Select 'Device Type' dropdown
+    send_key 'home';     # Jump to beginning of list
+    my $device_needle;
+    if ($device eq 'bridge') {
+        $device_needle = BRIDGE_DEVICE_IN_DROPDOWN;
+    }
+    elsif ($device eq 'bond') {
+        $device_needle = BOND_DEVICE_IN_DROPDOWN;
+    }
+    elsif ($device eq 'vlan') {
+        $device_needle = VLAN_DEVICE_IN_DROPDOWN;
+    }
+    else {
+        die "\"$device\" device is not known.";
+    }
+    send_key_until_needlematch $device_needle, 'down';
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->SUPER::press_next(HARDWARE_DIALOG);
+}
+
+1;

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/NetworkCardSetupWizard.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/NetworkCardSetupWizard.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class is a parent for all Pages of Network Card Setup Wizard.
+# Introduces accessing methods to the elements that are common for all steps
+# of the Wizard.
+
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+}
+
+sub press_next {
+    my ($self, $page_needle) = @_;
+    assert_screen($page_needle);
+    send_key('alt-n');
+}
+
+1;

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Address Tab in
+# YaST2 lan module dialog, when VLAN is selected to be configured. The Tab
+# contains all the same elements as the common Address Tab, but with some
+# additional elements that are specific for VLAN.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::NetworkCardSetup::VLANAddressTab;
+use strict;
+use warnings;
+use testapi;
+use parent 'YaST::NetworkSettings::NetworkCardSetup::AddressTab';
+
+use constant {
+    ADDRESS_TAB => 'yast2_lan_address_tab_selected'
+};
+
+sub fill_in_vlan_id {
+    my ($self, $vlan_id) = @_;
+    assert_screen(ADDRESS_TAB);
+    send_key 'alt-v';
+    send_key 'tab';
+    wait_screen_change { type_string($vlan_id) };
+}
+
+1;

--- a/lib/YaST/NetworkSettings/OverviewTab.pm
+++ b/lib/YaST/NetworkSettings/OverviewTab.pm
@@ -1,0 +1,77 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Overview Tab in YaST2
+# lan module dialog.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::OverviewTab;
+use strict;
+use warnings;
+use testapi;
+
+use constant {
+    OVERVIEW_TAB            => 'yast2_lan_overview_tab_selected',
+    NAME_COLUMN             => 'yast2_lan_overview_tab_name_column',
+    BRIDGE_DEVICE_IN_LIST   => 'yast2_lan_device_bridge_selected',
+    BOND_DEVICE_IN_LIST     => 'yast2_lan_device_bond_selected',
+    VLAN_DEVICE_IN_LIST     => 'yast2_lan_device_vlan_selected',
+    ETHERNET_DEVICE_IN_LIST => 'yast2_lan_device_ethernet_selected'
+};
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+}
+
+sub press_add {
+    assert_screen(OVERVIEW_TAB);
+    send_key('alt-a');
+}
+
+sub press_edit {
+    assert_screen(OVERVIEW_TAB);
+    send_key('alt-i');
+}
+
+sub press_delete {
+    assert_screen(OVERVIEW_TAB);
+    send_key('alt-t');
+}
+
+sub select_device {
+    my ($self, $device) = @_;
+    assert_and_click(NAME_COLUMN);
+    send_key 'home';
+    my $device_needle;
+    if ($device eq 'bridge') {
+        $device_needle = BRIDGE_DEVICE_IN_LIST;
+    }
+    elsif ($device eq 'bond') {
+        $device_needle = BOND_DEVICE_IN_LIST;
+    }
+    elsif ($device eq 'vlan') {
+        $device_needle = VLAN_DEVICE_IN_LIST;
+    }
+    elsif ($device eq 'eth') {
+        $device_needle = ETHERNET_DEVICE_IN_LIST;
+    }
+    else {
+        die "\"$device\" device is not known.";
+    }
+    send_key_until_needlematch $device_needle, 'down', 5;
+}
+
+sub press_ok {
+    assert_screen(OVERVIEW_TAB);
+    send_key('alt-o');
+}
+
+
+1;

--- a/lib/YaST/NetworkSettings/v3/NetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/v3/NetworkSettingsController.pm
@@ -1,0 +1,104 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for Network Settings Dialog
+# (yast2 lan module), version 3.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::v3::NetworkSettingsController;
+use parent 'YaST::NetworkSettings::AbstractNetworkSettingsController';
+use strict;
+use warnings;
+use YaST::NetworkSettings::NetworkCardSetup::HardwareDialog;
+use YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab;
+use YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = $class->SUPER::new($args);
+    $self->{HardwareDialog} = YaST::NetworkSettings::NetworkCardSetup::HardwareDialog->new();
+    $self->{BridgedDevicesTab} = YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab->new({tab_shortcut => 'alt-i', bridged_devices_shortcut => 'alt-d'});
+    $self->{BondSlavesTab} = YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab->new({tab_shortcut => 'alt-o'});
+    return $self;
+}
+
+sub get_hardware_dialog {
+    my ($self) = @_;
+    return $self->{HardwareDialog};
+}
+
+sub get_bridged_devices_tab {
+    my ($self) = @_;
+    return $self->{BridgedDevicesTab};
+}
+
+sub get_bond_slaves_tab {
+    my ($self) = @_;
+    return $self->{BondSlavesTab};
+}
+
+sub add_bridged_device {
+    my ($self) = @_;
+    $self->get_overview_tab()->press_add();
+    $self->get_hardware_dialog()->select_device_type('bridge');
+    $self->get_hardware_dialog()->press_next();
+    $self->get_address_tab()->select_dynamic_address();
+    # Bonding Devices tab does not have a shortcut when 'Network Card Setup'
+    # Dialog is initialized in v3 (e.g. sle12). It appears after selecting
+    # 'General' tab, though. So, apply the workaround here.
+    $self->get_general_tab()->select_tab();
+    $self->get_bridged_devices_tab()->select_tab();
+    $self->get_bridged_devices_tab()->select_bridged_device_in_list();
+    $self->get_bridged_devices_tab()->press_next();
+    $self->get_bridged_devices_tab()->select_continue_in_popup();
+}
+
+sub add_bond_slave {
+    my ($self) = @_;
+    $self->select_no_link_and_ip_for_ethernet();
+    $self->get_overview_tab()->press_add();
+    $self->get_hardware_dialog()->select_device_type('bond');
+    $self->get_hardware_dialog()->press_next();
+    $self->get_address_tab()->select_dynamic_address();
+    $self->get_bond_slaves_tab()->select_tab();
+    $self->get_bond_slaves_tab()->select_bond_slave_in_list();
+    $self->get_bond_slaves_tab()->press_next();
+}
+
+sub add_vlan_device {
+    my ($self) = @_;
+    $self->get_overview_tab()->press_add();
+    $self->get_hardware_dialog()->select_device_type('vlan');
+    $self->get_hardware_dialog()->press_next();
+    $self->get_vlan_address_tab()->select_dynamic_address();
+    $self->get_vlan_address_tab()->fill_in_vlan_id('12');
+    $self->get_vlan_address_tab()->press_next();
+}
+
+sub view_bridged_device_without_editing {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('bridge');
+    $self->get_overview_tab()->press_edit();
+    # Bridged Devices tab does not have a shortcut when 'Network Card Setup'
+    # Dialog is initialized in v3 (e.g. sle12). It appears after selecting
+    # 'General' tab, though. So, apply the workaround here.
+    $self->get_general_tab()->select_tab();
+    $self->get_bridged_devices_tab()->select_tab();
+    $self->get_bridged_devices_tab()->press_next();
+}
+
+sub view_bond_slave_without_editing {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('bond');
+    $self->get_overview_tab()->press_edit();
+    $self->get_bond_slaves_tab()->select_tab();
+    $self->get_bond_slaves_tab()->press_next();
+}
+
+1;

--- a/lib/YaST/NetworkSettings/v4/NetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/v4/NetworkSettingsController.pm
@@ -1,0 +1,109 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for Network Settings Dialog
+# (yast2 lan module), version 4.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package YaST::NetworkSettings::v4::NetworkSettingsController;
+use parent 'YaST::NetworkSettings::AbstractNetworkSettingsController';
+use strict;
+use warnings;
+use YaST::NetworkSettings::NetworkCardSetup::DeviceTypeDialog;
+use YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab;
+use YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = $class->SUPER::new($args);
+    $self->{DeviceTypeDialog} = YaST::NetworkSettings::NetworkCardSetup::DeviceTypeDialog->new();
+    $self->{BridgedDevicesTabOnAdd} = YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab->new({tab_shortcut => 'alt-v', bridged_devices_shortcut => 'alt-i'});
+    $self->{BridgedDevicesTabOnEdit} = YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab->new({tab_shortcut => 'alt-b', bridged_devices_shortcut => 'alt-i'});
+    $self->{BondSlavesTabOnAdd}  = YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab->new({tab_shortcut => 'alt-o'});
+    $self->{BondSlavesTabOnEdit} = YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab->new({tab_shortcut => 'alt-b'});
+    return $self;
+}
+
+sub get_device_type_dialog {
+    my ($self) = @_;
+    return $self->{DeviceTypeDialog};
+}
+
+sub get_bridged_devices_tab_on_add {
+    my ($self) = @_;
+    return $self->{BridgedDevicesTabOnAdd};
+}
+
+sub get_bridged_devices_tab_on_edit {
+    my ($self) = @_;
+    return $self->{BridgedDevicesTabOnEdit};
+}
+
+sub get_bond_slaves_tab_on_add {
+    my ($self) = @_;
+    return $self->{BondSlavesTabOnAdd};
+}
+
+sub get_bond_slaves_tab_on_edit {
+    my ($self) = @_;
+    return $self->{BondSlavesTabOnEdit};
+}
+
+sub add_bridged_device {
+    my ($self) = @_;
+    $self->get_overview_tab()->press_add();
+    $self->get_device_type_dialog()->select_device_type('bridge');
+    $self->get_device_type_dialog()->press_next();
+    $self->get_address_tab()->select_dynamic_address();
+    $self->get_bridged_devices_tab_on_add()->select_tab();
+    $self->get_bridged_devices_tab_on_add()->select_bridged_device_in_list();
+    $self->get_bridged_devices_tab_on_add()->press_next();
+    $self->get_bridged_devices_tab_on_add()->select_continue_in_popup();
+}
+
+sub add_bond_slave {
+    my ($self) = @_;
+    $self->get_overview_tab()->press_add();
+    $self->get_device_type_dialog()->select_device_type('bond');
+    $self->get_device_type_dialog()->press_next();
+    $self->get_address_tab()->select_dynamic_address();
+    $self->get_bond_slaves_tab_on_add()->select_tab();
+    $self->get_bond_slaves_tab_on_add()->select_bond_slave_in_list();
+    $self->get_bond_slaves_tab_on_add()->press_next();
+    $self->get_bond_slaves_tab_on_add()->select_continue_in_popup();
+}
+
+sub add_vlan_device {
+    my ($self) = @_;
+    $self->get_overview_tab()->press_add();
+    $self->get_device_type_dialog()->select_device_type('vlan');
+    $self->get_device_type_dialog()->press_next();
+    $self->get_vlan_address_tab()->select_dynamic_address();
+    $self->get_vlan_address_tab()->fill_in_vlan_id('12');
+    $self->get_vlan_address_tab()->press_next();
+}
+
+sub view_bridged_device_without_editing {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('bridge');
+    $self->get_overview_tab()->press_edit();
+    $self->get_bridged_devices_tab_on_edit()->select_tab();
+    $self->get_bridged_devices_tab_on_edit()->press_next();
+}
+
+sub view_bond_slave_without_editing {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('bond');
+    $self->get_overview_tab()->press_edit();
+    $self->get_bond_slaves_tab_on_edit()->select_tab();
+    $self->get_bond_slaves_tab_on_edit()->press_next();
+    $self->get_bond_slaves_tab_on_edit()->select_continue_in_popup();
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1526,7 +1526,6 @@ sub load_extra_tests_desktop {
     if (check_var('DESKTOP', 'gnome')) {
         loadtest "x11/rrdtool_x11";
         loadtest 'x11/yast2_lan_restart';
-        loadtest 'x11/yast2_lan_restart_devices' if (!is_opensuse || is_leap('<=15.0'));
         # we only have the test dependencies, e.g. hostapd available in
         # openSUSE
         if (check_var('DISTRI', 'opensuse')) {

--- a/schedule/yast/yast2_gui.yaml
+++ b/schedule/yast/yast2_gui.yaml
@@ -25,3 +25,6 @@ schedule:
     - yast2_gui/yast2_software_management
     - yast2_gui/yast2_users
     - yast2_gui/yast2_security
+    - yast2_gui/yast2_lan_restart_bridge
+    - yast2_gui/yast2_lan_restart_vlan
+    - yast2_gui/yast2_lan_restart_bond

--- a/tests/yast2_gui/yast2_lan_restart_bond.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bond.pm
@@ -7,11 +7,59 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-# Summary: TODO
+# Summary: The test verifies that network is not restarted if no changes were
+# made to the configuration of Bridged device but "Ok" button was pressed in
+# Network Settings. Related tasks: fate#318787 poo#11450
+#
+# Pre-conditions:
+# Create Bond device.
+#
+# Test:
+# 1. Open Network Settings Dialog;
+# 2. Press "Edit" button to view the configuration of Bond device;
+# 3. Proceed through the Edit configuration wizard, but do not change anything;
+# 4. Save the changes by pressing "Ok" button in Network Settings dialog;
+# 5. Verify the Network is not restarted.
+#
+# Post-condition:
+# Delete the Bond device.
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
 
-package yast2_lan_restart_bond;
+use base 'y2_installbase';
 use strict;
 use warnings;
+use testapi;
+use y2lan_restart_common qw(initialize_y2lan open_network_settings check_network_status wait_for_xterm_to_be_visible clear_journal_log close_xterm);
+
+my $network_settings;
+
+sub pre_run_hook {
+    initialize_y2lan;
+    open_network_settings;
+    $network_settings = $testapi::distri->get_network_settings();
+    $network_settings->add_bond_slave();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+}
+
+sub run {
+    record_info('bond', 'Verify network is not restarted after saving bond device settings without changes.');
+    open_network_settings;
+    $network_settings->view_bond_slave_without_editing();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+    clear_journal_log();
+    check_network_status('', 'bond');
+}
+
+sub post_run_hook {
+    open_network_settings;
+    $network_settings->delete_bond_device();
+    # return ethernet card settings to the default ones
+    $network_settings->select_dynamic_address_for_ethernet();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+    close_xterm();
+}
 
 1;

--- a/tests/yast2_gui/yast2_lan_restart_bond.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bond.pm
@@ -1,0 +1,17 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: TODO
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package yast2_lan_restart_bond;
+use strict;
+use warnings;
+
+1;

--- a/tests/yast2_gui/yast2_lan_restart_bridge.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bridge.pm
@@ -7,11 +7,59 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-# Summary: TODO
+# Summary: The test verifies that network is not restarted if no changes were
+# made to the configuration of Bridged device but "Ok" button was pressed in
+# Network Settings. Related tasks: fate#318787 poo#11450
+#
+# Pre-conditions:
+# Create Bridged device.
+#
+# Test:
+# 1. Open Network Settings Dialog;
+# 2. Press "Edit" button to view the configuration of Bridged device;
+# 3. Proceed through the Edit configuration wizard, but do not change anything;
+# 4. Save the changes by pressing "Ok" button in Network Settings dialog;
+# 5. Verify the Network is not restarted.
+#
+# Post-condition:
+# Delete the Bridged device.
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
 
-package yast2_lan_restart_bridge;
+use base 'y2_installbase';
 use strict;
 use warnings;
+use testapi;
+use y2lan_restart_common qw(initialize_y2lan open_network_settings check_network_status wait_for_xterm_to_be_visible clear_journal_log close_xterm);
+
+my $network_settings;
+
+sub pre_run_hook {
+    initialize_y2lan;
+    open_network_settings;
+    $network_settings = $testapi::distri->get_network_settings();
+    $network_settings->add_bridged_device();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+}
+
+sub run {
+    record_info('bridge', 'Verify network is not restarted after saving bridged device settings without changes.');
+    open_network_settings;
+    $network_settings->view_bridged_device_without_editing();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+    clear_journal_log();
+    check_network_status('', 'bridge');
+}
+
+sub post_run_hook {
+    open_network_settings;
+    $network_settings->delete_bridged_device();
+    # return ethernet card settings to the default ones
+    $network_settings->select_dynamic_address_for_ethernet();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+    close_xterm();
+}
 
 1;

--- a/tests/yast2_gui/yast2_lan_restart_bridge.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bridge.pm
@@ -1,0 +1,17 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: TODO
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package yast2_lan_restart_bridge;
+use strict;
+use warnings;
+
+1;

--- a/tests/yast2_gui/yast2_lan_restart_vlan.pm
+++ b/tests/yast2_gui/yast2_lan_restart_vlan.pm
@@ -1,0 +1,17 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: TODO
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package yast2_lan_restart_vlan;
+use strict;
+use warnings;
+
+1;

--- a/tests/yast2_gui/yast2_lan_restart_vlan.pm
+++ b/tests/yast2_gui/yast2_lan_restart_vlan.pm
@@ -7,11 +7,59 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-# Summary: TODO
+# Summary: The test verifies that network is not restarted if no changes were
+# made to the configuration of VLAN device but "Ok" button was pressed in
+# Network Settings. Related tasks: fate#318787 poo#11450
+#
+# Pre-conditions:
+# Create VLAN device.
+#
+# Test:
+# 1. Open Network Settings Dialog;
+# 2. Press "Edit" button to view the configuration of VLAN device;
+# 3. Proceed through the Edit configuration wizard, but do not change anything;
+# 4. Save the changes by pressing "Ok" button in Network Settings dialog;
+# 5. Verify the Network is not restarted.
+#
+# Post-condition:
+# Delete the VLAN device.
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
 
-package yast2_lan_restart_vlan;
+use base 'y2_installbase';
 use strict;
 use warnings;
+use testapi;
+use y2lan_restart_common qw(initialize_y2lan open_network_settings check_network_status wait_for_xterm_to_be_visible clear_journal_log close_xterm);
+
+my $network_settings;
+
+sub pre_run_hook {
+    initialize_y2lan;
+    open_network_settings;
+    $network_settings = $testapi::distri->get_network_settings();
+    $network_settings->add_vlan_device();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+}
+
+sub run {
+    record_info('VLAN', 'Verify network is not restarted after saving VLAN device settings without changes.');
+    open_network_settings;
+    $network_settings->view_vlan_device_without_editing();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+    clear_journal_log();
+    check_network_status('', 'vlan');
+}
+
+sub post_run_hook {
+    open_network_settings;
+    $network_settings->delete_vlan_device();
+    # return ethernet card settings to the default ones
+    $network_settings->select_dynamic_address_for_ethernet();
+    $network_settings->save_changes();
+    wait_for_xterm_to_be_visible();
+    close_xterm();
+}
 
 1;


### PR DESCRIPTION
The PR adds all the pages and controllers classes to represent Network Settings dialog.

Also it moves all the verifications from extra_tests_gnome test suite to yast2_gui test suite.

- Related ticket: https://progress.opensuse.org/issues/59315
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1284
- Verification run: http://10.160.65.138/tests/1241
