### PR TITLE
Skip unnecessary serial getty disable on more recent products

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1194,6 +1194,7 @@ Serial getty service pollutes serial output with login prompt, which
 interferes with the output, e.g. when calling C<script_output>.
 Login prompt messages on serial are used on some remote backend to
 identify that system has been booted, so do not mask on non-qemu backends.
+This is only necessary for Linux < 4.20.4 so skipped on more recent versions.
 
 =cut
 sub disable_serial_getty {
@@ -1201,6 +1202,8 @@ sub disable_serial_getty {
     my $service_name = "serial-getty\@$testapi::serialdev";
     # Do not run on zVM as running agetty is required by iucvconn in order to work
     return if check_var('BACKEND', 's390x');
+    # No need to apply on more recent kernels
+    return unless is_sle('<=15-SP2') || is_leap('<=15.2');
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt
     # Doing early due to bsc#1103199 and bsc#1112109
     # Mask if is qemu backend as use serial in remote installations e.g. during reboot


### PR DESCRIPTION
We are currently applying some workarounds to make access to the serial port
from tests more reliable. According to
https://bugzilla.suse.com/show_bug.cgi?id=1112108#c3 this should not be
necessary anymore with Linux => 4.20.4 but we keep the workaround for older
products. This is done in a conservative way as older products might have
received the same bugfix by backport but we still apply the workaround to be on
the safe side.

Less workarounds make the tests cleaner and faster.

Verification:

```
for i in https://openqa.opensuse.org/tests/1165424 https://openqa.opensuse.org/tests/1165398 https://openqa.opensuse.org/tests/1162614 https://openqa.opensuse.org/tests/1163571 https://openqa.opensuse.org/tests/1166172 https://openqa.opensuse.org/tests/1166050; do openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9534 $i ; done
```

* Created job #1166351: opensuse-Tumbleweed-DVD-x86_64-Build20200205-gnuhealth@64bit -> https://openqa.opensuse.org/t1166351
* Created job #1166352: opensuse-Tumbleweed-DVD-x86_64-Build20200205-minimalx@64bit -> https://openqa.opensuse.org/t1166352
* Created job #1166353: opensuse-Tumbleweed-DVD-aarch64-Build20200201-gnome@aarch64 -> https://openqa.opensuse.org/t1166353
* Created job #1166354: opensuse-Tumbleweed-DVD-aarch64-Build20200201-zdup-Leap-15.0-gnome@aarch64 -> https://openqa.opensuse.org/t1166354
* Created job #1166355: opensuse-15.2-DVD-x86_64-Build566.1-zdup-Leap-15.1-kde@64bit -> https://openqa.opensuse.org/t1166355
* Created job #1166356: opensuse-15.2-DVD-x86_64-Build563.1-textmode@64bit -> https://openqa.opensuse.org/t1166356

Related progress issue: https://progress.opensuse.org/issues/54293