### PR TITLE
HPC: Introduce new barrier

### DIFF
--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -23,6 +23,7 @@ sub run {
 
     # Initialize barriers
     if (check_var('HPC', 'slurm')) {
+        barrier_create('CLUSTER_PROVISIONED',          $nodes);
         barrier_create('SLURM_MASTER_SERVICE_ENABLED', $nodes);
         barrier_create('SLURM_SLAVE_SERVICE_ENABLED',  $nodes);
         barrier_create('SLURM_SETUP_DONE',             $nodes);

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -24,6 +24,9 @@ use version_utils 'is_sle';
 sub run {
     my $self     = shift;
     my $hostname = get_required_var("HOSTNAME");
+
+    barrier_wait('CLUSTER_PROVISIONED');
+
     $self->prepare_user_and_group();
 
     # Install slurm

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -432,6 +432,8 @@ sub run {
     my $nodes      = get_required_var('CLUSTER_NODES');
     my $slurm_conf = get_required_var('SLURM_CONF');
     my $version    = get_required_var('VERSION');
+
+    barrier_wait('CLUSTER_PROVISIONED');
     $self->prepare_user_and_group();
     $self->generate_and_distribute_ssh();
 

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -21,6 +21,8 @@ sub run {
     my $self  = shift;
     my $nodes = get_required_var("CLUSTER_NODES");
 
+    barrier_wait('CLUSTER_PROVISIONED');
+
     $self->prepare_user_and_group();
     zypper_call('in slurm slurm-munge');
 

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -22,6 +22,9 @@ use utils;
 sub run {
     my $self  = shift;
     my $nodes = get_required_var("CLUSTER_NODES");
+
+    barrier_wait('CLUSTER_PROVISIONED');
+
     $self->prepare_user_and_group();
     zypper_call('in slurm slurm-munge');
 

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -29,6 +29,7 @@ sub run {
     # install slurm-node if sle15, not available yet for sle12
     zypper_call('in slurm-node') if is_sle '15+';
 
+    barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait("SLURM_SETUP_DONE");
     barrier_wait('SLURM_SETUP_DBD');
     barrier_wait("SLURM_MASTER_SERVICE_ENABLED");


### PR DESCRIPTION
As the HPC test code is moving towards decoupling from the HPC cluster
provisioning, unwanted race conditation was introduced. Master node
can try to talk to any other node before sanity, node provisioning
operations will be completed. In order to avoid this, the new barrier
is introduced

- Verification run: http://10.160.65.14/tests/15288
