### PR TITLE
Add extended batch of tests for testing hpc

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -433,7 +433,20 @@ sub run_accounting_ha_tests {
 ###############################################
 
 sub extended_hpc_tests {
-    #TODO: to be done
+    #install some tools needed for extended tests
+    zypper_call('in git gcc bc');
+
+    #ensure HPC cluster installs needed rpms
+    zypper_call('in openmpi3-gnu-hpc openmpi3-gnu-hpc-devel bc openmpi3-devel');
+    zypper_call('in hypre_*-gnu-*-hpc* cpuid papi_*-hpc boost_*-gnu-hpc gsl_*-gnu-hpc petsc_*-gnu-*-hpc*');
+    script_run('export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/openmpi3/lib64/');
+    script_run('wget --quiet ' . data_url('hpc/simple_mpi.c') . ' -O /tmp/simple_mpi.c');
+    script_run('/usr/lib64/mpi/gcc/openmpi3/bin/mpicc /tmp/simple_mpi.c -o /tmp/simple_mpi | tee /tmp/make.out');
+    script_run('git clone https://github.com/schlad/havoxc_binary.git');
+    script_run('cd havoxc_binary');
+    script_run('wget --quiet ' . data_url('hpc/julog.sh') . ' -O julog.sh');
+    script_run('./havoxc.so');
+    parse_extra_log('XUnit', './results/TEST-havoxc_so.xml');
 }
 
 sub run {

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -30,7 +30,7 @@ sub run {
     zypper_call('in slurm-node') if is_sle '15+';
 
     if (get_required_var('EXT_HPC_TESTS')) {
-        #TODO: add compute node dep.
+        zypper_call('in openmpi3-gnu-hpc');
     }
 
     barrier_wait('CLUSTER_PROVISIONED');


### PR DESCRIPTION
The reasoning for those tests is to be able to easily test advanced HPC
features while the product is under development. Such tests should be
made stable, so they could be then moved - if needed - to regression
tests