### PR TITLE
WIP: Integrate hostname checks for ipmi

### DIFF
--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -27,6 +27,13 @@ sub run {
         # got from environment (DHCP, 'hostname=' as a kernel cmd line argument
         assert_script_run "test \"\$(hostname)\" == \"$expected_install_hostname\"";
     }
+    elsif (check_var("BACKEND", "ipmi")) {
+        my $host_name = script_output "hostname";
+        record_info "$host_name";
+        if ($host_name =~ /(?<host_found>(^openqaipmi5|^fozzie-1))/) {
+            assert_script_run "test \"\$(hostname)\" == \"$+{host_found}\"/";
+        }
+    }
     else {
         # 'install' is the default hostname if no hostname is get from environment
         assert_script_run 'test "$(hostname)" == "install"';


### PR DESCRIPTION
The ipmi machines contains SUT_IP hostnames. those are openqaipmi5 for
grenache-1 and fozzie-1 for openqaworker2.


- Related ticket: https://progress.opensuse.org/issues/64328
- Verification run: 
[64bit-ipmi](https://openqa.suse.de/t3978944)
[package-dependency testing breaking changes](http://aquarius.suse.cz/tests/2004)