### PR TITLE
x11: change_password should use assert_and_click

### DIFF
--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -63,9 +63,7 @@ sub reboot_system {
         $self->wait_boot(nologin => 1);
         assert_screen "displaymanager", 200;
         $self->{await_reboot} = 0;
-        # The keyboard focus is different between SLE15 and SLE12
-        send_key 'up' if is_sle('15+');
-        send_key "ret";
+        assert_and_click "displaymanager-$username";
         wait_still_screen;
         type_string "$newpwd\n";
     } else {


### PR DESCRIPTION
which is more accurate and portable than send_key.

This change doesn't affect Tumbleweed because it uses auto-login.

- Related ticket: https://progress.opensuse.org/issues/60530
- Needles: None
- Verification run: https://openqa.suse.de/tests/3783367#step/change_password/37
