### PR TITLE
rebootmgr: Remove etcd lock testing

### DIFF
--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -111,12 +111,6 @@ sub run {
 
     record_info 'Maint-window', 'Test maint-window strategy';
     check_strategy_maint_window;
-
-    if (is_tumbleweed) {
-        record_info 'Etcd', 'Test etcd locking strategy';
-        trup_install 'etcd';
-        check_strategy_etcd_lock;
-    }
 }
 
 1;


### PR DESCRIPTION
Tumbleweed rebootmgr no longer has etcd lock support, so stop testing it

https://openqa.opensuse.org/tests/1164390#step/rebootmgr/96