### PR TITLE
Remove qa-head repo after tests are done from pam PM

### DIFF
--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -58,6 +58,7 @@ sub run {
     assert_script_run("snapaf=\$(snapper create -p -d 'after pam test')");
     assert_script_run("snapper -v undochange \$snapbf..\$snapaf");
     assert_script_run("snapper delete \$snapaf \$snapbf");
+    zypper_call('rr qa-head-repo');
 
     die "pam.sh failed, see results.tap for details" if ($ret);
 }


### PR DESCRIPTION
remove qa-head repo after everythin is done,
because following test will use it:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8839#issuecomment-564927057