### PR TITLE
Rename *in_textmode_containers to *_textmode_containers

### DIFF
--- a/schedule/functional/extra_tests_textmode_containers.yaml
+++ b/schedule/functional/extra_tests_textmode_containers.yaml
@@ -1,7 +1,7 @@
-name:           extra_tests_in_textmode_cont
+name:           extra_tests_textmode_containers
 description:    >
     Maintainer: slindomansilla.
-    Extra tests about software in container module
+    Extra tests about software in containers module
 schedule:
     - boot/boot_to_desktop
     - console/docker


### PR DESCRIPTION
As agreed in team retro, using **extra_tests_textmode_containers**

- Parallel MR: https://gitlab.suse.de/qsf-u/qa-sle-functional-userspace/-/merge_requests/35