### PR TITLE
Use absolute domain name in host cmd

### DIFF
--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -35,8 +35,7 @@ sub run {
     systemctl 'show -p SubState named.service|grep SubState=running';
 
     # verify dns server responds to anything
-    my $e = script_run "host localhost localhost";
-    if ($e) {
+    if (script_run 'host localhost. localhost') {
         record_soft_failure 'bsc#1064438: "bind" cannot resolve localhost'         if check_var('ARCH', 's390x');
         record_info 'Skip the entire test on bridged networks (e.g. Xen, Hyper-V)' if (is_bridged_networking);
         return                                                                     if (is_bridged_networking || check_var('ARCH', 's390x'));


### PR DESCRIPTION
- Related ticket: [[JeOS] test fails in dns_srv - make it stable](https://progress.opensuse.org/issues/59894)
- Verification runs:
  * [Build6.18-jeos-main_xenpv_image@svirt-xen-pv](https://openqa.suse.de/tests/3819278#step/dns_srv/14)
  * [Build6.18-jeos-main_xenhvm_image@svirt-xen-hvm](https://openqa.suse.de/tests/3819253#step/dns_srv/14)
 
