### PR TITLE
Extend timeout for wait_boot in user_defined_snapshot

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -82,7 +82,7 @@ sub run {
     # request reboot again to ensure we will end up in the original system
     send_key 'ctrl-alt-delete';
     power_action('reboot', keepconsole => 1, textmode => 1, observe => 1);
-    $self->wait_boot;
+    $self->wait_boot(bootloader_time => 250);
 }
 
 1;


### PR DESCRIPTION
see https://progress.opensuse.org/issues/61925
verification test:
https://openqa.suse.de/tests/3826537#step/user_defined_snapshot
http://f40.suse.de/tests/6663#step/user_defined_snapshot
