### PR TITLE
Set timeout for wait_still_screen after type_string_very_slow 

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -450,7 +450,7 @@ sub type_string_very_slow {
         sleep 3;
     }
     else {
-        wait_still_screen 1;
+        wait_still_screen(1, 3);
     }
 }
 

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -25,7 +25,8 @@ sub run {
 
     $self->libreoffice_start_program('oowriter');
     # clicking the writing area to make sure the cursor addressed there
-    wait_screen_change { assert_and_click('ooffice-writing-area', timeout => 10) };
+    assert_and_click('ooffice-writing-area', timeout => 10);
+    wait_still_screen(5, 10);
     # auto-correction does not handle super-fast typing well
     type_string_very_slow 'Hello World!';
     assert_screen 'test-ooffice-2';


### PR DESCRIPTION
Because of blinking cursor it will wait full default timeout 30 seconds
& add 5 (max 10) seconds timeout before writing in ooffice

- Common fail: https://openqa.suse.de/tests/3849158#step/ooffice/6
- Verification run: http://10.100.12.155/tests/14326