### PR TITLE
remove unneeded symbolic link

### DIFF
--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -58,7 +58,6 @@ sub ibtest_master {
 
     # create symlinks, the package is (for now) broken
     assert_script_run('ln -sf /usr/lib64/libtwopence.so.0.3.8 /usr/lib64/libtwopence.so.0');
-    assert_script_run('ln -sf /usr/lib64/libtwopence.so.0.3.8 /usr/lib64/libtwopence.so');
     # pull in the testsuite
     assert_script_run("git -c http.sslVerify=false clone $hpc_testing --branch $hpc_testing_branch");
 


### PR DESCRIPTION
The second symbolic link is not required so let's delete it