### PR TITLE
[virt_autotest] used with virtio as the network device model during attach-interface via virsh

### DIFF
--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -53,7 +53,9 @@ sub run_test {
     my $gi_host_bridge = '';
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "HOST BRIDGE NETWORK for $guest";
-        assert_script_run("virsh attach-interface $guest network vnet_host_bridge --live");
+        #figure out that used with virtio as the network device model during
+        #attach-interface via virsh worked for all sles guest
+        assert_script_run("virsh attach-interface $guest network vnet_host_bridge --model virtio --live");
         #Get the Guest IP Address from HOST BRIDGE NETWORK
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             my $mac_host_bridge = script_output("virsh domiflist $guest | grep vnet_host_bridge|grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"");
@@ -80,6 +82,9 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
+    #Upload debug log
+    virt_autotest::virtual_network_utils::upload_debug_log();
+
     #Restart libvirtd service
     virt_autotest::virtual_network_utils::restart_libvirtd();
 
@@ -94,9 +99,6 @@ sub post_fail_hook {
 
     #Restore Network setting
     virt_autotest::virtual_network_utils::restore_network($virt_host_bridge);
-
-    #Upload debug log
-    virt_autotest::virtual_network_util::upload_debug_log();
 }
 
 1;

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -46,7 +46,9 @@ sub run_test {
     my $gi_vnet_isolated;
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "ISOLATED NETWORK for $guest";
-        assert_script_run("virsh attach-interface $guest network vnet_isolated --live");
+        #figure out that used with virtio as the network device model during
+        #attach-interface via virsh worked for all sles guest
+        assert_script_run("virsh attach-interface $guest network vnet_isolated --model virtio --live");
         #Get the Guest IP Address from ISOLATED NETWORK
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             my $mac_isolated = script_output("virsh domiflist $guest | grep vnet_isolated | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"");
@@ -82,6 +84,9 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
+    #Upload debug log
+    virt_autotest::virtual_network_utils::upload_debug_log();
+
     #Restart libvirtd service
     virt_autotest::virtual_network_utils::restart_libvirtd();
 
@@ -93,9 +98,6 @@ sub post_fail_hook {
 
     #Restore Guest systems
     virt_autotest::virtual_network_utils::restore_guests();
-
-    #Upload debug log
-    virt_autotest::virtual_network_utils::upload_debug_log();
 }
 
 1;

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -51,7 +51,9 @@ sub run_test {
     my $gi_vnet_nated;
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "NAT BASED NETWORK for $guest";
-        assert_script_run("virsh attach-interface $guest network vnet_nated --live", 60);
+        #figure out that used with virtio as the network device model during
+        #attach-interface via virsh worked for all sles guest
+        assert_script_run("virsh attach-interface $guest network vnet_nated --model virtio --live", 60);
         #Get the Guest IP Address from NAT BASED NETWORK
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             my $mac_nated = script_output("virsh domiflist $guest | grep vnet_nated | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"");
@@ -78,6 +80,9 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
+    #Upload debug log
+    virt_autotest::virtual_network_utils::upload_debug_log();
+
     #Restart libvirtd service
     virt_autotest::virtual_network_utils::restart_libvirtd();
 
@@ -92,9 +97,6 @@ sub post_fail_hook {
 
     #Restore Guest systems
     virt_autotest::virtual_network_utils::restore_guests();
-
-    #Upload debug log
-    virt_autotest::virtual_network_utils::upload_debug_log();
 }
 
 1;

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -62,8 +62,10 @@ sub run_test {
         assert_script_run("virt-clone -o $guest -n $guest.clone -f /var/lib/libvirt/images/$guest.clone");
         assert_script_run("virsh start $guest");
         assert_script_run("virsh start $guest.clone");
-        assert_script_run("virsh attach-interface $guest network vnet_routed --live");
-        assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --live");
+        #figure out that used with virtio as the network device model during
+        #attach-interface via virsh worked for all sles guest
+        assert_script_run("virsh attach-interface $guest network vnet_routed --model virtio --live");
+        assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --model virtio --live");
         #Get the Guest IP Address from ROUTED NETWORK
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             my $mac_routed = script_output("virsh domiflist $guest | grep vnet_routed | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"");
@@ -99,6 +101,9 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
+    #Upload debug log
+    virt_autotest::virtual_network_utils::upload_debug_log();
+
     #Restart libvirtd service
     virt_autotest::virtual_network_utils::restart_libvirtd();
 
@@ -110,9 +115,6 @@ sub post_fail_hook {
 
     #Restore Guest systems
     virt_autotest::virtual_network_utils::restore_guests();
-
-    #Upload debug log
-    virt_autotest::virtual_network_utils::upload_debug_log();
 }
 
 1;


### PR DESCRIPTION
There was created PCIE device as default on sles15sp1 and sles15sp2 guest.
So, figure out that used with virtio as the network device model during attach-interface via virsh
worked for all sles guest as this PR. 

- Verification run: http://10.67.19.82/tests/405