### PR TITLE
Add soft-failure for the remote vnc installation on openSUSE

### DIFF
--- a/tests/remote/remote_target.pm
+++ b/tests/remote/remote_target.pm
@@ -17,6 +17,8 @@ use warnings;
 use testapi;
 use lockapi;
 use mm_network;
+use version_utils 'is_opensuse';
+
 
 # poo#9576
 sub run {
@@ -25,9 +27,11 @@ sub run {
     mutex_create("installation_ready");
     # wait while whole installation process finishes
     mutex_wait("installation_done");
-    send_key('ctrl-alt-delete') if check_var('DISTRI', 'opensuse');
+    if (is_opensuse) {
+        record_soft_failure('bsc#1164503');
+        send_key('ctrl-alt-delete');
+    }
     $self->wait_boot(bootloader_time => 120);
 }
 
 1;
-


### PR DESCRIPTION
We have a kernel bug in TW which is visible in openQA, but we were not
able to catch it manually. System is able to boot normally, if we force
reboot by pressing ctr-alt-delete, so that will be used as a workaround
for now.

See [poo#63247](https://progress.opensuse.org/issues/63247).

- [Verification run](https://openqa.opensuse.org/tests/1182154#).
