### PR TITLE
Introduce timeout with softfailure for accept license

### DIFF
--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -32,7 +32,7 @@ use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
-    assert_screen('license-agreement');
+    assert_screen_with_soft_timeout('license-agreement', timeout => 60, soft_timeout => 120, bugref => 'poo#63724');
     # optional checks for the extended installation
     if (get_var('INSTALLER_EXTENDED_TEST')) {
         $self->verify_license_has_to_be_accepted;


### PR DESCRIPTION
We have an issue on arm that test fails before reaching license screen
as adding repos takes longer.
We tried disabling self-update and lower logging level in order to
improve installers performance, but that didn't help.

With 120 seconds 20/20 runs have succeeded.

See [poo#63724](https://progress.opensuse.org/issues/63724).

[Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23yast&version=15-SP2&distri=sle).
