### PR TITLE
Disable grub timeout in migration

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -31,7 +31,7 @@ sub run {
         # Select section booting on Installation Settings overview on text mode
         send_key $cmd{change};
         assert_screen 'inst-overview-options';
-        send_key 'alt-b';
+        is_upgrade() ? send_key 'alt-t' : send_key 'alt-b';
     }
     else {
         # Select section booting on Installation Settings overview (video mode)


### PR DESCRIPTION
Fix to use `disable_grub_timeout `module in our migration tests.
Current setting is to exclude that module with `EXCLUDE_MODULES`.
Full discussion can be found [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9200)

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1294
- Verification run: [Migration from 11SP4 to 15SP2](http://1a102.qa.suse.de/tests/2227)
- Regression tests: 
[create_hdd_gnome 15_SP2 Online](http://1a102.qa.suse.de/tests/2229)
[create_hdd_textmode](http://1a102.qa.suse.de/tests/2228)
[offline_sles11sp4_ltss_media_base_all_minimal](http://1a102.qa.suse.de/tests/2230)