### PR TITLE
Make welcome module more stable

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -105,7 +105,6 @@ sub run {
     # Add tag to check for https://progress.opensuse.org/issues/30823 "test is
     # stuck in linuxrc asking if dhcp should be used"
     push @welcome_tags, 'linuxrc-dhcp-question';
-    ensure_fullscreen;
 
     # Process expected pop-up windows and exit when welcome/beta_war is shown or too many iterations
     while ($iterations++ < scalar(@welcome_tags)) {
@@ -146,9 +145,13 @@ sub run {
         assert_screen 'inst-betawarning';
         wait_screen_change { send_key 'ret' };
     }
+
+    ensure_fullscreen;
+
     assert_screen((is_sle('15+') && get_var('UPGRADE')) ? 'inst-welcome-no-product-list' : 'inst-welcome');
     mouse_hide;
     wait_still_screen(3);
+
 
     # license+lang +product (on sle15)
     # On sle 15 license is on different screen, here select the product


### PR DESCRIPTION
Moving the ensure_fullscreen after the handling of the popups to avoid
fulscreen popups

- Related ticket: https://progress.opensuse.org/issues/63868
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
