### PR TITLE
podman: add -f/--force option to prune test

### DIFF
--- a/tests/console/podman.pm
+++ b/tests/console/podman.pm
@@ -108,7 +108,7 @@ sub run {
     assert_script_run("$cmd_podman_rm");
     $output_containers = script_output('podman container ls -a');
     die("error: container was not removed: $cmd_podman_rm") if ($output_containers =~ m/test_1/);
-    my $cmd_podman_container_prune = 'podman container prune';
+    my $cmd_podman_container_prune = 'podman container prune -f';
     assert_script_run("$cmd_podman_container_prune");
     $output_containers = script_output('podman container ls -a');
     die("error: container was not removed: $cmd_podman_container_prune") if ($output_containers =~ m/test_2/);


### PR DESCRIPTION
Since 1.7.0 podman ask for confirmation when pruning containers. Add
"-f" to the test avoid that.

Addresses this failure: https://openqa.opensuse.org/tests/1141129#step/podman/55