### PR TITLE
Adjust AY EULA profile to be used with Full medium

### DIFF
--- a/data/autoyast_sle15/autoyast_eula.xml
+++ b/data/autoyast_sle15/autoyast_eula.xml
@@ -15,19 +15,19 @@
     <add-on>
         <add_on_products config:type="list">
              <listentry>
-                <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+                <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
                 <product>sle-module-basesystem</product>
                 <product_dir>/Module-Basesystem</product_dir>
              </listentry>
              <listentry>
-                <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+                <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
                 <product_dir>/Product-HA</product_dir>
                 <product>sle-ha</product>
                 <alias>High availability module</alias>
                 <confirm_license config:type="boolean">true</confirm_license>
             </listentry>
             <listentry>
-                <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+                <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
                 <product_dir>/Product-WE</product_dir>
                 <product>sle-we</product>
                 <alias>Workstation Extension</alias>

--- a/schedule/yast/autoyast_eula.yaml
+++ b/schedule/yast/autoyast_eula.yaml
@@ -1,0 +1,21 @@
+name:           autoyast_eula
+description:    >
+  User agreement test, same as autoyast_eula but with modules adjusted for sle15.
+  Now expect single license, as content of all licenses is the same and we don't show it.
+  Packages DVD is vanished, using "Full" installer instead. 
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_eula.xml
+  AUTOYAST_LICENSE: 1
+  DESKTOP: textmode
+schedule:
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot


### PR DESCRIPTION
We have disabled scenario as all-packages DVD doesn't exist for
SLE15 SP2, whereas it still makes sense to execute this scenario for
the Full medium.

See [poo#57764](https://progress.opensuse.org/issues/57764).

[Verification run](https://openqa.suse.de/tests/3793267).

[Job group settings MR](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/merge_requests/119).
