### PR TITLE
Add Travis detection of removed/deleted modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test-spec:
 	tools/update_spec --check
 
 .PHONY: test-static
-test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-unused-modules test-soft_failure-no-reference test-spec test-invalid-syntax
+test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-unused-modules test-deleted-renamed-referenced-modules test-soft_failure-no-reference test-spec test-invalid-syntax
 .PHONY: test
 ifeq ($(TESTS),compile)
 test: test-compile
@@ -119,6 +119,10 @@ perlcritic: tools/lib/
 .PHONY: test-unused-modules
 test-unused-modules:
 	tools/detect_unused_modules
+
+.PHONY: test-deleted-renamed-referenced-modules
+test-deleted-renamed-referenced-modules:
+	tools/test_deleted_renamed_referenced_modules `git diff --name-only --exit-code --diff-filter=DR $$(git merge-base master HEAD) | grep '^tests/*'`
 
 .PHONY: test-soft_failure-no-reference
 test-soft_failure-no-reference:

--- a/tools/test_deleted_renamed_referenced_modules
+++ b/tools/test_deleted_renamed_referenced_modules
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+FILES="${@}"
+success=1
+for FILE in $FILES; do
+    if [ -f "$FILE" ]; then
+        # if file exists it means it was renamed, and then original file name is retrieved by git log
+        FILE=$(git log --follow -p $FILE | grep 'rename from tests/')
+    fi
+    # module name as appears in scheduling files excluding 'tests/' and file extension
+    module=$(echo $FILE | cut -f 2- -d '/' | cut -f 1 -d '.')
+    target_paths='schedule/ products/*/main.pm lib/main_common.pm'
+    MATCHED_SCHEDULE_FILES=$(grep --recursive --ignore-case --files-with-matches $module $target_paths)
+    if [ "$MATCHED_SCHEDULE_FILES" ]; then
+        echo -e "\"$module\" test module was removed or renamed, but it is still used in: \
+        \n$MATCHED_SCHEDULE_FILES\n"
+        success=0
+    fi
+done
+[ $success = 1 ] && echo "SUCCESS" && exit 0
+exit 1


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/62741
- Verification run: [Failure showing renamed and deleted files](https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse/builds/645919998) 
