### PR TITLE
Fix base module selection

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -77,7 +77,7 @@ sub handle_all_packages_medium {
     # Also record the addons which require license agreement
     my @addons_with_license = qw(ha we);
     my @addons_license_tags = ();
-    send_key 'tab' if (check_var('VIDEOMODE', 'text'));
+    send_key_until_needlematch 'addon-base-activated', 'tab' if (check_var('VIDEOMODE', 'text'));
     for my $i (@addons) {
         next if (skip_package_hub_if_necessary($i));
         push @addons_license_tags, "addon-license-$i" if grep(/^$i$/, @addons_with_license);


### PR DESCRIPTION
Now that bsc#1157780 is fixed we have to hit `tab` only if the cursor is not already on the base module selection.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1354
- Failing test: https://openqa.suse.de/tests/3994328
- Verification run: http://1b210.qa.suse.de/tests/6348