### PR TITLE
Do not assert_screen using serial terminal

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -12,7 +12,7 @@ package opensusebasetest;
 use base 'basetest';
 
 use bootloader_setup qw(boot_grub_item boot_local_disk stop_grub_timeout tianocore_enter_menu zkvm_add_disk zkvm_add_pty zkvm_add_interface);
-use testapi;
+use testapi qw(is_serial_terminal :DEFAULT);
 use strict;
 use warnings;
 use utils;
@@ -49,7 +49,7 @@ sub clear_and_verify_console {
     my ($self) = @_;
 
     clear_console;
-    assert_screen('cleared-console');
+    assert_screen('cleared-console') unless is_serial_terminal();
 }
 
 =head2 post_run_hook
@@ -1141,7 +1141,7 @@ base method using C<$self-E<gt>SUPER::post_fail_hook;> at the end.
 =cut
 sub post_fail_hook {
     my ($self) = @_;
-    return if testapi::is_serial_terminal();    # unless VIRTIO_CONSOLE=0 nothing below make sense
+    return if is_serial_terminal();    # unless VIRTIO_CONSOLE=0 nothing below make sense
 
     show_tasks_in_blocked_state;
     return if (get_var('NOLOGS'));

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -1,6 +1,6 @@
 # SUSE openQA tests
 #
-# Copyright (C) 2017 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The test module suseconnect_scc uses serial terminal, which doesn't
support screenshots and therefore causes unreliable behavior.

- Related ticket: https://progress.opensuse.org/issues/62735
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2225
