### PR TITLE
Enhance junit log to include customized individual assertion rules 

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -46,8 +46,8 @@ sub analyzeResult {
     my $rough_result = $1;
     foreach (split("\n", $rough_result)) {
         if ($_ =~ /(\S+)\s+\.{3}\s+\.{3}\s+(PASSED|FAILED|SKIPPED|TIMEOUT)\s+\((\S+)\)/g) {
-            $result->{$1}{status} = $2;
-            $result->{$1}{time}   = $3;
+            $result->{$1}{status}    = $2;
+            $result->{$1}{test_time} = $3;
         }
     }
     return $result;

--- a/tests/virt_autotest/guest_migration_source_migrate.pm
+++ b/tests/virt_autotest/guest_migration_source_migrate.pm
@@ -26,7 +26,7 @@ sub analyzeResult {
                 my ($case_name, $case_result) = ($1, $2);
                 $result->{$case_name}{status} = "PASSED" if ($case_result =~ /pass/);
                 $result->{$case_name}{status} = "FAILED" if ($case_result =~ /fail/);
-                $result->{$case_name}{time}   = 1;
+                $result->{$case_name}{test_time} = 1;
             }
         }
     }

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -32,11 +32,12 @@ sub get_script_run {
 sub generateXML {
     my ($self, $data) = @_;
     print Dumper($data);
-    my %my_hash   = %$data;
-    my $pass_nums = 0;
-    my $fail_nums = 0;
-    my $skip_nums = 0;
-
+    my %my_hash         = %$data;
+    my $pass_nums       = 0;
+    my $fail_nums       = 0;
+    my $skip_nums       = 0;
+    my $test_time_hours = 0;
+    my $test_time_mins  = 0;
     foreach my $item (keys(%my_hash)) {
         if ($my_hash{$item}->{status} =~ m/PASSED/) {
             $pass_nums += 1;
@@ -48,7 +49,19 @@ sub generateXML {
         else {
             $fail_nums += 1;
         }
+        my $test_time = eval { $my_hash{$item}->{test_time} ? $my_hash{$item}->{test_time} : '' };
+        if ($test_time ne '') {
+            my ($time_hours) = $test_time =~ /^(\d+)m.*s$/i;
+            my ($time_mins)  = $test_time =~ /^.*m(\d+)s$/i;
+            $test_time_hours += $time_hours;
+            $test_time_mins  += $time_mins;
+        }
     }
+    $self->{pass_nums} = $pass_nums;
+    $self->{fail_nums} = $fail_nums;
+    $self->{skip_nums} = $skip_nums;
+    $self->{test_time} = $test_time_hours . 'm' . $test_time_mins . 's';
+
     diag '@{$self->{success_guest_list}} content is: ' . Dumper(@{$self->{success_guest_list}});
     ###Load instance attributes into %xmldata
     my %xmldata;


### PR DESCRIPTION
1. Introduce $overall_status to indicate the overall pass/fail status

2. In analyzeResult(), initialize all testcase status counters to zero, then count up respective status counter by iterating over all testcases executed on all vm guests, at last handle corner situation in which test run did not fail at predefined step. By the way, the undefined command/step at which the test run failed is tored in /root/commands_history file obtained from "history -w". In order to keep clean and shorten the history file, "history -c" is called before executing every modules.
    
3. Extract junit log generation functionality for individual testcase into a separate subroutine generate_testcase(), which also handles legacy test scenairos like guest_installation_run.
    
4. Output vm guest name in failure element in testcase xml if any failure.
    
5. Some unused elements in JUnit log are given "n/a".
    
6. Correct ambiguous usage of "time" element in all data structures. Because "time" is keyword in Perl, avoid use it and use "test_time" instead. And improve all time output formats in JUnit log, which improves the legacy test scenarios junit log output like guest_installation_run so both total time spent and time cost for individual vm guest are recorded. Time cost display for newly developed feature test is also supported, although the author can decide whether use it or not.
    
7. The system error element also support newly developed feature test. And the author can decide whether use it or not. The same also applies to system out element.
    
8. Call junit_log_provision before any following operations in post_fail_hook to ensure JUnit log is alwasy available under any circumstances.
    
9. Please set assertion rules to be used with this any newly developed feature test like $self->{test_results}->{$guest}->{TEST1}->{status} = 'SKIPPED/FAILED/PASSED/SOFTFAILED/TIMEOUT/UNKNOWN'. Time spent for each test and corresponding error can also be given by using $self->{test_results}->{$guest}->{TEST1}->{test_time} = 'XXmYYs', $self->{test_results}->{$guest}->{TEST1}->{error} can be given "SPECIFIC SYSTEM ERROR" and $self->{test_results}->{$guest}->{TEST1}->{output} can be given "SPECIFIC SYSTEM OUTPUT" which are not mandatory and can be omitted in feature test design.

- Related ticket: n/a
- Needles: https: n/a
- Verification run: 
    1. sles15sp2 Run1 http://10.67.19.99/tests/700
    2.  sles15sp2 Run2 http://10.67.19.99/tests/701
    3.  sles11sp4 Run http://10.67.19.99/tests/649
    4.  Migration Run http://10.67.19.99/tests/702