### PR TITLE
Revert "LTP: Add debug_pagealloc=on kernel cmdline arg"

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -321,12 +321,9 @@ sub run {
 
     $self->select_serial_terminal;
 
-    # jsc#SLE-9743
-    $grub_param = 'debug_pagealloc=on';
-
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
         script_run('echo 1 > /sys/module/printk/parameters/time');
-        $grub_param .= ' printk.time=1';
+        $grub_param = 'printk.time=1';
     }
 
     # check kGraft if KGRAFT=1


### PR DESCRIPTION
This reverts commit ba40311d3219f511408bd86a271044e08e574801.

Although it'd be nice to find more bugs with it, it breaks booting on:
* s390x on SLE15 SP2 (bsc#1159455) and
* ppc64le on SLE12 SP5 (bsc#1159096) and Tumbleweed (poo#51743#note-31)

We can decide later for which test to enable it (and how to implement it
to have basic tests covered).

Fixes: bsc#1159455 and bsc#1159096
See also jsc#SLE-9743

Verification run: TBD
