### PR TITLE
Extend match_timeout for kontact in LIVETEST

### DIFF
--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -31,9 +31,10 @@ sub run {
         x11_start_program('echo -e "[General]\nfirst-start=false" >> ~/.kde4/share/config/kmail2rc', valid => 0);
     }
     x11_start_program('echo -e "[General]\nfirst-start=false" >> ~/.config/kmail2rc', valid => 0);
-
+    my $match_timeout = 90;
+    $match_timeout = $match_timeout * 3 if get_var('LIVETEST');
     my @tags = qw(test-kontact-1 kontact-import-data-dialog kontact-window);
-    x11_start_program('kontact', target_match => \@tags);
+    x11_start_program('kontact', target_match => \@tags, match_timeout => $match_timeout);
     do {
         assert_screen \@tags;
         # kontact might ask to import data from another mailer, don't
@@ -52,7 +53,9 @@ sub run {
     # persist consistently as a process in the background causing kontact to
     # be "restored" after a re-login/reboot causing later tests to fail. To
     # prevent this we explicitly stop the kontact background process.
-    x11_start_program('killall kontact', valid => 0);
+    # matching 'generic-desktop' needs more time for LIVETEST
+    @tags = qw(desktop-runner-border desktop-runner-plasma-suggestions generic-desktop);
+    x11_start_program('killall kontact', target_match => \@tags, match_timeout => $match_timeout);
 }
 
 1;


### PR DESCRIPTION
krypton-live@64bit-2G seems to have very poor performance.
extend match_timeout in start_x11_program can help.
see https://progress.opensuse.org/issues/63355
verification:
http://f40.suse.de/tests/7312#step/kontact/19
http://f40.suse.de/tests/7314#step/kontact/21
https://openqa.opensuse.org/tests/1219855#next_previous
