### PR TITLE
Drop yast2-trans-en_US package from AY profiles

### DIFF
--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -685,7 +685,6 @@
       <package>yast2-nis-client</package>
       <package>yast2-printer</package>
       <package>yast2-snapper</package>
-      <package>yast2-trans-en_US</package>
     </packages>
     <patterns config:type="list">
       <pattern>minimal_base</pattern>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -777,7 +777,6 @@ find / -name YaST2-Second-Stage.service
       <package>yast2-nis-client</package>
       <package>yast2-printer</package>
       <package>yast2-snapper</package>
-      <package>yast2-trans-en_US</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -449,7 +449,6 @@
       <package>yast2-nis-client</package>
       <package>yast2-printer</package>
       <package>yast2-snapper</package>
-      <package>yast2-trans-en_US</package>
       <package>yast2-x11</package>
     </packages>
     <patterns config:type="list">


### PR DESCRIPTION
As per [bsc#1167072](https://bugzilla.suse.com/show_bug.cgi?id=1167072).

[Verification run](https://openqa.suse.de/tests/4013474#).
