### PR TITLE
Increase installation timeout for PVM HMC

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -111,6 +111,8 @@ sub run {
     }
     # aarch64 can be particularily slow depending on the hardware
     $timeout *= 2 if check_var('ARCH', 'aarch64') && get_var('MAX_JOB_TIME');
+    # PPC HMC (Power9) performs very slow in general
+    $timeout *= 2 if check_var('BACKEND', 'pvm_hmc') && get_var('MAX_JOB_TIME');
     # encryption, LVM and RAID makes it even slower
     $timeout *= 2 if (get_var('ENCRYPT') || get_var('LVM') || get_var('RAID'));
     # "allpatterns" tests install a lot of packages


### PR DESCRIPTION
It performs very slow in general

- Failed test: https://openqa.suse.de/tests/4031264#step/await_install/70
- Depends on: https://gitlab.suse.de/qsf-u/qa-sle-functional-userspace/-/merge_requests/48
- Verification run: https://openqa.suse.de/tests/4035574
