### PR TITLE
extra_tests_textmode: Add bootloader for xen-svirt

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -9,6 +9,9 @@ conditional_schedule:
                 - boot/uefi_bootmenu
             s390x:
                 - installation/bootloader_zkvm
+        BACKEND:
+            svirt:
+                - installation/bootloader_svirt
     lshw:
         ARCH:
             x86_64:


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/64045