### PR TITLE
Add first-tty-selected in reboot_and_wait_up to cover issue from #9048

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -42,7 +42,7 @@ sub reboot_and_wait_up {
         #login
         #The timeout can't be too small since autoyast installation
         #need to wait 2nd phase install to finish
-        assert_screen("tty1-selected", 600);
+        assert_screen "first-tty-selected", 600;
         type_string "root\n";
         assert_screen "password-prompt";
         type_password;


### PR DESCRIPTION
Add now tag 'first-tty-selected' to cover ipmi installation
see https://progress.opensuse.org/issues/34471
Verification test:
https://openqa.suse.de/tests/3863221