### PR TITLE
Remove orphaned package check from online migration flow

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -473,7 +473,6 @@ sub load_online_migration_tests {
     if (check_var("MIGRATION_METHOD", 'zypper')) {
         loadtest "migration/sle12_online_migration/zypper_migration";
     }
-    loadtest 'console/orphaned_packages_check';
     loadtest "migration/sle12_online_migration/post_migration";
 }
 


### PR DESCRIPTION
Now the orphaned package check will be load on regression test, we don't need to load it during online migration test.

- Related ticket: https://progress.opensuse.org/issues/61892
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/3769382
