### PR TITLE
Add scripts to power on/off systems in generalhw with kasa tool and IFTTT webhooks

### DIFF
--- a/data/generalhw_scripts/power_off_kasa.sh
+++ b/data/generalhw_scripts/power_off_kasa.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Package dep: python3-kasa
+
+set -ex
+
+echo "Powering OFF"
+
+# Check number of args
+if [ "$#" -ne 1 ]; then
+    echo "Please provide IP or hostname of the plug as argument"
+    exit 1;
+fi
+
+# Get IP/hostname from arg
+device=$1
+
+/usr/bin/kasa --plug --host $device off
+/usr/bin/kasa --plug --host $device led 0

--- a/data/generalhw_scripts/power_on_kasa.sh
+++ b/data/generalhw_scripts/power_on_kasa.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Package dep: python3-kasa
+
+set -ex
+
+echo "Powering ON"
+
+# Check number of args
+if [ "$#" -ne 1 ]; then
+    echo "Please provide IP or hostname of the plug as argument"
+    exit 1;
+fi
+
+# Get IP/hostname from arg
+device=$1
+
+/usr/bin/kasa --plug --host $device on
+/usr/bin/kasa --plug --host $device led 1

--- a/data/generalhw_scripts/webhook_ifttt.sh
+++ b/data/generalhw_scripts/webhook_ifttt.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# You need to create:
+#   a webhook key at https://ifttt.com/maker_webhooks
+#   the applet itself on https://ifttt.com/create
+# Package dep: curl
+# TODO: Handle option values named: value1, value2, value3, in json format: { "value1" : "", "value2" : "", "value3" : "" }
+
+# Do not echo, to not leak private event/key in log
+set -e
+
+echo "IFTTT webhook"
+
+# Check number of args
+if [ "$#" -ne 2 ]; then
+    echo "Please provide <event_name> and <private_key> as arguments. (Optionnal values are not yet supported)"
+    exit 1;
+fi
+
+# Get args
+ifttt_event=$1
+ifttt_key=$2
+
+curl -X POST https://maker.ifttt.com/trigger/$ifttt_event/with/key/$ifttt_key


### PR DESCRIPTION
This has been tested locally with `python3-kasa` and IFTTT webhooks, with a `TP-Link HS100` SmartPlug.
Requires: https://github.com/os-autoinst/os-autoinst/pull/1362
