### PR TITLE
Revert "Move orphaned_packages_check before other console tests"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1125,7 +1125,6 @@ sub load_consoletests {
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";
     }
-    loadtest 'console/orphaned_packages_check' if is_jeos || get_var('UPGRADE') || get_var('ZDUP') || !is_sle('<12-SP4');
     loadtest "console/textinfo";
     loadtest "console/rmt" if is_rmt;
     loadtest "console/hostname" unless is_bridged_networking;
@@ -1239,6 +1238,7 @@ sub load_consoletests {
     if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && is_sle('<15') && !get_var("MEDIA_UPGRADE")) {
         loadtest "feature/feature_console/deregister";
     }
+    loadtest 'console/orphaned_packages_check' if is_jeos || get_var('UPGRADE') || get_var('ZDUP') || !is_sle('<12-SP4');
     loadtest "console/consoletest_finish";
 }
 

--- a/schedule/qam/12-SP1/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP1/qam-minimal-base.yaml
@@ -31,7 +31,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -58,5 +57,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/12-SP1/qam-textmode-autoyast.yaml
+++ b/schedule/qam/12-SP1/qam-textmode-autoyast.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -50,5 +49,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/12-SP2/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP2/qam-minimal-base.yaml
@@ -32,7 +32,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -60,5 +59,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/12-SP2/qam-textmode-autoyast.yaml
+++ b/schedule/qam/12-SP2/qam-textmode-autoyast.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -51,5 +50,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/12-SP3/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP3/qam-minimal-base.yaml
@@ -32,7 +32,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -60,5 +59,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/12-SP3/qam-textmode-autoyast.yaml
+++ b/schedule/qam/12-SP3/qam-textmode-autoyast.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -51,5 +50,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/12-SP4/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP4/qam-allpatterns.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/consoletest_setup
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -42,6 +41,7 @@ schedule:
 - console/ssh_cleanup
 - console/mtab
 - console/zypper_lifecycle
+- console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
 - x11/xterm

--- a/schedule/qam/12-SP4/qam-gnome.yaml
+++ b/schedule/qam/12-SP4/qam-gnome.yaml
@@ -21,7 +21,6 @@ schedule:
 - console/consoletest_setup
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -40,6 +39,7 @@ schedule:
 - console/ssh_cleanup
 - console/mtab
 - console/zypper_lifecycle
+- console/orphaned_packages_check
 - console/consoletest_finish
 - update/prepare_system_for_update_tests
 - update/updates_packagekit_gpk

--- a/schedule/qam/12-SP4/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP4/qam-minimal-base.yaml
@@ -31,7 +31,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -59,6 +58,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
   boot:

--- a/schedule/qam/12-SP4/qam-textmode-autoyast.yaml
+++ b/schedule/qam/12-SP4/qam-textmode-autoyast.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -51,5 +50,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/12-SP5/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP5/qam-allpatterns.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/consoletest_setup
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -42,6 +41,7 @@ schedule:
 - console/ssh_cleanup
 - console/mtab
 - console/zypper_lifecycle
+- console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
 - x11/xterm

--- a/schedule/qam/12-SP5/qam-gnome.yaml
+++ b/schedule/qam/12-SP5/qam-gnome.yaml
@@ -21,7 +21,6 @@ schedule:
 - console/consoletest_setup
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -40,6 +39,7 @@ schedule:
 - console/ssh_cleanup
 - console/mtab
 - console/zypper_lifecycle
+- console/orphaned_packages_check
 - console/consoletest_finish
 - update/prepare_system_for_update_tests
 - update/updates_packagekit_gpk

--- a/schedule/qam/12-SP5/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-base.yaml
@@ -31,7 +31,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -59,6 +58,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
   boot:

--- a/schedule/qam/12-SP5/qam-textmode-autoyast.yaml
+++ b/schedule/qam/12-SP5/qam-textmode-autoyast.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -51,5 +50,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/15-SP1/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP1/qam-allpatterns.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/consoletest_setup
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -43,6 +42,7 @@ schedule:
 - console/ssh_cleanup
 - console/mtab
 - console/zypper_lifecycle
+- console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
 - x11/xterm

--- a/schedule/qam/15-SP1/qam-gnome.yaml
+++ b/schedule/qam/15-SP1/qam-gnome.yaml
@@ -21,7 +21,6 @@ schedule:
 - console/consoletest_setup
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -41,6 +40,7 @@ schedule:
 - console/ssh_cleanup
 - console/mtab
 - console/zypper_lifecycle
+- console/orphaned_packages_check
 - console/consoletest_finish
 - update/prepare_system_for_update_tests
 - update/updates_packagekit_gpk

--- a/schedule/qam/15-SP1/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP1/qam-minimal-base.yaml
@@ -31,7 +31,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -60,6 +59,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
   boot:

--- a/schedule/qam/15-SP1/qam-textmode.yaml
+++ b/schedule/qam/15-SP1/qam-textmode.yaml
@@ -31,7 +31,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -61,5 +60,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...

--- a/schedule/qam/15/qam-allpatterns.yaml
+++ b/schedule/qam/15/qam-allpatterns.yaml
@@ -22,7 +22,6 @@ schedule:
 - console/consoletest_setup
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -43,6 +42,7 @@ schedule:
 - console/ssh_cleanup
 - console/mtab
 - console/zypper_lifecycle
+- console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
 - x11/xterm

--- a/schedule/qam/15/qam-gnome.yaml
+++ b/schedule/qam/15/qam-gnome.yaml
@@ -21,7 +21,6 @@ schedule:
 - console/consoletest_setup
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -41,6 +40,7 @@ schedule:
 - console/ssh_cleanup
 - console/mtab
 - console/zypper_lifecycle
+- console/orphaned_packages_check
 - console/consoletest_finish
 - update/prepare_system_for_update_tests
 - update/updates_packagekit_gpk

--- a/schedule/qam/15/qam-minimal-base.yaml
+++ b/schedule/qam/15/qam-minimal-base.yaml
@@ -31,7 +31,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -60,6 +59,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
   boot:

--- a/schedule/qam/15/qam-textmode.yaml
+++ b/schedule/qam/15/qam-textmode.yaml
@@ -31,7 +31,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - console/force_scheduled_tasks
-- console/orphaned_packages_check
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
@@ -61,5 +60,6 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- console/orphaned_packages_check
 - console/coredump_collect
 ...


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#9375

See comments on the poo ticket about the issues generated by this PR