### PR TITLE
sles4sap/saptune: Run test_bsc1152598 only on 12-SP3+

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -462,9 +462,9 @@ sub run {
         $self->test_note($test) if ($test ne "1805750");
         $self->test_override($test);
     } elsif ($test =~ m/^(x86_64|ppc64le)$/) {
-        $self->test_x86_64  if (check_var('BACKEND', 'ipmi'));
-        $self->test_ppc64le if is_ppc64le();
-        $self->test_bsc1152598;
+        $self->test_x86_64     if (check_var('BACKEND', 'ipmi'));
+        $self->test_ppc64le    if is_ppc64le();
+        $self->test_bsc1152598 if is_sle('>12-SP3');
     } elsif ($test eq "delete_rename") {
         $self->test_delete;
         $self->test_rename;


### PR DESCRIPTION
The saptune v2 test for bsc#1152598 only makes sense on newer kernels like those available in the latest SLES releases >12-SP3