### PR TITLE
Destroy the Public Cloud instance when the initial phase of QAM tests…

### DIFF
--- a/lib/publiccloud/ssh_interactive_init.pm
+++ b/lib/publiccloud/ssh_interactive_init.pm
@@ -1,0 +1,43 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Base class for the ssh_interactive initiation phase
+#
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+package publiccloud::ssh_interactive_init;
+use base "consoletest";
+
+use strict;
+use warnings;
+use testapi;
+
+sub post_fail_hook {
+    select_console 'tunnel-console', await_console => 0;
+    send_key "ctrl-c";
+    send_key "ret";
+    assert_script_run('cd /root/terraform');
+    script_run('terraform destroy -no-color -auto-approve', 240);
+}
+
+sub test_flags {
+    return {
+        fatal                    => 1,
+        milestone                => 0,
+        publiccloud_multi_module => 1
+    };
+}
+
+1;

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -11,7 +11,7 @@
 #
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
-use base 'consoletest';
+use Mojo::Base 'publiccloud::ssh_interactive_init';
 use registration;
 use warnings;
 use testapi;
@@ -27,13 +27,4 @@ sub run {
     $args->{my_instance}->softreboot();
 }
 
-sub test_flags {
-    return {
-        fatal                    => 1,
-        milestone                => 1,
-        publiccloud_multi_module => 1
-    };
-}
-
 1;
-

--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -11,7 +11,7 @@
 #
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
-use base 'consoletest';
+use Mojo::Base 'publiccloud::ssh_interactive_init';
 use version_utils;
 use registration;
 use warnings;
@@ -39,14 +39,6 @@ sub run {
     }
 
     $args->{my_instance}->run_ssh_command(cmd => "sudo zypper lr");
-}
-
-sub test_flags {
-    return {
-        fatal                    => 1,
-        milestone                => 1,
-        publiccloud_multi_module => 1
-    };
 }
 
 1;

--- a/tests/publiccloud/ssh_interactive_init.pm
+++ b/tests/publiccloud/ssh_interactive_init.pm
@@ -12,7 +12,6 @@
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
 use Mojo::Base 'publiccloud::basetest';
-use publiccloud::ssh_interactive;
 use testapi;
 use utils;
 
@@ -77,7 +76,7 @@ sub run {
 sub test_flags {
     return {
         fatal                    => 1,
-        milestone                => 1,
+        milestone                => 0,
         publiccloud_multi_module => 1
     };
 }

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -11,7 +11,7 @@
 #
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
-use Mojo::Base 'publiccloud::basetest';
+use Mojo::Base 'publiccloud::ssh_interactive_init';
 use publiccloud::ssh_interactive;
 use testapi;
 use utils;
@@ -28,13 +28,4 @@ sub run {
     select_console 'root-console';
 }
 
-sub test_flags {
-    return {
-        fatal                    => 1,
-        milestone                => 1,
-        publiccloud_multi_module => 1
-    };
-}
-
 1;
-

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -11,7 +11,7 @@
 #
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
-use base 'consoletest';
+use Mojo::Base 'publiccloud::ssh_interactive_init';
 use registration;
 use warnings;
 use testapi;
@@ -30,14 +30,6 @@ sub run {
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
-}
-
-sub test_flags {
-    return {
-        fatal                    => 1,
-        milestone                => 1,
-        publiccloud_multi_module => 1
-    };
 }
 
 1;


### PR DESCRIPTION
Hello,

let me introduce a `post_fail_hook()` for the initial phase of QAM Public Cloud test suite:
The problem I am trying to solve is that when this test suite fails for example on the `patch_and_reboot.pm` module, we know it is wrong, but it takes some time to repair it. During this time the test suite is obviously failing and the public cloud instances are not being removed and are consuming our resources. This fix is removing them when the failure occurs.

- Related ticket: [poo#63235](https://progress.opensuse.org/issues/63235)
- Verification run: [15-SP1-EC2-BYOS](http://pdostal-server.suse.cz/tests/6810#)
