### PR TITLE
KLP: Improve detection of cloned directory

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -12,6 +12,8 @@
 
 use strict;
 use warnings;
+use File::Basename 'basename';
+
 use base 'opensusebasetest';
 use testapi;
 use utils;
@@ -31,7 +33,8 @@ sub run {
     }
 
     my $git_repo = get_required_var('QA_TEST_KLP_REPO');
-    my ($test_type) = $git_repo =~ /qa_test_(\w+).git/;
+    my $dir      = basename($git_repo);
+    $dir =~ s/\.git$//;
 
     (is_sle(">12-sp1") || !is_sle) ? $self->select_serial_terminal() : select_console('root-console');
 
@@ -39,7 +42,7 @@ sub run {
     zypper_call('in -l autoconf automake gcc git make');
 
     assert_script_run('git clone ' . $git_repo);
-    assert_script_run("cd qa_test_$test_type; ./run.sh", 2760);
+    assert_script_run("cd $dir && ./run.sh", 2760);
 }
 
 1;


### PR DESCRIPTION
This way it does not require QA_TEST_KLP_REPO to have .git extension.

Even this is fixed by using supported URL format, I'd rather prevent this kind of failures in the future.
See http://quasar.suse.cz/tests/4454/file/serial_terminal.txt
```
# cd qa_test_; ./run.sh; echo okz03-$?-
-bash: cd: qa_test_: No such file or directory
-bash: ./run.sh: No such file or directory
```

Verification run:
- http://quasar.suse.cz/tests/4458 (URL without .git - unsupported URL)
- http://quasar.suse.cz/tests/4457 (URL with .git)