### PR TITLE
Fix get_node_number function for 15SP2+

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -123,7 +123,8 @@ sub get_my_ip {
 }
 
 sub get_node_number {
-    return script_output 'crm_mon -1 | awk \'/ nodes configured/ { print $1 }\'';
+    my $index = is_sle('15-sp2+') ? 2 : 1;
+    return script_output "crm_mon -1 | awk '/ nodes configured/ { print \$$index }'";
 }
 
 sub is_node {


### PR DESCRIPTION
This function has to be adapted since 15SP2, crm_mon output has changed, now we have a `*` behind each line:
```
...
Node List:
  * Online: [ node1 node2 ]

Active Resources:
  * stonith-sbd	(stonith:external/sbd):	 Started node1
  * Clone Set: base-clone [base-group]:
    * Started: [ node1 node2 ]
...
```

- Related ticket: N/A
- Needles: N/A
- Verification run: 
15SP2: [node01](http://1a102.qa.suse.de/tests/2413) - [node02](http://1a102.qa.suse.de/tests/2414) - [node03](http://1a102.qa.suse.de/tests/2411)
