### PR TITLE
Fix 'linux_boot_entry' for SLE15+

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -737,7 +737,7 @@ sub handle_grub {
     my ($self, %args) = @_;
     my $bootloader_time  = $args{bootloader_time};
     my $in_grub          = $args{in_grub};
-    my $linux_boot_entry = $args{linux_boot_entry} // 14;
+    my $linux_boot_entry = $args{linux_boot_entry} // (is_sle('15+') ? 15 : 14);
     my $grub_nondefault  = get_var('GRUB_BOOT_NONDEFAULT');
     my $first_menu       = get_var('GRUB_SELECT_FIRST_MENU');
     my $second_menu      = get_var('GRUB_SELECT_SECOND_MENU');
@@ -753,7 +753,7 @@ sub handle_grub {
         send_key_until_needlematch(get_var('EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET'), 'left', 1000) if get_var('EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET');
         for (1 .. get_var('EXTRABOOTPARAMS_DELETE_CHARACTERS', 0)) { send_key 'backspace' }
         bmwqemu::fctinfo("Adding boot params '$boot_params'");
-        type_string_very_slow "$boot_params ";
+        type_string_very_slow " $boot_params ";
         save_screenshot;
         send_key 'ctrl-x';
     }


### PR DESCRIPTION
By default in `handle_grub` function, the `$linux_boot_entry` variable is set to 14 lines, but this doesn't work in sle15+, as `load_video` Grub function is called in 15+ OSes.
So `$linux_boot_entry` should be set to 15 in that case.

This PR also add a space before typing `$boot_params`, as a space is not always set at the end of the line and having 2 spaces doesn't hurt.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/3755601#step/boot_to_desktop/2
- Verification run: https://openqa.suse.de/t3755668

**Note:** failure of the verification run is due to a known bug ([bsc#1158816](https://bugzilla.suse.com/show_bug.cgi?id=1158816)) and not this PR (in fact this PR is needed to add Grub option to analyze this bsc#).