### PR TITLE
Expect hostname by DHCP on SLE15-SP2+

### DIFF
--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,18 +18,22 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use version_utils;
 
 sub run {
     assert_screen "before-package-selection";
     select_console 'install-shell';
-    if (my $expected_install_hostname = get_var('EXPECTED_INSTALL_HOSTNAME')) {
-        # EXPECTED_INSTALL_HOSTNAME contains expected hostname YaST installer
-        # got from environment (DHCP, 'hostname=' as a kernel cmd line argument
-        assert_script_run "test \"\$(hostname)\" == \"$expected_install_hostname\"";
-    }
-    else {
-        # 'install' is the default hostname if no hostname is get from environment
-        assert_script_run 'test "$(hostname)" == "install"';
+    # NICTYPE_USER_OPTIONS="hostname=myguest" causes a fake DHCP hostname provided to SUT
+    my $NICTYPE_USER_OPTIONS      = get_required_var('NICTYPE_USER_OPTIONS');
+    my $expected_install_hostname = ($NICTYPE_USER_OPTIONS =~ s/hostname=//r);
+    # Before SLE15-SP2, yast didn't take during installation the hostname by DHCP
+    # See fate#319639
+    # 'install' is the default hostname if no hostname is get from environment
+    $expected_install_hostname = 'install' if (is_sle('<15-SP2'));
+    if (is_sle('<15-SP2') && (script_run(qq{test "\$(hostname)" == "linux"}) == 0)) {
+        record_soft_failure('bsc#1166778 - Default hostname in SLE15-SP1 is not "install"');
+    } else {
+        assert_script_run(qq{test "\$(hostname)" == "$expected_install_hostname"});
     }
     save_screenshot;
     # cleanup

--- a/variables.md
+++ b/variables.md
@@ -57,7 +57,6 @@ GRUB_SELECT_SECOND_MENU | integer | | Select grub menu entry in secondary grub m
 HASLICENSE | boolean | true if SLE, false otherwise | Enables processing and validation of the license agreements.
 HDDVERSION | string | | Indicates version of the system installed on the HDD.
 HTTPPROXY  |||
-EXPECTED_INSTALL_HOSTNAME | string | | Contains expected hostname YaST installer got from the environment (DHCP, 'hostname=' as a kernel cmd line argument)
 INSTALL_KEYBOARD_LAYOUT | string | | Specify one of the supported keyboard layout to switch to during installation or to be used in autoyast scenarios e.g.: cz, fr
 INSTALL_SOURCE | string | | Specify network protocol to be used as installation source e.g. MIRROR_HTTP
 INSTALLATION_VALIDATION | string | | Comma separated list of modules to be used for installed system validation, should be used in combination with INSTALLONLY, to schedule only relevant test modules.
@@ -88,6 +87,7 @@ NETDEV | string | | Network device to be used when adding interface on zKVM.
 NFSCLIENT | boolean | false | Indicates/enables nfs client in `console/yast2_nfs_client` for multi-machine test.
 NFSSERVER | boolean | false | Indicates/enables nfs server in `console/yast2_nfs_server`.
 NICEVIDEO |||
+NICTYPE_USER_OPTIONS | string | | `hostname=myguest` causes a fake DHCP hostname 'myguest' provided to SUT
 NOAUTOLOGIN | boolean | false | Indicates disabled auto login.
 NOIMAGES |||
 NOLOGS | boolean | false | Do not collect logs if set to true. Handy during development.


### PR DESCRIPTION
Before SLE15-SP2, yast didn't take during installation the hostname by
DHCP. See fate#319639

- Related ticket: https://progress.opensuse.org/issues/62852#note-9
- Verification runs:
  - Tumbleweed (not found)
  - [SLE15-SP2](http://openqa.slindomansilla-vm.qa.suse.de/tests/2300)
  - [SLE15-SP1](http://openqa.slindomansilla-vm.qa.suse.de/tests/2302)
  - Leap 15.2 (not found)
  - Leap 15.1 (not found)
