### PR TITLE
Increase bootloader timeout after reboot

### DIFF
--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -72,7 +72,7 @@ sub run {
 
     prepare_system_shutdown;
     type_string "reboot\n";
-    $self->wait_boot;
+    $self->wait_boot(bootloader_time => 200);
 }
 
 sub test_flags {


### PR DESCRIPTION
especially ppc64le and aarch64 fail here, same as in #9278 #9286

- Fail: https://openqa.suse.de/tests/3776144#step/install_patterns/26
- Verification run: https://openqa.suse.de/tests/3776591