### PR TITLE
xrdp_client: Fix sporadic failure based on incorrect 'script_output' use

### DIFF
--- a/tests/x11/remote_desktop/xrdp_client.pm
+++ b/tests/x11/remote_desktop/xrdp_client.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -31,10 +31,9 @@ sub run {
 
     # Disable Remmina news before launch Remmina
     x11_start_program('xterm');
-    my $pref_dir  = '/home/bernhard/.config/remmina';
-    my $timestamp = script_output('date "+%s"', type_command => 1);
+    my $pref_dir = '~/.config/remmina';
     assert_script_run "mkdir $pref_dir";
-    assert_script_run "echo -e \'[remmina_news]\\nperiodic_rmnews_last_get='$timestamp'\' >> '$pref_dir'/remmina.pref";
+    assert_script_run 'echo -e "[remmina_news]\\nperiodic_rmnews_last_get=$(date +%s)" >> ' . $pref_dir . '/remmina.pref';
     type_string "exit\n";
 
     # Start Remmina and login the remote server


### PR DESCRIPTION
As http://open.qa/api/testapi/#_script_output describes "NOTE: execution
result may include extra serial output which was on serial console since
command was triggered in case serial console is not dedicated for the
script output only."

It is in most cases simpler to stay within the scope of the SUT shell
session rather than pass content between SUT and worker.

Verification:

```
 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9541 https://openqa.opensuse.org/tests/1170206
```

Created job #1170426: opensuse-Tumbleweed-DVD-x86_64-Build20200209-desktopapps-remote-desktop-xrdp-server1@64bit_virtio -> https://openqa.opensuse.org/t1170426
Created job #1170427: opensuse-Tumbleweed-DVD-x86_64-Build20200209-desktopapps-remote-desktop-xrdp-client1@64bit_virtio -> https://openqa.opensuse.org/t1170427

Related progress issue: https://progress.opensuse.org/issues/63361