### PR TITLE
x11: fix application_starts_on_login by enabling new code path for SLE15SP2+

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -46,7 +46,7 @@ use x11utils qw(handle_relogin turn_off_gnome_screensaver);
 
 sub tweak_startupapp_menu {
     my ($self) = @_;
-    if (is_tumbleweed) {
+    if (!is_sle('<15-sp2') && !is_leap('<15.2')) {
         x11_start_program 'gnome-tweaks';
     }
     elsif (is_sle('15+')) {


### PR DESCRIPTION
This is a simple change that enables code path of Tumbleweed for SLE15SP2+, because they are both upgraded to GNOME-3.34.

The verification run failed later due to another bug, but now it correctly opens "gnome-tweaks" instead of "gnome-tweak-tool".

- Related ticket: https://progress.opensuse.org/issues/60530
- Needles: None
- Verification run: https://openqa.suse.de/tests/3769418#step/application_starts_on_login/11