### PR TITLE
[WIP]Add validation function for partition table

### DIFF
--- a/lib/partitions_validator_utils.pm
+++ b/lib/partitions_validator_utils.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+package partitions_validator_utils;
+use strict;
+use warnings;
+use scheduler 'get_test_suite_data';
+use testapi;
+use Test::Assert ':all';
+use Exporter 'import';
+our @EXPORT = 'validate_partition_table';
+
+
+sub validate_partition_table {
+    my ($args) = @_;
+
+    return if check_var('BACKEND', 's390x');    # fdisk output does not show partition table for dasd
+
+    record_info("Check $args->{table_type}", "Verify if partition table type is $args->{table_type}");
+    my @fdisk_output = split(/\n/, script_output("fdisk -l $args->{device}"));
+    my $table_type;
+    foreach (@fdisk_output) {
+        if ($_ =~ /Disklabel\stype: (.+)$/) { $table_type = $1 }
+    }
+    assert_equals($args->{table_type}, $table_type, "Partition table type does not correspond to the expected one.");
+}
+
+1;

--- a/schedule/yast/btrfs/btrfs_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs_opensuse.yaml
@@ -28,6 +28,8 @@ schedule:
   - console/validate_no_cow_attribute
   - console/verify_no_separate_home
 test_data:
+  device: /dev/vda
+  table_type: gpt
   subvolume:
     cow:
       - /

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
@@ -1,4 +1,4 @@
-name:           btrfs_libstorage-ng
+name:           btrfs_libstorage-ng@hmc+ipmi
 description:    >
   Validate default installation with btrfs and Libstorage NG.
 vars:
@@ -79,7 +79,7 @@ conditional_schedule:
       s390x:
         - console/verify_no_separate_home
 test_data:
-  device: /dev/vda
+  device: /dev/sda
   expected_table_type: gpt
   subvolume:
     cow:

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -32,4 +32,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/dasda
+  table_type: dasd
   !include: test_data/yast/ext4/ext4_no_separate_home.yaml

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -32,4 +32,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/vda
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
@@ -30,4 +30,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/xvdb
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -30,4 +30,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/xvdb
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -30,4 +30,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/vda
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -34,4 +34,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/sda
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/tests/console/validate_ext4_fs.pm
+++ b/tests/console/validate_ext4_fs.pm
@@ -16,12 +16,15 @@ use base "opensusebasetest";
 use testapi;
 use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
+use partitions_validator_utils 'validate_partition_table';
 
 sub run {
 
     select_console "root-console";
     my $test_data  = get_test_suite_data();
     my @partitions = @{$test_data->{partitions}};
+
+    validate_partition_table({root_disk => $test_data->{device}, table_type => $test_data->{table_type}});
 
     foreach (@partitions) {
         if ($_->{mnt_point} eq '[SWAP]') {

--- a/tests/console/validate_file_system.pm
+++ b/tests/console/validate_file_system.pm
@@ -19,10 +19,13 @@ use base "opensusebasetest";
 use testapi;
 use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
+use partitions_validator_utils 'validate_partition_table';
 
 sub run {
     my $test_data  = get_test_suite_data();
     my %partitions = %{$test_data->{file_system}};
+
+    validate_partition_table({root_disk => $test_data->{device}, table_type => $test_data->{table_type}});
 
     foreach (keys %partitions) {
         record_info("Check fs $_", "Verify the '$_' partition filesystem is '$partitions{$_}'");


### PR DESCRIPTION
Validate that partition table is GPT by default, except for msdos tests when set and and zVM where default is DASD.

- Related ticket: https://progress.opensuse.org/issues/58912
- Needles: N/A
- Verification runs: 

Ext4:
x64: http://waaa-amazing.suse.cz/tests/11189
x64-uefi:https://openqa.suse.de/tests/3831995
svirt-xen-pv: https://openqa.suse.de/tests/3831994
zkvm: https://openqa.suse.de/tests/3831991
ppc64-smp: https://openqa.suse.de/tests/3831990
aarch64: https://openqa.suse.de/tests/3831989

Excluded: 
zVM: https://openqa.suse.de/tests/3831992#step/validate_ext4_fs/8, as fdisk -l does not show partition tables for dasd

BTRFS:
x64: http://waaa-amazing.suse.cz/tests/11191
aarch64: https://openqa.suse.de/tests/3831696
zkvm: https://openqa.suse.de/tests/3831698
ppc64le: https://openqa.suse.de/tests/3831697



We cannot test on hmc and ipmi currently.
