### PR TITLE
Add check for Network restart in lib/y2lan_restart_common

### DIFF
--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -150,7 +150,7 @@ sub check_device {
 
     add_device($device);
     select_special_device_tab($device);
-    check_network_status('', $device);
+    check_network_status('no_restart', $device);
     delete_device($device);
 }
 

--- a/tests/yast2_gui/yast2_lan_restart_bond.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bond.pm
@@ -49,7 +49,7 @@ sub run {
     $network_settings->save_changes();
     wait_for_xterm_to_be_visible();
     clear_journal_log();
-    check_network_status('', 'bond');
+    check_network_status('no_restart', 'bond');
 }
 
 sub post_run_hook {

--- a/tests/yast2_gui/yast2_lan_restart_bridge.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bridge.pm
@@ -49,7 +49,7 @@ sub run {
     $network_settings->save_changes();
     wait_for_xterm_to_be_visible();
     clear_journal_log();
-    check_network_status('', 'bridge');
+    check_network_status('no_restart', 'bridge');
 }
 
 sub post_run_hook {

--- a/tests/yast2_gui/yast2_lan_restart_vlan.pm
+++ b/tests/yast2_gui/yast2_lan_restart_vlan.pm
@@ -49,7 +49,7 @@ sub run {
     $network_settings->save_changes();
     wait_for_xterm_to_be_visible();
     clear_journal_log();
-    check_network_status('', 'vlan');
+    check_network_status('no_restart', 'vlan');
 }
 
 sub post_run_hook {


### PR DESCRIPTION
An additonal check that will verify that network didn't restart when it wasn't expected was added. Also, configuration for debugging wicked and check if there is Network manager or wicked used, as opensuse tests use Network manager.

related progress ticket : https://progress.opensuse.org/issues/62465
**verification runs :**
_sle_
https://openqa.suse.de/tests/3929323
_tumbleweed_
http://falafel.suse.cz/tests/258

