### PR TITLE
Do not kill inexistent process from user postgress

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -346,7 +346,7 @@ sub postgresql_cleanup {
     systemctl 'stop postgresql';
     systemctl 'disable postgresql';
     systemctl 'is-active postgresql', expect_false => 1;
-    assert_script_run q{kill -s KILL $(ps -u postgres -o pid=)};
+    assert_script_run('kill -s KILL $(ps -u postgres -o pid=)') unless script_run('ps -u postgres -o pid=');
     zypper_call "rm postgresql";
     script_run q[snapper delete --sync $(snapper --quiet --machine-readable csv list | awk -F ',' 'NR>3 {print $3+0}')];
     assert_script_run 'userdel --remove postgres';


### PR DESCRIPTION
Test failed because kill process was missing the parameter PID, which
was sent empty.

- Related ticket: https://progress.opensuse.org/issues/63505
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2206