### PR TITLE
scc_registration: Need send next key after got removed repos

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -630,6 +630,7 @@ sub fill_in_registration_data {
                 record_soft_failure 'bsc#1080450: license agreement is shown twice' if match_has_tag("license-agreement-accepted");
                 send_key $cmd{next};
                 assert_screen "remove-repository";
+                send_key $cmd{next};
             }
         }
     }


### PR DESCRIPTION
As title, in scc_registration we need send next key after got removed repos.

- Related ticket: https://progress.opensuse.org/issues/62948
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/3857615
