### PR TITLE
Remove /dev from test data for file system validation

### DIFF
--- a/schedule/yast/btrfs/btrfs_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs_opensuse.yaml
@@ -28,7 +28,7 @@ schedule:
   - console/validate_no_cow_attribute
   - console/verify_no_separate_home
 test_data:
-  device: /dev/vda
+  device: vda
   table_type: gpt
   subvolume:
     cow:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
@@ -37,7 +37,7 @@ conditional_schedule:
       ipmi:
         - boot/reconnect_mgmt_console
 test_data:
-  device: /dev/sda
+  device: sda
   table_type: gpt
   subvolume:
     cow:


### PR DESCRIPTION
Related with #9695
More `/dev` to be removed from test data in file system validation.
I leave open for a while in case I could miss some other place where needs to be removed.
