### PR TITLE
xfstests: Modify reboot/reset boot setting

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -377,13 +377,13 @@ sub run {
         eval {
             power_action('reboot', keepconsole => is_pvm);
             reconnect_mgmt_console if is_pvm;
-            $self->wait_boot(in_grub => 1, bootloader_time => 60);
+            $self->wait_boot;
         };
         # If SUT didn't reboot for some reason, force reset
         if ($@) {
             power('reset', keepconsole => is_pvm);
             reconnect_mgmt_console if is_pvm;
-            $self->wait_boot(in_grub => 1);
+            $self->wait_boot;
         }
 
         sleep(1);


### PR DESCRIPTION
This PR to solve reboot not correct in xfstests in spvm.
Use the same code in https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/lib/kdump_utils.pm#L224

- Related ticket: https://progress.opensuse.org/issues/64171
- VR http://openqa.suse.de/tests/3952383