### PR TITLE
Update firefox_downloading.pm

### DIFF
--- a/tests/x11/firefox/firefox_downloading.pm
+++ b/tests/x11/firefox/firefox_downloading.pm
@@ -37,7 +37,7 @@ use testapi;
 use version_utils 'is_sle';
 
 my $dl_link_01 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso";
-my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/leap/42.3/iso/openSUSE-Leap-42.3-DVD-x86_64.iso";
+my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.0/iso/openSUSE-Leap-15.0-DVD-x86_64.iso";
 
 sub dl_location_switch {
     my ($tg) = @_;


### PR DESCRIPTION
Use 15.0 instead of 42.3 as the latter is a very old release and might disappear as happened with 42.2 (that was replaced with 15.1)

- Related ticket: https://progress.opensuse.org/issues/62120
- Verification run: https://openqa.suse.de/tests/3811386 :heavy_check_mark: 
