### PR TITLE
Perform login before switching to tty2

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1109,7 +1109,7 @@ sub get_x11_console_tty {
     # older versions in HDD
     my $newer_gdm
       = $new_gdm
-      && !is_sle('<15-SP2') && !check_var('SLE_PRODUCT', 'sled')
+      && !is_sle('<15-SP2')
       && !is_leap('<15.2')
       && get_var('HDD_1', '') !~ /opensuse-42/;
     return (check_var('DESKTOP', 'gnome') && (get_var('NOAUTOLOGIN') || $newer_gdm) && $new_gdm) ? 2 : 7;

--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (c) 2016-2018 SUSE LLC
+# Copyright (c) 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -49,7 +49,13 @@ sub run {
     my $docker_image = "registry.opensuse.org/home/rbranco/branches/opensuse/templates/images/tumbleweed/containers/hawk_test";
     assert_script_run("docker pull $docker_image", 240);
 
-    select_console 'x11';
+    # Rest of the test needs to be performed on the x11 console, but with the
+    # HA_CLUSTER setting that console is not yet activated; newer versions of gdm
+    # expect the console on tty2 which can lead to false positives as there is no
+    # session there yet, so instead this goes through the displaymanager console to
+    # login into the x11 session.
+    select_console 'displaymanager';
+    $self->handle_displaymanager_login();
     x11_start_program('xterm');
     turn_off_gnome_screensaver;
 


### PR DESCRIPTION
There is no GNOME session on tty2 if no user has logged in GDM first.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1167633
