### PR TITLE
publiccloud: Adjust vault token ttl

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -69,12 +69,11 @@ sub vault_create_credentials {
     my ($self) = @_;
 
     record_info('INFO', 'Get credentials from VAULT server.');
-    my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/azure/creds/openqa-role', method => 'get');
-    $self->vault_lease_id($res->{lease_id});
-    $self->key_id($res->{data}->{client_id});
-    $self->key_secret($res->{data}->{client_secret});
+    my $data = $self->vault_get_secrets('/azure/creds/openqa-role');
+    $self->key_id($data->{client_id});
+    $self->key_secret($data->{client_secret});
 
-    $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/secret/azure/openqa-role', method => 'get');
+    my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/secret/azure/openqa-role', method => 'get');
     $self->tenantid($res->{data}->{tenant_id});
     $self->subscription($res->{data}->{subscription_id});
 

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -26,10 +26,9 @@ sub vault_create_credentials {
     my ($self) = @_;
 
     record_info('INFO', 'Get credentials from VAULT server.');
-    my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/aws/creds/openqa-role', method => 'get');
-    $self->vault_lease_id($res->{lease_id});
-    $self->key_id($res->{data}->{access_key});
-    $self->key_secret($res->{data}->{secret_key});
+    my $data = $self->vault_get_secrets('/aws/creds/openqa-role');
+    $self->key_id($data->{access_key});
+    $self->key_secret($data->{secret_key});
     die('Failed to retrieve key') unless (defined($self->key_id) && defined($self->key_secret));
 }
 

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -59,12 +59,11 @@ sub create_credentials_file {
           . '}';
     } else {
         record_info('INFO', 'Get credentials from VAULT server.');
-        my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/gcp/key/openqa-role', method => 'get');
-        $credentials_file = b64_decode($res->{data}->{private_key_data});
+        my $data = $self->vault_get_secrets('/gcp/key/openqa-role');
+        $credentials_file = b64_decode($data->{private_key_data});
         my $cf_json = decode_json($credentials_file);
         $self->account($cf_json->{client_email});
         $self->project_id($cf_json->{'project_id'});
-        $self->vault_lease_id($res->{lease_id});
     }
 
     save_tmp_file(CREDENTIALS_FILE, $credentials_file);

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -490,6 +490,7 @@ sub vault_api {
 
     $ua->insecure(get_var('_SECRET_PUBLIC_CLOUD_REST_SSL_INSECURE', 0));
     $url = $url . $path;
+    bmwqemu::diag("Request Vault REST API: $url");
     if ($method eq 'get') {
         $res = $ua->get($url =>
               {'X-Vault-Token' => $self->vault_token()})->result;
@@ -512,6 +513,23 @@ sub vault_api {
     }
 
     return $res->json;
+}
+
+=head2 vault_get_secrets
+
+  my $data = $csp->vault_get_secrets('/azure/creds/openqa-role')
+
+This is a wrapper around C<vault_api()> to retrieve secrets from aws, gce or
+azure secret engine.
+It prepend C<'/v1/' + $NAMESPACE> to the given path before sending the request.
+It stores lease_id and also adjust the token-live-time.
+=cut
+sub vault_get_secrets {
+    my ($self, $path) = @_;
+    my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . $path, method => 'get');
+    $self->vault_lease_id($res->{lease_id});
+    $self->vault_api('/v1/auth/token/renew-self', method => 'post', data => {increment => $res->{lease_duration} . 's'});
+    return $res->{data};
 }
 
 =head2 vault_revoke


### PR DESCRIPTION
In case the authentication token expire, _all_ created leased which was
created in that session, are expired as well.
From [1] you can found an explanation:
```
Revocation can happen manually via the API, via the vault revoke cli command,
or automatically by Vault. When a lease is expired, Vault will automatically
revoke that lease. When a token is revoked, Vault will revoke all leases that
were created using that token.
```

So we use [2] to increase our token expire time.
As there is a other concept of "Explicit maximum lifetime" [3]. If I
understood this concept right, there is no way to have an unlimited token.

[1] https://www.vaultproject.io/docs/concepts/lease.html
[2] https://www.vaultproject.io/api/auth/token/index.html#renew-a-token
[3] https://www.vaultproject.io/docs/concepts/tokens.html#explicit-max-ttls

- Verification run: https://openqa.suse.de/tests/3858655
