### PR TITLE
Wait longer for text-logged-in-$user needle

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -769,7 +769,7 @@ sub activate_console {
                 ensure_user($user);
             }
         }
-        assert_screen "text-logged-in-$user";
+        assert_screen "text-logged-in-$user", 60;
         $self->set_standard_prompt($user, skip_set_standard_prompt => $args{skip_set_standard_prompt});
         assert_screen $console;
     }


### PR DESCRIPTION
60 seconds for this kind of needle is used in assert_screen
before and after. Failure which triggered this PR happened on ppc64le,
the VM had load ~2 at the time, login was successful and needle
just had to wait a bit longer for shell to show up

- Fail: https://openqa.suse.de/tests/3862863#step/shutdown_ltp/55
- Verification run: https://openqa.suse.de/tests/3863189