### PR TITLE
Fix HANA installation on ppc64le

### DIFF
--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -66,6 +66,9 @@ sub run {
 
     # Some specific package may be needed in HA mode
     zypper_call 'in sap-suse-cluster-connector' if get_var('HA_CLUSTER');
+
+    # Workaround for textmode based test, as there is no SAP profiles with textmode yet
+    zypper_call 'in libgomp1' if check_var('SYSTEM_ROLE', 'textmode');
 }
 
 sub test_flags {


### PR DESCRIPTION
Workaround for textmode based test, as there is no SAP profiles with textmode yet.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/3857620#step/hana_test/20
- Verification run: https://openqa.suse.de/t3858629