### PR TITLE
Wait more time for system boot and active serial for 390 backend

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -27,6 +27,12 @@ use warnings;
 
 sub run {
     my ($self) = @_;
+
+    # We should call reconnect_mgmt_console to handle_grub_zvm/grab serial iucvconn etc for s390 backend
+    if (check_var("BACKEND", "s390x") && check_var("UPGRADE", "1") && is_sle('15+')) {
+        reconnect_mgmt_console;
+    }
+
     select_console 'root-console';
 
     ensure_serialdev_permissions;


### PR DESCRIPTION
During migration, we found issue http://openqa.suse.de/t3935987, in order let test case pass i add wait time and active serial. 

- Related ticket: https://progress.opensuse.org/issues/62954
- Needles: n/a
- Verification run:http://openqa.suse.de/t3935987
