### PR TITLE
Enable remote installation over VNC for openSUSE

### DIFF
--- a/schedule/yast/remote_vnc_controller_opensuse.yaml
+++ b/schedule/yast/remote_vnc_controller_opensuse.yaml
@@ -1,0 +1,23 @@
+---
+name:           remote_vnc_controller
+description:    >
+  Install remote server (parallel job) with vnc.
+schedule:
+ - support_server/login
+ - support_server/setup
+ - remote/remote_controller
+ - installation/welcome
+ - installation/online_repos
+ - installation/installation_mode
+ - installation/system_role
+ - installation/partitioning
+ - installation/partitioning_finish
+ - installation/installer_timezone
+ - installation/user_settings
+ - installation/resolve_dependency_issues
+ - installation/installation_overview
+ - installation/disable_grub_timeout
+ - installation/start_install
+ - installation/await_install
+ - installation/reboot_after_installation
+ - support_server/wait_children

--- a/schedule/yast/remote_vnc_target_opensuse.yaml
+++ b/schedule/yast/remote_vnc_target_opensuse.yaml
@@ -1,0 +1,9 @@
+---
+name:           remote_vnc_target
+description:    >
+  Boot with vnc=1 parameter and wait for parallel job (remote_vnc_controller) 
+  to install the system.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - remote/remote_target


### PR DESCRIPTION
yaml schedulers for the controller and the target for opensuse.
i have already created the test suites with the corresponding yaml_schedule.
The NETBOOT and INSTALL_SOURCE are ommitted from the configuration
as the DVD flavor can be used.

- Related ticket: https://progress.opensuse.org/issues/52310
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: http://aquarius.suse.cz/tests/1179
