### PR TITLE
[WIP] Set desktop as gnome when patterns eq default or all

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -875,6 +875,8 @@ sub wait_boot_past_bootloader {
     my $nologin      = $args{nologin};
     my $forcenologin = $args{forcenologin};
 
+    #workaround to create HPC qcow2
+    set_var('DESKTOP', 'gnome') if (is_sle('15+'));
     # On IPMI, when selecting x11 console, we are connecting to the VNC server on the SUT.
     # select_console('x11'); also performs a login, so we should be at generic-desktop.
     my $gnome_ipmi = (check_var('BACKEND', 'ipmi') && check_var('DESKTOP', 'gnome'));


### PR DESCRIPTION
This is just a workaround to create HPC qcow2 files with DESKTOP=gnome. 
http://openqa.nue.suse.com/tests/3895235#step/first_boot/6 Even we set DESKTOP=gnome, it will be changed to txtmode, to quick up the creation of qcow2, we need the workaround.

- Related ticket: https://progress.opensuse.org/issues/62213
- Needles: N/A
- Verification run: Wait verify log on OSD.
