### PR TITLE
Add HA QAM automation for SLE12SP4/SP5

### DIFF
--- a/schedule/ha/qam/12-SP4/qam-client.yaml
+++ b/schedule/ha/qam/12-SP4/qam-client.yaml
@@ -1,0 +1,11 @@
+name:           qam-client_2nodes
+description:    >
+    Create a client server for 2 nodes cluster tests
+    Further info about the test suite
+schedule:
+    - boot/boot_to_desktop
+    - console/system_prepare
+    - console/consoletest_setup
+    - console/check_os_release
+    - console/hostname
+    - ha/ctdb

--- a/schedule/ha/qam/12-SP4/qam-cluster_2nodes_01.yaml
+++ b/schedule/ha/qam/12-SP4/qam-cluster_2nodes_01.yaml
@@ -1,0 +1,31 @@
+name:           qam-cluster_2nodes
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/fencing
+  - boot/boot_to_desktop
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs

--- a/schedule/ha/qam/12-SP4/qam-cluster_2nodes_02.yaml
+++ b/schedule/ha/qam/12-SP4/qam-cluster_2nodes_02.yaml
@@ -1,0 +1,30 @@
+name:           qam-cluster_2nodes
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/fencing
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs

--- a/schedule/ha/qam/12-SP5/qam-client.yaml
+++ b/schedule/ha/qam/12-SP5/qam-client.yaml
@@ -1,0 +1,11 @@
+name:           qam-client_2nodes
+description:    >
+    Create a client server for 2 nodes cluster tests
+    Further info about the test suite
+schedule:
+    - boot/boot_to_desktop
+    - console/system_prepare
+    - console/consoletest_setup
+    - console/check_os_release
+    - console/hostname
+    - ha/ctdb

--- a/schedule/ha/qam/12-SP5/qam-cluster_2nodes_01.yaml
+++ b/schedule/ha/qam/12-SP5/qam-cluster_2nodes_01.yaml
@@ -1,0 +1,31 @@
+name:           qam-cluster_2nodes
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/fencing
+  - boot/boot_to_desktop
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs

--- a/schedule/ha/qam/12-SP5/qam-cluster_2nodes_02.yaml
+++ b/schedule/ha/qam/12-SP5/qam-cluster_2nodes_02.yaml
@@ -1,0 +1,30 @@
+name:           qam-cluster_2nodes
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/fencing
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs


### PR DESCRIPTION
This PR enables both HA QAM automation for SLE12 SP4/SP5 and YAML scheduling.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1314
- Verification run: 
**-- 12SP5 --** 
**drbd MU:**  [Node1](http://1a102.qa.suse.de/tests/2992) - [Node2](http://1a102.qa.suse.de/tests/2993) - [Client](http://1a102.qa.suse.de/tests/2994)
**samba/ctdb MU:** [Node1](http://1a102.qa.suse.de/tests/2988) - [Node2](http://1a102.qa.suse.de/tests/2989) - [Client](http://1a102.qa.suse.de/tests/2990)
**haproxy MU:** [Node1](http://1a102.qa.suse.de/tests/2996) - [Node2](http://1a102.qa.suse.de/tests/2997) - [Client](http://1a102.qa.suse.de/tests/2998)
**basic MU:** [Node1](http://1a102.qa.suse.de/tests/3000) - [Node2](http://1a102.qa.suse.de/tests/3001) - [Client](http://1a102.qa.suse.de/tests/3002)
**-- 12SP4 --** 
**drbd MU:**  [Node1](http://1a102.qa.suse.de/tests/3032) - [Node2](http://1a102.qa.suse.de/tests/3033) - [Client](http://1a102.qa.suse.de/tests/3034)
**samba/ctdb MU:** [Node1](http://1a102.qa.suse.de/tests/3052) - [Node2](http://1a102.qa.suse.de/tests/3053) - [Client](http://1a102.qa.suse.de/tests/3054)
**haproxy MU:** [Node1](http://1a102.qa.suse.de/tests/3004) - [Node2](http://1a102.qa.suse.de/tests/3005) - [Client](http://1a102.qa.suse.de/tests/3006)
**basic MU:** [Node1](http://1a102.qa.suse.de/tests/3044) - [Node2](http://1a102.qa.suse.de/tests/3045) - [Client](http://1a102.qa.suse.de/tests/3046)