### PR TITLE
Fail early if prerequisites for aarch64 uefi boot disk workaround are not met

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -529,6 +529,7 @@ point the firmware boot manager to the right file.
 =cut
 sub handle_uefi_boot_disk_workaround {
     my ($self) = @_;
+    die "Need BOOT_MENU to select boot device" unless get_var('BOOT_MENU');
     record_info 'workaround', 'Manually selecting boot entry, see bsc#1022064 for details';
     tianocore_enter_menu;
     send_key_until_needlematch 'tianocore-boot_maintenance_manager', 'down', 5, 5;


### PR DESCRIPTION
Since https://github.com/os-autoinst/os-autoinst/pull/1275 the tianocore
boot menu does not show up anymore automatically and needs to be
requested with BOOT_MENU. This should be done by either test settings or
by os-autoinst as the setting effects the qemu command line parameter
which can not be influenced at the time the test code is evaluated.

Related progress issue: https://progress.opensuse.org/issues/61910