### PR TITLE
Wait longer for suseconnect registration

### DIFF
--- a/tests/console/suseconnect.pm
+++ b/tests/console/suseconnect.pm
@@ -38,7 +38,7 @@ sub run {
     zypper_call 'services';
     zypper_call 'products';
 
-    assert_script_run "SUSEConnect -r $reg_code";
+    assert_script_run "SUSEConnect -r $reg_code", 180;
     assert_script_run "SUSEConnect --status-text| grep -v 'Not Registered'";
     zypper_call 'ref';
     assert_script_run "SUSEConnect --list-extensions";


### PR DESCRIPTION
On SLE 15+ it can take longer due to registration of depending modules

- Fail: https://openqa.suse.de/tests/3775548#step/suseconnect/22
- Verification run: https://openqa.suse.de/tests/3776561