### PR TITLE
Run parent post fail hook first in iscsi MM test

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -155,10 +155,9 @@ sub run {
 
 sub post_fail_hook {
     my $self = shift;
-    select_console 'root-console';
+    $self->SUPER::post_fail_hook;
     $self->save_and_upload_log("iscsiadm --mode session -P 3",                     "/tmp/iscsi_init_session_data.log");
     $self->save_and_upload_log("tar czvf /tmp/iscsi_initconf.tar.gz /etc/iscsi/*", "/tmp/iscsi_initconf.tar.gz");
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -245,10 +245,10 @@ sub test_flags {
 }
 
 sub post_fail_hook {
-    my $self            = shift;
+    my $self = shift;
+    $self->SUPER::post_fail_hook;
     my $target_label    = $test_data->{target_conf}->{name} . '\\:' . $test_data->{target_conf}->{id};
     my $initiator_label = $test_data->{initiator_conf}->{name} . '\\:' . $test_data->{initiator_conf}->{id};
-    select_console 'root-console';
     display_targets;
     unless (script_run('ls -la /sys/kernel/config/iscsi')) {
         # show amount of normal logouts
@@ -264,7 +264,6 @@ sub post_fail_hook {
         # show auth credentials and acls configuration
         script_run 'cat /sys/kernel/config/target/iscsi/' . $target_label . '/tpgt_1/acls/' . $initiator_label . '/tpgt_1/acls/auth/*';
     }
-    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
We have a failure to display targets, as test fails before that moment,
so no logs are collected. Calling parent post fail hook first so can
file issues.

Fixes log collection in https://openqa.suse.de/tests/3850431#