### PR TITLE
Drop java-10-openjdk

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -500,10 +500,6 @@ sub zypper_call {
         $ret = script_run("zypper -n $command $printer; ( exit \${PIPESTATUS[0]} )", $timeout);
         die "zypper did not finish in $timeout seconds" unless defined($ret);
         if ($ret == 4) {
-            if ($command =~ /^in.*java-\*$/ && script_run('grep "do not install java-" /var/log/zypper.log') == 0) {
-                record_soft_failure 'bsc#1137466';
-                last;
-            }
             if (script_run('grep "Error code.*502" /var/log/zypper.log') == 0) {
                 die 'According to bsc#1070851 zypper should automatically retry internally. Bugfix missing for current product?';
             }

--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -21,56 +21,40 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils;
+use utils qw(pkcon_quit zypper_call);
+use version_utils qw(is_sle is_leap is_opensuse);
+use registration qw(add_suseconnect_product remove_suseconnect_product);
+use main_common 'is_updates_tests';
 
 sub run {
-    select_console 'root-console';
-
+    my ($self) = @_;
+    $self->select_serial_terminal;
     # Make sure that PackageKit is not running
     pkcon_quit;
+    # if !QAM test suite then register Legacy module
+    (!!is_updates_tests || is_opensuse) || add_suseconnect_product('sle-module-legacy');
+    # Supported Java versions for sle15sp2
+    # https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP2/#development-java-versions
+    # java-11-openjdk                   -> Basesystem
+    # java-10-openjdk & java-1_8_0-ibm  -> Legacy
+    my $cmd = 'install --auto-agree-with-licenses ';
+    $cmd .= (is_sle('15+') || is_leap) ? 'java-11-openjdk* java-1_*' : 'java-*';
+    zypper_call($cmd);
 
-    if (check_var("DISTRI", "sle")) {
-        if (zypper_call('in --auto-agree-with-licenses java-*', timeout => 500, exitcode => [0, 4])) {
-            # install only java-11-openjdk* & java-*-ibm*
-            zypper_call('in --auto-agree-with-licenses java-11-openjdk* java-*-ibm*');
-        }
+    if (script_run 'rpm -q wget') {
+        zypper_call 'in wget';
     }
-
-    if (check_var("DISTRI", "opensuse")) {
-        # Capture the return code value of the following scenarios
-        my $bootstrap_pkg_rt       = zypper_call("se java-*bootstrap",                             exitcode => [0, 104]);
-        my $bootstrap_conflicts_rt = zypper_call("in --auto-agree-with-licenses --dry-run java-*", exitcode => [0, 4]);
-
-        # logs / debugging purposes
-        diag "checking variable: bootstrap_pkg_rt = $bootstrap_pkg_rt";
-        diag "checking variable: bootstrap_conflicts_rt = $bootstrap_conflicts_rt";
-
-        if ($bootstrap_pkg_rt == 0) {
-            diag "There are java bootstrap packages available to be installed";
-            print "There are java bootstrap packages available to be installed\n";
-            if ($bootstrap_conflicts_rt == 0) {
-                diag "There is no conflict installing the java bootstrap packages";
-                print "There is no conflict installing the java bootstrap packages\n";
-                zypper_call("in java-*");
-            }
-            else {
-                diag "There are conflicts with the installation of java bootstrap packages";
-                print "There are conflicts with the installation of java bootstrap packages\n";
-                record_soft_failure 'boo#1019090';
-                # Workaround: install java-* except from the problematic bootstrap packages
-                zypper_call "in `(zypper se java-* | grep -v bootstrap | grep -v 'i ' | awk '{print \$2}' | sed -n -E -e '/java/,\$ p')`";
-            }
-        }
-        else {
-            diag "There are no java bootstrap packages";
-            print "There are no java bootstrap packages\n";
-            zypper_call("in java-*");
-        }
-    }
-
-    zypper_call 'in wget';
     assert_script_run 'wget --quiet ' . data_url('console/test_java.sh');
     assert_script_run 'chmod +x test_java.sh';
     assert_script_run './test_java.sh';
+    # if !QAM test suite then cleanup test suite environment
+    (!!is_updates_tests || is_opensuse) || remove_suseconnect_product('sle-module-legacy');
 }
+
+sub post_fail_hook {
+    select_console 'log-console';
+    upload_logs '/var/log/zypper.log';
+    upload_logs '/var/log/zypp/history';
+}
+
 1;


### PR DESCRIPTION
- Related ticket: [https://progress.opensuse.org/issues/64532](https://progress.opensuse.org/issues/64532)
- Verification runs:
  * [sle-15-Server-DVD-Updates-x86_64](https://openqa.suse.de/tests/4018117)
  * [sle-15-SP1-Server-DVD-Updates-x86_64](https://openqa.suse.de/tests/4018114)
  * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64](https://openqa.suse.de/tests/4018113)
  * [sle-12-SP4-Server-DVD-Updates-x86_64](https://openqa.suse.de/tests/4018115)
  * [sle-12-SP5-Server-DVD-Updates-x86_64](https://openqa.suse.de/tests/4018116)
  * [opensuse-15.1-JeOS-for-kvm-and-xen-x86_64](https://openqa.opensuse.org/tests/1209326)
  * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64](https://openqa.opensuse.org/tests/1209327)
  * [sle-15-SP2-Online-x86_64](https://openqa.suse.de/t4019023)

* `java-*bootstrap` support has been removed.
* soft fail code for bsc#1137466 has been removed since java-10 comes from legacy module