### PR TITLE
Run modhash only on SLE

### DIFF
--- a/tests/console/suse_module_tools.pm
+++ b/tests/console/suse_module_tools.pm
@@ -31,7 +31,7 @@ sub run {
     my $pth = (split '\n', $mds)[0];
 
     # Test modhash command
-    if (!is_sle('=12-sp1') && !is_sle('=12-sp5') && !is_sle('>=15-sp1') && !is_tumbleweed()) {
+    if (is_sle && !is_sle('=12-sp1') && !is_sle('=12-sp5') && is_sle('<15-sp1')) {
         # Get the output and test it against correct output
         assert_script_run("modhash $pth | grep -E \"$pth: [0-9a-fA-F]+\"");
     }


### PR DESCRIPTION
modhash is no more shipped in new versions.
But, it still need to be tested on old SLE releases.

- Related ticket: https://progress.opensuse.org/issues/59175
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2207
