### PR TITLE
Add bootloader for aarch64 and 390x for desktop

### DIFF
--- a/schedule/functional/extra_tests_textmode_mod_desktop.yaml
+++ b/schedule/functional/extra_tests_textmode_mod_desktop.yaml
@@ -2,7 +2,15 @@ name:           extra_tests_textmode_mod_desktop
 description:    >
     Maintainer: dheidler.
     Extra tests about CLI software in desktop applications module
+conditional_schedule:
+    bootloader:
+        ARCH:
+            aarch64:
+                - boot/uefi_bootmenu
+            s390x:
+                - installation/bootloader_zkvm
 schedule:
+    - {{bootloader}}
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/64045