### PR TITLE
Fix /dev prefixed on device test data

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -79,7 +79,7 @@ conditional_schedule:
       s390x:
         - console/verify_no_separate_home
 test_data:
-  device: /dev/vda
+  device: vda
   table_type: gpt
   subvolume:
     cow:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -33,6 +33,6 @@ schedule:
   - console/verify_separate_home
   - console/validate_file_system
 test_data:
-  device: /dev/sda
+  device: sda
   table_type: gpt
   !include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -28,7 +28,7 @@ schedule:
   - console/hostname
   - console/validate_file_system
 test_data:
-  device: /dev/vda
+  device: vda
   table_type: gpt
   file_system:
     /home: xfs


### PR DESCRIPTION
Problem found in several test suites, for example, https://openqa.suse.de/tests/3951600
