### PR TITLE
Adjust order of schedule for s390x-zVM-Upgrade.yaml

### DIFF
--- a/schedule/migration/s390x-zVM-Upgrade.yaml
+++ b/schedule/migration/s390x-zVM-Upgrade.yaml
@@ -15,8 +15,8 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - migration/post_upgrade
   - boot/reconnect_mgmt_console
+  - migration/post_upgrade
   - console/system_prepare
   - console/consoletest_setup
   - console/zypper_lr


### PR DESCRIPTION
Adjust order of schedule for s390x-zVM-Upgrade.yaml

- Related ticket: https://progress.opensuse.org/issues/62954
- Needles: na
- Verification run: na
