### PR TITLE
Workaround missing packages from WE

### DIFF
--- a/tests/x11/eog.pm
+++ b/tests/x11/eog.pm
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils;
 
 
 sub run {

--- a/tests/x11/eog.pm
+++ b/tests/x11/eog.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,6 +23,10 @@ use utils;
 
 
 sub run {
+    if (is_sle('15-SP2+')) {
+        record_soft_failure('bsc#1165520 - eog not installed by default anymore with system role GNOME and WE activated');
+        zypper_call('in eog');
+    }
     assert_gui_app('eog', exec_param => get_var('WALLPAPER'));
 }
 

--- a/tests/x11/evolution.pm
+++ b/tests/x11/evolution.pm
@@ -19,6 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils "is_gnome_next";
+use version_utils;
 
 sub run {
     my @tags = qw(test-evolution-1 evolution-default-client-ask);

--- a/tests/x11/evolution.pm
+++ b/tests/x11/evolution.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,6 +23,12 @@ use version_utils "is_gnome_next";
 sub run {
     my @tags = qw(test-evolution-1 evolution-default-client-ask);
     push(@tags, 'evolution-preview-release') if is_gnome_next;
+
+    if (is_sle('15-SP2+')) {
+        record_soft_failure('bsc#1165520 - evolution not installed by default anymore with system role GNOME and WE activated');
+        zypper_call('in evolution');
+    }
+
     x11_start_program('evolution', target_match => \@tags);
     my $times = scalar(@tags) - 1;
 

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -18,6 +18,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use version_utils;
 
 sub run {
     my ($self) = shift;

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,6 +21,11 @@ use testapi;
 
 sub run {
     my ($self) = shift;
+
+    if (is_sle('15-SP2+')) {
+        record_soft_failure('bsc#1165520 - oocalc not installed by default anymore with system role GNOME and WE activated');
+        zypper_call('in libreoffice-calc');
+    }
 
     $self->libreoffice_start_program('oocalc');
     wait_still_screen;    # extra wait because oo sometimes appears to be idle during start

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -19,6 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'type_string_very_slow';
+use version_utils;
 
 sub run {
     my ($self) = shift;

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,6 +22,11 @@ use utils 'type_string_very_slow';
 
 sub run {
     my ($self) = shift;
+
+    if (is_sle('15-SP2+')) {
+        record_soft_failure('bsc#1165520 - oowriter not installed by default anymore with system role GNOME and WE activated');
+        zypper_call('in libreoffice-writer');
+    }
 
     $self->libreoffice_start_program('oowriter');
     # clicking the writing area to make sure the cursor addressed there

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -22,6 +22,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'type_string_slow';
+use version_utils;
 
 sub run {
     my ($self) = shift;

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -25,6 +25,11 @@ use utils 'type_string_slow';
 
 sub run {
     my ($self) = shift;
+
+    if (is_sle('15-SP2+')) {
+        record_soft_failure('bsc#1165520 - oomath not installed by default anymore with system role GNOME and WE activated');
+        zypper_call('in libreoffice-math');
+    }
 
     $self->libreoffice_start_program('oomath');
     # be more resilient during the automatic evaluation of formulas to prevent


### PR DESCRIPTION
Previously eog, libreoffice suite and evolution were installed when
selecting GNOME role and WE was enabled. This is not the case now. It
could be a bug: bsc#1165520

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1165520
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2255
