### PR TITLE
publiccloud: Do not use --root-swap for BYOS images

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -129,7 +129,7 @@ sub upload_img {
           . "--machine '" . $img_arch . "' "
           . "-n '" . $self->prefix . '-' . $img_name . "' "
           . "--virt-type hvm --sriov-support "
-          . ($img_name !~ /byos/i && $img_arch eq 'arm64' ? '' : '--use-root-swap ')
+          . ($img_name =~ /byos/i || $img_arch eq 'arm64' ? '' : '--use-root-swap ')
           . '--ena-support '
           . "--verbose "
           . "--regions '" . $self->region . "' "


### PR DESCRIPTION
This fix a regression of a4daae7c5 .
We always use `--root-swap` when uploading EC images, except for
arm and BYOS.

- Verification run:
- https://openqa.suse.de/t3904499 - publiccloud_upload_img@cfconrad/os-autoinst-distri-opensuse#fix/image_upload_byos => passed
- https://openqa.suse.de/t3904500 - publiccloud_upload_img@cfconrad/os-autoinst-distri-opensuse#fix/image_upload_byos => passed
- https://openqa.suse.de/t3904498 - publiccloud_upload_img@cfconrad/os-autoinst-distri-opensuse#fix/image_upload_byos => passed

