### PR TITLE
Increase registration timeout

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -165,7 +165,7 @@ sub run {
         if ($self->process_unsigned_files([qw(inst-addon addon-products)])) {
             assert_screen_with_soft_timeout(
                 [qw(inst-addon addon-products)],
-                timeout      => 60,
+                timeout      => check_var('BACKEND', 'pvm_hmc') ? 240 : 60,
                 soft_timeout => 30,
                 bugref       => 'bsc#1123963');
         }


### PR DESCRIPTION
PowerVM HMC sporadically needs more time to finish registration.
Since there is already a soft-fail in place for more than 30 seconds,
the maximal timeout can be increased for all cases.

- Related ticket: https://progress.opensuse.org/issues/62699
- Verification run:
  - 120 seconds not enough: https://openqa.suse.de/tests/3978693
  - 180 seconds not enough: https://openqa.suse.de/tests/3978737
  - 240 seconds looks good: https://openqa.suse.de/tests/3979562
