### PR TITLE
Public Cloud: fix problem when returning malformed json

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -99,9 +99,14 @@ sub find_img {
     $name =~ s/\.vhdfixed$/.vhd/;
     my $json = script_output("az image show --resource-group " . $self->resource_group . " --name $name", 60, proceed_on_failure => 1);
     record_info('INFO', $json);
-    my $image = decode_azure_json($json);
-    return unless ($image);
-    return $image->{name};
+    eval {
+        my $image = decode_azure_json($json);
+        return $image->{name};
+    };
+    if ($@) {
+        record_info('INFO', "Cannot find image $name. Need to upload it.\n$@");
+        return;
+    }
 }
 
 sub get_storage_account_keys {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -423,6 +423,7 @@ Destroys the current terraform deployment
 =cut
 sub terraform_destroy {
     my ($self) = @_;
+    return if get_required_var('TEST') eq 'publiccloud_upload_img';
     record_info('INFO', 'Removing terraform plan...');
     if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
         assert_script_run('cd ' . TERRAFORM_DIR . '/' . $self->conv_openqa_tf_name);


### PR DESCRIPTION
When the image doesn't exist, the `az image show` command returns some error message (no json) and `decode_json` function fails and the test dies.

- Verification run: http://fromm.arch.suse.de/tests/406
