### PR TITLE
Add YAML schedule for systemd patches test

### DIFF
--- a/schedule/systemd/suse_patches-systemd_testsuite.yaml
+++ b/schedule/systemd/suse_patches-systemd_testsuite.yaml
@@ -1,0 +1,30 @@
+name:           suse_patches-systemd_testsuite
+description:    >
+    Maintainer: slindomansilla <slindomansilla@suse.com>
+    Modified upstream testsuite to be run as system test.
+schedule:
+    - boot/boot_to_desktop
+    - systemd_testsuite/binary_tests
+    - systemd_testsuite/test_01_basic
+    - systemd_testsuite/test_02_cryptsetup
+    - systemd_testsuite/test_03_jobs
+    - systemd_testsuite/test_04_journal
+    - systemd_testsuite/test_05_rlimits
+    - systemd_testsuite/test_07_issue_1981
+    - systemd_testsuite/test_08_issue_2730
+    - systemd_testsuite/test_09_issue_2691
+    - systemd_testsuite/test_10_issue_2467
+    - systemd_testsuite/test_11_issue_3166
+    - systemd_testsuite/test_12_issue_3171
+    - systemd_testsuite/test_13_nspawn_smoke
+    - systemd_testsuite/test_14_machine_id
+    - systemd_testsuite/test_15_dropin
+    - systemd_testsuite/test_16_extend_timeout
+    - systemd_testsuite/test_17_udev_wants
+    - systemd_testsuite/test_18_failureaction
+    - systemd_testsuite/test_19_delegate
+    - systemd_testsuite/test_20_mainpidgames
+    - systemd_testsuite/test_21_sysusers
+    - systemd_testsuite/test_22_tmpfiles
+    - systemd_testsuite/test_23_type_exec
+    - shutdown/shutdown


### PR DESCRIPTION
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9709
- Verification runs:
  - [Tumbleweed-x86_64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2303)
  - [Tumbleweed-aarch64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2304)
  - [SLE-x86_64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2305)