### PR TITLE
Fix typo in declarative-schedule-doc.md

### DIFF
--- a/declarative-schedule-doc.md
+++ b/declarative-schedule-doc.md
@@ -177,7 +177,7 @@ test_data:
 ```
 ...
 test_data:
-  - !include: 
+  !include: 
     - path/to/first_test_data.yaml
     - path/to/second_test_data.yaml
 ```


### PR DESCRIPTION
The present syntax for including multiple test data files, doesn't work.