### PR TITLE
Fix sporadic issue with send_key in vlc.pm

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -26,10 +26,8 @@ sub run {
     x11_start_program('vlc --no-autoscale', target_match => 'vlc-first-time-wizard');
     assert_and_click "vlc-first-time-wizard";
     assert_screen "vlc-main-window";
-    send_key "ctrl-l";
-    assert_and_click "vlc-playlist-empty";
-    send_key "ctrl-n";
-    assert_screen "vlc-network-window";
+    send_key_until_needlematch("vlc-playlist-empty", "ctrl-l", 3, 60);
+    send_key_until_needlematch("vlc-network-window", "ctrl-n", 3, 60);
     send_key "backspace";
     type_string autoinst_url . "/data/Big_Buck_Bunny_8_seconds_bird_clip.ogv";
     assert_screen "url_check", 90;


### PR DESCRIPTION
we have sporadic issue with send_key "ctrl-n" to get vlc-network-window.
Give 3 times to try and increase timeout for matching needle.

see https://progress.opensuse.org/issues/63415
test verification(over 100 times):
https://openqa.opensuse.org/tests/1179314#next_previous