### PR TITLE
Backport QAM SAP tests to SLES4SAP 12-SP2+

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key);
-use version_utils qw(is_sle is_caasp is_upgrade);
+use version_utils qw(is_sle is_sles4sap is_caasp is_upgrade);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
 
@@ -482,6 +482,7 @@ sub process_scc_register_addons {
             # Similarly for encrypted partitions activation
             push @needles, 'encrypted_volume_activation_prompt' if (get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_CANCEL_EXISTING'));
         }
+        push @needles, 'sles4sap-product-installation-mode' if (is_sles4sap() && is_sle('<=12-SP3'));
         while ($counter--) {
             die 'Addon registration repeated too much. Check if SCC is down.' if ($counter eq 1);
             assert_screen([@needles], 90);
@@ -527,6 +528,9 @@ sub process_scc_register_addons {
                 match_has_tag('encrypted_volume_activation_prompt')) {
                 # it would show Add On Product screen if scc registration correctly during installation
                 # it would show software install dialog if scc registration correctly by yast2 scc
+                last;
+            }
+            elsif (match_has_tag('sles4sap-product-installation-mode')) {
                 last;
             }
         }

--- a/schedule/qam/12-SP2/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/12-SP2/qam-create_hdd_sle_sap_gnome.yml
@@ -1,0 +1,32 @@
+name:           qam-create_hdd_sles4sap_gnome
+description:    >
+  Create an up-to-date sles4sap qcow2 image.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/no_separate_home
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/qam/12-SP2/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/12-SP2/qam-create_hdd_sles4sap_gnome.yml
@@ -1,0 +1,30 @@
+name:           qam-create_hdd_sles4sap_gnome
+description:    >
+  Create an up-to-date sles4sap qcow2 image.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/sles4sap_product_installation_mode
+  - installation/addon_products_sle
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/qam/12-SP3/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/12-SP3/qam-create_hdd_sle_sap_gnome.yml
@@ -1,0 +1,32 @@
+name:           qam-create_hdd_sles4sap_gnome
+description:    >
+  Create an up-to-date sles4sap qcow2 image.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/no_separate_home
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/qam/12-SP3/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/12-SP3/qam-create_hdd_sles4sap_gnome.yml
@@ -1,0 +1,30 @@
+name:           qam-create_hdd_sles4sap_gnome
+description:    >
+  Create an up-to-date sles4sap qcow2 image.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/sles4sap_product_installation_mode
+  - installation/addon_products_sle
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/qam/common/qam-sle_sles4sap_scc_gnome_netweaver_cli.yml
+++ b/schedule/qam/common/qam-sle_sles4sap_scc_gnome_netweaver_cli.yml
@@ -1,0 +1,9 @@
+name:           qam-sle_sles4sap_scc_gnome_netweaver_cli
+description:    >
+  Deploy a NW instance on top of gnome image using cli.
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/netweaver_install
+  - sles4sap/netweaver_test_instance

--- a/schedule/qam/common/qam-sle_sles4sap_scc_gnome_sapconf.yml
+++ b/schedule/qam/common/qam-sle_sles4sap_scc_gnome_sapconf.yml
@@ -1,0 +1,8 @@
+name:           qam-sle_sles4sap_scc_gnome_sapconf
+description:    >
+  Test sapconf on top of sles4sap gnome image.
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/sapconf

--- a/schedule/qam/common/qam-sle_sles4sap_scc_gnome_saptune.yml
+++ b/schedule/qam/common/qam-sle_sles4sap_scc_gnome_saptune.yml
@@ -1,0 +1,7 @@
+name:           qam-sle_sles4sap_scc_gnome_saptune
+description:    >
+  Test saptune on top of sles4sap gnome image.
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/saptune


### PR DESCRIPTION
This PR would remove redundancy between QAM tests for SAP products __except from the HANA test schedule__. I propose this because seems very unlikely that the test schedule itself for these products would differ in the future between the OS versions.
__NOTICE:__ ~~The tests have been moved to the common folder, so small changes in the configuration might be necessary on running instances.~~ The schedules for SLES4SAP 12 SP2 and SP3 have been added to the `common` directory while the other schedules remain at their position temporarily for compatibility reasons. The can be deleted later in order to use the same schedules in the `common` directory.

Secondly, it adds backports of the corresponding test schedules for SLES4SAP 12-SP2+.

The HANA schedule could not be tested yet, so it's not included in this PR.

- Verification run:
__SLE 12-SP2:__ https://mishmash.suse.de/tests/overview?distri=sle&build=20200325-1&groupid=3
__SLE 12-SP3:__ https://mishmash.suse.de/tests/overview?distri=sle&build=20200325-1&groupid=4
__SLE 12-SP4:__ https://mishmash.suse.de/tests/overview?distri=sle&build=20200325-1&groupid=5
__SLE 12-SP5:__ https://mishmash.suse.de/tests/overview?distri=sle&build=20200325-1&groupid=6

- Preventive regression tests for the change in `registration.pm`:
https://mishmash.suse.de/tests/173
https://mishmash.suse.de/tests/175