### PR TITLE
Allow cloning partitions in raid tests

### DIFF
--- a/lib/Installation/Partitioner/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/ExpertPartitionerPage.pm
@@ -24,16 +24,22 @@ use constant {
     SELECTED_RAID              => 'partitioning_raid-raid-selected',
     SELECTED_VOLUME_MANAGEMENT => 'volume_management_feature',
     SELECTED_HARD_DISKS        => 'partitioning_raid-hard_disks-selected',
-    SELECTED_EXISTING_PART     => 'partitioning_existing_part_%s-selected'
+    SELECTED_EXISTING_PART     => 'partitioning_existing_part_%s-selected',
+    CLONE_PARTITION            => 'clone_partition',
+    ALL_DISKS_SELECTED         => 'all_disks_selected'
 };
 
 sub new {
     my ($class, $args) = @_;
     my $self = bless {
-        add_raid_shortcut         => $args->{add_raid_shortcut},
-        add_partition_shortcut    => $args->{add_partition_shortcut},
-        edit_partition_shortcut   => $args->{edit_partition_shortcut},
-        resize_partition_shortcut => $args->{resize_partition_shortcut}
+        add_raid_shortcut               => $args->{add_raid_shortcut},
+        add_partition_shortcut          => $args->{add_partition_shortcut},
+        edit_partition_shortcut         => $args->{edit_partition_shortcut},
+        resize_partition_shortcut       => $args->{resize_partition_shortcut},
+        partition_table_shortcut        => $args->{partition_table_shortcut},
+        clone_partition_chortcut        => $args->{clone_partition_chortcut},
+        ok_clone_shortcut               => $args->{ok_clone_shortcut},
+        available_target_disks_shortcut => $args->{avail_tgt_disks_shortcut}
     }, $class;
 }
 
@@ -107,6 +113,32 @@ sub press_accept_button {
     wait_still_screen;
     assert_screen(EXPERT_PARTITIONER_PAGE);
     send_key('alt-a');
+}
+
+sub open_clone_partition_dialog {
+    my ($self) = @_;
+    assert_screen(EXPERT_PARTITIONER_PAGE);
+    send_key($self->{partition_table_shortcut});
+    for (1 .. 2) { wait_screen_change { send_key "down" } }
+    save_screenshot;
+    send_key "ret";
+}
+
+sub select_all_disks_to_clone {
+    my ($self, $numdisks) = @_;
+    assert_screen(CLONE_PARTITION);
+    send_key($self->{available_target_disks_shortcut});
+    send_key "spc";           # Select first disk before going down,
+    for (2 .. $numdisks) {    # then start from 2nd.
+        send_key "down";
+        send_key "spc";
+    }
+}
+
+sub press_ok_clone {
+    my ($self) = @_;
+    assert_screen(ALL_DISKS_SELECTED);
+    send_key($self->{ok_clone_shortcut});
 }
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
@@ -35,7 +35,10 @@ sub new {
                 add_partition_shortcut    => 'alt-r',
                 resize_partition_shortcut => 'alt-r',
                 edit_partition_shortcut   => 'alt-e',
-                add_raid_shortcut         => 'alt-d'
+                add_raid_shortcut         => 'alt-d',
+                partition_table_shortcut  => 'alt-r',
+                avail_tgt_disks_shortcut  => 'alt-a',
+                ok_clone_shortcut         => 'alt-o'
         }),
         NewPartitionSizePage => Installation::Partitioner::NewPartitionSizePage->new({
                 custom_size_shortcut => 'alt-o'
@@ -120,5 +123,16 @@ sub edit_partition_on_gpt_disk {
     $self->get_edit_formatting_options_page()->fill_in_mount_point_field($args->{mount_point});
     $self->get_edit_formatting_options_page()->press_next();
 }
+
+sub clone_partition_table {
+    my ($self, $args) = @_;
+    $self->get_expert_partitioner_page()->go_top_in_system_view_table();
+    $self->get_expert_partitioner_page()->select_item_in_system_view_table($args->{disk});
+    $self->get_expert_partitioner_page()->open_clone_partition_dialog();
+    $self->get_expert_partitioner_page()->select_all_disks_to_clone($args->{numdisks});
+    $self->get_expert_partitioner_page()->press_ok_clone();
+}
+
+
 
 1;

--- a/tests/installation/partitioning/raid_gpt.pm
+++ b/tests/installation/partitioning/raid_gpt.pm
@@ -25,13 +25,16 @@ sub run {
     my $partitioner = $testapi::distri->get_expert_partitioner();
     $partitioner->run_expert_partitioner();
 
-    # Create partitions with the data from yaml scheduling file
+    # Create partitions with the data from yaml scheduling file on first disk
     # (see YAML_SCHEDULE openQA variable value).
-    foreach my $disk (@{$test_data->{disks}}) {
-        foreach my $partition (@{$disk->{partitions}}) {
-            $partitioner->add_partition_on_gpt_disk({disk => $disk->{name}, partition => $partition});
-        }
+    my $first_disk = $test_data->{disks}[0];
+    foreach my $partition (@{$first_disk->{partitions}}) {
+        $partitioner->add_partition_on_gpt_disk({disk => $first_disk->{name}, partition => $partition});
     }
+
+    # Clone partition table from first disk to all other disks
+    my $numdisks = scalar(@{$test_data->{disks}}) - 1;
+    $partitioner->clone_partition_table({disk => $first_disk->{name}, numdisks => $numdisks});
 
     # Create RAID partitions with the data from yaml scheduling file
     # (see YAML_SCHEDULE openQA variable value).


### PR DESCRIPTION
Improve raid tests workflow by cloning partition table.
Currently, all the raid tests are working this way:
-    create some partitions on disk 1
-    create the same exact set of partitions on the next disk.
-    iterate the same exact operation for all the disks.

However, the partitioner allows to clone partition tables. Using this will drastically reduce the execution time of test modules, and makes more sense, the real users are more about to proceed this way.

Currently working, but only tested raid0 on TW. Requires a whole lot of VRs.

- Related ticket: https://progress.opensuse.org/issues/56486
- Needles: 
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/626
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1290
BIS:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1292
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/627
- Verification run: 

**X86:**
TW:
raid0: http://waaa-amazing.suse.cz/tests/11054
raid1: http://waaa-amazing.suse.cz/tests/11050
raid5: http://waaa-amazing.suse.cz/tests/11051
raid6: http://waaa-amazing.suse.cz/tests/11056
raid10: http://waaa-amazing.suse.cz/tests/11055

SLE:
raid0: http://waaa-amazing.suse.cz/tests/11043
raid1: http://waaa-amazing.suse.cz/tests/11045
raid5: http://waaa-amazing.suse.cz/tests/11047
raid10: http://waaa-amazing.suse.cz/tests/11046

Needs needles to be merged to be tested on other arches.