### PR TITLE
Check package version with script_output allow script fail

### DIFF
--- a/tests/console/check_package_version.pm
+++ b/tests/console/check_package_version.pm
@@ -56,7 +56,7 @@ sub cmp_version {
 sub cmp_packages {
     my ($pcks, $pckv, $jsc) = @_;
     record_info($pcks, "$pcks version check after migration");
-    my $output = script_output("zypper se -xs $pcks | grep -w $pcks | head -1 | awk -F '|' '{print \$4}'", proceed_on_failure => 1, 100);
+    my $output = script_output("zypper se -xs $pcks | grep -w $pcks | head -1 | awk -F '|' '{print \$4}'", 100, proceed_on_failure => 1);
     my $out    = '';
     for my $line (split(/\r?\n/, $output)) {
         if (trim($line) =~ m/^\d+\.\d+(\.\d+)?/) {


### PR DESCRIPTION
Check package version with script_output allow script fail
Background: Follow script_output API: script_output($script [, $wait, type_command => 1, proceed_on_failure => 1] [,quiet => $quiet]),  wait time need before proceed_on_failure

- Related ticket: https://progress.opensuse.org/issues/60305
- Verification run: https://openqa.nue.suse.com/tests/4022819
