### PR TITLE
Eat stale buffer contents before serial console login

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -81,6 +81,10 @@ sub login {
 
     bmwqemu::log_call;
 
+    # Eat stale buffer contents, otherwise the code below may get confused
+    # after reboot and start typing the username before the console is actually
+    # ready to accept it
+    wait_serial(qr/login:\s*$/i, timeout => 5, quiet => 1);
     # newline nudges the guest to display the login prompt, if this behaviour
     # changes then remove it
     type_string("\n");


### PR DESCRIPTION
Console activation may fail after VM reboot because it finds a stale login prompt and starts typing username before the console is ready to accept it. Fix this by eating stale console output before asking for fresh login prompt.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-12SP2@x86_64: https://openqa.suse.de/tests/3774084 (cloned from https://openqa.suse.de/tests/3772028 which consistently fails due to stale login prompt)
  - SLE-12SP4@x86_64: https://openqa.suse.de/tests/3776430 (serial login on first VM boot)
  - SLE-12SP5@PPC64LE: https://openqa.suse.de/tests/3774087
  - SLE-15SP1@s390x: https://openqa.suse.de/tests/3774088
