### PR TITLE
Whitelist error in yast logs as per bsc#1161234

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -243,9 +243,17 @@ sub investigate_yast2_failure {
     my %y2log_known_errors = (
         "<3>.*no[t]? mount"   => 'bsc#1092088',                   # Detect not mounted partition
         "<3>.*lib/cheetah.rb" => 'bsc#1153749',
-
         # The error below will be cleaned up, see https://trello.com/c/5qTQZKH3/2918-sp2-logs-cleanup
         # Adding reference to trello, detect those in single scenario
+        # (build97.1) regressions
+        # found https://openqa.suse.de/tests/3646274#step/logs_from_installation_system/412
+        "<3>.*SCR::Dir\\(\\) failed"                            => 'bsc#1158186',
+        "<3>.*Unknown desktop file: installation"               => 'bsc#1158186',
+        "<3>.*Bad options for module: virtio_net"               => 'bsc#1158186',
+        "<3>.*Wrong value for path ."                           => 'bsc#1158186',
+        "<3>.*setOptions:Empty map"                             => 'bsc#1158186',
+        "<3>.*Unmounting media failed"                          => 'bsc#1158186',
+        "<3>.*No base product has been found"                   => 'bsc#1158186',
         "<3>.*Error output: dracut:"                            => 'https://trello.com/c/5qTQZKH3/2918-sp2-logs-cleanup',
         "<3>.*Reading install.inf"                              => 'https://trello.com/c/5qTQZKH3/2918-sp2-logs-cleanup',
         "<3>.*shellcommand"                                     => 'https://trello.com/c/5qTQZKH3/2918-sp2-logs-cleanup',
@@ -326,15 +334,6 @@ sub investigate_yast2_failure {
         "<5>.*Path.*on medium"                  => 'https://trello.com/c/5qTQZKH3/2918-sp2-logs-cleanup',
         "<5>.*Aborting requested by user"       => 'https://trello.com/c/5qTQZKH3/2918-sp2-logs-cleanup',
         "<5>.*Exception.cc"                     => 'https://trello.com/c/5qTQZKH3/2918-sp2-logs-cleanup',
-        # (build97.1) regressions
-        # found https://openqa.suse.de/tests/3646274#step/logs_from_installation_system/412
-        "<3>.*SCR::Dir() failed"                  => 'bsc#1158186',
-        "<3>.*Unknown desktop file: installation" => 'bsc#1158186',
-        "<3>.*Bad options for module: virtio_net" => 'bsc#1158186',
-        "<3>.*Wrong value for path ."             => 'bsc#1158186',
-        "<3>.*setOptions:Empty map"               => 'bsc#1158186',
-        "<3>.*Unmounting media failed"            => 'bsc#1158186',
-        "<3>.*No base product has been found"     => 'bsc#1158186'
     );
 
     my $delimiter = '=========================================';


### PR DESCRIPTION
As per comment #5 in https://bugzilla.suse.com/show_bug.cgi?id=1161234 ,
this error is not new and will be acted on in the card regarding logs
clean-up. So adding soft-failure not to fail the test.

[Verification run](https://openqa.suse.de/tests/3870063).
