### PR TITLE
HPC: Create and grant privilages for user

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -50,8 +50,9 @@ EOF
     # handle db preparation
     assert_script_run("mysql -uroot -e \"CREATE DATABASE slurm_acct_db;\"");
     assert_script_run("mysql -uroot -e \"CREATE USER \'slurm\'@\'$hostname.openqa.test\' IDENTIFIED BY \'password\';\"");
-    assert_script_run("mysql -uroot -e \"GRANT ALL ON slurm_acct_db.* TO \'slurm\'@\'$hostname.openqa.test\';\"");
+    assert_script_run("mysql -uroot -e \"CREATE USER \'slurm\'@\'master-node00.openqa.test\' IDENTIFIED BY \'password\';\"");
     # Handle permissons for master node
+    assert_script_run("mysql -uroot -e \"GRANT ALL ON slurm_acct_db.* TO \'slurm\'@\'$hostname.openqa.test\';\"");
     assert_script_run("mysql -uroot -e \"GRANT ALL ON slurm_acct_db.* TO \'slurm\'@\'master-node00.openqa.test\';\"");
     assert_script_run("mysql -uroot -e \"FLUSH PRIVILEGES;\"");
 


### PR DESCRIPTION
With the update of MariaDB to 10.4, it seems like additional privilages
should be granted for slurm user@remote host. This is done now, to
help further investigation of bugzilla#1165151

- Verification run: running: http://10.160.65.14/tests/18173

