### PR TITLE
Add 12-sp5 check for http server

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -88,7 +88,7 @@ our $default_services = {
     apache => {
         srv_pkg_name       => 'apache2',
         srv_proc_name      => 'apache2',
-        support_ver        => '12-SP2,12-SP3,12-SP4,15,15-SP1',
+        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1',
         service_check_func => \&services::apache::full_apache_check
     },
     dhcpd => {


### PR DESCRIPTION
Add 12-sp5 check for http server

- Related ticket: na
- Needles: na
- Verification run: http://openqa.suse.de/t3739606
