### PR TITLE
multipath after registration for 15-SP2+

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -858,7 +858,8 @@ sub load_inst_tests {
     if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
         loadtest "installation/encrypted_volume_activation";
     }
-    if (get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
+    # SLE-15 SP2 pushes the multipath activation dialog after the scc_registration dialog, see below
+    if ((get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) and not is_sle('15-SP2+')) {
         loadtest "installation/multipath";
     }
     if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {
@@ -879,6 +880,11 @@ sub load_inst_tests {
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
         loadtest "installation/scc_registration";
+    }
+    if (is_sle('15-SP2+') and (get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM'))) {
+        loadtest "installation/multipath";
+    }
+    if (is_sle) {
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }


### PR DESCRIPTION
Conditionally change order: multipath activation dialog to
come up only after the SCC registration dialog to maintain
compatibility with the SLE-15 SP2 installer.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1165159
- Needles: (none)
- Verification run (SLE-15 SP2): [client (1053)](http://polya.suse.de/tests/1053), [supportserver (1052)](http://polya.suse.de/tests/1052)

_NOTE_  The following unsuccessful job pair demonstrates that the attempt to defined the modified scheduling for the mru-install-multipath-remote job by means of a *.yaml schedule file (job variable `YAML_SCHEDULE`) is improper (as of now). _Reason:_ the *.yaml schedule would be  forwarded to the parallel supportserver job, too, which is completely unwanted and bogus.
[client 1051](http://polya.suse.de/tests/1051), [supportserver 1050](http://polya.suse.de/tests/1050)

Therefore going the traditional way of a conditional reschedule via `main_common.pm` seems inevitable.