### PR TITLE
Improve HA QAM automation in openQA

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -59,6 +59,7 @@ our @EXPORT = qw(
   post_run_hook
   post_fail_hook
   test_flags
+  is_not_maintenance_update
 );
 
 # Global variables
@@ -504,6 +505,16 @@ sub post_fail_hook {
 
 sub test_flags {
     return {milestone => 1, fatal => 1};
+}
+
+sub is_not_maintenance_update {
+    my $package = shift;
+    # Allow to skip an openQA module if package is not targeted by maintenance update
+    if (get_var('MAINTENANCE') && get_var('BUILD') !~ /$package/) {
+        record_info('Skipped - MU', "$package test not needed here");
+        return 1;
+    }
+    return 0;
 }
 
 1;

--- a/schedule/ha/qam/15-SP1/qam-client.yaml
+++ b/schedule/ha/qam/15-SP1/qam-client.yaml
@@ -1,0 +1,11 @@
+name:           qam-client_2nodes
+description:    >
+    Create a client server for 2 nodes cluster tests
+    Further info about the test suite
+schedule:
+    - boot/boot_to_desktop
+    - console/system_prepare
+    - console/consoletest_setup
+    - console/check_os_release
+    - console/hostname
+    - ha/ctdb

--- a/schedule/ha/qam/15-SP1/qam-cluster_2nodes_01.yaml
+++ b/schedule/ha/qam/15-SP1/qam-cluster_2nodes_01.yaml
@@ -1,0 +1,31 @@
+name:           qam-cluster_2nodes
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/fencing
+  - boot/boot_to_desktop
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs

--- a/schedule/ha/qam/15-SP1/qam-cluster_2nodes_02.yaml
+++ b/schedule/ha/qam/15-SP1/qam-cluster_2nodes_02.yaml
@@ -1,0 +1,30 @@
+name:           qam-cluster_2nodes
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/fencing
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs

--- a/tests/ha/ctdb.pm
+++ b/tests/ha/ctdb.pm
@@ -20,6 +20,9 @@ use version_utils 'is_sle';
 use utils qw(systemctl file_content_replace);
 
 sub run {
+    # Exit of this module if we are in a maintenance update not related to samba
+    return 1 if is_not_maintenance_update('samba');
+
     my $cluster_name = get_cluster_name;
     my $vip_ip       = '10.0.2.20';
     my $ctdb_folder  = '/srv/fs_cluster_md/ctdb';

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -29,6 +29,10 @@ sub assert_standalone {
 }
 
 sub run {
+    # Exit of this module if we are in a maintenance update not related to drbd
+    # write_tag is mandatory for next filesystem module
+    write_tag('drbd_passive') and return 1 if is_not_maintenance_update('drbd');
+
     my $cluster_name  = get_cluster_name;
     my $drbd_rsc      = 'drbd_passive';
     my $drbd_rsc_file = "/etc/drbd.d/$drbd_rsc.res";

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -19,6 +19,9 @@ use lockapi;
 use hacluster;
 
 sub run {
+    # Exit of this module if 'tag=drbd_passive' and if we are in a maintenance update not related to drbd
+    return 1 if (read_tag eq 'drbd_passive' and is_not_maintenance_update('drbd'));
+
     my $cluster_name = get_cluster_name;
     my $node         = get_hostname;
     my $fs_lun       = undef;

--- a/tests/ha/haproxy.pm
+++ b/tests/ha/haproxy.pm
@@ -19,6 +19,9 @@ use utils qw(zypper_call systemctl);
 use hacluster;
 
 sub run {
+    # Exit of this module if we are in a maintenance update not related to haproxy
+    return 1 if is_not_maintenance_update('haproxy');
+
     my $cluster_name = get_cluster_name;
     my $haproxy_rsc  = 'haproxy';
     my $haproxy_cfg  = '/etc/haproxy/haproxy.cfg';


### PR DESCRIPTION
This PR adds more precision for HA QAM automation and scheduling YAML usage only for 15SP1.

Others PR will follow but I have to make sure that our current BV tests are working with previous SLE version (for QAM).

Until now, when a maintenance update is released for HA, we just create basic 2 nodes and 3 nodes clusters, tests are identical all the time, nothing specific in relation with packages to test.

With this PR, specific tests are triggered depending of BUILD variable content, we can take samba as an example:
`BUILD=":13499:samba"`
In this case, ctdb tests will be executed to find if regression exists.

- Related ticket: N/A
- Needles: N/A
- Verification run: 

**drbd MU 15SP1:** [Node1](http://1a102.qa.suse.de/tests/2872) - [Node2](http://1a102.qa.suse.de/tests/2873) - [Client](http://1a102.qa.suse.de/tests/2874)
**samba/ctdb MU 15SP1:** [Node1](http://1a102.qa.suse.de/tests/2868) - [Node2](http://1a102.qa.suse.de/tests/2869) - [Client](http://1a102.qa.suse.de/tests/2874)
**haproxy MU 15SP1:** [Node1](http://1a102.qa.suse.de/tests/2831) - [Node2](http://1a102.qa.suse.de/tests/2832) - [Client](http://1a102.qa.suse.de/tests/2833)
**15 SP2:** [Node1](http://1a102.qa.suse.de/tests/2876) - [Node2](http://1a102.qa.suse.de/tests/2877)
