### PR TITLE
WIP: Remove -e option to avoid interrupt

### DIFF
--- a/tools/test_deleted_renamed_referenced_modules
+++ b/tools/test_deleted_renamed_referenced_modules
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 
 FILES="${@}"
 success=1


### PR DESCRIPTION
This script use -e option, it will is interrupted when any command
return not 0 value.

the grep command is highly possible return not 0 value. so we could
check exit code manually.
