### PR TITLE
Avoid ambiguous matches when searching for 'About XFCE'

### DIFF
--- a/tests/x11/xfce4_appfinder.pm
+++ b/tests/x11/xfce4_appfinder.pm
@@ -24,7 +24,7 @@ sub run {
     send_key "down";
     # In XFCE 4.14+, a dynamic search is performed - poo#56111
     if (is_tumbleweed || is_leap(">=15.2")) {
-        type_string "about";
+        type_string "about xfce";
     } else {
         type_string "about\n";
     }


### PR DESCRIPTION
Current XFCE has added an 'About Me' app, extend the string to return
exactly one result.

- Related ticket: https://progress.opensuse.org/issues/62030
- Verification run: https://openqa.opensuse.org/t1141640#step/xfce4_appfinder/1