### PR TITLE
LTP: Put all assets into single archive

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -280,7 +280,7 @@ sub get_ltp_tag {
         }
     }
     $tag =~ s/[^a-zA-Z0-9_@]+/-/g;
-    return $tag . '.txt';
+    return $tag;
 }
 
 # Isolate the loading of LTP tests because they often rely on newer features


### PR DESCRIPTION
This hopefully fix failure on intel on o3.

It adds new dependency Archive::Tar, but that should be ok (on
openSUSE/SLE provided by by perl package). Using it was required due
AppArmor profile restrictions.

Fixes: poo#63373

Verification run: 
* install_ltp: http://quasar.suse.cz/tests/4825#downloads, http://quasar.suse.cz/tests/4821#downloads
* tests: http://quasar.suse.cz/tests/4830, http://quasar.suse.cz/tests/4829, http://quasar.suse.cz/tests/4828
* openposix tests: http://quasar.suse.cz/tests/4827, http://quasar.suse.cz/tests/4832