### PR TITLE
GraphicksMagick: Fix wrong base class assuming cleared console

### DIFF
--- a/tests/x11/graphicsMagick.pm
+++ b/tests/x11/graphicsMagick.pm
@@ -10,7 +10,7 @@
 # Summary: GraphicMagick testsuite
 # Maintainer: Ivan Lausuch <ilausuch@suse.com>
 
-use base 'consoletest';
+use base 'x11test';
 use testapi;
 use strict;
 use warnings;
@@ -56,6 +56,7 @@ sub run {
     send_key 'alt-f4';
 
     type_string "exit\n";
+    send_key 'alt-f4';
 }
 
 1;


### PR DESCRIPTION
Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9209 https://openqa.opensuse.org/tests/1118210
```

Created job #1118329: opensuse-Tumbleweed-DVD-x86_64-Build20191218-zdup-Leap-15.0-gnome@64bit_cirrus -> https://openqa.opensuse.org/tests/1118931