### PR TITLE
Do not require NICTYPE_USER_OPTIONS

### DIFF
--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -24,12 +24,11 @@ sub run {
     assert_screen "before-package-selection";
     select_console 'install-shell';
     # NICTYPE_USER_OPTIONS="hostname=myguest" causes a fake DHCP hostname provided to SUT
-    my $NICTYPE_USER_OPTIONS      = get_required_var('NICTYPE_USER_OPTIONS');
+    # 'install' is the default hostname if no hostname is get from environment
+    my $NICTYPE_USER_OPTIONS      = get_var('NICTYPE_USER_OPTIONS', 'install');
     my $expected_install_hostname = ($NICTYPE_USER_OPTIONS =~ s/hostname=//r);
     # Before SLE15-SP2, yast didn't take during installation the hostname by DHCP
     # See fate#319639
-    # 'install' is the default hostname if no hostname is get from environment
-    $expected_install_hostname = 'install' if (is_sle('<15-SP2'));
     if (is_sle('<15-SP2') && (script_run(qq{test "\$(hostname)" == "linux"}) == 0)) {
         record_soft_failure('bsc#1166778 - Default hostname in SLE15-SP1 is not "install"');
     } else {


### PR DESCRIPTION
There are other scenarios that do not use that setting and expect the
default hostname provided by yast.

- Related ticket: https://progress.opensuse.org/issues/62852
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9795
- Verification runs:
  - [Without NICTYPE_USER_OPTIONS](http://openqa.slindomansilla-vm.qa.suse.de/tests/2316)
  - [With NICTYPE_USER_OPTIONS](http://openqa.slindomansilla-vm.qa.suse.de/tests/2317)