### PR TITLE
Locate linux keyword in grub2 menu

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -358,9 +358,11 @@ sub uefi_bootmenu_params {
         for (1 .. 2) { send_key "up"; }
         if (is_jeos) {
             send_key "up";
+            send_key_until_needlematch('linux-keyword-in-grub2-menu', 'down', 15, 0.5);
+        } else {
+            sleep 5;
+            for (1 .. 4) { send_key "down"; }
         }
-        sleep 5;
-        for (1 .. 4) { send_key "down"; }
     }
 
     send_key "end";


### PR DESCRIPTION
- Related ticket: [[jeos] test fails in grub2 - grub2 options got new video option, gfxpayload handling requires update](https://progress.opensuse.org/issues/63412)
- Verification run: [opensuse_grub2_fb_hyperv@svirt-hyperv-uefi](https://openqa.suse.de/tests/3892106#step/grub2/19)