### PR TITLE
Enable validation for cryptlvm+activate_existing+force_recompute

### DIFF
--- a/schedule/yast/encryption/cryptlvm+activate_existing+force_recompute.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing+force_recompute.yaml
@@ -33,3 +33,4 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+  - console/validate_encrypt


### PR DESCRIPTION
We reuse validation_encryption and test_data from cryptlvm.


- Related ticket: https://progress.opensuse.org/issues/63328
- Verification run: http://aquarius.suse.cz/tests/2070
