### PR TITLE
Add basic tests for RStudio

### DIFF
--- a/lib/rstudio.pm
+++ b/lib/rstudio.pm
@@ -1,0 +1,104 @@
+package rstudio;
+use testapi;
+use strict;
+use warnings;
+use utils;
+
+our @ISA    = qw(Exporter);
+our @EXPORT = qw(rstudio_help_menu rstudio_sin_x_plot rstudio_create_and_test_new_project rstudio_cleanup_project);
+
+sub rstudio_help_menu {
+    my %args         = @_;
+    my $rstudio_mode = $args{rstudio_mode} || "server";
+    my $prefix       = "rstudio_$rstudio_mode";
+
+    # open the About RStudio menu
+    assert_and_click("$prefix-help-menu");
+    assert_and_click("$prefix-about-rstudio");
+    # and close it again
+    assert_and_click("$prefix-about-rstudio-close");
+}
+
+sub rstudio_sin_x_plot {
+    my %args         = @_;
+    my $rstudio_mode = $args{rstudio_mode} || "server";
+    my $prefix       = "rstudio_$rstudio_mode";
+
+    # enter a space after both commands, so that the cursor is no longer in the
+    # needle match area
+    assert_and_click("$prefix-prompt");
+    type_string('x = 2.*pi*seq(1, 100)/(100.) ');
+
+    assert_screen("$prefix-x-data-entered");
+    wait_screen_change { send_key('ret'); };
+
+    type_string('plot(x, sin(x)) ');
+    assert_screen("$prefix-plot-cmd-entered");
+
+    wait_screen_change { send_key('ret'); };
+
+    assert_screen("$prefix-sin-x-plot");
+}
+
+sub rstudio_create_and_test_new_project {
+    my %args         = @_;
+    my $rstudio_mode = $args{rstudio_mode} || "server";
+    my $prefix       = "rstudio_$rstudio_mode";
+
+    # open the "New Project" dialog
+    assert_and_click("$prefix-file-menu");
+    assert_and_click("$prefix-file-menu_new-project");
+    assert_and_click("$prefix-don-t-save-current-workspace");
+
+    # create a "New Directory" -> "New Project"
+    assert_and_click("$prefix-new-project_new-directory");
+    assert_and_click("$prefix-new-project_project-type");
+
+    # enter project name and select "Create a git repository"
+    assert_screen("$prefix-create-new-project");
+    type_string("test_project");
+    assert_and_click("$prefix-create-new-project_create-git-repository");
+    assert_and_click("$prefix-create-new-project_create-project");
+
+    # open the .gitignore file, enter *~ at the top and save it
+    assert_and_click("$prefix-files-tab_select-gitignore");
+    assert_screen("$prefix-gitignore-file");
+    type_string("*~");
+    wait_still_screen(1);
+    send_key('ret');
+    assert_screen("$prefix-gitignore-file-unsaved");
+    send_key('ctrl-s');
+    assert_screen("$prefix-gitignore-file-saved");
+
+    # open the Git tab, stage the .gitignore file and commit it
+    assert_and_click("$prefix-project_git-tab");
+    assert_and_click("$prefix-project_git-tab_stage-gitignore");
+    assert_and_click("$prefix-project_git-tab_commit");
+    assert_and_click("$prefix-project_git-commit-window_commit-message");
+    type_string("Add .gitignore");
+    assert_and_click("$prefix-project_git-commit-window_commit-button");
+    assert_and_click("$prefix-project_git-commit-window_commit-close");
+    send_key('alt-f4');
+
+    # open commit log and close it again
+    assert_and_click("$prefix-project_commit-log-button");
+    assert_screen("$prefix-project_commit-history");
+    send_key('alt-f4');
+
+    # close the project
+    assert_and_click("$prefix-project_current-project-menu");
+    assert_and_click("$prefix-project_current-project-menu_close-project");
+    check_screen("$prefix-project_close-project_save-window", timeout => 10) && assert_and_click("$prefix-project_close-project_save-window", timeout => 1);
+    assert_screen("$prefix-project_no-project-open");
+}
+
+sub rstudio_cleanup_project {
+    x11_start_program('xterm');
+    assert_script_run("rm -rf ~/test_project");
+    wait_still_screen(1);
+    send_key("alt-f4");
+
+    # try to close all open windows:
+    # => hammer alt+F4 and check if we match the generic desktop needle
+    send_key_until_needlematch('generic-desktop', "alt-f4");
+}

--- a/schedule/rstudio.yaml
+++ b/schedule/rstudio.yaml
@@ -1,0 +1,8 @@
+name:           rstudio
+description:    >
+    Tests for rstudio and rstudio server
+schedule:
+  - boot/boot_to_desktop
+  - x11/rstudio_prepare
+  - x11/rstudio_desktop
+  - x11/rstudio_server

--- a/tests/x11/rstudio_desktop.pm
+++ b/tests/x11/rstudio_desktop.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Basic test of RStudio Desktop
+# Maintainer: Dan Čermák <dcermak@suse.com>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use rstudio;
+
+sub run {
+    mouse_hide(1);
+    ensure_installed('rstudio-desktop');
+
+    x11_start_program('rstudio', target_match => 'rstudio_desktop-main-window');
+
+    rstudio_help_menu(rstudio_mode => "desktop");
+
+    rstudio_sin_x_plot(rstudio_mode => "desktop");
+
+    rstudio_create_and_test_new_project(rstudio_mode => "desktop");
+
+    # bye-bye
+    send_key('alt-f4');
+}
+
+sub post_run_hook() {
+    rstudio_cleanup_project();
+}
+
+1;

--- a/tests/x11/rstudio_prepare.pm
+++ b/tests/x11/rstudio_prepare.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Install the rstudio base package and Firefox
+# Maintainer: Dan Čermák <dcermak@suse.com>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run() {
+    # increase timeout to 15 mins, shouldn't take as long, but who knows...
+    ensure_installed('rstudio MozillaFirefox git', timeout => 900);
+
+    # setup git for later usage
+    x11_start_program('xterm');
+    assert_script_run('git config --global user.name "Geeko"');
+    assert_script_run('git config --global user.email "geeko-noreply@opensuse.org"');
+    wait_still_screen(1);
+    send_key("alt-f4");
+}
+
+sub test_flags {
+    return {milestone => 1};
+}
+
+1;

--- a/tests/x11/rstudio_server.pm
+++ b/tests/x11/rstudio_server.pm
@@ -1,0 +1,74 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Basic test of RStudio Server
+# Maintainer: Dan Čermák <dcermak@suse.com>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use rstudio;
+
+sub run() {
+    mouse_hide(1);
+    ensure_installed('rstudio-server');
+
+    x11_start_program('xterm');
+    become_root();
+    assert_script_run("systemctl start rstudio-server");
+    wait_still_screen(1);
+    send_key("alt-f4");
+
+    # open R Studio in the browser and don't verify that Firefox actually
+    # started via a needle
+    x11_start_program("firefox http://localhost:8787", valid => 0);
+
+    # login
+    assert_and_click("rstudio_server-login-username");
+    # username
+    type_string('bernhard');
+    # password
+    send_key('tab');
+    type_password;
+    send_key('ret');
+
+    # reject saving the password for bernhard but don't fail in case this doesn't show up
+    # definitely check that we're logged in
+    assert_screen([qw(rstudio_server-firefox-save-password-prompt rstudio_server-logged-in)]);
+    if (match_has_tag('rstudio_server-firefox-save-password-prompt')) {
+        click_lastmatch();
+        assert_screen('rstudio_server-logged-in');
+    }
+
+    rstudio_help_menu(rstudio_mode => "server");
+
+    rstudio_sin_x_plot(rstudio_mode => "server");
+
+    rstudio_create_and_test_new_project(rstudio_mode => "server");
+
+    # log out at last and close firefox
+    assert_and_click("rstudio_server-sign-out");
+    assert_screen("rstudio_server-login-username");
+    send_key('alt-f4');
+
+    # optionally click away the close all tabs window
+    assert_screen([qw(rstudio_server-firefox_quit-and-close-tabs generic-desktop)]);
+    if (match_has_tag('rstudio_server-firefox_quit-and-close-tabs')) {
+        click_lastmatch();
+        assert_screen('generic-desktop');
+    }
+}
+
+sub post_run_hook() {
+    rstudio_cleanup_project();
+}
+
+1;


### PR DESCRIPTION
- Related ticket: N.A.
- Needles: ~~https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/634~~, https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/639
- Verification run: ~~https://openqa.opensuse.org/t1173227~~ ~~https://openqa.opensuse.org/tests/1173265~~

~~Unfortunately, I don't really know how to make a verification run with this, as it requires additional needles that are not present on o3.~~ Also, it requires the creation of a new test suite with the following settings:
```
BOOT_HDD_IMAGE=1
DESKTOP=gnome
HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-x11@%MACHINE%.qcow2
NOAUTOLOGIN=0
REGRESSION=gnome
START_AFTER_TEST=create_hdd_gnome-x11
UEFI_PFLASH_VARS=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-gnome-x11@%MACHINE%-uefi-vars.qcow2
YAML_SCHEDULE=schedule/rstudio.yaml
```