### PR TITLE
Improve user typing workaround

### DIFF
--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -37,9 +37,10 @@ sub await_password_check {
 
 sub enter_userinfo {
     my (%args) = @_;
-    $args{username} //= $realname;
+    $args{username}     //= $realname;
+    $args{max_interval} //= undef;
     send_key 'alt-f';    # Select full name text field
-    wait_screen_change { $args{retry} ? type_string_slow $args{username} : type_string $args{username} };
+    wait_screen_change { type_string($args{username}, max_interval => $args{max_interval}); };
     send_key 'tab';      # Select password field
     send_key 'tab';
     type_password_and_verification;

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -22,6 +22,7 @@ use warnings;
 use parent qw(installation_user_settings y2_installbase);
 use testapi;
 use version_utils 'is_sle';
+use utils;
 
 sub run {
     my ($self) = @_;
@@ -38,11 +39,12 @@ sub run {
     my $max_tries = 4;
     my $retry     = 0;
     do {
-        $self->enter_userinfo(retry => $retry);
+        $self->enter_userinfo(max_interval => ($retry) ? utils::VERY_SLOW_TYPING_SPEED : undef);
         assert_screen([qw(inst-userinfostyped-ignore-full-name inst-userinfostyped-expected-typefaces)]);
         record_soft_failure('boo#1122804 - Typing issue with fullname') unless match_has_tag('inst-userinfostyped-expected-typefaces');
         $retry++;
     } while (($retry < $max_tries) && !match_has_tag('inst-userinfostyped-expected-typefaces'));
+    assert_screen('inst-userinfostyped-expected-typefaces');    # fail if mistyped
 
     if (get_var('NOAUTOLOGIN') && !check_screen('autologindisabled', timeout => 0)) {
         send_key $cmd{noautologin};


### PR DESCRIPTION
Fail if workaround is not successful.
Set typing speed by caller.

- Related ticket: https://progress.opensuse.org/issues/46190
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2280#step/user_settings/6
