### PR TITLE
[WIP] Increase the timeout for reboot_gnome

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -29,7 +29,7 @@ sub run {
     # bumped, due to tianocore being a bit slower, this brings this module
     # in sync
     # 12/2019: Increasing from 400 to 600 since more seems to be required.
-    my $bootloader_timeout = (is_boot_encrypted || check_var('ARCH', 'aarch64')) ? 600 : 300;
+    my $bootloader_timeout = (is_boot_encrypted || check_var('ARCH', 'aarch64')) ? 600 : 500;
 
     $self->wait_boot(bootloader_time => $bootloader_timeout);
 }


### PR DESCRIPTION
From log we can see 300s is not enough on s390 for reboot_gnome, we need increase the timeout value for s390x.

- Related ticket: https://progress.opensuse.org/issues/64622
- Needles: N/A
- Verification run: wait verify log on OSD.
