### PR TITLE
Revert "Revert "Remove hostname workaround bsc#1153402""

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -787,12 +787,6 @@ sub set_hostname {
     systemctl 'status network.service';
     save_screenshot;
     assert_script_run "if systemctl -q is-active network.service; then systemctl reload-or-restart network.service; fi";
-
-    # Workaround for HA MM test (hostname bug? in 15SP1/SP2)
-    if (script_run "uname -n | grep $hostname") {
-        record_soft_failure('bsc#1153402 hostname not properly configured');
-        assert_script_run "hostnamectl set-hostname $hostname";
-    }
 }
 
 =head2 assert_and_click_until_screen_change

--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -26,9 +26,13 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils "is_sle";
 
 sub run {
     select_console 'root-console';
+
+    # Since 15SP1 DHCLIENT_SET_HOSTNAME must be disable bsc#1153402
+    file_content_replace('/etc/sysconfig/network/dhcp', 'DHCLIENT_SET_HOSTNAME="yes"' => 'DHCLIENT_SET_HOSTNAME="no"') if is_sle('15-SP1+');
 
     set_hostname(get_var('HOSTNAME', 'susetest'));
 }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#9381

After more investigations, #9336 is not the culprit of broken tests. According with Jozef and Alvaro, we  do a revert of a revert.