### PR TITLE
add explicit bootloader installation to MBR

### DIFF
--- a/data/autoyast_sle15/autoyast_mlx_con5.xml
+++ b/data/autoyast_sle15/autoyast_mlx_con5.xml
@@ -25,6 +25,7 @@
     <global>
       <append>console=ttyS1,115200 noquiet crashkernel=172M,high crashkernel=72M,low</append>
       <gfxmode>auto</gfxmode>
+      <boot_mbr>true</boot_mbr>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <serial>serial --unit=1 --speed=115200 --parity=no</serial>


### PR DESCRIPTION
Sometimes, the bootloader gets not installed into the mbr properly, so let's enforce that.
