### PR TITLE
Virt typos, fixes, cleanings

### DIFF
--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -49,17 +49,17 @@ sub change_desktop {
     }
     send_key_until_needlematch 'patterns-list-selected', 'tab', 10, 2;
 
-    if ((is_sle('<=12-SP1')) && (check_var("REGRESSION", "xen-hypervisor") || check_var("REGRESSION", "qemu-hypervisor"))) {
+    if ((is_sle('<=12-SP1')) && (check_var("REGRESSION", "xen") || check_var("REGRESSION", "qemu"))) {
         assert_and_click 'gnome_logo';
         send_key 'spc';
 
         assert_and_click 'xorg_logo';
         send_key 'spc';
 
-        if (check_var("REGRESSION", "qemu-hypervisor")) {
+        if (check_var("REGRESSION", "qemu")) {
             assert_and_click 'kvm_logo';
             send_key 'spc';
-        } elsif (check_var("REGRESSION", "xen-hypervisor")) {
+        } elsif (check_var("REGRESSION", "xen")) {
             assert_and_click 'xen_logo';
             send_key 'spc';
         }

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -74,7 +74,7 @@ sub login_to_console {
     if (match_has_tag('prague-pxe-menu')) {
         send_key 'ret';
 
-        assert_screen([qw(grub2 grub1)], 60);
+        check_screen([qw(grub2 grub1)], 60);
     }
 
     if (!get_var("reboot_for_upgrade_step")) {

--- a/tests/virtualization/xen/dom_metrics.pm
+++ b/tests/virtualization/xen/dom_metrics.pm
@@ -30,7 +30,7 @@ sub run {
 
     foreach my $guest (keys %xen::guests) {
         record_info "$guest",                                                     "Obtaining dom0 metrics on xl-$guest";
-        assert_script_run "xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro", 90;
+        assert_script_run "xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro", 180;
         assert_script_run "ssh root\@$guest 'vm-dump-metrics' | grep 'SUSE LLC'";
         assert_script_run "xl block-detach xl-$guest xvdc";
     }

--- a/tests/virtualization/xen/guest_management.pm
+++ b/tests/virtualization/xen/guest_management.pm
@@ -53,8 +53,10 @@ sub run {
     }
 
     record_info "START", "Start all guests";
-    assert_script_run "virsh start $_" foreach (keys %xen::guests);
-    script_retry "nmap $_ -PN -p ssh | grep open", delay => 15, retry => 12 foreach (keys %xen::guests);
+    foreach my $guest (keys %xen::guests) {
+        script_retry "virsh start $guest",                 delay => 30, retry => 12;
+        script_retry "nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12;
+    }
 
     record_info "SUSPEND", "Suspend all guests";
     assert_script_run "virsh suspend $_" foreach (keys %xen::guests);

--- a/tests/virtualization/xen/hotplugging.pm
+++ b/tests/virtualization/xen/hotplugging.pm
@@ -29,7 +29,7 @@ sub run_test {
     assert_script_run "mkdir -p /var/lib/libvirt/images/add/";
     assert_script_run "qemu-img create -f raw /var/lib/libvirt/images/add/$_.raw 10G" foreach (keys %xen::guests);
     if (check_var('XEN', '1')) {
-        script_run "virsh detach-disk $_ xvdz", 120 foreach (keys %xen::guests);
+        script_run "virsh detach-disk $_ xvdz", 240 foreach (keys %xen::guests);
         assert_script_run "virsh attach-disk --domain $_ --source /var/lib/libvirt/images/add/$_.raw --target xvdz" foreach (keys %xen::guests);
         assert_script_run "virsh domblklist $_ | grep xvdz"                                                         foreach (keys %xen::guests);
         foreach my $guest (keys %xen::guests) {
@@ -37,9 +37,9 @@ sub run_test {
             record_soft_failure("lsblk failed - please check the output manually") if $lsblk != 0;
         }
         assert_script_run "ssh root\@$_ lsblk" foreach (keys %xen::guests);
-        assert_script_run "virsh detach-disk $_ xvdz", 120 foreach (keys %xen::guests);
+        assert_script_run "virsh detach-disk $_ xvdz", 240 foreach (keys %xen::guests);
     } else {
-        script_run "virsh detach-disk $_ vdz", 120 foreach (keys %xen::guests);
+        script_run "virsh detach-disk $_ vdz", 240 foreach (keys %xen::guests);
         assert_script_run "virsh attach-disk --domain $_ --source /var/lib/libvirt/images/add/$_.raw --target vdz" foreach (keys %xen::guests);
         assert_script_run "virsh domblklist $_ | grep vdz"                                                         foreach (keys %xen::guests);
         foreach my $guest (keys %xen::guests) {
@@ -47,7 +47,7 @@ sub run_test {
             record_soft_failure("lsblk failed - please check the output manually") if $lsblk != 0;
         }
         assert_script_run "ssh root\@$_ lsblk" foreach (keys %xen::guests);
-        assert_script_run "virsh detach-disk $_ vdz", 120 foreach (keys %xen::guests);
+        assert_script_run "virsh detach-disk $_ vdz", 240 foreach (keys %xen::guests);
     }
 
     # TODO:
@@ -55,8 +55,8 @@ sub run_test {
     foreach my $guest (keys %xen::guests) {
         unless ($guest =~ m/hvm/i) {
             # The guest should have 2 CPUs after the installation
-            assert_script_run "virsh vcpucount $guest | grep current | grep live";
-            assert_script_run "ssh root\@$guest nproc", 60;
+            assert_script_run "virsh vcpucount $guest | grep current | grep live", 90;
+            assert_script_run "ssh root\@$guest nproc",                            60;
             # Add 1 CPU for everu guest
             assert_script_run "virsh setvcpus --domain $guest --count 3 --live";
             sleep 5;

--- a/tests/virtualization/xen/prepare_guests.pm
+++ b/tests/virtualization/xen/prepare_guests.pm
@@ -64,6 +64,7 @@ sub run {
 
     script_run 'history -a';
     script_run('cat ~/virt-install* | grep ERROR', 30);
+    script_run('xl dmesg |grep -i "fail\|error" |grep -vi Loglevel') if (get_var("REGRESSION", '') =~ /xen/);
 }
 
 1;

--- a/tests/virtualization/xen/virtmanager_offon.pm
+++ b/tests/virtualization/xen/virtmanager_offon.pm
@@ -41,19 +41,7 @@ sub run {
         assert_and_click 'virt-manager_resizetovm';
 
         detect_login_screen();
-
-        mouse_set(0, 0);
-        assert_and_click 'virt-manager_shutdown';
-        if (!check_screen 'virt-manager_notrunning', 120) {
-            assert_and_click 'virt-manager_shutdown_menu';
-            assert_and_click 'virt-manager_shutdown_item';
-            # There migh me 'Are you sure' dialog window
-            if (check_screen "virt-manager_shutdown_sure", 2) {
-                assert_and_click "virt-manager_shutdown_sure";
-            }
-        }
-        assert_and_click 'virt-manager_poweron', 'left', 90;
-
+        powercycle();
         detect_login_screen(120);
         close_guest();
     }

--- a/tests/virtualization/xen/xl_create.pm
+++ b/tests/virtualization/xen/xl_create.pm
@@ -43,7 +43,7 @@ sub run {
     assert_script_run "xl list xl-$_"        foreach (keys %xen::guests);
 
     record_info "SSH", "Test that the new VM listens on SSH";
-    script_retry "nmap $_ -PN -p ssh | grep open", delay => 30, retry => 6 foreach (keys %xen::guests);
+    script_retry "nmap $_ -PN -p ssh | grep open", delay => 30, retry => 12 foreach (keys %xen::guests);
 
 }
 


### PR DESCRIPTION
Hello,
 * `tests/installation/change_desktop.pm` fix variables typo
 * `lib/virtmanager.pm add powercycle() so we can reuse it
 * `tests/virt_autotest/login_console.pm` continue even if grub is not detected after the prague-pxe-menu
 * `tests/virtualization/xen/guest_management.pm` start guest and then wait for it instead of starting all of them and then waiting for them
 * Various timeout adjustments

- Needles: [os-autoinst-needles-sles#1323](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1323)
- Verification run: [XEN@SLE12SP4](http://pdostal-server.suse.cz/tests/7018) [KVM@SLE12SP5](http://pdostal-server.suse.cz/tests/6943)[XEN@SLE12SP5](http://pdostal-server.suse.cz/tests/6950) [KVM@SLE15SP1](http://pdostal-server.suse.cz/tests/6959) 
