### PR TITLE
graphicsmagick: fix timeout

### DIFF
--- a/data/graphicsmagick/test.sh
+++ b/data/graphicsmagick/test.sh
@@ -407,8 +407,8 @@ tests=(
 
   # Test 10. Big images
 
-  # a. Scale a image to huge image
-  "resize_and_check degradation.png __1.png - 10000 10000"
+  # a. Scale a image to big image
+  "resize_and_check degradation.png __1.png - 5000 1000"
 
   # b. Downgrade a huge image
   "resize_and_check _-_1.png __1.png - 500 500"


### PR DESCRIPTION
problem: the VM seems doesn't have enough memory to manage images
of 10000x10000 size

solution: reduce the requirements of the test to 5000x1000

- Related ticket: https://progress.opensuse.org/issues/61759
- Needles: The same
- Verification run: pendent
