### PR TITLE
Correct the zypper option '--no-gpg-checks'

### DIFF
--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -38,7 +38,7 @@ sub run {
         my $qa_test_repo = 'http://dist.nue.suse.com/ibs/QA:/Head/SLE-' . uc($upgrade_release);
         script_run("zypper rm -n -y qa_lib_virtauto", 300);
         zypper_call("rr server-repo qa-test-repo");
-        zypper_call("--no-gpg-check ar -f '$qa_test_repo' qa-test-repo");
+        zypper_call("--no-gpg-checks ar -f '$qa_test_repo' qa-test-repo");
         zypper_call("--gpg-auto-import-keys ref", 300);
         zypper_call("in qa_lib_virtauto",         300);
     }

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -29,11 +29,11 @@ sub install_package {
     }
     if (check_var('ARCH', 's390x')) {
         lpar_cmd("zypper --non-interactive rr server-repo");
-        lpar_cmd("zypper --non-interactive --no-gpg-check ar -f '$qa_server_repo' server-repo");
+        lpar_cmd("zypper --non-interactive --no-gpg-checks ar -f '$qa_server_repo' server-repo");
     }
     else {
         script_run "zypper --non-interactive rr server-repo";
-        zypper_call("--no-gpg-check ar -f '$qa_server_repo' server-repo");
+        zypper_call("--no-gpg-checks ar -f '$qa_server_repo' server-repo");
     }
 
     #workaround for dependency on xmlstarlet for qa_lib_virtauto on sles11sp4 and sles12sp1
@@ -56,13 +56,13 @@ sub install_package {
 
     if ($dependency_repo) {
         if (check_var('ARCH', 's390x')) {
-            lpar_cmd("zypper --non-interactive --no-gpg-check ar -f ${dependency_repo} dependency_repo");
+            lpar_cmd("zypper --non-interactive --no-gpg-checks ar -f ${dependency_repo} dependency_repo");
             lpar_cmd("zypper --non-interactive --gpg-auto-import-keys ref");
             lpar_cmd("zypper --non-interactive in $dependency_rpms");
             lpar_cmd("zypper --non-interactive rr dependency_repo");
         }
         else {
-            zypper_call("--no-gpg-check ar -f ${dependency_repo} dependency_repo");
+            zypper_call("--no-gpg-checks ar -f ${dependency_repo} dependency_repo");
             zypper_call("--gpg-auto-import-keys ref", 180);
             zypper_call("in $dependency_rpms");
             zypper_call("rr dependency_repo");


### PR DESCRIPTION
the incorrect option made numerous tests fail at developing host including s390, such as 
https://openqa.nue.suse.com/tests/3927799#step/install_package/7

- Verification run: http://openqa.suse.de/tests/3930754#
the verification run has not began as it is waiting for an idle machine in OSD.  This PR involves s390 and host upgrade, please @xguo @waynechen55 do help review.

@alice-suse @xguo @waynechen55

