### PR TITLE
HPC: Remove slurm.conf sed adaptation

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -457,11 +457,6 @@ sub run {
 sed -i "/^ControlMachine.*/c\\ControlMachine=master-node00" /etc/slurm/slurm.conf
 EOF
         assert_script_run($_) foreach (split /\n/, $config);
-    } else {
-        my $config = << "EOF";
-sed -i "/^ControlMachine.*/c\\#ControlMachine" /etc/slurm/slurm.conf
-EOF
-        assert_script_run($_) foreach (split /\n/, $config);
     }
     record_info('slurmctl conf', script_output('cat /etc/slurm/slurm.conf'));
     $self->distribute_munge_key();


### PR DESCRIPTION
As the new lib/hpc/config is in place, there is no more need to edit
slurm.conf in slurm test code itself

- Verification run: 
http://10.160.65.14/tests/16515
http://10.160.65.14/tests/16520
