### PR TITLE
Increase assert_screen timeout for encrypted_volume_activation

### DIFF
--- a/tests/installation/encrypted_volume_activation.pm
+++ b/tests/installation/encrypted_volume_activation.pm
@@ -34,7 +34,7 @@ sub run {
     assert_screen 'encrypted_volume_activation_prompt';
     if (get_var('ENCRYPT_CANCEL_EXISTING')) {
         wait_screen_change { send_key 'alt-c'; };
-        assert_screen($after_cancel_tags);
+        assert_screen($after_cancel_tags, 60);
     }
     elsif (get_var('ENCRYPT_ACTIVATE_EXISTING')) {
         # pre storage NG has an additional question dialog


### PR DESCRIPTION
After failure of test suite "cryptlvm+cancel_existing@aarch64 " at module "encrypted_volume_activation" 
https://openqa.suse.de/tests/3927008#step/encrypted_volume_activation/5
increasing assert_screen timeout fixes the issue. 

Validation run:
https://openqa.suse.de/t3932970
