### PR TITLE
openSUSE supportserver: add multipath tests

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -347,6 +347,9 @@ elsif (get_var("SUPPORT_SERVER")) {
     loadtest "support_server/boot";
     loadtest "support_server/login";
     loadtest "support_server/setup";
+    loadtest "support_server/meddle_multipaths" if (get_var("SUPPORT_SERVER_TEST_INSTDISK_MULTIPATH"));
+    loadtest "support_server/custom_pxeboot"    if (get_var("SUPPORT_SERVER_PXE_CUSTOMKERNEL"));
+    loadtest "support_server/flaky_mp_iscsi"    if (get_var("ISCSI_MULTIPATH_FLAKY"));
     unless (load_slenkins_tests()) {    # either run the slenkins control node or just wait for connections
         loadtest "support_server/wait_children";
     }


### PR DESCRIPTION
Add conditional multipath test module invocations for the
supportserver like in the sle product so as to enable the
recently added multipath tests also for opensuse.

Purpose is also to comply with reviewer's demand for a Tumbleweed test run in [PR#9725](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9725).

- Related ticket: https://progress.opensuse.org/issues/50144
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/652
- Verification run: on Tumbleweed: [client](http://polya.suse.de/tests/1082), [supportserver](http://polya.suse.de/tests/1081) 
