### PR TITLE
Fix ssh terminal part of sshd test module

### DIFF
--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -43,14 +43,13 @@ sub ssh_interactive_tunnel {
 }
 
 sub ssh_interactive_join {
-    # Prepare the environment to use the SSH tunnel for upload/download from the worker
-    #set_var('SUT_HOSTNAME',          script_output('sed -n "s/^  Hostname \([0-9.]*\)$/\1/p" ~/.ssh/config'));
-    set_var('AUTOINST_URL_HOSTNAME', 'localhost');
-    set_sshserial_dev();
-
     # Open SSH interactive session and check the serial console works
     type_string("ssh -t sut\n");
-    wait_serial("ssh_serial_ready", 90);
+    wait_serial("ssh_serial_ready", 90) if (get_var("AUTOINST_URL_HOSTNAME", '') !~ /localhost/);
+
+    # Prepare the environment to use the SSH tunnel for upload/download from the worker
+    set_var('AUTOINST_URL_HOSTNAME', 'localhost');
+    set_sshserial_dev();
 
     $testapi::distri->set_standard_prompt('root');
 }

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -69,9 +69,9 @@ sub run {
         type_string "ssh -v -l $ssh_testman localhost -t\n";
         wait_serial('Are you sure you want to continue connecting \(yes/no(/\[fingerprint\])?\)\?', undef, 0, no_regex => 0);
         type_string "yes\n";
-        wait_serial('Password:', undef, 0, no_regex => 1);
+        wait_serial('[P|p]assword:', undef, 0, no_regex => 0);
         type_string "$ssh_testman_passwd\n";
-        wait_serial('sshboy@susetest:~>', undef, 0, no_regex => 1);
+        wait_serial('sshboy@', undef, 0, no_regex => 1);
         type_string "export PS1='# '\n";
 
         # Check that we are really in the SSH session


### PR DESCRIPTION
Hello, this fix mitigates 'hidden failures' of the serial terminal part of `sshd.pm` test module.
This also speeds the whole test module up, I measured progress from approx. 7 to 2 minutes.

- Related ticket: [poo#63532](https://progress.opensuse.org/issues/63532)
- Verification run:
   * [SLES12SP1@mau-extratests@64bit](http://pdostal-server.suse.cz/tests/7801)
   * [SLES15SP1@mau-extratests@64bit](http://pdostal-server.suse.cz/tests/7798)
   * [SLES12SP4@mau-extratests-pibliccloud@GCE](http://pdostal-server.suse.cz/tests/7800)
   * [SLES15SP1@mau-extratests-publiccloud@EC2](http://pdostal-server.suse.cz/tests/7799)