### PR TITLE
Remove unused variable $svirt_pty_saved

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -107,8 +107,6 @@ use constant VERY_SLOW_TYPING_SPEED => 4;
 # openQA internal ftp server url
 our $OPENQA_FTP_URL = "ftp://openqa.suse.de";
 
-my $svirt_pty_saved = 0;
-
 =head2 save_svirt_pty
 
  save_svirt_pty();


### PR DESCRIPTION
BTW understand poo#18016 handled broken testing, but I consider
multiple calls of save_svirt_pty as a bug: it slows down testing,
see LTP tests on s390x (svirt backend):

https://openqa.suse.de/tests/3766791#step/boot_ltp/9

Fixme: 5a09d4b23 Fix wait_serial waiting on svirt commands never sent