### PR TITLE
handle_Networkmanager_controlled: Accept exit code 16 as valid

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -305,7 +305,7 @@ sub handle_Networkmanager_controlled {
         # SLED11...
         send_key 'alt-y';
     }
-    wait_serial("$module_name-0", 60) || die "'yast2 lan' didn't finish";
+    wait_serial("$module_name-{0,16}", 60) || die "'yast2 lan' didn't finish";
 }
 
 =head2 handle_dhcp_popup


### PR DESCRIPTION
16 should have been the correct ret code for like ever: we press
'CANCEL', not 'OK', so yast goes into 'Abort mode', which should always have
been giving retval=16. Due to a long-standing yast bug though, the CLI always
exited with 0.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1136772
