### PR TITLE
Remove soft failure for bsc#1089723(RESOLVED INVALID)

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -36,7 +36,8 @@ sub run {
 
     if (get_var("DUALBOOT")) {
         if (is_sle('15+')) {
-            record_soft_failure('bsc#1089723 Make sure keep the existing windows partition');
+            # Based on comment from Dev in bsc#1089723, 50GB disk is not a real-world use case for dual boot
+            # We use 50GB for dual-boot openQA testing in order to save space
             assert_screen "delete-partition";
             send_key "alt-g";
             assert_and_click "resize-or-remove-ifneeded";


### PR DESCRIPTION
Based on the comment from https://bugzilla.suse.com/show_bug.cgi?id=1089723
"A 50 GB disk is not a real-world use case; nobody needs a multi-boot setup with both Windows and Linux in a virtual machine, and no real-world disk these days has only 50 GB anymore. For any realistic disk sizes with real disks, the algorithm will work nicely."

The reason sounds reasonable, so agree with resolved as invalid.
We use 50GB for dual-boot openQA testing in order to save space.

- Related ticket: https://progress.opensuse.org/issues/64346
- Verification run: https://openqa.nue.suse.com/tests/3973577#step/partitioning/2
