### PR TITLE
Install qa test repo on SLES after offline upgrade

### DIFF
--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -13,6 +13,7 @@
 
 use base "host_upgrade_base";
 use testapi;
+use utils "zypper_call";
 use virt_utils;
 use strict;
 use warnings;
@@ -28,6 +29,19 @@ sub get_script_run {
 
 sub run {
     my $self = shift;
+
+    #Install qa test repo
+    my $installed_product = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
+    my $upgrade_product   = get_required_var('UPGRADE_PRODUCT');
+    my ($upgrade_release) = lc($upgrade_product) =~ /sles-([0-9]+-sp[0-9]+)/;
+    if (check_var('ARCH', 'x86_64') && $installed_product =~ /12-sp5/img && $upgrade_product =~ /15-sp2/img) {
+        my $qa_test_repo = 'http://dist.nue.suse.com/ibs/QA:/Head/SLE-' . uc($upgrade_release);
+        script_run("zypper rm -n -y qa_lib_virtauto", 300);
+        zypper_call("rr server-repo qa-test-repo");
+        zypper_call("--no-gpg-check ar -f '$qa_test_repo' qa-test-repo");
+        zypper_call("--gpg-auto-import-keys ref", 300);
+        zypper_call("in qa_lib_virtauto",         300);
+    }
     update_guest_configurations_with_daily_build();
     $self->run_test(5400, "Host upgrade virtualization test pass", "no", "yes", "/var/log/qa/", "host-upgrade-postVerify-logs");
 }


### PR DESCRIPTION
Install qa test repo on upgraded SLES after offline upgrade, in order to prevent unnecessary missing files or directories.

- Related ticket: 
https://openqa.nue.suse.com/tests/3808854#step/host_upgrade_step3_run/40
https://openqa.nue.suse.com/tests/3808843#step/host_upgrade_step3_run/40
- Needles: n/a
- Verification run:
                          1.  http://10.67.19.99/tests/721
                          2. Manual verification for the following script:
                              my $installed_product = "12-SP5";
                              my $upgrade_product   = "sles-15-SP2";
                              if ($installed_product =~ /12-sp5/img && $upgrade_product =~ /15-sp2/img) {
                                  print 'OK';
                              }
