### PR TITLE
publiccloud: Set openqa_ttl tag

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -38,6 +38,11 @@ variable "storage-account" {
     default="openqa"
 }
 
+variable "tags" {
+    type = map(string)
+    default = {}
+}
+
 resource "random_id" "service" {
     count = var.instance_count
     keepers = {
@@ -51,11 +56,11 @@ resource "azurerm_resource_group" "openqa-group" {
     name     = "${var.name}-${element(random_id.service.*.hex, 0)}"
     location = var.region
 
-    tags = {
-        openqa_created_by = var.name
-        openqa_created_date = "${timestamp()}"
-        openqa_created_id = "${element(random_id.service.*.hex, 0)}"
-    }
+    tags = merge({
+            openqa_created_by = var.name
+            openqa_created_date = "${timestamp()}"
+            openqa_created_id = "${element(random_id.service.*.hex, 0)}"
+        }, var.tags)
 }
 
 resource "azurerm_virtual_network" "openqa-network" {
@@ -158,11 +163,12 @@ resource "azurerm_virtual_machine" "openqa-vm" {
         }
     }
 
-    tags = {
-        openqa_created_by = var.name
-        openqa_created_date = "${timestamp()}"
-        openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
-    }
+    tags = merge({
+            openqa_created_by = var.name
+            openqa_created_date = "${timestamp()}"
+            openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+        }, var.tags)
+
 
     boot_diagnostics {
         enabled = true

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -52,6 +52,11 @@ variable "uefi" {
     default=false
 }
 
+variable "tags" {
+    type = map(string)
+    default = {}
+}
+
 resource "random_id" "service" {
     count = var.instance_count
     keepers = {
@@ -72,12 +77,12 @@ resource "google_compute_instance" "openqa" {
         }
     }
 
-    metadata = {
-        sshKeys = "susetest:${file("/root/.ssh/id_rsa.pub")}"
-        openqa_created_by = var.name
-        openqa_created_date = "${timestamp()}"
-        openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
-    }
+    metadata = merge({
+            sshKeys = "susetest:${file("/root/.ssh/id_rsa.pub")}"
+            openqa_created_by = var.name
+            openqa_created_date = "${timestamp()}"
+            openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+        }, var.tags)
 
     network_interface {
         network = "default"

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -355,6 +355,7 @@ sub terraform_apply {
         $cmd .= "-var 'region=" . $self->region . "' ";
         $cmd .= "-var 'name=" . $name . "' ";
         $cmd .= "-var 'project=" . $args{project} . "' " if $args{project};
+        $cmd .= sprintf(q(-var 'tags={"openqa_ttl":"%d"}' ), get_var('MAX_JOB_TIME', 7200) + 300);
         if ($args{use_extra_disk}) {
             $cmd .= "-var 'create-extra-disk=true' ";
             $cmd .= "-var 'extra-disk-size=" . $args{use_extra_disk}->{size} . "' " if $args{use_extra_disk}->{size};


### PR DESCRIPTION
This tag can be used by pcw to automatically delete the instance.
See also: https://github.com/cfconrad/pcw/pull/71

- Verification run: https://openqa.suse.de/tests/3905329

And it is visible in pcw like: http://s.qa.suse.de/5766
