### PR TITLE
Drop removal of snapshots in postgre test case

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -340,16 +340,12 @@ qq{mysql -u root -e "CREATE DATABASE openQAdb; USE openQAdb; CREATE TABLE test (
 # poo#62000
 sub postgresql_cleanup {
     select_console 'root-console';
-    # Display current state of btrfs
-    assert_script_run 'btrfs fi show';
     # Clean up
     systemctl 'stop postgresql';
     systemctl 'disable postgresql';
     systemctl 'is-active postgresql', expect_false => 1;
     assert_script_run('kill -s KILL $(ps -u postgres -o pid=)') unless script_run('ps -u postgres -o pid=');
     zypper_call "rm postgresql";
-    script_run q[snapper delete --sync $(snapper --quiet --machine-readable csv list | awk -F ',' 'NR>3 {print $3+0}')];
-    assert_script_run 'userdel --remove postgres';
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [[qam][jeos] test fails in php7_postgresql](https://progress.opensuse.org/issues/63787)
- Verification runs: 
   * [sle-15-Server-DVD-Updates-x86_64-Build20200225-1-mau-apparmor@64bit](http://eris.suse.cz/tests/4818)
  * [sle-12-SP4-Server-DVD-Updates-x86_64-Build20200225-1-mau-bind@64bit](http://eris.suse.cz/tests/4819#)