### PR TITLE
Fix /dev/hvc0 permission denied on ppc64le

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -18,6 +18,7 @@ use Utils::Backends 'is_pvm';
 use Utils::Architectures qw(is_ppc64le is_aarch64);
 use power_action_utils 'power_action';
 use version_utils qw(is_sle is_jeos is_leap is_tumbleweed is_opensuse);
+use utils 'ensure_serialdev_permissions';
 
 
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump
@@ -313,6 +314,10 @@ sub full_kdump_check {
         configure_service('before');
     }
     check_function();
+
+    if ($stage ne 'before') {
+        ensure_serialdev_permissions;
+    }
 }
 
 1;


### PR DESCRIPTION
On ppc64le we need explicitly call ensure_serialdev_permissions  after kdump crash and boot up.

- Related ticket: https://progress.opensuse.org/issues/60662
- Needles: N/A
- Verification run:  

https://openqa.nue.suse.com/tests/4079380#step/curl_https/8
https://openqa.nue.suse.com/tests/4079381#step/curl_https/8
https://openqa.nue.suse.com/tests/4079382#step/curl_https/8
https://openqa.nue.suse.com/tests/4079383#step/curl_https/8

And the follow up mtab passed which also called select_console 'user-console'.

on X86_64:
https://openqa.nue.suse.com/tests/4096466#step/curl_https/2

with adding permission after kdump crash boot up
http://149.44.176.58/tests/4166035
http://149.44.176.58/tests/4166036