### PR TITLE
More setups add custom grub entries

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -51,7 +51,7 @@ FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DV
 FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only.
 FULL_LVM_ENCRYPT | boolean | false | Enables/indicates encryption using lvm. boot partition may or not be encrypted, depending on the product default behavior.
 FUNCTION | string | | Specifies SUT's role for MM test suites. E.g. Used to determine which SUT acts as target/server and initiator/client for iscsi test suite
-GRUB_PARAM | string | | Adds special grub menu entry (3rd and 4th entry in main grub, where 4th entry is the "Advanced options ..." submenu) with kernel parameters specified in this variable. See `add_custom_grub_entries()`.
+GRUB_PARAM | string | | A semicolon-separated list of extra boot options. Adds 2 grub meny entries per each item in main grub (2nd entry is the "Advanced options ..." submenu). See `add_custom_grub_entries()`.
 GRUB_BOOT_NONDEFAULT | boolean | false | Boot grub menu entry added by `add_custom_grub_entries`. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
 GRUB_SELECT_FIRST_MENU | integer | | Select grub menu entry in main grub menu, used together with GRUB_SELECT_SECOND_MENU. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
 GRUB_SELECT_SECOND_MENU | integer | | Select grub menu entry in secondary grub menu (the "Advanced options ..." submenu), used together with GRUB_SELECT_FIRST_MENU. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.


### PR DESCRIPTION
Verification run:
* http://quasar.suse.cz/tests/4532 (`GRUB_PARAM=ima_policy=tcb;debug_pagealloc=on;foo=bar foo2=bar2`)
and test which runs it: has 3 sections `ima_policy=tcb`, `debug_pagealloc=on` and `foo=bar foo2=bar2`
http://quasar.suse.cz/tests/4537#step/boot_ltp/2

* http://quasar.suse.cz/tests/4531 (`GRUB_PARAM=ima_policy=tcb;debug_pagealloc=on;foo=bar foo2=bar2`)
* http://quasar.suse.cz/tests/4528 (`GRUB_PARAM=ima_policy=tcb`)

* https://openqa.suse.de/tests/3731116 (sle-15-SP2-Online@**aarch64-virtio**, `GRUB_PARAM=ima_policy=tcb;debug_pagealloc=on;foo=bar`)
* https://openqa.suse.de/tests/3731098 (sle-15-SP2-Online@**aarch64-virtio**, `GRUB_PARAM=ima_policy=tcb`)
* https://openqa.suse.de/tests/3731099 (sle-12-SP3-Server-DVD-Incidents-Kernel@**ppc64le-virtio**, `GRUB_PARAM=ima_policy=tcb`)
* https://openqa.suse.de/tests/3731100 (sle-12-SP1-Server-DVD-Incidents-Kernel@64bit, `GRUB_PARAM=ima_policy=tcb`)