### PR TITLE
GraphicsMagick: skipt test on live tests and in Stagings

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1287,7 +1287,7 @@ sub load_x11tests {
             }
         }
         else {
-            loadtest "x11/graphicsMagick";
+            loadtest "x11/graphicsMagick" unless (is_staging || is_livesystem);
         }
     }
     if (libreoffice_is_applicable()) {


### PR DESCRIPTION
* The live medias are stripped down and not all fonts are present by default
  Installing all the neeeded packages will quickly lead to out-of-memory conditions
  as all package installs happen in the ram disk.
* In staging, we don't have GraphicsMagick on the test DVD, so let's not test that.

