### PR TITLE
Use same approach to assert system boot in yast first boot scenarios

### DIFF
--- a/schedule/yast/autoyast_y2_firstboot.yaml
+++ b/schedule/yast/autoyast_y2_firstboot.yaml
@@ -9,4 +9,5 @@ schedule:
     - installation/bootloader_start
     - autoyast/installation
     - installation/yast2_firstboot
+    - installation/first_boot
     - console/validate_yast2_firstboot_configuration

--- a/schedule/yast/yast2_firstboot.yaml
+++ b/schedule/yast/yast2_firstboot.yaml
@@ -13,4 +13,5 @@ schedule:
     - autoyast/autoyast_reboot
     - installation/grub_test
     - installation/yast2_firstboot
+    - installation/first_boot
     - console/validate_yast2_firstboot_configuration

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -92,7 +92,6 @@ sub run {
     root_setup;
     assert_screen 'installation_completed';
     send_key $cmd{finish};
-    assert_screen([qw(displaymanager generic-desktop)], 120);
 }
 
 sub post_fail_hook {

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -30,8 +30,6 @@ sub language_and_keyboard {
     foreach (sort keys %${shortcuts}) {
         send_key 'alt-' . $_;
         assert_screen $shortcuts->{$_} . '_selected';
-        send_key_until_needlematch 'expanded_list', 'spc', 5, 7;
-        wait_screen_change(sub { send_key 'ret'; }, 5);
     }
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
 }


### PR DESCRIPTION
Originally we used generic needles to assert boot of the system, but
practice proved that better use methods we use everywhere else, as we
got gnome bug that user is not pre-selected. We have implemented
workaround, but branched check didn't have it, so re-using same module
here as well.

See [poo#60641](https://progress.opensuse.org/issues/60641).

## Verification runs
* [autoyast](https://openqa.suse.de/tests/3782242)
* [manual](https://openqa.suse.de/tests/3782232)
