### PR TITLE
Replace salt by salt-minion

### DIFF
--- a/tests/console/validate_packages_and_patterns.pm
+++ b/tests/console/validate_packages_and_patterns.pm
@@ -26,7 +26,7 @@ my %software = ();
 
 # Define test data
 
-$software{salt} = {
+$software{'salt-minion'} = {
     repo      => 'Basesystem',
     installed => is_jeos() ? 1 : 0,       # On JeOS Salt is present in the default image
     condition => sub { is_sle('15+') },


### PR DESCRIPTION
- Related ticket: [[sle][JeOS] test fails in validate_packages_and_patterns - check for salt-minion instead of salt
](https://progress.opensuse.org/issues/62816)
- Verification run: none

Proxy SCC is not working and we do not have any reliable workaround. *salt-minion* should be located in Basesystem as it was in the Beta2C1 image.

![DeepinScreenshot_select-area_20200130132605](https://user-images.githubusercontent.com/35097794/73449737-208b1d80-4364-11ea-9d23-a87b83b6bb8c.png)
