### PR TITLE
Grub select menu helper

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -168,7 +168,7 @@ Boot the default kernel:
 
     boot_grub_item(1);
 
-Boot the default kernel recovery mode (goes through "Advanced options"):
+Boot the default kernel recovery mode (selected in the "Advanced options ..."):
 
     boot_grub_item(2, 2);
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -170,6 +170,8 @@ sub unlock_zvm_disk {
 Make sure that grub was started and send four enter keys to boot the system.
 C<$console> should be set to C<console('x3270')>.
 
+TODO: Add support for GRUB_BOOT_NONDEFAULT, GRUB_SELECT_FIRST_MENU, GRUB_SELECT_SECOND_MENU,
+see boot_grub_item()
 =cut
 sub handle_grub_zvm {
     my ($console) = @_;

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -14,7 +14,6 @@ use 5.018;
 use warnings;
 use base 'opensusebasetest';
 use testapi;
-use bootloader_setup 'boot_grub_item';
 use LTP::WhiteList 'download_whitelist';
 use version_utils 'is_jeos';
 
@@ -25,13 +24,7 @@ sub run {
     my $is_network = $cmd_file =~ m/^\s*(net|net_stress)\./;
     my $is_ima     = $cmd_file =~ m/^ima$/i;
 
-    if ($is_ima) {
-        record_info('INFO', 'IMA boot');
-        # boot kernel with IMA parameters
-        boot_grub_item();
-        $self->wait_boot_past_bootloader;
-    }
-    elsif (check_var('BACKEND', 'ipmi')) {
+    if (check_var('BACKEND', 'ipmi')) {
         record_info('INFO', 'IPMI boot');
         select_console 'sol', await_console => 0;
         assert_screen('linux-login', 1800);
@@ -40,7 +33,7 @@ sub run {
         record_info('Loaded JeOS image', 'nothing to do...');
     }
     else {
-        record_info('INFO', 'normal boot');
+        record_info('INFO', 'normal boot or boot with params');
         # during install_ltp, the second boot may take longer than usual
         $self->wait_boot(ready_time => 500);
     }

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -16,7 +16,6 @@ use base 'opensusebasetest';
 use testapi;
 use bootloader_setup 'boot_grub_item';
 use LTP::WhiteList 'download_whitelist';
-use serial_terminal 'get_login_message';
 use version_utils 'is_jeos';
 
 sub run {
@@ -30,7 +29,7 @@ sub run {
         record_info('INFO', 'IMA boot');
         # boot kernel with IMA parameters
         boot_grub_item();
-        wait_serial(get_login_message(), 500);
+        $self->wait_boot_past_bootloader;
     }
     elsif (check_var('BACKEND', 'ipmi')) {
         record_info('INFO', 'IPMI boot');

--- a/variables.md
+++ b/variables.md
@@ -52,6 +52,9 @@ FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only
 FULL_LVM_ENCRYPT | boolean | false | Enables/indicates encryption using lvm. boot partition may or not be encrypted, depending on the product default behavior.
 FUNCTION | string | | Specifies SUT's role for MM test suites. E.g. Used to determine which SUT acts as target/server and initiator/client for iscsi test suite
 GRUB_PARAM | string | | Adds special grub menu entry (3rd and 4th entry in main grub, where 4th entry is the "Advanced options ..." submenu) with kernel parameters specified in this variable. See `add_custom_grub_entries()`.
+GRUB_BOOT_NONDEFAULT | boolean | false | Boot grub menu entry added by `add_custom_grub_entries`. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
+GRUB_SELECT_FIRST_MENU | integer | | Select grub menu entry in main grub menu, used together with GRUB_SELECT_SECOND_MENU. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
+GRUB_SELECT_SECOND_MENU | integer | | Select grub menu entry in secondary grub menu (the "Advanced options ..." submenu), used together with GRUB_SELECT_FIRST_MENU. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
 HASLICENSE | boolean | true if SLE, false otherwise | Enables processing and validation of the license agreements.
 HDDVERSION | string | | Indicates version of the system installed on the HDD.
 HTTPPROXY  |||

--- a/variables.md
+++ b/variables.md
@@ -51,6 +51,7 @@ FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DV
 FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only.
 FULL_LVM_ENCRYPT | boolean | false | Enables/indicates encryption using lvm. boot partition may or not be encrypted, depending on the product default behavior.
 FUNCTION | string | | Specifies SUT's role for MM test suites. E.g. Used to determine which SUT acts as target/server and initiator/client for iscsi test suite
+GRUB_PARAM | string | | Adds special grub menu entry (3rd and 4th entry in main grub, where 4th entry is the "Advanced options ..." submenu) with kernel parameters specified in this variable. See `add_custom_grub_entries()`.
 HASLICENSE | boolean | true if SLE, false otherwise | Enables processing and validation of the license agreements.
 HDDVERSION | string | | Indicates version of the system installed on the HDD.
 HTTPPROXY  |||


### PR DESCRIPTION
Move boot_grub_item() usage from LTP to handle_grub(), to be usable for others.

LTP IMA tests now requires GRUB_BOOT_NONDEFAULT=1 variable
(or GRUB_SELECT_FIRST_MENU=3 or GRUB_SELECT_FIRST_MENU=4 or
GRUB_SELECT_FIRST_MENU=4 GRUB_SELECT_SECOND_MENU=2).

Document variables.

For LTP IMA tests, wait_serial() call, added in
a4fc9fada ("Fix boot_ltp failures in ltp_ima test jobs")
was replaced by wait_boot_past_bootloader().

\+ Print booted options in handle_grub().

Verification run:
* http://quasar.suse.cz/tests/4488#step/boot_ltp/4 (sle-12-SP4-Server-DVD-Incidents-Kernel-x86_64-Build:13534:kernel-azure-ltp_ima@64bit, using `GRUB_BOOT_NONDEFAULT=1`, `/proc/cmdline` contains `ima_policy=tcb`, see http://quasar.suse.cz/tests/4488/file/serial_terminal.txt)

* http://quasar.suse.cz/tests/4491#step/boot_ltp/4 (sle-15-SP1-Server-DVD-Incidents-Kernel-x86_64-Build4.12.14-729.1.g8159d30-ltp_ima_pre12SP4@64bit, using `GRUB_BOOT_NONDEFAULT=1`, `/proc/cmdline` contains `ima_policy=tcb`, see http://quasar.suse.cz/tests/4491/file/serial_terminal.txt)

* http://quasar.suse.cz/tests/4493#step/boot_ltp/4 (sle-12-SP5-Server-DVD-Incidents-Kernel-x86_64-Build4.12.14-154.1.g6c5578e-ltp_net_ipv6_lib@64bit, using `GRUB_SELECT_FIRST_MENU=2`, `GRUB_SELECT_SECOND_MENU=2` to boot recovery mode, `/proc/cmdline` has just `BOOT_IMAGE=/boot/vmlinuz-4.12.14-154.g6c5578e-default root=UUID=c30abf85-c12f-4089-ab2e-263c70eafdba`, see http://quasar.suse.cz/tests/4493/file/serial_terminal.txt)

* https://openqa.suse.de/tests/3730998#step/boot_ltp/4 (sle-15-SP2-Online-aarch64-Buildpevik_os-autoinst-distri-opensuse_grub-select-menu-ltp_net_ipv6_lib@**aarch64-virtio**, using `GRUB_SELECT_FIRST_MENU=3`, `/proc/cmdline` has `ima_policy=tcb`, see https://openqa.suse.de/tests/3730998/file/serial_terminal.txt)

* https://openqa.suse.de/tests/3730999#step/boot_ltp/4 (sle-12-SP3-Server-DVD-Incidents-Kernel-ppc64le-Buildgrub-select-menu-ltp_net_ipv6_lib@**ppc64le-virtio**, using `GRUB_SELECT_FIRST_MENU=3`, `/proc/cmdline` has `ima_policy=tcb`, see https://openqa.suse.de/tests/3730999/file/serial_terminal.txt)