### PR TITLE
Install additional packages in JeOS

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -365,6 +365,8 @@ sub run {
         loadtest_from_runtest_file('assets_public');
     }
 
+    is_jeos && zypper_call 'in system-user-bin system-user-daemon';
+
     power_action('reboot', textmode => 1) if (get_var('LTP_INSTALL_REBOOT') ||
         get_var('LTP_COMMAND_FILE')) && !is_jeos;
 }


### PR DESCRIPTION
- Related ticket: [[JeOS] test fails in chmod05 missing users and usergroups](https://progress.opensuse.org/issues/63502)
- Verification run: [kvm_syscalls@uefi-virtio-vga](http://eris.suse.cz/tests/4491#)
