### PR TITLE
Adopt qa_automation to QAM maintenance update test with result reporting simplified

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -888,7 +888,7 @@ sub load_inst_tests {
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
-        if (get_var('MAINT_TEST_REPO')) {
+        if (get_var('MAINT_TEST_REPO' and !get_var("USER_SPACE_TESTSUITES"))) {
             loadtest 'installation/add_update_test_repo';
         }
         loadtest "installation/addon_products_sle";
@@ -2570,7 +2570,7 @@ sub load_systemd_patches_tests {
 
 sub load_system_prepare_tests {
     loadtest 'ses/install_ses'                if check_var_array('ADDONS', 'ses') || check_var_array('SCC_ADDONS', 'ses');
-    loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+    loadtest 'qa_automation/patch_and_reboot' if (is_updates_tests and !get_var("USER_SPACE_TESTSUITES"));
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest 'console/sle15_workarounds'    if is_sle('15+');
     loadtest 'console/integration_services' if is_hyperv || is_vmware;

--- a/schedule/qam/12-SP1/mau-userspace.yaml
+++ b/schedule/qam/12-SP1/mau-userspace.yaml
@@ -1,0 +1,11 @@
+---
+name: mau-userspace
+description: >
+      Execute test suites in userspace using
+      variable USER_SPACE_TESTSUITES. 
+schedule:
+    - boot/boot_to_desktop
+    - qa_automation/qaset_pre_patch_run
+    - qa_automation/patch_and_reboot
+    - qa_automation/qaset_post_patch_run
+

--- a/schedule/qam/12-SP2/mau-userspace.yaml
+++ b/schedule/qam/12-SP2/mau-userspace.yaml
@@ -1,0 +1,11 @@
+---
+name: mau-userspace
+description: >
+      Execute test suites in userspace using
+      variable USER_SPACE_TESTSUITES. 
+schedule:
+    - boot/boot_to_desktop
+    - qa_automation/qaset_pre_patch_run
+    - qa_automation/patch_and_reboot
+    - qa_automation/qaset_post_patch_run
+

--- a/schedule/qam/12-SP3/mau-userspace.yaml
+++ b/schedule/qam/12-SP3/mau-userspace.yaml
@@ -1,0 +1,11 @@
+---
+name: mau-userspace
+description: >
+      Execute test suites in userspace using
+      variable USER_SPACE_TESTSUITES. 
+schedule:
+    - boot/boot_to_desktop
+    - qa_automation/qaset_pre_patch_run
+    - qa_automation/patch_and_reboot
+    - qa_automation/qaset_post_patch_run
+

--- a/schedule/qam/12-SP4/mau-userspace.yaml
+++ b/schedule/qam/12-SP4/mau-userspace.yaml
@@ -1,0 +1,11 @@
+---
+name: mau-userspace
+description: >
+      Execute test suites in userspace using
+      variable USER_SPACE_TESTSUITES. 
+schedule:
+    - boot/boot_to_desktop
+    - qa_automation/qaset_pre_patch_run
+    - qa_automation/patch_and_reboot
+    - qa_automation/qaset_post_patch_run
+

--- a/schedule/qam/12-SP5/mau-userspace.yaml
+++ b/schedule/qam/12-SP5/mau-userspace.yaml
@@ -1,0 +1,11 @@
+---
+name: mau-userspace
+description: >
+      Execute test suites in userspace using
+      variable USER_SPACE_TESTSUITES. 
+schedule:
+    - boot/boot_to_desktop
+    - qa_automation/qaset_pre_patch_run
+    - qa_automation/patch_and_reboot
+    - qa_automation/qaset_post_patch_run
+

--- a/schedule/qam/15-SP1/mau-userspace.yaml
+++ b/schedule/qam/15-SP1/mau-userspace.yaml
@@ -1,0 +1,11 @@
+---
+name: mau-userspace
+description: >
+      Execute test suites in userspace using
+      variable USER_SPACE_TESTSUITES. 
+schedule:
+    - boot/boot_to_desktop
+    - qa_automation/qaset_pre_patch_run
+    - qa_automation/patch_and_reboot
+    - qa_automation/qaset_post_patch_run
+

--- a/schedule/qam/15/mau-userspace.yaml
+++ b/schedule/qam/15/mau-userspace.yaml
@@ -1,0 +1,11 @@
+---
+name: mau-userspace
+description: >
+      Execute test suites in userspace using
+      variable USER_SPACE_TESTSUITES. 
+schedule:
+    - boot/boot_to_desktop
+    - qa_automation/qaset_pre_patch_run
+    - qa_automation/patch_and_reboot
+    - qa_automation/qaset_post_patch_run
+

--- a/tests/qa_automation/qaset_post_patch_run.pm
+++ b/tests/qa_automation/qaset_post_patch_run.pm
@@ -1,0 +1,139 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package qaset_post_patch_run;
+
+# Summary: Simplify test reporting for qa_automation
+#
+# This execution is entirely based on qa_automation/qa_run. The test result is simplfied to only show failed testcases
+# triggered by regression bug. That will satisfy the need for maintenance update test
+# Using YAML_SCHEDULE to schedule is recommanded to keep flexibility.
+# qaset_pre_patch_run, patch_and_reboot and qaset_post_patch_run should schedule in order.
+#
+# features:
+# 1. Only failed test case names triggered by regression are show on result page.
+# 2. QADB url of comparison of before update and after is posted under testcase name.
+# 3. Added var SOFTFAIL_TESTCASES which make a failed testcase softfailed to avoid triggering
+#    entire test failed until the corresponding bug is fixed.
+# 4. Auto define test in qaset if it's no defined.
+# 5. disble/enable QADB submission with var DISABLE_SUBMIT_QADB.
+#
+# Maintainer: Tony Yuan <tyuan@suse.com>
+
+use strict;
+use warnings;
+use base "qa_run";
+use testapi qw(is_serial_terminal :DEFAULT);
+use utils;
+
+# Create qaset/config file, reset qaset, and start testrun
+sub start_testrun {
+    assert_script_run("/usr/share/qa/qaset/qaset reset");
+    assert_script_run("/usr/share/qa/qaset/run/kernel-all-run.openqa");
+}
+
+my $xslt = <<'EOT';
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:param name="var" select="'title'" />
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()" />
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="testsuite">
+        <xsl:choose>
+            <xsl:when test="@failures!='0'">
+                <xsl:variable name="nreg" select="testcase[@status='failure' and not(contains($var, @classname))]" />
+                <xsl:choose>
+                    <xsl:when test="count($nreg) &gt; 0">
+                        <xsl:copy>
+                            <xsl:apply-templates select="@*" />
+                            <xsl:attribute name="failures">
+                                <xsl:value-of select="count($nreg)" />
+                            </xsl:attribute>
+                            <xsl:copy-of select="$nreg" />
+                        </xsl:copy>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:copy>
+                            <xsl:apply-templates select="@*" />
+                            <xsl:attribute name="failures">
+                                <xsl:value-of select="count($nreg)" />
+                            </xsl:attribute>
+                            <xsl:apply-templates select="testcase[1]/system-err" />
+                        </xsl:copy>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="@*" />
+                    <xsl:apply-templates select="testcase[1]/system-err" />
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>
+EOT
+
+my $compare_results = <<'EOT';
+while read test id_before 
+do 
+  echo "$test,$id_before"
+  id_after=`xml sel -t -v "/testsuites/testsuite[@name=\"$test\"]/testcase[1]/system-err" /tmp/junit.xml|sed -n "s/.*id=\(.*\)/\1/p"`
+  qadb_url="http://qadb2.suse.de/qadb/regression.php?ref_submission_id=${id_before}&cand_submission_id=$id_after"
+  echo "$qadb_url"
+  xml ed -L -u "/testsuites/testsuite[@name=\"$test\"]/testcase[1]/system-err" -v "Submission comparision between before and after results: $qadb_url" /tmp/junit.xml
+done < /tmp/submission_ids_before
+EOT
+
+# qa_testset_automation validation test
+sub run {
+    my $self = shift;
+    $self->system_login();
+    start_testrun;
+    my $testrun_finished = $self->wait_testrun(timeout => 180 * 60);
+
+    # Upload test logs
+    my $tarball = "/tmp/qaset.tar.bz2";
+    assert_script_run("tar cjf '$tarball' -C '/var/log/' 'qaset'");
+    upload_logs($tarball, timeout => 600);
+    my $log = $self->system_status();
+    upload_logs($log, timeout => 100);
+
+    # JUnit xml report
+    assert_script_run("/usr/share/qa/qaset/bin/junit_xml_gen.py -n 'regression' -d -o /tmp/junit.xml /var/log/qaset");
+
+    # Record into failure for known bugs to avoid triggering whole test failure.
+    if (my %softfail_tc = @{get_var_array('SOFTFAIL_TESTCASES')}) {
+        my $broken_tc_list;
+        while (my ($k, $v) = each %softfail_tc) {
+            next unless script_run("grep $k /tmp/broken_tclist");
+            $broken_tc_list .= "$k ";
+            record_info("$k => $v");
+        }
+        assert_script_run(qq(echo "`cat /tmp/broken_tclist` $broken_tc_list" > /tmp/broken_tclist ));
+    }
+
+    upload_logs("/tmp/junit.xml", timeout => 600);
+    # Construct qadb regression url
+    assert_script_run("cat > /tmp/compare_results.sh <<'END'\n$compare_results\nEND\n( exit \$?)");
+    assert_script_run("bash /tmp/compare_results.sh");
+
+    # transform junit.xml by xslt to filter the result of passed, broken and skipped testcases. Only new regression is kept;
+    assert_script_run("cat > /tmp/trans_junit.xsl <<'END'\n$xslt\nEND\n( exit \$?)");
+    assert_script_run("xsltproc  --stringparam var \"`cat /tmp/broken_tclist`\" /tmp/trans_junit.xsl /tmp/junit.xml > /tmp/junit_trans.xml");
+
+    parse_junit_log("/tmp/junit_trans.xml");
+    die "Test run didn't finish within time limit" unless ($testrun_finished);
+    select_console('root-console');
+}
+
+1;

--- a/tests/qa_automation/qaset_pre_patch_run.pm
+++ b/tests/qa_automation/qaset_pre_patch_run.pm
@@ -1,0 +1,94 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package qaset_pre_patch_run;
+# Summary: Simplify test reporting for qa_automation tests
+#
+# This execution is entirely based on qa_automation/qa_run. The test result is simplfied to only show failed testcases
+# triggered by regression bug. That will satisfy the need for maintenance update test
+# Using YAML_SCHEDULE to schedule is recommanded to keep flexibility.
+# qaset_pre_patch_run, patch_and_reboot and qaset_post_patch_run should schedule in order.
+#
+# features added:
+# 1. Only failed test case names triggered by regression are show on result page.
+# 2. QADB url of comparison of before update and after is posted under testcase name.
+# 3. Added var SOFTFAIL_TESTCASES which make a failed testcase softfailed to avoid triggering
+#    entire test failed until the corresponding bug is fixed.
+# 4. Auto define test in qaset if it's no defined.
+# 5. disble/enable QADB submission with var DISABLE_SUBMIT_QADB.
+#
+# Maintainer: Tony Yuan <tyuan@suse.com>
+
+use strict;
+use warnings;
+use base "qa_run";
+use testapi qw(is_serial_terminal :DEFAULT);
+use utils;
+
+sub test_run_list {
+    return ('_reboot_off', @{get_var_array('USER_SPACE_TESTSUITES')});
+}
+
+# Call test_run_list and write the result into /root/qaset/config
+sub qaset_config {
+    my $self = shift;
+    my @list = test_run_list();
+    return unless @list;
+    if (get_var("DISABLE_SUBMIT_QADB")) {
+        # disable submition
+        assert_script_run("sed -i '/sq_qadb_server_switch Nuremberg/,/already/ {s/^/#/}' /usr/share/qa/qaset/qavm/sq-result.sh");
+        assert_script_run(q(sed -i '/clean/aecho wwww >> \${SQ_TEST_SUBMISSION_DIR}/submission-\${_sq_run}.log' /usr/share/qa/qaset/qavm/sq-result.sh));
+    }
+    assert_script_run("mkdir -p /root/qaset");
+    my $testsuites = "\n\t" . join("\n\t", @list) . "\n";
+    assert_script_run("echo 'SQ_TEST_RUN_LIST=($testsuites)' > /root/qaset/config");
+
+    # define undefined testsuites in the testsuites list
+    shift @list;
+    my $cmd = "for n in " . join(" ", @list) . ";";
+    $cmd .= q( do grep test_$n-run /usr/share/qa/qaset/set/* >/dev/null || echo "def_simple_run $n '/usr/share/qa/tools/test_${n}-run' qa_test_$n" >> /usr/share/qa/qaset/set/regression.set; done);
+    assert_script_run($cmd);
+}
+
+# qa_testset_automation validation test
+sub run {
+    my $self = shift;
+    $self->system_login();
+    $self->prepare_repos();
+    zypper_call("in xmlstarlet libxslt-tools");
+    $self->start_testrun();
+    my $testrun_finished = $self->wait_testrun(timeout => 180 * 60);
+
+    # Upload test logs
+    my $tarball = "/tmp/qaset.tar.bz2";
+    assert_script_run("tar cjf '$tarball' -C '/var/log/' 'qaset'");
+    upload_logs($tarball, timeout => 600);
+    my $log = $self->system_status();
+    upload_logs($log, timeout => 100);
+
+    # JUnit xml report
+    assert_script_run("/usr/share/qa/qaset/bin/junit_xml_gen.py -n 'regression' -d -o /tmp/junit.xml /var/log/qaset");
+    upload_logs('/tmp/junit.xml', timeout => 600);
+
+    # Collect all testcases with status="failure"
+    assert_script_run(q(xml sel -t -v '//testcase[@status="failure"]/@classname' /tmp/junit.xml |sed '/\.dummy/d' | tr '\n' ' ' > /tmp/broken_tclist));
+    upload_logs('/tmp/broken_tclist', timeout => 100);
+
+    #Save submission ids of all tests to a file.
+    my $ts_list = join(" ", @{get_var_array('USER_SPACE_TESTSUITES')});
+    my $cmd = "for i in $ts_list; " . 'do xml sel -t -v "/testsuites/testsuite[@name=\"$i\"]/testcase[1]/system-err" /tmp/junit.xml|sed -n "s/.*id=\(.*\)/$i \1/p"; done > /tmp/submission_ids_before';
+    assert_script_run("$cmd");
+    die "Test run didn't finish within time limit" unless ($testrun_finished);
+
+    # clean up qaset
+    assert_script_run('rm -rf /tmp/junit.xml /var/log/qaset/submission/* /var/log/qaset/log/* /tmp/qaset.tar.bz2');
+    select_console('root-console');
+}
+
+1;


### PR DESCRIPTION
 Adopt qa_automation to QAM maintenance update test with test result reporting simplified.

This execution is entirely based on qa_automation/qa_run. The test result is simplfied to only show failed testcases
triggered by regression bug. That will satisfy the need for maintenance update test
Using YAML_SCHEDULE to schedule is recommanded to keep flexibility.
qaset_pre_patch_run, patch_and_reboot and qaset_post_patch_run should schedule in order.
- Related ticket: progress.opensuse.org/issues/63739
- Needles: no
- Verification run: 
sles12sp4: http://10.67.17.201/tests/507
sles12sp3: http://10.67.17.201/tests/512
sles12sp2: http://10.67.17.201/tests/518
sles15: http://10.67.17.201/tests/513
sles15sp1: http://10.67.17.201/tests/523