### PR TITLE
Add script which generates yaml schedulers

### DIFF
--- a/script/yaml_generator/README.md
+++ b/script/yaml_generator/README.md
@@ -1,0 +1,31 @@
+create a virtualenv and install the requirements.txt
+
+run as
+> python3 create_scheduler.py <jobid> <path_to_save> [<openqa_server>]
+
+This will generate the <path_to_save>/template.yaml
+ex:
+> python3 create_scheduler.py 1 /tmp
+or
+> python3 create_scheduler.py 1 /tmp openqa.opensuse.org
+
+If openqa_server is not given, OSD is used by default.
+All the params are positional.
+
+The template.yaml which is generated it has the
+- name
+- description
+- vars
+- schedule
+
+Vars are taken by the suites variables
+test_data are not included
+
+
+Issues to address
+---
+
+- some environment variables are not translated. for example
+> PUBLISH_HDD_1: SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-unregistered.qcow2
+- todo: path should be setup to point to the schedule dir by default 
+- todo: variables from a file

--- a/script/yaml_generator/create_scheduler.py
+++ b/script/yaml_generator/create_scheduler.py
@@ -1,0 +1,79 @@
+import requests
+import sys, os
+from openqa_client.client import OpenQA_Client
+from pathlib import Path
+import re
+import yaml
+
+
+class MyDumper(yaml.Dumper):
+    def increase_indent(self, flow = False, indentless = False):
+        return super(MyDumper, self).increase_indent(flow, False)
+
+    
+def _get_scheduling(jobid, srv):
+    testpage = 'https://%s/tests/%s/file/autoinst-log.txt' % (srv, jobid)
+    ctx = requests.get(testpage, verify=False)
+    regex = re.compile('scheduling\s\w+\stests\/\w+\/\w+\/?\w*')
+    matches = regex.findall(repr(ctx.content))
+    key = 'tests/'
+    job = []
+    for schedule_line in matches:
+        schedule = schedule_line[schedule_line.find(key)+len(key):]
+        job.append(schedule)
+    return job
+
+
+def _get_conf(jobid, srv):
+    client = OpenQA_Client(server='http://%s' % srv)
+    conf = client.openqa_request('GET', 'jobs/%s' % jobid)
+
+    testname = conf['job']['test']
+    jobvars = {}
+    jobvars['name'] = testname
+    suitevars = client.openqa_request('GET', 'test_suites')
+
+    vars_generator = (settings for settings in suitevars['TestSuites'])
+
+    for v in vars_generator:
+        # there are test jobs that the name is modified in job group and is run with
+        # another name than the name in 'TestSuites' ex installer_extended_textmode
+        # Because ususally the name just appends the name we just check if it startswith
+        if testname.startswith(v['name']):
+            jobvars.update(v)
+    return jobvars
+
+
+def _create_template(scheduling, configs, save_to):
+    # there are jobs come back from /test_suites wihtout description
+    if 'description' in configs.keys():
+        description = configs['description'].replace('\n', '')
+    else:
+        description = ""
+    
+    data = {'name': configs['name'],
+            'description': "|\n%s" % description}
+
+    if configs:
+        data['vars'] = {}
+        data['vars'].update({k['key']:k['value'] for k in configs['settings']})
+    data['schedule'] = scheduling
+    # TODO path configuration
+    out = Path(os.path.abspath(os.path.join(save_to, 'template.yaml')))
+
+    with(open(out, 'w')) as out:
+        yaml.dump(data,
+                  stream=out,
+                  default_flow_style=False,
+                  Dumper=MyDumper,
+                  explicit_start=True,
+                  sort_keys=False)
+
+
+if __name__ == '__main__':
+    jobid = sys.argv[1]
+    save_to = sys.argv[2]
+    openqa_server = sys.argv[3] if len(sys.argv) > 3  else 'openqa.suse.de'
+    schd = _get_scheduling(jobid, openqa_server)
+    conf = _get_conf(jobid, openqa_server)
+    _create_template(schd, conf, save_to)

--- a/script/yaml_generator/requirements.txt
+++ b/script/yaml_generator/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.21.0
+PyYAML>=5.3
+openqa-client


### PR DESCRIPTION
This is a python(v3) script which will generates a yaml scheduler
based on the information gained from the test suite settings and
parsing the corresponding openqa Job.