### PR TITLE
Grep from shells test log is timouting occasionally

### DIFF
--- a/tests/console/shells.pm
+++ b/tests/console/shells.pm
@@ -62,11 +62,11 @@ sub tcsh_extra_tests {
     script_run 'logout', 0;
     wait_still_screen(3);
 
-    validate_script_output 'grep -c /home/tcsh_user:/usr/bin/tcsh /tmp/tcsh', sub { /1/ };
-    validate_script_output 'grep -c ^/usr/bin/tcsh /tmp/tcsh',                sub { /1/ };
-    validate_script_output 'grep -c ^/home/tcsh_user /tmp/tcsh',              sub { /1/ };
-    validate_script_output 'grep -c Sourced! /tmp/tcsh',                      sub { /1/ };
-    validate_script_output 'grep 12 /tmp/tcsh',                               sub { /12/ };
+    validate_script_output 'grep -c /home/tcsh_user:/usr/bin/tcsh /tmp/tcsh', sub { /1/ },  timeout => 60;
+    validate_script_output 'grep -c ^/usr/bin/tcsh /tmp/tcsh',                sub { /1/ },  timeout => 60;
+    validate_script_output 'grep -c ^/home/tcsh_user /tmp/tcsh',              sub { /1/ },  timeout => 60;
+    validate_script_output 'grep -c Sourced! /tmp/tcsh',                      sub { /1/ },  timeout => 60;
+    validate_script_output 'grep 12 /tmp/tcsh',                               sub { /12/ }, timeout => 60;
 
     #cleanup:
     script_run 'rm /tmp/tcsh ~/.tcsh';


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3945270#step/shells/20
- Verification run:
https://openqa.suse.de/tests/3946470 s390x
https://openqa.suse.de/tests/3946483 x86_64