### PR TITLE
Reboot definitely does not work for inactive vm domain

### DIFF
--- a/data/virt_autotest/setup_dns_service.sh
+++ b/data/virt_autotest/setup_dns_service.sh
@@ -108,7 +108,7 @@ for vmguest in ${vm_guestnames_array[@]};do
 		vmguest_failed=$((${vmguest_failed} | $(echo $?)))
         else
             	virsh destroy ${vmguest}
-            	virsh reboot ${vmguest}
+            	virsh start ${vmguest}
 	    	vmguest_failed=$((${vmguest_failed} | $(echo $?)))
         fi
 done


### PR DESCRIPTION
Forgot about one thing: Reboot definitely does not work for inactive vm domain, use "virsh start" instead.

- Related ticket: n/a
- Needles: n/a
- Verification run: Already verified manually
