### PR TITLE
Ensure that ntpd/chronyd service is started/activated

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -60,6 +60,7 @@ our @EXPORT = qw(
   post_fail_hook
   test_flags
   is_not_maintenance_update
+  activate_ntp
 );
 
 # Global variables
@@ -520,6 +521,11 @@ sub is_not_maintenance_update {
         return 1;
     }
     return 0;
+}
+
+sub activate_ntp {
+    my $ntp_service = is_sle('15+') ? 'chronyd' : 'ntpd';
+    systemctl "enable --now $ntp_service.service";
 }
 
 1;

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -27,6 +27,9 @@ sub run {
     my $quorum_policy = 'stop';
     my $fencing_opt   = "-s $sbd_device";
 
+    # Ensure that ntp service is activated/started
+    activate_ntp;
+
     # If we failed to initialize the cluster, trying again but in debug mode
     # Note: the default timeout need to be increase because it can takes time to join the cluster
     # Initialize the cluster with diskless or shared storage SBD (default)

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -21,6 +21,9 @@ sub run {
     my $cluster_name = get_cluster_name;
     my $node_to_join = get_node_to_join;
 
+    # Ensure that ntp service is activated/started
+    activate_ntp;
+
     # Wait until cluster is initialized
     diag 'Wait until cluster is initialized...';
     barrier_wait("CLUSTER_INITIALIZED_$cluster_name");


### PR DESCRIPTION
On some system roles ntpd/chronyd is not always activated, which could lead to issues in HA cluster.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/3999510#step/ha_cluster_init/13
- Verification run: http://1b210.qa.suse.de/tests/6371#step/ha_cluster_init/15
