### PR TITLE
Extend cups test coverage

### DIFF
--- a/lib/services/cups.pm
+++ b/lib/services/cups.pm
@@ -81,6 +81,16 @@ sub check_function {
     record_info "access_log", "Access log should containt successful job submits";
     assert_script_run 'grep "Send-Document successful-ok" /var/log/cups/access_log';
 
+    # Check error log
+    my $error_log = "/var/log/cups/error_log";
+
+    if (script_run("test -s $error_log") == 0) {
+        record_info("error log");
+        upload_logs($error_log, failok => 1);
+
+        assert_script_run('! grep -q "Unrecoverable error" ' . "$error_log");
+    }
+
     # Remove printers
     record_info "lpadmin -x", "Removing printers";
     assert_script_run "lpadmin -x $_" foreach (qw(printer_tmp printer_null));


### PR DESCRIPTION
Due to ghostscript update causing issues in cups printing functionality,
the cups error log is now checked for unrecoverable errors.

- Related ticket: https://progress.opensuse.org/issues/58370
- Needles: No needles
- Verification runs:
http://angmar.suse.de/tests/1437#step/cups/1
http://angmar.suse.de/tests/1436#step/cups/1
http://angmar.suse.de/tests/1435#step/cups/1
http://angmar.suse.de/tests/1434#step/cups/1
http://angmar.suse.de/tests/1432#step/cups/1
http://angmar.suse.de/tests/1433#step/cups/1
http://angmar.suse.de/tests/1438#step/cups/1
