### PR TITLE
Use asterisk for vmlinux suffix

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -271,12 +271,10 @@ sub check_function {
     $self->wait_boot(bootloader_time => check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 200 : undef);
     select_console 'root-console';
 
-    # all but PPC64LE arch's vmlinux images are gzipped
-    my $suffix = check_var('ARCH', 'ppc64le') ? '' : '.gz';
     assert_script_run 'find /var/crash/';
 
     if ($test_type eq 'function') {
-        my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`$suffix";
+        my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`*";
         validate_script_output "$crash_cmd", sub { m/PANIC:\s([^\s]+)/ }, 600;
     }
     else {


### PR DESCRIPTION
Fix poo#62375: There are several options for vmlinux suffix across
distributions. Asterisk will cover all safely.

- Related ticket: https://progress.opensuse.org/issues/62375
- Needles: none
- Verification run: 
Tumbleweed x86_64: http://10.100.12.105/tests/3726#step/kdump_and_crash/67 (xz suffix)
SLE15-SP1 x86_64: http://10.100.12.105/tests/3725#step/kdump_and_crash/259 (gz suffix)
SLE15-SP2 x86_64: http://10.100.12.105/tests/3727#step/kdump_and_crash/73 (gz suffix)
SLE15-SP2 ppc64le: https://openqa.suse.de/tests/3883627#step/kdump_and_crash/76 (no suffix)
SLE12-SP5 x86_64: http://10.100.12.105/tests/3728#step/kdump_and_crash/235 (gz suffix)

