### PR TITLE
Add auto-select python2 module after user selected module for media upgrade

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -44,9 +44,6 @@ sub handle_all_packages_medium {
     # Refer to https://bugzilla.suse.com/show_bug.cgi?id=1078958#c4
     push @addons, 'we' if check_var('SLE_PRODUCT', 'sled') && !grep(/^we$/, @addons);
 
-    # Add python2 module, refer to https://jira.suse.de/browse/SLE-3167
-    push @addons, 'python2' if get_var('MEDIA_UPGRADE') && is_sle('<=15', get_var('HDDVERSION')) && is_sle('>15') && !check_var('SLE_PRODUCT', 'rt');
-
     # For SLES12SPx and SLES11SPx to SLES15 migration, need add the demand module at least for media migration manually
     # Refer to https://fate.suse.com/325293
     if (get_var('MEDIA_UPGRADE') && is_sle('<15', get_var('HDDVERSION')) && !check_var('SLE_PRODUCT', 'sled')) {
@@ -70,6 +67,9 @@ sub handle_all_packages_medium {
     for my $i (split(/,/, get_var('SCC_ADDONS', ''))) {
         push @addons, $i if !grep(/^$i$/, @addons);
     }
+
+    # Add python2 module, refer to https://jira.suse.de/browse/SLE-3167
+    push @addons, 'python2' if get_var('MEDIA_UPGRADE') && is_sle('<=15', get_var('HDDVERSION')) && is_sle('>15') && !check_var('SLE_PRODUCT', 'rt');
 
     # Record the addons to be enabled for debugging
     record_info 'Extension and Module Selection', join(' ', @addons);


### PR DESCRIPTION
Add auto-select python2 module after user selected module for media upgrade
Background: For scc/pscc upgrade, from 15 to 15sp2, python2 will be auto selected for 15sp2. But for media upgrade, we need add python2 for auto-selected. Python2 module have dependency with base. If select python2, need select base first. So for this change, we need add python2 after base. 

- Related ticket: https://progress.opensuse.org/issues/63586
- Verification run: https://openqa.nue.suse.com/tests/3904012#step/addon_products_sle/5
