### PR TITLE
Enhance code checking rules

### DIFF
--- a/tools/test_deleted_renamed_referenced_modules
+++ b/tools/test_deleted_renamed_referenced_modules
@@ -10,7 +10,7 @@ for FILE in $FILES; do
     # module name as appears in scheduling files excluding 'tests/' and file extension
     module=$(echo $FILE | cut -f 2- -d '/' | cut -f 1 -d '.')
     target_paths='schedule/ products/*/main.pm lib/main_common.pm'
-    MATCHED_SCHEDULE_FILES=$(grep --recursive --ignore-case --files-with-matches $module $target_paths)
+    MATCHED_SCHEDULE_FILES=$(grep --recursive --ignore-case --files-with-matches "${module}\b" $target_paths)
     if [ "$MATCHED_SCHEDULE_FILES" ]; then
         echo -e "\"$module\" test module was removed or renamed, but it is still used in: \
         \n$MATCHED_SCHEDULE_FILES\n"


### PR DESCRIPTION
we have a tool, test_deleted_renamed_referenced_modules.
It will check a module be renamed/deleted if still is in used.

But there is a bug when renaming a module. the old name is a substring of
new name, it will report check failed.

For example, the old module is 'cpu_bugs/xen_pv.pm', new module is
'cpu_bugs/xen_pv_hvm.pm', the tool will check 'cpu_bugs/xen_pv' string
to determine the old one if still is in use.
and then it will match the new one because it is a substring of the new
one. the tool will judge the old one still is in used. break code
checking.