### PR TITLE
Bring back EXPECTED_INSTALL_HOSTNAME

### DIFF
--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -23,10 +23,12 @@ use version_utils;
 sub run {
     assert_screen "before-package-selection";
     select_console 'install-shell';
-    # NICTYPE_USER_OPTIONS="hostname=myguest" causes a fake DHCP hostname provided to SUT
+    # NICTYPE_USER_OPTIONS="hostname=myguest" causes a fake DHCP hostname provided by QEMU to SUT
     # 'install' is the default hostname if no hostname is get from environment
-    my $NICTYPE_USER_OPTIONS      = get_var('NICTYPE_USER_OPTIONS', 'install');
-    my $expected_install_hostname = ($NICTYPE_USER_OPTIONS =~ s/hostname=//r);
+    # but, we may expect a different hostname (linuxrc, hostname, real DHCP server pushing a hostname)
+    # from setting EXPECTED_INSTALL_HOSTNAME
+    my $expected_install_hostname = get_var('EXPECTED_INSTALL_HOSTNAME', get_var('NICTYPE_USER_OPTIONS', 'install'));
+    $expected_install_hostname =~ s/hostname=//;
     # Before SLE15-SP2, yast didn't take during installation the hostname by DHCP
     # See fate#319639
     if (is_sle('<15-SP2') && (script_run(qq{test "\$(hostname)" == "linux"}) == 0)) {

--- a/variables.md
+++ b/variables.md
@@ -42,6 +42,7 @@ DVD |||
 ENCRYPT | boolean | false | Enables or indicates encryption of the disks. Can be combine with `FULL_LVM_ENCRYPT`, `ENCRYPT_CANCEL_EXISTING`, `ENCRYPT_ACTIVATE_EXISTING` and `UNENCRYPTED_BOOT`.
 EVERGREEN |||
 EXIT_AFTER_START_INSTALL | boolean | false | Indicates that test suite will be finished after `installation/start_install` test module. So that all the test modules after this one will not be scheduled and executed.
+EXPECTED_INSTALL_HOSTNAME | string | | Contains expected hostname YaST installer got from the environment (DHCP, 'hostname=', as a kernel cmd line argument)
 EXTRABOOTPARAMS | string | | Concatenates content of the string as boot options applied to the installation bootloader.
 EXTRABOOTPARAMS_BOOT_LOCAL | string | | Boot options applied during the boot process of a local installation.
 EXTRABOOTPARAMS_DELETE_CHARACTERS | string | | Characters to delete from boot prompt.
@@ -88,7 +89,7 @@ NETDEV | string | | Network device to be used when adding interface on zKVM.
 NFSCLIENT | boolean | false | Indicates/enables nfs client in `console/yast2_nfs_client` for multi-machine test.
 NFSSERVER | boolean | false | Indicates/enables nfs server in `console/yast2_nfs_server`.
 NICEVIDEO |||
-NICTYPE_USER_OPTIONS | string | | `hostname=myguest` causes a fake DHCP hostname 'myguest' provided to SUT
+NICTYPE_USER_OPTIONS | string | | `hostname=myguest` causes a fake DHCP hostname 'myguest' provided to SUT. It is used as expected hostname if `EXPECTED_INSTALL_HOSTNAME` is not set.
 NOAUTOLOGIN | boolean | false | Indicates disabled auto login.
 NOIMAGES |||
 NOLOGS | boolean | false | Do not collect logs if set to true. Handy during development.


### PR DESCRIPTION
Some scenarios still use it.

- Related ticket: https://progress.opensuse.org/issues/62852
- Affected scenario: https://openqa.suse.de/tests/4010605
