### PR TITLE
Fix LTP installation on SLE-11

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -352,7 +352,7 @@ sub run {
 
     $grub_param .= ' console=hvc0'     if (get_var('ARCH') eq 'ppc64le');
     $grub_param .= ' console=ttysclp0' if (get_var('ARCH') eq 's390x');
-    if (defined $grub_param) {
+    if (!is_sle('<12') && defined $grub_param) {
         add_grub_cmdline_settings($grub_param, update_grub => 1);
     }
 

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -53,7 +53,7 @@ sub update_kernel {
     my ($repo, $incident_id) = @_;
 
     fully_patch_system;
-    zypper_call('in kernel-devel');
+    zypper_call('in kernel-devel') if is_sle('12+');
 
     my @repos = split(",", $repo);
     while (my ($i, $val) = each(@repos)) {
@@ -153,7 +153,7 @@ sub install_lock_kernel {
 
     my @lpackages = @packages;
 
-    push @packages, "kernel-devel";
+    push @packages, "kernel-devel" if is_sle('12+');
 
     # extend list of packages with $version + workaround exceptions
     foreach my $package (@packages) {


### PR DESCRIPTION
The package `kernel-devel` isn't available on test systems and it's not needed for any kgraft tests.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-11SP3: https://openqa.suse.de/tests/3811593
  - SLE-12SP5: https://openqa.suse.de/tests/3811596
