### PR TITLE
gnuhealth: Fix tests after gnuhealth update to 3.6 in Leap 15.2

### DIFF
--- a/tests/gnuhealth/gnuhealth_client_first_time.pm
+++ b/tests/gnuhealth/gnuhealth_client_first_time.pm
@@ -18,7 +18,7 @@ use version_utils 'is_leap';
 
 sub run {
     my $gnuhealth    = get_var('GNUHEALTH_CLIENT', 'gnuhealth-client');
-    my $gnuhealth_34 = is_leap('<=15.2');
+    my $gnuhealth_34 = is_leap('<15.2');
     wait_screen_change { send_key 'tab' };
     send_key 'ret';
     assert_screen "$gnuhealth-login_password";

--- a/tests/gnuhealth/gnuhealth_setup.pm
+++ b/tests/gnuhealth/gnuhealth_setup.pm
@@ -31,7 +31,7 @@ sub run() {
     systemctl 'restart postgresql';
     assert_script_run 'echo susetesting > /tmp/pw';
     my $cmd = 'sudo -u tryton env TRYTONPASSFILE=/tmp/pw trytond-admin -c /etc/tryton/trytond.conf --all -d gnuhealth --password';
-    $cmd .= ' --email root' unless is_leap('<=15.2');
+    $cmd .= ' --email root' unless is_leap('<15.2');
     assert_script_run $cmd, 600;
     systemctl 'start gnuhealth';
     # exit from root session


### PR DESCRIPTION
Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9199 https://openqa.opensuse.org/tests/1116759
```

Created job #1117136: opensuse-15.2-DVD-x86_64-Build542.1-gnuhealth@64bit -> ~https://openqa.opensuse.org/t1117136~ https://openqa.opensuse.org/tests/1117161


Related progress issue: https://progress.opensuse.org/issues/61149