### PR TITLE
Upload solver test case for failed case

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -443,6 +443,11 @@ sub export_logs {
     my $compression = is_sle('=12-sp1') ? 'bz2' : 'xz';
     script_run "save_y2logs /tmp/y2logs_clone.tar.$compression";
     upload_logs "/tmp/y2logs_clone.tar.$compression";
+    if ($utils::IN_ZYPPER_CALL) {
+        script_run("zypper -n patch --debug-solver --with-interactive -l");
+        script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");
+        upload_logs "/tmp/solverTestCase.tar.bz2 ";
+    }
     $self->investigate_yast2_failure();
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -70,6 +70,7 @@ our @EXPORT = qw(
   get_root_console_tty
   get_x11_console_tty
   OPENQA_FTP_URL
+  IN_ZYPPER_CALL
   arrays_differ
   arrays_subset
   ensure_serialdev_permissions
@@ -106,6 +107,9 @@ use constant VERY_SLOW_TYPING_SPEED => 4;
 
 # openQA internal ftp server url
 our $OPENQA_FTP_URL = "ftp://openqa.suse.de";
+
+# set flag IN_ZYPPER_CALL in zypper_call and unset when leaving
+our $IN_ZYPPER_CALL = 0;
 
 =head2 save_svirt_pty
 
@@ -494,6 +498,7 @@ sub zypper_call {
     my $printer = $log ? "| tee /tmp/$log" : $dumb_term ? '| cat' : '';
     die 'Exit code is from PIPESTATUS[0], not grep' if $command =~ /^((?!`).)*\| ?grep/;
 
+    $IN_ZYPPER_CALL = 1;
     # Retrying workarounds
     my $ret;
     for (1 .. 5) {
@@ -522,6 +527,7 @@ sub zypper_call {
         upload_logs('/var/log/zypper.log');
         die "'zypper -n $command' failed with code $ret";
     }
+    $IN_ZYPPER_CALL = 0;
     return $ret;
 }
 


### PR DESCRIPTION
software suggests to store zypper.log as well as the "solver-testcase"

- Related ticket: https://progress.opensuse.org/issues/18194
- Needles: n/a
- Verification run: http://openqa.suse.de/t4040732
