### PR TITLE
Extend timeout for needle matching 'plasma-browser-integration-install'

### DIFF
--- a/tests/x11/plasma_browser_integration.pm
+++ b/tests/x11/plasma_browser_integration.pm
@@ -35,7 +35,7 @@ sub run {
     # Click on the reminder, it might take a while to appear
     assert_and_click('plasma-browser-integration-reminder', 30);
     # Click "Add to Firefox". Longer timeout as loading can take a while
-    assert_and_click('plasma-browser-integration-install', 90);
+    assert_and_click('plasma-browser-integration-install', 120);
     # Confirm installation
     assert_and_click('plasma-browser-integration-install-confirm');
     # Ack the "has been added" popup


### PR DESCRIPTION
we have sometime slow networking and browser needs more time to load
web page. So extend the timeout from 60 to 90 seconds
see: https://progress.opensuse.org/issues/59867
test verification:
https://openqa.opensuse.org/tests/1151664#step/plasma_browser_integration/45
test verification for aarch64 which has sometimes issue with stall detection:
http://f40.suse.de/tests/6613#next_previous