### PR TITLE
Install kiwi templates

### DIFF
--- a/schedule/jeos/sle/kvm/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/kvm/jeos-base+sdk+desktop.yaml
@@ -12,7 +12,9 @@ schedule:
   - jeos/build_key
   - console/suseconnect_scc
   - console/consoletest_setup
+  - jeos/kiwi_templates
   - console/zypper_ref
+  - console/zypper_lr
   - console/command_not_found
   - console/libvorbis
   - console/git

--- a/tests/jeos/kiwi_templates.pm
+++ b/tests/jeos/kiwi_templates.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Install kiwi templates for JeOS
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    select_console 'root-console';
+    zypper_call 'in kiwi-templates-JeOS';
+    script_run 'rpm -ql kiwi-templates-JeOS';
+}
+
+1;


### PR DESCRIPTION
- Related ticket: [[JeOS][sle] add test case to install kiwi-templates-JeOS](https://progress.opensuse.org/issues/63145)
- Verification run: [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build7.23-jeos-base+sdk+desktop@uefi-virtio-vga](http://eris.suse.cz/tests/4148#step/kiwi_templates/1) 
