### PR TITLE
wpa2_enterprise_setup: Fail setup module as fatal to not confuse follow-up modules

### DIFF
--- a/tests/x11/network/hwsim_wpa2_enterprise_setup.pm
+++ b/tests/x11/network/hwsim_wpa2_enterprise_setup.pm
@@ -92,4 +92,9 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
+# followup modules rely on the setup conducted here
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/63496