### PR TITLE
Use python virtenv for az, ec2uploadimg and aws

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -20,6 +20,38 @@ use registration 'add_suseconnect_product';
 use version_utils qw(is_sle is_opensuse);
 use repo_tools 'generate_version';
 
+sub install_in_venv {
+    my ($pip_packages, $binary) = @_;
+    die("Missing pip packages") unless ($pip_packages);
+    die("Missing binary name")  unless ($binary);
+    $pip_packages = [$pip_packages] unless ref $pip_packages eq 'ARRAY';
+
+    my $venv = '/root/.venv_' . $binary;
+    assert_script_run("virtualenv '$venv'");
+    assert_script_run(". '$venv/bin/activate'");
+    assert_script_run('pip install --force-reinstall ' . join(' ', map("'$_'", @$pip_packages)));
+    assert_script_run('deactivate');
+    my $script = <<EOT;
+#!/bin/sh
+. "$venv/bin/activate"
+if [ ! -e "$venv/bin/$binary" ]; then
+   echo "Missing $binary in virtualenv $venv"
+   deactivate
+   exit 2
+fi
+$binary "\$@"
+exit_code=\$?
+deactivate
+exit \$exit_code
+EOT
+    my $run           = $binary . '-run-in-venv';
+    my $run_full_path = "$venv/bin/$run";
+    save_tmp_file($run, $script);
+    assert_script_run(sprintf('curl -o "%s" "%s/files/%s"', $run_full_path, autoinst_url, $run));
+    assert_script_run(sprintf('chmod +x "%s"', $run_full_path));
+    assert_script_run(sprintf('ln -s "%s" "/usr/bin/%s"', $run_full_path, $binary));
+}
+
 sub run {
     my ($self) = @_;
 
@@ -32,37 +64,20 @@ sub run {
     }
 
     # Install prerequesite packages
-    zypper_call('-q in python-xml python3-devel python3-pip python3-img-proof python3-img-proof-tests');
+    zypper_call('-q in python-xml python3-devel python3-pip python3-virtualenv python3-img-proof python3-img-proof-tests');
     record_info('python', script_output('python --version'));
 
     # Install AWS cli
-    if (is_opensuse) {
-        assert_script_run("pip3 install -q pycrypto");
-        assert_script_run("pip3 install -q awscli");
-        assert_script_run("pip3 install -q keyring");
-    }
-    elsif (is_sle) {
-        zypper_call('-q in --force-resolution aws-cli');
-
-        if (script_output('aws --version', 60, proceed_on_failure => 1) =~ /No module named vendored.requests.packages.urllib3.exceptions/m) {
-            record_soft_failure('workaround for boo#1122199');
-            my $repo      = 'http://download.opensuse.org/repositories/devel:/languages:/python:/aws/' . generate_version();
-            my $repo_name = 'devel_languages_python_aws';
-            zypper_ar($repo, name => $repo_name);
-            zypper_call('-q in -f --repo ' . $repo_name . ' python-s3transfer');
-            zypper_call('rr ' . $repo_name);
-        }
-        assert_script_run('aws --version');
-    }
+    install_in_venv('awscli', 'aws');
     record_info('EC2', script_output('aws --version'));
 
     # Install ec2imgutils
-    assert_script_run('pip3 install ec2imgutils');
+    install_in_venv('ec2imgutils', 'ec2uploadimg');
     assert_script_run("curl " . data_url('publiccloud/ec2utils.conf') . " -o /root/.ec2utils.conf");
     record_info('ec2imgutils', 'ec2uploadimg:' . script_output('ec2uploadimg --version'));
 
     # Install Azure cli
-    assert_script_run("pip3 install -q --ignore-installed azure-cli", 240);
+    install_in_venv(['idna<2.9,>=2.5', 'azure-cli'], 'az');
     record_info('Azure', script_output('az -v'));
 
     # Install Google Cloud SDK


### PR DESCRIPTION
We continuously have problems when installing all of them on one system.
As each of them need different dependencies.
With this change, we completely separate the python dependencies from
each other, so we hopefully don't face such problems in the future.

- Related ticket: https://progress.opensuse.org/issues/63589
- Verification run: https://openqa.suse.de/t3902688
