### PR TITLE
LTP: Fix broken openposix runtest file

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -97,13 +97,13 @@ sub loadtest_from_runtest_file {
 
     mkdir($unpack_path, 0755);
     my $tar = Archive::Tar->new();
-    $tar->read("$path/runtest-files-${tag}.tar.gz") || die "tar read failed $? $!";
+    $tar->read("$path/runtest-files-$tag.tar.gz") || die "tar read failed $? $!";
     $tar->setcwd($unpack_path);
     $tar->extract() || die "tar extract failed $? $!";
 
     for my $name (split(/,/, $namelist)) {
         if ($name eq 'openposix') {
-            parse_openposix_runfile("$unpack_path/openposix-test-list-$tag", $name, $cmd_pattern, $cmd_exclude, $test_result_export);
+            parse_openposix_runfile("$unpack_path/openposix-test-list", $name, $cmd_pattern, $cmd_exclude, $test_result_export);
         }
         else {
             parse_runtest_file("$unpack_path/$name", $name, $cmd_pattern, $cmd_exclude, $test_result_export);

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -184,7 +184,7 @@ archive="\$ldir.tar.gz"
 mkdir -p \$ldir
 cd \$ldir
 ls --file-type $dir | sed "s/\\(.*\\)/ltp-\\1-$tag/" > \$ldir/ltp-runtest-files-$tag
-cp -v $dir/* ~/openposix-test-list-$tag \$ldir
+cp -v $dir/* ~/openposix-test-list \$ldir
 tar czvf \$archive *
 ls -la \$archive
 file \$archive
@@ -217,7 +217,7 @@ sub install_from_git {
     assert_script_run 'make -j$(getconf _NPROCESSORS_ONLN)', timeout => $timeout;
     script_run 'export CREATE_ENTRIES=1';
     assert_script_run 'make install', timeout => 360;
-    assert_script_run "find /opt/ltp -name '*.run-test' > ~/openposix-test-list-$tag";
+    assert_script_run "find /opt/ltp -name '*.run-test' > ~/openposix-test-list";
 }
 
 sub want_stable {
@@ -255,7 +255,7 @@ sub install_from_repo {
 
     zypper_call("in --recommends $pkg");
     script_run "rpm -qi $pkg | tee /opt/ltp_version";
-    assert_script_run q(find /opt/ltp/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > ~/openposix-test-list-) . $tag;
+    assert_script_run q(find /opt/ltp/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > ~/openposix-test-list);
 }
 
 sub setup_network {


### PR DESCRIPTION
File names are by default truncated to 100 chars, which is sometimes
not enough:
openposix-test-list-sle-12-SP2-x86_64-4-4-121-214-1-ge3bef1c-Server-DVD-Incidents-Kernel@64bit-with-

instead of
openposix-test-list-sle-12-SP2-x86_64-4-4-121-214-1-ge3bef1c-Server-DVD-Incidents-Kernel@64bit-with-ltp-qcow2

Fixes: 55a21538d ("LTP: Fix broken openposix runtest file")

Verification run:
- install_ltp: http://quasar.suse.cz/tests/4874#downloads
- ltp_openposix: http://quasar.suse.cz/tests/4875
