### PR TITLE
Set initiator to automatic startup after configuration

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -69,7 +69,7 @@ sub initiator_discovered_targets_tab {
     # next and press connect button
     send_key "alt-n";
     assert_and_click 'iscsi-initiator-connect-button';
-    assert_screen 'iscsi-initiator-connect-manual';
+    send_key_until_needlematch 'iscsi-initiator-connect-automatic', 'down';
     send_key 'alt-o';
     assert_screen 'iscsi-initiator-discovery-enable-login-auth';
     send_key 'alt-u';
@@ -116,6 +116,7 @@ sub run {
     record_info 'Systemd', 'Verify status of iscsi services and sockets';
     systemctl("is-active iscsid.service");
     systemctl("is-active iscsid.socket");
+    systemctl("is-active iscsiuio.socket");
     if (!is_sle('=12-SP4') && !is_sle('=12-SP5')) {
         systemctl("is-active iscsi.service");
     }


### PR DESCRIPTION
in the service widget it was selected to "restart" the service with the "on_boot" after reboot option.
But then the test checked that the iscsid.socket was active.
In that case "on_demand" after reboot should be selected.

Then, the test checked active sessions with iscsiadm, but, the targets
were configured to be connected manually, so after restarting the services there was no sessions.
Setting this to autoatic fixes the issue with the test


- Related ticket: https://progress.opensuse.org/issues/64403
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1349
- Verification run: http://aquarius.suse.cz/tests/2040