### PR TITLE
Use text-login for user/password login prompt

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -42,7 +42,7 @@ sub reboot_and_wait_up {
         #login
         #The timeout can't be too small since autoyast installation
         #need to wait 2nd phase install to finish
-        assert_screen "first-tty-selected", 600;
+        assert_screen "text-login", 600;
         type_string "root\n";
         assert_screen "password-prompt";
         type_password;


### PR DESCRIPTION
Change back to use text-login. This was accidentally modified by https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/674c4b5b579d6782dd97a49ddb240ac0ada153e6?_pjax=%23js-repo-pjax-container

- Related ticket: 
   - https://openqa.suse.de/tests/3866769#step/reboot_and_wait_up_normal/1
   - https://openqa.suse.de/tests/3866770#step/reboot_and_wait_up_normal/1
   - https://openqa.suse.de/tests/3866441#step/reboot_and_wait_up_normal/1
   - https://openqa.suse.de/tests/3866440#step/reboot_and_wait_up_normal/1
   and many more
- Needles: Should use 'text-login' for serial ssh login prompt
- Verification run: NO NEED
