### PR TITLE
Upload sonobuoy logs before extracted components

### DIFF
--- a/tests/console/kubeadm.pm
+++ b/tests/console/kubeadm.pm
@@ -67,9 +67,9 @@ sub run {
         }
         assert_script_run('outfile=$(./sonobuoy retrieve)');
         assert_script_run('mkdir ./results; tar xzf $outfile -C ./results');
-        upload_logs '~/sonobuoy/results/plugins/e2e/results/global/e2e.log';
-        upload_logs '~/sonobuoy/results/plugins/e2e/results/global/junit_01.xml';
         upload_logs '$outfile';
+        upload_logs './results/plugins/e2e/results/global/e2e.log';
+        upload_logs './results/plugins/e2e/results/global/junit_01.xml';
         assert_script_run('tail ~/sonobuoy/results/plugins/e2e/results/global/e2e.log|grep "Test Suite Passed"');
     }
 }


### PR DESCRIPTION
If k8s certification fails, all the individual logs might not be present, so upload at least the bundled logs before trying to upload the specific certification logs (which will rightly cause the test to fail if they don't exist)