### PR TITLE
Use tty2 for GNOME SLE15-SP2 - poo#48110

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1115,7 +1115,7 @@ sub get_x11_console_tty {
     # older versions in HDD
     my $newer_gdm
       = $new_gdm
-      && !is_sle('<=15-SP2')
+      && !is_sle('<15-SP2')
       && !is_leap('<15.2')
       && get_var('HDD_1', '') !~ /opensuse-42/;
     return (check_var('DESKTOP', 'gnome') && (get_var('NOAUTOLOGIN') || $newer_gdm) && $new_gdm) ? 2 : 7;


### PR DESCRIPTION
In Leap 15.2 and SLE15-SP2, we now have gdm 3.34.x so we need to use tty2, not tty7.

- Related ticket: https://progress.opensuse.org/issues/48110
- Verification run on Leap 15.2: 
  * toolkits@64bit: https://openqa.opensuse.org/t1190147
  * gnome@aarch64: https://openqa.opensuse.org/t1190130
