### PR TITLE
Handle gfxpayload with updated grub2 configuration

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -346,7 +346,7 @@ sub uefi_bootmenu_params {
         for (1 .. 10) { send_key "down"; }
     }
     else {
-        for (1 .. 2) { send_key "down"; }
+        for (1 .. ((is_jeos) ? 3 : 2)) { send_key "down"; }
         send_key "end";
         # delete "keep" word
         for (1 .. 4) { send_key "backspace"; }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/63412
* VR: 
   * [grub2-jeos-base+phub@uefi-virtio-vga](http://eris.suse.cz/tests/4482#step/grub2/6)
   * [tw-jeos@64bit_virtio](http://eris.suse.cz/tests/4483#step/grub2/5)