### PR TITLE
Add luks2 resizing AutoYaST validation

### DIFF
--- a/schedule/yast/autoyast_resize_luks2.yaml
+++ b/schedule/yast/autoyast_resize_luks2.yaml
@@ -15,8 +15,10 @@ schedule:
   - autoyast/installation
   - installation/first_boot
   - autoyast/console
+  - autoyast/repos
   - autoyast/clone
   - console/validate_file_system
+  - autoyast/verify_cloned_profile
 test_data:
   device: vdb
   table_type: gpt
@@ -24,3 +26,18 @@ test_data:
     - partition: vdb1
       size: 5G
       luks_type: 2
+  profile:
+      partitioning:
+        - drive:
+            unique_key: device
+            device: /dev/vda
+        - drive:
+            unique_key: device
+            device: /dev/vdb
+            disklabel: gpt
+            partitions:
+              - partition:
+                  unique_key: crypt_method
+                  # YaST is only capable of work with luks1
+                  crypt_method: luks1
+                  size: 5368709120


### PR DESCRIPTION
Add luks2 resizing AutoYaST validation of cloned profile.

- Related ticket: https://progress.opensuse.org/issues/58250
- Verification run: [sle-15-SP2-Online-x86_64-Build150.3-autoyast_resize_luks2@64bit](http://rivera-workstation.suse.cz/tests/1068)
