### PR TITLE
Fix password page not show for sles11sp4 migration

### DIFF
--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -41,7 +41,7 @@ sub run {
     }
 
     # Only 11-SP4 need set username, 11-SP4+ don't need set username
-    set_var('DM_NEEDS_USERNAME', '0') if (check_var('MEDIA_UPGRADE', '1') && is_sle('=11-SP4', get_var('HDDVERSION')) && check_var('DM_NEEDS_USERNAME', '1'));
+    set_var('DM_NEEDS_USERNAME', '0') if (is_sle('=11-SP4', get_var('HDDVERSION')) && check_var('DM_NEEDS_USERNAME', '1'));
 
     # Setup DM_NEEDS_USERNAME for SLE15 KDE migration case
     # In SLES15 KDE has been drop, after migration the default desktop is XDM


### PR DESCRIPTION
In sles11sp4 to sles15sp2 online migration the password page can't be shown.
Background: 
In version_switch_upgrade_target.pm we just cover the sles11sp4 media migration
to set DM_NEEDS_USERNAME=0. But for online migration this will cause the fist_boot.pm
can't goes to select_user_gnome.

- Related ticket: https://progress.opensuse.org/issues/63038
- Needles: N/A
- Verification run: 
        https://openqa.nue.suse.com/tests/3928734
        https://openqa.nue.suse.com/tests/3928735
        https://openqa.nue.suse.com/tests/3929313