### PR TITLE
Before enter regcode, check untrust gpg key for packagehub

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -464,6 +464,9 @@ sub process_scc_register_addons {
         wait_still_screen 2;
         # Process addons licenses
         accept_addons_license @scc_addons;
+        if (get_var('SCC_ADDONS') =~ /phub/ && check_screen('import-untrusted-gpg-key')) {
+            handle_untrusted_gpg_key;
+        }
         # Press next only if entered reg code for any addon
         if (register_addons @scc_addons) {
             assert_screen 'ext-modules-reg-codes';


### PR DESCRIPTION
If add package-hub module, it need check untrust gpg key first. Then enter the reg-code for other modules.

- Related ticket: https://progress.opensuse.org/issues/62318
- Verification run: https://openqa.suse.de/tests/3810029#step/register_system/27