### PR TITLE
Add flavor filter for LTP whitelist

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -63,7 +63,7 @@ sub override_known_failures {
 
   ISSUE:
     foreach my $cond (@issues) {
-        foreach my $filter (qw(product ltp_version revision arch kernel backend retval)) {
+        foreach my $filter (qw(product ltp_version revision arch kernel backend retval flavor)) {
             next ISSUE if exists $cond->{$filter} and $env->{$filter} !~ m/$cond->{$filter}/;
         }
 

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -85,6 +85,7 @@ sub run {
         my $environment = {
             product     => get_var('DISTRI') . ':' . get_var('VERSION'),
             revision    => get_var('BUILD'),
+            flavor      => get_var('FLAVOR'),
             arch        => get_var('ARCH'),
             kernel      => '',
             libc        => '',


### PR DESCRIPTION
New LTP whitelist filter for `FLAVOR` so we can distinguish two different branches of 12SP3 kernel tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3727564
