### PR TITLE
Enlarge the timeout for zypper in pattern

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -225,7 +225,7 @@ sub install_patterns {
             record_soft_failure 'bsc#1034541';
             next;
         }
-        zypper_call("in -t pattern $pt", timeout => 900);
+        zypper_call("in -t pattern $pt", timeout => 1200);
 
     }
 }


### PR DESCRIPTION
Enlarge the timeout of zypper operation

- Related ticket: https://progress.opensuse.org/issues/63901
- Needles: n/a
- Verification run: http://openqa.suse.de/t3984135

Base on the failed case, even 900 seconds is not enough