### PR TITLE
Check device status is up after renaming in yast2 lan

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -150,6 +150,19 @@ sub check_network_status {
     type_string "\n\n";                                               # make space for better readability of the console
 }
 
+=head2 check_device_state
+
+ check_device_state($args);
+
+Checks state of the device using ip command, receives keys C<device> which contains
+device name and C<state> which contains expected state of the device.
+
+=cut
+sub check_device_state {
+    my ($args) = @_;
+    assert_script_run "ip -s link show @{ [ $args->{device} ] } | grep -i 'state @{ [ $args->{state} ] }'";    # check if provided device is up and running
+}
+
 =head2 verify_network_configuration
 
  verify_network_configuration([$fn], [$dev_name], [$expected_status], [$workaround], [$no_network_check]);
@@ -176,6 +189,7 @@ sub verify_network_configuration {
     $fn->($dev_name) if $fn;    # verify specific action
 
     close_network_settings;
+    check_device_state({device => $dev_name, state => 'UP'}) if $dev_name;
     check_network_status($expected_status, $workaround) unless defined $no_network_check;
 }
 

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -92,7 +92,7 @@ sub run {
         check_etc_hosts_update() if get_var('VALIDATE_ETC_HOSTS');
         verify_network_configuration(\&check_network_card_setup_tabs);
         verify_network_configuration(\&check_default_gateway);
-        verify_network_configuration(\&change_hw_device_name, 'dyn0', 'restart');
+        verify_network_configuration(\&change_hw_device_name, 'dyn0');
     }
     type_string "killall xterm\n";
 }


### PR DESCRIPTION
We have this test failing because yast doesn't restart network after
renaming device anymore. Point is that device is correctly renamed and
reconfigured. Therefore, it makes more sense to check that state is
correct instead of verifying if network was restarted.

See [poo#60392](https://progress.opensuse.org/issues/60392).

More improvements will be added in [poo#62465](https://progress.opensuse.org/issues/62465).

[Verification run](https://openqa.suse.de/tests/3814222#).
