### PR TITLE
Implement valgrind tests

### DIFF
--- a/data/valgrind/valgrind-test.c
+++ b/data/valgrind/valgrind-test.c
@@ -1,0 +1,152 @@
+/* Valgrind test program
+ * 
+ * Copyright © 2020 SUSE LLC
+ * 
+ * Copying and distribution of this file, with or without modification,
+ * are permitted in any medium without royalty provided the copyright
+ * notice and this notice are preserved.  This file is offered as-is,
+ * without any warranty.
+ * 
+ * Memory leak, uninitialzed values, out-of-bounds read test program to testing
+ * valgrind
+ * 
+ * Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+ * 
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+// memory pointers for still_reachable
+static void* mem_pointers[64];
+static int mem_pointer_i = 0;
+
+void say(const char* string) {
+	printf(string);
+}
+void say_hello() {
+	say("Hello World!\n");
+}
+
+void* leak_some_mem(size_t size) {
+	if(size == 0) {
+		errno = EINVAL;
+		return NULL;
+	}
+	void* mem = malloc(size);
+	return mem;
+}
+
+/* create simple xor hash over the defined memory region. return value is 
+ * always positive */
+int xor_hash(const char* mem, const size_t n) {
+	int hash = 0;
+	for(size_t i=0;i<n;i++)
+		hash ^= mem[i];
+	return hash>=0?hash:-hash;
+}
+
+/* Test for uninitialized read. Allocates size bytes and
+ * creates a simple hash over the allocated region.
+ * returns the hash of the region on success (zero or positive) or -1 on error */
+int uninitialized(size_t size) {
+	void *mem = malloc(size);
+	if(mem == NULL)
+		return -1;
+	
+	int ret = xor_hash(mem, size);
+	free(mem);
+	return ret;
+}
+
+/* out of bytes read. Allocates alloc bytes and creates a simple XOR hash over 
+ * the allocated region+n bytes
+ */ 
+int oob(size_t size, size_t n) {
+	void *mem = malloc(size);
+	if(mem == NULL)
+		return -1;
+	
+	int ret = xor_hash(mem, size+n);
+	free(mem);
+	return ret;
+}
+
+/* Performs an out-of bounds read on a stack array. The array is nulled and
+ * exactly 64 bytes long, so every n>64 will trigger the read */
+int oob_stack(size_t n) {
+	char array[64];
+	bzero(array, sizeof(char)*64);
+	return xor_hash(array, n);
+}
+
+void printHelp(const char* progname) {
+	printf("Valgrind test program\n  Usage: %s [OPTIONS]\n\n", progname);
+	printf("OPTIONS\n\n");
+	printf("  --sayhello                Print hello (two function calls)\n");
+	printf("  --fork                    Fork to child (Use this as first argument!)\n");
+	printf("  --leak BYTES              Leak defined amount of memory\n");
+	printf("  --still-reachable BYTES   Leak defined amount of memory as still-reachable\n");
+	printf("  --uninitialized BYTES     Test for usage of uninitialized memory\n");
+	printf("  --oob ALLOC BYTES         Allocate ALLOC bytes and read BYTES bytes larger than ALLOC\n");
+	printf("  --oob-stack BYTES         Perform out-of-bounds read from stack\n");
+	printf("                            Allocates 64 bytes of nulled space on the stack, so every BYTES>64 will trigger an oob\n");
+	printf("\n");
+}
+
+int main(int argc, char** argv) {
+	int ret = EXIT_SUCCESS;
+	for (int i=1;i<argc;i++) {
+		const char *arg = argv[i];
+		if(strcmp("--help", arg) == 0 || strcmp("-h", arg) == 0) {
+			printHelp(argv[0]);
+			exit(EXIT_SUCCESS);
+		} else if(strcmp("--sayhello", arg) == 0) {
+			say_hello();
+		} else if(strcmp("--fork", arg) == 0) {
+			// Fork to child, wait for child to exit and return exit code of child
+			pid_t pid = fork();
+			if (pid < 0) {
+				fprintf(stderr, "Fork failed: %s\n", strerror(errno));
+				exit(EXIT_FAILURE);
+			} else if (pid > 0) {
+				pid = waitpid(pid, &ret, 0);
+				exit(WEXITSTATUS(ret));
+			} // else - child, resume from here
+		} else if(strcmp("--leak", arg) == 0) {
+			if(leak_some_mem(atol(argv[++i])) == NULL) {
+				fprintf(stderr, "Allocating leaking memory failed: %s\n", strerror(errno));
+				ret = EXIT_FAILURE;
+			}
+		} else if(strcmp("--still-reachable", arg) == 0) {
+			mem_pointers[mem_pointer_i++] = leak_some_mem(atol(argv[++i]));
+			if(mem_pointers[mem_pointer_i-1] == NULL) {
+				fprintf(stderr, "Allocating still-reachable memory failed: %s\n", strerror(errno));
+				ret = EXIT_FAILURE;
+			}
+		} else if(strcmp("--uninitialized", arg) == 0) {
+			if(uninitialized(atol(argv[++i])) < 0) {
+				fprintf(stderr, "Error reading uninitialzed memory: %s\n", strerror(errno));
+			}
+		} else if(strcmp("--oob", arg) == 0) {
+			if(oob(atol(argv[i+1]), atol(argv[i+2])) < 0) {
+				fprintf(stderr, "Error reading oob memory: %s\n", strerror(errno));
+			}
+			i+=2;
+		} else if(strcmp("--oob-stack", arg) == 0) {
+			if(oob_stack(atol(argv[++i])) < 0) {
+				fprintf(stderr, "Error reading oob-stack memory: %s\n", strerror(errno));
+			}
+		} else {
+			fprintf(stderr, "Illegal argument: %s\n", arg);
+			ret = EXIT_FAILURE;
+		}
+	}
+	return ret;
+}

--- a/data/valgrind/valgrind-test.sh
+++ b/data/valgrind/valgrind-test.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+# 
+# Regression test for valgrind
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+
+# Helper function to grep and ident the output
+function GREP {
+    grep "$@" | sed 's/^/   > /'
+    status="${PIPESTATUS[0]}"
+    if [[ $status != 0 ]]; then
+        echo "[ERROR] 'grep $@' failed with status $status"
+        exit 1
+    fi
+}
+
+# Exit on errors
+set -e
+
+echo "Compiling test program ... "
+gcc -Wall -Werror -Wextra -std=c99 -g2 -O0 -o valgrind-test valgrind-test.c
+
+echo "Testing valgrind ... "
+valgrind --tool=memcheck --trace-children=yes ./valgrind-test 2>/dev/null
+valgrind --leak-check=full --show-leak-kinds=all --log-file="output_0.txt" ./valgrind-test --leak 2048 --leak 1024 --still-reachable 4096 2>/dev/null
+GREP '3,072 bytes in 2 blocks are definitely lost in loss record 1 of 2' output_0.txt
+GREP '4,096 bytes in 1 blocks are still reachable in loss record 2 of 2' output_0.txt
+GREP 'leak_some_mem' output_0.txt
+GREP 'definitely lost: 3,072 bytes in 2 blocks' output_0.txt
+GREP 'still reachable: 4,096 bytes in 1 blocks' output_0.txt
+valgrind --tool=memcheck --trace-children=yes  --log-file="output_1.txt" ./valgrind-test --fork --leak 1024 2>/dev/null
+GREP 'in use at exit: 1,024 bytes in 1 blocks' output_1.txt
+GREP 'total heap usage: 1 allocs, 0 frees, 1,024 bytes allocated' output_1.txt
+GREP 'definitely lost: 1,024 bytes in 1 blocks' output_1.txt
+
+valgrind --tool=memcheck --trace-children=yes  --log-file="output_2.txt" ./valgrind-test --leak 1024 --leak 1024 --leak 1024 2>/dev/null
+GREP 'in use at exit: 3,072 bytes in 3 blocks' output_2.txt
+GREP 'total heap usage: 3 allocs, 0 frees, 3,072 bytes allocated' output_2.txt
+GREP 'definitely lost: 3,072 bytes in 3 blocks' output_2.txt
+
+valgrind --tool=memcheck --leak-resolution=high --log-file="output_3.txt" ./valgrind-test --leak 1024 2>/dev/null
+GREP 'in use at exit: 1,024 bytes in 1 blocks' output_3.txt
+GREP 'total heap usage: 1 allocs, 0 frees, 1,024 bytes allocated' output_3.txt
+GREP 'definitely lost: 1,024 bytes in 1 blocks' output_3.txt
+
+valgrind --tool=memcheck --show-reachable=yes  --log-file="output_4.txt" ./valgrind-test --leak 1024 --leak 1024 --still-reachable 2048 2>/dev/null
+GREP 'in use at exit: 4,096 bytes in 3 blocks' output_4.txt
+GREP 'total heap usage: 3 allocs, 0 frees, 4,096 bytes allocated' output_4.txt
+GREP 'definitely lost: 2,048 bytes in 2 blocks' output_4.txt
+GREP 'still reachable: 2,048 bytes in 1 blocks' output_4.txt
+
+valgrind --tool=memcheck --log-file="output_5.txt" ./valgrind-test 2>/dev/null
+GREP 'All heap blocks were freed -- no leaks are possible' "output_5.txt"
+
+valgrind --track-origins=yes --log-file="output_6.txt" ./valgrind-test --oob 256 40 2>/dev/null
+GREP 'Invalid read of size' "output_6.txt"
+GREP 'bytes after a block of size 256 alloc' "output_6.txt"
+GREP 'Conditional jump or move depends on uninitialised value' "output_6.txt"
+GREP 'Uninitialised value was created by a heap allocation' "output_6.txt"
+GREP 'All heap blocks were freed -- no leaks are possible' "output_6.txt"
+
+valgrind --track-origins=yes  --log-file="output_7.txt" ./valgrind-test --uninitialized 256
+GREP 'Conditional jump or move depends on uninitialised value' "output_7.txt"
+GREP 'Uninitialised value was created by a heap allocation' "output_7.txt"
+GREP 'All heap blocks were freed -- no leaks are possible' "output_7.txt"
+
+valgrind --tool=exp-sgcheck --log-file="output_8.txt" ./valgrind-test --oob-stack 65
+GREP 'Invalid read of size ' "output_8.txt"
+
+
+echo "Testing callgrind ... "
+valgrind --tool=callgrind --callgrind-out-file="callgrind.out" ./valgrind-test 2>/dev/null
+GREP '# callgrind format' callgrind.out
+GREP 'version: ' callgrind.out
+GREP 'creator: ' callgrind.out
+GREP 'pid: ' callgrind.out
+GREP 'cmd: ' callgrind.out
+GREP 'desc: ' callgrind.out
+GREP 'events: ' callgrind.out
+GREP 'summary: ' callgrind.out
+GREP 'totals: ' callgrind.out
+
+echo "Testing cachegrind ... "
+valgrind --tool=cachegrind --cachegrind-out-file="cachegrind.out" ./valgrind-test 2>/dev/null
+GREP "desc: I1" cachegrind.out
+GREP "desc: D1" cachegrind.out
+GREP "desc: LL" cachegrind.out
+GREP "cmd: " cachegrind.out
+GREP "events: " cachegrind.out
+GREP "summary: " cachegrind.out
+
+echo "Testing helgrind ... "
+valgrind --tool=helgrind ./valgrind-test 2>/dev/null
+# Not output test, we rely on the correct execution and exit status
+
+echo "Testing massif ... "
+valgrind --tool=massif --massif-out-file="massif.out" ./valgrind-test 2>/dev/null
+GREP 'desc:' massif.out
+GREP 'cmd:' massif.out
+GREP 'mem_heap_B=' massif.out
+GREP 'mem_heap_extra_B=' massif.out
+GREP 'heap_tree=' massif.out
+
+rm -f output_{0..8}.txt callgrind.out cachegrind.out massif.out valgrind-test
+echo -e "\n\n[ OK ] All Valgrind tests PASSED"

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1708,6 +1708,7 @@ sub load_extra_tests_console {
     loadtest 'console/osinfo_db' if (is_sle('12-SP3+') && !is_jeos);
     loadtest 'console/libgcrypt' if ((is_sle(">=12-SP4") && (check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk'))) || is_opensuse);
     loadtest "console/gd";
+    loadtest 'console/valgrind' unless is_sle('<=12-SP3');
 }
 
 sub load_extra_tests_sdk {

--- a/schedule/qam/12-SP4/mau-extratests.yaml
+++ b/schedule/qam/12-SP4/mau-extratests.yaml
@@ -61,6 +61,7 @@ schedule:
 - console/libgcrypt
 - console/libqca2
 - console/gd
+- console/valgrind
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -60,6 +60,7 @@ schedule:
 - console/osinfo_db
 - console/libgcrypt
 - console/gd
+- console/valgrind
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -62,6 +62,7 @@ schedule:
 - console/libgcrypt
 - console/libqca2
 - console/gd
+- console/valgrind
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -64,6 +64,7 @@ schedule:
 - console/libgcrypt
 - console/libqca2
 - console/gd
+- console/valgrind
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/tests/console/valgrind.pm
+++ b/tests/console/valgrind.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: valgrind test
+#          compile a test program and run valgrind to detect memory leaks on it
+# - compile test program with gcc
+# - Check if valgrind runs
+# - Check if valgrind correctly detects memory leaks
+# - Check if valgrind correctly detects memory leak from a forked child
+# - Check if valgrind correctly detects memory leaks from a forked child
+# - Check if valgrind correctly detects memory leaks that are still reachable
+# - Check the valgrind tool "memcheck"
+# - Check the valgrind tool "callgrind"
+# - Check the valgrind tool "cachegrind"
+# - Check the valgrind tool "helgrind"
+# - Check the valgrind tool "massif"
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
+use version_utils "is_sle";
+
+sub run {
+    # Preparation
+    my $self = shift;
+    $self->select_serial_terminal;
+    # development module needed for dependencies, released products are tested with sdk module
+    if (is_sle && !main_common::is_updates_tests()) {
+        cleanup_registration;
+        register_product;
+        add_suseconnect_product(get_addon_fullname('sdk'));
+    }
+    # install requirements
+    zypper_call 'in gcc valgrind';
+    # run test script
+    assert_script_run 'cd /var/tmp';
+    assert_script_run 'curl -v -o valgrind-test.c ' . data_url('valgrind/valgrind-test.c');
+    assert_script_run 'curl -v -o valgrind-test.sh ' . data_url('valgrind/valgrind-test.sh');
+    assert_script_run 'bash -e valgrind-test.sh';
+    # unregister SDK
+    if (is_sle && !main_common::is_updates_tests()) {
+        remove_suseconnect_product(get_addon_fullname('sdk'));
+    }
+}
+
+1;


### PR DESCRIPTION
Implements test run for valgrind, where a c program with leaking
memory gets compiled and used. Valgrind is then executed to detect
various kinds of memory leaks under various conditions.

We test for leaking blocks, leaking blocks in child processes,
lekaing but still reachable blocks and the following valgrind tools:
memcheck, callgrind, cachegrind, helgrind, massif.

- Related ticket: https://progress.opensuse.org/issues/49148
- Needles: None
- Verification run: [SLE15-SP1](http://phoenix-openqa.qam.suse.de/tests/345) | [SLE15](http://phoenix-openqa.qam.suse.de/tests/346) | [SLE12-SP5](http://phoenix-openqa.qam.suse.de/tests/347) | [SLE12-SP4](http://phoenix-openqa.qam.suse.de/tests/348) | [Leap](http://phoenix-openqa.qam.suse.de/tests/343) | [Tumbleweed](http://phoenix-openqa.qam.suse.de/tests/344)
