### PR TITLE
Drop procps test case from hyperv test suite

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-extratest.yaml
@@ -47,7 +47,6 @@ schedule:
   - console/shells
   - console/dstat
   - console/journalctl
-  - console/procps
   - console/docker
   - console/docker_runc
   - console/docker_image


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/60566
