### PR TITLE
Workaround missing desktop session in tty2 on SLED

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1109,7 +1109,7 @@ sub get_x11_console_tty {
     # older versions in HDD
     my $newer_gdm
       = $new_gdm
-      && !is_sle('<15-SP2')
+      && !is_sle('<15-SP2') && !check_var('SLE_PRODUCT', 'sled')
       && !is_leap('<15.2')
       && get_var('HDD_1', '') !~ /opensuse-42/;
     return (check_var('DESKTOP', 'gnome') && (get_var('NOAUTOLOGIN') || $newer_gdm) && $new_gdm) ? 2 : 7;


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1167633
- Verification run:
  - suportserver: https://openqa.suse.de/tests/4034754 (deleted)
  - hawk: https://openqa.suse.de/tests/4034755 (failed, missing import)