### PR TITLE
Do not set desktop in boot_linuxrc yaml

### DIFF
--- a/schedule/yast/boot_linuxrc.yaml
+++ b/schedule/yast/boot_linuxrc.yaml
@@ -1,8 +1,6 @@
 name:           boot_linuxrc
 description:    >
     Test booting from cd to existing linux with linuxrc.
-vars:
-    DESKTOP: gnome
 schedule:
      - boot/boot_linuxrc
      - installation/first_boot


### PR DESCRIPTION
For Leap.15.2 we get KDE as desktop, so asserting fails. Moving this
setting to the test suite to reuse same yaml file.

Fixes issue mentioned in #9340.