### PR TITLE
Fail immediately when repo can't be created

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -129,7 +129,8 @@ sub advance_installer_window {
     my ($screenName) = @_;
 
     send_key $cmd{next};
-    unless (check_screen "$screenName", 90) {
+    die 'Unable to create repository' if check_screen('unable-to-create-repo', 5);
+    unless (check_screen "$screenName", 60) {
         send_key_until_needlematch $screenName, $cmd{next}, 3, 90;
         record_soft_failure 'Retry most probably due to network problems poo#52319 or failed next click';
     }


### PR DESCRIPTION
- Fail:
https://openqa.suse.de/tests/3838009#step/add_update_test_repo/154
https://openqa.suse.de/tests/3838022#step/add_update_test_repo/13
- Verification run:
https://openqa.suse.de/tests/3838188 bad repo
https://openqa.suse.de/tests/3838189 bad repo
https://openqa.suse.de/tests/3838190 passing s390x
https://openqa.suse.de/tests/3838191 passing x86_64
