### PR TITLE
Revert "Add a small fix for nis_server"

### DIFF
--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -45,7 +45,6 @@ sub nis_server_configuration {
     send_key 'tab';                              # jump to NIS domain name
     type_string $setup_nis_nfs_x11{nis_domain};
     assert_screen 'nis-server-master-server-setup-nis-domain';
-    wait_still_screen 4, 4;                      # wait for blinking cursor, fixes poo#64195
     send_key 'alt-f';                            # open firewall port
     assert_screen 'nis-master-server-tab-opened-fw';
     wait_screen_change { send_key 'alt-a' };


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#9714

Works sporadically. I also tried to send alt-tab before, but really, the problem is that openqa sends "f" instead of "alt-f". so we can try something like for (1 .. 5) send_key 'tab', but then I suppose we will have some tab that will be skipped as well. 

That test has been working for ages, I think it's not for us to fix this, it seems tp be a problem in openqa.