### PR TITLE
Make sure the 'tip of the day' window disappear

### DIFF
--- a/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
+++ b/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
@@ -27,6 +27,8 @@ sub run {
     # Open LibreOffice
     $self->libreoffice_start_program('oowriter');
 
+    # Make sure the tip of the day window disappear
+    wait_still_screen;
     # Open the tools and navigate to macro selector
     assert_and_click 'ooffice-writer-tools';
     assert_and_click 'ooffice-tools-macros';


### PR DESCRIPTION
On o.s.d the tip of the day window doesn't disappear immediately
Add wait_still_screen to fix this

- Related ticket: https://progress.opensuse.org/issues/61209
- Verification run: https://openqa.suse.de/tests/3744670#
