### PR TITLE
Fix kdump wait_boot timeout and workaround for s390x

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -224,7 +224,7 @@ sub configure_service {
     # restart to activate kdump
     power_action('reboot', keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
-    $self->wait_boot;
+    $self->wait_boot(bootloader_time => 300);
 
     select_console 'root-console';
     if (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'ppc64')) {

--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -181,6 +181,11 @@ service package name.
 
 sub _is_applicable {
     my ($srv_pkg_name) = @_;
+    if ($srv_pkg_name eq 'kdump' && check_var('ARCH', 's390x')) {
+        # workaround for bsc#116300 on s390x
+        record_soft_failure 'bsc#1163000 - System does not come back after crash on s390x';
+        return 0;
+    }
     if (get_var('EXCLUDE_SERVICES')) {
         my %excluded = map { $_ => 1 } split(/\s*,\s*/, get_var('EXCLUDE_SERVICES'));
         return 0 if $excluded{$srv_pkg_name};


### PR DESCRIPTION
When run kdump on some platforms the wait_boot will timeout for waiting the grub entry. we need
to enlarge the wait time to make it work.
Currently on s390x we need workaround it for bsc#1163000. we skip it and make it softfail for the 
time being.

- Related ticket: https://progress.opensuse.org/issues/62267
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/3968367
   https://openqa.nue.suse.com/tests/3968589
   https://openqa.nue.suse.com/tests/3968670
   https://openqa.nue.suse.com/tests/3973471
