### PR TITLE
Use sleep 2, same as in every other sssd test script

### DIFF
--- a/data/sssd-tests/krb/test.sh
+++ b/data/sssd-tests/krb/test.sh
@@ -33,6 +33,7 @@ cp ldap.crt /tmp/ldap-sssdtest.cacrt &&
 cp ldap.crt /tmp/ldap-sssdtest.crt &&
 cp ldap.key /tmp/ldap-sssdtest.key &&
 $SLAPD -h 'ldap:///' -f $CONF &&
+sleep 2 &&
 ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif &> /dev/null &&
 ldappasswd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -spass 'cn=krbkdc,dc=ldapdom,dc=net' &&
 ldappasswd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -spass 'cn=krbadm,dc=ldapdom,dc=net' || test_abort 'Failed to prepare LDAP server'


### PR DESCRIPTION
This test is failing randomly exactly on this krb test,
on following ldapadd command after slapd is started.
As each other test has 2 seconds sleep after slapd is launched,
looks like slapd need some time to startup, to return successfuly
on ldap commands
```
+ /usr/sbin/slapd -h ldap:/// -f slapd.conf
+ ldapadd -x -D cn=root,dc=ldapdom,dc=net -wpass -f db.ldif
+ test_abort 'Failed to prepare LDAP server'

data/sssd-tests/ldap-nested-groups/test.sh:$SLAPD -h 'ldap:///' -f slapd.conf &&
data/sssd-tests/ldap-nested-groups/test.sh-sleep 2 &&
--
data/sssd-tests/ldap-no-auth/test.sh:$SLAPD -h 'ldap:///' -f slapd.conf &&
data/sssd-tests/ldap-no-auth/test.sh-sleep 2 &&
--
data/sssd-tests/ldap/test.sh:$SLAPD -h 'ldap:///' -f slapd.conf &&
data/sssd-tests/ldap/test.sh-sleep 2 &&
```

- Fail:
15sp1
https://openqa.suse.de/tests/3854141#step/sssd/112
https://openqa.suse.de/tests/3851884#step/sssd/114
https://openqa.suse.de/tests/3850161#step/sssd/114
https://openqa.suse.de/tests/3846928#step/sssd/114
https://openqa.suse.de/tests/3846822#step/sssd/114
https://openqa.suse.de/tests/3855774#step/sssd/114
https://openqa.suse.de/tests/3851289#step/sssd/114
https://openqa.suse.de/tests/3838111#step/sssd/114
https://openqa.suse.de/tests/3837248#step/sssd/114
15
https://openqa.suse.de/tests/3832639#step/sssd/114
https://openqa.suse.de/tests/3831394#step/sssd/114
https://openqa.suse.de/tests/3831113#step/sssd/114
https://openqa.suse.de/tests/3828795#step/sssd/114

- Verification run:
https://openqa.suse.de/tests/3856783
https://openqa.suse.de/tests/3856784
https://openqa.suse.de/tests/3856785
https://openqa.suse.de/tests/3856786
https://openqa.suse.de/tests/3856787
https://openqa.suse.de/tests/3856788
https://openqa.suse.de/tests/3856789
https://openqa.suse.de/tests/3856796
https://openqa.suse.de/tests/3856797
https://openqa.suse.de/tests/3856798