### PR TITLE
regproxy: connect to obs-login, not hydra

### DIFF
--- a/data/regproxy/regproxy.py
+++ b/data/regproxy/regproxy.py
@@ -8,7 +8,7 @@ import json
 import _thread
 
 def availableRepos(prefix):
-	conn = http.client.HTTPSConnection("hydra.opensuse.org")
+	conn = http.client.HTTPSConnection("obs-login.opensuse.org")
 	headers={"Host": "registry.opensuse.org"}
 	conn.request("GET", "/v2/_catalog", None, headers)
 	resp = conn.getresponse()


### PR DESCRIPTION
registry.o.o is actually not behind hydra - and the network is being cleaned
up from stuff that should no longer exist.

- Related ticket: 
- Needles: 
- Verification run: https://openqa.opensuse.org/t1164979
