### PR TITLE
welcome.pm: handle preselected NO in DHCP dialog

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -136,6 +136,7 @@ sub run {
             next;
         }
         if (match_has_tag 'linuxrc-dhcp-question') {
+            send_key 'tab' if (match_has_tag 'linuxrc-dhcp-question-no');
             send_key 'ret';
         }
     }


### PR DESCRIPTION
A one-liner add-on to welcome.pm to handle the case of the DHCP dialog popping up with the "No" button selected.

- Related ticket: https://progress.opensuse.org/issues/50144
- Needles: existing `products/sle/os-autoinst-needles-sles/inuxrc-dhcp-question-no-20200124`
- Verification run: http://polya.suse.de/tests/936#step/welcome/1
