### PR TITLE
Double the timeout for ib_tests

### DIFF
--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -64,7 +64,7 @@ sub ibtest_master {
     # wait until the two machines under test are ready setting up their local things
     assert_script_run('cd hpc-testing');
     barrier_wait('IBTEST_BEGIN');
-    assert_script_run("./ib-test.sh $master $slave", 1800);
+    assert_script_run("./ib-test.sh $master $slave", 3600);
 
     barrier_wait('IBTEST_DONE');
     barrier_destroy('IBTEST_SETUP');


### PR DESCRIPTION
Right now, we have a situation where many tests in the testsuite fail
(bsc#1142095), the testsuite is running for longer than 30 minutes.
However, as there may be additional bugs, we should give the testsuite a
longer runtime.

