### PR TITLE
Adapt yast nis mm tests for openSUSE

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -7,6 +7,7 @@ use base 'Exporter';
 use Exporter;
 
 use testapi;
+use version_utils 'is_opensuse';
 
 our @EXPORT = qw(configure_hostname get_host_resolv_conf
   configure_static_ip configure_dhcp configure_default_gateway configure_static_dns
@@ -172,6 +173,10 @@ sub check_ip_in_subnet {
 
 sub setup_static_mm_network {
     my $ip = shift;
+    if (is_opensuse && !check_var('DESKTOP', 'textmode')) {
+        assert_script_run "systemctl disable NetworkManager --now";
+        assert_script_run "systemctl enable wicked --now";
+    }
     configure_default_gateway;
     configure_static_ip($ip);
     configure_static_dns(get_host_resolv_conf());

--- a/schedule/yast/nis/nis_client.yaml
+++ b/schedule/yast/nis/nis_client.yaml
@@ -1,0 +1,7 @@
+---
+name:          nis_client
+description:    >
+  Multimachine nis test, client side. Configures a nis client and enables a nfs export with autofs.
+schedule:
+  - boot/boot_to_desktop
+  - x11/nis_client

--- a/schedule/yast/nis/nis_server_sle.yaml
+++ b/schedule/yast/nis/nis_server_sle.yaml
@@ -1,0 +1,9 @@
+---
+name:          nis_server
+description:    >
+  Multimachine nis test, server side. Configures a nis server and creates a nfs export.
+schedule:
+  - boot/boot_to_desktop
+  - x11/nis_server
+test_data:
+  maps: 11

--- a/schedule/yast/nis/nis_server_tw.yaml
+++ b/schedule/yast/nis/nis_server_tw.yaml
@@ -1,0 +1,9 @@
+---
+name:          nis_server
+description:    >
+  Multimachine nis test, server side. Configures a nis server and creates a nfs export.
+schedule:
+  - boot/boot_to_desktop
+  - x11/nis_server
+test_data:
+  maps: 8


### PR DESCRIPTION
Adapted some small pieces to work withTW, added a workaround for the reported bug  ["yast2 nis and nfs clients do not find server on the same lan"](https://bugzilla.suse.com/show_bug.cgi?id=1167589), and removed outdated workarounds that were for closed bugs, or for SLE<15-sp2, as it seems like we (qa-sle-y) are the only ones now to use this test suite.

- Related ticket: https://progress.opensuse.org/issues/9900
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/653
- Verification run: 
SLE: [client](http://waaa-amazing.suse.cz/tests/11900) [server](http://waaa-amazing.suse.cz/tests/11899)
TW: [client](http://waaa-amazing.suse.cz/tests/11914) [server](http://waaa-amazing.suse.cz/tests/11913)

more test runs after small changes :
TW/nis http://waaa-amazing.suse.cz/tests/11949
TW/nfs http://waaa-amazing.suse.cz/tests/11939
SLE on prod https://openqa.suse.de/tests/4087257
