### PR TITLE
Replace get_required_var with get_var when calling set_dom0_mem

### DIFF
--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -48,7 +48,7 @@ sub run {
         # set serial console for xen
         set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN')                      || check_var('HOST_HYPERVISOR', 'xen'));
         set_serial_console_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE',     'kvm'));
-        set_dom0_mem('/mnt')    if (get_required_var('REGRESSION') && (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')));
+        set_dom0_mem('/mnt')    if (get_var('REGRESSION') && (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')));
         set_pxe_efiboot('/mnt') if check_var('ARCH', 'aarch64');
     }
     else {


### PR DESCRIPTION
This regression was introduced in #9182, and on power VM test started to
fail as `REGRESSION` variable is not set.
It is not used in the set_dom0_mem subroutine itself, so it should be
safe to use `get_var` instead.

Fixes https://openqa.suse.de/tests/3822670#step/logs_from_installation_system/3