### PR TITLE
Remove orphaned packages check for zdup migration cases

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -499,7 +499,6 @@ sub load_zdup_tests {
     loadtest 'boot/boot_to_desktop';
     loadtest "installation/opensuse_welcome"  if opensuse_welcome_applicable();
     loadtest 'console/check_upgraded_service' if !is_desktop;
-    loadtest 'console/orphaned_packages_check';
 }
 
 sub load_autoyast_tests {


### PR DESCRIPTION
Request to remove the orphaned packages check on zdup migration cases, we have test the orphaned packages check on Migration Regression Group cases. 

- Related ticket: https://progress.opensuse.org/issues/62975
- Verification run: 
  https://openqa.nue.suse.com/tests/3981389
  https://openqa.nue.suse.com/tests/3981391