### PR TITLE
Remove slehpc15 ltss module after all patch updated for migration

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -106,7 +106,9 @@ sub remove_ltss {
     if (get_var('SCC_ADDONS', '') =~ /ltss/) {
         my $scc_addons = get_var_array('SCC_ADDONS');
         record_info 'remove ltss', 'got all updates from ltss channel, now remove ltss and drop it from SCC_ADDONS before migration';
-        if (is_sle('15+')) {
+        if (check_var('SLE_PRODUCT', 'hpc')) {
+            remove_suseconnect_product('SLE_HPC-LTSS');
+        } elsif (is_sle('15+') && check_var('SLE_PRODUCT', 'sles')) {
             remove_suseconnect_product('SLES-LTSS');
         } else {
             zypper_call 'rm -t product SLES-LTSS';


### PR DESCRIPTION
Remove slehpc15 ltss module after all patch updated for migration

- Related ticket: https://progress.opensuse.org/issues/63481
- Verification run: https://openqa.nue.suse.com/tests/3892144#step/patch_sle/93
