### PR TITLE
XEN & IPMI installation improvements

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -21,7 +21,7 @@ use version_utils qw(is_storage_ng is_sle);
 use utils;
 use power_action_utils 'prepare_system_shutdown';
 
-our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console set_dom0_mem set_pxe_efiboot boot_local_disk_arm_huawei);
+our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot boot_local_disk_arm_huawei);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
@@ -215,7 +215,7 @@ sub get_installation_partition {
 
 
 # This works only on SLES 12+
-sub set_dom0_mem {
+sub adjust_for_ipmi_xen {
     my ($root_prefix) = @_;
     $root_prefix = "/" if (!defined $root_prefix) || ($root_prefix eq "");
     my $installation_disk = "";
@@ -238,6 +238,7 @@ sub set_dom0_mem {
     assert_script_run ". /etc/default/grub";
     my $xen_dom0_mem = get_var('XEN_DOM0_MEM', '4096M');
     assert_script_run "sed -i '/GRUB_CMDLINE_XEN_DEFAULT/c\\GRUB_CMDLINE_XEN_DEFAULT=\"\$GRUB_CMDLINE_XEN_DEFAULT dom0_mem=$xen_dom0_mem\"' /etc/default/grub";
+    assert_script_run "sed -i '/GRUB_DEFAULT/c\\GRUB_DEFAULT=\"2\"' /etc/default/grub";
     assert_script_run "cat /etc/default/grub";
     assert_script_run "grub2-mkconfig -o /boot/grub2/grub.cfg";
 

--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -49,14 +49,14 @@ sub change_desktop {
     }
     send_key_until_needlematch 'patterns-list-selected', 'tab', 10, 2;
 
-    if ((is_sle('<=12-SP1')) && (check_var("REGRESSION", "xen") || check_var("REGRESSION", "qemu"))) {
+    if (is_sle('<=12-SP1') && get_var("REGRESSION", '') =~ /xen|kvm|qemu/) {
         assert_and_click 'gnome_logo';
         send_key 'spc';
 
         assert_and_click 'xorg_logo';
         send_key 'spc';
 
-        if (check_var("REGRESSION", "qemu")) {
+        if (get_var("REGRESSION", '') =~ /kvm|qemu/) {
             assert_and_click 'kvm_logo';
             send_key 'spc';
         } elsif (check_var("REGRESSION", "xen")) {

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -48,8 +48,8 @@ sub run {
         # set serial console for xen
         set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN')                      || check_var('HOST_HYPERVISOR', 'xen'));
         set_serial_console_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE',     'kvm'));
-        set_dom0_mem('/mnt')    if (get_var('REGRESSION') && (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')));
-        set_pxe_efiboot('/mnt') if check_var('ARCH', 'aarch64');
+        adjust_for_ipmi_xen('/mnt') if (get_var('REGRESSION') && (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')));
+        set_pxe_efiboot('/mnt')     if check_var('ARCH', 'aarch64');
     }
     else {
         # avoid known issue in FIPS mode: bsc#985969

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -67,7 +67,7 @@ sub login_to_console {
         ipmitool("chassis power reset");
         reset_consoles;
         select_console 'sol', await_console => 0;
-        assert_screen([qw(grub2 grub1 prague-pxe-menu)], 90);
+        check_screen([qw(grub2 grub1 prague-pxe-menu)], 90);
     }
 
     # If a PXE menu will appear just select the default option (and save us the time)


### PR DESCRIPTION
Hello,

purposes of this pull request are to:
* Modify the `GRUB_DEFAULT` for XEN IPMI scenarios so that XEN is the default option.
* Fix `virt_autotest/login_console.pm` so even if the SOL console is black we still try the SSH.
* Repair some `get_var('REGRESSION')` expressions to accept both `kvm` and `qemu` values.

---

* Test runs: [gi-guest_developing-on-host_developing-xen](https://openqa.nue.suse.com/tests/4028583) [qam-xen-*](http://pdostal-server.suse.cz/tests/7660#dependencies)