### PR TITLE
HPC: Deal with Service Pack '0' while migrating HPC

### DIFF
--- a/tests/hpc/hpc_migration.pm
+++ b/tests/hpc/hpc_migration.pm
@@ -77,9 +77,15 @@ sub run {
     $current_version =~ s/..-SP//;
     $version         =~ s/..-SP//;
 
+    #for sle12/15 SP0 returned value for $current_version is major code version (12/15)
+    if ($current_version > 12) {
+        $current_version = 0;
+    }
+
     my $diff = $version - $current_version;
 
     record_info('INFO: migrate-to version', "$version");
+    record_info('DEBUG: diff',              "$diff");
 
     if (get_var('HPC_PRODUCT_MIGRATION')) {
         if ($diff != $num_of_migration_targets) {


### PR DESCRIPTION
While checking for correct number of migration targets, while initial
platfrom to migrate from is the service pack 0 of given major code
stream version, the returned $current_version value is that of a major
code stream version. So for SLE15 SP0 the value is 15. That makes the
check of correct number of possible migration targets incorrect

- Verification run: http://10.160.65.14/tests/16864
not broken sp1-sp2 migration: http://10.160.65.14/tests/16866

