### PR TITLE
Fix code checking rules - referenced files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test-spec:
 	tools/update_spec --check
 
 .PHONY: test-static
-test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-unused-modules test-deleted-renamed-referenced-modules test-soft_failure-no-reference test-spec test-invalid-syntax
+test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-modules test-unused-modules test-soft_failure-no-reference test-spec test-invalid-syntax
 .PHONY: test
 ifeq ($(TESTS),compile)
 test: test-compile

--- a/tools/test_deleted_renamed_referenced_modules
+++ b/tools/test_deleted_renamed_referenced_modules
@@ -10,8 +10,8 @@ for FILE in $FILES; do
     # module name as appears in scheduling files excluding 'tests/' and file extension
     module=$(echo $FILE | cut -f 2- -d '/' | cut -f 1 -d '.')
     target_paths='schedule/ products/*/main.pm lib/main_common.pm'
-    MATCHED_SCHEDULE_FILES=$(grep --recursive --ignore-case --files-with-matches "${module}\b" $target_paths)
-    if [ "$MATCHED_SCHEDULE_FILES" ]; then
+    if MATCHED_SCHEDULE_FILES="$(grep --recursive --ignore-case --files-with-matches "${module}\b" $target_paths)"
+    then
         echo -e "\"$module\" test module was removed or renamed, but it is still used in: \
         \n$MATCHED_SCHEDULE_FILES\n"
         success=0


### PR DESCRIPTION
Regarding issue found in #9612 for a successful delete or rename we need to handle a couple of things:
- Fix the grep condition, otherwise that line always would fail.
- Schedule this code check rule before `test-unused-modules` as it is faster and there is some overlapping with the one aforementioned.

For example, if these two action are performed: (1) Rename `tests/cpu_bugs/xen_pv.pm → tests/cpu_bugs/xen_pv_hvm.pm` (2) Delete `tests/yast2_gui/yast2_keyboard.pm` script fails notifying them: [FAILURE OK](https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse/jobs/654807018?utm_medium=notification&utm_source=github_status)
Once those errors are corrected we have [SUCCESS](https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse/jobs/654810037?utm_medium=notification&utm_source=github_status)

With current script for CI (without this modification), once the problems notified are fixed, the script is still failing without explanation (which is `grep` returning error when not result found): [FAILURE NOT_OK](https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse/jobs/654826310?utm_medium=notification&utm_source=github_status)
