### PR TITLE
Remove bsc#980337 soft failure

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -178,12 +178,10 @@ sub reset_consoles_tty {
 
 # Assert read-only snapshot before migrated
 # Assert screen 'linux-login' with 200s
-# Workaround known issue: bsc#980337
 # In this case try to select tty1 with multi-times then select root console
 sub boot_into_ro_snapshot {
     unlock_if_encrypted(check_typed_password => 1);
     if (!check_screen('linux-login', 200)) {
-        record_soft_failure 'bsc#980337';
         for (1 .. 10) {
             check_var('VIRSH_VMM_FAMILY', 'hyperv') ? send_key 'alt-f1' : send_key 'ctrl-alt-f1';
             if (check_screen('tty1-selected', 12)) {

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -815,8 +815,6 @@ sub wait_boot_textmode {
         assert_screen $textmode_needles, $ready_time;
     }
     elsif (is_sle('<15') && !check_screen $textmode_needles, $ready_time / 2) {
-        # We are not able to boot due to bsc#980337
-        record_soft_failure 'bsc#980337';
         # Switch to root console and continue
         select_console 'root-console';
     }


### PR DESCRIPTION
Remove bsc#980337 soft failure

The aforementioned bug is long gone, and systems are able to boot
properly.

Related ticket: https://progress.opensuse.org/issues/48566

* XEN: https://openqa.suse.de/tests/3766976#step/user_defined_snapshot/40 
* Migration: https://openqa.suse.de/tests/2915080#step/snapper_rollback/14 
* X86: https://openqa.suse.de/tests/3796732#step/user_defined_snapshot/41 