### PR TITLE
generalhw_scripts fixes

### DIFF
--- a/data/generalhw_scripts/flash_usb_otg.sh
+++ b/data/generalhw_scripts/flash_usb_otg.sh
@@ -47,7 +47,7 @@ ssh $username@$flasher_ip rm -f $destination_folder/*.{raw,xz,iso}
 scp $image_to_flash $username@$destination
 # Extract compressed image, if needed
 if [[ "$image_to_flash_extension" == "xz" ]]; then
-	ssh $username@$flasher_ip unxz $image_to_flash_full_path
+	ssh $username@$flasher_ip unxz --threads=0 $image_to_flash_full_path
 	echo "**** xz image uncompressed"
 	# Resize *.raw image
 	ssh $username@$flasher_ip qemu-img resize $destination_folder/$uncompressed_filename $size

--- a/data/generalhw_scripts/get_sol_ttyUSB0.sh
+++ b/data/generalhw_scripts/get_sol_ttyUSB0.sh
@@ -7,7 +7,7 @@ device=/dev/ttyUSB0
 speed=115200
 
 # Set up device
-stty -F $device $speed
+stty -F $device $speed -echo -icrnl -onlcr
 
 # Read the device $device in the background
 # tail -f $device &


### PR DESCRIPTION
* Do not rely on any previous config of ttyUSB: disable echo and carriage return translated to newline (icrnl /onlcr)
* Improve unxz decompression speed by using all available CPU