### PR TITLE
Wait screen still then send 'next' key for yast2-migration-proposal

### DIFF
--- a/tests/migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/migration/sle12_online_migration/yast2_migration.pm
@@ -204,6 +204,7 @@ sub run {
     assert_screen 'yast2-migration-target';
     send_key "alt-p";                                       # focus on the item of possible migration targets
     send_key_until_needlematch 'migration-target-' . get_var("VERSION"), 'down', 5;
+    wait_still_screen 5;
     send_key "alt-n";
     assert_screen ['yast2-migration-installupdate', 'yast2-migration-proposal'], 500;
     if (match_has_tag 'yast2-migration-installupdate') {


### PR DESCRIPTION
After match the 'migration-target-15-SP2' we will send the key 'alt-n', but the next screen 'yast2-migration-proposal' can't be catched. I think it is because the screen 'migration-target-15-SP2' is not shown completely so send 'next' key is not accepted. Just wait the screen still then send 'next' key.

- Related ticket: https://progress.opensuse.org/issues/61877
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3813032#step/yast2_migration/21
                            https://openqa.suse.de/tests/3813046#step/yast2_migration/21
                            https://openqa.suse.de/tests/3813047#step/yast2_migration/21
