### PR TITLE
[WIP] Adapt yast2-nis tests for opensuse in textmode

### DIFF
--- a/schedule/yast/nis/nis_client.yaml
+++ b/schedule/yast/nis/nis_client.yaml
@@ -1,0 +1,7 @@
+---
+name:          yast2_nfs_v3_client
+description:    >
+  Multimachine nis test, client side. Configures a nis client and enables a nfs export with autofs.
+schedule:
+  - boot/boot_to_desktop
+  - x11/nis_client

--- a/schedule/yast/nis/nis_server.yaml
+++ b/schedule/yast/nis/nis_server.yaml
@@ -1,0 +1,7 @@
+---
+name:          nis_server
+description:    >
+  Multimachine nis test, server side. Configures a nis server and creates a nfs export.
+schedule:
+  - boot/boot_to_desktop
+  - x11/nis_server

--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -105,9 +105,13 @@ sub setup_verification {
 
 sub run {
     my ($self) = @_;
-    x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
-    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
-    become_root;
+    if (check_var("DESKTOP", "gnome")) {
+        x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
+        turn_off_gnome_screensaver;
+        become_root;
+    } else {
+        select_console 'root-console';
+    }
     setup_static_mm_network($setup_nis_nfs_x11{client_address});
     zypper_call 'in yast2-nis-server';
 

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -116,9 +116,14 @@ sub nfs_server_configuration {
 
 sub run {
     my ($self) = @_;
-    x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
-    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
-    become_root;
+    my ($self) = @_;
+    if (check_var("DESKTOP", "gnome")) {
+        x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
+        turn_off_gnome_screensaver;
+        become_root;
+    } else {
+        select_console 'root-console';
+    }
     setup_static_mm_network($setup_nis_nfs_x11{server_address});
     zypper_call 'in yast2-nis-server yast2-nfs-server';
     # Workarounds:


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
