### PR TITLE
boot_ltp: Activate hugepages before test execution

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -161,6 +161,11 @@ EOF
         script_run('ping6 -c 2 $IPV6_RNETWORK:$RHOST_IPV6_HOST');
     }
 
+    # Check and activate hugepages before test execution
+    script_run 'grep -e Huge -e PageTables /proc/meminfo';
+    script_run 'echo 1 > /proc/sys/vm/nr_hugepages';
+    script_run 'grep -e Huge -e PageTables /proc/meminfo';
+
     assert_script_run('cd $LTPROOT/testcases/bin');
 }
 


### PR DESCRIPTION
Fix poo#63943: Test pkey01 randomly fails on hugepages activation.
Let's activate hugepages before test execution. This should be
addressed in LTP upstream by separation of test requirements
in metadata.

- Related ticket: https://progress.opensuse.org/issues/63943
- Needles: none
- Verification run: http://black-bit.suse.cz/tests/3901#step/boot_ltp/30
