### PR TITLE
Fix shells test breaking on s390x

### DIFF
--- a/tests/console/shells.pm
+++ b/tests/console/shells.pm
@@ -60,6 +60,7 @@ sub tcsh_extra_tests {
 
     #Go back to root/openqa and do the validations:
     script_run 'logout', 0;
+    wait_still_screen(3);
 
     validate_script_output 'grep -c /home/tcsh_user:/usr/bin/tcsh /tmp/tcsh', sub { /1/ };
     validate_script_output 'grep -c ^/usr/bin/tcsh /tmp/tcsh',                sub { /1/ };


### PR DESCRIPTION
after logout, which takes some times test continues to type, first characters get lost

- Fail: https://openqa.suse.de/tests/3805886#step/shells/20
- Verification run: https://openqa.suse.de/tests/3818935
