### PR TITLE
Move license page after registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -567,6 +567,9 @@ sub fill_in_registration_data {
         if (get_var('SCC_URL') || get_var('SMT_URL')) {
             push @tags, 'untrusted-ca-cert';
         }
+        # The SLE15-SP2 license page moved after registration.
+        push @tags, 'license-agreement'          if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
+        push @tags, 'license-agreement-accepted' if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
         # The "Extension and Module Selection" won't be shown during upgrade to sle15, refer to:
         # https://bugzilla.suse.com/show_bug.cgi?id=1070031#c11
         push @tags, 'inst-addon' if is_sle('15+') && is_upgrade;
@@ -618,6 +621,12 @@ sub fill_in_registration_data {
             }
             elsif (match_has_tag('inst-addon')) {
                 return;
+            }
+            elsif (match_has_tag("license-agreement") || match_has_tag("license-agreement-accepted")) {
+                send_key 'alt-a' unless match_has_tag("license-agreement-accepted");
+                record_soft_failure 'bsc#1080450: license agreement is shown twice' if match_has_tag("license-agreement-accepted");
+                send_key $cmd{next};
+                assert_screen "remove-repository";
             }
         }
     }

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -41,14 +41,17 @@ sub run {
     if (match_has_tag("select-for-update")) {
         send_key $cmd{next};
     }
-    assert_screen [qw(remove-repository license-agreement license-agreement-accepted)], 240;
-    if (match_has_tag("license-agreement") || match_has_tag("license-agreement-accepted")) {
-        send_key 'alt-a' unless match_has_tag("license-agreement-accepted");
-        record_soft_failure 'bsc#1080450: license agreement is shown twice' if match_has_tag("license-agreement-accepted");
+    # The SLE15-SP2 license page moved after registration.
+    if (get_var('MEDIA_UPGRADE') || is_sle('<15-SP2')) {
+        assert_screen [qw(remove-repository license-agreement license-agreement-accepted)], 240;
+        if (match_has_tag("license-agreement") || match_has_tag("license-agreement-accepted")) {
+            send_key 'alt-a' unless match_has_tag("license-agreement-accepted");
+            record_soft_failure 'bsc#1080450: license agreement is shown twice' if match_has_tag("license-agreement-accepted");
+            send_key $cmd{next};
+            assert_screen "remove-repository";
+        }
         send_key $cmd{next};
-        assert_screen "remove-repository";
     }
-    send_key $cmd{next};
     # Select migration target in sle15 upgrade
     if (is_sle '15+') {
         if (get_var('MEDIA_UPGRADE')) {


### PR DESCRIPTION
Confirmed in bsc#1158975, we need update test code to move sle15sp2 license page after registration.

Bug 1158975 - [Migration][Build 104.1] openQA test fails in upgrade_select - Cannot get sles15sp2 license
- Related ticket: https://progress.opensuse.org/issues/61653
- Needles: N/A.
- Verification run: offline migration via package media: http://10.161.8.44/tests/23
                            offline migration via SCC/ProxySCC: http://10.161.8.44/tests/24#step/scc_registration/16    The failure is for bsc#1159433 and no relation with this PR.