### PR TITLE
enlightenment: Handle new assistant step for bluez missing

### DIFF
--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -34,9 +34,17 @@ sub run {
     assert_and_click "enlightenment_assistant_next";
     assert_screen "enlightenment_keybindings";
     assert_and_click "enlightenment_assistant_next";
-    assert_screen "enlightenment_compositing";
+    assert_screen [qw(enlightenment_compositing enlightenment_bluez_not_found)];
+    if (match_has_tag 'enlightenment_bluez_not_found') {
+        assert_and_click 'enlightenment_assistant_next';
+        assert_screen 'enlightenment_compositing';
+    }
     assert_and_click "enlightenment_assistant_next";
-    assert_screen "enlightenment_generic_desktop";
+    assert_screen [qw(enlightenment_generic_desktop enlightenment_acpid_missing)];
+    if (match_has_tag 'enlightenment_acpid_missing') {
+        assert_and_click 'enlightenment_acpid_missing';
+        assert_screen 'enlightenment_generic_desktop';
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9538 https://openqa.opensuse.org/tests/1167766
```

Created job #1169409: opensuse-Tumbleweed-NET-x86_64-Build20200207-otherDE_enlightenment@64bit -> https://openqa.opensuse.org/tests/1170105#step/enlightenment_first_start/19
Related progress issue: https://progress.opensuse.org/issues/62591