### PR TITLE
Adjust kdump memory if QEMURAM < 2GB and also soft-fail for aarch64

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -15,7 +15,7 @@ use testapi;
 use utils;
 use registration;
 use Utils::Backends 'is_pvm';
-use Utils::Architectures 'is_ppc64le';
+use Utils::Architectures qw(is_ppc64le is_aarch64);
 use power_action_utils 'power_action';
 use version_utils qw(is_sle is_jeos is_leap is_tumbleweed is_opensuse);
 
@@ -121,18 +121,18 @@ sub activate_kdump {
     zypper_call('rm -y ruby2.1-rubygem-nokogiri', exitcode => [0, 104]);
     # get kdump memory size bsc#1161421
     my $memory_total = script_output('kdumptool  calibrate | awk \'/Total:/ {print $2}\'');
-    my $memory_kdump = $memory_total >= 2048 ? 1024 : 640;
+    my $memory_kdump = $memory_total >= 2048 ? 1024 : 320;
     my $memory_kdump_set;
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'kdump', yast2_opts => '--ncurses');
     my @tags = qw(yast2-kdump-unexpected-issue yast2-kdump-disabled yast2-kdump-enabled yast2-kdump-restart-info yast2-missing_package yast2_console-finished);
     do {
         assert_screen \@tags, 300;
         # ppcl64e needs increased kdump memory bsc#1161421
-        if (is_ppc64le && !$memory_kdump_set) {
+        if ((is_ppc64le || is_aarch64) && !$memory_kdump_set) {
             send_key 'alt-y';
             type_string $memory_kdump;
             send_key 'ret';
-            record_soft_failure 'default kdump memory size is too small for ppc64le bsc#1161421';
+            record_soft_failure 'default kdump memory size is too small for ppc64le and aarch64, see bsc#1161421';
             $memory_kdump_set = 1;
         }
         # enable and verify fadump settings


### PR DESCRIPTION
we have also the issue on aarch64, see bsc#1161421
see https://progress.opensuse.org/issues/63772
Update memory requirements for kdump on ppc64le64
Set memory to 320 if the SUT has only 1GB of ram
Show soft failure if the SUT is aarch64 too
test verifications:
https://openqa.suse.de/tests/4028997#next_previous (QEMURAM 1024 aarch64)
https://openqa.suse.de/tests/4019082#next_previous (QEMURAM 4086 aarch64)
https://openqa.suse.de/tests/4028977#next_previous (QEMURAM 1024 ppc64le)
