### PR TITLE
Change iscsi workaround from 15SP2 to 15SP1

### DIFF
--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -63,8 +63,8 @@ sub run {
     wait_still_screen 3;
     wait_serial('yast2-iscsi-client-status-0', 90) || die "'yast2 iscsi-client' didn't finish";
 
-    if (is_sle('=15-SP2') && systemctl('-q is-active iscsi', ignore_failure => 1)) {
-        record_soft_failure('iscsi issue: bug bsc#1160374');
+    if (is_sle('=15-SP1') && systemctl('-q is-active iscsi', ignore_failure => 1)) {
+        record_soft_failure('iscsi issue: bug bsc#1162078');
         systemctl('start iscsi');
     }
 


### PR DESCRIPTION
This PR changes the workaround for iscsi bug.
It is fixed in 15SP2, however we still have it in 15SP1.

- Failed test: http://1a102.qa.suse.de/tests/2935#step/iscsi_client/21
- Related ticket: N/A
- Needles: N/A
- Verification run for 15SP1 [Node1](http://1a102.qa.suse.de/tests/2939) - [Node2](http://1a102.qa.suse.de/tests/2940)
- Regression test for 15SP2: [Node1](http://1a102.qa.suse.de/tests/2943) - [Node2](http://1a102.qa.suse.de/tests/2944)
**Unable** to test it in 15-SP2 for the moment due to scc proxy issue.