### PR TITLE
Add HA repo to qam autoyast profile

### DIFF
--- a/data/autoyast_qam/15_installtest.xml.ep
+++ b/data/autoyast_qam/15_installtest.xml.ep
@@ -128,6 +128,18 @@
         <alias>sle-module-development-tools:<%= $get_var->('VERSION') %>::update</alias>
         <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
       </listentry>
+      % if ($check_var->('HA_QAM', '1')) {
+      <listentry>
+        <name>sle-ha:<%= $get_var->('VERSION') %>::pool</name>
+        <alias>sle-ha:<%= $get_var->('VERSION') %>::pool</alias>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/product/]]></media_url>
+      </listentry>
+      <listentry>
+        <name>sle-ha:<%= $get_var->('VERSION') %>::update</name>
+        <alias>sle-ha:<%= $get_var->('VERSION') %>::update</alias>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
+      </listentry>
+      % }
     </add_on_products>
   </add-on>
   <bootloader>


### PR DESCRIPTION
This PR add ha repos for generating installtest qcow2 images (15,SP1 and SP2) for HA (`if HA_QAM=1`)

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[15 with HA_QAM=1](http://1a102.qa.suse.de/tests/2771#step/repos/11)
[15 without HA_QAM=1](http://1a102.qa.suse.de/tests/2770#step/repos/11)