### PR TITLE
HPC: Remove added sdk repositories for sle<15

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -23,20 +23,13 @@ use version_utils 'is_sle';
 
 sub run {
     my $self          = shift;
-    my $version       = get_required_var('VERSION');
-    my $arch          = get_required_var('ARCH');
-    my $sdk_version   = get_required_var('BUILD_SDK');
     my $mpi           = get_required_var('MPI');
     my $mpi_c         = 'simple_mpi.c';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);
 
     ## adding required sdk and gcc
-    if (is_sle '<15') {
-        zypper_call("ar -f ftp://openqa.suse.de/SLE-$version-SDK-POOL-$arch-Build$sdk_version-Media1/ SDK");
-        zypper_call("ar -f http://download.suse.de/ibs/SUSE/Products/SLE-Module-Toolchain/12/$arch/product/ SLE-Module-Toolchain12-Pool");
-        zypper_call("ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Toolchain/12/$arch/update/ SLE-Module-Toolchain12-Updates");
-    } else {
+    if (is_sle '>=15') {
         add_suseconnect_product('sle-module-development-tools');
     }
 


### PR DESCRIPTION
Adding repositories from within the mpi_master module is removed, and, for sle-12 this is now done the SCC_ADDONS setting.
In some cases those repositories were not providing the required
packages.

- Related ticket: https://progress.opensuse.org/issues/63664

- Needles: No needles

- Verification runs:

12-sp2 with sdk in SCC_ADDONS: http://angmar.suse.de/tests/1301
12-sp2 without sdk in SCC_ADDONS: http://angmar.suse.de/tests/1291

12-sp3 with sdk in SCC_ADDONS: http://angmar.suse.de/tests/1273
12-sp3 without sdk in SCC_ADDONS: http://angmar.suse.de/tests/1251

12-sp4 with sdk in SCC_ADDONS: http://angmar.suse.de/tests/1287
12-sp4 without sdk in SCC_ADDONS: http://angmar.suse.de/tests/1279

12-sp5 with sdk in SCC_ADDONS: http://angmar.suse.de/tests/1301
12-sp5 without sdk in SCC_ADDONS: N/A