### PR TITLE
yast2_firstboot: wait 60 seconds instead of 45 to reach the keyboard/…

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -25,7 +25,7 @@ sub language_and_keyboard {
         l => 'lang',
         k => 'keyboard'
     };
-    assert_screen('lang_and_keyboard', 45);
+    assert_screen('lang_and_keyboard', 60);
     mouse_hide(1);
     foreach (sort keys %${shortcuts}) {
         send_key 'alt-' . $_;


### PR DESCRIPTION
…language screen

https://progress.opensuse.org/issues/61832

- Related ticket: https://progress.opensuse.org/issues/61832
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1135089 (in progress)
