### PR TITLE
Update y2 fs probing

### DIFF
--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -35,16 +35,8 @@ sub ncurses_filesystem_probing {
     assert_screen([('fs-probing-failed', $exit_needle)], 300);
     return unless (match_has_tag('fs-probing-failed'));
 
-    assert_screen 'fs-probing-details-btn';
-    send_key 'alt-d';
-
-    my $keymapping = {'probing-error' => 'ret', 'fs-probing-failed' => 'alt-i'};
-    foreach (qw(probing-error fs-probing-failed)) {
-        assert_screen $_;
-        send_key $keymapping->{$_};
-    }
-
-    assert_screen($exit_needle);
+    send_key 'alt-n';
+    assert_screen($exit_needle, 60);
 }
 
 sub post_run_hook {


### PR DESCRIPTION
- Related ticket: [[functional][y][JeOS] test fails in yast2_bootloader - needs adjustement to product change, act on dialog to install missing packages
](https://progress.opensuse.org/issues/64287)
- Verification run: [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-opensuse_update_y2_fs_probing@64bit_virtio](https://openqa.opensuse.org/tests/1204535#step/yast2_bootloader/1)
