### PR TITLE
KLP: remove outdated docs

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -49,12 +49,6 @@ sub run {
 
 =head1 Example configuration
 
-=head2 QA_HEAD_REPO
-
-RPM repository for used for hiworkload.
-QA_HEAD_REPO=http://dist.nue.suse.com/ibs/QA:/Head/SLE-%VERSION%
-QA_HEAD_REPO=http://dist.nue.suse.com/ibs/QA:/Head/openSUSE_%VERSION%
-
 =head2 QA_TEST_KLP_REPO
 
 Git repository for kernel live patching infrastructure tests.


### PR DESCRIPTION
QA_HEAD_REPO usage was removed in 84f6a52ab.

Fixes: 84f6a52ab ("KLP: Remove hiworkload and bats")

Simple perlpod fix.