### PR TITLE
Enhance service check for supported version

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -35,6 +35,7 @@ use services::rpcbind;
 use autofs_utils;
 use services::postfix;
 use kdump_utils;
+use version_utils 'is_sle';
 
 our @EXPORT = qw(
   $hdd_base_version
@@ -45,6 +46,10 @@ our @EXPORT = qw(
 );
 
 our $hdd_base_version;
+our $support_ver_def  = '12+';
+our $support_ver_12   = '=12';
+our $support_ver_ge15 = '15+';
+
 our %srv_check_results = (
     before_migration => 'PASS',
     after_migration  => 'PASS',
@@ -54,108 +59,108 @@ our $default_services = {
     registered_addons => {
         srv_pkg_name       => 'registered_addons',
         srv_proc_name      => 'registered_addons',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&services::registered_addons::full_registered_check
     },
     susefirewall => {
         srv_pkg_name  => 'SuSEfirewall2',
         srv_proc_name => 'SuSEfirewall2',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5'
+        support_ver   => $support_ver_12
     },
     firewall => {
         srv_pkg_name  => 'firewalld',
         srv_proc_name => 'firewalld.service',
-        support_ver   => '15,15-SP1,15-SP2'
+        support_ver   => $support_ver_ge15
     },
     ntp => {
         srv_pkg_name       => 'ntp',
         srv_proc_name      => 'ntpd',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5',
+        support_ver        => $support_ver_12,
         service_check_func => \&services::ntpd::full_ntpd_check
     },
     chrony => {
         srv_pkg_name  => 'chrony',
         srv_proc_name => 'chronyd',
-        support_ver   => '15,15-SP1,15-SP2'
+        support_ver   => $support_ver_ge15
     },
     postfix => {
         srv_pkg_name       => 'postfix',
         srv_proc_name      => 'postfix',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&services::postfix::full_postfix_check
     },
     # Quick hack for poo 50576, we need this workround before full solution
     apache => {
         srv_pkg_name       => 'apache2',
         srv_proc_name      => 'apache2',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&services::apache::full_apache_check
     },
     dhcpd => {
         srv_pkg_name       => 'dhcp-server',
         srv_proc_name      => 'dhcpd',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&services::dhcpd::full_dhcpd_check
     },
     bind => {
         srv_pkg_name  => 'bind',
         srv_proc_name => 'named',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2'
+        support_ver   => $support_ver_def
     },
     snmp => {
         srv_pkg_name  => 'net-snmp',
         srv_proc_name => 'snmpd',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2'
+        support_ver   => $support_ver_def
     },
     nfs => {
         srv_pkg_name       => 'yast2-nfs-server',
         srv_proc_name      => 'nfs',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&check_y2_nfs_func
     },
     rpcbind => {
         srv_pkg_name       => 'rpcbind',
         srv_proc_name      => 'rpcbind',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&services::rpcbind::full_rpcbind_check
     },
     autofs => {
         srv_pkg_name       => 'autofs',
         srv_proc_name      => 'autofs',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&full_autofs_check
     },
     cups => {
         srv_pkg_name       => 'cups',
         srv_proc_name      => 'cups',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&services::cups::full_cups_check
     },
     radvd => {
         srv_pkg_name  => 'radvd',
         srv_proc_name => 'radvd',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2'
+        support_ver   => $support_ver_def
     },
     cron => {
         srv_pkg_name  => 'cron',
         srv_proc_name => 'cron',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2'
+        support_ver   => $support_ver_def
     },
     apparmor => {
         srv_pkg_name       => 'apparmor',
         srv_proc_name      => 'apparmor',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&services::apparmor::full_apparmor_check
     },
     vsftp => {
         srv_pkg_name  => 'vsftpd',
         srv_proc_name => 'vsftpd',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2'
+        support_ver   => $support_ver_def
     },
     kdump => {
         srv_pkg_name       => 'kdump',
         srv_proc_name      => 'kdump',
-        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1,15-SP2',
+        support_ver        => $support_ver_def,
         service_check_func => \&full_kdump_check
     },
 };
@@ -208,7 +213,7 @@ sub install_services {
         next unless _is_applicable($srv_pkg_name);
         record_info($srv_pkg_name, "service check before migration");
         eval {
-            if (grep { $_ eq $hdd_base_version } split(',', $support_ver)) {
+            if (is_sle($support_ver, $hdd_base_version)) {
                 if (exists $service->{$s}->{service_check_func}) {
                     $service->{$s}->{service_check_func}->('before');
                     next;
@@ -243,7 +248,7 @@ sub check_services {
         next unless _is_applicable($srv_pkg_name);
         record_info($srv_pkg_name, "service check after migration");
         eval {
-            if (grep { $_ eq $hdd_base_version } split(',', $support_ver)) {
+            if (is_sle($support_ver, $hdd_base_version)) {
                 # service check after migration. if we've set up service check
                 # function, we don't need following actions to check the service.
                 if (exists $service->{$s}->{service_check_func}) {


### PR DESCRIPTION
As currently design, we need update the support_ver so much lines when a new product such as SLE15SP2 comes, we'd better to make this easy and don't need update too much.
Consider to set a variable to save all support version support_defver='12,15' as default support version list. '12','15' means support all versions belongs sle12 or sle15. So we just update the support_ver => $support_defver, and set it as '12' or '15' if only support '12' or '15'.

- Related ticket: https://progress.opensuse.org/issues/61762
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/3762622#step/install_service/306  These failure in install_service has no relationship with this PR.
