### PR TITLE
Fix socket usage in ctdb test

### DIFF
--- a/data/ha/smb.conf
+++ b/data/ha/smb.conf
@@ -3,7 +3,7 @@
     clustering = yes
     idmap config * : backend = tdb2
     passdb backend = tdbsam
-    ctdbd socket = /var/lib/ctdb/ctdb.socket
+    ctdbd socket = %CTDB_SOCKET%
     # settings necessary for CTDB on OCFS2
     fileid:algorithm = fsid
     vfs objects = fileid
@@ -36,3 +36,4 @@
     valid users = root, administrator
     read only = No
     inherit acls = Yes
+


### PR DESCRIPTION
ctdb socket is different according to OS version.

- Failed test: https://openqa.suse.de/tests/3772879
- Related ticket: N/A
- Needles: N/A
- Verification run: TBD
15SP2: [ha_ctdb_client](http://1a102.qa.suse.de/tests/2727) [ha_ctdb_node01](http://1a102.qa.suse.de/tests/2728) [ha_ctdb_node02](http://1a102.qa.suse.de/tests/2729)
15SP1: [ha_ctdb_client](http://1a102.qa.suse.de/tests/2717) [ha_ctdb_node01](http://1a102.qa.suse.de/tests/2715) [ha_ctdb_node02](http://1a102.qa.suse.de/tests/2716)
15SP1 test failed in haproxy but it's not related to this PR.

