### PR TITLE
Fix switch to tty6 failed in orphaned_packages_check

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -473,8 +473,8 @@ sub load_online_migration_tests {
     if (check_var("MIGRATION_METHOD", 'zypper')) {
         loadtest "migration/sle12_online_migration/zypper_migration";
     }
-    loadtest 'console/orphaned_packages_check';
     loadtest "migration/sle12_online_migration/post_migration";
+    loadtest 'console/orphaned_packages_check';
 }
 
 sub load_patching_tests {

--- a/tests/console/orphaned_packages_check.pm
+++ b/tests/console/orphaned_packages_check.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -38,8 +38,8 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
 
-    $self->export_logs();
-    upload_logs '/tmp/orphaned.log';
+    $self->SUPER::post_fail_hook;
+    $self->upload_packagekit_logs;
 }
 
 1;


### PR DESCRIPTION
Sometimes the select_console can't switch to tty6 in orphaned_packages_check while migration from SLES15 to  SLES15-SP2. To fix it, we need to move orphaned_packages_check after post_migration.
We also have another ticket https://progress.opensuse.org/issues/48110 for this.

- Related ticket: 
    https://progress.opensuse.org/issues/57281
    https://progress.opensuse.org/issues/48110
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/3769433#step/orphaned_packages_check/6
  https://openqa.suse.de/tests/3769437#step/orphaned_packages_check/6
