### PR TITLE
Send f5 more often to avoid screen blanking

### DIFF
--- a/tests/openqa/webui/test_results.pm
+++ b/tests/openqa/webui/test_results.pm
@@ -54,10 +54,10 @@ sub run {
     wait_still_screen;
 
     # wait for result
-    for (1 .. 5) {
+    for (1 .. 25) {
         send_key 'f5';
         wait_still_screen;
-        last if check_screen('openqa-testresult', 300);
+        last if check_screen('openqa-testresult', 60);
     }
     assert_screen 'openqa-testresult';
 }


### PR DESCRIPTION
With a timeout value of 300 for `check_screen` with a `TIMEOUT_SCALE` of 2, it leads to screen blanking and no match can be performed. See: https://openqa.opensuse.org/tests/1185449#step/test_results/13
- Verification run: https://openqa.opensuse.org/tests/1186110