### PR TITLE
Enable RAID tests on powerVM

### DIFF
--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -1,0 +1,68 @@
+name:           RAID0_gpt
+description:    >
+  Configure RAID 0 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates PReP boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 0 for root, RAID 1 for /boot and RAID 0 for swap.
+  For pvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  RAIDLEVEL: 0
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_raid
+test_data:
+  # We have same partitioning layout for all raid tests, except mds
+  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  mds:
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 3
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 1
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: data
+        formatting_options:
+          should_format: 1
+          filesystem: ext4
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot'
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: swap
+        formatting_options:
+          should_format: 1
+        filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -1,0 +1,68 @@
+name:           RAID10_gpt
+description:    >
+  Configure RAID 10 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates PReP boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 10 for root, RAID 1 for /boot and RAID 0 for swap.
+  For pvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  RAIDLEVEL: 10
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_raid
+test_data:
+  # We have same partitioning layout for all raid tests, except mds
+  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  mds:
+    - raid_level: 10
+      chunk_size: 64
+      device_selection_step: 3
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 1
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: data
+        formatting_options:
+          should_format: 1
+          filesystem: ext4
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot'
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: swap
+        formatting_options:
+          should_format: 1
+        filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -1,0 +1,68 @@
+name:           RAID1_gpt
+description:    >
+  Configure RAID 1 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates PReP boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 1 for root, RAID 1 for /boot and RAID 0 for swap.
+  For pvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  RAIDLEVEL: 1
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_raid
+test_data:
+  # We have same partitioning layout for all raid tests, except mds
+  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  mds:
+    - raid_level: 1
+      chunk_size: 64
+      device_selection_step: 3
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 1
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: data
+        formatting_options:
+          should_format: 1
+          filesystem: ext4
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot'
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: swap
+        formatting_options:
+          should_format: 1
+        filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -1,0 +1,68 @@
+name:           RAID5_gpt
+description:    >
+  Configure RAID 5 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates PReP boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 5 for root, RAID 1 for /boot and RAID 0 for swap.
+  For pvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  RAIDLEVEL: 5
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_raid
+test_data:
+  # We have same partitioning layout for all raid tests, except mds
+  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  mds:
+    - raid_level: 5
+      chunk_size: 64
+      device_selection_step: 3
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 1
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: data
+        formatting_options:
+          should_format: 1
+          filesystem: ext4
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot'
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: swap
+        formatting_options:
+          should_format: 1
+        filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -1,0 +1,68 @@
+name:           RAID6_gpt
+description:    >
+  Configure RAID 6 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates PReP boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 6 for root, RAID 1 for /boot and RAID 0 for swap.
+  For pvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  RAIDLEVEL: 6
+  DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_raid
+test_data:
+  # We have same partitioning layout for all raid tests, except mds
+  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  mds:
+    - raid_level: 6
+      chunk_size: 64
+      device_selection_step: 3
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 1
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: data
+        formatting_options:
+          should_format: 1
+          filesystem: ext4
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot'
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: swap
+        formatting_options:
+          should_format: 1
+        filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+++ b/test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
@@ -1,0 +1,50 @@
+# This is test data for powerVM, as we have sda as disk name
+# Partitioning itself remains same as on qemu setup.
+disks:
+  - name: sda
+    partitions:
+      - size: 8mb
+        role: raw-volume
+        id: prep-boot
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 310mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: sdb
+    partitions:
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 310mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: sdc
+    partitions:
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 310mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: sdd
+    partitions:
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 310mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid

--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -29,11 +29,11 @@ my $raid_partitions_2_arrays = qr/(md(0|1).*){8}|(md(0|1).*){2}/s;
 # 12 raid partitions, with new lsblk output partitions are listed only once
 my $raid_partitions_3_arrays = qr/(md(0|1|2).*){12}|(md(0|1|2).*){3}/s;
 # 8 linux raid members
-my $linux_raid_member_2_arrays = qr/(vd(a|b|c|d)(2|3).+linux_raid_member.*){8}/s;
+my $linux_raid_member_2_arrays = qr/((v|s)d(a|b|c|d)(2|3).+linux_raid_member.*){8}/s;
 # 12 linux raid members
-my $linux_raid_member_3_arrays = qr/(vd(a|b|c|d)(1|2|3|4).+linux_raid_member.*){12}/s;
+my $linux_raid_member_3_arrays = qr/((v|s)d(a|b|c|d)(1|2|3|4).+linux_raid_member.*){12}/s;
 # 4 hard disks
-my $hard_disks = qr/(vd(a|b|c|d)\D+.*){4}/s;
+my $hard_disks = qr/((v|s)d(a|b|c|d)\D+.*){4}/s;
 # 4 ext4 partitions mounted on /boot, with new lsblk output partitions are listed only once
 my $ext4_boot = qr/(md1(p1)?.+ext4.+\/boot.*){4}|(md1(p1)?.+ext4.+\/boot.*){1}/s;
 # Unique vfat partition in first disk (mounted on /boot)


### PR DESCRIPTION
On powerVM we have multiple differences in comparison to powerKVM in scope of the schedule and settings, so creating separate yamls for it.

See [poo#62729](https://progress.opensuse.org/issues/62729).

* [Verification runs](https://openqa.suse.de/tests/overview?version=15-SP2&build=rwx788%2Fos-autoinst-distri-opensuse%239578&distri=sle)