### PR TITLE
Attempt to rework uefi_bootmenu_params

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -327,43 +327,23 @@ sub get_bootmenu_console_params {
 }
 
 sub uefi_bootmenu_params {
+    # Enter GRUB2 menu
     # assume bios+grub+anim already waited in start.sh
     # in grub2 it's tricky to set the screen resolution
-    #send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5);
     (is_jeos) ? send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5)
       :         send_key 'e';
     # Kiwi in TW uses grub2-mkconfig instead of the custom kiwi config
     # Locate gfxpayload parameter and update it
-    if (is_jeos && (is_tumbleweed || is_sle('>=15-sp2') || is_leap('>=15.2'))) {
-        for (1 .. 3) { send_key "down"; }
-        send_key "end";
-        # delete "keep" word
-        for (1 .. 4) { send_key "backspace"; }
-        # hardcoded the value of gfxpayload to 1024x768
-        type_string "1024x768";
-        assert_screen "gfxpayload_changed", 10;
-        # back to the entry position
-        send_key "home";
-        for (1 .. 10) { send_key "down"; }
-    }
-    else {
-        for (1 .. 2) { send_key "down"; }
-        send_key "end";
-        # delete "keep" word
-        for (1 .. 4) { send_key "backspace"; }
-        # hardcoded the value of gfxpayload to 1024x768
-        type_string "1024x768";
-        assert_screen "gfxpayload_changed", 10;
-        # back to the entry position
-        send_key "home";
-        for (1 .. 2) { send_key "up"; }
-        if (is_jeos) {
-            send_key "up";
-        }
-        sleep 5;
-        for (1 .. 4) { send_key "down"; }
-    }
-
+    send_key_until_needlematch('gfxpayload-original', 'down', 5, 0.5);
+    send_key "end";
+    # delete "keep" word
+    send_key "backspace" for (1 .. 4);
+    # hardcoded the value of gfxpayload to 1024x768
+    type_string "1024x768";
+    assert_screen "gfxpayload_changed", 10;
+    send_key "home";
+    # Locate linux kernel parameters
+    send_key_until_needlematch('linux-keyword-in-grub2-menu', 'down', 15, 0.5);
     send_key "end";
 
     if (get_var("NETBOOT")) {

--- a/tests/jeos/grub2.pm
+++ b/tests/jeos/grub2.pm
@@ -35,6 +35,7 @@ sub run {
     } while ((!check_screen('grub2', 1)) && ($counter < 10));
     $self->wait_grub(in_grub => 1, bootloader_time => 10);
     uefi_bootmenu_params;
+    type_string_very_slow(get_var('EXTRABOOTPARAMS', '') . ' ');
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
         type_string_very_slow(get_hyperv_fb_video_resolution);
         assert_screen('set-hyperv-framebuffer');


### PR DESCRIPTION
- Related ticket: [[jeos] test fails in grub2 - grub2 options got new video option, gfxpayload handling requires update](https://progress.opensuse.org/issues/63412)
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification runs: 
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build7.50-jeos-base+phub@uefi-virtio-vga](http://eris.suse.cz/tests/4519#step/grub2/1)
   * [Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20200215-jeos@64bit_virtio](http://eris.suse.cz/tests/4518#step/grub2/1)
   * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build24.5-jeos@64bit_virtio-2G](http://eris.suse.cz/tests/4517#step/grub2/1)