### PR TITLE
xfstests: Specify mkfs parameter for different scenario

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -256,6 +256,18 @@ sub shuffle {
     return @arr;
 }
 
+# Set mkfs parameter for different scenario
+sub mkfs_setting {
+    # In case to test xfs reflink feature, test name contain "reflink"
+    if (index(get_required_var('TEST'), 'reflink') != -1) {
+        my $cmd = <<END_CMD;
+mkfs.xfs -f -m reflink=1 \$TEST_DEV
+export XFS_MKFS_OPTIONS="-m reflink=1"
+END_CMD
+        script_run($cmd);
+    }
+}
+
 # Log & Must included: Copy log to ready to save
 sub copy_log {
     my ($category, $num, $log_type) = @_;
@@ -330,6 +342,7 @@ sub run {
         @tests = shuffle(@tests);
     }
 
+    mkfs_setting;
     test_prepare;
     heartbeat_start;
     my $status_log_content = "";


### PR DESCRIPTION
This PR add mkfs_setting function to setup different parameter when use mkfs during xfstests. And add the first scenario to test reflink feature in xfs.
Test name in xfstests contain "reflink" will goes into "mkfs.xfs -m reflink=1" setting.
I'll created two new tests in osd for reflink test. (xfstests_xfs-xfs-reflink and xfstests_xfs-generic-reflink)

- Related ticket: https://progress.opensuse.org/issues/63484
- Verify run: https://openqa.nue.suse.com/tests/3898636 (to prove this PR not influence exist tests, for new test I'll test in development job group)