### PR TITLE
Search explicitly only package

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -53,7 +53,7 @@ sub install_packages {
             );
             zypper_call("rm $conflict{$package}", exitcode => [0, 104]) if $conflict{$package};
             # go to next package if it's not provided by repos
-            record_info('Not present', "$package is added in patch") && next if (script_run("zypper -n se -x $package") == 104);
+            record_info('Not present', "$package is added in patch") && next if (script_run("zypper -n se -t package -x $package") == 104);
             # install package
             zypper_call("in -l $package", exitcode => [0, 102, 103]);
             save_screenshot;


### PR DESCRIPTION
Avoid finding srcpackage, which don't prove that package is available before patch

- Fail: https://openqa.suse.de/tests/3813349#step/update_install/36
- Verification run: https://openqa.suse.de/tests/3814653