### PR TITLE
LTP: Enable s390x on o3, move bare metal setup to main_common.pm

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -64,6 +64,7 @@ our @EXPORT = qw(
   load_autoyast_clone_tests
   load_autoyast_tests
   load_ayinst_tests
+  load_baremetal_tests
   load_bootloader_s390x
   load_boot_tests
   load_common_installation_steps_tests
@@ -3146,6 +3147,24 @@ sub load_mm_autofs_tests {
             loadtest "network/autofs_client";
         }
     }
+}
+
+sub load_baremetal_tests {
+    set_var('ADDONURL', 'sdk')          if (is_sle('>=12') && is_sle('<15')) && !is_released;
+    loadtest "kernel/ibtests_barriers"  if get_var("IBTESTS");
+    loadtest "autoyast/prepare_profile" if get_var("AUTOYAST_PREPARE_PROFILE");
+    if (get_var('IPXE')) {
+        loadtest "installation/ipxe_install";
+        loadtest "console/suseconnect_scc";
+    } else {
+        load_boot_tests();
+        get_var("AUTOYAST") ? load_ayinst_tests() : load_inst_tests();
+        load_reboot_tests();
+    }
+    # make sure we always have the toolchain installed
+    loadtest "toolchain/install";
+    # some tests want to build and run a custom kernel
+    loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
 }
 
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -64,7 +64,6 @@ our @EXPORT = qw(
   load_autoyast_clone_tests
   load_autoyast_tests
   load_ayinst_tests
-  load_baremetal_tests
   load_bootloader_s390x
   load_boot_tests
   load_common_installation_steps_tests
@@ -76,6 +75,7 @@ our @EXPORT = qw(
   load_inst_tests
   load_iso_in_external_tests
   load_jeos_tests
+  load_kernel_baremetal_tests
   load_kernel_tests
   load_networkd_tests
   load_nfv_master_tests
@@ -3149,7 +3149,7 @@ sub load_mm_autofs_tests {
     }
 }
 
-sub load_baremetal_tests {
+sub load_kernel_baremetal_tests {
     set_var('ADDONURL', 'sdk')          if (is_sle('>=12') && is_sle('<15')) && !is_released;
     loadtest "kernel/ibtests_barriers"  if get_var("IBTESTS");
     loadtest "autoyast/prepare_profile" if get_var("AUTOYAST_PREPARE_PROFILE");

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -129,9 +129,10 @@ sub stress_snapshots {
 sub load_kernel_tests {
     if (get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) {
         load_kernel_baremetal_tests();
+    } else {
+        load_bootloader_s390x();
     }
 
-    load_bootloader_s390x();
     loadtest "../installation/bootloader" if is_pvm;
 
     if (get_var('INSTALL_LTP')) {

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -24,7 +24,7 @@ use Archive::Tar;
 use utils;
 use LTP::TestInfo 'testinfo';
 use File::Basename 'basename';
-use main_common qw(boot_hdd_image get_ltp_tag load_baremetal_tests load_bootloader_s390x);
+use main_common qw(boot_hdd_image get_ltp_tag load_bootloader_s390x load_kernel_baremetal_tests);
 use 5.018;
 use Utils::Backends 'is_pvm';
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
@@ -128,7 +128,7 @@ sub stress_snapshots {
 
 sub load_kernel_tests {
     if (get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) {
-        load_baremetal_tests();
+        load_kernel_baremetal_tests();
     }
 
     load_bootloader_s390x();

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -24,7 +24,7 @@ use Archive::Tar;
 use utils;
 use LTP::TestInfo 'testinfo';
 use File::Basename 'basename';
-use main_common qw(load_bootloader_s390x boot_hdd_image get_ltp_tag);
+use main_common qw(boot_hdd_image get_ltp_tag load_baremetal_tests load_bootloader_s390x);
 use 5.018;
 use Utils::Backends 'is_pvm';
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
@@ -127,6 +127,10 @@ sub stress_snapshots {
 }
 
 sub load_kernel_tests {
+    if (get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) {
+        load_baremetal_tests();
+    }
+
     load_bootloader_s390x();
     loadtest "../installation/bootloader" if is_pvm;
 

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1094,7 +1094,7 @@ sub select_serial_terminal {
         }
     } elsif (has_serial_over_ssh) {
         $console = 'root-ssh';
-    } elsif ($backend eq 'generalhw' && !has_serial_over_ssh) {
+    } elsif (($backend eq 'generalhw' && !has_serial_over_ssh) || $backend eq 's390x') {
         $console = $root ? 'root-console' : 'user-console';
     }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -17,7 +17,7 @@ use registration;
 use utils;
 use mmapi 'get_parents';
 use version_utils
-  qw(is_vmware is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem is_desktop_installed is_jeos is_released is_sle is_staging is_upgrade);
+  qw(is_vmware is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem is_desktop_installed is_jeos is_sle is_staging is_upgrade);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
@@ -530,24 +530,6 @@ sub mellanox_config {
     load_reboot_tests() if (check_var('BACKEND', 'ipmi'));
 }
 
-sub load_baremetal_tests {
-    set_var('ADDONURL', 'sdk')               if (is_sle('>=12') && is_sle('<15')) && !is_released;
-    loadtest 'tests/kernel/ibtests_barriers' if get_var('IBTESTS');
-    loadtest "autoyast/prepare_profile"      if get_var "AUTOYAST_PREPARE_PROFILE";
-    if (get_var('IPXE')) {
-        loadtest 'installation/ipxe_install';
-        loadtest "console/suseconnect_scc";
-    } else {
-        load_boot_tests();
-        get_var("AUTOYAST") ? load_ayinst_tests() : load_inst_tests();
-        load_reboot_tests();
-    }
-    # make sure we always have the toolchain installed
-    loadtest "toolchain/install";
-    # some tests want to build and run a custom kernel
-    loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
-}
-
 sub load_nfv_tests {
     loadtest "nfv/hugepages_config" if get_var('HUGEPAGES');
     mellanox_config();
@@ -615,9 +597,6 @@ if (is_jeos) {
 
 # load the tests in the right order
 if (is_kernel_test()) {
-    if (get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) {
-        load_baremetal_tests();
-    }
     load_kernel_tests();
 }
 elsif (get_var("NFV")) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -600,7 +600,7 @@ if (is_kernel_test()) {
     load_kernel_tests();
 }
 elsif (get_var("NFV")) {
-    load_baremetal_tests();
+    load_kernel_baremetal_tests();
     load_nfv_tests();
 }
 elsif (get_var("REGRESSION")) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -430,6 +430,13 @@ OpenQA is configured the ISO variable may not be necessary either.
 Either should contain 'git' or 'repo'. Git is recommended for now. If you decide
 to install from the repo then also specify QA_HEAD_REPO.
 
+=head2 LTP_BAREMETAL
+
+Loads installer modules to install OS before running install_ltp.
+
+This was originally used to install LTP on baremetal, but now used also on other
+platforms which do not support QCOW2 image snapshot (PowerVM, s390x backend).
+
 =head2 LTP_REPOSITORY
 
 When installing from repository default repository URL is generated (for SLES


### PR DESCRIPTION
Loading load_baremetal_tests() for LTP_BAREMETAL && INSTALL_LTP
was moved to main_ltp.pm which enables this fix also for openSUSE.
Although IPMI is not yet used in o3, be prepared for future.

This required to move also load_baremetal_tests(), which in turn causes
main_ltp.pm to load some modules from main_common.pm and
products/sle/main.pm to load load_baremetal_tests().

Fixes: d83486058 ("LTP: Introduce bare metal tests")

Verification run:
- opensuse-Tumbleweed-DVD-s390x https://openqa.opensuse.org/tests/1221134
- install_ltp baremetal https://openqa.suse.de/tests/4073665 https://openqa.suse.de/tests/4073666
- various QEMU intel based regression tests tests (install_ltp and actual tests) running locally (SLES, QAM, Tumbleweed; both using package and compiling from git): http://quasar.suse.cz/tests/5011, http://quasar.suse.cz/tests/5012, http://quasar.suse.cz/tests/5013, http://quasar.suse.cz/tests/5014, http://quasar.suse.cz/t5016, http://quasar.suse.cz/t5023
http://quasar.suse.cz/t5017, http://quasar.suse.cz/t5018, http://quasar.suse.cz/tests/5021