### PR TITLE
Check urlbar selected before typing in chromium

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -30,15 +30,18 @@ sub run {
     # Additional waiting to prevent unready address bar
     # https://progress.opensuse.org/issues/36304
     wait_still_screen(1);
+    assert_screen 'chromium-hightlighted-urlbar';
     type_string "chrome://version \n";
     assert_screen 'chromium-about';
 
     wait_screen_change { send_key 'ctrl-l' };
+    assert_screen 'chromium-hightlighted-urlbar';
     type_string "https://html5test.opensuse.org\n";
     assert_screen 'chromium-html-test', 90;
 
     # check a site with different ssl configuration (boo#1144625)
     wait_screen_change { send_key 'ctrl-l' };
+    assert_screen 'chromium-hightlighted-urlbar';
     type_string("https://upload.wikimedia.org/wikipedia/commons/d/d0/OpenSUSE_Logo.svg\n");
     assert_screen 'chromium-opensuse-logo', 90;
     send_key 'alt-f4';


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/63334
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/642
Verification: http://artemis.suse.de/tests/2265#step/chromium/19