### PR TITLE
Fix pressure_stall_information on s390x (svirt backend)

### DIFF
--- a/schedule/kernel/pressure_stall_information.yaml
+++ b/schedule/kernel/pressure_stall_information.yaml
@@ -11,5 +11,11 @@ vars:
   # HDD_1: SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2
   # START_AFTER_TEST: create_hdd_minimal_base+sdk
   # UEFI_PFLASH_VARS: SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed-uefi-vars.qcow2
+conditional_schedule:
+  bootloader_zkvm:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
 schedule:
+  - {{bootloader_zkvm}}
   - kernel/pressure_stall_information


### PR DESCRIPTION
pressure_stall_information run on s390x-kvm-sle15 needs
installation/bootloader_zkvm.

- Verification run:
- http://quasar.suse.cz/tests/4705 (s390x-kvm-sle15)
- http://quasar.suse.cz/tests/4706 (intel)
