### PR TITLE
Add YAML schedule for raid0 on IBM zVM

### DIFF
--- a/schedule/yast/raid/raid0_opensuse_gpt_zvm.yaml
+++ b/schedule/yast/raid/raid0_opensuse_gpt_zvm.yaml
@@ -1,0 +1,55 @@
+name:           RAID0_gpt_opensuse
+description:    >
+  Configure RAID 0 on the disks with GPT partition tables using Expert Partitioner.
+  Creates BIOS boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 0.
+vars:
+  RAIDLEVEL: 0
+schedule:
+  - installation/bootloader_s390
+  - installation/welcome
+  - installation/disk_activation
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_raid
+test_data:
+  mds:
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/tests/installation/partitioning/raid_gpt.pm
+++ b/tests/installation/partitioning/raid_gpt.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -350,11 +350,15 @@ sub add_partitions {
     my @devices = qw(vda vdb vdc vdd);
     @devices = qw(xvdb xvdc xvdd xvde) if check_var('VIRSH_VMM_FAMILY', 'xen');
     @devices = qw(sda sdb sdc sdd)     if check_var('VIRSH_VMM_FAMILY', 'hyperv');
+    @devices = qw(dsada dasdb)         if check_var('backend', 's390x');
     for (@devices) {
         send_key_until_needlematch "partitioning_raid-disk_$_-selected", "down";
         # storage-ng requires bios boot partition if not UEFI and not OFW
         if (get_var('UEFI')) {
             addpart('boot-efi');
+        }
+        elsif (get_var('backend', 's390x')) {
+            addpart('zipl');
         }
         elsif (is_storage_ng && !get_var('OFW')) {
             addpart('bios-boot');


### PR DESCRIPTION
## Description
There are different actions to perform like:
- the bootloader, which is done by IPL'ing initrd
- DASD activation has to be done explicitly
- The consoles to the remote SUT need to be reconnected after reboot.

## Needles
- https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/649
## Verification run
- (coming soon)
