### PR TITLE
Remove soft-fail for yast2_samba bsc#1068900

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -388,8 +388,6 @@ sub run {
         setup_yast2_auth_server;
     }
     else {
-        # dirsrv@openqa cannot be restarted due to dependency issues
-        record_soft_failure "bsc#1088152";
         setup_yast2_ldap_server;
     }
     setup_samba;


### PR DESCRIPTION
The [issue](https://bugzilla.suse.com/show_bug.cgi?id=1088152) was reported for sp0 and not reproducible on the latest sle15. The bsc is closed also.

- Related ticket: https://progress.opensuse.org/issues/60701