### PR TITLE
Fix auto-selected modules

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -88,11 +88,11 @@ sub handle_all_packages_medium {
         next if (skip_package_hub_if_necessary($i));
         push @addons_license_tags, "addon-license-$i" if grep(/^$i$/, @addons_with_license);
         send_key 'home';
-        send_key_until_needlematch ["addon-products-all_packages-$i-highlighted", "addon-products-all_packages-$i-selected"], "down", 30;
-        if (match_has_tag("addon-products-all_packages-$i-highlighted")) {
-            send_key 'spc';
-        } else {
+        send_key_until_needlematch ["addon-products-all_packages-$i-selected", "addon-products-all_packages-$i-highlighted"], "down", 30;
+        if (match_has_tag("addon-products-all_packages-$i-selected")) {
             record_info("Module preselected", "Module $i is already selected");
+        } elsif (match_has_tag("addon-products-all_packages-$i-highlighted")) {
+            send_key 'spc';
         }
     }
     send_key $cmd{next};


### PR DESCRIPTION
In some cases where 'highlighted' and 'selected' needles are both at 100% we can have issue because 'highlighted' tags are handled by default.

This commit fixes this by checking for 'selected' tags first. It also adds an explicit check on 'highlighted' tags.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/3945235#step/addon_products_sle/10
- Verification run: https://openqa.suse.de/tests/3945325