### PR TITLE
HPC: Set ControlMachine to master-node00 for all QAM tests

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -452,7 +452,7 @@ sub run {
     }
 
     $self->prepare_slurm_conf();
-    if ($version =~ /15-SP1/) {
+    if ($version !~ /15-SP2/) {
         my $config = << "EOF";
 sed -i "/^ControlMachine.*/c\\ControlMachine=master-node00" /etc/slurm/slurm.conf
 EOF


### PR DESCRIPTION
Apply @schlad 's slurm.conf fix to all of the HPC QAM tests, not only the 15-SP1 ones.

- Verification run:
Sample slurm_master node job for:
12sp2: http://angmar.suse.de/tests/590
15: http://angmar.suse.de/tests/586
15sp1: http://angmar.suse.de/tests/558
