### PR TITLE
Virsh destroy to shutdown vm forcibly

### DIFF
--- a/data/virt_autotest/setup_dns_service.sh
+++ b/data/virt_autotest/setup_dns_service.sh
@@ -107,6 +107,7 @@ for vmguest in ${vm_guestnames_array[@]};do
 		virsh start ${vmguest}
 		vmguest_failed=$((${vmguest_failed} | $(echo $?)))
         else
+            	virsh destroy ${vmguest}
             	virsh reboot ${vmguest}
 	    	vmguest_failed=$((${vmguest_failed} | $(echo $?)))
         fi


### PR DESCRIPTION
Shutdown some vm guests on sles11sp4 host takes extraodinary long time, which delays following operations, for example, reboot and obtain new ip address. So at some point it can not be reached by its dns name.

- Related ticket: https://openqa.suse.de/3885758#step/setup_dns_service/1
- Needles: n/a
- Verification run: NO NEED