### PR TITLE
Use iscsi workaround only in SLE15+

### DIFF
--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (c) 2016-2018 SUSE LLC
+# Copyright (c) 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,6 +16,7 @@ use warnings;
 use utils qw(zypper_call systemctl);
 use testapi;
 use hacluster;
+use version_utils 'is_sle';
 
 sub run {
     # Installation of iSCSI client package(s) if needed
@@ -62,7 +63,7 @@ sub run {
     wait_still_screen 3;
     wait_serial('yast2-iscsi-client-status-0', 90) || die "'yast2 iscsi-client' didn't finish";
 
-    if (systemctl('-q is-active iscsi', ignore_failure => 1)) {
+    if (is_sle('=15-SP2') && systemctl('-q is-active iscsi', ignore_failure => 1)) {
         record_soft_failure('iscsi issue: bug bsc#1160374');
         systemctl('start iscsi');
     }


### PR DESCRIPTION
Iscsi workaround for bsc#1160374 has to be triggered only in SLE15SP2 version.
This PR had this condition.

- Related ticket: N/A
- Needles: N/A
- Verification run: [SLES15-SP2](http://1a102.qa.suse.de/tests/2617) / [SLE12SP4](http://1a102.qa.suse.de/tests/2623)
