### PR TITLE
Register QAM Public Cloud instances properly

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2667,6 +2667,7 @@ sub load_publiccloud_tests {
         loadtest "publiccloud/download_repos";
         my $args = OpenQA::Test::RunArgs->new();
         loadtest "publiccloud/ssh_interactive_init",  run_args => $args;
+        loadtest "publiccloud/register_system",       run_args => $args;
         loadtest "publiccloud/transfer_repos",        run_args => $args;
         loadtest "publiccloud/patch_and_reboot",      run_args => $args;
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;

--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Register the remote system
+#
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base 'consoletest';
+use version_utils;
+use registration;
+use warnings;
+use testapi;
+use strict;
+use utils;
+
+sub run {
+    my ($self, $args) = @_;
+
+    my @addons = split(/,/, get_var('SCC_ADDONS', ''));
+
+    select_console 'tunnel-console';
+
+    $args->{my_instance}->run_ssh_command(cmd => "sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'), timeout => 180) unless (get_var('FLAVOR') =~ 'On-Demand');
+
+    for my $addon (@addons) {
+        if (is_sle('<15') && $addon =~ /tcm|wsm|contm|asmm|pcm/) {
+            ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '`echo ${VERSION} | cut -d- -f1`') unless ($addon eq '');
+        } elsif (is_sle('<15') && $addon =~ /sdk|we/) {
+            ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '${VERSION_ID}') unless ($addon eq '');
+        } else {
+            ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon)) unless ($addon eq '');
+        }
+    }
+
+    $args->{my_instance}->run_ssh_command(cmd => "sudo zypper lr");
+}
+
+sub test_flags {
+    return {
+        fatal                    => 1,
+        milestone                => 1,
+        publiccloud_multi_module => 1
+    };
+}
+
+1;
+

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -25,12 +25,7 @@ sub run {
 
     select_console 'tunnel-console';
 
-    $args->{my_instance}->run_ssh_command(cmd => "sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'), timeout => 180) unless (get_var('FLAVOR') =~ 'On-Demand');
-
-    for my $addon (@addons) {
-        ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon)) unless ($addon eq '');
-    }
-
+    assert_script_run("du -sh ~/repos");
     assert_script_run("rsync -va -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");


### PR DESCRIPTION
Hello,

This started because of failing `orphaned_packages_check.pm` on [12-SP4@EC2](https://openqa.suse.de/tests/3812499#step/orphaned_packages_check/11) & [15-SP1@GCE](https://openqa.suse.de/tests/3812493#step/orphaned_packages_check/2).
The first problem were patched #9445 some trailing whitespaces while using the SSH serial console.
The current problem is broken registration process - the version part of the product string may differ.

- Verification run: [SLE15SP1@GCE](http://pdostal-server.suse.cz/tests/6723) [SLE12SP4@EC2](http://pdostal-server.suse.cz/tests/6721)
