### PR TITLE
Fix ctdb test to be dependent on samba version

### DIFF
--- a/tests/ha/ctdb.pm
+++ b/tests/ha/ctdb.pm
@@ -31,7 +31,7 @@ sub run {
     # CTDB configuration must be done only in cluster nodes
     if (check_var('CTDB_TEST_ROLE', 'server')) {
         my $ctdb_cfg    = '/etc/samba/smb.conf';
-        my $ctdb_socket = is_sle('15-SP2+') ? '/var/run/ctdb/ctdbd.socket' : '/var/lib/ctdb/ctdb.socket';
+        my $ctdb_socket = '/var/run/ctdb/ctdbd.socket';
         my $ctdb_rsc    = 'ctdb';
         my $nmb_rsc     = 'nmb';
         my $smb_rsc     = 'smb';
@@ -46,6 +46,10 @@ sub run {
 
         # Make sure samba is installed
         zypper_call 'in samba';
+
+        # We need to check samba version because ctdb socket has changed for samba >= 4.10
+        my $samba_version = script_output('rpm -q samba --qf \'%{VERSION}\'|awk -F "+" \'{print "v"$1}\'');
+        $ctdb_socket = '/var/lib/ctdb/ctdb.socket' if (version->parse($samba_version) < version->parse(v4.10.0));
 
         # Make sure the services ctdb , smb , and nmb are disabled
         if (is_sle('15+')) {


### PR DESCRIPTION
Before this PR, ctdb socket was set depending on OS version but that's not a proper approach.
It rather needs to be dependent to the samba version.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1314
- Verification run: 
15SP2 -> [Node1](http://1a102.qa.suse.de/tests/3057) [Node2](http://1a102.qa.suse.de/tests/3058) [Client](http://1a102.qa.suse.de/tests/3059)
15SP1 -> [Node1](http://1a102.qa.suse.de/tests/3048) [Node2](http://1a102.qa.suse.de/tests/3049) [Client](http://1a102.qa.suse.de/tests/3050)
12SP4 -> [Node1](http://1a102.qa.suse.de/tests/3052) [Node2](http://1a102.qa.suse.de/tests/3053) [Client](http://1a102.qa.suse.de/tests/3054)

