### PR TITLE
Add fatal => 0 flag for orphaned packages module

### DIFF
--- a/tests/console/orphaned_packages_check.pm
+++ b/tests/console/orphaned_packages_check.pm
@@ -79,4 +79,8 @@ sub post_fail_hook {
 
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
We need regression test continue even after orphaned packages module failed.

- Related ticket: https://progress.opensuse.org/issues/62273
- Needles: na
- Verification run: http://openqa.suse.de/t3813014