### PR TITLE
Fix orphaned_packages_check

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1622,6 +1622,7 @@ sub load_extra_tests_geo_desktop {
 
 sub load_extra_tests_console {
     loadtest "console/check_os_release";
+    loadtest "console/orphaned_packages_check";
     # JeOS kernel is missing 'openvswitch' kernel module
     loadtest "console/openvswitch" unless is_jeos;
     loadtest "console/pam"         unless is_leap;
@@ -1706,7 +1707,6 @@ sub load_extra_tests_console {
     loadtest 'console/libgpiod' if (is_leap('15.1+') || is_tumbleweed) && !(is_jeos && is_x86_64);
     loadtest 'console/osinfo_db' if (is_sle('12-SP3+') && !is_jeos);
     loadtest 'console/libgcrypt' if ((is_sle(">=12-SP4") && (check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk'))) || is_opensuse);
-    loadtest "console/orphaned_packages_check";
 }
 
 sub load_extra_tests_sdk {

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -31,6 +31,7 @@ schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup
+    - console/orphaned_packages_check
     - console/zypper_lr_validate
     - console/zypper_ref
     - console/zypper_info
@@ -84,7 +85,6 @@ schedule:
     - console/firewalld
     - console/aaa_base
     - console/osinfo_db
-    - console/orphaned_packages_check
     - console/zypper_ref
     - console/docker
     - console/docker_runc


### PR DESCRIPTION
Move the module in front of the pam test which installes some pkgs that would otherwise be detected as orphaned.

Ticket: https://progress.opensuse.org/issues/64355
https://openqa.suse.de/t4030063
https://openqa.suse.de/t4030071