### PR TITLE
Fix exit startshell in AutoYaST

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -284,6 +284,7 @@ sub run {
             send_key 'alt-o';
         }
         elsif (match_has_tag('linuxrc-start-shell-after-installation')) {
+            @needles = grep { $_ ne 'linuxrc-start-shell-after-installation' } @needles;
             type_string "exit\n";
         }
     }


### PR DESCRIPTION
In order to avoid to match needle twice, we need to remove it once has done its works as in the rest of the code is doing, otherwise 'e' (first letter of exit) in the second time that matches is doing this: https://openqa.suse.de/tests/3951882#step/installation/43. Besides that, the needle in prod has been modified to match only when there is no line after the one where 'exit' is typed.
In local setup the problem is not showed.

- Related ticket: https://progress.opensuse.org/issues/58250
