### PR TITLE
Add data for partition table test on hmc

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -33,4 +33,6 @@ schedule:
   - console/verify_separate_home
   - console/validate_file_system
 test_data:
+  device: /dev/sda
+  table_type: gpt
   !include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -25,6 +25,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/hostname
   - console/validate_file_system
 test_data:
   device: /dev/vda

--- a/tests/console/validate_file_system.pm
+++ b/tests/console/validate_file_system.pm
@@ -25,7 +25,6 @@ sub run {
     my $test_data  = get_test_suite_data();
     my %partitions = %{$test_data->{file_system}};
 
-    select_console('root-console') unless (current_console() eq "root_console");
     validate_partition_table({device => $test_data->{device}, table_type => $test_data->{table_type}});
 
     foreach (keys %partitions) {
@@ -34,7 +33,6 @@ sub run {
         assert_equals($partitions{$_}, $fstype,
             "File system on '$_' partition does not correspond to the expected one");
     }
-
 }
 
 1;


### PR DESCRIPTION
Related to #9453. With spvm (now hmc) we still use a yaml schedule for libstorage, not libstorage-ng, so the file has to be adapted. On hmc, we cannot use twice select_console, so we have to work-around this too.

- Related ticket: https://progress.opensuse.org/issues/58912w
- Verification run:
btrfs/x86 : http://waaa-amazing.suse.cz/tests/11257
btrfs/ppc64le-hmc: https://openqa.suse.de/tests/3866386
gpt/uefi: https://openqa.suse.de/t3866388
gpt/x64: http://waaa-amazing.suse.cz/tests/11258
gpt/ppc64le: https://openqa.suse.de/t3866389

