### PR TITLE
Do not test glibc_sanity in staging

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1186,9 +1186,9 @@ sub load_consoletests {
     if (is_opensuse || !is_staging && (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && !is_desktop)) {
         loadtest "console/salt";
     }
-    if (is_x86_64
-        || check_var('ARCH', 'i686')
-        || check_var('ARCH', 'i586'))
+    if (!is_staging && (is_x86_64
+            || check_var('ARCH', 'i686')
+            || check_var('ARCH', 'i586')))
     {
         loadtest "console/glibc_sanity";
     }


### PR DESCRIPTION
Due to a stricter (but more correct) test suite of the build package,
said package needed to be moved to ring1. As a result, build-mkbaselibs
is no longer available in ring0 - resulting in 'no -32bit packages' being built
(only in Ring0 - the actual product does not have any impact here)

As ring0 packages are binary aggregated to stgings, and not rebuilt there, this
change results in the side effect of not habing glibc-32bit available in the Stagings.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1168050
