### PR TITLE
Increase bootloader timeout after reboot

### DIFF
--- a/tests/qam-minimal/update_minimal.pm
+++ b/tests/qam-minimal/update_minimal.pm
@@ -42,7 +42,7 @@ sub run {
 
     prepare_system_shutdown;
     type_string "reboot\n";
-    $self->wait_boot;
+    $self->wait_boot(bootloader_time => 200);
 }
 
 sub test_flags {


### PR DESCRIPTION
especially ppc64le and aarch64 fail here

- Fail: https://openqa.suse.de/tests/3774939#step/update_minimal/62
- Verification run: https://openqa.suse.de/tests/3775882