### PR TITLE
sles4sap: Increase timeout after stopping SAP daemon

### DIFF
--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -76,10 +76,10 @@ sub run {
         barrier_wait "HANA_INIT_CONF_$cluster_name";
 
         assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StopSystem HDB'";
-        sleep 10;
+        assert_script_run "until su - $sapadm -c 'hdbnsutil -sr_state' | grep -q 'online: false' ; do sleep 1 ; done", 120;
         assert_script_run "su - $sapadm -c 'hdbnsutil -sr_register --remoteHost=$node1 -remoteInstance=$instance_id --replicationMode=sync --name=NODE2 --operationMode=logreplay'";
         assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StartSystem HDB'";
-        sleep 10;
+        assert_script_run "until su - $sapadm -c 'hdbnsutil -sr_state' | grep -q 'online: true' ; do sleep 1 ; done";
 
         # Synchronize the nodes
         barrier_wait "HANA_CREATED_CONF_$cluster_name";


### PR DESCRIPTION
This PR increases the timeout after the stopping the SAP daemon to fix the current issue with the HANA SR cluster test in openQA.

- Verification run: [node1](http://ix64hae1001.qa.suse.de/tests/2016) & [node2](http://ix64hae1001.qa.suse.de/tests/2017)
