### PR TITLE
Revert "openqa: Fix missing qemu dependencies since change in os-autoinst deps"

### DIFF
--- a/tests/openqa/install/openqa_bootstrap.pm
+++ b/tests/openqa/install/openqa_bootstrap.pm
@@ -24,9 +24,7 @@ sub run {
         record_info('No nested virt', 'No /dev/kvm found');
     }
 
-    # install qemu tools as we want to test using qemu and the bootstrap skips
-    # the "recommends"
-    zypper_call('in openQA-bootstrap qemu-tools');
+    zypper_call('in openQA-bootstrap');
     assert_script_run('/usr/share/openqa/script/openqa-bootstrap', 4000);
 }
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#8878

This should be fixed in the product and not worked around in the test:
https://github.com/os-autoinst/openQA/pull/2809

Ticket: https://progress.opensuse.org/issues/57014