### PR TITLE
Inject registration for autoyast profile cloned

### DIFF
--- a/schedule/yast/autoyast_reinstall.yaml
+++ b/schedule/yast/autoyast_reinstall.yaml
@@ -3,6 +3,7 @@ description:    >
     Parent job produces autoyast profile after successful completion. 
     This test uses generated profile to do autoyast installation.
 schedule:
+  - autoyast/prepare_cloned_profile
   # Called on BACKEND: qemu
   - {{isosize}}
   - installation/bootloader_start

--- a/tests/autoyast/prepare_cloned_profile.pm
+++ b/tests/autoyast/prepare_cloned_profile.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: - Inject registration block for an AutoYaST profile cloned
+#            due to registration code is never cloned as it is not stored in the system anywhere.
+#          - Expand variables
+#          - Upload modified profile
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use autoyast qw(inject_registration expand_variables upload_profile);
+
+sub run {
+    my $path = get_required_var('AUTOYAST');
+    # Get file from data directory
+    my $profile = get_test_data($path);
+    # Inject registration block with template variables
+    $profile = inject_registration($profile);
+    # Expand injected template variables
+    $profile = expand_variables($profile);
+    # Upload asset
+    upload_profile(profile => $profile, path => $path);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,78 +20,32 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use version_utils 'is_sle';
-use registration 'scc_version';
-use autoyast 'expand_template';
-use File::Copy 'copy';
-use File::Path 'make_path';
+use autoyast qw(
+  detect_profile_directory
+  expand_template
+  expand_version
+  adjust_network_conf
+  expand_variables
+  upload_profile);
 
 sub run {
     my $path = get_required_var('AUTOYAST');
     # Get file from data directory
     my $profile = get_test_data($path);
 
-    # try to detect directory (autoyast_opensuse/, autoyast_sle{12,15}/, autoyast_sles11/)
-    # TODO: autoyast_{caasp,kvm,qam,xen}
-    my $dir    = "autoyast_";
-    my $regexp = $dir . '\E[^/]+\/';
+    $path    = detect_profile_directory(profile => $profile, path => $path);
+    $profile = get_test_data($path);
+    die "Empty profile" unless $profile;
 
-    if (!$profile && $path !~ /\Q$regexp/) {
-        my $distri = get_required_var('DISTRI');
-        if (is_sle) {
-            $distri .= "s" if is_sle('<12');    # sles11
-            my $major_version = get_required_var('VERSION');
-            $major_version =~ s/-SP.*//;
-            $distri .= $major_version;
-        }
-        $path = "$dir${distri}/$path";
-        record_info('INFO', "Trying to use path with detected folder: '$path'");
-        $profile = get_test_data($path);
-    }
-
-    return unless $profile;
-
-    # Profile is a template, expand and rename
+    # if profile is a template, expand and rename
     $profile = expand_template($profile) if $path =~ s/^(.*\.xml)\.ep$/$1/;
     die $profile if $profile->isa('Mojo::Exception');
 
-    # Expand VERSION, as e.g. 15-SP1 has to be mapped to 15.1
-    if (my $version = scc_version(get_var('VERSION', ''))) {
-        $profile =~ s/\{\{VERSION\}\}/$version/g;
-    }
-    # For s390x and svirt backends need to adjust network configuration
-    my $hostip;
-    if (check_var('BACKEND', 's390x')) {
-        ($hostip) = get_var('S390_NETWORK_PARAMS') =~ /HostIP=(.*?)\//;
-    }
-    elsif (check_var('BACKEND', 'svirt')) {
-        $hostip = get_var('VIRSH_GUEST');
-    }
-    $profile =~ s/\{\{HostIP\}\}/$hostip/g if $hostip;
-
-    # Expand other variables
-    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_URL ARCH LOADER_TYPE);
-    # Push more variables to expand from the job setting
-    my @extra_vars = push @vars, split(/,/, get_var('AY_EXPAND_VARS', ''));
-
-    for my $var (@vars) {
-        # Skip if value is not defined
-        next unless my ($value) = get_var($var);
-        $profile =~ s/\{\{$var\}\}/$value/g;
-    }
-    if (check_var('IPXE', '1')) {
-        $path = get_required_var('SUT_IP') . $path;
-    }
-    # Upload modified profile
-    save_tmp_file($path, $profile);
-    # Copy profile to ulogs directory, so profile is available in job logs
-    make_path('ulogs');
-    copy(hashed_string($path), 'ulogs/autoyast_profile.xml');
-    # Set AUTOYAST variable with new url
-    my $url = autoinst_url . "/files/$path";
-    set_var('AUTOYAST', $url);
+    $profile = expand_version($profile);
+    $profile = adjust_network_conf($profile);
+    $profile = expand_variables($profile);
+    upload_profile(profile => $profile, path => $path);
 }
-
 
 sub test_flags {
     return {fatal => 1};


### PR DESCRIPTION
Inject registration block with variable replacement when AutoYaST profile used is a cloned one.

- Related ticket: https://progress.opensuse.org/issues/61931
- Needles: n/a
- Verification run: 
  - [sle-15-SP2-Online-x86_64-Build122.1-autoyast_reinstall@64bit](http://rivera-workstation.suse.cz/tests/834)
  - [sle-15-SP2-Online-x86_64-Build122.1-autoyast_ext4@64bit](http://rivera-workstation.suse.cz/tests/836)