### PR TITLE
Add a new test for ctdb

### DIFF
--- a/data/ha/smb.conf
+++ b/data/ha/smb.conf
@@ -1,0 +1,38 @@
+[global]
+    netbios name = CTDBTEST
+    clustering = yes
+    idmap config * : backend = tdb2
+    passdb backend = tdbsam
+    ctdbd socket = /var/lib/ctdb/ctdb.socket
+    # settings necessary for CTDB on OCFS2
+    fileid:algorithm = fsid
+    vfs objects = fileid
+    workgroup = SMB
+    realm = SMB
+    encrypt passwords  = yes
+    idmap config * : range = 10000-20000
+    template shell = /bin/bash
+    template homedir = /home/%D/%U
+    preferred master = no
+    inherit acls = Yes
+    map acl inherit = Yes
+    acl group control = yes
+    load printers = no
+    debug level = 3
+    use sendfile = no
+    printing = cups
+    printcap name = cups
+    printcap cache time = 750
+    cups options = raw
+    map to guest = Bad User
+    include = /etc/samba/dhcp.conf
+    logon path = \\%L\profiles\.msprofile
+    logon home = \\%L\%U\.9xprofile
+    logon drive = P:
+    usershare allow guests = Yes
+[ctdb]
+    comment = ocfs2 fs
+    path = /srv/fs_cluster_md/ctdb/
+    valid users = root, administrator
+    read only = No
+    inherit acls = Yes

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2756,10 +2756,11 @@ sub load_ha_cluster_tests {
     # When not using a support server, node 1 setups barriers and mutex
     loadtest 'ha/barrier_init' if (get_var('HOSTNAME') =~ /node01$/ and !get_var('USE_SUPPORT_SERVER'));
 
-    # Wait for barriers to be initialized except when testing HAWK as a client
-    # or Pacemaker CTS regression tests
+    # Wait for barriers to be initialized except when testing with a client
+    # HAWK, Pacemaker CTS regression tests or CTDB
     loadtest 'ha/wait_barriers' unless (check_var('HAWKGUI_TEST_ROLE', 'client') or
-        (get_var('PACEMAKER_CTS_REG')) or (check_var('PACEMAKER_CTS_TEST_ROLE', 'client')));
+        (get_var('PACEMAKER_CTS_REG')) or (check_var('PACEMAKER_CTS_TEST_ROLE', 'client')) or
+        (check_var('CTDB_TEST_ROLE', 'client')));
 
     # Test HA after an upgrade, so no need to configure the HA stack
     if (get_var('HDDVERSION')) {
@@ -2779,6 +2780,12 @@ sub load_ha_cluster_tests {
     # If HAWKGUI_TEST_ROLE is set to client, only load client side test
     if (check_var('HAWKGUI_TEST_ROLE', 'client')) {
         loadtest 'ha/hawk_gui';
+        return 1;
+    }
+
+    # If CTDB_TEST_ROLE is set to client, only load client side test
+    if (check_var('CTDB_TEST_ROLE', 'client')) {
+        loadtest 'ha/ctdb';
         return 1;
     }
 
@@ -2871,6 +2878,11 @@ sub load_ha_cluster_tests {
         loadtest 'ha/cluster_md';
         loadtest 'ha/vg';
         loadtest 'ha/filesystem';
+
+        # Test ctdb feature
+        if (check_var('CTDB_TEST_ROLE', 'server')) {
+            loadtest 'ha/ctdb';
+        }
 
         # Test DRBD feature
         if (get_var('HA_CLUSTER_DRBD')) {

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -111,6 +111,10 @@ sub run {
         barrier_create("HAWK_GUI_CHECKED_$cluster_name", $num_nodes + 1);
         barrier_create("HAWK_FENCE_$cluster_name",       $num_nodes + 1);
 
+        # CTDB barriers
+        barrier_create("CTDB_INIT_$cluster_name", $num_nodes + 1);
+        barrier_create("CTDB_DONE_$cluster_name", $num_nodes + 1);
+
         # Create barriers for multiple tests
         foreach my $fs_tag ('LUN', 'CLUSTER_MD', 'DRBD_PASSIVE', 'DRBD_ACTIVE') {
             barrier_create("VG_INIT_${fs_tag}_$cluster_name",             $num_nodes);

--- a/tests/ha/ctdb.pm
+++ b/tests/ha/ctdb.pm
@@ -1,0 +1,121 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test ctdb resource agent
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use hacluster;
+use version_utils 'is_sle';
+use utils 'systemctl';
+
+sub run {
+    my $cluster_name = get_cluster_name;
+    my $vip_ip       = '10.0.2.20';
+    my $ctdb_folder  = '/srv/fs_cluster_md/ctdb';
+
+    # CTDB configuration must be done only in cluster nodes
+    if (check_var('CTDB_TEST_ROLE', 'server')) {
+        my $ctdb_cfg = '/etc/samba/smb.conf';
+        my $ctdb_rsc = 'ctdb';
+        my $nmb_rsc  = 'nmb';
+        my $smb_rsc  = 'smb';
+        my $ip_rsc   = 'vip';
+        my @node_list;
+
+        foreach my $node (1 .. get_node_number) {
+            my $node_ip = get_ip(choose_node($node));
+            push @node_list, $node_ip;
+        }
+        assert_script_run 'echo -e "' . join("\n", @node_list) . '" > /etc/ctdb/nodes';
+
+        # Make sure the services ctdb , smb , and nmb are disabled
+        if (is_sle('15+')) {
+            systemctl 'disable --now ctdb smb nmb';
+        }
+        else {
+            systemctl 'disable ctdb smb nmb';
+            systemctl 'stop ctdb smb nmb';
+        }
+
+        # Create ctdb folder
+        assert_script_run "mkdir -p $ctdb_folder";
+
+        # Get smb conf file from the openQA server
+        assert_script_run "curl -f -v " . autoinst_url . "/data/ha/smb.conf -o $ctdb_cfg";
+
+        if (is_node(1)) {
+            # Set maintenance mode before adding resources
+            assert_script_run "crm configure property maintenance-mode=true";
+
+            # Create vip resource
+            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $ip_rsc IPaddr2 params ip='$vip_ip' nic='eth0' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
+
+            # Add ctdb, nmb, smb, group, clone and order resources
+            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $ctdb_rsc CTDB params ctdb_manages_winbind=false ctdb_manages_samba=false ctdb_recovery_lock='$ctdb_folder/ctdb.lock' ctdb_socket='/var/lib/ctdb/ctdb.socket''\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $nmb_rsc systemd:nmb'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $smb_rsc systemd:smb'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a group ctdb-group $ctdb_rsc $nmb_rsc $smb_rsc'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a clone ctdb-clone ctdb-group meta interleave=true'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a colocation col-ctdb-with-clusterfs inf: ctdb-clone base-clone'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a colocation col-ip-with-ctdb Mandatory: $ip_rsc ctdb-clone'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a order o-clusterfs-then-ctdb Mandatory: base-clone ctdb-clone'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a order o-ip-then-ctdb Mandatory: $ip_rsc ctdb-clone'\" crm configure edit";
+
+            # Remove maintenance mode and wait for resources start
+            assert_script_run "crm configure property maintenance-mode=false";
+            sleep 60;
+            save_state;
+
+            # Check CTDB status
+            assert_script_run "ctdb status";
+
+            # Add SMB password for root
+            type_string "smbpasswd -a root ; echo smbpasswd-finished-\$? > /dev/$serialdev\n";
+            assert_screen 'smbpasswd-password', $join_timeout;
+            type_password;
+            send_key 'ret';
+            assert_screen 'smbpasswd-confirm-password', $join_timeout;
+            type_password;
+            send_key 'ret';
+            wait_serial("smbpasswd-finished-0", $join_timeout);
+            save_screenshot;
+        }
+    }
+
+    # Barrier to start tests from client
+    barrier_wait("CTDB_INIT_$cluster_name");
+
+    # Tests done by a client server
+    if (check_var('CTDB_TEST_ROLE', 'client')) {
+        # Mount the shared filesystem and test access
+        type_string "mount -t cifs //$vip_ip/ctdb /mnt/ -o rw,user=root ; echo smbmount-finished-\$? > /dev/$serialdev\n";
+        assert_screen 'smbmount-password', $join_timeout;
+        type_password;
+        send_key 'ret';
+        wait_serial("smbmount-finished-0", $join_timeout);
+        assert_script_run "cd /mnt; ls -altrh";
+        save_screenshot;
+
+        # Add files/data in the CIFS share
+        assert_script_run "for i in \$(seq 1 5); do dd if=/dev/urandom of=file\${i} bs=1M count=10; md5sum file\${i} >> files.md5 ; done", $default_timeout;
+    }
+
+    # Synchronize all the nodes
+    barrier_wait("CTDB_DONE_$cluster_name");
+
+    # Check files consistency
+    assert_script_run "cd $ctdb_folder; md5sum -c files.md5" if (is_node(1));
+}
+
+1;


### PR DESCRIPTION
This PR adds a test for CTDB (cluster implementation of the TDB database used by Samba and other projects to store temporary data).

[Official documentation](https://documentation.suse.com/sle-ha/15-SP1/pdf/book-sleha-guide_color_en.pdf) was used to write tests.

Basically, ctdb, nmb and smb resources are added to the cluster configuration via group and clone.
A clustered IP address is also used for the mount endpoint.
A client server is started to mount and test access to the cifs mount.
Last but not least, client server writes data in the cifs mount and cluster node 1 tests files with md5sum check.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1295
- Verification run: 
3 nodes - x86_64: [client](http://1a102.qa.suse.de/tests/2417) - [node1](http://1a102.qa.suse.de/tests/2418) - [node2](http://1a102.qa.suse.de/tests/2419) - [node3](http://1a102.qa.suse.de/tests/2416)
2 nodes - x86_64: [client](http://1a102.qa.suse.de/tests/2421) - [node1](http://1a102.qa.suse.de/tests/2422) - [node2](http://1a102.qa.suse.de/tests/2423) 
2 nodes - aarch64: [client](http://1a102.qa.suse.de/tests/2425) - [node1](http://1a102.qa.suse.de/tests/2426) - [node2](http://1a102.qa.suse.de/tests/2427) 