### PR TITLE
Apply workaround to remote controller on SLES

### DIFF
--- a/tests/remote/remote_controller.pm
+++ b/tests/remote/remote_controller.pm
@@ -19,6 +19,7 @@ use utils;
 use mm_network;
 use lockapi;
 use mmapi;
+use version_utils 'is_sle';
 
 sub run {
     my $target_ip;
@@ -49,7 +50,12 @@ sub run {
     ensure_serialdev_permissions;
 
     if (check_var("REMOTE_CONTROLLER", "vnc")) {
-        select_console 'x11';
+        if (is_sle()) {
+            select_console 'root-console';
+            send_key('alt-f7', wait_screen_change => 10);
+        } else {
+            select_console 'x11';
+        }
         x11_start_program('xterm');
         type_string "vncviewer -fullscreen $lease_ip:1\n";
         # wait for password prompt


### PR DESCRIPTION
Somehow we have weird behavior on SLE 12 SP3 support server, so as temporary solution, I keep correct behavior for opensuse, where it works fine https://openqa.opensuse.org/tests/1206955# and fixes the instability and keep old behavior for SLES, where we will have to adjust code in case SLE 15 images will be used.

[Verification run](https://openqa.suse.de/tests/4013486).