### PR TITLE
Add support for multiple HDD in generalhw flash script

### DIFF
--- a/data/generalhw_scripts/flash_usb_otg.sh
+++ b/data/generalhw_scripts/flash_usb_otg.sh
@@ -6,58 +6,72 @@ set -ex
 # ssh-copy-id -i ~/.ssh/id_rsa.pub root@192.168.0.35
 # ssh-copy-id -i ~/.ssh/id_rsa.pub geekotest@192.168.0.35
 
-# Get parameters
-# Destination: <IP_or_hostname>:/storage/
-destination=$1
-# Image: *.raw.xz or *.iso file
-image_to_flash=$2
-# Size to resize
-size=$3
+echo "Flash script start...";
+
 # user
 username=root # $(whoami)
 
-
-if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]
-  then
-    echo "Please provide <destination>, <image to flash> and <hdd size> as arguments."
+# Check number of args
+if [ "$(($# % 2))" -ne 1 ] || [ "$#" -lt 3 ]; then
+    echo "Please provide <destination>, <image1 to flash> and <hdd1 size> as arguments. Optionnaly, <image2 to flash> and <hdd2 size>, etc."
     exit 1;
 fi
 
+# Get destination: <IP_or_hostname>:/storage/
+destination=$1
 # Extract IP/hostanme from $destination
 IFS=: read -r flasher_ip destination_folder <<< "$destination"
-image_to_flash_full_path="$destination_folder/$(basename $image_to_flash)"
-
-image_to_flash_extension="${image_to_flash##*.}"
-uncompressed_filename=$(basename $image_to_flash_full_path .xz)
-
-umount_previous_image="modprobe -r g_mass_storage || true"
-mount_current_image="modprobe g_mass_storage file=$destination_folder/$uncompressed_filename removable=1 || true"
-
-
-echo "Flash script start...";
+# Number of disks
+numberofdisks=$(( ($# - 1) / 2 ));
 
 # Disconnect previous image, if any
+umount_previous_image="modprobe -r g_mass_storage || true"
 ssh root@$flasher_ip $umount_previous_image
-echo "** USB disk disconnected"
+echo "** Previous USB disk(s) disconnected"
 
 # Cleanup target folder
 ssh $username@$flasher_ip rm -f $destination_folder/*.{raw,xz,iso}
+echo "** Previous image(s) deleted"
 
-# Copy current image
-scp $image_to_flash $username@$destination
-# Extract compressed image, if needed
-if [[ "$image_to_flash_extension" == "xz" ]]; then
-	ssh $username@$flasher_ip unxz --threads=0 $image_to_flash_full_path
-	echo "**** xz image uncompressed"
-	# Resize *.raw image
-	ssh $username@$flasher_ip qemu-img resize $destination_folder/$uncompressed_filename $size
-	echo "**** raw image resized to $size"
-fi
-echo "** USB disk flashed"
+# Handle each HDD/SIZE passed in argument
+for i in $(seq 1 $numberofdisks); do
+	argnumber=$(($i * 2));
+	# Image: *.raw.xz or *.iso file
+	image_to_flash=${!argnumber};
+	# Size to resize
+	argnumber=$(($argnumber + 1));
+	hdd_size=${!argnumber};
 
+	image_to_flash_full_path="$destination_folder/$(basename $image_to_flash)"
 
-# Mount current image
-ssh root@$flasher_ip $mount_current_image
-echo "** USB disk connected"
+	image_to_flash_extension="${image_to_flash##*.}"
+	uncompressed_filename=$(basename $image_to_flash_full_path .xz)
+
+	# Copy current image
+	scp $image_to_flash $username@$destination
+	# Extract compressed image, if needed
+	if [[ "$image_to_flash_extension" == "xz" ]]; then
+		ssh $username@$flasher_ip unxz --threads=0 $image_to_flash_full_path
+		echo "**** xz image uncompressed"
+		# Resize *.raw image
+		ssh $username@$flasher_ip qemu-img resize $destination_folder/$uncompressed_filename $hdd_size
+		echo "**** raw image resized to $hdd_size"
+	fi
+	#  Build args list for modprobe g_mass_storage
+	if [ "$i" -eq 1 ]; then
+		images_list_full_path=$destination_folder/$uncompressed_filename;
+		images_removable_list="1";
+	else
+		images_list_full_path="$images_list_full_path,$destination_folder/$uncompressed_filename";
+		images_removable_list="$images_removable_list,1";
+	fi;
+	echo "** USB disk $i/$numberofdisks flashed"
+
+done
+
+# Mount current image(s)
+mount_current_images="modprobe g_mass_storage file=$images_list_full_path removable=$images_removable_list"
+ssh root@$flasher_ip $mount_current_images
+echo "** USB disk(s) connected"
 
 echo "Flash script done!";


### PR DESCRIPTION
Now that all code updates required to support multiple HDD in generalhw are in place, here is the update for the flash script.
Tested locally with:
  * 1 single HDD with an `ISO` image
  * 1 single HDD with a `raw.xz` image
  * 2 HDD: `ISO` image + `raw.xz` image
