### PR TITLE
Update YaST2 bootloader according to boo#1140040 

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -30,7 +30,22 @@ sub run {
     zypper_call 'in yast2-bootloader';
 
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'bootloader');
-    assert_screen "test-yast2_bootloader-1", 300;
+
+    # YaST2 prompts user to install missing packages found during storage probing.
+    # Otherwise YaST2 shows bootloader settings options
+    assert_screen([qw(test-yast2_bootloader-1 fs-probing-failed)], 300);
+
+    if (match_has_tag('fs-probing-failed')) {
+        send_key 'alt-d';
+
+        my $keymapping = {'probing-error' => 'ret', 'fs-probing-failed' => 'alt-i'};
+        foreach (qw(probing-error fs-probing-failed)) {
+            assert_screen $_;
+            send_key $keymapping->{$_};
+        }
+        assert_screen 'test-yast2_bootloader-1';
+    }
+
     # OK => Close
     send_key "alt-o";
     # Our Hyper-V host is slow when initrd is being re-generated

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -38,9 +38,8 @@ sub run {
     assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], $timeout);
     if (match_has_tag('yast2_bootloader-missing_package')) {
         wait_screen_change { send_key 'alt-i'; };
-        assert_screen 'yast2_console-finished', $timeout;
     }
-    wait_serial("$module_name-0") || die "'yast2 bootloader' didn't finish";
+    wait_serial("$module_name-0", timeout => $timeout) || die "'yast2 bootloader' didn't finish";
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [[JeOS][yast2] test fails in yast2_bootloader - remove redundant exit check](https://progress.opensuse.org/issues/64313) &&
[[functional][y][JeOS] test fails in yast2_bootloader - needs adjustement to product change, act on dialog to install missing packages](https://progress.opensuse.org/issues/64287)
- Verification runs: 
   * [opensuse-15.2-NET-ppc64le-Buildmloviska_os-autoinst-distri-opensuse_9723-minimalx@mloviska_os-autoinst-distri-opensuse_y2_bootloader_exit_check@ppc64le](https://openqa.opensuse.org/tests/1199063#step/yast2_bootloader/8)
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build8.15-jeos-main_intel_image@uefi-virtio-vga](http://eris.suse.cz/tests/4815#step/yast2_bootloader/7)
   * [sle-15-SP2-JeOS-for-MS-HyperV-x86_64-Build8.15-jeos-main_hyperv_image@svirt-hyperv-uefi](https://openqa.suse.de/tests/3968845#step/yast2_bootloader/8)
   * [opensuse-15.1-JeOS-for-kvm-and-xen-x86_64-Build8.10.26-jeos@64bit_virtio-2G](http://eris.suse.cz/tests/4813#step/yast2_bootloader/7)
   * [opensuse-Tumbleweed-NET-x86_64-Build20200307-gnome@64bit](http://eris.suse.cz/tests/4812#step/yast2_bootloader/7)
   
   * probing
      * [Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20200307-jeos@64bit_virtio](http://eris.suse.cz/tests/4829#step/yast2_bootloader/4)