### PR TITLE
Remove hostname_inst from ipmi jobs

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
@@ -15,7 +15,6 @@ schedule:
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues


### PR DESCRIPTION
Due to the hostname_inst is not implemented to get the correct
hostname to validate we have to remove it for now. The hostname
for the ipmi is taken from the SUT_IP variable. There is a draft
fix https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9732


- Related ticket: https://progress.opensuse.org/issues/64328
- Verification run: 
https://openqa.suse.de/tests/3975644