### PR TITLE
Increase timeout for unlock of encrypted disk for pvm backend

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -16,7 +16,7 @@ use testapi qw(is_serial_terminal :DEFAULT);
 use strict;
 use warnings;
 use utils;
-use Utils::Backends 'has_serial_over_ssh';
+use Utils::Backends qw(has_serial_over_ssh is_pvm);
 use lockapi 'mutex_wait';
 use serial_terminal 'get_login_message';
 use version_utils qw(is_sle is_leap is_upgrade is_aarch64_uefi_boot_hdd is_tumbleweed is_jeos is_sles4sap is_desktop_installed);
@@ -618,7 +618,7 @@ sub wait_grub {
     elsif (match_has_tag('encrypted-disk-password-prompt')) {
         # unlock encrypted disk before grub
         workaround_type_encrypted_passphrase;
-        assert_screen "grub2", 90;
+        assert_screen("grub2", timeout => ((is_pvm) ? 300 : 90));
     }
     mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');
 }


### PR DESCRIPTION
There is sometimes need for increased timeout on PoweVM for unlocking of encrypted disk after is password entered and occurrence of grub menu. Timeout for pvm backend is set to 300s and rest keeps original 90s.

- Related ticket: https://progress.opensuse.org/issues/64460
- Needles: none
- Verification run:
pvm: http://10.100.12.105/tests/4560#step/system_reboot/4
```
[2020-03-20T12:28:10.234 CET] [debug] tests/kernel/system_reboot.pm:11 called opensusebasetest::wait_boot -> lib/opensusebasetest.pm:980 called opensusebasetest::handle_grub -> lib/opensusebasetest.pm:784 called opensusebasetest::wait_grub -> lib/opensusebasetest.pm:621 called testapi::assert_screen
[2020-03-20T12:28:10.234 CET] [debug] <<< testapi::assert_screen(mustmatch="grub2", timeout=300)
```
x86_64: http://10.100.12.105/tests/4561#step/kdump_and_crash/14
```
[2020-03-20T12:27:30.345 CET] [debug] tests/boot/boot_to_desktop.pm:42 called opensusebasetest::wait_boot -> lib/opensusebasetest.pm:980 called opensusebasetest::handle_grub -> lib/opensusebasetest.pm:784 called opensusebasetest::wait_grub -> lib/opensusebasetest.pm:621 called testapi::assert_screen
[2020-03-20T12:27:30.345 CET] [debug] <<< testapi::assert_screen(mustmatch="grub2", timeout=90)
```
