### PR TITLE
Make yast2_cmdline die if not wicked net manager

### DIFF
--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -44,7 +44,7 @@ sub run_yast_cli_test {
 
 sub run {
     select_console 'root-console';
-    return if (systemctl("status wicked.service", ignore_failure => 1) != 0);
+    die "wicked is not used. The yast2_network tests can run only against wicked." if (systemctl("status wicked.service", ignore_failure => 1) != 0);
     prepare_source_repo;
 
     # Install test requirement


### PR DESCRIPTION
As the yast2-network modules contains tests against wicked network manager
the test module should fail in case that other manager is used.
The test can be valid and work only when wicked is used.

- Related ticket: https://progress.opensuse.org/issues/61901
- Verification run: http://aquarius.suse.cz/tests/2087
