### PR TITLE
Merge x11test::post_fail_hook into opensusebasetest

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1,3 +1,13 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 package opensusebasetest;
 use base 'basetest';
 
@@ -1135,6 +1145,7 @@ sub post_fail_hook {
     return if testapi::is_serial_terminal();    # unless VIRTIO_CONSOLE=0 nothing below make sense
 
     show_tasks_in_blocked_state;
+    return if (get_var('NOLOGS'));
 
     # just output error if selected program doesn't exist instead of collecting all logs
     # set current variables in x11_start_program
@@ -1183,6 +1194,8 @@ sub post_fail_hook {
     # the space prevents the esc from eating up the next alphanumerical
     # character typed into the console
     send_key 'spc';
+
+    $self->export_logs;
 }
 
 sub test_flags {

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1,3 +1,13 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 ## no critic (RequireFilenameMatchesPackage);
 package x11test;
 use base "opensusebasetest";
@@ -11,17 +21,6 @@ use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
 use POSIX 'strftime';
 use mm_network;
-
-sub post_fail_hook {
-    my ($self) = shift;
-
-    return if (get_var('NOLOGS'));
-
-    $self->export_logs;
-    $self->SUPER::post_fail_hook;
-
-    save_screenshot;
-}
 
 sub post_run_hook {
     my ($self) = @_;

--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/54488
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2083 (notice that kontact was not opened in purpose to produce the fail)
