### PR TITLE
publiccloud: Change ami in ec2utils.conf for upload-img

### DIFF
--- a/data/publiccloud/ec2utils.conf
+++ b/data/publiccloud/ec2utils.conf
@@ -81,8 +81,8 @@ user = ec2-user
 # ssh_private_key =
 
 [region-eu-central-1]
-# suse-sles-12-sp3-v20181004-hvm-ssd-x86_64
-ami = ami-0fa9bde3f3d40e5ae
+# suse-sles-15-sp1-v20200226-hvm-ssd-x86_64
+ami = ami-0d63f0d5c7bc514dd
 instance_type = t2.micro
 aki_i386 = aki-3e4c7a23
 aki_x86_64 = aki-184c7a05


### PR DESCRIPTION
We updated the AMI from `suse-sles-12-sp3-v20181004-hvm-ssd-x86_64` to
`suse-sles-15-sp1-v20200226-hvm-ssd-x86_64`.

Old ami was is deprecated.

- Related ticket: https://progress.opensuse.org/issues/64797

