### PR TITLE
Enable remote installation over VNC for openSUSE

### DIFF
--- a/tests/remote/remote_target.pm
+++ b/tests/remote/remote_target.pm
@@ -25,6 +25,7 @@ sub run {
     mutex_create("installation_ready");
     # wait while whole installation process finishes
     mutex_wait("installation_done");
+    send_key('ctrl-alt-delete') if check_var('DISTRI', 'opensuse');
     $self->wait_boot(bootloader_time => 120);
 }
 


### PR DESCRIPTION
yaml schedulers for the controller and the target for opensuse.
i have already created the test suites with the corresponding yaml_schedule.
The NETBOOT and INSTALL_SOURCE are ommitted from the configuration
as the DVD flavor can be used.
I tried to take away the HDD_1 from the test_suite and move it in the
yaml but the job fails reporting that the image cant found( searching in
/var/lib/openqa/pool/3/raid/ somehow)
I had to terminate the yast2 manually after the mutex.

- Related ticket: https://progress.opensuse.org/issues/52310
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/628 (merged)
- Verification run: http://aquarius.suse.cz/tests/1202
