### PR TITLE
Increase timeout value for snapper list

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -30,7 +30,7 @@ sub run {
     script_run("cat /etc/os-release", 0);
     # rollback
     script_run("snapper rollback -d rollback-before-migration");
-    assert_script_run("snapper list | tail -n 2 | grep rollback");
+    assert_script_run("snapper list | tail -n 2 | grep rollback", 180);
     power_action('reboot', textmode => 1, keepconsole => 1);
     $self->wait_boot(ready_time => 300, bootloader_time => 300);
     select_console 'root-console';


### PR DESCRIPTION
It seems sometimes 90s is not enough for snapper list on slow environment, so increase the timeout value to 180s. 

- Related ticket: https://progress.opensuse.org/issues/63181
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/3935943#step/snapper_rollback/13
                            http://openqa.nue.suse.com/tests/3935944#step/snapper_rollback/13
