### PR TITLE
Workaround workqueue lockup message for select_console

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -825,6 +825,11 @@ sub activate_console {
         (get_var('PUBLIC_CLOUD')) ? ssh_interactive_join() : $self->script_run('ssh -t sut', 0);
         ensure_user($user) unless (get_var('PUBLIC_CLOUD'));
     }
+    # workaround workqueue lockup message bsc#1126782
+    if (check_screen('workqueue-lockup-message')) {
+        record_soft_failure "boo#1126782 - Spurious kernel message on console";
+        send_key 'ret';
+    }
     set_var('CONSOLE_JUST_ACTIVATED', 1);
 }
 


### PR DESCRIPTION
we have sporadic issue with workqueue lockup message over console,
this breaks our test module.
see https://progress.opensuse.org/issues/60992
Needle PR:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/630
verfication test run:
http://f40.suse.de/tests/6211
http://f40.suse.de/tests/6229
http://f40.suse.de/tests/6230