### PR TITLE
Add smoke test for cpu shielding

### DIFF
--- a/schedule/rt/sle12/create_hdd_rt.yaml
+++ b/schedule/rt/sle12/create_hdd_rt.yaml
@@ -1,0 +1,34 @@
+---
+description: "Maintainer: mloviska@suse.com\nDescription: Create qcow2 image with preinstalled RT product"
+name: 'create_hdd_rt ( qemu )'
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - locale/keymap_or_locale
+  - console/force_scheduled_tasks
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/rt/sle12/rt.yaml
+++ b/schedule/rt/sle12/rt.yaml
@@ -2,27 +2,7 @@
 description: "Maintainer: thehejik;  SLERT installation from scratch\n\nBUILD_SLE=GM"
 name: 'rt@64bit ( qemu )'
 schedule:
-  - installation/isosize
-  - installation/bootloader
-  - installation/welcome
-  - installation/accept_license
-  - installation/scc_registration
-  - installation/addon_products_sle
-  - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_finish
-  - installation/installer_timezone
-  - installation/user_settings
-  - installation/user_settings_root
-  - installation/resolve_dependency_issues
-  - installation/installation_overview
-  - installation/disable_grub_timeout
-  - installation/start_install
-  - installation/await_install
-  - installation/logs_from_installation_system
-  - installation/reboot_after_installation
-  - installation/grub_test
-  - installation/first_boot
+  - boot/boot_to_desktop
   - rt/kmp_modules
   - rt/rt_is_realtime
   - rt/rt_peak_pci

--- a/schedule/rt/sle12/rt_utilities.yaml
+++ b/schedule/rt/sle12/rt_utilities.yaml
@@ -1,0 +1,8 @@
+---
+description: "Tunning pre-installed RT system, adjust RT attributes of a process, configure basic CPU shield\nMaintainer: mloviska"
+name: 'rt_utils ( qemu )'
+schedule:
+     - rt/boot_rt_kernel
+     - rt/rt_chrt
+     - rt/cpuset_shield
+

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -300,9 +300,9 @@ sub setup_network {
 }
 
 sub run {
-    my $self     = shift;
-    my $inst_ltp = get_var 'INSTALL_LTP';
-    my $tag      = get_ltp_tag();
+    my $self       = shift;
+    my $inst_ltp   = get_var 'INSTALL_LTP';
+    my $tag        = get_ltp_tag();
     my $grub_param = 'ignore_loglevel';
 
     if ($inst_ltp !~ /(repo|git)/i) {

--- a/tests/rt/cpuset_shield.pm
+++ b/tests/rt/cpuset_shield.pm
@@ -1,0 +1,83 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+# Summary: Basic CPU shielding smoke test with a single memory node
+#		The cpuset feature provides “soft partitioning” of the system's CPUs and memory nodes.
+#	 	A shielded CPU is dedicated to the activities associated with high-priority real-time tasks.
+#		Shield takes care of mounting cpuset filesystems and with naming of cpusets
+#		Subcmd *shield* moves all movable tasks to the unshielded cpuset on shield activation
+#		A simple shielded configuration typically uses three cpusets:
+#				1) root set (always present and contains all CPUs)
+#				2) system set (system tasks, unshielded)
+#				3) user set (important tasks for user, shielded)
+#		Test case should not combine *set* and *proc* subcommands with *shield* to configure sets
+# Maintainer: mloviska <mloviska@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+
+# Used in post_fail_hook as well
+my $cpuset_log = '/var/log/cpuset';
+
+sub run {
+    my $self     = shift;
+    my $cmd_base = 'cset --log ' . $cpuset_log . ' shield ';
+
+    $self->select_serial_terminal;
+
+    # Support for cpuset filesystem has to enabled in kernel during compilation
+    ((script_output 'cat /proc/filesystems') =~ m/\bnodev\s+cpuset\b/) or
+      die "System does not support cpuset!";
+
+    # List cpusets in default setup
+    assert_script_run 'cset set -l';
+
+    # Check if there are any activated shields
+    unless (script_run $cmd_base) {
+        die 'Shielding has been already defined!';
+    }
+
+    # Let's create a shield with CPU1 and CPU3
+    # CPU0 should always stay unshielded
+    assert_script_run($cmd_base . '--cpu=1,3');
+    # Show shields and their processes
+    assert_script_run($cmd_base . '--verbose');
+    # Show shielded processes only
+    assert_script_run($cmd_base . '--verbose --shield');
+    # Show unshielded processes only
+    assert_script_run($cmd_base . '--verbose --unshield');
+    # Shift moveable kernel threads
+    assert_script_run($cmd_base . '--kthread=on');
+    # Show shielded processes only
+    assert_script_run($cmd_base . '--verbose --shield');
+    # Show unshielded processes only
+    assert_script_run($cmd_base . '--verbose --unshield');
+    # Run a new process in the shield
+    assert_script_run($cmd_base . '--exec -- ls -l');
+    # Shield current shell
+    assert_script_run($cmd_base . '-s -p $$');
+    # Unshield current shell
+    assert_script_run($cmd_base . '-u -p $$');
+    # Show shielded processes only
+    assert_script_run($cmd_base . '--verbose --shield');
+    # Reset to default state
+    assert_script_run($cmd_base . '--reset');
+}
+
+sub post_fail_hook {
+    my $self = shift;
+
+    select_console 'log-console';
+    $self->export_logs_basic;
+    $self->upload_coredumps;
+    upload_logs($cpuset_log) unless (script_run("test -f $cpuset_log"));
+}
+
+1;


### PR DESCRIPTION
- Related ticket: [[slert12sp5][rt] Introduce smoke test for cpu shielding](https://progress.opensuse.org/issues/61088)
- Verification runs: 
   * [create_hdd_rt@64bit](http://eris.suse.cz/tests/3504)
   * [rt@64bit](http://eris.suse.cz/tests/3511)
   * [rt_utilities](http://eris.suse.cz/tests/3513)