### PR TITLE
Reuse toolchain installation for ib_tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -542,6 +542,8 @@ sub load_baremetal_tests {
         get_var("AUTOYAST") ? load_ayinst_tests() : load_inst_tests();
         load_reboot_tests();
     }
+    # make sure we always have the toolchain installed
+    loadtest "toolchain/install";
     # some tests want to build and run a custom kernel
     loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
 }

--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -108,15 +108,6 @@ sub run {
 
     $self->select_serial_terminal;
 
-    ## adding required sdk
-    ##TODO: consider better ways of handling addons/modules etc
-    ## https://progress.opensuse.org/issues/54773
-    if (is_sle '<15') {
-        zypper_call("ar -f ftp://openqa.suse.de/SLE-$version-SDK-POOL-$arch-Build$sdk_version-Media1/ SDK");
-    } else {
-        add_suseconnect_product("sle-module-development-tools");
-    }
-
     # unload firewall. MPI- and libfabric-tests require too many open ports
     systemctl("stop " . opensusebasetest::firewall);
     barrier_wait('IBTEST_SETUP');


### PR DESCRIPTION
Instead of having a workaround activating the toolchain module,
we can just load the correct test module which installls the toolchain
for us. Remove handling of the toolchain from ib_tests.

Signed-off-by: Michael Moese <mmoese@suse.de>