### PR TITLE
GRUB_BOOT_NONDEFAULT: Allow to select also other than first non-default

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -741,9 +741,6 @@ sub handle_grub {
     my $bootloader_time  = $args{bootloader_time};
     my $in_grub          = $args{in_grub};
     my $linux_boot_entry = $args{linux_boot_entry} // (is_sle('15+') ? 15 : 14);
-    my $grub_nondefault  = get_var('GRUB_BOOT_NONDEFAULT');
-    my $first_menu       = get_var('GRUB_SELECT_FIRST_MENU');
-    my $second_menu      = get_var('GRUB_SELECT_SECOND_MENU');
 
     # On Xen PV and svirt we don't see a Grub menu
     # If KEEP_GRUB_TIMEOUT is defined it means that GRUB menu will appear only for one second
@@ -760,9 +757,10 @@ sub handle_grub {
         save_screenshot;
         send_key 'ctrl-x';
     }
-    elsif (my $grub_nondefault = get_var('GRUB_BOOT_NONDEFAULT')) {
-        bmwqemu::fctinfo("Boot non-default grub option");
-        boot_grub_item();
+    elsif ((my $grub_nondefault = get_var('GRUB_BOOT_NONDEFAULT', 0)) gt 0) {
+        my $menu = $grub_nondefault * 2 + 1;
+        bmwqemu::fctinfo("Boot non-default grub option $grub_nondefault (menu item $menu)");
+        boot_grub_item($menu);
     } elsif (my $first_menu = get_var('GRUB_SELECT_FIRST_MENU')) {
         if (my $second_menu = get_var('GRUB_SELECT_SECOND_MENU')) {
             bmwqemu::fctinfo("Boot $first_menu > $second_menu");

--- a/variables.md
+++ b/variables.md
@@ -52,9 +52,9 @@ FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only
 FULL_LVM_ENCRYPT | boolean | false | Enables/indicates encryption using lvm. boot partition may or not be encrypted, depending on the product default behavior.
 FUNCTION | string | | Specifies SUT's role for MM test suites. E.g. Used to determine which SUT acts as target/server and initiator/client for iscsi test suite
 GRUB_PARAM | string | | A semicolon-separated list of extra boot options. Adds 2 grub meny entries per each item in main grub (2nd entry is the "Advanced options ..." submenu). See `add_custom_grub_entries()`.
-GRUB_BOOT_NONDEFAULT | boolean | false | Boot grub menu entry added by `add_custom_grub_entries`. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
-GRUB_SELECT_FIRST_MENU | integer | | Select grub menu entry in main grub menu, used together with GRUB_SELECT_SECOND_MENU. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
-GRUB_SELECT_SECOND_MENU | integer | | Select grub menu entry in secondary grub menu (the "Advanced options ..." submenu), used together with GRUB_SELECT_FIRST_MENU. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
+GRUB_BOOT_NONDEFAULT | boolean | false | Boot grub menu entry added by `add_custom_grub_entries` (having setup `GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb;slub_debug=FZPU`, `GRUB_BOOT_NONDEFAULT=1` selects 3rd entry, which contains `debug_pagealloc=on`, `GRUB_BOOT_NONDEFAULT=2` selects 5th entry, which contains `ima_policy=tcb`). NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
+GRUB_SELECT_FIRST_MENU | integer | | Select grub menu entry in main grub menu, used together with GRUB_SELECT_SECOND_MENU. GRUB_BOOT_NONDEFAULT has higher preference when both set. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
+GRUB_SELECT_SECOND_MENU | integer | | Select grub menu entry in secondary grub menu (the "Advanced options ..." submenu), used together with GRUB_SELECT_FIRST_MENU. GRUB_BOOT_NONDEFAULT has higher preference when both set. NOTE: s390x not supported. See `boot_grub_item()`, `handle_grub()`.
 HASLICENSE | boolean | true if SLE, false otherwise | Enables processing and validation of the license agreements.
 HDDVERSION | string | | Indicates version of the system installed on the HDD.
 HTTPPROXY  |||


### PR DESCRIPTION
grub entry. Previously it was just boolean value to select 3rd grub
entry (which contains 1st non-default kernel), now it calculates other
non-default.

Example: having setup `GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb;slub_debug=FZPU`,
`GRUB_BOOT_NONDEFAULT=1` selects 3rd entry, which contains `debug_pagealloc=on`,
`GRUB_BOOT_NONDEFAULT=2` selects 5th entry, which contains `ima_policy=tcb`.

Verification run
* http://quasar.suse.cz/tests/4589#step/boot_ltp/4 (GRUB_BOOT_NONDEFAULT=1, debug_pagealloc=on)
* http://quasar.suse.cz/tests/4587#step/boot_ltp/4 (GRUB_BOOT_NONDEFAULT=2, ima_policy=tcb)
* http://quasar.suse.cz/tests/4566#step/boot_ltp/4 (GRUB_BOOT_NONDEFAULT=3; broken, because `slub_debug=FZPU` has some issues on the default kernel)
* http://quasar.suse.cz/tests/4590#step/boot_ltp/2 (default)