### PR TITLE
publiccloud: Run SUSEConnect only for BYOS images

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -70,7 +70,7 @@ sub run {
     assert_script_run('git clone -q --single-branch -b runltp_ng_openqa --depth 1 https://github.com/cfconrad/ltp.git');
 
     # Install ltp from package on remote
-    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . $REG_CODE, timeout => 600) if (get_required_var('FLAVOR') !~ m/On-Demand/);
+    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . $REG_CODE, timeout => 600) if (get_required_var('FLAVOR') =~ m/BYOS/);
     $instance->run_ssh_command(cmd => 'sudo zypper --no-gpg-checks --gpg-auto-import-keys -q in -y ' . $remote_rpm_path, timeout => 600);
     $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh',                                       timeout => 300);
 


### PR DESCRIPTION
We previously run SUSEConnect if __no__ 'On-Demand' is in the FLAVOR of
the image. But this isn't valid anymore.
They changed the FLAVOR of the On-Demand images like:
Azure-Standard, Azure-Basic, GCE

So we checking for BYOS and then run SUSEConnect.

- Verification run: https://openqa.suse.de/t3781757 - publiccloud_ltp_syscalls@cfconrad/os-autoinst-distri-opensuse#fix_suseconnect_calls => scheduled

