### PR TITLE
Fadump on LVM with encryption

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -257,6 +257,7 @@ sub check_function {
 
     if (get_var('FADUMP')) {
         reconnect_mgmt_console;
+        unlock_if_encrypted;
         assert_screen 'grub2', 180;
         wait_screen_change { send_key 'ret' };
     }

--- a/schedule/kernel/prepare_pvm_lvm_encrypt.yaml
+++ b/schedule/kernel/prepare_pvm_lvm_encrypt.yaml
@@ -1,0 +1,46 @@
+---
+description: >
+  Conduct installation with encrypted LVM without separate boot partition.
+  We have to disable plymouth for PowerVM, edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+name: prepare_pvm_lvm_encrypt
+vars:
+  DESKTOP: textmode
+  ENCRYPT: 1
+  FULL_LVM_ENCRYPT: 1
+  SCC_ADDONS: sdk
+  PATTERNS: base,minimal
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+schedule:
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/select_patterns
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
PoverVM  system installation is done in own separate job. Preparation job will use new YAML schedule. Existing fadump test was extended with unlock of encrypted  system after generated crash.

- Related ticket: https://progress.opensuse.org/issues/64460
- Needles: none
- Verification run:
preparation job: http://black-bit.suse.cz/tests/4173#
system unlock: http://black-bit.suse.cz/tests/4181#step/kdump_and_crash/65 