### PR TITLE
btrfs-progs: Increase test run timeout value to avoid error on aarch64

### DIFF
--- a/tests/btrfs-progs/run.pm
+++ b/tests/btrfs-progs/run.pm
@@ -68,7 +68,7 @@ sub test_run {
     my $logfile = "$category-tests-results.txt";
 
     script_run("./clean-tests.sh");
-    my $ret = script_output("TEST=$num\\* ./$category-tests.sh | tee output.log", 600, proceed_on_failure => 1);
+    my $ret = script_output("TEST=$num\\* ./$category-tests.sh | tee output.log", 1800, proceed_on_failure => 1);
 
     if ($ret =~ /test\s+failed\s+for\s+case/i) {
         $status = 'FAILED';


### PR DESCRIPTION
Increase test run timeout value to avoid error on aarch64

- Verification run: http://openqa.suse.de/tests/3930816