### PR TITLE
yast2_client_exit: in case of a soft-failure, return code 16 is a val…

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -189,11 +189,13 @@ sub yast2_server_initial {
 sub yast2_client_exit {
     my $module_name = shift;
     wait_screen_change { send_key 'alt-o' };
+    my $expret = "0";
     if (check_screen("cannot-mount-nfs-from-fstab", 10)) {
         send_key 'alt-o';
         record_soft_failure 'bsc#1157892';
+        $expret = "{0,16}";
     }
-    wait_serial("$module_name-0") or die "'yast2 $module_name' didn't finish";
+    wait_serial("$module_name-$expret") or die "'yast2 $module_name' didn't finish";
     clear_console;
 }
 


### PR DESCRIPTION
…id exit code

When the module is being closed and actually quits with an error, yast now correctly
returns errorcode != 0. So, together with recording the soffailure on exit, we also
need to adjust for the fact that we will now return with an error code.

- Related ticket: https://progress.opensuse.org/issues/62054
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1142270 (passed/softfail as expected)
