### PR TITLE
Use condition for bootloader_svirt that won't affect s390x

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -9,8 +9,10 @@ conditional_schedule:
                 - boot/uefi_bootmenu
             s390x:
                 - installation/bootloader_zkvm
-        BACKEND:
-            svirt:
+        MACHINE:
+            svirt-xen-pv:
+                - installation/bootloader_svirt
+            svirt-xen-hvm:
                 - installation/bootloader_svirt
     lshw:
         ARCH:

--- a/schedule/functional/extra_tests_textmode_mod_desktop.yaml
+++ b/schedule/functional/extra_tests_textmode_mod_desktop.yaml
@@ -9,6 +9,11 @@ conditional_schedule:
                 - boot/uefi_bootmenu
             s390x:
                 - installation/bootloader_zkvm
+        MACHINE:
+            svirt-xen-pv:
+                - installation/bootloader_svirt
+            svirt-xen-hvm:
+                - installation/bootloader_svirt
     tests_requiring_soundcard:
         ARCH:
             aarch64:


### PR DESCRIPTION
Ticket https://progress.opensuse.org/issues/64045
https://openqa.suse.de/tests/4026785
https://openqa.suse.de/tests/4026825