### PR TITLE
Fix zypper_migration

### DIFF
--- a/tests/migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/migration/sle12_online_migration/zypper_migration.pm
@@ -103,7 +103,9 @@ sub run {
         }
         $out = wait_serial($migration_checks, $timeout);
     }
-    power_action('reboot', keepconsole => 1, textmode => 1);
+    # We can't use 'keepconsole' here, because sometimes a display-manager upgrade can lead to a screen change
+    # during restart of the X/GDM stack
+    power_action('reboot', textmode => 1);
 
     # Do not attempt to log into the desktop of a system installed with SLES4SAP
     # being prepared for upgrade, as it does not have an unprivileged user to test


### PR DESCRIPTION
Sometimes during zypper upgrade the display-manager can be restarted and the "focus" in the current console lost. So, we need to ensure that we are in a console in that case.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/3810873#step/zypper_migration/13
- Verification run: http://1b210.qa.suse.de/tests/6244

**NOTE:** The failure in the verification run is due to a display-manager restarting issue and is not related to this PR (a bug will be opened for this).
