### PR TITLE
Register ssh service in slpd

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-main.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-main.yaml
@@ -39,6 +39,7 @@ schedule:
   - console/firewall_enabled
   - console/gpt_ptable
   - console/kdump_disabled
+  - console/slp
   - console/sshd_running
   - console/sshd
   - console/ssh_cleanup

--- a/schedule/jeos/sle/kvm/jeos-main.yaml
+++ b/schedule/jeos/sle/kvm/jeos-main.yaml
@@ -39,6 +39,7 @@ schedule:
   - console/firewall_enabled
   - console/gpt_ptable
   - console/kdump_disabled
+  - console/slp
   - console/sshd_running
   - console/sshd
   - console/ssh_cleanup
@@ -49,4 +50,3 @@ schedule:
   - console/repo_orphaned_packages_check
   - console/orphaned_packages_check
   - console/consoletest_finish
-  

--- a/schedule/jeos/sle/xen/hvm/jeos-main.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-main.yaml
@@ -39,6 +39,7 @@ schedule:
   - console/firewall_enabled
   - console/gpt_ptable
   - console/kdump_disabled
+  - console/slp
   - console/sshd_running
   - console/sshd
   - console/ssh_cleanup

--- a/schedule/jeos/sle/xen/pv/jeos-main.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-main.yaml
@@ -38,6 +38,7 @@ schedule:
   - console/firewall_enabled
   - console/gpt_ptable
   - console/kdump_disabled
+  - console/slp
   - console/sshd_running
   - console/sshd
   - console/ssh_cleanup


### PR DESCRIPTION
- Related ticket: [[jeos] test fails in slp - slpd cannot find statically registered ssh service](https://progress.opensuse.org/issues/56048)
- Verification runs: 
   * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build24.28-jeos-extra@64bit_virtio-2G](http://eris.suse.cz/tests/4691#step/slp/1)
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build7.77-jeos-main_intel_image@uefi-virtio-vga](http://eris.suse.cz/tests/4693#step/slp/57)
- Issue:
   * [missing slp.conf file when slpd starts/slpd initialization failed](https://bugzilla.opensuse.org/show_bug.cgi?id=1165121)
   * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20200225-jeos@64bit_virtio](http://eris.suse.cz/tests/4701#step/slp/22)
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build7.77-jeos-main_intel_image@uefi-virtio-vga](http://eris.suse.cz/tests/4704#step/slp/53)
   * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build24.28-jeos-extra@64bit_virtio-2G](http://eris.suse.cz/tests/4707#step/slp/53)