### PR TITLE
WIP: Revert "Remove hostname_inst from ipmi jobs"

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@hmc+ipmi.yaml
@@ -15,6 +15,7 @@ schedule:
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
+  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues


### PR DESCRIPTION
This reverts commit b4fec1a42f094c0fe6217c05845d1b5c458283f4.


- Related ticket: https://progress.opensuse.org/issues/64328

