### PR TITLE
Fix for kiwi errors on all builds

### DIFF
--- a/tests/kiwi_images_test/kiwi_boot.pm
+++ b/tests/kiwi_images_test/kiwi_boot.pm
@@ -21,37 +21,35 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils "is_sle";
 
 sub run {
-    my $install_type = get_var('KIWI_OLD');
-    my $iso_name     = get_var('ISO');
+    my $iso_name = get_var('ISO');
     # bootloader screen is too fast to openqa
     sleep(10);
-    send_key 'down';
-    send_key 'up';
-    # perl kiwi oem installer does not work correctly on non interactive
-    if (($install_type == 1) && ($iso_name =~ /OEM/)) {
+    if ($iso_name =~ /OEM/) {
+        send_key 'up';
+        send_key 'down';
         assert_screen('kiwi_boot', 15);
         send_key 'ret';
-        # choose last option on installer screen
-        assert_screen('kiwi_oem_install_installer', 300);
-        my $count = 0;
-        while ($count < 16) {
-            send_key 'down';
-            $count++;
+        # SLE12SP3 image contains a interactive installer
+        if ($iso_name =~ /12-SP3/) {
+            assert_screen('kiwi_oem_install_installer', 300);
+            my $count = 0;
+            while ($count < 16) {
+                send_key 'down';
+                $count++;
+            }
+            sleep 2;
+            send_key 'spc';
+            send_key 'ret';
+            assert_screen('kiwi_oem_install_confirm', 1200);
+            send_key 'ret';
         }
-        sleep 2;
-        send_key 'spc';
-        send_key 'ret';
-        assert_screen('kiwi_oem_install_confirm', 1200);
-        send_key 'ret';
-        assert_screen('linux-login', 1200);
     }
     else {
-        assert_screen('kiwi_boot', 15);
+        # ISO image without installer
         send_key 'ret';
-        assert_screen('linux-login', 1000);
     }
+    assert_screen('linux-login', 1200);
 }
 1;

--- a/tests/kiwi_images_test/login_reboot.pm
+++ b/tests/kiwi_images_test/login_reboot.pm
@@ -18,7 +18,6 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils "is_sle";
 
 sub run {
     # login

--- a/tests/kiwi_images_test/validate_build.pm
+++ b/tests/kiwi_images_test/validate_build.pm
@@ -23,7 +23,6 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils "is_sle";
 my $logfile = 'build.log';
 
 sub run {


### PR DESCRIPTION
Kiwi bootscreen has changed for some builds.
Also includes a fix on image detection (iso, oem and sle12sp3 (perl kiwi, rather
python kiwi)).
Remove uneeded is_sle.

Verification run at:
SLE12SP3: http://10.161.229.180/tests/3217
SLE12SP3 (ISO): http://10.161.229.180/tests/3216
SLE12SP4: http://10.161.229.180/tests/3209
SLE12SP5: http://10.161.229.180/tests/3207
SLE15: http://10.161.229.180/tests/3210
SLE15SP1: http://10.161.229.180/tests/3215
