### PR TITLE
[WIP] No separate home when system role is not default

### DIFF
--- a/tests/installation/partitioning/no_separate_home.pm
+++ b/tests/installation/partitioning/no_separate_home.pm
@@ -15,10 +15,12 @@
 use parent 'y2_installbase';
 use strict;
 use warnings FATAL => 'all';
+use testapi;
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();
-    $partitioner->edit_proposal(has_separate_home => 0);
+    my $has_separate_home = check_var('SYSTEM_ROLE', 'default') ? 0 : 1; 
+    $partitioner->edit_proposal(has_separate_home => $has_separate_home);
 }
 
 1;


### PR DESCRIPTION
There is no separate home when system role is 'hpc-server' etc. while not default.

- Related ticket: https://progress.opensuse.org/issues/62213
- Needles: N/A
- Verification run: Wait verify log on OSD.
