### PR TITLE
Reuse existing root-ssh for root-console

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -20,6 +20,7 @@ use Utils::Backends qw(has_serial_over_ssh set_sshserial_dev use_ssh_serial_cons
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
 use publiccloud::ssh_interactive 'ssh_interactive_join';
 use Cwd;
+use autotest 'query_isotovideo';
 
 =head1 SUSEDISTRIBUTION
 
@@ -856,6 +857,12 @@ known uncheckable consoles are already ignored.
 =cut
 sub console_selected {
     my ($self, $console, %args) = @_;
+    if ((exists $testapi::testapi_console_proxies{'root-ssh'}) && $console eq 'root-console') {
+        $console = 'root-ssh';
+        my $ret = query_isotovideo('backend_select_console', {testapi_console => $console});
+        die $ret->{error} if $ret->{error};
+        $autotest::selected_console = $console;
+    }
     $args{await_console} //= 1;
     $args{tags}          //= $console;
     $args{ignore}        //= qr{sut|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary};


### PR DESCRIPTION
Fix poo#59843: If is `select_console 'root-console'` called several
times on remote backend, second use will fail. It works properly when
it runs only once. When is `root-console` selected for the first time,
`root-ssh` is used during console initiation. When is `root-console`
selected after, it will fail, the switch to `root-ssh` will not happen.

The fix was intended for spvm issue:
https://openqa.suse.de/tests/3920655#step/coredump_collect/2

But it fixed ipmi issue as well:
https://openqa.suse.de/tests/3915770#step/keymap_or_locale/6



- Related ticket: https://progress.opensuse.org/issues/59843
                          https://progress.opensuse.org/issues/60497
- Needles:none
- Verification run:
spvm: http://10.100.12.105/tests/3879
ipmi: https://openqa.suse.de/tests/3925443#step/keymap_or_locale/3