### PR TITLE
Copy required files to uSD card to chain boot RPi2 and RPi3 on USB

### DIFF
--- a/schedule/RPi_flash_firmware.yaml
+++ b/schedule/RPi_flash_firmware.yaml
@@ -1,0 +1,9 @@
+name:           RPi_flash_firmware
+description:    >
+    Copy required files to uSD card to chain boot on USB with latest firmware and u-boot with generalhw backend for RPi2 and RPi3.
+    Usage: Schedule this test suite before your actual test (e.g. jeos) by adding START_DIRECTLY_AFTER_TEST=RPi_flash_firmware
+    to your test (jeos).
+schedule:
+    - jeos/prepare_firstboot
+    - jeos/firstrun
+    - jeos/flash_rpi_firmware_workaround

--- a/tests/jeos/flash_rpi_firmware_workaround.pm
+++ b/tests/jeos/flash_rpi_firmware_workaround.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: This module copies all files required to chain boot from µSD to USB on Raspberry Pi.
+# It is currently used on:
+#   * RPi2 v1.1: as it cannot boot directly from USB at all
+#   * RPi2 v1.2 / RPi3: will use bootcode.bin only once https://github.com/raspberrypi/firmware/issues/1322 will be fixed
+# It does not support:
+#   * RPi4 : as it cannot boot from USB (USB is not supported neither in firmware, nor in u-boot)
+# Maintainer: Guillaume GARDET <guillaume@opensuse.org>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use Utils::Architectures 'is_aarch64';
+
+sub run {
+    my ($self) = @_;
+
+    select_console('root-console');
+
+    # Mount SD card
+    assert_script_run('mount /dev/mmcblk0p1 /mnt');
+
+    # Clean target
+    assert_script_run('rm -rf /mnt/*');
+    # Copy required files (firmware, firmware-config, firmware-dt, firmware-dt overlays, u-boot bin)
+    assert_script_run('rsync --recursive /boot/efi/{bootcode.bin,*.elf,*.dat,*.dtb,config.txt,u-boot.bin,overlays} /mnt/');
+    # u-boot config is only available in u-boot-rpiarm64 package for rpi3/4 to boot in 64-bit mode
+    assert_script_run('cp /boot/efi/ubootconfig.txt /mnt/') if is_aarch64;
+    # Show files
+    assert_script_run('ls /mnt/');
+
+    # Enable debug output on bootcode.bin firmware
+    assert_script_run('sed -i -e "s/BOOT_UART=0/BOOT_UART=1/" /mnt/bootcode.bin');
+
+    # Unmount SD card
+    assert_script_run('umount /mnt');
+}
+
+1;


### PR DESCRIPTION
Tested locally with 2 directly chained tests on RPi2 v1.1:
1. `RPi_flash_firmware` test: `SCHEDULE=tests/jeos/prepare_firstboot,tests/jeos/firstrun,tests/jeos/flash_rpi_firmware_workaround` or `YAML_SCHEDULE=schedule/RPi_flash_firmware.yaml`
2. `jeos` test with `START_DIRECTLY_AFTER_TEST=RPi_flash_firmware`
3. `jeos-extra` test with `START_DIRECTLY_AFTER_TEST=RPi_flash_firmware`

Background information:
* RPi2 v1.1: firmware cannot boot from USB, so you need to boot until u-boot from uSD and then use USB.
* RPi2 v1.2, RPi3B, RPi3B+: `bootcode.bin` should be able to boot from USB, but USB OTG is a bit special. See: https://github.com/raspberrypi/firmware/issues/1322