### PR TITLE
GNOME Multi Writer: authorize root to unmount

### DIFF
--- a/tests/x11/gnomeapps/gnome_multi_writer.pm
+++ b/tests/x11/gnomeapps/gnome_multi_writer.pm
@@ -17,7 +17,11 @@ use testapi;
 use utils;
 
 sub run {
-    assert_gui_app('gnome-multi-writer');
+    x11_start_program('gnome-multi-writer', target_match => [qw(test-gnome-multi-writer-started polkit-unmount-auth-required)]);
+    # With GNOME 3.34, elevated permissions using polkit need be confirmed even if root has no password
+    assert_and_click('polkit-unmount-auth-required', 1) if (match_has_tag 'polkit-unmount-auth-required');
+    assert_screen('test-gnome-multi-writer-started', 2);
+    send_key "alt-f4";
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/61713
- Needles: Already in place
- Verification runs: [openQA](https://openqa.opensuse.org/tests/overview?version=3.34.3&build=DimStar77%2Fos-autoinst-distri-opensuse%239344&distri=opensuse)
