### PR TITLE
Change parent for modules in yast_cmd test suite

### DIFF
--- a/tests/yast2_cmd/yast_ftp_server.pm
+++ b/tests/yast2_cmd/yast_ftp_server.pm
@@ -54,7 +54,7 @@ c)
 =cut
 
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -26,7 +26,7 @@ https://www.suse.com/documentation/sles-15/singlehtml/book_sle_admin/book_sle_ad
 
 =cut
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_lan.pm
+++ b/tests/yast2_cmd/yast_lan.pm
@@ -17,7 +17,7 @@
 # - List all available network interfaces
 # Maintainer: Vit Pelcak <vpelcak@suse.cz>
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_nfs_client.pm
+++ b/tests/yast2_cmd/yast_nfs_client.pm
@@ -17,7 +17,7 @@
 #       - restores all configs
 # Maintainer: Jun Wang <jgwang@suse.com>
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_nfs_server.pm
+++ b/tests/yast2_cmd/yast_nfs_server.pm
@@ -34,7 +34,7 @@ https://www.suse.com/documentation/sles-15/singlehtml/book_sle_admin/book_sle_ad
  
 =cut
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_rdp.pm
+++ b/tests/yast2_cmd/yast_rdp.pm
@@ -17,7 +17,7 @@
 # - Stop rdp service and check
 # Maintainer: Jun Wang <jgwang@suse.com>
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_sysconfig.pm
+++ b/tests/yast2_cmd/yast_sysconfig.pm
@@ -62,7 +62,7 @@
 #               expection:
 #                   "details" command get a null value.
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_tftp_server.pm
+++ b/tests/yast2_cmd/yast_tftp_server.pm
@@ -18,7 +18,7 @@
 # - Cleanup
 # Maintainer: Shukui Liu <skliu@suse.com>
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_timezone.pm
+++ b/tests/yast2_cmd/yast_timezone.pm
@@ -16,7 +16,7 @@
 # - Return to previous timezone
 # Maintainer: Katerina Lorenzova <klorenzova@suse.cz>
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/yast2_cmd/yast_users.pm
+++ b/tests/yast2_cmd/yast_users.pm
@@ -19,7 +19,7 @@
 # Maintainer: Jun Wang <jgwang@suse.com>
 #
 
-use base 'consoletest';
+use base 'y2_module_basetest';
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION
Parent module is changed to use the proper post_fail_hook when the
module is failed. consoletest module, that was used as parent, does not
contain yast2_logs, which is very important while investigating
failures.

- Verification run: http://10.160.65.138/tests/1287