### PR TITLE
Accept non-empty description for last snapshot

### DIFF
--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -47,7 +47,7 @@ sub run {
     assert_script_run('snapper --iso list | grep \'number.*after installation\'.*important=yes');
     assert_script_run('snapper --iso list | grep \'number.*rollback\'.*important=yes',
         fail_message => 'rollback backup should be marked for cleanup fate#321773');
-    assert_script_run('snapper --iso list | tail -n 1 | grep \'|\s*|\s*|\s*$\'', fail_message => 'last snapshot should not be cleaned up but is not-important');
+    assert_script_run('snapper --iso list | tail -n 1 | grep \'|\s*| [^|]\+ |\s*$\'', fail_message => 'last snapshot should not be cleaned up but is not-important');
     script_run("systemctl reboot", 0);
     reset_consoles;
     $self->wait_boot;


### PR DESCRIPTION
Since snapper 0.8.8, the second snapshot has a non-empty
description.

- Related ticket: https://progress.opensuse.org/issues/62045
- Verification run: https://openqa.opensuse.org/tests/1142863#step/boot_into_snapshot/25