### PR TITLE
Correct the zypper option '--no-gpg-checks'

### DIFF
--- a/tests/btrfs-progs/install.pm
+++ b/tests/btrfs-progs/install.pm
@@ -46,7 +46,7 @@ sub run {
     if (get_var('BTRFS_PROGS_REPO')) {
         # Add filesystems repository and install btrfs-progs package
         zypper_call 'rm btrfsprogs';
-        zypper_call '--no-gpg-check ar -f ' . get_var('BTRFS_PROGS_REPO') . ' filesystems';
+        zypper_call '--no-gpg-checks ar -f ' . get_var('BTRFS_PROGS_REPO') . ' filesystems';
         zypper_call '--gpg-auto-import-keys ref';
         zypper_call 'in -r filesystems btrfs-progs';
         zypper_call 'rr filesystems';

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -57,7 +57,7 @@ sub run {
 
     if (get_var('XFSTESTS_REPO')) {
         # Add filesystems repository and install xfstests package
-        zypper_call '--no-gpg-check ar -f ' . get_var('XFSTESTS_REPO') . ' filesystems';
+        zypper_call '--no-gpg-checks ar -f ' . get_var('XFSTESTS_REPO') . ' filesystems';
         zypper_call '--gpg-auto-import-keys ref';
         zypper_call 'in xfstests';
         zypper_call 'rr filesystems';


### PR DESCRIPTION
Correct the zypper option '--no-gpg-checks'
Reference https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9642 
Since the build 146.1, zypper check option more exactly. It's only works with --no-gpg-checks, and this option forward compatible with previous versions.

- Verification run: 
