### PR TITLE
x11: remove soft-failure for GNOME-3.34+ login

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -248,7 +248,11 @@ sub select_user_gnome {
     assert_screen [qw(displaymanager-user-selected displaymanager-user-notselected dm-nousers)];
     if (match_has_tag('displaymanager-user-notselected')) {
         assert_and_click "displaymanager-$myuser";
-        record_soft_failure 'bsc#1086425- user account not selected by default, have to use mouse to login';
+        # for GNOME-3.34+, user acount is not select by default by design,
+        # so do not record_soft_failure for those products, see bsc#1164856
+        if (is_sle('<15-sp2') || is_leap('<15.2')) {
+            record_soft_failure 'bsc#1086425- user account not selected by default, have to use mouse to login';
+        }
     }
     elsif (match_has_tag('displaymanager-user-selected')) {
         send_key 'ret';


### PR DESCRIPTION
From the discussion in https://bugzilla.suse.com/show_bug.cgi?id=1164856, it's not a bug that user account is not selected by default in GDM, so the soft failure message "bsc#1086425- user account not selected by default, have to use mouse to login" doesn't apply for SLE15SP2+.

So remove this soft failure from tests (for products with GNOME-3.34).

- Related ticket: https://progress.opensuse.org/issues/63949
- Needles: None
- Verification run: https://openqa.nue.suse.com/tests/3935949#step/boot_to_desktop/6
