### PR TITLE
Adjust opensuse checks to the profile

### DIFF
--- a/data/autoyast_opensuse/opensuse_gnome.xml
+++ b/data/autoyast_opensuse/opensuse_gnome.xml
@@ -12,14 +12,6 @@
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
-  <services-manager>
-    <default_target>graphical</default_target>
-    <services>
-      <enable config:type="list">
-        <service>SuSEfirewall2</service>
-      </enable>
-    </services>
-  </services-manager>
   <software>
     <install_recommended config:type="boolean">true</install_recommended>
     <products config:type="list">

--- a/tests/console/autoyast_smoke.pm
+++ b/tests/console/autoyast_smoke.pm
@@ -33,8 +33,8 @@ sub run {
         # opensuse_gnome has simpler configuration and timezone or network are not defined
         record_info('INFO', 'Check firewall is not enabled and not running');
         my $service = opensusebasetest::firewall();
-        assert_script_run qq{systemctl status $service | grep \"inactive \(dead\)\"};
-        assert_script_run qq{systemctl is-enabled $service | grep disabled};
+        assert_script_run qq{systemctl status $service | grep \"active \(running\)\"};
+        assert_script_run qq{systemctl is-enabled $service | grep enabled};
 
         record_info('INFO', 'Verify networking');
         assert_script_run "ip link show | grep -E \"(ens|enp|eth)[0-9]\" | grep UP";


### PR DESCRIPTION
The profile has the firewall enabled by defautlt so checks moodified to
reflect the profile. In addition, i removed the section that defines
the firewall in the autoyast such as it gets its default value, which is
to be enabled.

- Related ticket: https://progress.opensuse.org/issues/64102
- Verification run: http://aquarius.suse.cz/tests/2052