### PR TITLE
sles4sap/hana_cluster: Upload trace logs for hdbnsutil

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -320,6 +320,12 @@ sub ha_export_logs {
     # HAWK test logs if present
     upload_logs("/tmp/hawk_test.log", failok => 1);
     upload_logs("/tmp/hawk_test.ret", failok => 1);
+
+    # HANA hdbnsutil logs
+    if (check_var('CLUSTER_NAME', 'hana')) {
+        script_run 'tar -zcf /tmp/trace.tgz $(find /hana/shared -name nameserver_*.trc)';
+        upload_logs('/tmp/trace.tgz', failok => 1);
+    }
 }
 
 sub check_cluster_state {


### PR DESCRIPTION
Note: The other PR was accidentally closed.

Upload trace logs for hdbnsutil in case of failure.

Needed to debug:
https://openqa.suse.de/tests/3909235#step/hana_cluster/25

