### PR TITLE
Add a small fix for nis_server

### DIFF
--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -45,6 +45,7 @@ sub nis_server_configuration {
     send_key 'tab';                              # jump to NIS domain name
     type_string $setup_nis_nfs_x11{nis_domain};
     assert_screen 'nis-server-master-server-setup-nis-domain';
+    wait_still_screen 4, 4;                      # wait for blinking cursor, fixes poo#64195
     send_key 'alt-f';                            # open firewall port
     assert_screen 'nis-master-server-tab-opened-fw';
     wait_screen_change { send_key 'alt-a' };


### PR DESCRIPTION
Fixes poo#64195 "When alt-f reaches the VM instead of opening firewall port is typing 'f' on the first textbox"

- Related ticket: https://progress.opensuse.org/issues/64195
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1342
- Verification run: http://waaa-amazing.suse.cz/tests/11670
(several VRs passed)
