### PR TITLE
Fix sapconf QAM issue on 15-SP1

### DIFF
--- a/schedule/qam/15-SP1/qam-sle_sles4sap_scc_gnome_sapconf.yml
+++ b/schedule/qam/15-SP1/qam-sle_sles4sap_scc_gnome_sapconf.yml
@@ -4,4 +4,5 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - console/system_prepare
+  - sles4sap/patterns
   - sles4sap/sapconf


### PR DESCRIPTION
This PR adds the `sles4sap/patterns` module for 15-SP1 QAM.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://1a102.qa.suse.de/tests/3674
