### PR TITLE
Increase timeout when a node is removed

### DIFF
--- a/tests/ha/remove_node.pm
+++ b/tests/ha/remove_node.pm
@@ -20,15 +20,16 @@ use version_utils 'is_sle';
 
 sub remove_state_join {
     my ($method, $cluster_name, $node_01, $node_02) = @_;
-    my $remove_cmd = 'ha-cluster-remove -y -c';
-    my $join_cmd   = 'ha-cluster-join -y -i ' . get_var('SUT_NETDEVICE', 'eth0') . ' -c';
-    my $timer      = bmwqemu::scale_timeout(5);
+    my $remove_cmd     = 'ha-cluster-remove -y -c';
+    my $join_cmd       = 'ha-cluster-join -y -i ' . get_var('SUT_NETDEVICE', 'eth0') . ' -c';
+    my $remove_timeout = bmwqemu::scale_timeout(60);
+    my $timer          = bmwqemu::scale_timeout(5);
 
     # Waiting for the other nodes to be ready
     barrier_wait("REMOVE_NODE_BY_" . "$method" . "_INIT_" . "$cluster_name");
 
     # Remove the second node
-    assert_script_run("$remove_cmd $node_02", $default_timeout) if is_node(1);
+    assert_script_run("$remove_cmd $node_02", $remove_timeout) if is_node(1);
     # Need to wait a bit for cluster configuration refresh
     sleep $timer;
 


### PR DESCRIPTION
Some jobs failed due to a timeout issue in remove_node test, so instead of using `$default_timeout`, I've used a dedicated one `$remove_timeout`.

- Failed tests: https://openqa.suse.de/tests/3838963#step/remove_node/6 - http://1a102.qa.suse.de/tests/2946#step/remove_node/6 
- Related ticket: N/A
- Needles: N/A
- Verification run: 
15: [Node1](http://1a102.qa.suse.de/tests/2956) - [Node2](http://1a102.qa.suse.de/tests/2957)
15SP1: [Node1](http://1a102.qa.suse.de/tests/2960) - [Node2](http://1a102.qa.suse.de/tests/2961)
