### PR TITLE
Only fail for fullname mistype on functional

### DIFF
--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -44,7 +44,7 @@ sub run {
         record_soft_failure('boo#1122804 - Typing issue with fullname') unless match_has_tag('inst-userinfostyped-expected-typefaces');
         $retry++;
     } while (($retry < $max_tries) && !match_has_tag('inst-userinfostyped-expected-typefaces'));
-    assert_screen('inst-userinfostyped-expected-typefaces');    # fail if mistyped
+    assert_screen('inst-userinfostyped-expected-typefaces') if (check_var('SLE_PRODUCT', 'sles') && is_sle('15-SP2+'));    # fail if mistyped
 
     if (get_var('NOAUTOLOGIN') && !check_screen('autologindisabled', timeout => 0)) {
         send_key $cmd{noautologin};


### PR DESCRIPTION
Other teams have to do extra work in order to make their tests work.
Their scenarios are covering other areas of the product so they can
ignore the mistyped fullname.

- Related PR's: 
  - https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9780
  - https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9793
- Verification runs:
  - functional group: (coming soon)
  - non-functional group: (coming soon)
