### PR TITLE
Also skip unnecessary check for enabled getty on Tumbleweed

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -404,7 +404,10 @@ sub become_root {
     my ($self) = @_;
 
     $self->script_sudo('bash', 0);
-    disable_serial_getty() unless $self->script_run("systemctl is-enabled serial-getty\@$testapi::serialdev");
+    # No need to apply on more recent kernels
+    if (is_sle('<=15-SP2') || is_leap('<=15.2')) {
+        disable_serial_getty() unless $self->script_run("systemctl is-enabled serial-getty\@$testapi::serialdev");
+    }
     type_string "cd /tmp\n";
     $self->set_standard_prompt('root');
     type_string "clear\n";


### PR DESCRIPTION
After
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9534 we
can also skip the check for the getty when we would not do anything
different based on the result anyway.

Verification:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9601 https://openqa.opensuse.org/tests/1181825
```

Created job #1182183: opensuse-Tumbleweed-DVD-x86_64-Build20200220-gnuhealth@64bit -> https://openqa.opensuse.org/t1182183

Related progress issue: https://progress.opensuse.org/issues/54293