### PR TITLE
Add summary record info box for service check module

### DIFF
--- a/tests/console/check_upgraded_service.pm
+++ b/tests/console/check_upgraded_service.pm
@@ -22,7 +22,11 @@ use main_common 'is_desktop';
 sub run {
     select_console 'root-console';
     check_services($default_services) if (is_sle && !is_desktop && !is_sles4sap && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && !get_var('INSTALLONLY'));
-    die "Service check after migration failed!" if $srv_check_results{'after_migration'} eq 'FAIL';
+
+    if ($srv_check_results{'after_migration'} eq 'FAIL') {
+        record_info("Summary", "failed", result => 'fail');
+        die "Service check after migration failed!";
+    }
 }
 
 sub test_flags {

--- a/tests/installation/install_service.pm
+++ b/tests/installation/install_service.pm
@@ -39,7 +39,10 @@ sub run {
       && !get_var('ZDUP')
       && !get_var('INSTALLONLY');
 
-    die "Service check before migration failed!" if $srv_check_results{'before_migration'} eq 'FAIL';
+    if ($srv_check_results{'before_migration'} eq 'FAIL') {
+        record_info("Summary", "failed", result => 'fail');
+        die "Service check before migration failed!";
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
[sle][Migration][SLE15SP2] test fails in install_service - improvement for summary of install_service

- Related ticket: https://progress.opensuse.org/issues/60842
- Needles: na
- Verification run: https://openqa.suse.de/tests/3739549#step/install_service/14
