### PR TITLE
Fix a path issue in prepare_pvm_installation

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -119,9 +119,9 @@ sub prepare_pvm_installation {
     select_console('install-shell');
 
 
-    my $disks = script_output('lsblk -n -p -l -o NAME -d -e 7,11');
+    my $disks = script_output('lsblk -n -l -o NAME -d -e 7,11');
     for my $d (split('\n', $disks)) {
-        script_run "wipefs -a $d";
+        script_run "wipefs -a /dev/$d";
         create_encrypted_part("$d") if get_var('ENCRYPT_ACTIVATE_EXISTING');
     }
     # Switch to installation console (ssh or vnc)


### PR DESCRIPTION
Fixes that path issue: https://openqa.suse.de/tests/3909752#step/bootloader_start/34: the subroutine "create_encrypted_part" adds /dev so we end up with /dev//dev/sda. the function being used in various places it is much easier to just remove the -p option from lsblk here.

- Verification run: https://openqa.suse.de/tests/3916528
