### PR TITLE
Extend time to get the whole test data

### DIFF
--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -25,7 +25,7 @@ sub run {
     check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
 
     select_console 'user-console';
-    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data";
+    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data", timeout => 300;
     assert_script_run " cpio -id < test.data";
     assert_script_run "rm test.data";
     script_run "ls -al data";


### PR DESCRIPTION
Extend time to get the whole test data.
Background: Prepare test data file need get one data file. It need time to get the whole file. Sometimes, we can only get part of file. Need extend more time to run the command.

- Related ticket: https://progress.opensuse.org/issues/63214
- Verification run: https://openqa.nue.suse.com/tests/3925212#step/prepare_test_data/11
