### PR TITLE
Check if wicked is running for yast command line tests

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -32,8 +32,8 @@ my $module_name;
 
 sub run {
     my $self = shift;
-
     select_console 'root-console';
+    die "Wicked is not running" if (systemctl("status wicked.service", ignore_failure => 1) != 0);
     zypper_call "in yast2-network";    # make sure yast2 lan module installed
 
     # those two are for debugging purposes only


### PR DESCRIPTION
If systemctl status returns 0 then wicked is running
for any other return code die.
The funtion systemctl uses the output of the script_run. To do so
the function is called with ignore_failure enabled.


- Related ticket: https://progress.opensuse.org/issues/61901
- Verification run:
[wicked running](http://aquarius.suse.cz/tests/1985#step/yast2_lan/2)
[wicked not running](http://aquarius.suse.cz/tests/1987#step/yast2_lan/11)