### PR TITLE
xfstests: Install test in s390x use the same way as spvm

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -730,7 +730,7 @@ elsif (get_var("QA_TESTSUITE")) {
 }
 elsif (get_var('XFSTESTS')) {
     prepare_target;
-    if (is_spvm) {
+    if (is_spvm || check_var('ARCH', 's390x')) {
         loadtest 'xfstests/install';
         loadtest 'xfstests/partition';
         loadtest 'xfstests/run';


### PR DESCRIPTION
Considering they has some steps in common, we could use the same way to install xfstests in s390x as what we do in spvm. 
If not install before s390x, test will fail like: https://openqa.suse.de/tests/3724961
This change will only affect xfstests.

- Related ticket: https://progress.opensuse.org/issues/60106