### PR TITLE
publiccloud: Improve timeout handling for azure login

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -52,17 +52,10 @@ sub init {
 }
 
 sub az_login {
-    my ($self)    = @_;
-    my $max_tries = 3;
-    my $login_cmd = sprintf('az login --service-principal -u %s -p %s -t %s',
+    my ($self) = @_;
+    my $login_cmd = sprintf(q(while ! az login --service-principal -u '%s' -p '%s' -t '%s'; do sleep 10; done),
         $self->key_id, $self->key_secret, $self->tenantid);
-
-    for (1 .. $max_tries) {
-        my $ret = script_run($login_cmd);
-        return 1 if (defined($ret) && $ret == 0);
-        sleep 30;
-    }
-    die("Azure login failed!");
+    assert_script_run($login_cmd, timeout => 5 * 60);
 }
 
 sub vault_create_credentials {


### PR DESCRIPTION
Azure login sometimes takes more time. With `script_run()`, we faced the
problem that the previous command timed out, but we didn't checked for
valid shell prompt. So we messed up the shell parsing and sometimes used
the result of previous command.
With this mess shell handling, we called `az login` sometimes twice [1],
even if we already got valid login and it appears that the second call
failed :/.

- Verification run: https://openqa.suse.de/tests/3978726

[1] https://openqa.suse.de/tests/3976910
