### PR TITLE
Document IS_MM_SERVER multi machine variable

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -65,6 +65,7 @@ INSTALLONLY | boolean | false | Indicates that test suite conducts only installa
 INSTLANG | string | en_US | Installation locale settings.
 IPXE | boolean | false | Indicates ipxe boot.
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
+IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
 KEEP_ONLINE_REPOS | boolean | false | openSUSE specific variable, not to replace original repos in the installed system with snapshot mirrors which are not yet published.
 LAPTOP |||
 LINUX_BOOT_IPV6_DISABLE | boolean | false | If set, boots linux kernel with option named "ipv6.disable=1" which disables IPv6 from startup.


### PR DESCRIPTION
In the Wireguard test (see #9657) I ntroduced `IS_MM_SERVER` variable. Here I want to document it so it can slowly replace variables like `NFS4SERVER` or conditions like `if (check_var('HOSTNAME', 'server'))`