### PR TITLE
Fix keymap in autoyast profile as per bsc#1161792

### DIFF
--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -164,7 +164,7 @@
     </general>
   </kdump>
   <keyboard>
-    <keymap>en</keymap>
+    <keymap>english-us</keymap>
   </keyboard>
   <language>
     <language>en_US</language>


### PR DESCRIPTION
Another case, where error was not reported, so test was green. YaST team
has improved error reporting and our profile needs this adjustment.

See [bsc#1161792](https://bugzilla.suse.com/show_bug.cgi?id=1161792).
