### PR TITLE
Add tests non-available systemd target

### DIFF
--- a/data/autoyast_sle15/autoyast_invalid_default_target.xml
+++ b/data/autoyast_sle15/autoyast_invalid_default_target.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons config:type="list">
+            <addon>
+                <name>sle-module-basesystem</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+    </general>
+    <services-manager>
+        <default_target>non_existing_target</default_target>
+        <services config:type="list"/>
+    </services-manager>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+</profile>

--- a/data/autoyast_sle15/autoyast_non_existing_graphical_target.xml
+++ b/data/autoyast_sle15/autoyast_non_existing_graphical_target.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons config:type="list">
+            <addon>
+                <name>sle-module-basesystem</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+    </general>
+    <services-manager>
+        <default_target>graphical</default_target>
+        <services config:type="list"/>
+    </services-manager>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+</profile>

--- a/schedule/yast/autoyast_invalid_default_target.yaml
+++ b/schedule/yast/autoyast_invalid_default_target.yaml
@@ -1,0 +1,22 @@
+name:           autoyast_invalid_default_target
+description:    >
+        Test AutoYaST installation while invalid default target is specified in
+        AutoYaST control file.
+        Covered cases:
+           - Verify that warning message is shown during installation;
+           - Verify that multi-user target is set as default in the case.
+
+vars:
+        AUTOYAST: autoyast_sle15/autoyast_invalid_default_target.xml
+        AUTOYAST_PREPARE_PROFILE: 1
+schedule:
+        - autoyast/prepare_profile
+        - installation/isosize
+        - installation/bootloader_start
+        - autoyast/installation
+        - autoyast/console
+        - autoyast/verify_default_target
+test_data:
+  default_target: "multi-user.target"
+  expected_warnings:
+    - autoyast-warning-invalid-default-target

--- a/schedule/yast/autoyast_non_existing_graphical_target.yaml
+++ b/schedule/yast/autoyast_non_existing_graphical_target.yaml
@@ -1,0 +1,23 @@
+name:           autoyast_non_existing_graphical_target
+description:    >
+  Test AutoYaST installation when graphical target is specified as default in
+  AutoYaST control file, but the system does not have graphical environment
+  installed.
+  Covered cases:
+     - Verify that graphical target is set as default even if there is no
+       graphical environment installed. When there are no graphical components
+       installed, graphical.target is equal to multi-user.target;
+     - Verify that the system loads and don't hang after installation. This is
+       done indirectly by logging in to the system after installation.
+
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_non_existing_graphical_target.xml
+  AUTOYAST_PREPARE_PROFILE: 1
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/verify_default_target
+test_data:
+  default_target: "graphical.target"

--- a/tests/autoyast/verify_default_target.pm
+++ b/tests/autoyast/verify_default_target.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Test module to verify that actual default target corresponds to the
+# expected one.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+use strict;
+use warnings;
+use testapi;
+use base 'basetest';
+use scheduler 'get_test_suite_data';
+use Test::Assert 'assert_equals';
+
+my $test_data;
+
+sub run {
+    $test_data = get_test_suite_data();
+
+    select_console 'root-console';
+    my $actual_default_target = script_output('systemctl get-default');
+
+    record_info('Default target',
+        'Verify that actual default target corresponds to the expected one.');
+    assert_equals($test_data->{default_target}, $actual_default_target,
+        'Default target does not correspond to the expected one.');
+}
+
+1;


### PR DESCRIPTION
**For reviewers: Please, merge needles and Job Group settings in order to make the test work on osd.**

Test AutoYaST installation while invalid default target is specified in
AutoYaST control file.
Covered cases:
Verify that warning message is shown during installation;
Verify that multi-user target is set as default in the case.


- Related ticket: https://progress.opensuse.org/issues/48095
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1328
- Job Group Settings: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/merge_requests/136
- Verification run: 
autoyast_invalid_default_target: http://10.160.66.6/tests/1334