### PR TITLE
system logging: Check that the logs are inserted properly in the journal

### DIFF
--- a/data/journalctl_levels/test.sh
+++ b/data/journalctl_levels/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test to check that the logs with the custom error level are inserted
+# in the journal
+# Maintainer: Ivan Lausuch <ilausuch@suse.de>
+
+code=$(date +%s)
+logger -p $1 -t Test "This message comes from $USER $code"
+
+sleep 1
+retries=3
+
+while [ $(journalctl -r --no-pager --since "1 minute ago"  | grep $code | wc -l) -eq 0 -a $retries -gt 0 ]; do
+  sleep 1
+  retries=$(expr $retries - 1)
+done
+
+echo -n "TEST logger & journalctl - "
+if [ $retries -eq 0 ]; then
+  echo "ERR"
+  exit 1
+else
+  echo "OK"
+  exit 0
+fi

--- a/schedule/qam/12-SP1/mau-extratests.yaml
+++ b/schedule/qam/12-SP1/mau-extratests.yaml
@@ -40,6 +40,7 @@ schedule:
 - console/supportutils
 - console/mdadm
 - console/journalctl
+- console/journalctlLevels
 - console/quota
 - console/vhostmd
 - console/rpcbind

--- a/schedule/qam/12-SP2/mau-extratests.yaml
+++ b/schedule/qam/12-SP2/mau-extratests.yaml
@@ -43,6 +43,7 @@ schedule:
 - console/supportutils
 - console/mdadm
 - console/journalctl
+- console/journalctlLevels
 - console/quota
 - console/vhostmd
 - console/rpcbind

--- a/schedule/qam/12-SP3/mau-extratests.yaml
+++ b/schedule/qam/12-SP3/mau-extratests.yaml
@@ -45,6 +45,7 @@ schedule:
 - console/supportutils
 - console/mdadm
 - console/journalctl
+- console/journalctlLevels
 - console/quota
 - console/vhostmd
 - console/rpcbind

--- a/schedule/qam/12-SP4/mau-extratests.yaml
+++ b/schedule/qam/12-SP4/mau-extratests.yaml
@@ -45,6 +45,7 @@ schedule:
 - console/supportutils
 - console/mdadm
 - console/journalctl
+- console/journalctlLevels
 - console/quota
 - console/vhostmd
 - console/rpcbind

--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -45,6 +45,7 @@ schedule:
 - console/supportutils
 - console/mdadm
 - console/journalctl
+- console/journalctlLevels
 - console/quota
 - console/vhostmd
 - console/rpcbind

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -44,6 +44,7 @@ schedule:
 - console/supportutils
 - console/mdadm
 - console/journalctl
+- console/journalctlLevels
 - console/quota
 - console/vhostmd
 - console/rpcbind

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -46,6 +46,7 @@ schedule:
 - console/supportutils
 - console/mdadm
 - console/journalctl
+- console/journalctlLevels
 - console/quota
 - console/vhostmd
 - console/rpcbind

--- a/tests/console/journalctlLevels.pm
+++ b/tests/console/journalctlLevels.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test to check that the logs with the custom error level are inserted
+# in the journal
+# Maintainer: Ivan Lausuch <ilausuch@suse.de>
+
+use base "consoletest";
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+sub run {
+    my $self = shift;
+    select_console 'root-console';
+
+    record_info("INFO", "Logs all level0 severity types");
+    assert_script_run "wget --quiet " . data_url('journalctl_levels/test.sh') . " -O test.sh";
+    assert_script_run "chmod +x test.sh";
+
+    my @levels = ("emerg", "alert", "crit", "warning", "notice", "info", "debug");
+
+    foreach my $level (@levels)
+    {
+        assert_script_run "./test.sh $level";
+    }
+}
+
+1;


### PR DESCRIPTION
This test the levels: "emerg", "alert", "crit", "warning", "notice", "info", "debug"

For each level creates a log entry an check if appears on the journal
log. To ensure that is not a delay problem, retry 3 times the check

- Related ticket: https://progress.opensuse.org/issues/48971
- Needles: None
- Verification run:
  - 15 SP1 - http://d462.qam.suse.de/tests/4
  - 15         - http://d462.qam.suse.de/tests/5
  - 12 SP1 - http://d462.qam.suse.de/tests/6
  - 12 SP2 - http://d462.qam.suse.de/tests/7
  - 12 SP3 - http://d462.qam.suse.de/tests/8
  - 12 SP4 - http://d462.qam.suse.de/tests/9
  - 12 SP5 - http://d462.qam.suse.de/tests/10
