### PR TITLE
GraphicsMagick: Fixed timeout

### DIFF
--- a/tests/x11/graphicsMagick.pm
+++ b/tests/x11/graphicsMagick.pm
@@ -29,7 +29,7 @@ sub run {
     record_info("INFO", "Step 1. Runs command line tests");
     assert_script_run "wget --quiet " . data_url('graphicsmagick/test.sh') . " -O test.sh";
     assert_script_run "chmod +x test.sh";
-    assert_script_run "./test.sh " . data_url('graphicsmagick');
+    assert_script_run("./test.sh " . data_url('graphicsmagick'), 3 * 60);
 
     record_info("INFO", "Step 2. Runs visual tests");
 


### PR DESCRIPTION
Problem: Sometimes the tests fails because timeout running the
script. The default 90 seconds is too low if system is overloaded

https://openqa.opensuse.org/tests/1118134#step/graphicsMagick/22

Solution: Increase the timeout to 180 seconds

- Related ticket: https://progress.opensuse.org/issues/48971
- Needles: No changes
- Verification run: Pendent
