### PR TITLE
Add allmodules+allpatterns+registration test

### DIFF
--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration.yaml
@@ -1,10 +1,19 @@
 ---
-name:           skip_registration@svirt-xen-pv
+name:           allmodules+allpatterns+registration
 description:    >
-  Like a standard scenario with explicit skipping of SCC registration
-  in case where we register by default, e.g. for SLE >= 15
-  See https://progress.opensuse.org/issues/25264 for details.
-
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
+        Scripting, Containers, Desktop Applications);
+     2. All patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  SCC_REGISTER: ''
+  ENABLE_ALL_SCC_MODULES: 1
+  PATTERNS:	all
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -15,19 +24,24 @@ schedule:
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
+  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
+  - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/grub_test
   - installation/first_boot
+  - console/suseconnect_scc
   - console/sle15_workarounds
+  - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
-  - shutdown/svirt_upload_assets

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x-zVM.yaml
@@ -1,10 +1,19 @@
 ---
-name:           skip_registration@s390x-zVM
+name:           allmodules+allpatterns+registration@s390x-zVM
 description:    >
-  Like a standard scenario with explicit skipping of SCC registration
-  in case where we register by default, e.g. for SLE >= 15
-  See https://progress.opensuse.org/issues/25264 for details.
-
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
+        Scripting, Containers, Desktop Applications);
+     2. All patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  SCC_REGISTER: ''
+  ENABLE_ALL_SCC_MODULES: 1
+  PATTERNS:	all
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -19,6 +28,7 @@ schedule:
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -27,6 +37,7 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/suseconnect_scc
   - console/check_resume
   - console/sle15_workarounds
   - console/hostname

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x.yaml
@@ -1,10 +1,19 @@
 ---
-name:           skip_registration@s390x
+name:           allmodules+allpatterns+registration@s390x
 description:    >
-  Like a standard scenario with explicit skipping of SCC registration
-  in case where we register by default, e.g. for SLE >= 15
-  See https://progress.opensuse.org/issues/25264 for details.
-
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
+        Scripting, Containers, Desktop Applications);
+     2. All patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  SCC_REGISTER: ''
+  ENABLE_ALL_SCC_MODULES: 1
+  PATTERNS:	all
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -19,6 +28,7 @@ schedule:
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -27,6 +37,7 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/suseconnect_scc
   - console/check_resume
   - console/sle15_workarounds
   - console/hostname

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
@@ -1,10 +1,19 @@
 ---
-name:           skip_registration@svirt-hyperv
+name:           allmodules+allpatterns+registration@svirt-hyperv
 description:    >
-  Like a standard scenario with explicit skipping of SCC registration
-  in case where we register by default, e.g. for SLE >= 15
-  See https://progress.opensuse.org/issues/25264 for details.
-
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
+        Scripting, Containers, Desktop Applications);
+     2. All patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  SCC_REGISTER: ''
+  ENABLE_ALL_SCC_MODULES: 1
+  PATTERNS:	all
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -18,6 +27,7 @@ schedule:
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -25,6 +35,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/suseconnect_scc
   - console/sle15_workarounds
   - console/integration_services
   - console/system_prepare

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-hvm.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-hvm.yaml
@@ -1,24 +1,33 @@
 ---
-name:           skip_registration@uefi
+name:           allmodules+allpatterns+registration@svirt-xen-hvm
 description:    >
-  Like a standard scenario with explicit skipping of SCC registration
-  in case where we register by default, e.g. for SLE >= 15
-  See https://progress.opensuse.org/issues/25264 for details.
-
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
+        Scripting, Containers, Desktop Applications);
+     2. All patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  SCC_REGISTER: ''
+  ENABLE_ALL_SCC_MODULES: 1
+  PATTERNS:	all
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
-  - installation/scc_registration  
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -27,10 +36,11 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/suseconnect_scc
   - console/sle15_workarounds
-  - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+  - shutdown/svirt_upload_assets

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-pv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-pv.yaml
@@ -1,10 +1,19 @@
 ---
-name:           skip_registration
+name:           allmodules+allpatterns+registration@svirt-xen-pv
 description:    >
-  Like a standard scenario with explicit skipping of SCC registration
-  in case where we register by default, e.g. for SLE >= 15
-  See https://progress.opensuse.org/issues/25264 for details.
-
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
+        Scripting, Containers, Desktop Applications);
+     2. All patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  SCC_REGISTER: ''
+  ENABLE_ALL_SCC_MODULES: 1
+  PATTERNS:	all
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -15,22 +24,21 @@ schedule:
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
-  - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
   - installation/first_boot
+  - console/suseconnect_scc
   - console/sle15_workarounds
-  - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+  - shutdown/svirt_upload_assets

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@uefi.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@uefi.yaml
@@ -1,23 +1,34 @@
 ---
-name:           skip_registration@svirt-xen-hvm
+name:           allmodules+allpatterns+registration@uefi
 description:    >
-  Like a standard scenario with explicit skipping of SCC registration
-  in case where we register by default, e.g. for SLE >= 15
-  See https://progress.opensuse.org/issues/25264 for details.
-
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
+        Scripting, Containers, Desktop Applications);
+     2. All patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  SCC_REGISTER: ''
+  ENABLE_ALL_SCC_MODULES: 1
+  PATTERNS:	all
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
-  - installation/scc_registration
+  - installation/scc_registration  
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
+  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -26,10 +37,11 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/suseconnect_scc
   - console/sle15_workarounds
+  - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
-  - shutdown/svirt_upload_assets

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -33,7 +33,7 @@ sub run {
     my $scc_url    = get_required_var('SCC_URL');
     my $scc_addons = get_var('SCC_ADDONS', '');
 
-    get_var('JEOSINSTLANG', '') =~ 'DE' ? select_console('root-console') : $self->select_serial_terminal;
+    select_console('root-console');
     assert_script_run "SUSEConnect --url $scc_url -r $reg_code";
     assert_script_run 'SUSEConnect --list-extensions';
 


### PR DESCRIPTION
The PR changes skip_registration test suite to be allmodules+allpatterns+registration, to test full medium installation with all patterns and modules selected and registration after the system being installed.

**Requires also the PR to be merged:** https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/141
Also, after it all the PRs are merged, allmodules+allpatterns+registration test suite has to be added on osd. skip_registation test suite should be removed for YaST Job Group.

Related ticket: [poo#63217](https://progress.opensuse.org/issues/63217)
Verification Runs: 
https://openqa.suse.de/tests/3984762
https://openqa.suse.de/tests/3984971
https://openqa.suse.de/tests/3984986
https://openqa.suse.de/tests/3984984
https://openqa.suse.de/tests/3997535