### PR TITLE
User defined snapshot

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -36,7 +36,6 @@ our @EXPORT = qw(
   record_disk_info
   check_rollback_system
   reset_consoles_tty
-  boot_into_ro_snapshot
   set_scc_proxy_url
 );
 
@@ -183,27 +182,6 @@ sub reset_consoles_tty {
     console('x11')->set_tty(get_x11_console_tty);
     console('root-console')->set_tty(get_root_console_tty);
     reset_consoles;
-}
-
-# Assert read-only snapshot before migrated
-# Assert screen 'linux-login' with 200s
-# Workaround known issue: bsc#980337
-# In this case try to select tty1 with multi-times then select root console
-sub boot_into_ro_snapshot {
-    unlock_if_encrypted(check_typed_password => 1);
-    if (!check_screen('linux-login', 200)) {
-        record_soft_failure 'bsc#980337';
-        for (1 .. 10) {
-            check_var('VIRSH_VMM_FAMILY', 'hyperv') ? send_key 'alt-f1' : send_key 'ctrl-alt-f1';
-            if (check_screen('tty1-selected', 12)) {
-                return 1;
-            }
-            else {
-                record_info('not in tty1', 'switch to tty1 failed', result => 'softfail');
-            }
-        }
-        die "Boot into read-only snapshot failed over 5 minutes, considering a product issue";
-    }
 }
 
 # Register the already installed system on a specific SCC server/proxy if needed

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -381,7 +381,7 @@ sub is_sle12_hdd_in_upgrade {
 Returns true if a desktop is installed
 =cut
 sub is_desktop_installed {
-    return get_var("DESKTOP") !~ /textmode|minimalx/;
+    return get_var("DESKTOP") !~ /textmode/;
 }
 
 =head2 is_system_upgrading

--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,13 +15,14 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use migration qw(check_rollback_system);
+use migration 'check_rollback_system';
 use power_action_utils 'power_action';
 
 sub run {
     my ($self) = @_;
 
     $self->wait_boot_past_bootloader(textmode => 1);
+    select_console 'root-console';
     # 1)
     script_run('touch NOWRITE;test ! -f NOWRITE', 0);
     # 1b) just debugging infos
@@ -31,7 +32,7 @@ sub run {
     script_run("snapper rollback -d rollback-before-migration");
     assert_script_run("snapper list | tail -n 2 | grep rollback", 180);
     power_action('reboot', textmode => 1, keepconsole => 1);
-    $self->wait_boot(ready_time => 300, bootloader_time => 300);
+    $self->wait_boot(ready_time => 300, bootloader_time => 300, textmode => 1);
     select_console 'root-console';
     check_rollback_system;
 }

--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -15,14 +15,13 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use migration qw(check_rollback_system boot_into_ro_snapshot);
+use migration qw(check_rollback_system);
 use power_action_utils 'power_action';
 
 sub run {
     my ($self) = @_;
 
-    boot_into_ro_snapshot;
-    select_console 'root-console';
+    $self->wait_boot_past_bootloader(textmode => 1);
     # 1)
     script_run('touch NOWRITE;test ! -f NOWRITE', 0);
     # 1b) just debugging infos

--- a/tests/migration/sle12_online_migration/snapper_rollback.pm
+++ b/tests/migration/sle12_online_migration/snapper_rollback.pm
@@ -1,6 +1,6 @@
 # SLE12 online migration tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,18 +16,18 @@ use warnings;
 use testapi;
 use power_action_utils 'power_action';
 use version_utils 'is_desktop_installed';
-use migration qw(check_rollback_system boot_into_ro_snapshot);
+use migration 'check_rollback_system';
 
 sub run {
     my ($self) = @_;
 
-    boot_into_ro_snapshot;
+    $self->wait_boot_past_bootloader(textmode => 1);
     select_console 'root-console';
     script_run "snapper rollback";
 
     # reboot into the system before online migration
     power_action('reboot', textmode => 1, keepconsole => 1);
-    $self->wait_boot(textmode => !is_desktop_installed);
+    $self->wait_boot(textmode => 1);
     select_console 'root-console';
 
     check_rollback_system;

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -67,7 +67,7 @@ sub run {
     wait_serial("$module_name-0", 200) || die "'yast2 $module_name' didn't finish";
     $self->{in_wait_boot} = 1;
     record_info 'Snapshot created', 'booting the system into created snapshot';
-    power_action('reboot', keepconsole => 1, observe => is_remote_backend);
+    power_action('reboot');
     $self->wait_grub(bootloader_time => 250);
     send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
     send_key 'ret';
@@ -84,11 +84,11 @@ sub run {
     record_info 'Snapshot found', 'Waiting to boot the system';
     # boot into the snapshot
     # do not try to search for the grub menu again as we are already here
-    $self->wait_boot(textmode => $is_textmode, in_grub => 1);
+    $self->wait_boot(in_grub => 1);
     # request reboot again to ensure we will end up in the original system
     record_info 'Desktop reached', 'Now return system to original state with a reboot';
-    power_action('reboot', keepconsole => 1, observe => is_remote_backend);
-    $self->wait_boot(textmode => $is_textmode, in_grub => 1, bootloader_time => 250);
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(bootloader_time => 250);
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/60779
- Verification run:
WIP
https://openqa.suse.de/tests/4014439 15sp2 HA
https://openqa.suse.de/tests/4017761 15sp1 user_defined_snapshot
https://openqa.suse.de/tests/4017759 15 user_defined_snapshot
https://openqa.suse.de/tests/4014813 12sp5 user_defined_snapshot
https://openqa.suse.de/tests/4017757 12sp4 user_defined_snapshot
https://openqa.suse.de/tests/4017756 12sp3 user_defined_snapshot
http://10.100.12.155/tests/14795#step/zypper_migration/14 15sp2 HPC online_*_full_zypp migration
http://10.100.12.155/tests/14794#step/yast2_migration/14 15sp2 HPC online_*_full_yast migration
http://10.100.12.155/tests/14819#step/snapper_rollback/11 15sp2 HPC offline_*_def_full migration
http://10.100.12.155/tests/14813#step/opensuse_welcome/1 opensuse staging kde
http://10.100.12.155/tests/14811#step/first_boot/1 opensuse staging upgrade_staging
http://10.100.12.155/tests/14806#step/first_boot/1 opensuse staging cryptlvm
http://10.100.12.155/tests/14818#step/first_boot/1 opensuse staging cryptlvm uefi
http://10.100.12.155/tests/14805#step/first_boot/1 opensuse staging textmode
http://10.100.12.155/tests/14802#step/first_boot/1 opensuse staging autoyast_mini
http://10.100.12.155/tests/14790#step/first_boot/1 opensuse 15.2 gnome-gdm
