### PR TITLE
SLES for SAP Applications Changes for spvm and pvm_hmc

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -132,7 +132,7 @@ if (is_sle('15+')) {
     # depending on registration only limited system roles are available
     set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', is_desktop_module_available() ? 'default' : 'minimal'));
     # set SYSTEM_ROLE to textmode for SLE15 if DESKTOP = textmode instead of triggering change_desktop (see poo#29589)
-    if (is_sles4sap && check_var('SYSTEM_ROLE', 'default') && check_var('DESKTOP', 'textmode')) {
+    if (is_sles4sap && check_var('SYSTEM_ROLE', 'default') && check_var('DESKTOP', 'textmode') && check_var('BACKEND', 'qemu')) {
         set_var('SYSTEM_ROLE', 'textmode');
     }
     # in the 'minimal' system role we can not execute many test modules

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,7 +69,7 @@ sub get_product_shortcuts {
             : is_aarch64() ? 's'
             : 'i',
             sled     => 'x',
-            sles4sap => get_var('OFW') ? 'i'
+            sles4sap => is_ppc64le() ? 'i'
             : (is_sle('=15-SP2') && is_x86_64()) ? 't'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',
@@ -80,7 +80,7 @@ sub get_product_shortcuts {
     return (
         sles     => 's',
         sled     => 'u',
-        sles4sap => get_var('OFW') ? 'u' : 'x',
+        sles4sap => is_ppc64le() ? 'u' : 'x',
         hpc      => is_x86_64() ? 'x' : 'u',
         rt       => is_x86_64() ? 'u' : undef
     );

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -14,6 +14,7 @@ use base "sles4sap";
 use testapi;
 use utils "zypper_call";
 use version_utils qw(is_sle is_upgrade);
+use Utils::Architectures;
 use strict;
 use warnings;
 
@@ -31,7 +32,7 @@ sub run {
     $self->select_serial_terminal;
 
     # saptune is not installed by default on SLES4SAP 12 on ppc64le
-    zypper_call "-n in saptune" if (get_var('OFW') and is_sle('<15'));
+    zypper_call "-n in saptune" if (is_ppc64le() and is_sle('<15'));
 
     unless (tuned_is 'running') {
         assert_script_run "saptune daemon start";

--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -14,6 +14,7 @@ use base "sles4sap";
 use testapi;
 use utils;
 use version_utils 'is_sle';
+use Utils::Architectures;
 use strict;
 use warnings;
 
@@ -40,7 +41,7 @@ sub setup {
     # Disable packagekit
     pkcon_quit;
     # saptune is not installed by default on SLES4SAP 12 on ppc64le and in textmode profile
-    zypper_call "-n in saptune" if ((get_var('OFW') and is_sle('<15')) or check_var('DESKTOP', 'textmode'));
+    zypper_call "-n in saptune" if ((is_ppc64le() and is_sle('<15')) or check_var('DESKTOP', 'textmode'));
     # Install mr_test dependencies
     zypper_call "-n in python3-rpm";
     # Download mr_test and extract it to $HOME
@@ -297,7 +298,7 @@ sub run {
         $self->test_override($test);
     } elsif ($test =~ m/^(x86_64|ppc64le)$/) {
         $self->test_x86_64  if (check_var('BACKEND', 'ipmi'));
-        $self->test_ppc64le if (get_var('OFW'));
+        $self->test_ppc64le if is_ppc64le();
         # DISABLED for now until newest saptune with fix is released
         #$self->test_bsc1152598;
     } else {


### PR DESCRIPTION
This PR introduces changes to allow SLES for SAP Applications tests to be run on ppc64le over the spvm and/or the pvm_hmc back ends.

1. SLES for SAP Applications test code relies on the **OFW** environment variable to determine when the test is running in the ppc64le architecture, however this variable is not set when running with back ends other than qemu, for example spvm or pvm_hmc. This PR replaces `get_var('OFW')` for `is_ppc64le()` from `lib/Utils/Architectures` which was introduced after the introduction of the SLES for SAP Applications tests, and which provides a more readable alternative.

2. In SLES4SAP 15+ tests, **SYSTEM_ROLE** is set to **textmode** when `DESKTOP=textmode`. This is useful to test the system in textmode, but does not allow the tests of SLES4SAP in textmode with the default SLES for SAP Applications system role. Tests in textmode with the default SLES for SAP Applications system role are necessary when testing SLES4SAP over the spvm or pvm_hmc back ends. This PR limits the change of the **SYSTEM_ROLE** variable to **textmode** when `DESKTOP=textmode` only for SLES4SAP tests over qemu where a graphical environment is available.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1309
- Verification run: [Graphical Installation and default SLES for SAP Applications system role, with added DESKTOP=textmode](http://mango.suse.de/tests/2075); [Textmode installation with textmode system role](http://mango.suse.de/tests/2057)
