### PR TITLE
Shutdown before publishing hdd in skip_reg test suite

### DIFF
--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -29,3 +29,10 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
The commit fixes offline_install+skip_registration fail, as it is
designed to publish HDD, but the latter requires the system to be
shut down before publishing.

- Related ticket: https://progress.opensuse.org/issues/63217
- Verification run: https://openqa.suse.de/tests/4040879
