### PR TITLE
Add yast2_clone_system to validate generated profile on stagingY

### DIFF
--- a/schedule/staging/autoyast_mini@64bit-staging.yaml
+++ b/schedule/staging/autoyast_mini@64bit-staging.yaml
@@ -8,6 +8,7 @@ schedule:
     - autoyast/installation
     - autoyast/console
     - autoyast/login
+    - console/yast2_clone_system
     - autoyast/wicked
     - autoyast/repos
     - autoyast/clone

--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -15,7 +15,7 @@ use base "y2_module_consoletest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle is_opensuse);
+use version_utils qw(is_sle is_opensuse is_staging);
 use utils 'zypper_call';
 use repo_tools 'get_repo_var_name';
 
@@ -44,21 +44,23 @@ sub run {
 
     unless (is_opensuse) {
         my $devel_repo = get_required_var(is_sle('>=15') ? get_repo_var_name("MODULE_DEVELOPMENT_TOOLS") : 'REPO_SLE_SDK');
-        zypper_call "ar -c $utils::OPENQA_FTP_URL/" . $devel_repo . " devel-repo";
+        # As developement_tools are not build for staging, we will attempt to get the package from the factory repo
+        # otherwise MODULE_DEVELOPMENT_TOOLS should be used
+        my $uri = (is_staging) ? "http://download.opensuse.org/tumbleweed/repo/oss/" : "$utils::OPENQA_FTP_URL/" . $devel_repo;
+        zypper_call "ar -c $uri devel-repo";
     }
-
     zypper_call '--gpg-auto-import-keys ref';
+
     zypper_call 'install jing';
+    zypper_call "rr devel-repo" if (is_staging);
+    my $rc_jing = script_run "jing $xml_schema_path $ay_profile_path";
 
-    my $rc_jing    = script_run "jing $xml_schema_path $ay_profile_path";
-    my $rc_xmllint = script_run "xmllint --noout --relaxng $xml_schema_path $ay_profile_path";
-
-    if (($rc_jing) || ($rc_xmllint)) {
+    if ($rc_jing) {
         if (is_sle('<15')) {
             record_soft_failure 'bsc#1103712';
         }
         else {
-            die "autoinst.xml does not validate for unknown reason";
+            die "$ay_profile_path does not validate";
         }
     }
 


### PR DESCRIPTION
I updated the yaml scheduler.
I havent done any other change in test_suite.
REPO_SLE_MODULE_DEVELOPMENT_TOOLS is set to factory repo.
After installation of jing is removed.
Also I removed the xmllint.

- Related ticket: https://progress.opensuse.org/issues/49415
- Needles: N/A
- Verification run: 
http://aquarius.suse.cz/tests/1233
http://aquarius.suse.cz/tests/1231
updated: http://aquarius.suse.cz/tests/1318
nonstaging: http://aquarius.suse.cz/tests/1335#step/yast2_clone_system/31

http://aquarius.suse.cz/tests/1347 using http://download.opensuse.org/tumbleweed/repo/oss/

final VR with factory repo: http://aquarius.suse.cz/tests/1356