### PR TITLE
Fix SLES4SAP on Public Cloud Tests

### DIFF
--- a/data/publiccloud/terraform/sap/gce.tfvars
+++ b/data/publiccloud/terraform/sap/gce.tfvars
@@ -14,6 +14,7 @@ iscsi_ip = "10.0.0.253"
 
 # Type of VM (vCPUs and RAM)
 machine_type = "%MACHINE_TYPE%"
+machine_type_iscsi_server = "custom-1-2048"
 
 # Disk type for HANA
 hana_data_disk_type = "pd-ssd"

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -329,7 +329,7 @@ sub terraform_apply {
         assert_script_run('cd ' . TERRAFORM_DIR . "/$cloud_name");
         my $sap_media   = get_required_var('HANA');
         my $sap_regcode = get_required_var('SCC_REGCODE_SLES4SAP');
-        my $sle_version = get_required_var('VERSION');
+        my $sle_version = get_var('FORCED_DEPLOY_REPO_VERSION') ? get_var('FORCED_DEPLOY_REPO_VERSION') : get_var('VERSION');
         $sle_version =~ s/-/_/g;
         file_content_replace('terraform.tfvars',
             q(%MACHINE_TYPE%)         => $instance_type,


### PR DESCRIPTION
During Build Validation the deployment repo could not be yet at the needed version, so in that case we have to/could use another one

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/3868671#step/sles4sap/113
- Verification run: https://openqa.suse.de/tests/3868826