### PR TITLE
Fix zypper --no-gpg-checks calls

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -67,7 +67,7 @@ sub prepare_for_kdump_sle {
             next unless $i;
             $i =~ s,/$,_debug/,;
             $counter++;
-            zypper_call("--no-gpg-check ar -f $i 'DEBUG_$counter'");
+            zypper_call("--no-gpg-checks ar -f $i 'DEBUG_$counter'");
         }
     }
     script_run(q(zypper mr -e $(zypper lr | awk '/Debug/ {print $1}')), 60);

--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -88,7 +88,7 @@ sub add_test_repositories {
     @repos = split(',', $oldrepo) if ($oldrepo);
 
     for my $var (@repos) {
-        zypper_call("--no-gpg-check ar -f -n 'TEST_$counter' $var 'TEST_$counter'");
+        zypper_call("--no-gpg-checks ar -f -n 'TEST_$counter' $var 'TEST_$counter'");
         $counter++;
     }
     # refresh repositories, inf 106 is accepted because repositories with test
@@ -109,7 +109,7 @@ sub ssh_add_test_repositories {
     @repos = split(',', $oldrepo) if ($oldrepo);
 
     for my $var (@repos) {
-        assert_script_run("ssh root\@$host 'zypper -n --no-gpg-check ar -f -n TEST_$counter $var TEST_$counter'");
+        assert_script_run("ssh root\@$host 'zypper -n --no-gpg-checks ar -f -n TEST_$counter $var TEST_$counter'");
         $counter++;
     }
     # refresh repositories, inf 106 is accepted because repositories with test

--- a/tests/btrfs-progs/install.pm
+++ b/tests/btrfs-progs/install.pm
@@ -46,7 +46,7 @@ sub run {
     if (get_var('BTRFS_PROGS_REPO')) {
         # Add filesystems repository and install btrfs-progs package
         zypper_call 'rm btrfsprogs';
-        zypper_call '--no-gpg-check ar -f ' . get_var('BTRFS_PROGS_REPO') . ' filesystems';
+        zypper_call '--no-gpg-checks ar -f ' . get_var('BTRFS_PROGS_REPO') . ' filesystems';
         zypper_call '--gpg-auto-import-keys ref';
         zypper_call 'in -r filesystems btrfs-progs';
         zypper_call 'rr filesystems';

--- a/tests/console/avocado_prepare.pm
+++ b/tests/console/avocado_prepare.pm
@@ -32,7 +32,7 @@ sub run {
     my $counter = 1;
     my @repos   = split(/,/, get_var('AVOCADO_REPO'));
     for my $var (@repos) {
-        zypper_call("--no-gpg-check ar -f $var 'AVOCADO_$counter'");
+        zypper_call("--no-gpg-checks ar -f $var 'AVOCADO_$counter'");
         $counter++;
     }
     zypper_call '--gpg-auto-import-keys ref';

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -74,9 +74,9 @@ sub prepare_repos {
     if ($qa_server_repo) {
         # Remove all existing repos and add QA_SERVER_REPO
         script_run('for ((i = $(zypper lr| tail -n+5 |wc -l); i >= 1; i-- )); do zypper -n rr $i; done; unset i', 300);
-        zypper_call("--no-gpg-check ar -f '$qa_server_repo' server-repo");
+        zypper_call("--no-gpg-checks ar -f '$qa_server_repo' server-repo");
         if ($qa_sdk_repo) {
-            zypper_call("--no-gpg-check ar -f '$qa_sdk_repo' sle-sdk");
+            zypper_call("--no-gpg-checks ar -f '$qa_sdk_repo' sle-sdk");
         }
     }
 

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -57,7 +57,7 @@ sub run {
 
     if (get_var('XFSTESTS_REPO')) {
         # Add filesystems repository and install xfstests package
-        zypper_call '--no-gpg-check ar -f ' . get_var('XFSTESTS_REPO') . ' filesystems';
+        zypper_call '--no-gpg-checks ar -f ' . get_var('XFSTESTS_REPO') . ' filesystems';
         zypper_call '--gpg-auto-import-keys ref';
         zypper_call 'in xfstests';
         zypper_call 'rr filesystems';


### PR DESCRIPTION
With zypper 1.14.34, parameter abbreviations are no longer supported
as they could lead to ambiguities between specific command parameters
vs global parameters.

According to the zypper man page, the correct parameter for no gpg checks is
--no-gpg-checks. So far this worked as zypper 'guessed' that the user
wanted to use the 'close match'.
