### PR TITLE
Handle license in openSUSE JeOS images

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -88,14 +88,10 @@ sub run {
     send_key 'ret';
 
     # Accept license
-    if (is_sle) {
-        if (check_screen 'jeos-license', 60) {
+    unless (is_leap('<15.2')) {
+        foreach my $license_needle (qw(jeos-license jeos-doyouaccept)) {
+            assert_screen $license_needle;
             send_key 'ret';
-            assert_screen 'jeos-doyouaccept';
-            send_key 'ret';
-        }
-        else {
-            record_soft_failure 'bsc#1127166 - License moved to another location';
         }
     }
 
@@ -103,15 +99,12 @@ sub run {
     send_key_until_needlematch "jeos-timezone-$lang", $tz_key{$lang}, 10;
     send_key 'ret';
 
-    # Enter password
-    assert_screen 'jeos-root-password';
-    type_password;
-    send_key 'ret';
-
-    # Confirm password
-    assert_screen 'jeos-confirm-root-password';
-    type_password;
-    send_key 'ret';
+    # Enter password & Confirm
+    foreach my $password_needle (qw(jeos-root-password jeos-confirm-root-password)) {
+        assert_screen $password_needle;
+        type_password;
+        send_key 'ret';
+    }
 
     if (is_sle) {
         assert_screen 'jeos-please-register';


### PR DESCRIPTION
- Related ticket: [[JeOS][o3] test fails in firstrun - handle license agreement in openSUSE](https://progress.opensuse.org/issues/64048)
- Needles: [Add openSUSE license needles for JeOS #647](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/647)
- Verification runs: 
   * [Build20200229-jeos@64bit_virtio](http://eris.suse.cz/tests/4770)
   * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build24.35-jeos@64bit_virtio-2G](http://eris.suse.cz/tests/4771#)
   * [opensuse-15.1-JeOS-for-kvm-and-xen-x86_64-Build8.10.26-jeos@64bit_virtio-2G](http://eris.suse.cz/tests/4772)
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build8.2-jeos-base+sdk+desktop@uefi-virtio-vga](http://eris.suse.cz/tests/4773)