### PR TITLE
Fix hyperv failure for module validate_fs_table 

### DIFF
--- a/lib/partitions_validator_utils.pm
+++ b/lib/partitions_validator_utils.pm
@@ -38,7 +38,7 @@ sub validate_partition_creation {
     my @lsblk_output = split(/\n/, script_output("lsblk -n"));
     my $check;
     foreach (@lsblk_output) {
-        if ($_ =~ /(?<check>\Q$args->{mount_point}\E\z)/) {
+        if ($_ =~ /(?<check>\Q$args->{mount_point}\E\s*\Z)/) {
             $check = $+{check};
             last;
         }


### PR DESCRIPTION
On msdos@hyperv test suite, there is a failure at last module, due to difference between hyperV and other architectures on how the worker saves a particular array.  The change implemented here, allows test to run successfully on hyperv as well.

- Related ticket: https://progress.opensuse.org/issues/63814
- Verification run: 
         hyperv: https://openqa.suse.de/tests/4036659
         x86_64: https://openqa.suse.de/tests/4037379 