### PR TITLE
Adapt WSL test suite for YaST2 firstboot and registration

### DIFF
--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -62,14 +62,12 @@ sub run {
     wait_still_screen stilltime => 1, timeout => 5;
     assert_and_click 'browse';
     assert_and_click 'select-store-trusted-roots';
-    # confirm selected certificate store
-    wait_screen_change(sub { send_key 'ret' }, 10);
+    # confirm selected certificate store and then
     # hit next
-    wait_screen_change(sub { send_key 'ret' }, 10);
-    for (1 .. 2) {
-        assert_screen 'successful-certificate-import';
-        wait_screen_change(sub { send_key 'ret' }, 10);
-    }
+    wait_screen_change(sub { send_key 'ret' }, 10) for (1 .. 2);
+    assert_screen 'completing-cert-import';
+    assert_and_click 'finish-button-in-win10';
+    assert_screen 'successful-certificate-import';
 
     # close all opened windows, including powershell
     send_key_until_needlematch 'powershell-ready-prompt', 'alt-f4', 25, 2;


### PR DESCRIPTION
- Related ticket: [[WSL][sle15sp2] test fails in prepare_wsl_feature - click finish](https://progress.opensuse.org/issues/63130)
- Needles: [Add YaST2 firstboot needles for wsl](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1321)
  * https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/637
- Verification runs:
   * [Build31.72-wsl-main skipped registration](http://eris.suse.cz/tests/4256#) && [WSL: "The installation URL is not set"](https://bugzilla.suse.com/show_bug.cgi?id=1162841)
   * [opensuse-Tumbleweed-WSL-x86_64-Build20200205.20.3-wsl-main@64bit_win](http://eris.suse.cz/tests/4455#)
   * [sle-15-SP2-WSL-x86_64-Build34.43-wsl-main-unregistered@windows_bios_boot](http://eris.suse.cz/tests/4452)
   * [sle-15-SP2-WSL-x86_64-Build34.43-wsl-main@windows_bios_boot](http://eris.suse.cz/tests/4448)
