### PR TITLE
xfstests: Max time for subtests configurable

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -47,7 +47,7 @@ my $STATUS_LOG   = '/opt/status.log';
 my $INST_DIR     = '/opt/xfstests';
 my $LOG_DIR      = '/opt/log';
 my $KDUMP_DIR    = '/opt/kdump';
-my $MAX_TIME     = 2400;
+my $MAX_TIME     = get_var('XFSTESTS_SUBTEST_MAXTIME') || 2400;
 my $FSTYPE       = get_required_var('XFSTESTS');
 
 # Create heartbeat script, directories(Call it only once)


### PR DESCRIPTION
The max time for subtests was hard code set to 2400 as before. But some test in spvm or s390x may need more time to finish. Make this time configurable to debug some bug in spvm.

- Verification run: https://openqa.nue.suse.com/tests/3920192#
XFSTESTS_SUBTEST_MAXTIME works to control sub test waiting time.
