### PR TITLE
Add test suite for autoyast installation on UEFI mode with non_secure_boot

### DIFF
--- a/data/autoyast_sle15/autoyast_non_secure_boot.xml
+++ b/data/autoyast_sle15/autoyast_non_secure_boot.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+      <do_registration config:type="boolean">true</do_registration>
+      <email/>
+      <reg_code>{{SCC_REGCODE}}</reg_code>
+      <install_updates config:type="boolean">true</install_updates>
+      <reg_server>{{SCC_URL}}</reg_server>
+      <addons config:type="list">
+        <addon>
+          <name>sle-module-basesystem</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+      </addons>
+    </suse_register>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+    </general>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+            <secure_boot>false</secure_boot>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+</profile>

--- a/schedule/yast/autoyast_non_secure_boot.yaml
+++ b/schedule/yast/autoyast_non_secure_boot.yaml
@@ -1,0 +1,85 @@
+name:       autoyast_non_secure_boot
+description:   >
+  Test autoyast installation with non-secure boot option.
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_non_secure_boot.xml
+  AUTOYAST_PREPARE_PROFILE: 1
+  EXTRABOOTPARAMS: startshell=1
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/verify_secure_boot_bios
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/verify_cloned_profile
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/verify_secure_boot
+test_data:
+  secure_boot: disabled
+  profile:
+    bootloader:
+      global:
+        secure_boot: false
+    partitioning:
+      - drive:
+          unique_key: device
+          device: /dev/vda
+          disklabel: gpt
+          type: CT_DISK
+          partitions:
+            - partition:
+                unique_key: partition_nr 
+                mount: /boot/efi 
+                filesystem: vfat
+                partition_nr: 1
+            - partition:
+                unique_key: partition_nr
+                mount: /
+                filesystem: btrfs
+                partition_nr: 2
+                subvolumes_prefix: '@'
+                subvolumes:
+                  - subvolume:
+                      unique_key: path
+                      path: srv
+                      copy_on_write: true
+                  - subvolume:
+                      unique_key: path
+                      path: root
+                      copy_on_write: true
+                  - subvolume:
+                      unique_key: path
+                      path: var
+                      copy_on_write: false
+                  - subvolume:
+                      unique_key: path
+                      path: boot/grub2/x86_64-efi 
+                      copy_on_write: true
+                  - subvolume:
+                      unique_key: path
+                      path: usr/local
+                      copy_on_write: true
+                  - subvolume:
+                      unique_key: path
+                      path: home 
+                      copy_on_write: true
+                  - subvolume:
+                      unique_key: path
+                      path: boot/grub2/i386-pc
+                      copy_on_write: true
+                  - subvolume:
+                      unique_key: path
+                      path: opt
+                      copy_on_write: true
+                  - subvolume:
+                      unique_key: path
+                      path: tmp
+                      copy_on_write: true 

--- a/tests/console/verify_secure_boot.pm
+++ b/tests/console/verify_secure_boot.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that secure boot is set as expected.
+# Maintainer: Sofia Syrianidou <ssyrianidou@suse.com>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+sub run {
+    my $test_data = get_test_suite_data();
+    select_console 'root-console';
+    record_info("Check file", "Check if file /sys/firmware/efi/vars/SecureBoot-*/data exists");
+    assert_script_run("ls /sys/firmware/efi/vars/SecureBoot-*/data");
+    record_info("Check secure boot", "Check if secure boot option is set as expected");
+    my $secure_boot = script_output("od -An -t u1 /sys/firmware/efi/vars/SecureBoot-*/data") ? 'enabled' : 'disabled';
+    assert_equals($test_data->{secure_boot}, $secure_boot, "The secure boot option is not $test_data->{secure_boot}");
+}
+
+1;
+
+

--- a/tests/installation/verify_secure_boot_bios.pm
+++ b/tests/installation/verify_secure_boot_bios.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Checks Secure Boot status, before installation.
+# Maintainer: Sofia Syrianidou <ssyrianidou@suse.com>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+use scheduler 'get_test_suite_data';
+
+
+sub run {
+    my $test_data = get_test_suite_data();
+    assert_screen 'linuxrc-start-shell-before-installation', 60;
+    assert_script_run("bootctl status | grep \"Secure Boot: $test_data->{secure_boot}\"");
+    type_string "exit\n";
+}
+
+1;
+


### PR DESCRIPTION
Installation via autoyast profile on UEFI machine. Secure boot is set to false in the autoyast profile. After the installation it is verified if the secure boot is disabled.

- Related ticket   :  https://progress.opensuse.org/issues/62051
- Verification run :  http://falafel.suse.cz/tests/404

