### PR TITLE
Use select_console in remote_controller instead of alt-f7

### DIFF
--- a/tests/remote/remote_controller.pm
+++ b/tests/remote/remote_controller.pm
@@ -49,9 +49,7 @@ sub run {
     ensure_serialdev_permissions;
 
     if (check_var("REMOTE_CONTROLLER", "vnc")) {
-        select_console 'root-console';
-        # wait to change tty, in case support server sle 15, use alt-f2
-        send_key('alt-f7', 10);
+        select_console 'x11';
         x11_start_program('xterm');
         type_string "vncviewer -fullscreen $lease_ip:1\n";
         # wait for password prompt
@@ -82,4 +80,3 @@ sub test_flags {
 }
 
 1;
-


### PR DESCRIPTION
Somehow we had hardcoded key presses to switch to x11 in the remote
controller. It not only doesn't scale to SLE 15 support server (as
we need alt-f2 there), but also doesn't trigger all the logic we
have already implemented to handle login screen.

See [poo#63910](https://progress.opensuse.org/issues/63910).

- Verification run: https://openqa.opensuse.org/tests/1205882#
