### PR TITLE
Add wait time to avoid occasional failures

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -38,6 +38,7 @@ sub verify_default_keymap_textmode {
         assert_screen(has_ttys() ? 'linux-login' : 'cleared_console');
     }
 
+    wait_still_screen;
     type_string($test_string);
     assert_screen($tag);
     # clear line in order to add user bernhard to tty group

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -135,6 +135,7 @@ sub test_http_instserver {
 sub start_yast2_instserver {
     my $self = shift;
     $self->launch_yast2_module_x11("instserver", match_timeout => 120);
+    wait_still_screen;
 }
 
 sub run {
@@ -146,20 +147,16 @@ sub run {
     select_console "x11";
 
     start_yast2_instserver $self;
-    wait_still_screen 2;
     test_http_instserver;
 
     start_yast2_instserver $self;
-    wait_still_screen 2;
     test_ftp_instserver;
 
     start_yast2_instserver $self;
-    wait_still_screen 2;
     test_nfs_instserver;
 
     # clean existing config
     start_yast2_instserver $self;
-    wait_still_screen 2;
     clean_env;
 }
 


### PR DESCRIPTION
- Fail:
https://openqa.suse.de/tests/3849610#step/yast2_instserver/66
https://openqa.suse.de/tests/3849169#step/keymap_or_locale/4
- Verification run:
http://10.100.12.155/tests/14311#step/keymap_or_locale/3
http://10.100.12.155/tests/14309#step/keymap_or_locale/3
http://10.100.12.155/tests/14312#step/yast2_instserver/56
http://10.100.12.155/tests/14314#step/yast2_instserver/56