### PR TITLE
Ignore fullname mistype with setting

### DIFF
--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -36,7 +36,7 @@ sub await_password_check {
 }
 
 sub enter_userinfo {
-    my (%args) = @_;
+    my ($self, %args) = @_;
     $args{username}     //= $realname;
     $args{max_interval} //= undef;
     send_key 'alt-f';    # Select full name text field

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -35,22 +35,21 @@ sub run {
         return;
     }
 
-    if (check_var('SLE_PRODUCT', 'hpc')) {
-        # in case of HPC product we okay to ignore mistyped username
-        $self->enter_userinfo(max_interval => utils::VERY_SLOW_TYPING_SPEED);
-        assert_screen([qw(inst-userinfostyped-ignore-full-name inst-userinfostyped-expected-typefaces)]);
-    }
-    else {
+    if (get_var('ASSERT_BSC1122804')) {
         # retry if not typed correctly
         my $max_tries = 4;
         my $retry     = 0;
         do {
-            $self->enter_userinfo(max_interval => ($retry) ? utils::VERY_SLOW_TYPING_SPEED : undef);
+            $self->enter_userinfo(max_interval => utils::VERY_SLOW_TYPING_SPEED);
             assert_screen([qw(inst-userinfostyped-ignore-full-name inst-userinfostyped-expected-typefaces)]);
             record_soft_failure('boo#1122804 - Typing issue with fullname') unless match_has_tag('inst-userinfostyped-expected-typefaces');
             $retry++;
         } while (($retry < $max_tries) && !match_has_tag('inst-userinfostyped-expected-typefaces'));
         assert_screen('inst-userinfostyped-expected-typefaces');    # fail if mistyped
+    }
+    else {
+        $self->enter_userinfo(username => 'bernhard', max_interval => utils::VERY_SLOW_TYPING_SPEED);
+        assert_screen([qw(inst-userinfostyped-ignore-full-name inst-userinfostyped-expected-typefaces)]);
     }
 
     if (get_var('NOAUTOLOGIN') && !check_screen('autologindisabled', timeout => 0)) {

--- a/variables.md
+++ b/variables.md
@@ -10,6 +10,7 @@ Variable        | Type      | Default value | Details
 ADDONS          | string    |               | Comma separated list of addons to be added using DVD. Also used to indicate addons in the SUT.
 ADDONURL        | string    |               | Comma separated list of addons. Includes addon names to get url defined in ADDONURL_*. For example: ADDONURL=sdk,we ADDONURL_SDK=https://url ADDONURL_WE=ftp://url
 ADDONURL_*      | string    |               | Define url for the addons list defined in ADDONURL
+ASSERT_BSC1122804 | boolean | false | In some scenarios it is necessary to check if the mistyped full name still happens.
 ASSERT_Y2LOGS   | boolean   | false         | If set to true, we will parse YaST logs after installation and fail test suite in case unknown errors were detected.
 AUTOCONF        | boolean   | false         | Toggle automatic configuration
 AUTOYAST        | string    |               | Full url to the AY profile or relative path if in [data directory of os-autoinst-distri-opensuse repo](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data). If value starts with `aytests/`, these profiles are provided by suport server, source code is available in [aytests repo](https://github.com/yast/aytests-tests)


### PR DESCRIPTION
Allow to ignore mistyped full name with setting `IGNORE_BSC1122804=1`

- Related ticket: https://progress.opensuse.org/issues/46190