### PR TITLE
Fix select_packages to support text mode and detect blocker_packages 

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -144,10 +144,18 @@ Performs steps needed to go from the "pattern selection" screen to
 =cut
 sub go_to_search_packages {
     my ($self) = @_;
-    send_key 'alt-d';    # details button
-    assert_screen 'packages-manager-detail';
-    assert_and_click 'packages-search-tab';
-    assert_and_click 'packages-search-field-selected';
+    if (check_var('VIDEOMODE', 'text')) {
+      wait_screen_change { send_key 'alt-f' };
+      for (1 .. 3) { send_key 'down'; }
+      send_key 'ret';
+      assert_screen 'search-list-selected';
+    }
+    else {
+      send_key 'alt-d';    # details button
+      assert_screen 'packages-manager-detail';
+      assert_and_click 'packages-search-tab';
+      assert_and_click 'packages-search-field-selected';
+    }
 }
 
 =head2 move_down
@@ -194,11 +202,20 @@ C<$package_name>
 =cut
 sub search_package {
     my ($self, $package_name) = @_;
-    assert_and_click 'packages-search-field-selected';
-    wait_screen_change { send_key 'ctrl-a' };
-    wait_screen_change { send_key 'delete' };
-    type_string_slow "$package_name";
-    send_key 'alt-s';    # search button
+    if (check_var('VIDEOMODE', 'text')) {
+        send_key 'alt-p';
+        assert_screen 'packages-search-field-selected';
+        send_key_until_needlematch 'search-field-empty', 'backspace';
+        type_string_slow "$package_name";
+        send_key 'ret';    # search package
+    }
+    else {
+        assert_and_click 'packages-search-field-selected';
+        wait_screen_change { send_key 'ctrl-a' };
+        wait_screen_change { send_key 'delete' };
+        type_string_slow "$package_name";
+        send_key 'alt-s';    # search button
+    }
 }
 
 =head2 select_all_patterns_by_menu

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -145,16 +145,16 @@ Performs steps needed to go from the "pattern selection" screen to
 sub go_to_search_packages {
     my ($self) = @_;
     if (check_var('VIDEOMODE', 'text')) {
-      wait_screen_change { send_key 'alt-f' };
-      for (1 .. 3) { send_key 'down'; }
-      send_key 'ret';
-      assert_screen 'search-list-selected';
+        wait_screen_change { send_key 'alt-f' };
+        for (1 .. 3) { send_key 'down'; }
+        send_key 'ret';
+        assert_screen 'search-list-selected';
     }
     else {
-      send_key 'alt-d';    # details button
-      assert_screen 'packages-manager-detail';
-      assert_and_click 'packages-search-tab';
-      assert_and_click 'packages-search-field-selected';
+        send_key 'alt-d';    # details button
+        assert_screen 'packages-manager-detail';
+        assert_and_click 'packages-search-tab';
+        assert_and_click 'packages-search-field-selected';
     }
 }
 

--- a/tests/installation/select_packages.pm
+++ b/tests/installation/select_packages.pm
@@ -51,6 +51,9 @@ sub run {
     }
     $self->back_to_overview_from_packages();
 
+    # If not $blocker_packages, return directly
+    return unless ($blocker_packages);
+
     if (is_sle('<15') && !check_screen('inst-overview-blocked', 0)) {
         record_soft_failure('bsc#1029660 - package removal, different result with same workflow');
         $self->go_to_patterns();


### PR DESCRIPTION
The changes will address the following:

1) select_packages should send correct key code in text mode, modify y2_installbase.pm to make go_to_search_packages() and search_package() support GUI and text mode at same time.

2) select_packages will work on blocker package although $blocker_packages is not set,  detect $blocker_packages and return if it is undefined.

- Related ticket: https://progress.opensuse.org/issues/64334
- Needles: N/A
- Verification run: http://10.67.19.186/tests/12
