### PR TITLE
Public Cloud: Increase bootime limits

### DIFF
--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -99,9 +99,9 @@ sub run {
     my $thresholds = {
         # First boot after provisioning
         kernel     => 15,
-        userspace  => 60,
-        initrd     => 10,
-        overall    => 120,
+        userspace  => 90,
+        initrd     => 20,
+        overall    => 160,
         ssh_access => 60,
 
         # Values after soft reboot


### PR DESCRIPTION
Some images take longer to boot and if developers
agree that the bootup time is ok we should not raise a bug
when this happens.

See bsc#1165722 for more info
