### PR TITLE
HPC: Extend timeout for script_run

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -441,7 +441,7 @@ sub extended_hpc_tests {
     script_run('git clone https://github.com/schlad/havoxc_binary.git');
     script_run('cd havoxc_binary');
     script_run('wget --quiet ' . data_url('hpc/julog.sh') . ' -O julog.sh');
-    script_run('./havoxc.so');
+    script_run('./havoxc.so', 180);
     parse_extra_log('XUnit', './results/TEST-havoxc_so.xml');
 }
 


### PR DESCRIPTION
As the stress tests are added in the external tests scripts, the default
timeout isn't sufficient. Extending to a safer one
