### PR TITLE
Increase still time in yast2_lan

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -42,7 +42,7 @@ sub run {
     save_screenshot;
 
     my $opened = open_yast2_lan();
-    wait_still_screen;
+    wait_still_screen(14);
     if ($opened eq "Controlled by network manager") {
         return;
     }


### PR DESCRIPTION
Increase still time in yast2_lan. For the mentioned [failure](https://openqa.opensuse.org/tests/1175316#step/yast2_lan/13), in the video is clear that is reaching step 'Read Routing Configuration' without being stuck, but it might take more than 7s (depending on the status of the system) in some step, so increase the value should help to stabilize the test and avoid this sporadic failure.

- Related ticket: https://progress.opensuse.org/issues/63400
