### PR TITLE
Clear console after dracut test

### DIFF
--- a/tests/console/dracut_enhanced.pm
+++ b/tests/console/dracut_enhanced.pm
@@ -57,6 +57,8 @@ sub run {
         send_key 'ret';
         assert_script_run "cd /usr/src/packages/BUILD/dracut-*/test/$dracut_test";
         assert_script_run './test.sh --clean';
+        wait_still_screen(3);
+        assert_script_run "\nclear";
     }
 }
 


### PR DESCRIPTION
To pass consoletest post run check of clear console

- Related ticket: https://progress.opensuse.org/issues/62486
- Verification run: https://openqa.suse.de/tests/3820814