### PR TITLE
Fix grub_test with more time to wait for inst-bootmenu

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -33,7 +33,7 @@ sub handle_installer_medium_bootup {
     my ($self) = @_;
 
     return unless (check_var("BOOTFROM", "d") || (get_var('UEFI') && get_var('USBBOOT')));
-    assert_screen 'inst-bootmenu', 60;
+    assert_screen 'inst-bootmenu', 180;
 
     if (check_var("BOOTFROM", "d") && check_var("AUTOUPGRADE") && check_var("PATCH")) {
         assert_screen 'grub2';


### PR DESCRIPTION
In the grub_test module, sometimes after reboots, the boot menu shows a little bit slower than normal
 in auto-upgrade tests. we need to enlarge the wait time for the grub menu to show up.

- Related ticket: https://progress.opensuse.org/issues/60887
- Needles: N/A
- Verification run: 
   https://openqa.suse.de/tests/3780960
   https://openqa.suse.de/tests/3780971
   https://openqa.suse.de/tests/3780972
   https://openqa.suse.de/tests/3780993
   https://openqa.suse.de/tests/3781090
