### PR TITLE
Implement test for Switch to CC_STACKPROTECTOR_STRONG

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2390,6 +2390,12 @@ sub load_security_tests_system_check {
     loadtest "security/nproc_limits";
 }
 
+sub load_security_tests_check_kernel_config {
+    load_security_console_prepare;
+
+    loadtest "security/check_kernel_config/CC_STACKPROTECTOR_STRONG";
+}
+
 sub load_vt_perf_tests {
     loadtest "virt_autotest/login_console";
     if (get_var('VT_PERF_BAREMETAL')) {
@@ -2472,6 +2478,7 @@ sub load_security_tests {
       openscap
       mok_enroll ima_measurement ima_appraisal evm_protection
       system_check
+      check_kernel_config
     );
 
     # Check SECURITY_TEST and call the load functions iteratively.

--- a/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
+++ b/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
@@ -1,0 +1,33 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: switch from CC_STACKPROTECTOR to CC_STACKPROTECTOR_STRONG in the kernel.
+# This provides better protection against stack based buffer overflows.
+# The feature is not included in s390x platform yet.
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#64084, tc#1744070
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    # check the kernel configuration file to make sure the parameter is there
+    validate_script_output "cat /boot/config-`uname -r`|grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
+}
+
+1;


### PR DESCRIPTION
We (security team) would like to see a switch from CC_STACKPROTECTOR to CC_STACKPROTECTOR_STRONG in the kernel. This provides better protection against stack based buffer overflows. We hope that it's an easy switch since we have CC_STACKPROTECTOR for quite a while and CC_STACKPROTECTOR_STRONG only add some additional criteria when to add the code to check the canary.
To be mentioned here, the feature should be applied to all platforms (x86_64/aarch64/ppc64) but not ready in s390x platform yet.

- Related ticket: https://progress.opensuse.org/issues/64084
- Needles: N/A
- Verification run: http://10.67.17.9/tests/34#step/CC_STACKPROTECTOR_STRONG/3
-Snip of my test result:
validate_script_output got:
CONFIG_STACKPROTECTOR=y
CONFIG_STACKPROTECTOR_STRONG=y

Regular expression:
(?^:CONFIG_STACKPROTECTOR_STRONG=y)