### PR TITLE
Enable full lvm encrypt scenario for powerVM

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -16,6 +16,7 @@ use warnings;
 use testapi;
 use version_utils ':VERSION';
 use installation_user_settings 'await_password_check';
+use Utils::Architectures;
 
 our @EXPORT = qw(
   addboot
@@ -180,8 +181,8 @@ sub mount_device {
 =head2 set_partition_size
 
  set_partition_size([size => $size]);
-  
-The function can be executed when the SUT is on the yast partitioner panel 
+
+The function can be executed when the SUT is on the yast partitioner panel
 `Add partition on /dev/xxx -> New Partition Size` to set the C<$args{size}> in megabytes.
 
 Example:
@@ -302,7 +303,7 @@ sub addpart {
  addvg(name => $name [, add_all_pvs => $add_all_pvs]);
 
 Add a LVM volume group.
-Example: 
+Example:
 
  addvg(name => 'vg-system', add_all_pvs => 1);
 
@@ -404,7 +405,7 @@ sub addlv {
 
 Add a boot partition based on architecture.
 
-C<$part_size> is the size of partition. 
+C<$part_size> is the size of partition.
 
 =cut
 sub addboot {
@@ -417,7 +418,7 @@ sub addboot {
         unenc_boot => 500
     );
 
-    if (get_var('OFW')) {    # ppc64le always needs PReP boot
+    if (is_ppc64le()) {    # ppc64le always needs PReP boot
         addpart(role => 'raw', size => $part_size // $default_boot_sizes{ofw}, fsid => 'PReP');
     }
     elsif (get_var('UEFI')) {    # UEFI needs partition mounted to /boot/efi for
@@ -582,7 +583,7 @@ Take the first disk to be partitioned. Take first partition as storage ng if it 
 C<[%args]> is device type.
 
 Example:
- 
+
  take_first_disk(iscsi => 1);
 
 =cut

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -1,0 +1,39 @@
+---
+description: >
+  Conduct installation with encrypted LVM without separate boot partition,
+  only prep boot is created. Partitioning is validated after the installation.
+  For powerVM we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+name: lvm-full-encrypt
+vars:
+  DESKTOP: textmode
+  ENCRYPT: 1
+  FULL_LVM_ENCRYPT: 1
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_full_lvm
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/validate_lvm
+  - console/validate_encrypt


### PR DESCRIPTION
This PR contains required changes to successfully execute full lvm encrypt scenario on powerVM.

See [poo#62723](https://progress.opensuse.org/issues/62723).

[Verification run](https://openqa.suse.de/tests/3858432).

[Changes to the job group](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/merge_requests/129).