### PR TITLE
Fix X11 tty selection for 15-SP2

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1115,7 +1115,7 @@ sub get_x11_console_tty {
     # older versions in HDD
     my $newer_gdm
       = $new_gdm
-      && !is_sle('<=15-SP1')
+      && !is_sle('<=15-SP2')
       && !is_leap('<=15.2')
       && get_var('HDD_1', '') !~ /opensuse-42/;
     return (check_var('DESKTOP', 'gnome') && (get_var('NOAUTOLOGIN') || $newer_gdm) && $new_gdm) ? 2 : 7;


### PR DESCRIPTION
Currently in some tests with SLED 15-SP2, the command `select_console('x11')` is attempting to access the X11 console in tty2 and [finding instead a serial terminal there](https://openqa.suse.de/tests/3797308#step/hawk_gui/10). This workaround adds 15-SP2 to the newer gdm condition in `get_x11_console_tty` so the appropriate tty value is returned in such cases.

- Failing test: https://openqa.suse.de/tests/3797308
- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/2065

- Regression tests with SLES and SLED 15-SP2:
SLES allpatterns: http://mango.suse.de/tests/2058
SLES gnome: http://mango.suse.de/tests/2059
SLES proxy SCC + all modules: http://mango.suse.de/tests/2055
SLED X11 desktop apps + others: http://mango.suse.de/tests/2062
