### PR TITLE
Fixes to test SAP HANA on pvm_hmc backend

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2926,7 +2926,7 @@ sub load_ha_cluster_tests {
             loadtest 'sles4sap/hana_install';
             loadtest 'sles4sap/hana_cluster';
         }
-        loadtest 'sles4sap/sap_suse_cluster_connector';
+        loadtest 'sles4sap/sap_suse_cluster_connector' if (get_var('HA_CLUSTER_INIT'));
     }
     else {
         # Test Hawk Web interface


### PR DESCRIPTION
Current SAP HANA CLI installation module when used with default settings, attempts to partition a second disk on the system per SAP's documentation only when the test is running with `BACKEND=qemu` and when the VM has a second disk defined by `HDDSIZEGB_2`. In all other cases partitioning is not performed, and HANA installation is attempted on the root FS.

This pull request extends the partitioning code to also work on backends different than `qemu` by assuming the system has an **sdb** device.

Also included in the PR is the rescheduling of the test `sles4sap/sap_suse_cluster_connector` only in the first node (as defined by `HA_CLUSTER_INIT`) of a HanaSR cluster to avoid 2 competing tests in different cluster nodes from attempting to stop and start resources at the same time. 

- Related ticket: N/A
- Needles: N/A
- Verification run: [x86_64 on qemu - regression](http://mango.suse.de/tests/2108), [ppc64le over pvm_hmc](http://mango.suse.de/tests/2117), [ppc64le over pvm_hmc, LPAR with no sdb device](http://mango.suse.de/tests/2110), [ppc64le over pvm_hmc with HANA_PARTITIONING_BY=yast](http://mango.suse.de/tests/2112)
