### PR TITLE
x11utils: Also handle 'authentication-required-modify-system'

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -69,7 +69,7 @@ all possible options should be handled within loop to get unlocked desktop
 sub ensure_unlocked_desktop {
     my $counter = 10;
     while ($counter--) {
-        assert_screen [qw(displaymanager displaymanager-password-prompt generic-desktop screenlock screenlock-password authentication-required-user-settings)], no_wait => 1;
+        assert_screen [qw(displaymanager displaymanager-password-prompt generic-desktop screenlock screenlock-password authentication-required-user-settings authentication-required-modify-system)], no_wait => 1;
         if (match_has_tag 'displaymanager') {
             if (check_var('DESKTOP', 'minimalx')) {
                 type_string "$username";
@@ -84,7 +84,7 @@ sub ensure_unlocked_desktop {
                 select_user_gnome($username);
             }
         }
-        if (match_has_tag 'authentication-required-user-settings') {
+        if (match_has_tag('authentication-required-user-settings') || match_has_tag('authentication-required-modify-system')) {
             type_password;
             assert_and_click "authenticate";
         }


### PR DESCRIPTION
Next to "authentication-required-user-settings" there can also be a
slightly different popup asking for authentication to modify system
repositories. While in theory both cases could be covered with a single
tag for backwards compatibility reasons I kept the old tag and added a
new which however is named more generic so we can also use the new one
for all cases.

Related progress issue: https://progress.opensuse.org/issues/63394