### PR TITLE
Call enter_userinfo as a function not as a method

### DIFF
--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -36,7 +36,7 @@ sub await_password_check {
 }
 
 sub enter_userinfo {
-    my ($self, %args) = @_;
+    my (%args) = @_;
     $args{username}     //= $realname;
     $args{max_interval} //= undef;
     send_key 'alt-f';    # Select full name text field

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -40,7 +40,7 @@ sub run {
         my $max_tries = 4;
         my $retry     = 0;
         do {
-            $self->enter_userinfo(max_interval => utils::VERY_SLOW_TYPING_SPEED);
+            enter_userinfo(max_interval => utils::VERY_SLOW_TYPING_SPEED);
             assert_screen([qw(inst-userinfostyped-ignore-full-name inst-userinfostyped-expected-typefaces)]);
             record_soft_failure('boo#1122804 - Typing issue with fullname') unless match_has_tag('inst-userinfostyped-expected-typefaces');
             $retry++;
@@ -48,7 +48,7 @@ sub run {
         assert_screen('inst-userinfostyped-expected-typefaces');    # fail if mistyped
     }
     else {
-        $self->enter_userinfo(username => 'bernhard', max_interval => utils::VERY_SLOW_TYPING_SPEED);
+        enter_userinfo(username => 'bernhard', max_interval => utils::VERY_SLOW_TYPING_SPEED);
         assert_screen([qw(inst-userinfostyped-ignore-full-name inst-userinfostyped-expected-typefaces)]);
     }
 


### PR DESCRIPTION
$self is not needed and changes to make $self work are not desired.
