### PR TITLE
Add click to start playback and check if video changed

### DIFF
--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -24,19 +24,9 @@ use testapi;
 sub run {
     my ($self) = @_;
     $self->start_firefox_with_profile;
-
-    $self->firefox_open_url('youtube.com/html5');
-    assert_screen('firefox-html5-youtube');
-    send_key "pgdn";
-    send_key "up";
-    send_key "up";
-    sleep 1;
-    assert_screen('firefox-html5-support', 60);
-
     $self->firefox_open_url('youtube.com/watch?v=Z4j5rJQMdOU');
-    assert_screen('firefox-flashplayer-video_loaded');
-
-    # Exit
+    assert_and_click('firefox-flashplayer-video_loaded');
+    assert_screen("firefox-testvideo");
     $self->exit_firefox;
 }
 1;


### PR DESCRIPTION
Make the firefox_html5 test actually test video playback and no longer visit youtube.com/html5.

- Related ticket: https://progress.opensuse.org/issues/55286
- Needles: 
  opensuse: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/644
  sles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1327
  
- Verification run: http://d505.qam.suse.de/tests/14#step/firefox_html5/10
