### PR TITLE
JUnit log parser should support softfail overall

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -457,26 +457,28 @@ sub generateXML_from_data {
     my $timestamp = localtime(time);
     $writer->startTag(
         'testsuites',
-        id       => "0",
-        error    => "n/a",
-        failures => $xmldata{"fail_nums"},
-        name     => $xmldata{"product_name"},
-        skipped  => $xmldata{"skip_nums"},
-        tests    => "$count",
-        time     => $xmldata{"test_time"}
+        id           => "0",
+        error        => "n/a",
+        failures     => $xmldata{"fail_nums"},
+        softfailures => $xmldata{"softfail_nums"},
+        name         => $xmldata{"product_name"},
+        skipped      => $xmldata{"skip_nums"},
+        tests        => "$count",
+        time         => $xmldata{"test_time"}
     );
     $writer->startTag(
         'testsuite',
-        id        => "0",
-        error     => "n/a",
-        failures  => $xmldata{"fail_nums"},
-        hostname  => hostname(),
-        name      => $xmldata{"product_tested_on"},
-        package   => $xmldata{"package_name"},
-        skipped   => $xmldata{"skip_nums"},
-        tests     => $count,
-        time      => $xmldata{"test_time"},
-        timestamp => $timestamp
+        id           => "0",
+        error        => "n/a",
+        failures     => $xmldata{"fail_nums"},
+        softfailures => $xmldata{"softfail_nums"},
+        hostname     => hostname(),
+        name         => $xmldata{"product_tested_on"},
+        package      => $xmldata{"package_name"},
+        skipped      => $xmldata{"skip_nums"},
+        tests        => $count,
+        time         => $xmldata{"test_time"},
+        timestamp    => $timestamp
     );
 
     #Generate testcase xml by calling subroutine generate_testcase_xml


### PR DESCRIPTION
The rule should be if there are soft failures and, at the same time no faiures, the result should be softfail. This functionality can not be realized unless openQA pull request https://github.com/os-autoinst/openQA/pull/2871 is merged together. Currently openQA JUnit log parser does not support soft fail overall result.


- Related ticket: 
  - All test suites that have soft failed modules and, at the same time generate corresponding JUnit log output.
  - https://github.com/os-autoinst/openQA/pull/2871
- Needles: n/a
- Verification run: http://10.67.133.40/tests/21
