### PR TITLE
Add pbkdf2 parameter to fix the deprecated key derivation in openssl_fips_cipher

### DIFF
--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -1,13 +1,14 @@
 # openssl fips test
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: FIPS: In fips mode, openssl only works with the FIPS
+# Summary: FIPS: openssl_fips_cipher
+#          In fips mode, openssl only works with the FIPS
 #          approved Cihper algorithms: AES and DES3
 #
 # Maintainer: Ben Chou <bchou@suse.com>
@@ -33,23 +34,23 @@ sub run {
     assert_script_run "mkdir fips-test && cd fips-test && echo Hello > $file_raw";
 
     # With FIPS approved Cipher algorithms, openssl should work
-    my @approved_cipher = ("aes128", "aes192", "aes256", "des3");
+    my @approved_cipher = ("aes128", "aes192", "aes256", "des3", "des-ede3");
     for my $cipher (@approved_cipher) {
-        assert_script_run "openssl enc -$cipher -e -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg";
-        assert_script_run "openssl enc -$cipher -d -in $file_enc -out $file_dec -k $enc_passwd -md $hash_alg";
+        assert_script_run "openssl enc -$cipher -e -pbkdf2 -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg";
+        assert_script_run "openssl enc -$cipher -d -pbkdf2 -in $file_enc -out $file_dec -k $enc_passwd -md $hash_alg";
         validate_script_output "cat $file_dec", sub { m/^Hello$/ };
         script_run "rm -f $file_enc $file_dec";
     }
 
     # With FIPS non-approved Cipher algorithms, openssl shall report failure
-    my @invalid_cipher = ("bf", "cast5", "rc4", "seed", "des", "desx");
+    my @invalid_cipher = ("bf", "cast", "rc4", "seed", "des", "desx");
     if (is_sle('12-SP2+')) {
         push @invalid_cipher, "des-ede";
     }
     for my $cipher (@invalid_cipher) {
         validate_script_output
-          "openssl enc -$cipher -e -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 || true",
-          sub { m/disabled for fips|unknown option|Unknown cipher/ };
+          "openssl enc -$cipher -e -pbkdf2 -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 || true",
+          sub { m/disabled for fips|disabled for FIPS|unknown option|Unknown cipher/ };
     }
 
     script_run 'cd - && rm -rf fips-test';


### PR DESCRIPTION
1. Add pbkdf2 for encrypted and decrypted cipher
2. Add approved cipher: des-ede3
3. Update the unsupported cipher: cast

- Related ticket: https://progress.opensuse.org/issues/63526
- Needles: N/A
- Verification run: 
  - http://10.100.202.37/tests/630 (Kernel Mode)
  - http://10.100.202.37/tests/631 (ENV Mode) 