### PR TITLE
user_settings: Not fail on mistyped user name for HPC

### DIFF
--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -35,16 +35,23 @@ sub run {
         return;
     }
 
-    # retry if not typed correctly
-    my $max_tries = 4;
-    my $retry     = 0;
-    do {
-        $self->enter_userinfo(max_interval => ($retry) ? utils::VERY_SLOW_TYPING_SPEED : undef);
+    if (check_var('SLE_PRODUCT', 'hpc')) {
+        # in case of HPC product we okay to ignore mistyped username
+        $self->enter_userinfo(max_interval => utils::VERY_SLOW_TYPING_SPEED);
         assert_screen([qw(inst-userinfostyped-ignore-full-name inst-userinfostyped-expected-typefaces)]);
-        record_soft_failure('boo#1122804 - Typing issue with fullname') unless match_has_tag('inst-userinfostyped-expected-typefaces');
-        $retry++;
-    } while (($retry < $max_tries) && !match_has_tag('inst-userinfostyped-expected-typefaces'));
-    assert_screen('inst-userinfostyped-expected-typefaces');    # fail if mistyped
+    }
+    else {
+        # retry if not typed correctly
+        my $max_tries = 4;
+        my $retry     = 0;
+        do {
+            $self->enter_userinfo(max_interval => ($retry) ? utils::VERY_SLOW_TYPING_SPEED : undef);
+            assert_screen([qw(inst-userinfostyped-ignore-full-name inst-userinfostyped-expected-typefaces)]);
+            record_soft_failure('boo#1122804 - Typing issue with fullname') unless match_has_tag('inst-userinfostyped-expected-typefaces');
+            $retry++;
+        } while (($retry < $max_tries) && !match_has_tag('inst-userinfostyped-expected-typefaces'));
+        assert_screen('inst-userinfostyped-expected-typefaces');    # fail if mistyped
+    }
 
     if (get_var('NOAUTOLOGIN') && !check_screen('autologindisabled', timeout => 0)) {
         send_key $cmd{noautologin};


### PR DESCRIPTION
After merge of #9780 we start fail test every time there is typo in username
This looks irrelevant for HPC because we not using full username anywhere. So
we okay if there is typo in username