### PR TITLE
Set empty root password for mariadb > 10.4

### DIFF
--- a/data/console/test_mysql_connector.php
+++ b/data/console/test_mysql_connector.php
@@ -1,9 +1,17 @@
 <?php
-    $link = mysqli_connect('localhost', 'root', '', 'openQAdb');
-    $result = mysqli_query($link, "SELECT * FROM test");
-    while($row = mysqli_fetch_assoc($result)){
-        echo $row['entry'];
-    }
-    mysqli_query($link, "INSERT INTO test (entry) VALUE ('can php write this?')");
+ini_set('display_errors', 1);
+ini_set('html_errors', 0);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+$link = mysqli_connect('localhost', 'root', '', 'openQAdb');
+$result = mysqli_query($link, "SELECT * FROM test");
+
+while($row = mysqli_fetch_assoc($result)){
+    echo $row['entry'];
+}
+
+mysqli_query($link, "INSERT INTO test (entry) VALUE ('can php write this?')");
+
 ?>
 

--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -1,6 +1,6 @@
 # SUSE's Apache tests
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -1,4 +1,4 @@
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -49,6 +49,7 @@ use constant {
           is_using_system_role
           is_using_system_role_first_flow
           requires_role_selection
+          check_version
           )
     ],
     BACKEND => [

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -23,6 +23,9 @@ subtest 'check_version' => sub {
     for (qw(=1.3+ >1.3+ <>1.3 > 12 abc)) {
         dies_ok { version_utils::check_version($_, '12-sp3') } "check $_, 12-sp3";
     }
+
+    ok version_utils::check_version($_, '10.5.0-Maria'), "check $_, 15.5"   for qw(>10.4.4 10.4+ >=10.4-Maria >10.3.0-MySQL);
+    ok !version_utils::check_version($_, '10.5.1'),      "check $_, 10.5.1" for qw(=10.4.9 <10.5.0);
 };
 
 subtest 'is_caasp' => sub {

--- a/tests/console/php7_mysql.pm
+++ b/tests/console/php7_mysql.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/console/php7_mysql.pm
+++ b/tests/console/php7_mysql.pm
@@ -29,11 +29,16 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
+use registration qw(add_suseconnect_product get_addon_fullname);
 use apachetest;
 
 sub run {
     select_console 'root-console';
-
+    if (is_sle) {
+        add_suseconnect_product(get_addon_fullname('serverapp'));
+        add_suseconnect_product(get_addon_fullname('wsm'));
+    }
     setup_apache2(mode => 'PHP7');
     # install requirements
     zypper_call "in php7-mysql mysql sudo";


### PR DESCRIPTION
MariaDB 10.4 changed the default authentication plugin to unix_socket,
meaning that default or traditional method of connecting using a empty
root password from localhost, does not work anymore, unless that
password is updated.

Export check_versions routine from version_utils
Enable error reporting in PHP+MySQL test code
Install dependencies for php7_mysql on SLE

See https://bugzilla.suse.com/show_bug.cgi?id=1165151#c26

VR:
 * [SLE 15 SP2](http://phobos.suse.de/tests/3856923#)
 * [SLE 15 SP1](http://phobos.suse.de/tests/3856927)
 * [LEAP 15.1](http://phobos.suse.de/tests/3856929)
 * [Tumbleweed](http://phobos.suse.de/tests/3856924)