### PR TITLE
Add offline_install+skip_registration test module for aarch64 and ppc64le

### DIFF
--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration.yaml
@@ -10,7 +10,7 @@ description:    >
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: ''
+  SCC_REGISTER: 'console'
   ENABLE_ALL_SCC_MODULES: 1
   PATTERNS:	all
   ADDONS: all-packages

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration.yaml
@@ -37,11 +37,11 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
-  - console/suseconnect_scc
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x-zVM.yaml
@@ -10,7 +10,7 @@ description:    >
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: ''
+  SCC_REGISTER: 'console'
   ENABLE_ALL_SCC_MODULES: 1
   PATTERNS:	all
   ADDONS: all-packages

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x-zVM.yaml
@@ -37,12 +37,12 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
-  - console/suseconnect_scc
   - console/check_resume
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x.yaml
@@ -10,7 +10,7 @@ description:    >
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: ''
+  SCC_REGISTER: 'console'
   ENABLE_ALL_SCC_MODULES: 1
   PATTERNS:	all
   ADDONS: all-packages

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x.yaml
@@ -37,13 +37,13 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
-  - console/suseconnect_scc
   - console/check_resume
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
   - shutdown/svirt_upload_assets

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
@@ -35,12 +35,12 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
-  - console/suseconnect_scc
   - console/sle15_workarounds
   - console/integration_services
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
+  - console/suseconnect_scc
   - shutdown/shutdown
   - shutdown/hyperv_upload_assets

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
@@ -10,7 +10,7 @@ description:    >
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: ''
+  SCC_REGISTER: 'console'
   ENABLE_ALL_SCC_MODULES: 1
   PATTERNS:	all
   ADDONS: all-packages

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-hvm.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-hvm.yaml
@@ -10,7 +10,7 @@ description:    >
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: ''
+  SCC_REGISTER: 'console'
   ENABLE_ALL_SCC_MODULES: 1
   PATTERNS:	all
   ADDONS: all-packages

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-hvm.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-hvm.yaml
@@ -36,11 +36,11 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
-  - console/suseconnect_scc
   - console/sle15_workarounds
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
   - shutdown/svirt_upload_assets

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-pv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-pv.yaml
@@ -34,11 +34,11 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/first_boot
-  - console/suseconnect_scc
   - console/sle15_workarounds
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
   - shutdown/svirt_upload_assets

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-pv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-pv.yaml
@@ -10,7 +10,7 @@ description:    >
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: ''
+  SCC_REGISTER: 'console'
   ENABLE_ALL_SCC_MODULES: 1
   PATTERNS:	all
   ADDONS: all-packages

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@uefi.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@uefi.yaml
@@ -10,7 +10,7 @@ description:    >
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: ''
+  SCC_REGISTER: 'console'
   ENABLE_ALL_SCC_MODULES: 1
   PATTERNS:	all
   ADDONS: all-packages

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@uefi.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@uefi.yaml
@@ -37,11 +37,11 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
-  - console/suseconnect_scc
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -3,6 +3,9 @@ name:           offline_install+skip_registration
 description:    >
   Offline installation. Skipping registration for SLE 15, as requires network connection.
   This is default behavior for SLE 12.
+vars:
+  SCC_REGISTER: 'none'
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -10,6 +13,7 @@ schedule:
   - installation/network_configuration
   - installation/scc_registration
   - installation/addon_products_sle
+  - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone


### PR DESCRIPTION
The PR adds offline_install+skip_registration test module for aarch64 and ppc64le.

**For reviewers:** Please, also merge job schedule: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/150

- Related ticket: https://progress.opensuse.org/issues/63217
- Verification run: https://openqa.suse.de/tests/4029061
https://openqa.suse.de/tests/4029063
https://openqa.suse.de/tests/4029062