### PR TITLE
Select always system role for Full media

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -471,8 +471,9 @@ sub is_using_system_role {
       && (install_this_version() || install_to_other_at_least('12-SP2'))
       || (is_sles4sap() && main_common::is_updates_test_repo())
       || is_sle('=15')
-      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
-      || (is_opensuse   && !is_leap('<15.1'))                                                                         # Also on leap 15.1, TW, MicroOS
+      || (is_sle('>15')     && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
+      || (is_sle('15-SP2+') && check_var('FLAVOR', 'Full'))
+      || (is_opensuse       && !is_leap('<15.1'))                                                                         # Also on leap 15.1, TW, MicroOS
 }
 
 =head2 is_using_system_role_first_flow


### PR DESCRIPTION
Full media have access to all modules and system roles even without
registration.

- Related ticket: https://progress.opensuse.org/issues/61158
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2050
