### PR TITLE
Exclude yast keyboard from s390x cmd tests (bsc#1161234)

### DIFF
--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -6,6 +6,15 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/bootloader_zkvm
+  # As per bsc#1161234 yast keyaboard won't be fixed on s390x
+  yast_keyboard:
+    ARCH:
+      aarch64:
+        - yast2_cmd/yast_keyboard
+      ppc64le:
+        - yast2_cmd/yast_keyboard
+      x86_64:
+        - yast2_cmd/yast_keyboard
 schedule:
   - {{bootloader_zkvm}}
   - boot/boot_to_desktop
@@ -17,5 +26,5 @@ schedule:
   - yast2_cmd/yast_tftp_server
   - yast2_cmd/yast_lan
   - yast2_cmd/yast_users
-  - yast2_cmd/yast_keyboard
+  - {{yast_keyboard}}
   - yast2_cmd/yast_sysconfig


### PR DESCRIPTION
As per [bsc#1161234](https://bugzilla.suse.com/show_bug.cgi?id=1161234).

[Verification run](https://openqa.suse.de/t3861420).
