### PR TITLE
Enlarge the timeout for zypper in pattern

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -225,7 +225,8 @@ sub install_patterns {
             record_soft_failure 'bsc#1034541';
             next;
         }
-        zypper_call "in -t pattern $pt";
+        zypper_call("in -t pattern $pt", timeout => 900);
+
     }
 }
 


### PR DESCRIPTION
Time out happen when do zypper in pattern, so update the value of zypper timeout.

- Related ticket: https://progress.opensuse.org/issues/63901
- Needles: na
- Verification run: http://openqa.suse.de/t3946457
