### PR TITLE
Fix ltss in sle15 qam installtest autoyast profile

### DIFF
--- a/data/autoyast_qam/15_installtest.xml.ep
+++ b/data/autoyast_qam/15_installtest.xml.ep
@@ -4,7 +4,7 @@
   <add-on>
     <add_on_products config:type="list">
       % unless ($check_var->('SLE_PRODUCT', 'sled')) {
-      % if ($get_var->('VERSION') =~ m/15/) {
+      % if ($get_var->('VERSION') =~ m/15$/) {
       <listentry>
         <name>SLES-LTSS:15::update</name>
         <alias>SLES-LTSS:15::update</alias>


### PR DESCRIPTION
This PR improves regular expression for adding LTSS repo.
With the current code, [LTSS is added for 15-SP1](http://1a102.qa.suse.de/tests/3194#step/repos/11) and it's nonsense.

Regex must only match to `SLE15` for adding LTSS repo.

- Related ticket: N/A
- Needles: N/A
- Verification run: [15](http://1a102.qa.suse.de/tests/3199#step/repos/11) - [15SP1](http://1a102.qa.suse.de/tests/3198#step/repos/11)
