### PR TITLE
HPC: Workaround for slurm.config problem

### DIFF
--- a/lib/hpc/configs.pm
+++ b/lib/hpc/configs.pm
@@ -35,7 +35,7 @@ sub prepare_slurm_conf {
 
     if ($slurm_conf eq "basic") {
         my $config = << "EOF";
-sed -i "/^SlurmctldHost.*/c\\SlurmctldHost=$cluster_ctl_nodes[0]" /etc/slurm/slurm.conf
+sed -i "/^ControlMachine.*/c\\SlurmctldHost=$cluster_ctl_nodes[0]" /etc/slurm/slurm.conf
 sed -i "/^NodeName.*/c\\NodeName=$cluster_ctl_nodes,$cluster_compute_nodes Sockets=1 CoresPerSocket=1 ThreadsPerCore=1 State=unknown" /etc/slurm/slurm.conf
 sed -i "/^PartitionName.*/c\\PartitionName=normal Nodes=$cluster_ctl_nodes,$cluster_compute_nodes Default=YES MaxTime=24:00:00 State=UP" /etc/slurm/slurm.conf
 sed -i "/^SlurmctldDebug.*/c\\SlurmctldDebug=debug5" /etc/slurm/slurm.conf

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -457,6 +457,11 @@ sub run {
 sed -i "/^ControlMachine.*/c\\ControlMachine=master-node00" /etc/slurm/slurm.conf
 EOF
         assert_script_run($_) foreach (split /\n/, $config);
+    } else {
+        my $config = << "EOF";
+sed -i "/^ControlMachine.*/c\\#ControlMachine" /etc/slurm/slurm.conf
+EOF
+        assert_script_run($_) foreach (split /\n/, $config);
     }
     record_info('slurmctl conf', script_output('cat /etc/slurm/slurm.conf'));
     $self->distribute_munge_key();


### PR DESCRIPTION
In slurm 19.05 the slurm-config provides outdated slurm.config.
bug#1162377
