### PR TITLE
Workaround crashing wayland with alt-f11

### DIFF
--- a/tests/x11/firefox/firefox_fullscreen.pm
+++ b/tests/x11/firefox/firefox_fullscreen.pm
@@ -29,15 +29,14 @@ sub run {
 
     $self->start_firefox_with_profile;
 
-    $self->firefox_open_url('file:///usr/share/w3m/w3mhelp.html');
-    assert_screen('firefox-fullscreen-page');
+    assert_screen('firefox-url-loaded');
 
     send_key "f11";
-    assert_screen('firefox-fullscreen-enter', 90);
+    assert_screen('firefox-fullscreen');
 
     wait_still_screen 2, 4;
     send_key "f11";
-    assert_screen('firefox-fullscreen-page', 90);
+    assert_screen('firefox-url-loaded');
 
     $self->exit_firefox;
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/60242
- Verification run:
http://openqa.suse.de/tests/3833297 15sp1
http://openqa.suse.de/tests/3833301 15sp1 virtio
http://openqa.suse.de/tests/3833298 12sp1
http://openqa.suse.de/tests/3833299 15sp2
http://openqa.suse.de/tests/3833300 15sp2 virtio
