### PR TITLE
Increase timeout for libqca* install

### DIFF
--- a/tests/console/libqca2.pm
+++ b/tests/console/libqca2.pm
@@ -29,10 +29,10 @@ use registration qw(add_suseconnect_product register_product);
 sub run {
     select_console 'root-console';
     if (is_tumbleweed || is_leap) {
-        zypper_call("in libqca-qt5 libqca-qt5-devel", timeout => 300);
+        zypper_call("in libqca-qt5 libqca-qt5-devel", timeout => 600);
     } else {
         add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1) if is_sle(">=15");
-        zypper_call("in libqca2 libqca2-devel", timeout => 300);
+        zypper_call("in libqca2 libqca2-devel", timeout => 600);
     }
 
     my $qca_cmd;


### PR DESCRIPTION
With 300 timeout it will pass maybe 99/100, but then it will fail
due to network or whatever. It is better to have longer timeout,
to give time to the command to finish, instead failing due to short
timeout. Command will return exit value doesn't really matter here
after how long.

- Fail: https://openqa.suse.de/tests/3929088#step/libqca2/6
- Verification run: https://openqa.suse.de/tests/3930743