### PR TITLE
Increase bootloader timeout after reboot

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -108,7 +108,7 @@ sub run {
 
     prepare_system_shutdown;
     power_action("reboot");
-    $self->wait_boot;
+    $self->wait_boot(bootloader_time => 200);
 }
 
 sub test_flags {


### PR DESCRIPTION
especially ppc64le and aarch64 failed here

- Fail: https://openqa.suse.de/tests/3771445#step/update_install/38
- Verification run: 
https://openqa.suse.de/tests/3772359 ppc64le
https://openqa.suse.de/tests/3772364 aarch64
