### PR TITLE
Clean up after postgre

### DIFF
--- a/tests/console/php7_postgresql.pm
+++ b/tests/console/php7_postgresql.pm
@@ -36,8 +36,9 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils;
-use apachetest;
+use utils 'zypper_call';
+use apachetest qw(setup_apache2 setup_pgsqldb test_pgsql destroy_pgsqldb postgresql_cleanup);
+use Utils::Systemd 'systemctl';
 
 sub run {
     select_console 'root-console';
@@ -59,5 +60,9 @@ sub run {
 
     # destroy database
     destroy_pgsqldb;
+
+    # poo#62000
+    postgresql_cleanup;
 }
+
 1;

--- a/tests/console/postgresql_server.pm
+++ b/tests/console/postgresql_server.pm
@@ -20,8 +20,9 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils;
-use apachetest;
+use utils 'zypper_call';
+use apachetest qw(setup_pgsqldb destroy_pgsqldb test_pgsql postgresql_cleanup);
+use Utils::Systemd 'systemctl';
 
 sub run {
     select_console 'root-console';


### PR DESCRIPTION
- Related ticket: [[opensuse][aarch64][jeos] test fails in php7_postgresql because HDD is full- cleanup, or split tests or increase HDD](https://progress.opensuse.org/issues/62000)
- Verification runs: 
   * [opensuse-15.2-JeOS-for-AArch64-aarch64-Build1.8-jeos@aarch64-HD24G (BUG?!)](http://eris.suse.cz/tests/4092#step/php7_postgresql/159)
   * [opensuse-Tumbleweed-DVD-x86_64-Build20200127-extra_tests_filesystem@64bit](http://eris.suse.cz/tests/4093)
   * [opensuse-Tumbleweed-JeOS-for-AArch64-aarch64-Build20200127-jeos@aarch64-HD24G (o3 worker)](https://openqa.opensuse.org/tests/1158503#)