### PR TITLE
Wait before assert_and_click, to avoid movement of click area

### DIFF
--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -104,7 +104,8 @@ sub run {
     # select 'data and isv applications'
     send_key "alt-d";
     # next
-    wait_screen_change { send_key "alt-n" };
+    send_key "alt-n";
+    wait_still_screen(2);
     assert_and_click "yast2_storage_ng-filesystem-dropdown";
     # XFS is the default filesystem, so we have to move up
     send_key_until_needlematch("yast2_storage_ng-ext4", "up");
@@ -200,6 +201,7 @@ sub run {
 
     # EXT4, encrypted
     add_logical_volume "lv2", "alt-d";
+    wait_still_screen(2);
     assert_and_click "yast2_storage_ng-filesystem-dropdown";
     send_key_until_needlematch("yast2_storage_ng-ext4", "up");
     send_key "ret";
@@ -207,6 +209,7 @@ sub run {
 
     # BtrFS, encrypted
     add_logical_volume "lv3", "alt-d";
+    wait_still_screen(2);
     assert_and_click "yast2_storage_ng-filesystem-dropdown";
     send_key_until_needlematch("yast2_storage_ng-btrfs", "up");
     send_key "ret";


### PR DESCRIPTION
Captured screen may be not the final one, buttons can move or appear.
It happens that asserted screen is different than screen when click is
done. Wait until the windows does not change/move any more.

![storage](https://paste.opensuse.org/images/e9ad0a67.gif)

- Fail: https://openqa.suse.de/tests/3869407#step/yast2_storage_ng/75
- Verification run:
https://openqa.suse.de/tests/3870054
https://openqa.suse.de/tests/3870062
