### PR TITLE
Handle arm architecture in suse_container_urls

### DIFF
--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -31,7 +31,7 @@ sub get_opensuse_registry_prefix {
     if (check_var("VERSION", "Tumbleweed") && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
         return "opensuse/factory/totest/containers/";
     }
-    elsif (check_var("VERSION", "Tumbleweed") && check_var('ARCH', 'aarch64')) {
+    elsif (check_var("VERSION", "Tumbleweed") && (check_var('ARCH', 'aarch64') || check_var('ARCH', 'arm'))) {
         return "opensuse/factory/arm/totest/containers/";
     }
     elsif (check_var("VERSION", "Tumbleweed") && check_var('ARCH', 'ppc64le')) {
@@ -81,7 +81,7 @@ sub get_suse_container_urls {
         push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
         push @stable_names, "docker.io/opensuse/leap:${version}";
     }
-    elsif (is_leap(">15.0") && check_var('ARCH', 'aarch64')) {
+    elsif (is_leap(">15.0") && (check_var('ARCH', 'aarch64') || check_var('ARCH', 'arm'))) {
         push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/arm/images/totest/containers/opensuse/leap:${version}";
         push @stable_names, "docker.io/opensuse/leap:${version}";
     }


### PR DESCRIPTION
This will fix the incomplete on jeos-extra@aarch32 seen at https://openqa.opensuse.org/tests/1200666
- Verification run: https://openqa.opensuse.org/t1201036 => Incomplete is gone
