### PR TITLE
Extract filesystem probing subroutine to library

### DIFF
--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -29,6 +29,24 @@ sub yast2_console_exec {
     }
 }
 
+sub ncurses_filesystem_probing {
+    my $exit_needle = pop();
+
+    assert_screen([('fs-probing-failed', $exit_needle)], 300);
+    return unless (match_has_tag('fs-probing-failed'));
+
+    assert_screen 'fs-probing-details-btn';
+    send_key 'alt-d';
+
+    my $keymapping = {'probing-error' => 'ret', 'fs-probing-failed' => 'alt-i'};
+    foreach (qw(probing-error fs-probing-failed)) {
+        assert_screen $_;
+        send_key $keymapping->{$_};
+    }
+
+    assert_screen($exit_needle);
+}
+
 sub post_run_hook {
     my ($self) = @_;
 

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -15,15 +15,15 @@
 # - Wait to yast2 to finish (initrd regenerated)
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
-use base "y2_module_consoletest";
-
 use strict;
+use base 'y2_module_consoletest';
 use warnings;
 use testapi;
 use utils;
 use Utils::Backends 'is_hyperv';
 
 sub run {
+    my $self = shift;
     select_console 'root-console';
 
     # make sure yast2 bootloader module is installed
@@ -33,18 +33,7 @@ sub run {
 
     # YaST2 prompts user to install missing packages found during storage probing.
     # Otherwise YaST2 shows bootloader settings options
-    assert_screen([qw(test-yast2_bootloader-1 fs-probing-failed)], 300);
-
-    if (match_has_tag('fs-probing-failed')) {
-        send_key 'alt-d';
-
-        my $keymapping = {'probing-error' => 'ret', 'fs-probing-failed' => 'alt-i'};
-        foreach (qw(probing-error fs-probing-failed)) {
-            assert_screen $_;
-            send_key $keymapping->{$_};
-        }
-        assert_screen 'test-yast2_bootloader-1';
-    }
+    $self->ncurses_filesystem_probing('test-yast2_bootloader-1');
 
     # OK => Close
     send_key "alt-o";

--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -15,8 +15,8 @@
 #
 # Maintainer: Veronika Svecova <vsvecova@suse.com>
 
-use base "y2_module_consoletest";
 use strict;
+use base 'y2_module_consoletest';
 use warnings;
 use testapi;
 use utils;
@@ -105,8 +105,10 @@ sub run {
     }
 
     assert_screen 'add-vlan-selected';
-    send_key "alt-n";    # next
-    assert_screen 'edit-network-card';
+    # next
+    send_key "alt-n";
+    # YaST2 starts filesystem probing after adding VLAN device
+    $self->ncurses_filesystem_probing('edit-network-card');
     send_key "alt-y";    # set dynamic address
     assert_screen 'dynamic-address-selected';
     send_key "alt-n";    # next


### PR DESCRIPTION
- Related ticket: [[opensuse][JeOS] adapt yast2_lan_device_settings for filesystem probing](https://progress.opensuse.org/issues/64409)
- Verification runs: 
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20200309-jeos-extra@64bit_virtio-2G](http://eris.suse.cz/tests/4850)
  * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build27.4-jeos-extra@64bit_virtio-2G](http://eris.suse.cz/tests/4851)
