### PR TITLE
Only try to purge kernels

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -117,7 +117,7 @@ sub add_custom_grub_entries {
     }
 
     bmwqemu::diag("Trying to trigger purging old kernels before changing grub menu");
-    assert_script_run('[ -x /sbin/purge-kernels ] && /sbin/purge-kernels');
+    script_run('/sbin/purge-kernels');
 
     assert_script_run("cp " . GRUB_CFG_FILE . " $cfg_old");
     upload_logs($cfg_old, failok => 1);


### PR DESCRIPTION
This might fail for some unknown reason and if so, then purging shouldn't
happen while updating the grub menu because the service should also fail.

@pevik @metan-ucw