### PR TITLE
Remove the modules which non-existed after upgrade

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -32,6 +32,7 @@ our @EXPORT = qw(
   setup_migration
   register_system_in_textmode
   remove_ltss
+  remove_unexsited
   disable_installation_repos
   record_disk_info
   check_rollback_system
@@ -115,6 +116,22 @@ sub remove_ltss {
             zypper_call 'rm sles-ltss-release-POOL';
         }
         set_var('SCC_ADDONS', join(',', grep { $_ ne 'ltss' } @$scc_addons));
+    }
+}
+
+# Remove unexsited modules after upgrade
+sub remove_unexsited {
+    if (check_var('SLE_PRODUCT', 'hpc') && check_var('HDDVERSION', '15')) {
+        my $scc_addons = get_var_array('SCC_ADDONS');
+        record_info 'remove unexsited modules', 'Remove unexsited moduels after upgrade';
+        if (get_var('SCC_ADDONS', '') =~ /lgm/) {
+            remove_suseconnect_product(get_addon_fullname('lgm'));
+            set_var('SCC_ADDONS', join(',', grep { $_ ne 'lgm' } @$scc_addons));
+        }
+        if (get_var('SCC_ADDONS', '') =~ /live/) {
+            remove_suseconnect_product(get_addon_fullname('live'));
+            set_var('SCC_ADDONS', join(',', grep { $_ ne 'live' } @$scc_addons));
+        }
     }
 }
 

--- a/tests/migration/sle12_online_migration/minimal_patch.pm
+++ b/tests/migration/sle12_online_migration/minimal_patch.pm
@@ -21,6 +21,7 @@ sub run {
     select_console 'root-console';
     minimal_patch_system(version_variable => 'HDDVERSION');
     remove_ltss;
+    remove_unexsited;
 }
 
 sub test_flags {

--- a/tests/migration/sle12_online_migration/zypper_patch.pm
+++ b/tests/migration/sle12_online_migration/zypper_patch.pm
@@ -27,6 +27,7 @@ sub run {
     add_test_repositories;
     fully_patch_system;
     remove_ltss;
+    remove_unexsited;
     power_action('reboot', keepconsole => 1, textmode => 1);
 
     # Do not attempt to log into the desktop of a system installed with SLES4SAP

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -92,6 +92,9 @@ sub patching_sle {
 
     #migration with LTSS is not possible, remove it before upgrade
     remove_ltss;
+
+    #migration with unexstied modules, remove them before upgrade
+    remove_unexsited;
     if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ || get_var('KEEP_REGISTERED')) {
         # The system is registered.
         set_var('HDD_SCC_REGISTERED', 1);


### PR DESCRIPTION
Remove the modules which non-existed after upgrade
Background: for slehpc15 has legacy and live patching modules, but if it upgrade to slehpc15sp2, it doesn't existed those modules. Need disable them before upgrade 

- Related ticket: https://progress.opensuse.org/issues/63679
- Verification run: 
https://openqa.nue.suse.com/tests/3913671
https://openqa.nue.suse.com/tests/3900869