### PR TITLE
publiccloud: terraform_destroy() - avoid on upload

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -423,7 +423,7 @@ Destroys the current terraform deployment
 =cut
 sub terraform_destroy {
     my ($self) = @_;
-    return if get_required_var('TEST') eq 'publiccloud_upload_img';
+    return if get_required_var('TEST') =~ /^publiccloud_upload_img/;
     record_info('INFO', 'Removing terraform plan...');
     if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
         assert_script_run('cd ' . TERRAFORM_DIR . '/' . $self->conv_openqa_tf_name);


### PR DESCRIPTION
There is a special handling for publiccloud_upload_img test. But the
check fails, if a such a test was triggered with openqa-clone-job*
This change check if the TEST variable begins with
`publiccloud_upload_img`, which should do it for now.

In general I would prefer a solution, where we do not rely on a test name. But I don't see the need
to invest more for now.

- Failed run: https://openqa.suse.de/tests/3904498#step/upload_image/89
- Verification run: https://openqa.suse.de/t3904521
