### PR TITLE
Remove extra screen_assertion for user_settings

### DIFF
--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -44,7 +44,6 @@ sub run {
         record_soft_failure('boo#1122804 - Typing issue with fullname') unless match_has_tag('inst-userinfostyped-expected-typefaces');
         $retry++;
     } while (($retry < $max_tries) && !match_has_tag('inst-userinfostyped-expected-typefaces'));
-    assert_screen('inst-userinfostyped-expected-typefaces');    # fail if mistyped
 
     if (get_var('NOAUTOLOGIN') && !check_screen('autologindisabled', timeout => 0)) {
         send_key $cmd{noautologin};


### PR DESCRIPTION
inst-userinfostyped-expected-typefaces tag is checked in the precedence loop.
It should not be needed outside of the workaround an extra assert_screen
If it match the tests should continue.

- Related ticket: https://progress.opensuse.org/issues/46190 fix issue caused by this 
- Verification run: https://openqa.suse.de/tests/3996551