### PR TITLE
opensuse_welcome: is applicable for Leap 15.2+ on xfce (poo#62597)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -211,11 +211,11 @@ sub any_desktop_is_applicable {
 }
 
 sub opensuse_welcome_applicable {
-    # openSUSE-welcome is expected to show up on openSUSE Tumbleweed only (Leap possibly in the future)
+    # openSUSE-welcome is expected to show up on openSUSE Tumbleweed and Leap 15.2+ XFCE only
     # since not all DEs honor xdg/autostart, we are filtering based on desktop environments
     # except for ppc64/ppc64le because not built libqt5-qtwebengine sr#323144
     my $desktop = shift // get_var('DESKTOP', '');
-    return $desktop =~ /gnome|kde|lxde|lxqt|mate|xfce/ && is_tumbleweed && (get_var('ARCH') !~ /ppc64/);
+    return (($desktop =~ /gnome|kde|lxde|lxqt|mate|xfce/ && is_tumbleweed) || ($desktop =~ /xfce/ && is_leap(">=15.2"))) && (get_var('ARCH') !~ /ppc64/);
 }
 
 sub logcurrentenv {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/62597
- Verification run: https://openqa.opensuse.org/t1169831 (passed: https://openqa.opensuse.org/tests/1169831#step/opensuse_welcome/5 )
