### PR TITLE
xfstests: Solve reboot and reset fail issue in spvm

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -27,6 +27,7 @@ use base 'opensusebasetest';
 use File::Basename;
 use testapi;
 use utils;
+use Utils::Backends 'is_pvm';
 use power_action_utils 'power_action';
 
 # Heartbeat variables
@@ -374,12 +375,14 @@ sub run {
         # SUT crashed. Wait for kdump to finish.
         # After that, SUT will reboot automatically
         eval {
-            power_action('reboot', keepconsole => 1);
+            power_action('reboot', keepconsole => is_pvm);
+            reconnect_mgmt_console if is_pvm;
             $self->wait_boot(in_grub => 1, bootloader_time => 60);
         };
         # If SUT didn't reboot for some reason, force reset
         if ($@) {
-            power('reset');
+            power('reset', keepconsole => is_pvm);
+            reconnect_mgmt_console if is_pvm;
             $self->wait_boot(in_grub => 1);
         }
 


### PR DESCRIPTION
In case system hang, xfstests will trigger reset. And spvm has issue when reset, so I add these code to solve spvm reset issue during xfstests.

- Related ticket: https://progress.opensuse.org/issues/62507
- Verification run: https://openqa.nue.suse.com/tests/3904015
  Previous tests fails in generic/127 reboot, but this VR not fails there. That prove this PR works.
