### PR TITLE
Implement tests for SELinux: semodule+setsebool

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2355,6 +2355,8 @@ sub load_security_tests_selinux {
     loadtest "security/selinux/selinux_smoke";
     loadtest "security/selinux/print_se_context";
     loadtest "security/selinux/audit2allow";
+    loadtest "security/selinux/semodule";
+    loadtest "security/selinux/setsebool";
 }
 
 sub load_security_tests_mok_enroll {

--- a/tests/security/selinux/semodule.pm
+++ b/tests/security/selinux/semodule.pm
@@ -1,0 +1,73 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test "# semodule" command with options "-l / -d / -e" can work
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#63490, tc#1741286
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    my $test_module = "apache";
+
+    $self->select_serial_terminal;
+
+    # test option "-l": list and verify some (not all as it changes often) standard modules
+    validate_script_output(
+        "semodule -lstandard",
+        sub {
+            m/
+            apache.*application.*auditadm.*authlogin.*base.*bootloader.*clock.*
+            dbus.*dmesg.*fstools.*getty.*hostname.*inetd.*init.*ipsec.*iptables.*
+            kerberos.*libraries.*locallogin.*logadm.*logging.*lvm.*
+            miscfiles.*modutils.*mount.*mta.*netlabel.*
+            netutils.*nis.*nscd.*postfix.*postgresql.*
+            secadm.*selinuxutil.*setrans.*seunshare.*ssh.*
+            staff.*su.*sudo.*sysadm.*sysadm_secadm.*sysnetwork.*
+            systemd.*udev.*unconfined.*unconfineduser.*unlabelednet.*
+            unprivuser.*userdomain.*usermanage.*xserver.*/sx
+        });
+
+    # test option "-d": to disable a module, enable it in case
+    assert_script_run("semodule -e $test_module");
+    assert_script_run("semodule -d $test_module");
+    validate_script_output("semodule -lfull | grep -w $test_module", sub { m/100\ $test_module\ .*pp\ disabled/sx });
+
+    # test option "-e": to enable a module
+    assert_script_run("semodule -e $test_module");
+    my $ret = script_run("semodule -lfull | grep -w $test_module | grep disabled");
+    if (!$ret) {
+        die "ERROR:\ \"$test_module\"\ module\ was\ not\ enabled!";
+    }
+    assert_script_run("semodule -lfull | grep -w $test_module", sub { m/100\ $test_module\ .*pp.*/sx });
+
+    # test option "-l": list all modules and verify some of them (disabled + enabled)
+    validate_script_output(
+        "semodule -lfull",
+        sub {
+            m/
+            100\ abrt.*pp\ disabled.*
+            100\ apache.*pp.*
+            100\ userdomain.*pp.*
+            100\ zosremote.*pp\ disabled.*/sx
+        });
+}
+
+1;

--- a/tests/security/selinux/setsebool.pm
+++ b/tests/security/selinux/setsebool.pm
@@ -1,0 +1,70 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test "# setsebool" command with options "-P / -N" can work
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#63751, tc#1741287
+
+use base 'opensusebasetest';
+use power_action_utils "power_action";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    my $test_boolean = "fips_mode";
+
+    $self->select_serial_terminal;
+
+    # list and verify some (not all as it changes often) boolean(s)
+    validate_script_output(
+        "getsebool -a",
+        sub {
+            m/
+            authlogin_.*\ -->\ off.*
+            daemons_.*\ -->\ off.*
+            domain_.*\ -->\ on.*
+            selinuxuser_.*\ -->\ off.*
+            selinuxuser_.*\ -->\ on.*/sx
+        });
+
+    # test option "-P": to set boolean value "off/on"
+    assert_script_run("setsebool -P $test_boolean 0");
+    validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ off/ });
+    assert_script_run("setsebool -P $test_boolean 1");
+    validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ on/ });
+
+    # reboot and check again
+    power_action("reboot", textmode => 1);
+    $self->wait_boot;
+    $self->select_serial_terminal;
+
+    validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ on/ });
+
+    # test option "-N": to set boolean value "off/on"
+    assert_script_run("setsebool -N $test_boolean 0");
+    validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ off/ });
+
+    # reboot and check again
+    power_action("reboot", textmode => 1);
+    $self->wait_boot;
+    $self->select_serial_terminal;
+
+    validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ on/ });
+}
+
+1;


### PR DESCRIPTION
Implement new tests for SELinux: semodule+setsebool
New added two test cases are PASS and introduced no issue. 

- Related ticket: 
   https://progress.opensuse.org/issues/63751
   https://progress.opensuse.org/issues/63490
- Needles: NA
- Verification run: http://openqa.nue.suse.com/t3987646 （SLE15SP2_b155.1）
