### PR TITLE
Rename the header of *.repo files to be unique

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -37,6 +37,7 @@ sub run {
             die "wget error: The $maintrepo download failed with $ret return code.";
         }
         assert_script_run("echo -en '# $maintrepo:\\n\\n' >> /tmp/repos.list.txt");
+        assert_script_run("sed -i \"1 s/\\]/_\$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 4)]/\" $parent*.repo");
         assert_script_run("find $parent >> /tmp/repos.list.txt");
     }
 

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -41,6 +41,10 @@ sub run {
 
     zypper_call("in traceroute bzip2");
     assert_script_run("traceroute -I gate.suse.cz", 90);
+
+    assert_script_run("rpm -qa > /tmp/rpm.list.txt");
+    upload_logs('/tmp/rpm.list.txt');
+    upload_logs('/var/log/zypper.log');
 }
 
 1;


### PR DESCRIPTION
Hello,

in QAM Public Cloud scenario, all the maintenance updates are downloaded, transfered into the PC instance and then added.
The problem I am fixing here is, that there are multiple modules of single incident and all the `*.repo` files have the same header such as `[SUSE_Maintenance_13632]`.
Here I am adding four random characters to make them unique.

- Verification run: [here](http://pdostal-server.suse.cz/tests/6869)
