### PR TITLE
Check if wicked is running for yast command line tests

### DIFF
--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -15,7 +15,7 @@ use base "y2_module_consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils 'zypper_call';
+use utils qw(zypper_call systemctl);
 use repo_tools 'prepare_source_repo';
 
 # Executes the command line tests from a yast repository (in master or in the
@@ -44,7 +44,7 @@ sub run_yast_cli_test {
 
 sub run {
     select_console 'root-console';
-
+    return if (systemctl("status wicked.service", ignore_failure => 1) != 0);
     prepare_source_repo;
 
     # Install test requirement


### PR DESCRIPTION
If systemctl status returns 0 then wicked is running
for any other return code die.
The funtion systemctl uses the output of the script_run. To do so
the function is called with ignore_failure enabled.


- Related ticket: https://progress.opensuse.org/issues/61901
- Verification run: 
[nm](https://openqa.opensuse.org/tests/1206067)
[wicked](https://openqa.suse.de/tests/3995411)