### PR TITLE
Adapt schedule/vagrant.yaml to handle tests on generalhw on top of a JeOS image

### DIFF
--- a/schedule/vagrant.yaml
+++ b/schedule/vagrant.yaml
@@ -4,7 +4,7 @@ description:    >
 vars:
     QEMUCPU: host
 schedule:
-  - boot/boot_to_desktop
+  - {{boot_to_desktop}}
   - {{add_box_virtualbox}}
   - virtualization/vagrant/add_box_libvirt
   - virtualization/vagrant/sshfs
@@ -14,3 +14,10 @@ conditional_schedule:
     ARCH:
       x86_64:
         - virtualization/vagrant/add_box_virtualbox
+  boot_to_desktop:
+    BACKEND:
+      qemu:
+        - boot/boot_to_desktop
+      generalhw:
+        - jeos/prepare_firstboot
+        - jeos/firstrun


### PR DESCRIPTION
- Verification run: 
  * Tumbleweed `extra_tests_vagrant@64bit`: https://openqa.opensuse.org/t1209292
  * locally for generalhw part
