### PR TITLE
Clean-up registration in addon_products_via_SCC_yast2

### DIFF
--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -26,6 +26,10 @@ sub test_setup {
     x11_start_program('xterm');
     turn_off_gnome_screensaver;
     become_root;
+    # We use image which is registered, so remove previous registration first
+    if (is_sle('>=15')) {
+        cleanup_registration();
+    }
 
     my @addon_proxy = ('url: http://' . (is_sle('<15') ? 'server-' : 'all-') . get_var('BUILD_SLE'));
     # Add every used addon to regurl for proxy SCC, sle12 addons can have different build numbers


### PR DESCRIPTION
This is regression introduced in b5cc3b1bf2797b1f30524d04cf88245aa80d48a9 , image we boot into is registered in case of SLE 15, so we need to remove it first before trying to register.

See [poo#61979](https://progress.opensuse.org/issues/61979).

* [Verification run](https://openqa.suse.de/tests/3781146#).
