### PR TITLE
x11/libreoffice: use more accurate shortcut "alt-f" than "ret"

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -84,7 +84,7 @@ sub select_base_and_cleanup {
     }
     send_key "ret";
     assert_screen 'oobase-save-database';
-    send_key "ret";
+    send_key "alt-f";    # "Finish" button
     assert_screen 'oobase-save-database-prompt';
     type_string "testdatabase";
     send_key "ret";


### PR DESCRIPTION
This is a simple fix, in newer libreoffice 6.4, shortcut "ret" no longer works, we should use more accurate "alt-f" to choose the "Finish" button.

- Related ticket: https://progress.opensuse.org/issues/62060
- Needles: none
- Verification run:
SLE: https://openqa.nue.suse.com/tests/3920433#step/libreoffice_mainmenu_components/7
TW: https://openqa.opensuse.org/tests/1186031#step/libreoffice_mainmenu_components/14
