### PR TITLE
Typo: replace cleared_console by cleared-console

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -35,7 +35,7 @@ sub verify_default_keymap_textmode {
         send_key('alt-f3');
         # remote backends can not provide a "not logged in console" so we use
         # a cleared remote terminal instead
-        assert_screen(has_ttys() ? 'linux-login' : 'cleared_console');
+        assert_screen(has_ttys() ? 'linux-login' : 'cleared-console');
     }
 
     wait_still_screen;


### PR DESCRIPTION
`cleared_console` (with an underscore) has no matching needle and all other are `cleared-console` (with a dash). So, fix the typo.