### PR TITLE
Refactor zypper orphan test case

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-base+sdk+desktop.yaml
@@ -24,3 +24,5 @@ schedule:
   - toolchain/install
   - toolchain/gcc_compilation
   - toolchain/gcc_fortran_compilation
+  - console/orphaned_packages_check
+  - console/consoletest_finish

--- a/schedule/jeos/sle/hyperv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-extratest.yaml
@@ -45,7 +45,6 @@ schedule:
   - console/gpg
   - console/rsync
   - console/shells
-  - console/repo_orphaned_packages_check
   - console/dstat
   - console/journalctl
   - console/procps

--- a/schedule/jeos/sle/hyperv/jeos-main.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-main.yaml
@@ -46,6 +46,6 @@ schedule:
   - console/mysql_srv
   - console/rsync
   - console/zypper_lifecycle
+  - console/repo_orphaned_packages_check
   - console/orphaned_packages_check
   - console/consoletest_finish
-  

--- a/schedule/jeos/sle/kvm/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/kvm/jeos-base+sdk+desktop.yaml
@@ -24,3 +24,5 @@ schedule:
   - toolchain/install
   - toolchain/gcc_compilation
   - toolchain/gcc_fortran_compilation
+  - console/orphaned_packages_check
+  - console/consoletest_finish

--- a/schedule/jeos/sle/kvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/kvm/jeos-extratest.yaml
@@ -43,7 +43,6 @@ schedule:
   - console/gpg
   - console/rsync
   - console/shells
-  - console/repo_orphaned_packages_check
   - console/dstat
   - console/journalctl
   - console/procps

--- a/schedule/jeos/sle/kvm/jeos-main.yaml
+++ b/schedule/jeos/sle/kvm/jeos-main.yaml
@@ -46,6 +46,7 @@ schedule:
   - console/mysql_srv
   - console/rsync
   - console/zypper_lifecycle
+  - console/repo_orphaned_packages_check
   - console/orphaned_packages_check
   - console/consoletest_finish
   

--- a/schedule/jeos/sle/xen/hvm/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-base+sdk+desktop.yaml
@@ -24,3 +24,5 @@ schedule:
   - toolchain/install
   - toolchain/gcc_compilation
   - toolchain/gcc_fortran_compilation
+  - console/orphaned_packages_check
+  - console/consoletest_finish

--- a/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
@@ -45,7 +45,6 @@ schedule:
   - console/gpg
   - console/rsync
   - console/shells
-  - console/repo_orphaned_packages_check
   - console/dstat
   - console/journalctl
   - console/procps

--- a/schedule/jeos/sle/xen/hvm/jeos-main.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-main.yaml
@@ -47,5 +47,5 @@ schedule:
   - console/rsync
   - console/zypper_lifecycle
   - console/orphaned_packages_check
+  - console/repo_orphaned_packages_check
   - console/consoletest_finish
-  

--- a/schedule/jeos/sle/xen/pv/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-base+sdk+desktop.yaml
@@ -23,3 +23,5 @@ schedule:
   - toolchain/install
   - toolchain/gcc_compilation
   - toolchain/gcc_fortran_compilation
+  - console/orphaned_packages_check
+  - console/consoletest_finish

--- a/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
@@ -44,7 +44,6 @@ schedule:
   - console/gpg
   - console/rsync
   - console/shells
-  - console/repo_orphaned_packages_check
   - console/dstat
   - console/journalctl
   - console/procps

--- a/schedule/jeos/sle/xen/pv/jeos-main.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-main.yaml
@@ -46,5 +46,5 @@ schedule:
   - console/rsync
   - console/zypper_lifecycle
   - console/orphaned_packages_check
+  - console/repo_orphaned_packages_check
   - console/consoletest_finish
-  

--- a/tests/console/orphaned_packages_check.pm
+++ b/tests/console/orphaned_packages_check.pm
@@ -19,26 +19,59 @@ use testapi;
 use utils 'zypper_call';
 use version_utils 'is_upgrade';
 
+# Performing a DVD/Offline system upgrade cannot update
+# all potential packages already present on the SUT
+# A subsequent 'zypper dup' is necessary to ensure
+# all packages available in the repo are up-to-date
+# poo#61829
+sub is_offline_upgrade {
+    return !get_var('ONLINE_MIGRATION') && is_upgrade;
+}
+
+# Compare detected orphans with whitelisted if any
+sub compare_orphans_lists {
+    my %args = @_;
+
+    record_info('Detected Orphans', "@{ $args{zypper_orphans} }");
+    record_info('Orphans whitelisted',
+        $args{whitelist} // 'No orphans whitelisted within the test suite',
+        result => $args{whitelist} ? 'ok' : 'fail');
+
+    return 0 unless ($args{whitelist});
+
+    # Remove duplicate packages from the list
+    my %wl = map { $_ => 1 } (split(',', $args{whitelist}));
+
+    return 0 if ((scalar @{$args{zypper_orphans}}) > (scalar(keys %wl)));
+
+    my @not_handled_orphans = grep { !$wl{$_} } @{$args{zypper_orphans}};
+    record_info('Missing', (@not_handled_orphans) ? ("@not_handled_orphans", result => 'fail') : 'None');
+
+    return ((scalar @not_handled_orphans) == 0);
+}
+
 sub run {
     select_console 'root-console';
+
+    record_info('Upgraded?',
+        'Has the SUT been upgraded? Offline upgrades can possibly cause orphans',
+        result => (is_offline_upgrade) ? 'ok' : 'fail');
+
+    # Orphans are also expected on JeOS without SDK module (jeos-firstboot, jeos-license and live-langset-data)
     # Save the orphaned packages list to one log file and upload the log, so QA can use this log to report bug
-    my $cmd = 'zypper pa --orphaned | grep -v "\(release-DVD\|release-dvd\|openSUSE-release\|skelcd\)" | (! grep "@System") > /tmp/orphaned.log';
-    # there are orphans on older, unsupported openSUSE versions which we
-    # upgrade from. They will most likely never be fixed
-    my $expect_failure = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
-    set_var('ZYPPER_ORPHANED_CHECK_ONLY', get_var('ZYPPER_ORPHANED_CHECK_ONLY', $expect_failure));
-    if (get_var('ZYPPER_ORPHANED_CHECK_ONLY')) {
-        script_run($cmd);
-    }
-    else {
-        assert_script_run($cmd, fail_message => "Orphaned packages found, set 'ZYPPER_ORPHANED_CHECK_ONLY' to only check and not fail the test");
+    my @orphans = split('\n', script_output q[zypper -qs 11 pa --orphaned | tee -a /tmp/orphaned.log | awk 'NR>2 {print $3}']);
+
+    if (((scalar @orphans) > 0) && !is_offline_upgrade) {
+        compare_orphans_lists(zypper_orphans => \@orphans,
+            whitelist => get_var('ZYPPER_WHITELISTED_ORPHANS')) or
+          die "There have been unexpected orphans detected!";
     }
 }
 
 sub post_fail_hook {
     my $self = shift;
 
-    $self->export_logs();
+    select_console 'log-console';
     upload_logs '/tmp/orphaned.log';
 }
 

--- a/variables.md
+++ b/variables.md
@@ -142,4 +142,4 @@ YAST2_FIRSTBOOT_USERNAME | string | | Defines username for the user to be create
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Comma separated list of repositories to be added/used for zypper dup call, defaults to SUSEMIRROR or attached media, e.g. ISO.
 LINUXRC_BOOT | boolean | true | To be used only in scenarios where we are booting an installed system from the installer medium (for example, a DVD) with the menu option "Boot Linux System" (not "boot From Hard Disk"). This option uses linuxrc.
-ZYPPER_ORPHANED_CHECK_ONLY | boolean | false | Within tests/console/orphaned_packages_check.pm only check for orphaned packages, do not fail if any are found.
+ZYPPER_WHITELISTED_ORPHANS | string | empty | Whitelist expected orphaned packages, do not fail if any are found. Upgrade scenarios are expecting orphans by default. Used by console/orphaned_packages_check.pm


### PR DESCRIPTION
Registered JeOS image should not have any **orphans** or **mini-*** packages installed. In case  JeOS is not registered against SDK module, we should expect 3 packages as orphans

1) live-langset-data
2) jeos-licenses
3) jeos-firstboot

Anything else should be denoted and reported as a bug.

- Related ticket: [[jeos] test fails in repo_orphaned_packages_check](https://progress.opensuse.org/issues/40448) 
- Motivation: [[functional][jeos] Verify that no installed packages are orphaned](https://progress.opensuse.org/issues/32800)
- Verification runs:
   * **Successful runs** 
        * [JeOS-15sp2-base, whitelisted=systemd-logger,live-langset-data,jeos-licenses,jeos-firstboot](http://eris.suse.cz/tests/3870#step/orphaned_packages_check/1)
        * [JeOS-15sp2-base,sdk, whitelisted=systemd-logger,live-langset-data,jeos-licenses,jeos-firstboot](http://eris.suse.cz/tests/3869#step/orphaned_packages_check/1)
   * **fails** 
        * [JeOS-15sp2-base,desktop, missing 2 orphans from wl](http://eris.suse.cz/tests/3886#step/orphaned_packages_check/7)
        * [JeOS-15sp2-base,desktop,sdk, no whitelist defined](http://eris.suse.cz/tests/3874#step/orphaned_packages_check/5)
* **opensuse - jeos**
     * [Build20200113-tw_no_wl@64bit_virtio](http://eris.suse.cz/tests/3885#step/orphaned_packages_check/3)
* **opensuse - upgrades**
      * [Build20200114-upgrade_Leap_15.0_gnome@64bit](https://openqa.opensuse.org/t1145649)
      * [Build20200115-zdup-Leap-15.0-gnome@64bit_cirrus](https://openqa.opensuse.org/t1145650)
      * [Build20200115-upgrade_Leap_42.3_kde@64bit](https://openqa.opensuse.org/t1145651)