### PR TITLE
Update libreoffice_pyuno_bridge_no_evolution_dep

### DIFF
--- a/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
+++ b/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
@@ -22,8 +22,10 @@ use warnings;
 use testapi;
 
 sub run {
+    my $self = shift;
+
     # Open LibreOffice
-    x11_start_program('oowriter');
+    $self->libreoffice_start_program('oowriter');
 
     # Open the tools and navigate to macro selector
     assert_and_click 'ooffice-writer-tools';
@@ -38,7 +40,9 @@ sub run {
     send_key_until_needlematch 'ooffice-python-samples', 'down';
 
     # expand python samples and navigate to table sample
-    send_key 'right';
+    # In Libreoffice 6.3 send_key 'right'; doesn't work
+    # So use assert_and_dclick instead
+    assert_and_dclick 'ooffice-python-samples';
     send_key_until_needlematch 'ooffice-table-sample', 'down';
 
     # run create table


### PR DESCRIPTION
Fix libreoffice_pyuno_bridge_no_evolution_dep failure in QAM
Use libreoffice_start_program('oowriter') instead of x11_start_program
Use assert_and_dclick instead of shotcut key to expand python samples

- Related ticket: https://progress.opensuse.org/issues/61209
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1288
- Verification run:
QAM: http://10.67.19.11/tests/1615
SLED15SP2: http://10.67.19.11/tests/1614
