### PR TITLE
Move testdate far into future, so we won't pass it

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -81,9 +81,9 @@ sub run {
     }
     die "No suitable package found. Script output:\nOutput: '$output'" unless $package;
 
-    my $testdate        = '2020-02-03';
-    my $testdate_after  = '2020-02-04';
-    my $testdate_before = '2020-02-02';
+    my $testdate        = '2620-02-03';
+    my $testdate_after  = '2620-02-04';
+    my $testdate_before = '2620-02-02';
     # backup and create our lifecycle data with known content
     select_console 'root-console';
     assert_script_run "


### PR DESCRIPTION
- Related issue: https://bugzilla.suse.com/show_bug.cgi?id=1162560
- Fail: https://openqa.suse.de/tests/3859449#step/zypper_lifecycle/21
- Verification run:
https://openqa.suse.de/tests/3860175
https://openqa.suse.de/tests/3860176