### PR TITLE
Increase still time until license can appear

### DIFF
--- a/tests/console/yast2_registration.pm
+++ b/tests/console/yast2_registration.pm
@@ -41,7 +41,7 @@ sub register_system_and_add_extension {
     }
     wait_screen_change { send_key "spc" };
     send_key "alt-n";
-    wait_still_screen(stilltime => 7, timeout => 60);
+    wait_still_screen(stilltime => 15, timeout => 60);
     if (check_screen "yast2_registration-license-agreement") {
         wait_screen_change { send_key "alt-a" };
         send_key "alt-n";


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3838590#step/yast2_registration/16
- Verification run: https://openqa.suse.de/tests/3838967