### PR TITLE
Reboot_after_installation should end on grub menu

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -73,7 +73,11 @@ use constant GRUB_DEFAULT_FILE => "/etc/default/grub";
 # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
 # 'up' also works in textmode and UEFI menues.
 sub stop_grub_timeout {
-    send_key 'up';
+    if (assert_screen [qw(grub2 bootloader)], 600) {
+        send_key_until_needlematch('bootloader-timeout-disabled', 'up', 8, 1);
+        assert_screen 'bootloader-timeout-disabled';
+        save_screenshot;
+    }
 }
 
 =head2 add_custom_grub_entries

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -22,7 +22,8 @@ use testapi;
 use utils;
 use mmapi;
 use power_action_utils 'power_action';
-use Utils::Backends 'has_ttys';
+use Utils::Backends qw(has_ttys is_remote_backend);
+use bootloader_setup 'stop_grub_timeout';
 
 sub run {
     select_console 'installation' unless get_var('REMOTE_CONTROLLER');
@@ -103,6 +104,11 @@ sub run {
     }
     else {
         power_action('reboot', observe => 1, keepconsole => 1, first_reboot => 1);
+        # exclude remote backend where no grub_test follows reboot_after_installation and exclude test with
+        # encrypted partition as well because encrypted bootloader is handled via grub_test and it takes long time.
+        # it requires also to exclude USBBOOT because reboot after installation will come back to
+        # bootloader of installationn medium and it breaks then grub_test or first_boot
+        stop_grub_timeout unless (is_remote_backend || get_var('ENCRYPT') || get_var('USBBOOT'));
     }
 }
 


### PR DESCRIPTION
we had sometimes situation that grub_menu got already to start even
when reboot from new installation is not finished yet.
see https://progress.opensuse.org/issues/63649

test verification runs:
x86_64
https://openqa.suse.de/tests/3971654 (encyrpted LVM, not effected)
https://openqa.suse.de/tests/3997566#step/reboot_after_installation/11 (svirt-xen-pv, not effected)
https://openqa.suse.de/tests/3971655#step/reboot_after_installation (svirt-xen-hvm, not effected)
https://openqa.opensuse.org/tests/1199431#step/grub_test/ (usbboot is not effected)

s390 is not effected:
https://openqa.suse.de/tests/3997586#step/reboot_after_installation/2
aarch64 encrypted LVM, not effected:
https://openqa.suse.de/tests/3971660#step/reboot_after_installation/

ppc64le
https://openqa.suse.de/tests/3997689#step/reboot_after_installation/3 (ppc64le-hmc)
https://openqa.suse.de/tests/3997688#step/reboot_after_installation/3 (ppc64le-spvm)
https://openqa.suse.de/tests/3997559#step/reboot_after_installation/4 (textmode)
https://openqa.suse.de/tests/3968840#step/reboot_after_installation/4 (Full)
https://openqa.suse.de/tests/3971658#step/reboot_after_installation/4 (YaST)

aarch64
https://openqa.suse.de/tests/3996228#step/reboot_after_installation/4 (textmode)
https://openqa.suse.de/tests/3965059#step/reboot_after_installation/4
https://openqa.suse.de/tests/3965060#step/reboot_after_installation/4 (virtio)
https://openqa.suse.de/tests/3971662#step/reboot_after_installation/4 (minimal)

x86_64
https://openqa.suse.de/tests/3984292#step/reboot_after_installation/4 (gnome+proxy_SCC+allmodules)
http://openqa.suse.de/tests/3985115#step/reboot_after_installation/4 (sle-15-SP1-Server-DVD-Updates)
http://openqa.suse.de/tests/3985114#step/reboot_after_installation/4 (sle-15-SP1-Desktop-DVD-Updates)
http://openqa.suse.de/tests/3987825#step/reboot_after_installation/4 (sle-15-SP1-Desktop-DVD-Updates textmode)
https://openqa.suse.de/tests/3987822#step/reboot_after_installation/4 (sle-15-Server-DVD-Incidents)
https://openqa.suse.de/tests/3964919#step/reboot_after_installation/4 (Full)
https://openqa.suse.de/tests/3997511#step/reboot_after_installation/4 (XEN)
https://openqa.suse.de/tests/3997575#step/reboot_after_installation/4 (Online textmode+role_kvm)
https://openqa.suse.de/tests/3996227#step/reboot_after_installation/6 (external_iso)
https://openqa.suse.de/tests/3971653#step/reboot_after_installation/4 (uefi)
https://openqa.suse.de/tests/3972168#step/reboot_after_installation/5 (Migration)
http://openqa.suse.de/tests/3968933#step/reboot_after_installation/4 (YaST)
http://openqa.suse.de/tests/3968935#step/reboot_after_installation/4 (YaST)
http://openqa.suse.de/tests/3968937#step/reboot_after_installation/4 (YaST)
http://openqa.suse.de/tests/3968938#step/reboot_after_installation/6 (YaST USBinstall)
http://openqa.suse.de/tests/3968939#step/reboot_after_installation/4 (YaST autologin)
http://openqa.suse.de/tests/3968943#step/reboot_after_installation/4 (YaST)
http://openqa.suse.de/tests/3971657#step/reboot_after_installation/4 (YaST 64bit-no-tmpfs)

openSUSE TW
https://openqa.opensuse.org/tests/1199326#step/reboot_after_installation/2 (lvm-full-encrypt, not effected)
https://openqa.opensuse.org/tests/1199332#step/reboot_after_installation/2 (upgrade_Leap_42.3_cryptlvm, not effected)
https://openqa.opensuse.org/tests/1199281#step/reboot_after_installation/6 (microOS)
https://openqa.opensuse.org/tests/1199344#step/reboot_after_installation/5 (xfce)
https://openqa.opensuse.org/tests/1199343#step/reboot_after_installation/5 (upgrade_Leap_42.2_kde)
https://openqa.opensuse.org/tests/1199341#step/reboot_after_installation/5 (minimalx)
https://openqa.opensuse.org/tests/1199340#step/reboot_after_installation/5 (gnome)
https://openqa.opensuse.org/tests/1199338#step/reboot_after_installation/10 (kde-live_installation)
https://openqa.opensuse.org/tests/1199337#step/reboot_after_installation/5 (xfs_textmod)
https://openqa.opensuse.org/tests/1199330#step/reboot_after_installation/6 (upgrade_Leap_42.1_kde)
https://openqa.opensuse.org/tests/1200375#step/reboot_after_installation/6 (upgrade_Leap_42.2_kde)
https://openqa.opensuse.org/tests/1199329#step/reboot_after_installation/6 (upgrade_Leap_42.1_gnome)
https://openqa.opensuse.org/tests/1199327#step/reboot_after_installation/5 (textmode)
https://openqa.opensuse.org/tests/1199324#step/reboot_after_installation/6 (lvm)
https://openqa.opensuse.org/tests/1199323#step/reboot_after_installation/5 (kde_dual_windows10)
https://openqa.opensuse.org/tests/1199319#step/reboot_after_installation/5 (kde@USBboot_64)
https://openqa.opensuse.org/tests/1199318#step/reboot_after_installation/5 (install_offline)
https://openqa.opensuse.org/tests/1199316#step/reboot_after_installation/5 (xfce)
https://openqa.opensuse.org/tests/1199315#step/reboot_after_installation/5 (create_hdd_textmode)
https://openqa.opensuse.org/tests/1199314#step/reboot_after_installation/5 (create_hdd_kde)
https://openqa.opensuse.org/tests/1199370#step/reboot_after_installation/6 (kde)
https://openqa.opensuse.org/tests/1199382#step/reboot_after_installation/7 (kde-USBboot_64)
https://openqa.opensuse.org/tests/1199313#step/reboot_after_installation/5 (create_hdd_gnome-x11)
https://openqa.opensuse.org/tests/1199312#step/reboot_after_installation/5 (create_hdd_gnome-wayland)
https://openqa.opensuse.org/tests/1199310#step/reboot_after_installation/6 (RAID0_gpt)
https://openqa.opensuse.org/tests/1199309#step/reboot_after_installation/5 (kubeadm)
https://openqa.opensuse.org/tests/1199308#step/reboot_after_installation/5 (container-host)
https://openqa.opensuse.org/tests/1199307#step/reboot_after_installation/5 (microos)
https://openqa.opensuse.org/tests/1199306#step/reboot_after_installation/5 (microos_textmode)
https://openqa.opensuse.org/tests/1200110#step/reboot_after_installation/5 (Tumbleweed-DVD-aarch64)
https://openqa.opensuse.org/tests/1200432#step/reboot_after_installation/9 (Krypton-Live)

openSUSE Leap
https://openqa.opensuse.org/tests/1200213#step/reboot_after_installation/5 (ppc64le, textmode)
https://openqa.opensuse.org/tests/1200212#step/reboot_after_installation/5 (NET-ppc64le)
https://openqa.opensuse.org/tests/1200416#step/reboot_after_installation/9 (KDE-live)
https://openqa.opensuse.org/tests/1200417#step/reboot_after_installation/9 (Argon-live)
