### PR TITLE
HPC: Fix syntax on dhcp config of cluster

### DIFF
--- a/lib/hpc/cluster.pm
+++ b/lib/hpc/cluster.pm
@@ -24,7 +24,7 @@ our @EXPORT = qw(
 sub provision_cluster {
     my ($self) = @_;
     my $config = << "EOF";
-sed -i "/^DHCLIENT_SET_HOSTNAME.*/c\\\"DHCLIENT_SET_HOSTNAME=\"no\"" /etc/sysconfig/network/dhcp
+sed -i '/^DHCLIENT_SET_HOSTNAME.*/c\\DHCLIENT_SET_HOSTNAME="no"' /etc/sysconfig/network/dhcp
 EOF
     assert_script_run($_) foreach (split /\n/, $config);
 }


### PR DESCRIPTION
Most likely an aesthetic change, but the original sed command resulted in `"DHCLIENT_SET_HOSTNAME=no` instead of `DHCLIENT_SET_HOSTNAME="no"` in the dhcp config file. Changed just to be on the safe side.

- Verification run: 
http://angmar.suse.de/tests/698