### PR TITLE
Use common method to assert booted system in boot_linuxrc

### DIFF
--- a/schedule/yast/boot_linuxrc.yaml
+++ b/schedule/yast/boot_linuxrc.yaml
@@ -1,5 +1,8 @@
 name:           boot_linuxrc
 description:    >
     Test booting from cd to existing linux with linuxrc.
+vars:
+    DESKTOP: gnome
 schedule:
      - boot/boot_linuxrc
+     - installation/first_boot

--- a/tests/boot/boot_linuxrc.pm
+++ b/tests/boot/boot_linuxrc.pm
@@ -36,7 +36,6 @@ sub run {
     }
     send_key "ret";
     $self->{in_boot_desktop} = 1;
-    assert_screen([qw(linux-login displaymanager generic-desktop)], 180);
 }
 
 


### PR DESCRIPTION
We used `displaymanager` tag to assert that system has booted, but there
is [bsc#1160969](https://bugzilla.suse.com/show_bug.cgi?id=1160969). We
already have a workaround in the first_boot module, so using that one to
avoid unnecessary work in future and be consistent.

- [Verification run](https://openqa.suse.de/tests/3789495#).
