### PR TITLE
Btrfs snapshot not supported on xfs

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1773,7 +1773,8 @@ sub load_rollback_tests {
     return if check_var('ARCH', 's390x');
     # On Xen PV we don't have GRUB.
     # For continuous migration test from SLE11SP4, the filesystem is 'ext3' and btrfs snapshot is not supported.
-    loadtest "boot/grub_test_snapshot" unless check_var('VIRSH_VMM_TYPE', 'linux') || check_var('FILESYSTEM', 'ext3');
+    # For HPC migration test with 'management server' role, the filesystem is 'xfs', btrfs snapshot is not supported.
+    loadtest "boot/grub_test_snapshot" unless check_var('VIRSH_VMM_TYPE', 'linux') || get_var('FILESYSTEM') =~ /ext3|xfs/;
     # Skip load version switch for online migration
     loadtest "migration/version_switch_origin_system" if (!get_var("ONLINE_MIGRATION"));
     if (get_var('UPGRADE') || get_var('ZDUP')) {


### PR DESCRIPTION
For HPC migration test with 'management server' role, the filesystem is 'xfs', btrfs snapshot is not supported.

- Related ticket: https://progress.opensuse.org/issues/63676
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/3908964