### PR TITLE
Change install service test module position for online migration

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -461,9 +461,9 @@ sub load_online_migration_tests {
     if (get_var('SCC_ADDONS', '') =~ /ltss/) {
         loadtest "migration/sle12_online_migration/register_without_ltss";
     }
+    loadtest 'installation/install_service' if (is_sle && !is_desktop && !get_var('INSTALLONLY'));
     loadtest "migration/version_switch_upgrade_target";
     loadtest "migration/sle12_online_migration/pre_migration";
-    loadtest 'installation/install_service' if (is_sle && !is_desktop && !get_var('INSTALLONLY'));
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }


### PR DESCRIPTION
For online migration, install_service test module should not separate 'pre_migration' and 'yast2 migration'. Change 'install_service' before 'pre_migration' test module.

- Related ticket: https://progress.opensuse.org/issues/60938
- Verification run: https://openqa.suse.de/tests/3781096#step/yast2_migration/20
