### PR TITLE
[qam][newt] libqca2

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1595,6 +1595,7 @@ sub load_extra_tests_opensuse {
     loadtest "console/weechat";
     loadtest "console/nano";
     loadtest "console/steamcmd" if (check_var('ARCH', 'i586') || is_x86_64);
+    loadtest "console/libqca2";
 }
 
 sub load_extra_tests_qemu {

--- a/schedule/qam/12-SP4/mau-extratests.yaml
+++ b/schedule/qam/12-SP4/mau-extratests.yaml
@@ -59,6 +59,7 @@ schedule:
 - console/aaa_base
 - console/osinfo_db
 - console/libgcrypt
+- console/libqca2
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -60,6 +60,7 @@ schedule:
 - console/aaa_base
 - console/osinfo_db
 - console/libgcrypt
+- console/libqca2
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -62,6 +62,7 @@ schedule:
 - console/aaa_base
 - console/osinfo_db
 - console/libgcrypt
+- console/libqca2
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/tests/console/libqca2.pm
+++ b/tests/console/libqca2.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: test qcatool commands
+# - check program version
+# - list plugins
+# - create new rsa key
+# - create new cert
+# - show cert
+# - bundle key and cert
+# - list stores
+# - monitor keystore
+# Maintainer: Paolo Stivanin <pstivanin@suse.com>
+
+use base "opensusebasetest";
+use testapi;
+use utils;
+use strict;
+use warnings;
+use version_utils qw(is_sle is_leap is_tumbleweed);
+use registration qw(add_suseconnect_product register_product);
+
+sub run {
+    select_console 'root-console';
+    if (is_tumbleweed || is_leap) {
+        zypper_call("in libqca-qt5 libqca-qt5-devel", timeout => 300);
+    } else {
+        add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1) if is_sle(">=15");
+        zypper_call("in libqca2 libqca2-devel", timeout => 300);
+    }
+
+    my $qca_cmd;
+    if (is_sle("<15")) {
+        $qca_cmd = "qcatool2";
+    }
+    if (is_sle(">=15")) {
+        $qca_cmd = "qcatool";
+    }
+    if (is_tumbleweed || is_leap) {
+        $qca_cmd = "qcatool-qt5";
+    }
+
+    assert_script_run "$qca_cmd version";
+    assert_script_run "$qca_cmd plugins";
+    assert_script_run "$qca_cmd plugins --debug";
+    assert_script_run "$qca_cmd key make rsa 1024 --newpass=suse";
+    script_run "$qca_cmd cert makeself rsapriv.pem --pass=suse";
+    type_string "tester\n";
+    type_string "DE\n";
+    type_string "SUSE\n";
+    type_string "tester\@suse.com\n";
+    type_string "1y\n";
+
+    assert_script_run "$qca_cmd show cert cert.pem";
+    assert_script_run "$qca_cmd keybundle make rsapriv.pem cert.pem --pass=suse --newpass=suse";
+    assert_script_run "$qca_cmd keystore list-stores";
+    script_run "$qca_cmd keystore monitor";
+    type_string "q\n";
+    assert_script_run "$qca_cmd show kb cert.p12 --pass=suse";
+
+    script_run "rm -f cert.pem rsapriv.pem rsapub.pem";
+}
+
+1;


### PR DESCRIPTION
Add test for libqca on SLE >= 12.sp4 (it needs SDK).

- Related ticket: https://progress.opensuse.org/issues/52349
- Verification runs:
  - oS TW: https://openqa.opensuse.org/tests/1146628 :heavy_check_mark: 
  - oS Leap: https://openqa.opensuse.org/tests/1146629 :heavy_check_mark: 
  - 15sp1: http://d250.qam.suse.de/tests/2386 :heavy_check_mark: 
  - 15sp0: http://d250.qam.suse.de/tests/2398 :heavy_check_mark: 
  - 12sp4: http://d250.qam.suse.de/tests/2390 :heavy_check_mark: 