### PR TITLE
Fix ay profile injection

### DIFF
--- a/tests/autoyast/prepare_cloned_profile.pm
+++ b/tests/autoyast/prepare_cloned_profile.pm
@@ -20,15 +20,25 @@ use testapi;
 use autoyast qw(inject_registration expand_variables upload_profile);
 
 sub run {
-    my $path = get_required_var('AUTOYAST');
-    # Get file from data directory
-    my $profile = get_test_data($path);
+    # Get path in the worker
+    my $path = get_var('ASSETDIR') . '/other/' . get_var('ASSET_1');
+    record_info('path', $path);
+
+    # Read content of file
+    my $fh;
+    open($fh, '<:encoding(UTF-8)', $path) or die "Could not open file '$path'";
+    read $fh, my $profile, -s $fh;
+    close $fh;
+    record_info('profile before:', $profile);
+
     # Inject registration block with template variables
     $profile = inject_registration($profile);
+
     # Expand injected template variables
     $profile = expand_variables($profile);
-    # Upload asset
-    upload_profile(profile => $profile, path => $path);
+    record_info('profile after:', $profile);
+
+    upload_profile(profile => $profile, path => get_var('AUTOYAST'));
 }
 
 sub test_flags {


### PR DESCRIPTION
Fix ay profile injection for cloned profile. I didn't find in the api any function working to read that path from the worker due to the internal network is not accessible. Once we read the file directly and do the modification we can still use logic in `upload_profile`, so at the end, a profile with registration is read by AutoYaST in boot parameters.

- Related ticket: https://progress.opensuse.org/issues/61931
- Needles: n/a
- Verification run: http://rivera-workstation.suse.cz/tests/930
