### PR TITLE
SLES-15 SP1 supportserver: correct repo URL

### DIFF
--- a/data/supportserver/autoyast_supportserver_x86_sle15.xml
+++ b/data/supportserver/autoyast_supportserver_x86_sle15.xml
@@ -130,10 +130,9 @@
         <selected config:type="boolean">true</selected>
       </listentry>
       <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE/Backports/SLE-15-SP1_x86_64/standard/standard</media_url>
-        <!-- NFS: /mounts/mirror/SuSE/build.suse.de/SUSE/Backports/SLE-15-SP1_x86_64/standard/standard
-             NOTE: *four* RPM subdirs: noarch{,_GA}, x86_64{,_GA}. Looks like both GA pool and updates.
-             CAVEAT: there is  also the .../SLE-15-SP1_x86_64/standard repo which looks alike but is just a bit older... -->
+        <media_url>http://download.suse.de/ibs/SUSE/Backports/SLE-15-SP1_x86_64/standard</media_url>
+        <!-- NFS: /mounts/mirror/SuSE/build.suse.de/SUSE/Backports/SLE-15-SP1_x86_64/standard
+             NOTE: *four* RPM subdirs: noarch{,_GA}, x86_64{,_GA}. Looks like both GA pool and updates.  -->
         <alias>PackageHub:15.1::pool</alias>
         <name>PackageHub:15.1::pool</name>
         <priority config:type="integer">20</priority>


### PR DESCRIPTION
Correct one repository URL specified in the autoyast file for the new
SLES-15 SP1 supportserver due to its having meanwhile turned invalid.

- Related ticket: https://progress.opensuse.org/issues/50144
- Needles: (none)
- Verification run: [sle-15-SP1-Server-DVD-x86_64-Build228.2-supportserver_generator@64bit](http://polya.suse.de/tests/888)

This reacts to the recent failing verification run in [PR#8982](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8982).
