### PR TITLE
Add HA QAM automation for SLE15

### DIFF
--- a/schedule/ha/qam/15/qam-client.yaml
+++ b/schedule/ha/qam/15/qam-client.yaml
@@ -1,0 +1,11 @@
+name:           qam-client_2nodes
+description:    >
+    Create a client server for 2 nodes cluster tests
+    Further info about the test suite
+schedule:
+    - boot/boot_to_desktop
+    - console/system_prepare
+    - console/consoletest_setup
+    - console/check_os_release
+    - console/hostname
+    - ha/ctdb

--- a/schedule/ha/qam/15/qam-cluster_2nodes_01.yaml
+++ b/schedule/ha/qam/15/qam-cluster_2nodes_01.yaml
@@ -1,0 +1,31 @@
+name:           qam-cluster_2nodes
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/fencing
+  - boot/boot_to_desktop
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs

--- a/schedule/ha/qam/15/qam-cluster_2nodes_02.yaml
+++ b/schedule/ha/qam/15/qam-cluster_2nodes_02.yaml
@@ -1,0 +1,30 @@
+name:           qam-cluster_2nodes
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/fencing
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs


### PR DESCRIPTION
This PR enables both HA QAM automation for SLE15 and YAML scheduling.
I do it as a separate of #9372 because some verification tests needs to be done before merging.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
**drbd MU 15:**  [Node1](http://1a102.qa.suse.de/tests/2919) - [Node2](http://1a102.qa.suse.de/tests/2920) - [Client](http://1a102.qa.suse.de/tests/2921)
**samba/ctdb MU 15:** [Node1](http://1a102.qa.suse.de/tests/2946) - [Node2](http://1a102.qa.suse.de/tests/2947) - [Client](http://1a102.qa.suse.de/tests/2948)
*Tests failed in remove_node due to a timeout issue not related to this PR.Will be fixed by #9461*
**haproxy MU 15:** [Node1](http://1a102.qa.suse.de/tests/2907) - [Node2](http://1a102.qa.suse.de/tests/2908) - [Client](http://1a102.qa.suse.de/tests/2909)
**basic MU 15:** [Node1](http://1a102.qa.suse.de/tests/2911) - [Node2](http://1a102.qa.suse.de/tests/2912) - [Client](http://1a102.qa.suse.de/tests/2913)
