### PR TITLE
Increase timeout for user_defined_snapshot module

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -77,6 +77,7 @@ sub create_list_of_serial_failures {
         push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta '-[ cut here ]-'};
     }
 
+    push @$serial_failures, {type => 'soft', message => 'Low memory problem detected bsc#1166955', pattern => quotemeta 'kswapd0 Kdump'};
 
     # Disable CPU soft lockup detection on aarch64 until https://progress.opensuse.org/issues/46502 get resolved
     push @$serial_failures, {type => 'hard', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'} unless check_var('ARCH', 'aarch64');

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -66,7 +66,7 @@ sub run {
     wait_serial("$module_name-0", 200) || die "'yast2 $module_name' didn't finish";
     $self->{in_wait_boot} = 1;
     power_action('reboot', keepconsole => 1, textmode => 1);
-    $self->wait_grub(bootloader_time => 150);
+    $self->wait_grub(bootloader_time => 250);
     send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
     send_key 'ret';
     $self->{in_wait_boot} = 0;


### PR DESCRIPTION
Bootloader takes a bit longer to show up propely, when power machine is
under a bit more of load giving a higher failure rate

Add new pattern to detect low memory problems [bsc#1165814](https://bugzilla.suse.com/show_bug.cgi?id=1165814)

[Verification runs](https://openqa.suse.de/tests/overview?arch=&machine=&modules=user_defined_snapshot&modules_result=passed&distri=sle&version=15-SP2&build=foursixnine_164.1&groupid=96)