### PR TITLE
Hackweek19: Implements design pattern for main.pm

### DIFF
--- a/lib/SchedulerFactory.pm
+++ b/lib/SchedulerFactory.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Factory for Test Suites classes
+
+package SchedulerFactory {
+    use TestSuiteAbstract;
+
+    sub new {
+        my ($class, $testname) = @_;
+        my $self = {
+            testname_factory => TestSuiteAbstract::getTestSuite($testname)
+        };
+        bless $self, $class;
+        return $self;
+    }
+
+    # returns an instance of the factory
+    sub createScheduler {
+        my ($self) = shift;
+        $self->{testname_factory};
+    }
+}
+
+1;

--- a/lib/TestSuiteInterface.pm
+++ b/lib/TestSuiteInterface.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Parent class used as Interface which test suites classes
+# inherit and implement
+
+package TestSuiteInterface {
+    use File::Find;
+    use File::Basename;
+
+    BEGIN {
+        unshift @INC, dirname(__FILE__) . '/../../lib';
+    }
+
+    sub new {
+        my ($class, $name) = @_;
+        my $self = {};
+        $self->{name} = $name;
+        bless $self, $class;
+        return $self;
+    }
+
+    sub getVariables {
+        my ($self) = shift;
+        return $self->{variables};
+    }
+
+    # parses and loads the modules of a test suite
+    sub loadtests {
+        my ($self) = shift;
+        {
+            die "oops" unless $self->{scheduler_order};
+            $_->() for (@{$self->{scheduler_order}});
+            return 1;
+        }
+        return 0;
+    }
+
+    # Defines the scheduler variable. Due to the scheduler needs to be in order
+    # another variable got introduced which stores the loadtest command in the
+    # correct sequence.
+    #https://gist.github.com/perlpunk/1a91716e994e1c13605310ed06287584
+    sub set_scheduler {
+        my ($self, @list) = @_;
+        # get a list of the subroutines of the hash
+        my @order    = map { $list[($_ * 2) + 1] } 0 .. (@list / 2) - 1;
+        my %schedule = @list;
+        $self->{scheduler}       = \%schedule;
+        $self->{scheduler_order} = \@order;
+        return $self;
+    }
+}
+
+1;

--- a/lib/testSuites/BootLinuxrcSuite.pm
+++ b/lib/testSuites/BootLinuxrcSuite.pm
@@ -1,0 +1,24 @@
+package BootLinuxrcSuite {
+    use base 'TestSuiteInterface';
+    use main_common;
+    sub new {
+        my ($class, $name) = @_;
+        my $self = {};
+        $self = $class->SUPER::new($name);
+        $self->{variables} = {
+            DESKTOP          => 'gnome',
+            HDD_1            => 'SLES-%VERSION%-%ARCH%-Build%BUILD%@%MACHINE%-gnome.qcow2',
+            LINUXRC_BOOT     => '1',
+            START_AFTER_TEST => 'create_hdd_gnome',
+            YAML_SCHEDULE    => 'schedule/yast/boot_linuxrc.yaml'
+        };
+        $self->set_scheduler(
+            boot_linuxrc       => sub { loadtest("boot/boot_linuxrc") },
+            installer_extended => sub { loadtest("installation/first_boot") }
+        );
+        bless $self, $class;
+        return $self;
+    }
+}
+
+1;

--- a/lib/testSuites/InstallerExtendedSuite.pm
+++ b/lib/testSuites/InstallerExtendedSuite.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Concrete TestSuite Class to test Extended
+# partitioning in YaST Installer
+
+package InstallerExtendedSuite {
+    use base 'TestSuiteInterface';
+    use main_common;
+    sub new {
+        my ($class, $name) = @_;
+        my $self = {};
+
+        $self = $class->SUPER::new($name);
+        $self->{variables} = {
+            CHECK_PRESELECTED_MODULES => '1',
+            CHECK_RELEASENOTES        => '1',
+            EULA_LANGUAGES            => 'korean',
+            EXIT_AFTER_START_INSTALL  => '1',
+            EXTRABOOTPARAMS           => 'Y2STRICTTEXTDOMAIN=1',
+            INSTALLER_EXTENDED_TEST   => "1",
+            VALIDATE_CHECKSUM         => "1"
+        };
+        $self->set_scheduler(
+            isosize                   => sub { loadtest("installation/isosize") },
+            data_integrity            => sub { loadtest("installation/data_integrity") },
+            bootloader                => sub { loadtest("installation/bootloader") },
+            welcome                   => sub { loadtest("installation/welcome") },
+            accept_license            => sub { loadtest("installation/accept_license") },
+            scc_registration          => sub { loadtest("installation/scc_registration") },
+            addon_products_sle        => sub { loadtest("installation/addon_products_sle") },
+            system_role               => sub { loadtest("installation/system_role") },
+            partitioning              => sub { loadtest("installation/partitioning") },
+            partitioning_finish       => sub { loadtest("installation/partitioning_finish") },
+            releasenotes              => sub { loadtest("installation/releasenotes") },
+            installer_timezone        => sub { loadtest("installation/installer_timezone") },
+            user_settings             => sub { loadtest("installation/user_settings") },
+            user_settings_root        => sub { loadtest("installation/user_settings_root") },
+            resolve_dependency_issues => sub { loadtest("installation/resolve_dependency_issues") },
+            installation_overview     => sub { loadtest("installation/installation_overview") },
+            disable_grub_timeout      => sub { loadtest("installation/disable_grub_timeout") },
+            start_install             => sub { loadtest("installation/start_install") }
+        );
+        bless $self, $class;
+        return $self;
+    }
+}
+
+1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -33,7 +33,13 @@ use utils;
 use main_common;
 use known_bugs;
 
+use SchedulerFactory;
+
 init_main();
+
+my $schedulerFactory = SchedulerFactory->new(get_required_var("TEST_SUITE_NAME"));
+my $scheduler        = $schedulerFactory->createScheduler();
+return 1 if $scheduler->loadtests();
 
 sub is_new_installation {
     return !get_var('UPGRADE') && !get_var('ONLINE_MIGRATION') && !get_var('ZDUP') && !get_var('AUTOUPGRADE');


### PR DESCRIPTION
Implementation of a design which each test_suite will 'loadtest'
explcity. For now all the code appears in the main.pm for convenience.

It uses a factory pattern to find the test suite class and schedule the
modules for it.

- Verification run: 
http://aquarius.suse.cz/tests/1625
http://aquarius.suse.cz/tests/1770