### PR TITLE
Fix cpu_bugs test cases issue: l1tf, itlb and Mitigation lib.

### DIFF
--- a/lib/Mitigation.pm
+++ b/lib/Mitigation.pm
@@ -95,7 +95,13 @@ our $syspath = '/sys/devices/system/cpu/vulnerabilities/';
 #
 sub new {
     my ($class, $args) = @_;
-    return bless $args, $class;
+    if (ref($args)) {
+        return bless $args, $class;
+    }
+    else {
+        my $self = $class->SUPER::new($args);
+        return bless $self, $class;
+    }
 }
 
 sub Parameter {

--- a/tests/cpu_bugs/itlb.pm
+++ b/tests/cpu_bugs/itlb.pm
@@ -38,8 +38,12 @@ sub run {
     }
     assert_script_run('modprobe kvm nx_huge_pages=0;lsmod | grep "kvm"');
     assert_script_run('modprobe kvm_intel; lsmod | grep "kvm_intel"');
-    assert_file_content('/sys/module/kvm/parameters/nx_huge_pages', "N");
+    check_param('/sys/module/kvm/parameters/nx_huge_pages', "N");
 }
 
+sub check_param {
+    my ($param, $value) = @_;
+    assert_script_run("cat $param | grep $value");
+}
 
 1;

--- a/tests/cpu_bugs/l1tf.pm
+++ b/tests/cpu_bugs/l1tf.pm
@@ -58,30 +58,31 @@ sub run {
     }
     my $obj = Mitigation->new(\%mitigations_list);
     #run base function testing
-    $obj->do_test();
-
-    assert_script_run('cat /sys/devices/system/cpu/smt/active | grep "1"');
-    assert_script_run('echo off>/sys/devices/system/cpu/smt/control');
-    assert_script_run('lscpu | grep "Off-line CPU(s) list"');
-    assert_script_run('cat /sys/devices/system/cpu/smt/active | grep "0"');
-    add_grub_cmdline_settings("l1tf=full,force");
-    update_grub_and_reboot($self, 150);
-    assert_script_run('lscpu | grep "Off-line CPU(s) list"');
-    assert_script_run('cat /sys/devices/system/cpu/smt/active | grep "0"');
-    assert_script_run('cat /sys/devices/system/cpu/smt/control | grep "forceoff"');
-    die "Control cannot be modified under the mode of forceoff" unless script_run('echo on>/sys/devices/system/cpu/smt/control');
-    assert_script_run('cat /sys/devices/system/cpu/smt/control | grep "forceoff"');
-    remove_grub_cmdline_settings("l1tf=full,force");
-    update_grub_and_reboot($self, 150);
-    assert_script_run('cat /sys/module/kvm_intel/parameters/ept | grep "Y"');
-    my $damn = script_run('modprobe -r kvm_intel | grep "kvm"');
-    if ($damn eq 0) {
-        record_info('fail', "Couldn't find kvm when removed the kvm_intel");
-        die;
+    my $ret = $obj->do_test();
+    if ($ret ne 2) {
+        assert_script_run('cat /sys/devices/system/cpu/smt/active | grep "1"');
+        assert_script_run('echo off>/sys/devices/system/cpu/smt/control');
+        assert_script_run('lscpu | grep "Off-line CPU(s) list"');
+        assert_script_run('cat /sys/devices/system/cpu/smt/active | grep "0"');
+        add_grub_cmdline_settings("l1tf=full,force");
+        update_grub_and_reboot($self, 150);
+        assert_script_run('lscpu | grep "Off-line CPU(s) list"');
+        assert_script_run('cat /sys/devices/system/cpu/smt/active | grep "0"');
+        assert_script_run('cat /sys/devices/system/cpu/smt/control | grep "forceoff"');
+        die "Control cannot be modified under the mode of forceoff" unless script_run('echo on>/sys/devices/system/cpu/smt/control');
+        assert_script_run('cat /sys/devices/system/cpu/smt/control | grep "forceoff"');
+        remove_grub_cmdline_settings("l1tf=full,force");
+        update_grub_and_reboot($self, 150);
+        assert_script_run('cat /sys/module/kvm_intel/parameters/ept | grep "Y"');
+        my $damn = script_run('modprobe -r kvm_intel | grep "kvm"');
+        if ($damn eq 0) {
+            record_info('fail', "Couldn't find kvm when removed the kvm_intel");
+            die;
+        }
+        assert_script_run('modprobe kvm_intel ept=0;lsmod | grep "kvm"');
+        check_param('/sys/module/kvm_intel/parameters/ept', "N");
+        assert_script_run('cat /sys/devices/system/cpu/vulnerabilities/l1tf | grep "EPT disabled"');
     }
-    assert_script_run('modprobe kvm_intel ept=0;lsmod | grep "kvm"');
-    check_param('/sys/module/kvm_intel/parameters/ept', "N");
-    assert_script_run('cat /sys/devices/system/cpu/vulnerabilities/l1tf | grep "EPT disabled"');
 }
 
 sub update_grub_and_reboot {


### PR DESCRIPTION
The changes address the followed issues:
l1tf: Fix for "Undefined subroutine &itlb::assert_file_content"
itlb: Fix for CPU is not effected, testing should skip on this machine.
Mitigation lib: Fix bless non-reference value issue reported on constructor Mitigation new() when running TAA and meltdown.

- Related ticket: https://progress.opensuse.org/issues/64292
- Needles: N/A
- Verification run: 
l1tf: http://10.67.134.217/tests/9329
itlb: http://10.67.134.217/tests/9317
TAA:  http://10.67.134.217/tests/9318
MELTDOWN:  http://10.67.134.217/tests/9311
Please refer to more cpu_bugs test cases on URL: http://10.67.134.217/tests/overview?distri=sle&version=15.2&build=150.1&groupid=1
