### PR TITLE
Add check for test_data files in Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test-spec:
 	tools/update_spec --check
 
 .PHONY: test-static
-test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-modules test-unused-modules test-soft_failure-no-reference test-spec test-invalid-syntax
+test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-modules test-deleted-renamed-testdata detect-nonexistent-testdata test-unused-modules test-soft_failure-no-reference test-spec test-invalid-syntax
 .PHONY: test
 ifeq ($(TESTS),compile)
 test: test-compile
@@ -123,6 +123,14 @@ test-unused-modules:
 .PHONY: test-deleted-renamed-referenced-modules
 test-deleted-renamed-referenced-modules:
 	tools/test_deleted_renamed_referenced_modules `git diff --name-only --exit-code --diff-filter=DR $$(git merge-base master HEAD) | grep '^tests/*'`
+
+.PHONY: test-deleted-renamed-testdata
+test-deleted-renamed-testdata:
+	tools/test_deleted_renamed_testdata `git diff --name-only --exit-code --diff-filter=DR $$(git merge-base master HEAD) | grep '^test_data/*'`
+
+.PHONY: detect-nonexistent-testdata
+detect-nonexistent-testdata:
+	tools/detect_nonexistent_testdata `git diff --exit-code $$(git merge-base master HEAD) | grep '+  !include: test_data/' | grep 'yaml$$' | awk '{print $$3}'`
 
 .PHONY: test-soft_failure-no-reference
 test-soft_failure-no-reference:

--- a/tools/detect_nonexistent_testdata
+++ b/tools/detect_nonexistent_testdata
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+FILES="${@}"
+success=1
+for FILE in $FILES; do
+	if  ! [ -f "$FILE" ]; then
+		echo "Error! $FILE does not exist."
+		success=0
+	elif ! [ -s "$FILE" ]; then
+		echo "Warning! The test_data file $FILE is empty."
+	fi
+done
+[ $success = 1 ] && echo "SUCCESS" && exit 0
+exit 1

--- a/tools/test_deleted_renamed_testdata
+++ b/tools/test_deleted_renamed_testdata
@@ -1,0 +1,19 @@
+#!/bin/sh -e
+
+FILES="${@}"
+success=1
+for FILE in $FILES; do
+    if [ -f "$FILE" ]; then
+        # if file exists it means it was renamed, and then original file name is retrieved by git log
+        FILE=$(git log --follow -p $FILE | grep 'rename from test_data/')
+    fi
+    if MATCHED_SCHEDULE_FILES="$(grep --recursive --ignore-case --files-with-matches "$FILE\b" schedule/)"
+    then
+        echo -e "\"$FILE\" test data file was removed or renamed, but it is still used in: \
+        \n$MATCHED_SCHEDULE_FILES\n"
+        success=0
+    fi
+done
+[ $success = 1 ] && echo "SUCCESS" && exit 0
+exit 1
+


### PR DESCRIPTION
Add check in Travis for detecting non existent test_data files included in yaml schedule and check for deleting/renaming test_data files that are still in use.

- [Related ticket](https://progress.opensuse.org/issues/63331)
- [Verification run for renamed/deleted](https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/jobs/664847482?utm_medium=notification&utm_source=github_status)
- [Verification run for non existent data](https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/jobs/664799883?utm_medium=notification&utm_source=github_status)
