### PR TITLE
xfstests: Add sub tests group exclude/input feature

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -40,9 +40,15 @@ my $HB_EXIT_FILE = '/opt/test.exit';
 my $HB_SCRIPT    = '/opt/heartbeat.sh';
 
 # xfstests variables
+# - XFSTESTS_RANGES: Set sub tests ranges. e.g. XFSTESTS_RANGES=xfs/100-199 or XFSTESTS_RANGES=generic/010,generic/019,generic/038
+# - XFSTESTS_BLACKLIST: Set sub tests not run in XFSTESTS_RANGES. e.g. XFSTESTS_BLACKLIST=generic/010,generic/019,generic/038
+# - XFSTESTS_GROUPLIST: Include/Exclude tests in group(a classification by upstream). e.g. XFSTESTS_GROUPLIST='auto,!dangerous_online_repair'
+# - XFSTESTS_SUBTEST_MAXTIME: Debug use. To set the max time to wait for sub test to finish. Meet this time frame will trigger reboot, and continue next tests.
+# - XFSTESTS: TEST_DEV type, and test in this folder and generic/ folder will be triggered. XFSTESTS=(xfs|btrfs|ext4)
 my $TEST_RANGES  = get_required_var('XFSTESTS_RANGES');
 my $TEST_WRAPPER = '/usr/share/qa/qa_test_xfstests/wrapper.sh';
 my %BLACKLIST    = map { $_ => 1 } split(/,/, get_var('XFSTESTS_BLACKLIST'));
+my @GROUPLIST    = split(/,/, get_var('XFSTESTS_GROUPLIST'));
 my $STATUS_LOG   = '/opt/status.log';
 my $INST_DIR     = '/opt/xfstests';
 my $LOG_DIR      = '/opt/log';
@@ -170,6 +176,45 @@ sub tests_from_category {
     return @tests;
 }
 
+# Return matched exclude tests from groups in @GROUPLIST
+# return structure - hash
+# Group name start with ! will exclude in test, and expected to use to update blacklist
+sub exclude_grouplist {
+    my %tests_list = ();
+    foreach my $group_name (@GROUPLIST) {
+        next if ($group_name !~ /^\!/);
+        $group_name = substr($group_name, 1);
+        my $cmd = "awk '/$group_name/ {printf \"$FSTYPE/\"}{printf \$1}{printf \",\"}' $INST_DIR/tests/$FSTYPE/group > tmp.group";
+        script_run($cmd);
+        $cmd = "awk '/$group_name/ {printf \"generic/\"}{printf \$1}{printf \",\"}' $INST_DIR/tests/generic/group >> tmp.group";
+        script_run($cmd);
+        $cmd = "cat tmp.group";
+        my %tmp_list = map { $_ => 1 } split(/,/, substr(script_output($cmd), 0, -1));
+        %tests_list = (%tests_list, %tmp_list);
+    }
+    return %tests_list;
+}
+
+# Return matched include tests from groups in @GROUPLIST
+# return structure - array
+# Group name start without ! will include in test, and expected to use to update test ranges
+sub include_grouplist {
+    my @tests_list;
+    foreach my $group_name (@GROUPLIST) {
+        next if ($group_name =~ /^\!/);
+        my $cmd = "awk '/$group_name/ {printf \"$FSTYPE/\"}{printf \$1}{printf \",\"}' $INST_DIR/tests/$FSTYPE/group > tmp.group";
+        script_run($cmd);
+        $cmd = "awk '/$group_name/ {printf \"generic/\"}{printf \$1}{printf \",\"}' $INST_DIR/tests/generic/group >> tmp.group";
+        script_run($cmd);
+        $cmd = "cat tmp.group";
+        my $tests = substr(script_output($cmd), 0, -1);
+        foreach my $single_test (split(/,/, $tests)) {
+            push(@tests_list, $single_test);
+        }
+    }
+    return @tests_list;
+}
+
 # Return a list of tests to run from given test ranges
 # ranges - test ranges(e.g. xfs/001-100,btrfs/100-159)
 # dir    - xfstests installation dir(e.g. /opt/xfstests)
@@ -178,7 +223,6 @@ sub tests_from_ranges {
     if ($ranges !~ /\w+(\/\d+-\d+)?(,\w+(\/\d+-\d+)?)*/) {
         die "Invalid test ranges: $ranges";
     }
-
     my %cache;
     my @tests;
     foreach my $range (split(/,/, $ranges)) {
@@ -339,9 +383,18 @@ sub run {
 
     # Get test list
     my @tests = tests_from_ranges($TEST_RANGES, $INST_DIR);
+    my %uniq;
+    @tests = (@tests, include_grouplist);
+    @tests = grep { ++$uniq{$_} < 2; } @tests;
+
+    # Shuffle tests list
     unless (get_var('NO_SHUFFLE')) {
         @tests = shuffle(@tests);
     }
+
+    # Maintain BLACKLIST by exclude group list
+    my %tests_needto_exclude = exclude_grouplist;
+    %BLACKLIST = (%BLACKLIST, %tests_needto_exclude);
 
     mkfs_setting;
     test_prepare;


### PR DESCRIPTION
The motivation is XFSTESTS_BLACKLIST and XFSTESTS_RANGES getting too long. And upstream xfstests has test classification in group file.
This PR could combine following parameter:
1. XFSTESTS_BLACKLIST and XFSTESTS_GROUPLIST: Sub tests in XFSTESTS_BLACKLIST and group start with '!' will all excluded.
2. XFSTSETS_RANGES and XFSTESTS_GROUPLIST: Sub tests in XFSTSETS_RANGES and group start without '!' will all included.

Also This PR add some comments to explain exist parameters in tests.

- Related ticket: https://progress.opensuse.org/issues/64183
- Verification run: 
Setting with XFSTESTS_GROUPLIST=quick,!dangerous_online_repair
1:  Test exclude: 
http://10.67.133.102/tests/1164
xfs/286 is in group dangerous_online_repair should be skip, xfs/285, 287, 288 should run.
2:  Test include: 
http://10.67.133.102/tests/1170
xfs/285, 287, 288 should run. xfs/286 skip because it's in group dangerous_online_repair group. All others tests in group quick will run (a lot of other case)
3:  Test no XFSTESTS_GROUPLIST setting tests runs ok
http://10.67.133.102/tests/1169
xfs/285, 286, 287, 288 should run.