### PR TITLE
Set DESKTOP=gnome explicitly for the btrfs and ext4 tests

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -2,6 +2,7 @@ name:           btrfs_libstorage-ng
 description:    >
   Validate default installation with btrfs and Libstorage NG.
 vars:
+  DESKTOP: gnome
   FILESYSTEM: btrfs
 schedule:
   # Called on BACKEND: qemu

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -4,6 +4,7 @@ description:    >
   Test for ext4 filesystem.
   Grub is not displayed due to console reconnection.
 vars:
+  DESKTOP: gnome
   FILESYSTEM: ext4
   FORMAT_DASD: install
 schedule:

--- a/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
@@ -3,8 +3,8 @@ name:           ext4@yast
 description:    >
   Test for ext4 filesystem.
 vars:
+  DESKTOP: gnome
   FILESYSTEM: ext4
-  FORMAT_DASD: install
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -5,8 +5,8 @@ description:    >
   Test modules 'grub_disable_timeout' and 'grub_test' in xen-pv are not scheduled
   due to grub2 doesnt support xfb console.
 vars:
+  DESKTOP: gnome
   FILESYSTEM: ext4
-  FORMAT_DASD: install
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -3,8 +3,8 @@ name:           ext4@yast
 description:    >
   Test for ext4 filesystem.
 vars:
+  DESKTOP: gnome
   FILESYSTEM: ext4
-  FORMAT_DASD: install
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -5,8 +5,8 @@ description:    >
   For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
   module is scheduled and OPT_KERNEL_PARAMS variable is set.
 vars:
-  FILESYSTEM: ext4
   DESKTOP: textmode
+  FILESYSTEM: ext4
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
 schedule:
   - installation/bootloader_start


### PR DESCRIPTION
During the review we have found failing tests on zVM because early
return somehow didn't work for the setup and tests started to fail.
However, there was a second issue we missed as DESKTOP was changed to
textmode for many of the scenarios we had.
I was not able to figure out why `SCC_ADDONS` setting got changed
between last good and failing ones, but as a result we started selecting
different modules and end up with text mode.
With this change, we set DM explicitly to have same behavior as in build
89.1.

See [poo#61964](https://progress.opensuse.org/issues/61964).

- [Verification run](https://openqa.suse.de/tests/3775052#).
