### PR TITLE
Do not upload assets on hyperv when do not publish image

### DIFF
--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
@@ -43,4 +43,3 @@ schedule:
   - shutdown/cleanup_before_shutdown
   - console/suseconnect_scc
   - shutdown/shutdown
-  - shutdown/hyperv_upload_assets


### PR DESCRIPTION
We have issue with schedule, as test suite doesn't publish image but
module to do that is scheduled. So solution to fix the issue is simple
to unschedule the test module.

See [poo#64607](https://progress.opensuse.org/issues/64607).

* [Verification run](https://openqa.suse.de/tests/4041419). 
