### PR TITLE
Multi-tag to match auto-selected modules  for offline migration via package media

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -88,8 +88,12 @@ sub handle_all_packages_medium {
         next if (skip_package_hub_if_necessary($i));
         push @addons_license_tags, "addon-license-$i" if grep(/^$i$/, @addons_with_license);
         send_key 'home';
-        send_key_until_needlematch "addon-products-all_packages-$i-highlighted", 'down', 30;
-        send_key 'spc';
+        send_key_until_needlematch ["addon-products-all_packages-$i-highlighted", "addon-products-all_packages-$i-selected"], "down", 30;
+        if (match_has_tag("addon-products-all_packages-$i-highlighted")) {
+            send_key 'spc';
+        } else {
+            record_info("Module preselected", "Module $i is already selected");
+        }
     }
     send_key $cmd{next};
     # Check the addon license agreement


### PR DESCRIPTION
Multi-tag to match auto-selected modules for offline migration via package media.
Some module auto-selected, need check before send spc key
Background: For example, if WE is selected first, then python2 will auto-select. So need add tag 'selected' to check this scenario.
- Related ticket: https://progress.opensuse.org/issues/63688
- Verification run:https://openqa.nue.suse.com/tests/3920175#step/addon_products_sle/26
