### PR TITLE
HPC: Add barrier to wait for slave nodes

### DIFF
--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -58,9 +58,10 @@ sub run {
         barrier_create('GANGLIA_GMOND_STARTED',  $nodes);
     }
     elsif (check_var('HPC', 'mpi')) {
-        barrier_create('MPI_SETUP_READY',    $nodes);
-        barrier_create('MPI_BINARIES_READY', $nodes);
-        barrier_create('MPI_RUN_TEST',       $nodes);
+        barrier_create('CLUSTER_PROVISIONED', $nodes);
+        barrier_create('MPI_SETUP_READY',     $nodes);
+        barrier_create('MPI_BINARIES_READY',  $nodes);
+        barrier_create('MPI_RUN_TEST',        $nodes);
     }
     elsif (check_var('HPC', 'hpc_comprehensive')) {
         if (get_var('HPC_MIGRATION')) {

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -42,6 +42,7 @@ sub run {
     zypper_call("in $mpi $mpi-devel gcc");
     assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
 
+    barrier_wait('CLUSTER_PROVISIONED');
     ## all nodes should be able to ssh to each other, as MPIs requires so
     $self->generate_and_distribute_ssh();
 

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -29,6 +29,7 @@ sub run {
 
     zypper_call("in $mpi");
 
+    barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
     barrier_wait('MPI_BINARIES_READY');
     barrier_wait('MPI_RUN_TEST');


### PR DESCRIPTION
The master node should wait for all the slave nodes before attempting
to distribute ssh keys