### PR TITLE
Fix upgrade_select test in openSUSE

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'assert_screen_with_soft_timeout';
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_opensuse);
 
 sub run {
     if (get_var('ENCRYPT')) {
@@ -42,7 +42,7 @@ sub run {
         send_key $cmd{next};
     }
     # The SLE15-SP2 license page moved after registration.
-    if (get_var('MEDIA_UPGRADE') || is_sle('<15-SP2')) {
+    if (get_var('MEDIA_UPGRADE') || is_sle('<15-SP2') || is_opensuse) {
         assert_screen [qw(remove-repository license-agreement license-agreement-accepted)], 240;
         if (match_has_tag("license-agreement") || match_has_tag("license-agreement-accepted")) {
             send_key 'alt-a' unless match_has_tag("license-agreement-accepted");


### PR DESCRIPTION
PR#9272 breaks openSUSE upgrade test because it now conditions some code to old SLE version only. openSUSE condition should be also added.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.opensuse.org/tests/1139734#step/online_repos/2