### PR TITLE
Start iscsi if it is not started during boot

### DIFF
--- a/tests/ha/upgrade_from_sle11sp4_workarounds.pm
+++ b/tests/ha/upgrade_from_sle11sp4_workarounds.pm
@@ -68,6 +68,9 @@ sub run {
     systemctl 'enable sbd';
     systemctl 'enable pacemaker';
 
+    # Start iscsi service if it is not started yet
+    systemctl 'start iscsi' if (systemctl 'status iscsi', ignore_failure => 1);
+
     # Wait for all nodes to finish
     barrier_wait("SLE11_UPGRADE_INIT_$cluster_name");
 


### PR DESCRIPTION
Sometime, iscsi service failed to start during [boot time](http://1a102.qa.suse.de/tests/1980#step/upgrade_from_sle11sp4_workarounds/36)

- Related ticket: N/A
- Needles: N/A
- Verification run: [Node1](http://1a102.qa.suse.de/tests/2006) [Node2](http://1a102.qa.suse.de/tests/2007)