### PR TITLE
Increase timeout to let zypper info command finish

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -70,7 +70,7 @@ sub get_patch {
 }
 sub get_patchinfos {
     my ($patches) = @_;
-    my $patches_status = script_output("zypper -n info -t patch $patches");
+    my $patches_status = script_output("zypper -n info -t patch $patches", 200);
     return $patches_status;
 }
 


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3771794#step/update_install/35
