### PR TITLE
sles4sap/saptune/mr_test: use reboot() instead of reboot_wait() on sa…

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -111,13 +111,13 @@ sub test_sapconf {
     } else {
         assert_script_run "sapconf netweaver";
     }
-    $self->reboot_wait;
+    $self->reboot;
     assert_script_run "mr_test verify Pattern/$SLE/testpattern_Upd#2_2";
 
     # Scenario 2: sapconf has been disabled (only the service), but the package is still there.
     assert_script_run "cp /etc/security/limits.conf{.bak,}";
     systemctl "disable --now sapconf";
-    $self->reboot_wait;
+    $self->reboot;
     assert_script_run "mr_test verify Pattern/$SLE/testpattern_Upd#3_2";
 }
 


### PR DESCRIPTION
This PR fixes sles4sap_gnome_saptune_v2_note_sapconf

As tuned is disabled in the `test_sapconf` function, the `tuned-adm verify` command doesn't work.  So, instead of using `reboot_wait` (which uses the above command), we simply use `reboot`.

- Failing test: https://openqa.suse.de/tests/3868247#step/mr_test/94
- Verification run: http://ix64hae1001.qa.suse.de/tests/2018
