### PR TITLE
Add test for installation with MSDOS partition table

### DIFF
--- a/lib/Installation/Partitioner/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/ExpertPartitionerPage.pm
@@ -29,6 +29,10 @@ use constant {
     ALL_DISKS_SELECTED         => 'all_disks_selected',
     PARTITIONS_TAB             => 'partitions_tab_selected',
     OVERVIEW_TAB               => 'overview_tab_selected',
+    NEW_PARTITION_TABLE_TYPE   => 'new_partition_table_type',
+    SELECTED_CREATE_NEW_TABLE  => 'selected_create_new_table',
+    DELETING_CURRENT_DEVICES   => 'deleting_current_devices',
+    NEW_PARTITION_TYPE         => 'partition-type'
 };
 
 sub new {
@@ -43,7 +47,13 @@ sub new {
         ok_clone_shortcut               => $args->{ok_clone_shortcut},
         available_target_disks_shortcut => $args->{avail_tgt_disks_shortcut},
         overview_tab                    => 'alt-o',
-        partitions_tab                  => 'alt-p',
+        select_msdos_shortcut           => $args->{select_msdos_shortcut},
+        modify_hard_disks_shortcut      => $args->{modify_hard_disks_shortcut},
+        press_yes_shortcut              => $args->{press_yes_shortcut},
+        partitions_tab_shortcut         => $args->{partitions_tab_shortcut},
+        select_gpt_shortcut             => $args->{select_gpt_shortcut},
+        select_primary_shortcut         => $args->{select_primary_shortcut},
+        select_extended_shortcut        => $args->{select_extended_shortcut}
     }, $class;
 }
 
@@ -87,7 +97,7 @@ sub go_top_in_system_view_table {
 sub select_partitions_tab {
     my ($self) = @_;
     assert_screen(EXPERT_PARTITIONER_PAGE);
-    send_key($self->{partitions_tab});
+    send_key($self->{partitions_tab_shortcut});
 }
 
 sub select_overview_tab {
@@ -152,6 +162,48 @@ sub press_ok_clone {
     my ($self) = @_;
     assert_screen(ALL_DISKS_SELECTED);
     send_key($self->{ok_clone_shortcut});
+}
+
+sub modify_hard_disks {
+    my ($self, $item) = @_;
+    assert_screen(EXPERT_PARTITIONER_PAGE);
+    _select_system_view_section();
+    send_key_until_needlematch(SELECTED_HARD_DISKS, 'down');
+    send_key($self->{modify_hard_disks_shortcut});
+}
+sub open_partition_table_menu {
+    my ($self) = @_;
+    assert_screen(EXPERT_PARTITIONER_PAGE);
+    send_key($self->{partition_table_shortcut});
+}
+
+sub create_new_partition_table {
+    my ($self) = @_;
+    send_key_until_needlematch(SELECTED_CREATE_NEW_TABLE, 'down');
+    send_key "ret";
+}
+
+sub select_partition_table_type {
+    my ($self, $table_type) = @_;
+    assert_screen(NEW_PARTITION_TABLE_TYPE);
+    my $selection = "select_" . $table_type . "_shortcut";
+    send_key($self->{$selection});
+    send_key "ret";
+}
+
+sub check_confirm_deleting_current_devices {
+    my ($self) = @_;
+    if (check_screen(DELETING_CURRENT_DEVICES)) {
+        send_key($self->{press_yes_shortcut});
+    }
+}
+
+sub select_new_partition_type {
+    my ($self, $partition_type) = @_;
+    assert_screen(NEW_PARTITION_TYPE);
+    my $selection = "select_" . $partition_type . "_shortcut";
+    send_key($self->{$selection});
+    send_key "ret";
 }
 
 1;

--- a/lib/Installation/Partitioner/FormattingOptionsPage.pm
+++ b/lib/Installation/Partitioner/FormattingOptionsPage.pm
@@ -20,9 +20,7 @@ use parent 'Installation::WizardPage';
 
 use constant {
     FORMATTING_OPTIONS_PAGE => 'partition-format',
-    FILESYSTEM_SWAP         => 'partitioning_raid-swap_format-selected',
-    FILESYSTEM_FAT          => 'partitioning_raid-fat_format-selected',
-    FILESYSTEM_EXT4         => 'partitioning_raid-filesystem_ext4',
+    FILESYSTEM_TYPE         => 'partitioning_%s-format-selected',
     PARTITION_ID_PREP_BOOT  => 'filesystem-prep',
     PARTITION_ID_EFI_SYSTEM => 'partition-selected-efi-type',
     PARTITION_ID_BIOS_BOOT  => 'partition-selected-bios-boot-type',
@@ -90,18 +88,7 @@ sub select_filesystem {
     wait_screen_change(sub {
             send_key 'end';
     }, 20);
-    if ($filesystem eq 'swap') {
-        send_key_until_needlematch(FILESYSTEM_SWAP, 'up');
-    }
-    elsif ($filesystem eq 'fat') {
-        send_key_until_needlematch(FILESYSTEM_FAT, 'up');
-    }
-    elsif ($filesystem eq 'ext4') {
-        send_key_until_needlematch(FILESYSTEM_EXT4, 'up');
-    }
-    else {
-        die "\"$filesystem\" Filesystem is not known.";
-    }
+    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up');
 }
 
 # Mounting Options

--- a/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
@@ -32,13 +32,20 @@ sub new {
     my $self = bless {
         SuggestedPartitioningPage => Installation::Partitioner::LibstorageNG::SuggestedPartitioningPage->new(),
         ExpertPartitionerPage     => Installation::Partitioner::LibstorageNG::ExpertPartitionerPage->new({
-                add_partition_shortcut    => 'alt-r',
-                resize_partition_shortcut => 'alt-r',
-                edit_partition_shortcut   => 'alt-e',
-                add_raid_shortcut         => 'alt-d',
-                partition_table_shortcut  => 'alt-r',
-                avail_tgt_disks_shortcut  => 'alt-a',
-                ok_clone_shortcut         => 'alt-o'
+                add_partition_shortcut     => 'alt-r',
+                resize_partition_shortcut  => 'alt-r',
+                edit_partition_shortcut    => 'alt-e',
+                add_raid_shortcut          => 'alt-d',
+                partition_table_shortcut   => 'alt-r',
+                avail_tgt_disks_shortcut   => 'alt-a',
+                ok_clone_shortcut          => 'alt-o',
+                select_msdos_shortcut      => 'alt-m',
+                select_gpt_shortcut        => 'alt-g',
+                modify_hard_disks_shortcut => 'alt-m',
+                press_yes_shortcut         => 'alt-y',
+                partitions_tab_shortcut    => 'alt-p',
+                select_primary_shortcut    => 'alt-p',
+                select_extended_shortcut   => 'alt-e'
         }),
         NewPartitionSizePage => Installation::Partitioner::NewPartitionSizePage->new({
                 custom_size_shortcut => 'alt-o'
@@ -133,6 +140,44 @@ sub clone_partition_table {
     $self->get_expert_partitioner_page()->press_ok_clone();
 }
 
+sub create_new_partition_table {
+    my ($self, $args) = @_;
+    $self->get_expert_partitioner_page()->select_item_in_system_view_table($args->{disk});
+    $self->get_expert_partitioner_page()->open_partition_table_menu();
+    $self->get_expert_partitioner_page()->create_new_partition_table();
+    $self->get_expert_partitioner_page()->check_confirm_deleting_current_devices();
+    $self->get_expert_partitioner_page()->select_partition_table_type($args->{table_type});
+}
 
+sub add_partition_msdos {
+    my ($self, $args) = @_;
+    $self->get_expert_partitioner_page()->select_item_in_system_view_table($args->{disk});
+    $self->get_expert_partitioner_page()->select_partitions_tab();
+    $self->get_expert_partitioner_page()->press_add_partition_button();
+    $self->get_expert_partitioner_page()->select_new_partition_type($args->{partition_type});
+    $self->add_new_partition($args->{partition});
+}
+
+sub add_new_partition {
+    my ($self, $args) = @_;
+    if ($args->{size} eq "max") {
+        $self->get_edit_partition_size_page()->press_next();
+    }
+    else {
+        $self->set_new_partition_size($args->{size});
+    }
+    $self->_set_partition_role($args->{role});
+    $self->_set_partition_options($args);
+    $self->_finish_partition_creation();
+}
+
+sub set_new_partition_size {
+    my ($self, $size) = @_;
+    if (defined $size) {
+        $self->get_edit_partition_size_page()->select_custom_size_radiobutton();
+        $self->get_edit_partition_size_page()->enter_size($size);
+    }
+    $self->get_edit_partition_size_page()->press_next();
+}
 
 1;

--- a/lib/partitions_validator_utils.pm
+++ b/lib/partitions_validator_utils.pm
@@ -14,14 +14,61 @@ use scheduler 'get_test_suite_data';
 use testapi;
 use Test::Assert ':all';
 use Exporter 'import';
-our @EXPORT = 'validate_partition_table';
+our @EXPORT = qw(
+  validate_partition_table
+  validate_partition_creation
+  validate_filesystem
+  validate_read_write
+  validate_unpartitioned_space);
 
 sub validate_partition_table {
     my $args = shift;
     return if check_var('BACKEND', 's390x');    # blkid output does not show partition table for dasd
     record_info("Check $args->{table_type}", "Verify if partition table type is $args->{table_type}");
     my $table_type = (split(/\"/, script_output("blkid $args->{device}")))[-1];    # last element of output eg "gpt"
-    assert_equals($args->{table_type}, $table_type, "Partition table type does not correspond to the expected one.");
+    my $converter  = {msdos => 'dos'};
+    my $expected   = $args->{table_type};
+    $expected = $converter->{$expected} if (exists $converter->{$expected});
+    assert_equals($expected, $table_type, "Partition table type does not correspond to the expected one.");
+}
+
+sub validate_partition_creation {
+    my $args = shift;
+    record_info("Check $args->{mount_point}", "Verify that partition $args->{mount_point} was created.");
+    my @lsblk_output = split(/\n/, script_output("lsblk -n"));
+    my $check;
+    foreach (@lsblk_output) {
+        if ($_ =~ /(?<check>\Q$args->{mount_point}\E\z)/) {
+            $check = $+{check};
+            last;
+        }
+    }
+    die "The $args->{mount_point} partition was not created." if (!$check);
+}
+
+sub validate_filesystem {
+    my $args = shift;
+    record_info("Check filesystem", "Verify that $args->{mount_point} partition filesystem is $args->{fs_type}");
+    my @df_output = split(/\n/, script_output("df -T $args->{mount_point}"));
+    my $type      = ((split(/\s*\s/, $df_output[1])))[1];
+    assert_equals($args->{fs_type}, $type, "Filesystem type does not correspond to the expected one.");
+}
+
+sub validate_read_write {
+    my $args = shift;
+    assert_script_run("echo Hello > $args->{mount_point}/emptyfile", fail_message => 'Failure while writing in ' . $args->{mount_point});
+    assert_script_run("grep Hello $args->{mount_point}/emptyfile",   fail_message => 'Failure while reading from ' . $args->{mount_point});
+}
+
+sub validate_unpartitioned_space {
+    my $args = shift;
+    record_info("Check $args->{disk} partitioning", "Verify that the '$args->{disk}' does not have unpartitioned disk space.");
+    my $parted_output = script_output("parted \/dev\/$args->{disk} unit GB print free");
+    foreach (split(/\n/, $parted_output)) {
+        if ($_ =~ /(?<unpartitioned>(\S+))\s* Free Space/) {
+            die "There is $+{unpartitioned} unpartitioned disk space." if ($+{unpartitioned} gt $args->{allowed_unpartitioned});
+        }
+    }
 }
 
 1;

--- a/schedule/yast/msdos.yaml
+++ b/schedule/yast/msdos.yaml
@@ -1,0 +1,72 @@
+---
+name:           msdos@yast
+description:    >
+  Test for installation on msdos partition table.
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/msdos_partition_table
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - {{disable_grub_timeout}}
+  - installation/start_install
+  - installation/await_install
+  - {{installation/logs_from_installation_system}}
+  - installation/reboot_after_installation
+  - {{reconnect_mgmt_console}}
+  - installation/first_boot
+  - console/validate_fs_table
+conditional_schedule:
+  disable_grub_timeout:
+    MACHINE:
+      64bit:
+        - installation/disable_grub_timeout
+      ppc64le-hmc-single-disk:
+        - installation/edit_optional_kernel_cmd_parameters
+        - installation/disable_grub_timeout
+      s390x-kvm-sle12:
+        - installation/disable_grub_timeout
+      svirt-xen-hvm:
+        - installation/disable_grub_timeout
+      svirt-hyperv:
+        - installation/disable_grub_timeout
+  logs_from_installation_system:
+    MACHINE:
+      64bit:
+        - installation/logs_from_installation_system
+      ppc64le:
+        - installation/logs_from_installation_system
+      ppc64le-hmc-single-disk:
+        - installation/logs_from_installation_system
+      s390x-kvm-sle12:
+        - installation/logs_from_installation_system
+      svirt-xen-hvm:
+        - installation/logs_from_installation_system
+      svirt-xen-pv:
+        - installation/logs_from_installation_system
+  reconnect_mgmt_console:
+    MACHINE:
+      64bit:
+        - installation/grub_test
+      ppc64le:
+        - installation/grub_test
+      ppc64le-hmc-single-disk:
+        - boot/reconnect_mgmt_console
+        - installation/grub_test
+      s390x-kvm-sle12:
+        - boot/reconnect_mgmt_console
+      svirt-xen-hvm:
+        - installation/grub_test
+      svirt-hyperv:
+        - installation/grub_test
+test_data:
+  !include: test_data/yast/msdos/msdos.yaml
+

--- a/test_data/yast/msdos/msdos.yaml
+++ b/test_data/yast/msdos/msdos.yaml
@@ -1,0 +1,36 @@
+table_type: msdos
+partition_table_disk: vda
+disks:
+  - name: vda
+    allowed_unpartitioned: 0.00GB
+    partitions:
+      - size: 9250Mib
+        role: operating-system
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/'
+      - size: 9250Mib
+        role: data
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/home'
+      - size: max 
+        role: swap
+        partition_type: primary
+        validation_flag: 0 
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+          mount_point: '[SWAP]' 

--- a/test_data/yast/msdos/msdos_hmc.yaml
+++ b/test_data/yast/msdos/msdos_hmc.yaml
@@ -1,0 +1,41 @@
+table_type: msdos
+partition_table_disk: sda
+disks:
+  - name: sda 
+    allowed_unpartitioned: 0.00GB
+    partitions:
+      - size: 8Mib
+        role: raw-volume
+        id: prep-boot
+        partition_type: primary
+        validation_flag: 0
+      - size: 20000Mib
+        role: operating-system
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/'
+      - size: 12000Mib
+        role: data
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/home'
+      - size: max
+        role: swap
+        partition_type: primary
+        validation_flag: 0
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+          mount_point: '[SWAP]'

--- a/test_data/yast/msdos/msdos_hvm.yaml
+++ b/test_data/yast/msdos/msdos_hvm.yaml
@@ -1,0 +1,37 @@
+table_type: msdos
+partition_table_disk: xvdb
+disks:
+  - name: xvdb
+    allowed_unpartitioned: 0.00GB
+    partitions:
+      - size: 9250Mib
+        role: operating-system
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/'
+      - size: 9250Mib
+        role: data
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/home'
+      - size: max
+        role: swap
+        partition_type: primary
+        validation_flag: 0 
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+          mount_point: '[SWAP]'
+

--- a/test_data/yast/msdos/msdos_hyperv.yaml
+++ b/test_data/yast/msdos/msdos_hyperv.yaml
@@ -1,0 +1,37 @@
+table_type: msdos
+partition_table_disk: sda
+disks:
+  - name: sda
+    allowed_unpartitioned: 0.00GB
+    partitions:
+      - size: 9250Mib
+        role: operating-system
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/'
+      - size: 9250Mib
+        role: data
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/home'
+      - size: max
+        role: swap
+        partition_type: primary
+        validation_flag: 0 
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+          mount_point: '[SWAP]'
+

--- a/test_data/yast/msdos/msdos_ppc64le.yaml
+++ b/test_data/yast/msdos/msdos_ppc64le.yaml
@@ -1,0 +1,41 @@
+table_type: msdos
+partition_table_disk: vda
+disks:
+  - name: vda 
+    allowed_unpartitioned: 0.00GB
+    partitions:
+      - size: 8Mib
+        role: raw-volume
+        id: prep-boot
+        partition_type: primary
+        validation_flag: 0
+      - size: 9250Mib
+        role: operating-system
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/'
+      - size: 9250Mib
+        role: data
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/home'
+      - size: max
+        role: swap
+        partition_type: primary
+        validation_flag: 0 
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+          mount_point: '[SWAP]'

--- a/test_data/yast/msdos/msdos_pv.yaml
+++ b/test_data/yast/msdos/msdos_pv.yaml
@@ -1,0 +1,37 @@
+table_type: msdos
+partition_table_disk: xvdb
+disks:
+  - name: xvdb
+    allowed_unpartitioned: 0.00GB
+    partitions:
+      - size: 9250Mib
+        role: operating-system
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/'
+      - size: 9250Mib
+        role: data
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/home'
+      - size: max
+        role: swap
+        partition_type: primary
+        validation_flag: 0
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+          mount_point: '[SWAP]'
+

--- a/test_data/yast/msdos/msdos_s390x.yaml
+++ b/test_data/yast/msdos/msdos_s390x.yaml
@@ -1,0 +1,36 @@
+table_type: msdos
+partition_table_disk: vda
+disks:
+  - name: vda
+    allowed_unpartitioned: 0.00GB
+    partitions:
+      - size: 9250Mib
+        role: operating-system
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/'
+      - size: 8700Mib
+        role: data
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: '/home'
+      - size: max
+        role: swap
+        partition_type: primary
+        validation_flag: 0 
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+          mount_point: '[SWAP]'

--- a/tests/console/validate_fs_table.pm
+++ b/tests/console/validate_fs_table.pm
@@ -1,0 +1,58 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Validation of filesystem table type, filesystem partitioning, reading and writting in specified partitions, check of unpartitioned disk space.
+# Maintainer: Sofia Syrianidou <ssyrianidou@suse.com>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+use partitions_validator_utils qw(
+  validate_partition_table
+  validate_partition_creation
+  validate_filesystem
+  validate_read_write
+  validate_unpartitioned_space);
+
+sub run {
+
+    select_console "root-console";
+    my $test_data = get_test_suite_data();
+    if (defined $test_data->{table_type}) {
+        # Validate that the partition table type is the expected one.
+        validate_partition_table({device => "/dev/" . $test_data->{partition_table_disk}, table_type => $test_data->{table_type}});
+    }
+
+    foreach my $disk (@{$test_data->{disks}}) {
+        foreach my $partition (@{$disk->{partitions}}) {
+            # Validate that all partitions were created.
+            my $mnt = $partition->{mounting_options}->{mount_point};
+            # Avoiding checking prep-boot partition creation, which does not have a defined mount point.
+            validate_partition_creation({mount_point => $mnt}) if $mnt;
+            # "validation_flag" is used in order to avoid validating filesystem type and ability to read-write in swap and boot partitions.
+            if ($partition->{validation_flag} == 1) {
+                # Validate the partitions' filesystem is the expected one.
+                my $fmt = $partition->{formatting_options}->{filesystem};
+                validate_filesystem({mount_point => $mnt, fs_type => $fmt});
+                validate_read_write({mount_point => $mnt});
+            }
+        }
+
+        if (defined $disk->{allowed_unpartitioned}) {
+            validate_unpartitioned_space({disk => $disk->{name}, allowed_unpartitioned => $disk->{allowed_unpartitioned}});
+        }
+    }
+}
+
+1;
+
+

--- a/tests/installation/partitioning/msdos_partition_table.pm
+++ b/tests/installation/partitioning/msdos_partition_table.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Create new partition table during installation.
+# Maintainer: Sofia Syrianidou <ssyrianidou@suse.com>
+
+use strict;
+use warnings;
+use parent 'installbasetest';
+use testapi;
+use version_utils ':VERSION';
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my $test_data   = get_test_suite_data();
+    my $partitioner = $testapi::distri->get_expert_partitioner();
+    $partitioner->run_expert_partitioner();
+    $partitioner->create_new_partition_table({disk => $test_data->{partition_table_disk}, table_type => $test_data->{table_type}});
+    foreach my $disk (@{$test_data->{disks}}) {
+        foreach my $partition (@{$disk->{partitions}}) {
+            $partitioner->add_partition_msdos({disk => $disk->{name}, partition => $partition});
+        }
+    }
+    $partitioner->accept_changes();
+}
+1;
+
+


### PR DESCRIPTION
Test for new installation on MSDOS partition table.
Related to : 
https://progress.opensuse.org/issues/58915

**Pull requests**
Job groups (merged):
https://gitlab.suse.de/qsf-y/qa-sle-functional-y/merge_requests/115/
Needles:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/641
and
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1322
should be also merged, in order that changes in "lib/Installation/Partitioner/FormattingOptionsPage.pm" will not break RAID tests.  
(Looks like QAM doesn't use this library, so I don't see the need to duplicate needles for older sle versions.)

There is an issue with the validation_fs_table module on hyperv, that will be investigated separately.

Validation test on osd under name "msdos":
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=139.4&groupid=129
Validation that raid_gpt doesn't break:
https://openqa.suse.de/tests/3905129