### PR TITLE
Add soft failure for iscsi-client

### DIFF
--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -13,7 +13,7 @@
 use base 'opensusebasetest';
 use strict;
 use warnings;
-use utils 'zypper_call';
+use utils qw(zypper_call systemctl);
 use testapi;
 use hacluster;
 
@@ -61,6 +61,11 @@ sub run {
     send_key 'alt-o';    # Ok
     wait_still_screen 3;
     wait_serial('yast2-iscsi-client-status-0', 90) || die "'yast2 iscsi-client' didn't finish";
+
+    if (systemctl('-q is-active iscsi', ignore_failure => 1)) {
+        record_soft_failure('iscsi issue: bug bsc#1160374');
+        systemctl('start iscsi');
+    }
 
     # iSCSI LUN must be present
     assert_script_run 'ls -1 /dev/disk/by-path/ip-*-lun-*';


### PR DESCRIPTION
Add a workaround and a `record_soft_failure` for [yast2/iscsi bug](https://bugzilla.suse.com/show_bug.cgi?id=1160374)

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[build 120.1](http://1a102.qa.suse.de/tests/2585#step/iscsi_client/21)
[build 108.1](http://1a102.qa.suse.de/tests/2588)
