### PR TITLE
Move ibtests barrier creation to a separate test module

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -531,9 +531,9 @@ sub mellanox_config {
 }
 
 sub load_baremetal_tests {
-    set_var('ADDONURL', 'sdk') if (is_sle('>=12') && is_sle('<15')) && !is_released;
-
-    loadtest "autoyast/prepare_profile" if get_var "AUTOYAST_PREPARE_PROFILE";
+    set_var('ADDONURL', 'sdk')               if (is_sle('>=12') && is_sle('<15')) && !is_released;
+    loadtest 'tests/kernel/ibtests_barriers' if get_var('IBTESTS');
+    loadtest "autoyast/prepare_profile"      if get_var "AUTOYAST_PREPARE_PROFILE";
     if (get_var('IPXE')) {
         loadtest 'installation/ipxe_install';
         loadtest "console/suseconnect_scc";
@@ -549,14 +549,6 @@ sub load_baremetal_tests {
 }
 
 sub load_infiniband_tests {
-    # The barriers below must be created
-    # here to ensure they are a) only created once and b) early enough
-    # to be available when needed.
-    if (get_var('IBTEST_ROLE') eq 'IBTEST_MASTER') {
-        barrier_create('IBTEST_SETUP', 2);
-        barrier_create('IBTEST_BEGIN', 2);
-        barrier_create('IBTEST_DONE',  2);
-    }
     mellanox_config();
     loadtest "kernel/ib_tests";
 }

--- a/tests/kernel/ibtests_barriers.pm
+++ b/tests/kernel/ibtests_barriers.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: run InfiniBand test suite hpc-testing
+#
+# Maintainer: Michael Moese <mmoese@suse.de>,
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+
+
+sub run {
+    if (get_required_var('IBTEST_ROLE') eq 'IBTEST_MASTER') {
+        barrier_create('IBTEST_SETUP', 2);
+        barrier_create('IBTEST_BEGIN', 2);
+        barrier_create('IBTEST_DONE',  2);
+    }
+
+}
+
+1;


### PR DESCRIPTION
Move ibtests barrier creation to a separate test module in preparation to move the ibtests to a declarative schedule