### PR TITLE
fadump: Add test for error check during system reboot

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -282,6 +282,21 @@ sub check_function {
         # migration tests need remove core files before migration start
         assert_script_run 'rm -fr /var/crash/*';
     }
+
+    # Test PoverVM specific scenario with disabled fadump on encrypted filesystem
+    if (is_pvm && get_var('ENCRYPT') && get_var('FADUMP')) {
+        # Disable fadump
+        assert_script_run('yast2 kdump fadump disable', 120);
+        assert_script_run('yast2 kdump show',           120);
+        # Set print_delay to slow down kernel
+        assert_script_run('echo 1000 > /proc/sys/kernel/printk_delay');
+        # Restart system and check console
+        power_action('reboot', keepconsole => 1);
+        reconnect_mgmt_console;
+        assert_screen('system-reboot', timeout => 120, no_wait => 1);
+        $self->wait_boot(bootloader_time => 300);
+        select_console 'root-console';
+    }
 }
 
 #


### PR DESCRIPTION
Enhancement poo#44534: There can be hidden issues behind plymouth
screen. Kdump test was modified with disabled fadump scenario for
screen check during system reboot to check unexpected errors.

- Related ticket: https://progress.opensuse.org/issues/44534
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1361
- Verification run: 
15-SP2 x86_64: http://black-bit.suse.cz/tests/4833 (verification that we have no impact by the change)
15-SP2 ppc pvm: http://black-bit.suse.cz/tests/4834#step/kdump_and_crash/95
(failed to unmount var is wontfix bug bsc#1166601, it is ok)