### PR TITLE
Fix apparmor_profile failed on maritadb setup

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -460,6 +460,14 @@ sub mariadb_setup {
             {
                 prompt => qr/Enter current password for root/m,
                 string => "\n",
+            },
+            {
+                prompt => qr/Switch to unix_socket authentication \[Y\/n\]/m,
+                string => "n\n",
+            },
+            {
+                prompt => qr/Change the root password\? \[Y\/n\]/m,
+                string => "Y\n",
             },
             {
                 prompt => qr/Set root password\? \[Y\/n\]/m,


### PR DESCRIPTION
Test case "apache2_changehat" failed on 
mariadb_setup.
Revised the code according to the changes of 
interactive process of the command.

- Related ticket: https://progress.opensuse.org/issues/63880
- Needles: NA
- Verification run: http://openqa.nue.suse.com/tests/3931006
