### PR TITLE
HPC: Register HPC module as the last one

### DIFF
--- a/lib/hpc/migration.pm
+++ b/lib/hpc/migration.pm
@@ -42,9 +42,15 @@ sub register_products {
     s{^\s+|\s+$}{}g foreach @products_to_register;
 
     record_info('Some registration is ongoing');
+    my $tmp_hpc_module;
     foreach my $i (@products_to_register) {
+        if ($i =~ m/sle-module-hpc/) {
+            $tmp_hpc_module = $i;
+            next;
+        }
         script_run("SUSEConnect -p $i -r $reg_code");
     }
+    script_run("SUSEConnect -p $tmp_hpc_module -r $reg_code");
 
   NOREGISTRATION:
     record_info('All installed products are registered!');


### PR DESCRIPTION
For SLE15 SP2 the HPC module is listed before the Web and Scripting
module however in case the HPC module should be registered, it will
fail as the Web and Scripting module is the prerequisite. This patch
is ensuring the HPC Module is registered as the last one

- Verification run: http://10.160.65.14/tests/18213
http://10.160.65.14/tests/18213#step/before_test/52
http://localhost/tests/18213#step/hpc_migration/39
