### PR TITLE
Handle different certificate imports

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -41,13 +41,17 @@ sub open_powershell_as_admin {
 }
 
 sub run_in_powershell {
-    my ($self, $code) = @_;
+    my ($self, %args) = @_;
 
-    type_string $code, max_interval => 125;
+    type_string $args{cmd}, max_interval => 125;
     save_screenshot;
     wait_screen_change(sub { send_key 'ret' }, 10);
-    assert_screen([qw(opened-explorer opened-wsl-image powershell-ready-prompt)], 600);
-    send_key 'ctrl-l';
+    assert_screen($args{tags}, 400);
+    if (match_has_tag 'confirm-reboot') {
+        send_key 'ret';
+    } else {
+        send_key 'ctrl-l';
+    }
 }
 
 sub reboot_or_shutdown {

--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -8,18 +8,28 @@
 # without any warranty.
 
 # Summary: Configure windows 10 to host WSL image
+# Currently we have self signed images as sle12sp5 and leap
+# tumbleweed and sle15sp2 or higher contain a chain of certificates
+# In case of chain certificates, store only CA certificate
+# 1) Download the image and CA cert if any
+# 2) Enable developer mode Import certificates
+# 3) Import downloaded or embedded certificate
+# 4) Enable WSL feature
+# 5) Reboot
+# 6) Install WSL image
 # Maintainer: Martin Loviska <mloviska@suse.com>
 
 use base 'windowsbasetest';
 use strict;
 use warnings;
 use testapi;
+use version_utils qw(is_sle is_tumbleweed);
 
 my $powershell_cmds = {
     enable_developer_mode =>
-q{reg add `"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock`" /t REG_DWORD /f /v `"AllowDevelopmentWithoutDevLicense`" /d `"1`"},
+q{New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -Name AllowDevelopmentWithoutDevLicense -PropertyType DWORD -Value 1},
     enable_wsl_feature => {
-        wsl         => q{Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Windows-Subsystem-Linux" -NoRestart},
+        wsl         => q{Enable-WindowsOptionalFeature -Online -FeatureName "Microsoft-Windows-Subsystem-Linux"},
         vm_platform => q{Enable-WindowsOptionalFeature -Online -FeatureName "VirtualMachinePlatform" -NoRestart}
     }
 };
@@ -28,63 +38,75 @@ sub run {
     my ($self)            = @_;
     my $wsl_appx_filename = get_required_var('ASSET_1');
     my $certs             = {opensuse => '/wsl/openSUSE-UEFI-CA-Certificate.crt', sle => '/wsl/SLES-UEFI-CA-Certificate.crt'};
+    my $ms_cert_store     = 'cert:\\LocalMachine\\Root';
+    my $cert_file_path    = 'C:\Users\Public\image-ca.cert';
 
     assert_screen 'windows-desktop';
-
-    # 0) Enable developer mode
     $self->open_powershell_as_admin;
-    $self->run_in_powershell($powershell_cmds->{enable_developer_mode});
 
-    # 1) Enable WSL 1 or 2
-    $self->run_in_powershell($powershell_cmds->{enable_wsl_feature}->{vm_platform}) if (get_var('some_future_var') =~ m/wsl/);
-    $self->run_in_powershell($powershell_cmds->{enable_wsl_feature}->{wsl});
+    $self->run_in_powershell(
+        cmd  => 'Invoke-WebRequest -Uri ' . data_url('ASSET_1') . ' -O C:\\' . $wsl_appx_filename . ' -UseBasicParsing',
+        tags => 'powershell-ready-prompt'
+    );
+    $self->run_in_powershell(
+        cmd  => $powershell_cmds->{enable_developer_mode},
+        tags => 'powershell-ready-prompt'
+    );
 
-    # 2) Download the image and CA cert
-    $self->run_in_powershell('Invoke-WebRequest -Uri ' . data_url('ASSET_1') . ' -O C:\\' . $wsl_appx_filename . ' -UseBasicParsing');
-    $self->run_in_powershell('Invoke-WebRequest -Uri ' . data_url($certs->{get_required_var('DISTRI')}) . ' -O C:\Users\Public\image-ca.cert -UseBasicParsing');
-    $self->run_in_powershell('Import-Certificate -FilePath C:\Users\Public\image-ca.cert -CertStoreLocation cert:\\LocalMachine\\Root -Verbose');
+    if (is_sle('>=15-sp2') || is_tumbleweed) {
+        $self->run_in_powershell(
+            cmd  => 'Invoke-WebRequest -Uri ' . data_url($certs->{get_required_var('DISTRI')}) . ' -O ' . $cert_file_path . ' -UseBasicParsing',
+            tags => 'powershell-ready-prompt'
+        );
+        $self->run_in_powershell(
+            cmd  => 'Import-Certificate -FilePath ' . $cert_file_path . ' -CertStoreLocation ' . $ms_cert_store . ' -Verbose',
+            tags => 'powershell-ready-prompt'
+        );
+    } else {
+        # a) Open the image file in Explorer
+        $self->run_in_powershell(
+            cmd  => q{ii C:\\},
+            tags => 'opened-explorer'
+        );
+        assert_and_click 'wsl-appx-file', timeout => 60, button => 'right';
+        wait_still_screen stilltime => 3, timeout => 10;
+        # b) Reach certificate installation
+        assert_and_click 'open-file-properties';
+        assert_and_click 'digital-signatures';
+        assert_and_click 'build-service-cert';
+        assert_and_click 'cert-details';
+        assert_and_click 'view-certificate-details';
+        assert_and_click 'install-certificate';
+        wait_still_screen stilltime => 3, timeout => 10;
+        assert_and_click 'install-certificate-to-local-machine';
+        wait_screen_change(sub { send_key 'ret' }, 10);
+        assert_screen 'user-acount-ctl-allow-make-changes', 20;
+        assert_and_click 'user-acount-ctl-yes';
+        wait_still_screen stilltime => 3, timeout => 10;
+        assert_and_click 'select-custom-store', timeout => 120;
+        wait_still_screen stilltime => 1, timeout => 5;
+        assert_and_click 'browse';
+        assert_and_click 'select-store-trusted-roots';
+        # confirm selected certificate store and then
+        # hit next
+        wait_screen_change(sub { send_key 'ret' }, 10) for (1 .. 2);
+        assert_screen 'completing-cert-import';
+        assert_and_click 'finish-button-in-win10';
+        assert_screen 'successful-certificate-import';
+        # close all opened windows, including powershell
+        send_key_until_needlematch 'powershell-ready-prompt', 'alt-f4', 25, 2;
+    }
 
-    # 3) Open the image file in Explorer
-    $self->run_in_powershell('ii C:\\');
-    assert_and_click 'wsl-appx-file', timeout => 60, button => 'right';
-    wait_still_screen stilltime => 3, timeout => 10;
+    # enable WSL & VM platform (WSL2) features
+    # reboot the SUT
+    $self->run_in_powershell(
+        cmd  => $powershell_cmds->{enable_wsl_feature}->{wsl},
+        tags => 'confirm-reboot'
+    );
 
-    # 4) Reach certificate installation
-    assert_and_click 'open-file-properties';
-    assert_and_click 'digital-signatures';
-    assert_and_click 'build-service-cert';
-    wait_screen_change(sub { send_key 'alt-d' }, 10);
-    assert_and_click 'view-certificate-details';
-    assert_and_click 'install-certificate';
-    wait_still_screen stilltime => 3, timeout => 10;
-    assert_and_click 'install-certificate-to-local-machine';
-    wait_screen_change(sub { send_key 'ret' }, 10);
-    assert_screen 'user-acount-ctl-allow-make-changes', 20;
-    assert_and_click 'user-acount-ctl-yes';
-    wait_still_screen stilltime => 3, timeout => 10;
-    assert_and_click 'select-custom-store', timeout => 120;
-    wait_still_screen stilltime => 1, timeout => 5;
-    assert_and_click 'browse';
-    assert_and_click 'select-store-trusted-roots';
-    # confirm selected certificate store and then
-    # hit next
-    wait_screen_change(sub { send_key 'ret' }, 10) for (1 .. 2);
-    assert_screen 'completing-cert-import';
-    assert_and_click 'finish-button-in-win10';
-    assert_screen 'successful-certificate-import';
-
-    # close all opened windows, including powershell
-    send_key_until_needlematch 'powershell-ready-prompt', 'alt-f4', 25, 2;
-    # close
-    type_string "exit", max_interval => 125;
-    send_key 'ret';
-    assert_screen 'windows-desktop';
-
-    # 5) reboot the SUT
-    $self->reboot_or_shutdown('reboot');
     $self->wait_boot_windows;
 
-    # 6) Install Linux in WSL
+    # 5) Install Linux in WSL
     $self->open_powershell_as_admin;
     type_string "C:\\$wsl_appx_filename";
     wait_still_screen stilltime => 3, timeout => 10;


### PR DESCRIPTION
- Related ticket: [[wsl] test fails in prepare_wsl_feature - misclicked details button in certificate management](https://progress.opensuse.org/issues/64631)
- Verification runs:
   * [opensuse-Tumbleweed-WSL-x86_64](https://openqa.opensuse.org/tests/1208401)
   * [sle-15-SP2-WSL-x86_64](https://openqa.suse.de/tests/4013568)
   * [opensuse-15.2-WSL-x86_64]()