### PR TITLE
fix online textmode install expertpartitioner key

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -160,6 +160,10 @@ sub init_cmd {
         $testapi::cmd{sync_without_daemon} = "alt-s";
     }
     ## keyboard cmd vars end
+
+    if (check_var('FLAVOR', 'Online') && check_var('DESKTOP', 'textmode')) {
+        $testapi::cmd{expertpartitioner} = "alt-x";
+    }
 }
 
 =head2 init_desktop_runner


### PR DESCRIPTION
add online textmode install expertpartitioner key

Related ticket:N/A
Needles: N/A
Verification run: http://10.67.129.48/tests/339#step/partitioning/1
