### PR TITLE
Fix mapped device for multi btrfs

### DIFF
--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -23,7 +23,7 @@ test_data:
       label: test_multi_btrfs
       devices:
         - /dev/vdc
-        - /dev/mapper/cr_vdd1
+        - /dev/mapper/cr_test
   crypttab:
     num_devices_encrypted: 1
   !include: test_data/yast/encryption/default_enc.yaml


### PR DESCRIPTION
Issue seen in: https://openqa.suse.de/tests/3759579#step/validate_multi_btrfs_partitioning/20
