### PR TITLE
Assert virt-manager preferences shown before altering values

### DIFF
--- a/tests/virtualization/virtman_view.pm
+++ b/tests/virtualization/virtman_view.pm
@@ -28,6 +28,7 @@ sub run {
     # go to preferences
     assert_and_click 'virtman-edit-menu';
     assert_and_click 'virtman-preferences';
+    assert_screen 'virtman-preferences-general';
     # go to polling
     wait_screen_change { send_key 'right' };
     for (1 .. 3) { send_key 'tab' }
@@ -35,7 +36,7 @@ sub run {
     # activate disk I/O
     wait_screen_change { send_key 'spc' };
     send_key 'tab';
-    # acrtivate net I/O
+    # activate net I/O
     wait_screen_change { send_key 'spc' };
     send_key 'tab';
     # activate Mem stat


### PR DESCRIPTION
Without the assert_screen keys are send immediately after the
'Preferences' menu item has been clicked, i.e. possibly before the dialog
has appeared.

- Related ticket: https://progress.opensuse.org/issues/63775
- Verification run: https://openqa.opensuse.org/tests/1186951#step/virtman_view/9
