### PR TITLE
HPC: ensure correct hostname

### DIFF
--- a/lib/hpc/cluster.pm
+++ b/lib/hpc/cluster.pm
@@ -1,0 +1,20 @@
+package hpc::cluster;
+use base hpcbase;
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+our @EXPORT = qw(
+  provision_cluster
+);
+
+sub provision_cluster {
+    my ($self) = @_;
+    my $config = << "EOF";
+sed -i "/^DHCLIENT_SET_HOSTNAME.*/c\\\"DHCLIENT_SET_HOSTNAME=\"no\"" /etc/sysconfig/network/dhcp
+EOF
+    assert_script_run($_) foreach (split /\n/, $config);
+}
+
+1;

--- a/tests/hpc/before_test.pm
+++ b/tests/hpc/before_test.pm
@@ -11,6 +11,7 @@
 # Maintainer: Sebastian Chlad <schlad@suse.de>
 
 use base 'hpcbase';
+use base 'hpc::cluster';
 use strict;
 use warnings;
 use testapi;
@@ -26,6 +27,9 @@ sub run {
 
     # Stop firewall
     systemctl 'stop ' . $self->firewall;
+
+    $self->provision_cluster();
+
     set_hostname(get_var('HOSTNAME', 'susetest'));
 
     if (get_var('HPC_REPO')) {


### PR DESCRIPTION
Current multimachine/HPC tests rely on using support server, so that
for instance DHCP is used for assigning hostnames etc. This overall
might be problematic for some specific HPC tests, where correct set-up
of a private network is a requirement and not the goal of the tests.
For this reason it make sense to gradually decouple cluster provisioning
form the test execution.

This patch is an introduction to a new hpc specific lib which could
eventually ensure specific configuration for creating private network
and thus provision HPC cluster are done as expected

Initially the plan was to completly remove support config from cluster
provisioning however as of now slurm updates are getting no acceptance
so this intermediate commit is merged
