### PR TITLE
Enable IUCV console via linuxrc parameter

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -83,7 +83,7 @@ sub prepare_parmfile {
     $params .= " " . get_var('S390_NETWORK_PARAMS');
     $params .= " " . get_var('EXTRABOOTPARAMS');
     if ((is_sle('>=15-SP2') || is_tumbleweed()) && get_var('WORKAROUND_BUGS') =~ 'bsc1156047') {
-        $params .= ' hardened_usercopy=off';
+        $params .= ' hardened_usercopy=off hvc_iucv=8';
         record_soft_failure('bsc#1156053 - hardened_usercopy=off to avoid "/dev/hvc0: cannot get controlling tty: Operation not permitted" (Kernel memory overwrite attempt detected to SLUB object - illegal operation)');
     }
 


### PR DESCRIPTION
## Description
As suggested by Berthold in
https://bugzilla.suse.com/show_bug.cgi?id=1156053#c32

```
With IUCV on current kernels, there are two issues. First ist the one
with HARDENED_USERCOPY, the other one is, that current kernels do not
provide a hvc iucv console by default anymore. Please try to add
hvc_iucv=8 to the kernel command line to make sure that this is not the
reason for the failure.
```

## Related ticket
- https://bugzilla.suse.com/show_bug.cgi?id=1156053#c32

## Verification run
- http://openqa.slindomansilla-vm.qa.suse.de/tests/2269