### PR TITLE
[WIP] Add data for partition table test on hmc

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -33,4 +33,6 @@ schedule:
   - console/verify_separate_home
   - console/validate_file_system
 test_data:
+  device: /dev/sda
+  table_type: gpt
   !include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml


### PR DESCRIPTION
Related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9453. With spvm (now hmc) we still use a yaml schedule for libstorage, not libstorage-ng, so the file has to be adapted.

- Related ticket: https://progress.opensuse.org/issues/58912w
- Needles: N/A
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
