### PR TITLE
Add module to migrate clvmd cluster resources to lvmlockd

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -53,6 +53,8 @@ our @EXPORT = qw(
   wait_until_resources_started
   get_lun
   check_device_available
+  set_lvm_config
+  add_lock_mgr
   pre_run_hook
   post_run_hook
   post_fail_hook
@@ -439,6 +441,28 @@ sub check_device_available {
     die "Test timed out while checking $dev"   unless (defined $ret);
     die "Nonexistent $dev after $tout seconds" unless ($tries > 0 or $ret == 0);
     return $ret;
+}
+
+sub set_lvm_config {
+    my ($lvm_conf, %args) = @_;
+    my $cmd;
+
+    foreach my $param (keys %args) {
+        $cmd = sprintf("sed -ie 's/^\\([[:blank:]]*%s[[:blank:]]*=\\).*/\\1 %s/' %s", $param, $args{$param}, $lvm_conf);
+        assert_script_run $cmd;
+    }
+
+    script_run "grep -E '^[[:blank:]]*use_lvmetad|^[[:blank:]]*locking_type|^[[:blank:]]*use_lvmlockd' $lvm_conf";
+}
+
+sub add_lock_mgr {
+    my ($lock_mgr) = @_;
+
+    assert_script_run "EDITOR=\"sed -ie '\$ a primitive $lock_mgr ocf:heartbeat:$lock_mgr'\" crm configure edit";
+    assert_script_run "EDITOR=\"sed -ie 's/^\\(group base-group.*\\)/\\1 $lock_mgr/'\" crm configure edit";
+
+    # Wait to get clvmd/lvmlockd running on all nodes
+    sleep 5;
 }
 
 sub pre_run_hook {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2765,6 +2765,7 @@ sub load_ha_cluster_tests {
     if (get_var('HDDVERSION')) {
         loadtest 'ha/setup_hosts_and_luns' unless get_var('USE_SUPPORT_SERVER');
         loadtest 'ha/upgrade_from_sle11sp4_workarounds' if check_var('HDDVERSION', '11-SP4');
+        loadtest 'ha/migrate_clvmd_to_lvmlockd'         if (is_sle('15-SP2+') and get_var('HDDVERSION') =~ /1[12]-SP/);
         loadtest 'ha/check_after_reboot';
         loadtest 'ha/check_hawk';
         return 1;

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -99,6 +99,8 @@ sub run {
         barrier_create("CSYNC2_SYNC_$cluster_name",                 $num_nodes);
         barrier_create("SBD_DONE_$cluster_name",                    $num_nodes);
         barrier_create("SSH_KEY_CONFIGURED_$cluster_name",          $num_nodes);
+        barrier_create("CLVM_TO_LVMLOCKD_START_$cluster_name",      $num_nodes);
+        barrier_create("CLVM_TO_LVMLOCKD_DONE_$cluster_name",       $num_nodes);
 
         # PACEMAKER_TEST_ barriers also have to wait in the client
         barrier_create("PACEMAKER_CTS_INIT_$cluster_name",    $num_nodes + 1);

--- a/tests/ha/migrate_clvmd_to_lvmlockd.pm
+++ b/tests/ha/migrate_clvmd_to_lvmlockd.pm
@@ -1,0 +1,85 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Workarounds after upgrade from cluster with clvmd into lvmlockd only systems
+# Maintainer: Alvaro Carvajal <acarvajal@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use utils qw(zypper_call systemctl zypper_enable_install_dvd);
+use testapi;
+use lockapi;
+use hacluster;
+
+sub run {
+    my ($self)       = @_;
+    my $cluster_name = get_cluster_name;
+    my $lvm_conf     = '/etc/lvm/lvm.conf';
+
+    # We may execute this test after a reboot, so we need to log in
+    select_console 'root-console';
+
+    # Only perform clvm to lvmlockd migration if the cluster has clvm resources
+    my $clvm_rsc = script_run "$crm_mon_cmd | grep -wq clvm";
+    return unless (defined $clvm_rsc and $clvm_rsc == 0);
+
+    barrier_wait("CLVM_TO_LVMLOCKD_START_$cluster_name");
+    my $ret = zypper_call('in lvm2-lockd', exitcode => [0, 104]);
+
+    if ($ret == 104) {
+        # Workaround for offline migrations
+        zypper_enable_install_dvd;
+        zypper_call 'in lvm2-lockd';
+    }
+
+    if (is_node(1)) {
+        # Stop all affected resources, and remove clvm resource from cluster
+        for my $rsc (qw(fs_cluster_md vg_cluster_md cluster_md clvm)) {
+            assert_script_run "crm resource stop $rsc";
+        }
+        assert_script_run 'crm configure delete clvm';
+
+        # With clvm resource removed from the cluster, configure lvmlockd
+        # Set use_lvmetad=1, lvmlockd supports lvmetad. Set locking_type=1 for lvmlockd. Enable lvmlockd
+        set_lvm_config($lvm_conf, use_lvmetad => 1, locking_type => 1, use_lvmlockd => 1);
+
+        # Sync files with other nodes
+        exec_csync;
+
+        # Add lvmlockd resource to cluster
+        add_lock_mgr('lvmlockd');
+        save_state;
+
+        # Restart cluster_md
+        assert_script_run 'crm resource start cluster_md';
+        sleep 5;
+
+        # Migrate volume group to lvmlockd
+        assert_script_run 'vgchange --lock-type none --lock-opt force -y vg_cluster_md';
+        assert_script_run 'vgchange --lock-type dlm vg_cluster_md';
+
+        # Start volume group and filesystem resources
+        assert_script_run 'crm resource start vg_cluster_md';
+        assert_script_run 'crm resource start fs_cluster_md';
+        sleep 5;
+        save_state;
+    }
+
+    # Screenshot before cleaning the screen
+    save_screenshot;
+
+    # Reset the console on all nodes, as the next test will re-select them
+    $self->clear_and_verify_console;
+
+    # Wait for all nodes to finish
+    barrier_wait("CLVM_TO_LVMLOCKD_DONE_$cluster_name");
+}
+
+1;


### PR DESCRIPTION
Starting with SLES+HA 15-SP2, clvmd is removed from the cluster stack.

This PR introduces a module to migrate clvmd cluster resources to lvmlockd when migrating from an older (11-SP4, 12-SP*) version of SLES+HA.

- Related ticket: N/A
- Failed tests: https://openqa.suse.de/tests/3715159, https://openqa.suse.de/tests/3702587, etc.
- Needles: N/A
- Verification run: [node 1](http://mango.suse.de/tests/2012) & [node2](http://mango.suse.de/tests/2011)
- Regression test (alpha cluster): [node 1](http://mango.suse.de/tests/2017) & [node 2](http://mango.suse.de/tests/2018) (remove_node failure is unrelated to this PR)
