### PR TITLE
Use $include instead of !include as is invalid yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ test-deleted-renamed-testdata:
 
 .PHONY: detect-nonexistent-testdata
 detect-nonexistent-testdata:
-	tools/detect_nonexistent_testdata `git diff --exit-code $$(git merge-base master HEAD) | grep '+  !include: test_data/' | grep 'yaml$$' | awk '{print $$3}'`
+	tools/detect_nonexistent_testdata `git diff --exit-code $$(git merge-base master HEAD) | grep '+  $include: test_data/' | grep 'yaml$$' | awk '{print $$3}'`
 
 .PHONY: test-soft_failure-no-reference
 test-soft_failure-no-reference:

--- a/declarative-schedule-doc.md
+++ b/declarative-schedule-doc.md
@@ -158,7 +158,7 @@ Besides having test_data in the same yaml file for scheduling, it is possible to
       - size: 2mb
   ...
 ```
-And we can include those data in `scenario_name.yaml` using `!include` and the path to the file:
+And we can include those data in `scenario_name.yaml` using `$include` and the path to the file:
 ```
 name:           scenario_name_test_data.yaml
 description:    >
@@ -169,20 +169,20 @@ schedule:
   - path/to/module
 ...
 test_data:
-  !include: schedule/path/to/scenario_name_test_data.yaml
+  $include: schedule/path/to/scenario_name_test_data.yaml
 ```
--  it is allowed to use multiple `!include` tags in yaml scheduling
+-  it is allowed to use multiple `$include` tags in yaml scheduling
    file. In the case they should be provided as list:
 
 ```
 ...
 test_data:
-  !include: 
+  $include: 
     - path/to/first_test_data.yaml
     - path/to/second_test_data.yaml
 ```
 
-- `!include` tag can be mixed with the test data that is defined in
+- `$include` tag can be mixed with the test data that is defined in
   scheduling file directly:
 
 > **_IMPORTANT:_** Test data in scheduling file has priority over the
@@ -195,9 +195,9 @@ test_data:
     - name: vdb
       partitions:
         - size: 3mb
-  !include: path/to/test_data.yaml
+  $include: path/to/test_data.yaml
 ```
-Test data sometimes are more related to a particular schedule, sometimes to other test data shared with other test suites and sometimes it is a mix. In those cases, `YAML_TEST_DATA` setting can be used to give us the flexibility to avoid duplicate schedule files just because they have different data and due to it will be pointing to a test data file and at the moment recursive inclusion is not implemented (to reduce complexity),only for this particular case, is allowed the possibility to use `!include` functionality in test data file, not cutting any path for the tester. For instance:
+Test data sometimes are more related to a particular schedule, sometimes to other test data shared with other test suites and sometimes it is a mix. In those cases, `YAML_TEST_DATA` setting can be used to give us the flexibility to avoid duplicate schedule files just because they have different data and due to it will be pointing to a test data file and at the moment recursive inclusion is not implemented (to reduce complexity),only for this particular case, is allowed the possibility to use `$include` functionality in test data file, not cutting any path for the tester. For instance:
 
 In your yaml for your Job Group configuration for one product you could have:
 ```
@@ -224,7 +224,7 @@ disks:
   - name: vda
     partitions:
       - size: 2mb
-!include: path/to/test_data/shared/among/test_suites.yaml
+$include: path/to/test_data/shared/among/test_suites.yaml
   ...
 ```
 In the other data file we could have:
@@ -233,7 +233,7 @@ disks:
   - name: vdb
     partitions:
       - size: 5mb
-!include: path/to/test_data/shared/among/test_suites.yaml
+$include: path/to/test_data/shared/among/test_suites.yaml
   ...
 ```
 

--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -30,7 +30,7 @@ use Data::Dumper;
 our @EXPORT = qw(load_yaml_schedule get_test_suite_data);
 
 my $test_suite_data;
-my $include_tag = "!include";
+my $include_tag = '$include';
 
 sub parse_vars {
     my ($schedule) = shift;
@@ -83,7 +83,7 @@ sub parse_test_suite_data {
 
     # if test_data section is defined in schedule file
     if (exists $schedule->{test_data}) {
-        # import test data using !include from test_data section in schedule file
+        # import test data using $include from test_data section in schedule file
         _import_test_data_included($schedule->{test_data});
 
         # test_data from schedule file has priority over included data
@@ -121,7 +121,7 @@ sub _import_test_data_included {
     my ($test_data) = shift;
 
     if (defined(my $import = $test_data->{$include_tag})) {
-        # Allow both lists and scalar value for import "!include" key
+        # Allow both lists and scalar value for import "$include" key
         if (ref $import eq 'ARRAY') {
             for my $include (@{$import}) {
                 _import_test_data_from_yaml(path => $include);
@@ -147,7 +147,7 @@ sub _import_test_data_from_yaml {
 
     my $include_yaml = YAML::Tiny::LoadFile(dirname(__FILE__) . '/../' . $args{path});
     if ($args{allow_included}) {
-        # import test data using !include from test data file
+        # import test data using $include from test data file
         _import_test_data_included($include_yaml);
     }
     _ensure_include_not_present($include_yaml);

--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -29,7 +29,7 @@ test_data:
         - /dev/mapper/cr_test
   crypttab:
     num_devices_encrypted: 1
-  !include: test_data/yast/encryption/default_enc.yaml
+  $include: test_data/yast/encryption/default_enc.yaml
   profile:
     partitioning:
       - drive:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage.yaml
@@ -79,4 +79,4 @@ conditional_schedule:
         - console/verify_separate_home
         - console/validate_file_system
 test_data:
-  !include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml
+  $include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -35,4 +35,4 @@ schedule:
 test_data:
   device: sda
   table_type: gpt
-  !include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml
+  $include: test_data/yast/btrfs/btrfs_sle_libstorage.yaml

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -33,4 +33,4 @@ schedule:
 test_data:
   device: /dev/dasda
   table_type: dasd
-  !include: test_data/yast/ext4/ext4_no_separate_home.yaml
+  $include: test_data/yast/ext4/ext4_no_separate_home.yaml

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -33,4 +33,4 @@ schedule:
 test_data:
   device: /dev/vda
   table_type: gpt
-  !include: test_data/yast/ext4/ext4.yaml
+  $include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
@@ -31,4 +31,4 @@ schedule:
 test_data:
   device: /dev/xvdb
   table_type: gpt
-  !include: test_data/yast/ext4/ext4.yaml
+  $include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -31,4 +31,4 @@ schedule:
 test_data:
   device: /dev/xvdb
   table_type: gpt
-  !include: test_data/yast/ext4/ext4.yaml
+  $include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -31,4 +31,4 @@ schedule:
 test_data:
   device: /dev/vda
   table_type: gpt
-  !include: test_data/yast/ext4/ext4.yaml
+  $include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -35,4 +35,4 @@ schedule:
 test_data:
   device: /dev/sda
   table_type: gpt
-  !include: test_data/yast/ext4/ext4.yaml
+  $include: test_data/yast/ext4/ext4.yaml

--- a/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
@@ -7,7 +7,7 @@
     RAIDLEVEL: 1
     LVM: 1
   test_data:
-    !include: test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+    $include: test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
   schedule :
     - installation/isosize
     - installation/bootloader_start

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12.yaml
@@ -7,7 +7,7 @@ vars:
   RAIDLEVEL: 1
   LVM: 1
 test_data:
-  !include: test_data/yast/lvm_raid1/lvm+raid1_sle12.yaml
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle12.yaml
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv-uefi.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv-uefi.yaml
@@ -7,7 +7,7 @@ vars :
   RAIDLEVEL : 1
   LVM       : 1
 test_data :
-  !include : test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+  $include : test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
 schedule :
   - installation/isosize
   - installation/bootloader_hyperv

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
@@ -7,7 +7,7 @@ vars:
   RAIDLEVEL: 1
   LVM: 1
 test_data:
-  !include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen-hvm.yaml
@@ -7,7 +7,7 @@ vars:
   RAIDLEVEL: 1
   LVM: 1
 test_data:
-  !include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen-pv.yaml
@@ -7,7 +7,7 @@ vars:
   RAIDLEVEL: 1
   LVM: 1
 test_data:
-  !include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -7,7 +7,7 @@ vars:
   RAIDLEVEL: 1
   LVM: 1
 test_data:
-  !include: test_data/yast/lvm_raid1/lvm+raid1_sle15.yaml
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle15.yaml
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -7,7 +7,7 @@ vars :
   RAIDLEVEL : 1
   LVM       : 1
 test_data :
-  !include : test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+  $include : test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
 schedule :
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -7,7 +7,7 @@ vars:
   RAIDLEVEL: 1
   LVM: 1
 test_data:
-  !include: test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen.yaml
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen.yaml
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -7,7 +7,7 @@ vars:
   RAIDLEVEL: 1
   LVM: 1
 test_data:
-  !include: test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen.yaml
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen.yaml
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/modify_existing_partition_opensuse.yaml
+++ b/schedule/yast/modify_existing_partition_opensuse.yaml
@@ -26,4 +26,4 @@ schedule:
   - console/validate_modify_existing_partition
 
 test_data:
-  !include: test_data/yast/modify_existing_partition/modify_existing_partition.yaml
+  $include: test_data/yast/modify_existing_partition/modify_existing_partition.yaml

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/first_boot
   - console/validate_modify_existing_partition
 test_data:
-  !include: test_data/yast/modify_existing_partition/modify_existing_partition.yaml
+  $include: test_data/yast/modify_existing_partition/modify_existing_partition.yaml
 conditional_schedule:
   reconnect_mgmt_console:
     ARCH:

--- a/schedule/yast/msdos.yaml
+++ b/schedule/yast/msdos.yaml
@@ -68,5 +68,5 @@ conditional_schedule:
       svirt-hyperv:
         - installation/grub_test
 test_data:
-  !include: test_data/yast/msdos/msdos.yaml
+  $include: test_data/yast/msdos/msdos.yaml
 

--- a/schedule/yast/raid/raid0_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid0_opensuse_gpt.yaml
@@ -52,4 +52,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid0_opensuse_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_opensuse_gpt_uefi.yaml
@@ -32,4 +32,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid0_gpt_uefi_test_data.yaml
+  $include: test_data/yast/raid/raid0_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -53,4 +53,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -33,4 +33,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid_prep_boot_test_data.yaml
+  $include: test_data/yast/raid/raid_prep_boot_test_data.yaml

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -34,7 +34,7 @@ schedule:
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
-  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  $include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 0
       chunk_size: 64

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -33,4 +33,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid0_gpt_uefi_test_data.yaml
+  $include: test_data/yast/raid/raid0_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid0_sle_msdos.yaml
+++ b/schedule/yast/raid/raid0_sle_msdos.yaml
@@ -33,4 +33,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid_msdos_test_data.yaml
+  $include: test_data/yast/raid/raid_msdos_test_data.yaml

--- a/schedule/yast/raid/raid0_sle_msdos_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_msdos_prep_boot.yaml
@@ -33,4 +33,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid_msdos_prep_boot_test_data.yaml
+  $include: test_data/yast/raid/raid_msdos_prep_boot_test_data.yaml

--- a/schedule/yast/raid/raid10_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid10_opensuse_gpt.yaml
@@ -52,4 +52,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid10_opensuse_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_opensuse_gpt_uefi.yaml
@@ -31,4 +31,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid10_gpt_uefi_test_data.yaml
+  $include: test_data/yast/raid/raid10_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -53,4 +53,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -34,7 +34,7 @@ schedule:
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
-  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  $include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 10
       chunk_size: 64

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -33,4 +33,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid10_gpt_uefi_test_data.yaml
+  $include: test_data/yast/raid/raid10_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid1_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid1_opensuse_gpt.yaml
@@ -52,4 +52,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid1_opensuse_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_opensuse_gpt_uefi.yaml
@@ -31,4 +31,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid1_gpt_uefi_test_data.yaml
+  $include: test_data/yast/raid/raid1_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -53,4 +53,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -34,7 +34,7 @@ schedule:
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
-  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  $include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 1
       chunk_size: 64

--- a/schedule/yast/raid/raid5_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid5_opensuse_gpt.yaml
@@ -52,4 +52,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid5_opensuse_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_opensuse_gpt_uefi.yaml
@@ -31,4 +31,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid5_gpt_uefi_test_data.yaml
+  $include: test_data/yast/raid/raid5_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -53,4 +53,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -34,7 +34,7 @@ schedule:
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
-  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  $include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 5
       chunk_size: 64

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -33,4 +33,4 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_raid
 test_data:
-  !include: test_data/yast/raid/raid5_gpt_uefi_test_data.yaml
+  $include: test_data/yast/raid/raid5_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -53,4 +53,4 @@ test_data:
           filesystem: swap
         mounting_options:
           should_mount: 1
-  !include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  $include: test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -34,7 +34,7 @@ schedule:
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
-  !include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
+  $include: test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 6
       chunk_size: 64

--- a/t/data/test_data_nested_import.yaml
+++ b/t/data/test_data_nested_import.yaml
@@ -1,2 +1,2 @@
 test_in_yaml_schedule: test_in_yaml_import_value_1
-!include: this_is_not_allowed
+$include: this_is_not_allowed

--- a/t/data/test_data_yaml_data_setting.yaml
+++ b/t/data/test_data_yaml_data_setting.yaml
@@ -1,2 +1,2 @@
 test_in_yaml_data: test_in_yaml_data
-!include: t/data/test_data_3.yaml
+$include: t/data/test_data_3.yaml

--- a/t/data/test_schedule_multi_imports.yaml
+++ b/t/data/test_schedule_multi_imports.yaml
@@ -1,5 +1,5 @@
 test_data:
     test_in_yaml_schedule: test_in_yaml_schedule_value
-    !include:
+    $include:
         - t/data/test_data_1.yaml
         - t/data/test_data_2.yaml

--- a/t/data/test_schedule_nested_import.yaml
+++ b/t/data/test_schedule_nested_import.yaml
@@ -1,3 +1,3 @@
 test_data:
     test_in_yaml_schedule: test_in_yaml_schedule_value
-    !include: t/data/test_data_nested_import.yaml
+    $include: t/data/test_data_nested_import.yaml

--- a/t/data/test_schedule_single_import.yaml
+++ b/t/data/test_schedule_single_import.yaml
@@ -1,3 +1,3 @@
 test_data:
     test_in_yaml_schedule: test_in_yaml_schedule_value
-    !include: t/data/test_data_1.yaml
+    $include: t/data/test_data_1.yaml

--- a/test_data/yast/encryption/encrypt_no_lvm.yaml
+++ b/test_data/yast/encryption/encrypt_no_lvm.yaml
@@ -1,3 +1,3 @@
 crypttab:
   num_devices_encrypted: 3
-!include: test_data/yast/encryption/default_enc.yaml
+$include: test_data/yast/encryption/default_enc.yaml

--- a/test_data/yast/encryption/full_lvm_enc.yaml
+++ b/test_data/yast/encryption/full_lvm_enc.yaml
@@ -1,3 +1,3 @@
 crypttab:
   num_devices_encrypted: 1
-!include: test_data/yast/encryption/default_enc.yaml
+$include: test_data/yast/encryption/default_enc.yaml


### PR DESCRIPTION
We have used '!include' tag for referencing another yaml file in the
test_data section of the schedule. If not quoted this is invalid yaml
format and worked due to a bug in YAML::Tiny.

Using `$include` doesn't introduce any of these issues.

See [poo#64755](https://progress.opensuse.org/issues/64755).

* [Verification run](https://openqa.suse.de/tests/4047253#settings) this is one of the affected scenarios
