### PR TITLE
Use python3 to run python script instead of python if python is not exsited

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -172,7 +172,10 @@ sub check_rollback_system {
     zypper_call("mr -d -m cd -m dvd");
     # Verify registration status matches current system version
     # system is un-registered during media based upgrade
-    assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | python') unless get_var('MEDIA_UPGRADE');
+    unless (get_var('MEDIA_UPGRADE')) {
+        my $py = (-e '/usr/bin/python3') ? 'python3' : 'python';
+        assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | ' . $py);
+    }
 }
 
 # Reset tty for x11 and root consoles


### PR DESCRIPTION
Background: It will install python3 as default python version at sles15sp1. So, if run python script, it need user python3 command instead of python. We need use correct python3 to run python script at sles15sp1 system at ppc64le, aarch64, x86 and s390x platform.
For sles15-sp1+, we will use python3 instead of python to run python script.

- Related ticket: https://progress.opensuse.org/issues/64222
- Verification run: 
ppc64le: https://openqa.nue.suse.com/tests/3973425#
aarch64: https://openqa.nue.suse.com/tests/3973475
x86: https://openqa.nue.suse.com/tests/3973476

As, s390x don't run snapper_rollback module.
