### PR TITLE
Follow python3 format

### DIFF
--- a/data/console/check_registration_status.py
+++ b/data/console/check_registration_status.py
@@ -29,7 +29,7 @@ if proc.returncode != 0:
 # Return the account of missing matched product
 ret = 0
 try:
-    for prod in json.loads(stdout, encoding="utf-8"):
+    for prod in json.loads(stdout.decode(), encoding="utf-8"):
         prod['base_version'] = prod['version'].split('.')[0]
         prod['result'] = 'match'
 


### PR DESCRIPTION
 JASON object must be str not 'bytes' - need follow python3 format.
Background: As we install python3 as default installation, our python script need follow python3 format

- Related ticket: https://progress.opensuse.org/issues/64484
- Verification run: 
https://openqa.nue.suse.com/tests/3994155#step/snapper_rollback/49
https://openqa.nue.suse.com/tests/3987850#step/snapper_rollback/45

[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/4335877/autoinst-log.txt)
