### PR TITLE
HPC: Select suitable openmpi version

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -22,8 +22,14 @@ use registration;
 use version_utils 'is_sle';
 
 sub run {
-    my $self          = shift;
-    my $mpi           = get_required_var('MPI');
+    my $self = shift;
+    my $mpi  = get_required_var('MPI');
+    if (is_sle('<15')) {
+        $mpi = 'openmpi';
+    } elsif (is_sle('<15-SP2')) {
+        $mpi = 'openmpi2';
+    }
+
     my $mpi_c         = 'simple_mpi.c';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -16,10 +16,16 @@ use warnings;
 use testapi;
 use lockapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
     my $mpi  = get_required_var('MPI');
+    if (is_sle('<15')) {
+        $mpi = 'openmpi';
+    } elsif (is_sle('<15-SP2')) {
+        $mpi = 'openmpi2';
+    }
 
     zypper_call("in $mpi");
 


### PR DESCRIPTION
The openmpi version is different for different SLE versions.
Selectin between openmpi, openmpi2 and openmpi3 from within the mpi perl modules was deemed preferable, since creating extra testsuites for each case would increase the complexity of maintaining the tests.

- Related ticket: https://progress.opensuse.org/issues/63664
- Needles: NO NEEDLES
- Verification runs:
 
12-SP5: http://angmar.suse.de/tests/1382
12-SP4: http://angmar.suse.de/tests/1378
12-SP3: http://angmar.suse.de/tests/1374
12-SP2: http://angmar.suse.de/tests/1370

15: http://angmar.suse.de/tests/1394
15-SP1: http://angmar.suse.de/tests/1390

15-SP2: http://angmar.suse.de/tests/1366
