### PR TITLE
add_custom_grub_entries: Fix regexp for SLE12 SP3

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -139,7 +139,7 @@ sub add_custom_grub_entries {
     die("Unexpected number of grub entries: $cnt_new, expected: $cnt_old") if ($cnt_old != $cnt_new);
     $cnt_new = script_output("grep -c 'menuentry .$distro.*($grub_param)' " . GRUB_CFG_FILE);
     die("Unexpected number of new grub entries: $cnt_new, expected: " . ($cnt_old)) if ($cnt_old != $cnt_new);
-    $cnt_new = script_output("grep -c 'linux.*/boot/.* $grub_param ' " . GRUB_CFG_FILE);
+    $cnt_new = script_output("grep -c -E 'linux.*(/boot|/vmlinu[xz]-).* $grub_param ' " . GRUB_CFG_FILE);
     die("Unexpected number of new grub entries with '$grub_param': $cnt_new, expected: " . ($cnt_old)) if ($cnt_old != $cnt_new);
 }
 


### PR DESCRIPTION
Fix regexp for SLE12 SP3 by checking also /vmlinu[xz]-

SLE12 SP3 doesn't use /boot/ directory (images are directly in root
directory, not in /boot/).

SLES use /vmlinuz, but expect also /vmlinux to avoid other failures
in the future.

Fixes: a0b10d08d Fix regexp for linux command in some archs

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - http://quasar.suse.cz/tests/4440 (SLE15 SP2)
  - http://quasar.suse.cz/tests/4437 (SLE15 SP1)
  - http://quasar.suse.cz/tests/4439 (SLE12 SP5)
  - http://quasar.suse.cz/tests/4436 (SLE12 SP3, the broken one)
  - http://quasar.suse.cz/tests/4435 (SLE12 SP1)
  - http://quasar.suse.cz/tests/4446 (SLE11 SP3)
  - http://quasar.suse.cz/tests/4443 (Tumbleweed)