### PR TITLE
Fix issue with default hostname for hostname_inst.pm

### DIFF
--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -22,10 +22,10 @@ use testapi;
 sub run {
     assert_screen "before-package-selection";
     select_console 'install-shell';
-    if (my $expected_install_hostname = get_var('EXPECTED_INSTALL_HOSTNAME')) {
-        # EXPECTED_INSTALL_HOSTNAME contains expected hostname YaST installer
-        # got from environment (DHCP, 'hostname=' as a kernel cmd line argument
-        assert_script_run "test \"\$(hostname)\" == \"$expected_install_hostname\"";
+    # In network configuration, YaST-Installer has now 'Set hostname via DHCP: No'
+    # NICTYPE_USER_OPTIONS hostname=myguest is used as well.
+    if (get_var('NICTYPE_USER_OPTIONS', 'hostname=myguest')) {
+        assert_script_run "test \"\$(hostname)\" == \"myguest\"";
     }
     else {
         # 'install' is the default hostname if no hostname is get from environment


### PR DESCRIPTION
With the change of network setting 'DHCP set hostname from yes to no',
and NICTYPE_USER_OPTIONS=hostname=myguest is used for testsuite, so simply
check default hostname 'linux' is not working anymore.

see https://progress.opensuse.org/issues/62852
verification test:
http://f40.suse.de/tests/6789#step/hostname_inst