### PR TITLE
Handle blackscreen in ensure_unlocked_desktop

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -69,7 +69,9 @@ all possible options should be handled within loop to get unlocked desktop
 sub ensure_unlocked_desktop {
     my $counter = 10;
     while ($counter--) {
-        assert_screen [qw(displaymanager displaymanager-password-prompt generic-desktop screenlock screenlock-password authentication-required-user-settings authentication-required-modify-system)], no_wait => 1;
+        my @tags = qw(displaymanager displaymanager-password-prompt generic-desktop screenlock screenlock-password authentication-required-user-settings authentication-required-modify-system);
+        push(@tags, 'blackscreen') if get_var("DESKTOP") =~ /minimalx/;    # Only xscreensaver has a blackscreen as screenlock
+        assert_screen \@tags, no_wait => 1;
         if (match_has_tag 'displaymanager') {
             if (check_var('DESKTOP', 'minimalx')) {
                 type_string "$username";
@@ -116,7 +118,7 @@ sub ensure_unlocked_desktop {
             last;            # desktop is unlocked, mission accomplished
         }
         die 'ensure_unlocked_desktop repeated too much. Check for X-server crash.' if ($counter eq 1);    # die loop when generic-desktop not matched
-        if (match_has_tag 'screenlock') {
+        if (match_has_tag('screenlock') || match_has_tag('blackscreen')) {
             wait_screen_change {
                 send_key 'esc';                                                                           # end screenlock
             };


### PR DESCRIPTION
- Fixup after deletion of screenlock needle matching blackscreen: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/646
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/9aa16a19b79a765d6082f7bb8f6601f45aab7bfd
- Verification run: 
  * lvm (minimalx): https://openqa.opensuse.org/t1185271
  * minimalx NET: https://openqa.opensuse.org/t1185272
  * create_hdd_minimal_x: https://openqa.opensuse.org/t1185555