### PR TITLE
Add autoyast xml and yaml scheduler for bcache test job

### DIFF
--- a/data/autoyast_sle15/autoyast_bcache.xml
+++ b/data/autoyast_sle15/autoyast_bcache.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
+  <bootloader>
+      <global>
+          <timeout config:type="integer">-1</timeout>
+      </global>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition>
+          <mount>/swap</mount>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <size>auto</size>
+        </partition>
+	<partition>
+	  <create config:type="boolean">true</create>
+	  <format config:type="boolean">true</format>
+	  <filesystem config:type="symbol">ext3</filesystem>
+	  <mount>/boot</mount>
+	  <size>5%</size>
+	</partition>
+        <partition>
+          <bcache_backing_for>/dev/bcache0</bcache_backing_for>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">false</format>
+          <size>max</size>
+        </partition>
+      </partitions>
+    </drive>
+    <drive>
+      <type config:type="symbol">CT_DISK</type>
+      <device>/dev/vdb</device>
+      <use>all</use>
+      <disklabel>none</disklabel>
+      <partitions config:type="list">
+        <partition>
+          <bcache_caching_for config:type="list">
+            <listentry>/dev/bcache0</listentry>
+          </bcache_caching_for>
+          <create config:type="boolean">false</create>
+          <format config:type="boolean">false</format>
+          <resize config:type="boolean">false</resize>
+        </partition>
+      </partitions>
+    </drive>
+    <drive>
+      <type config:type="symbol">CT_BCACHE</type>
+      <device>/dev/bcache0</device>
+      <bcache_options>
+        <cache_mode>writethrough</cache_mode>
+      </bcache_options>
+      <use>all</use>
+      <partitions config:type="list">
+	<partition>
+          <mount>/</mount>
+	  <filesystem config:type="symbol">btrfs</filesystem>
+          <size>max</size>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
+  <software>
+    <packages config:type="list">
+      <package>glibc</package>
+      <package>grub2</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>enhanced_base</pattern>
+      <pattern>yast2_basis</pattern>
+    </patterns>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+  </software>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <networking>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+  </networking>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/schedule/yast/autoyast_bcache.yaml
+++ b/schedule/yast/autoyast_bcache.yaml
@@ -1,0 +1,76 @@
+---
+name: autoyast_bcache
+description: |
+  Test installation with AY profile for bcache.
+  One contains bios boot partition, /boot and not formatted native linux partition.
+  Bcache uses not formatted native linux partition as backing device and second disk as a whole as caching device.
+vars:
+  NUMDISKS: 2
+  AUTOYAST_PREPARE_PROFILE: 1
+  AUTOYAST: autoyast_sle15/autoyast_bcache.xml
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/clone
+  - autoyast/repos
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_file_system
+  - console/verify_bcache_partitioning
+  - autoyast/verify_cloned_profile
+test_data:
+  backingdev: vda4
+  device: vdb
+  table_type: bcache
+  file_system:
+    /: btrfs
+    /boot: ext3
+  profile:
+    partitioning:
+      - drive:
+          unique_key: device
+          device: /dev/vda
+          type: CT_DISK
+          partitions:
+            - partition:
+                unique_key: mount
+                mount: /boot
+                filesystem: ext3
+            - partition:
+                unique_key: mount
+                mount: swap
+                filesystem: swap
+            - partition:
+                unique_key: bcache_backing_for
+                bcache_backing_for: /dev/bcache0
+            - partition:
+                # BIOS Boot Partition
+                unique_key: partition_nr
+                partition_nr: 1
+      - drive:
+          unique_key: device
+          device: /dev/vdb
+          disklabel: none
+          type: CT_DISK
+          partitions:
+            partition:
+              bcache_caching_for:
+                unique_key: listentry
+                listentry: /dev/bcache0
+      - drive:
+          unique_key: device
+          device: /dev/bcache0
+          bcache_options:
+            unique_key: cache_mode
+            cache_mode: writethrough
+          type: CT_BCACHE
+          partitions:
+            - partition:
+                unique_key: mount
+                mount: /

--- a/tests/console/validate_file_system.pm
+++ b/tests/console/validate_file_system.pm
@@ -28,6 +28,8 @@ sub run {
 
     select_console 'root-console';
 
+    my $partitioning = script_output "lsblk -l";
+    record_info "lsblk", "$partitioning";
     validate_partition_table({device => "/dev/$test_data->{device}", table_type => $test_data->{table_type}});
 
     if (defined $partitions) {

--- a/tests/console/verify_bcache_partitioning.pm
+++ b/tests/console/verify_bcache_partitioning.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate bcache in writethrough
+# Usually the caching device is a fast device (ssd). In this scenario a rotational device is used.
+# The whole second disk is used as a caching device with /home mounted as a backing partition.
+# This doesnt give any significant performance advantages but it is better to test bcache with this setup
+# than use bcache without caching(which yast provides a option if we want to do so)
+# Scenarios covered:
+# - Verify that certain values are set correctly in a bcache setup after installation.
+# - Write operation in a backing device can be performed and validate that cache is working watching the cache hits.
+# Maintainer: yiannis bonatakis <ybonatakis@suse.com>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert 'assert_true';
+
+sub run {
+    my $test_data  = get_test_suite_data();
+    my $cachingdev = $test_data->{profile}->{partitioning}->[1]->{drive}->{device};
+    select_console 'root-console';
+
+    # assert the registered backing dev
+    assert_script_run "cat /sys/block/bcache0/bcache/backing_dev_name | grep $test_data->{backingdev}";
+    # assert bcache is running
+    assert_script_run "cat /sys/block/bcache0/bcache/running | grep 1";
+    # assert bcache is setup and is not cached dirty data
+    assert_script_run "cat /sys/block/bcache0/bcache/state | grep clean";
+
+    record_info("bcache info", "Show info of bcache $cachingdev");
+    assert_script_run "bcache-super-show $cachingdev";
+    assert_script_run "cat /proc/partitions";
+
+    record_info("write operation");
+    my $hit_i = script_output "cat /sys/block/bcache0/bcache/stats_total/cache_hits";
+    record_info "cache_hits before", "$hit_i";
+    my $path_in_backingdev = "/home/bernhard/one/two/three";
+    assert_script_run "mkdir -p $path_in_backingdev";
+    assert_script_run "touch ${path_in_backingdev}/data";
+    assert_script_run "dd bs=1024 count=1000000 < /dev/random > ${path_in_backingdev}/data";
+
+    my $hits_f = script_output "cat /sys/block/bcache0/bcache/stats_total/cache_hits";
+    assert_true($hit_i < $hits_f, "$hits_f should be bigger than $hit_i");
+}
+
+1;


### PR DESCRIPTION
Create a new yaml scheduler and the xml for the autoyast.
The yaml scheduler adds verification for the partitioning
and of the AY profile.


- Related ticket: https://progress.opensuse.org/issues/49823
- Verification run: 
http://aquarius.suse.cz/tests/1956