### PR TITLE
Fix bootloader_start for pvm_hmc BACKEND

### DIFF
--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -71,7 +71,7 @@ sub run {
         }
     }
     # Wrapped call for powerVM
-    if (check_var('BACKEND', 'spvm')) {
+    if (get_var('BACKEND', '') =~ /spvm|pvm_hmc/) {
         $self->bootloader::run();
         return;
     }


### PR DESCRIPTION
We got hmc backend which has different name than we had for novalink.

- [Verification run](https://openqa.suse.de/tests/3850688).
