### PR TITLE
[WIP] await_install: Prevent infinite loop on screenlock for live-installs

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -58,7 +58,8 @@ use ipmi_backend_utils;
 sub handle_livecd_screenlock {
     record_soft_failure 'boo#994044: Kde-Live net installer is interrupted by screenlock';
     diag('unlocking screenlock with no password in LIVECD mode');
-    do {
+    my $retries = 7;
+    for (1 .. $retries) {
         # password and unlock button seem to be not in focus so switch to
         # the only 'window' shown, tab over the empty password field and
         # confirm unlocking
@@ -67,7 +68,9 @@ sub handle_livecd_screenlock {
             send_key 'tab';
             send_key 'ret';
         }
-    } while (check_screen('screenlock', 20));
+        last unless check_screen 'screenlock', 20;
+        die "Failed to unlock screen within multiple retries" if $_ == $retries;
+    }
     save_screenshot;
     # can take a long time until the screen unlock happens as the
     # system is busy installing.


### PR DESCRIPTION
Verification:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9602 https://openqa.opensuse.org/tests/1182023
```

Created job #1182221: opensuse-Tumbleweed-KDE-Live-x86_64-Build20200220-kde_live_upgrade_leap_42.3@64bit-2G -> https://openqa.opensuse.org/t1182221

Related progress issue: https://progress.opensuse.org/issues/48899