### PR TITLE
Reorder expressions to avoid failure on non-XEN

### DIFF
--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -48,7 +48,7 @@ sub run {
         # set serial console for xen
         set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN')                      || check_var('HOST_HYPERVISOR', 'xen'));
         set_serial_console_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE',     'kvm'));
-        set_dom0_mem('/mnt')    if (get_var('REGRESSION') && (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')));
+        set_dom0_mem('/mnt')    if ((get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')) && get_var('REGRESSION'));
         set_pxe_efiboot('/mnt') if check_var('ARCH', 'aarch64');
     }
     else {


### PR DESCRIPTION
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/080d9dba383d1223c18e55a8102dbd547c67d660
- Failed test: https://openqa.suse.de/tests/3822468#step/logs_from_installation_system/3
- Verification run: (coming soon)
