### PR TITLE
Fix opensuse welcome popup processing for AY reinstall

### DIFF
--- a/schedule/yast/autoyast_reinstall.yaml
+++ b/schedule/yast/autoyast_reinstall.yaml
@@ -1,13 +1,16 @@
 name:           autoyast_reinstall
 description:    >
-    Parent job produces autoyast profile after successful completion. 
+    Parent job produces autoyast profile after successful completion.
     This test uses generated profile to do autoyast installation.
 schedule:
-  - autoyast/prepare_cloned_profile
+  # Registration section is required for SLES only
+  - {{inject_registration}}
   # Called on BACKEND: qemu
   - {{isosize}}
   - installation/bootloader_start
   - autoyast/installation
+  # On Tumbleweed process Welcome pop-up screen
+  - {{opensuse_welcome}}
   - autoyast/console
   - autoyast/login
   - autoyast/verify_imported_users
@@ -34,6 +37,14 @@ conditional_schedule:
     BACKEND:
       qemu:
         - installation/grub_test
+  opensuse_welcome:
+      VERSION:
+        Tumbleweed:
+          - installation/opensuse_welcome
+  inject_registration:
+      DISTRI:
+        sle:
+          - autoyast/prepare_cloned_profile
 test_data:
   paths:
     - /var/lib/gdm/.bashrc

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -353,7 +353,7 @@ sub run {
             return;
         }
         elsif (match_has_tag('opensuse-welcome')) {
-            untick_welcome_on_next_startup;
+            return;             # Popup itself is processed in opensuse_welcome module
         }
     }
     # ssh console was activated at this point of time, so need to reset


### PR DESCRIPTION
We had wrong schedule, trying to process pop-up twice.

See [poo#59864](https://progress.opensuse.org/issues/59864).

NOTE: this change requires adding `YAML_SCHEDULE=schedule/yast/autoyast_reinstall.yaml` to the test suite.

### Verification runs
- [TW](http://d27.suse.de/tests/299#)
- [Leap](http://d27.suse.de/tests/300)