### PR TITLE
Wait more time for rollback.service to be active

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -161,8 +161,8 @@ sub check_rollback_system {
     # Check SUSEConnect status for SLE
     # check rollback-helper service is enabled and worked properly
     # If rollback service is activating, need wait some time
-    # Add wait in a loop, max time is 5 minute, because case with much more modules need more time
-    for (1 .. 5) {
+    # Add wait in a loop, max time is 10 minute, because case with much more modules need more time
+    for (1 .. 10) {
         last unless script_run('systemctl --no-pager status rollback') != 0;
         sleep 60;
     }


### PR DESCRIPTION
With more modules on SLE15SP2, we need more time to wait the rollback.service to be active.

- Related ticket: https://progress.opensuse.org/issues/64391
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/3981404

From verify log we can see the rollback.service will be active around 7m,  http://openqa.nue.suse.com/tests/3981404#step/snapper_rollback/51. While we can set it a bit larger to ensure rollback in active state, we can decrease it later after we collecting enough proof that it can be ready in lesser time.