### PR TITLE
Use tty2 for GNOME Leap 15.2 - poo#48110

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1116,7 +1116,7 @@ sub get_x11_console_tty {
     my $newer_gdm
       = $new_gdm
       && !is_sle('<=15-SP2')
-      && !is_leap('<=15.2')
+      && !is_leap('<15.2')
       && get_var('HDD_1', '') !~ /opensuse-42/;
     return (check_var('DESKTOP', 'gnome') && (get_var('NOAUTOLOGIN') || $newer_gdm) && $new_gdm) ? 2 : 7;
 }


### PR DESCRIPTION
This PR is split from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9659 for Leap 15.2 only for a faster merge.

- Related ticket: https://progress.opensuse.org/issues/48110
