### PR TITLE
await_install: Prevent endless loop on false-positive needle matches

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -122,16 +122,11 @@ sub run {
     my $screenlock_previously_detected = 0;
     my $mouse_x                        = 1;
     while (1) {
+        die 'timeout hit on during await_install' if $timeout <= 0;
         my $ret = check_screen \@tags, 30;
-
+        $timeout -= 30;
+        diag("left total await_install timeout: $timeout");
         if (!$ret) {
-            $timeout -= 30;
-            diag("left total await_install timeout: $timeout");
-            if ($timeout <= 0) {
-                assert_screen \@tags;
-                die "timeout hit on during await_install";
-            }
-
             if (get_var('LIVECD') && $screenlock_previously_detected) {
                 diag('installation not finished, move mouse around a bit to keep screen unlocked');
                 $mouse_x = ($mouse_x + 10) % 1024;


### PR DESCRIPTION
As happened in
https://openqa.opensuse.org/tests/latest?test=kde_live_upgrade_leap_42.3&version=Tumbleweed&arch=x86_64&machine=64bit-2G&distri=opensuse&flavor=KDE-Live
a black screen was incorrectly matched as "screenlock" causing the
internal timeout counter to never decrease until the test job is aborted
as incomplete without any logs by openQA. This commit changes behaviour
to always decrease the timeout regardless of the match result. This
simplifies the logic and prevents an endless loop. The only other
functional impact is that the overall timeout time is reduced by a
negligible 30s for each correct match.

Verification:

```
for i in https://openqa.opensuse.org/tests/1166278 https://openqa.opensuse.org/tests/1162613 https://openqa.opensuse.org/tests/1165657; do openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9533 $i ; done
```

* Created job #1166348: opensuse-Tumbleweed-KDE-Live-x86_64-Build20200205-kde_live_upgrade_leap_42.3@64bit-2G -> https://openqa.opensuse.org/t1166348
* Created job #1166349: opensuse-Tumbleweed-DVD-aarch64-Build20200201-install_only@aarch64 -> https://openqa.opensuse.org/t1166349
* Created job #1166350: opensuse-Tumbleweed-DVD-x86_64-Build20200205-gnome@64bit -> https://openqa.opensuse.org/t1166350

Related progress issue: https://progress.opensuse.org/issues/48899