### PR TITLE
krb5 test: get/set user id on demand

### DIFF
--- a/tests/console/krb5.pm
+++ b/tests/console/krb5.pm
@@ -65,8 +65,8 @@ sub run {
     systemctl 'start krb5kdc';
     systemctl 'status krb5kdc';
 
-    script_run 'mkdir -p /run/user/1001/krb5cc';
-    script_run 'chown tester:users /run/user/1001/krb5cc';
+    script_run "mkdir -p /run/user/`id -u tester`/krb5cc";
+    script_run "chown tester:users /run/user/`id -u tester`/krb5cc";
 
     #confirm we have no existing kinit tickets cache:
     script_run 'su - tester', 0;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/60317
- Needles: None
- Verification run: 
Tumbleweed http://deathstar.suse.cz/tests/2291

SLE 15 http://deathstar.suse.cz/tests/2290
SLE 15.1 http://deathstar.suse.cz/tests/2288
SLE 12.5 http://deathstar.suse.cz/tests/2289
SLE 12.3 http://deathstar.suse.cz/tests/2285
SLE 12.2 http://deathstar.suse.cz/tests/2287
SLE 12.4 http://deathstar.suse.cz/tests/2286