### PR TITLE
Revert "fix online install expertpartitioner key"

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -153,9 +153,6 @@ sub init_cmd {
     if (check_var('INSTLANG', "fr_FR")) {
         $testapi::cmd{next} = "alt-s";
     }
-    if (check_var('FLAVOR', 'Online')) {
-        $testapi::cmd{expertpartitioner} = "alt-x";
-    }
 
     if (!is_sle('<15') && !is_leap('<15.0')) {
         # SLE15/Leap15 use Chrony instead of ntp


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#9683

The changes introduced in the PR made jobs fail on the latest build:

https://openqa.suse.de/tests/3950681#step/partitioning_lvm_thin_provisioning/1
https://openqa.suse.de/tests/3951085#step/partitioning_full_lvm/1
https://openqa.suse.de/tests/3951071#step/partitioning_warnings/1