### PR TITLE
Add validation for partition table

### DIFF
--- a/lib/partitions_validator_utils.pm
+++ b/lib/partitions_validator_utils.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+package partitions_validator_utils;
+use strict;
+use warnings;
+use scheduler 'get_test_suite_data';
+use testapi;
+use Test::Assert ':all';
+use Exporter 'import';
+our @EXPORT = 'validate_partition_table';
+
+sub validate_partition_table {
+    my $args = shift;
+    return if check_var('BACKEND', 's390x');    # blkid output does not show partition table for dasd
+    record_info("Check $args->{table_type}", "Verify if partition table type is $args->{table_type}");
+    my $table_type = (split(/\"/, script_output("blkid $args->{device}")))[-1];    # last element of output eg "gpt"
+    assert_equals($args->{table_type}, $table_type, "Partition table type does not correspond to the expected one.");
+}
+
+1;

--- a/schedule/yast/btrfs/btrfs_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs_opensuse.yaml
@@ -28,6 +28,8 @@ schedule:
   - console/validate_no_cow_attribute
   - console/verify_no_separate_home
 test_data:
+  device: /dev/vda
+  table_type: gpt
   subvolume:
     cow:
       - /

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
-  # Called on all, except BACKEND: s390x, ipmi
+  # Called on all, except BACKEND: s390x
   - {{hostname_inst}}
   - installation/user_settings
   - installation/user_settings_root
@@ -30,7 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on BACKEND: s390x, svirt, ipmi
+  # Called on BACKEND: s390x, svirt
   - {{reconnect_mgmt_console}}
   # Called on BACKEND: qemu
   - {{grub_test}}
@@ -54,8 +54,6 @@ conditional_schedule:
         - boot/reconnect_mgmt_console
       svirt:
         - boot/reconnect_mgmt_console
-      ipmi:
-        - boot/reconnect_mgmt_console
   check_resume:
     ARCH:
       s390x:
@@ -78,12 +76,11 @@ conditional_schedule:
       svirt:
         - console/verify_separate_home
         - console/validate_file_system
-      ipmi:
-        - console/verify_separate_home
-        - console/validate_file_system
       s390x:
         - console/verify_no_separate_home
 test_data:
+  device: /dev/vda
+  table_type: gpt
   subvolume:
     cow:
       - /root

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
@@ -1,16 +1,13 @@
----
-name:           ext4@yast-s390x-disk-activation
+name:           btrfs_libstorage-ng@hmc+ipmi
 description:    >
-  Test for ext4 filesystem.
-  Requires disk activation and grub is not displayed due to console reconnection.
+  Validate default installation with btrfs and Libstorage NG.
 vars:
-  FILESYSTEM: ext4
-  FORMAT_DASD: install
+  DESKTOP: gnome
+  FILESYSTEM: btrfs
 schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
-  - installation/disk_activation
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
@@ -18,6 +15,7 @@ schedule:
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
+  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
@@ -27,10 +25,30 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  # Called on BACKEND: ipmi
+  - {{reconnect_mgmt_console}}
   - installation/first_boot
-  - console/validate_ext4_fs
+  - console/validate_no_cow_attribute
+  - console/verify_separate_home
+  - console/validate_file_system
+conditional_schedule:
+  reconnect_mgmt_console:
+    BACKEND:
+      ipmi:
+        - boot/reconnect_mgmt_console
 test_data:
-  device: /dev/dasda
-  table_type: dasd
-  !include: test_data/yast/ext4/ext4_no_separate_home.yaml
+  device: /dev/sda
+  table_type: gpt
+  subvolume:
+    cow:
+      - /root
+      - /tmp
+      - /usr/local
+      - /.snapshots
+      - /srv
+      - /opt
+    no_cow:
+      - /var
+  file_system:
+    /home: xfs
+    /: btrfs

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -32,4 +32,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/vda
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
@@ -30,4 +30,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/xvdb
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -30,4 +30,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/xvdb
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -30,4 +30,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/vda
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -34,4 +34,5 @@ schedule:
   - console/validate_ext4_fs
 test_data:
   device: /dev/sda
+  table_type: gpt
   !include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -1,36 +1,34 @@
----
-name:           ext4@yast-s390x-disk-activation
-description:    >
-  Test for ext4 filesystem.
-  Requires disk activation and grub is not displayed due to console reconnection.
-vars:
-  FILESYSTEM: ext4
-  FORMAT_DASD: install
+name: gpt
+description:    > 
+  Test installation on a very large hard disk which needs GPT partition format.
 schedule:
+  - installation/isosize
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
-  - installation/disk_activation
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
-  - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
+  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/change_desktop
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/grub_test
   - installation/first_boot
-  - console/validate_ext4_fs
+  - console/validate_file_system
 test_data:
-  device: /dev/dasda
-  table_type: dasd
-  !include: test_data/yast/ext4/ext4_no_separate_home.yaml
+  device: /dev/vda
+  table_type: gpt
+  file_system:
+    /home: xfs
+    /: btrfs

--- a/tests/console/validate_ext4_fs.pm
+++ b/tests/console/validate_ext4_fs.pm
@@ -16,12 +16,15 @@ use base "opensusebasetest";
 use testapi;
 use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
+use partitions_validator_utils 'validate_partition_table';
 
 sub run {
 
     select_console "root-console";
     my $test_data  = get_test_suite_data();
     my @partitions = @{$test_data->{partitions}};
+
+    validate_partition_table({device => $test_data->{device}, table_type => $test_data->{table_type}});
 
     foreach (@partitions) {
         if ($_->{mnt_point} eq '[SWAP]') {

--- a/tests/console/validate_file_system.pm
+++ b/tests/console/validate_file_system.pm
@@ -19,10 +19,14 @@ use base "opensusebasetest";
 use testapi;
 use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
+use partitions_validator_utils 'validate_partition_table';
 
 sub run {
     my $test_data  = get_test_suite_data();
     my %partitions = %{$test_data->{file_system}};
+
+    select_console('root-console') unless (current_console() eq "root_console");
+    validate_partition_table({device => $test_data->{device}, table_type => $test_data->{table_type}});
 
     foreach (keys %partitions) {
         record_info("Check fs $_", "Verify the '$_' partition filesystem is '$partitions{$_}'");


### PR DESCRIPTION
Validate that partition table is GPT by default, except for msdos tests when set and and zVM where default is DASD.
This is a fork of previous PR  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9342, as I decided to change the approach but want to keep the old one for reference.

    Related ticket: https://progress.opensuse.org/issues/58912
    Needles: N/A
    Verification runs:

Ext4:
x64: http://waaa-amazing.suse.cz/tests/11229#
x64_uefi: https://openqa.suse.de/tests/3839538
aarch64: https://openqa.suse.de/tests/3839534#
ppc64le: https://openqa.suse.de/tests/3839535
zkvm: https://openqa.suse.de/tests/3839537

Excluded:
zVM: https://openqa.suse.de/tests/3831992#step/validate_ext4_fs/8, as fdisk -l does not show partition tables for dasd. Not gpt anyway.

BTRFS:
x64: http://waaa-amazing.suse.cz/tests/11229
aarch64: https://openqa.suse.de/tests/3839541
zkvm: https://openqa.suse.de/tests/3839543
ppc64le: https://openqa.suse.de/tests/3839542

GPT: 
x64: http://waaa-amazing.suse.cz/tests/11234
x64_uefi: http://waaa-amazing.suse.cz/tests/11233
ppc64le: https://openqa.suse.de/tests/3839575

We cannot test on hmc and ipmi currently.