### PR TITLE
[virt_autotest] check guest disk target dev before create external snapshot

### DIFF
--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -52,8 +52,9 @@ sub run_test {
 
     foreach my $guest (keys %xen::guests) {
         record_info "virsh-snapshot", "Creating External Snapshot of guest's disk";
+        my $vm_target_dev     = script_output("virsh domblklist $guest --details | awk '/disk/{ print \$3 }'");
         my $pre_snapshot_cmd  = "virsh snapshot-create-as $guest";
-        my $diskspec_diskonly = "vda,snapshot=external,file=/var/lib/libvirt/images/$guest.disk-only";
+        my $diskspec_diskonly = "$vm_target_dev,snapshot=external,file=/var/lib/libvirt/images/$guest.disk-only";
         $pre_snapshot_cmd = $pre_snapshot_cmd . " --disk-only ";
         $pre_snapshot_cmd = $pre_snapshot_cmd . " --diskspec " . $diskspec_diskonly;
         my $ex_snapshot_name = "external-snapshot-$guest";
@@ -68,7 +69,7 @@ sub run_test {
         my $live_es_memspec   = "snapshot=external,file=/var/lib/libvirt/images/$guest.memspec";
         $pre_esnapshot_cmd = $pre_esnapshot_cmd . " --live ";
         $pre_esnapshot_cmd = $pre_esnapshot_cmd . " --memspec " . $live_es_memspec;
-        my $live_es_diskspec = "vda,snapshot=external,file=/var/lib/libvirt/images/$guest.diskspec";
+        my $live_es_diskspec = "$vm_target_dev,snapshot=external,file=/var/lib/libvirt/images/$guest.diskspec";
         $pre_esnapshot_cmd = $pre_esnapshot_cmd . " --diskspec " . $live_es_diskspec;
         my $live_es_name = "external-snapshot-live-$guest";
         $pre_esnapshot_cmd = $pre_esnapshot_cmd . " --name " . $live_es_name;


### PR DESCRIPTION
Refer to the different SLES OS version, there was the different guest disk target dev value (guest target dev = vda on sles15sp2 kvm host) as default. So, before create external snapshot, check with guest disk target dev firstly. 

- Verification run: 
gi-guest_developing-on-host-developing-kvm
http://10.67.19.82/tests/414
gi-guest_developing-on-host_sles12sp4-kvm
http://10.67.19.82/tests/410
