### PR TITLE
Adding test_data for no separate home scenario.

### DIFF
--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -32,4 +32,4 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/dasda
-  !include: test_data/yast/ext4/ext4.yaml
+  !include: test_data/yast/ext4/ext4_no_separate_home.yaml

--- a/test_data/yast/ext4/ext4_no_separate_home.yaml
+++ b/test_data/yast/ext4/ext4_no_separate_home.yaml
@@ -1,0 +1,7 @@
+  allowed_unpartitioned: 0.00GB
+  partitions:
+    - mnt_point: /
+      fs_type: ext4
+    - mnt_point: [SWAP]
+      fs_type: swap
+


### PR DESCRIPTION
validate_ext4_fs module fails for s390 - zVM due to not having separate home partition.
Related ticket https://progress.opensuse.org/issues/62057

Validation test:
s390 - zVM: https://openqa.suse.de/t3781634
