### PR TITLE
Add Y2STRICTTEXTDOMAIN to the yast applications

### DIFF
--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -31,7 +31,22 @@ our @EXPORT = qw(is_network_manager_default
   continue_info_network_manager_default
   accept_warning_network_manager_default
   workaround_suppress_lvm_warnings
+  with_yast_env_variables
 );
+
+=head2 with_yast_env_variables
+
+ with_yast_env_variables([extra_vars]);
+
+Set environment variables for yast application.
+C<extra_vars> extends the variables that can be used. C<extra_vars> expects a string.
+ex: with_yast_env_variables("foo=bar");
+
+=cut
+sub with_yast_env_variables {
+    my ($extra_vars) = shift // '';
+    return "Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 Y2STRICTTEXTDOMAIN=1 $extra_vars";
+}
 
 =head2 is_network_manager_default
 

--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -10,7 +10,7 @@ use Utils::Backends 'is_hyperv';
 sub yast2_console_exec {
     my %args = @_;
     die "Yast2 module has not been found among function arguments!\n" unless (defined($args{yast2_module}));
-    my $y2_start    = 'Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 yast2 ';
+    my $y2_start    = y2_module_basetest::with_yast_env_variables() . ' yast2 ';
     my $module_name = 'yast2-' . $args{yast2_module} . '-status';
     $y2_start .= (defined($args{yast2_opts})) ?
       $args{yast2_opts} . ' ' . $args{yast2_module} . ';' :

--- a/lib/y2_module_guitest.pm
+++ b/lib/y2_module_guitest.pm
@@ -48,8 +48,9 @@ sub launch_yast2_module_x11 {
         script_run('pkill -TERM -e yast2');
         select_console('x11');
     }
+    my $yast_env_variables = y2_module_basetest::with_yast_env_variables();
     # the command started with 'sh -c' to be able to execute 'echo' in Desktop Runner on Gnome
-    x11_start_program("sh -c 'xdg-su -c \"env Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 /sbin/yast2 $module\"; echo \"yast2-$module-status-\$?\" > /dev/$serialdev'", target_match => @tags, match_timeout => $args{match_timeout});
+    x11_start_program("sh -c 'xdg-su -c \"env $yast_env_variables /sbin/yast2 $module\"; echo \"yast2-$module-status-\$?\" > /dev/$serialdev'", target_match => @tags, match_timeout => $args{match_timeout});
     foreach ($args{target_match}) {
         return if match_has_tag($_);
     }


### PR DESCRIPTION
We set Y2STRICTTEXTDOMAIN environment variables to the yast calls
to detect missing `textdomain` declarations with explicit exception
as it is descripted in https://bugzilla.suse.com/show_bug.cgi?id=1130822

I remove the hardcoded variables to make it more flexible to be used in
the y2_module_guitest and y2_module_consoletest.

For installer we need to set the *EXTRABOOTPARAMS=Y2STRICTTEXTDOMAIN=1* and the variable will set in the bootloader

https://youtu.be/g6VAVWiCgac

- Related ticket: https://progress.opensuse.org/issues/poo51680
- Needles: 
- Verification run: 
[installer](http://aquarius.suse.cz/tests/1476#step/bootloader/12)
[consoleyast 1](http://aquarius.suse.cz/tests/1474)
[consoleyast 2](http://aquarius.suse.cz/tests/1475)
[x11](http://localhost/t1477)