### PR TITLE
boot_ltp: Increase boot timeout

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -35,7 +35,7 @@ sub run {
     else {
         record_info('INFO', 'normal boot or boot with params');
         # during install_ltp, the second boot may take longer than usual
-        $self->wait_boot(ready_time => 500);
+        $self->wait_boot(ready_time => 1800);
     }
 
     $self->select_serial_terminal;


### PR DESCRIPTION
Troubleshoot #64030: LTP boot time takes even more than usual, we need to increase timeout for troubleshooting.

- Related ticket: https://progress.opensuse.org/issues/64030
- Needles: none
- Verification run: none
