### PR TITLE
Add conflicting packages for high availability in QAM

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -38,20 +38,24 @@ sub install_packages {
         if (my ($package) = $line =~ $pattern and $1 !~ /-devel$|-patch-/) {
             # uninstall conflicting packages to allow problemless install
             my %conflict = (
-                'reiserfs-kmp-default' => 'kernel-default-base',
-                'kernel-default'       => 'kernel-default-base',
-                'kernel-default-extra' => 'kernel-default-base',
-                'kernel-default-base'  => 'kernel-default',
-                'kernel-azure'         => 'kernel-azure-base',
-                'kernel-azure-base'    => 'kernel-azure',
-                'kernel-rt'            => 'kernel-rt-base',
-                'kernel-rt-base'       => 'kernel-rt',
-                'kernel-xen'           => 'kernel-xen-base',
-                'kernel-xen-base'      => 'kernel-xen',
-                'xen-tools'            => 'xen-tools-domU',
-                'xen-tools-domU'       => 'xen-tools',
-                'p11-kit-nss-trust'    => 'mozilla-nss-certs',
-                'rmt-server-config'    => 'rmt-server-pubcloud'
+                'reiserfs-kmp-default'   => 'kernel-default-base',
+                'kernel-default'         => 'kernel-default-base',
+                'kernel-default-extra'   => 'kernel-default-base',
+                'kernel-default-base'    => 'kernel-default',
+                'kernel-azure'           => 'kernel-azure-base',
+                'kernel-azure-base'      => 'kernel-azure',
+                'kernel-rt'              => 'kernel-rt-base',
+                'kernel-rt-base'         => 'kernel-rt',
+                'kernel-xen'             => 'kernel-xen-base',
+                'kernel-xen-base'        => 'kernel-xen',
+                'xen-tools'              => 'xen-tools-domU',
+                'xen-tools-domU'         => 'xen-tools',
+                'p11-kit-nss-trust'      => 'mozilla-nss-certs',
+                'rmt-server-config'      => 'rmt-server-pubcloud',
+                'cluster-md-kmp-default' => 'kernel-default-base',
+                'dlm-kmp-default'        => 'kernel-default-base',
+                'gfs2-kmp-default'       => 'kernel-default-base',
+                'ocfs2-kmp-default'      => 'kernel-default-base'
             );
             zypper_call("rm $conflict{$package}", exitcode => [0, 104]) if $conflict{$package};
             # go to next package if it's not provided by repos


### PR DESCRIPTION
This PR adds conflicting packages related to HA (High Availability).

Until now we are not able to test kernel installation automatically in openQA, as you can see [here](https://openqa.suse.de/tests/3930832#step/update_install/71), it failed because our kmp require `kernel-default` and it can't be installed because `kernel-default-base`.
It's not possible to have both installed in the same time.

With this PR, we make sure that `kernel-default-base` is removed to satisfy kmp dependency with `kernel-default`. 

- Related ticket: N/A
- Needles: N/A
- Verification run: 
QAM HA: [sle-15-SP1-Server-DVD-HA-Incidents-Install-x86_64-Build:14138:dtb-aarch64-qam-incidentinstall-ha](http://1a102.qa.suse.de/tests/3343)
QAM SLE: [sle-15-SP1-Server-DVD-Incidents-Install-x86_64-Build:14138:dtb-aarch64-qam-incidentinstall](http://1a102.qa.suse.de/tests/3344)
