### PR TITLE
Keep documented yast2 lan behavior

### DIFF
--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -92,7 +92,7 @@ sub run {
         check_etc_hosts_update() if get_var('VALIDATE_ETC_HOSTS');
         verify_network_configuration(\&check_network_card_setup_tabs);
         verify_network_configuration(\&check_default_gateway);
-        verify_network_configuration(\&change_hw_device_name, 'dyn0');
+        verify_network_configuration(\&change_hw_device_name, 'dyn0', 'restart');
     }
     type_string "killall xterm\n";
 }


### PR DESCRIPTION
- Related ticket:
https://progress.opensuse.org/issues/60392
https://fate.suse.com/318787
- Verification run:
http://dzedro.suse.cz/tests/14549 15sp2
http://dzedro.suse.cz/tests/14548#step/yast2_lan_restart/119 15sp1
