### PR TITLE
Revert "HPC: Select suitable openmpi version"

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -22,14 +22,8 @@ use registration;
 use version_utils 'is_sle';
 
 sub run {
-    my $self = shift;
-    my $mpi  = get_required_var('MPI');
-    if (is_sle('<15')) {
-        $mpi = 'openmpi';
-    } elsif (is_sle('<15-SP2')) {
-        $mpi = 'openmpi2';
-    }
-
+    my $self          = shift;
+    my $mpi           = get_required_var('MPI');
     my $mpi_c         = 'simple_mpi.c';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -16,16 +16,10 @@ use warnings;
 use testapi;
 use lockapi;
 use utils;
-use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
     my $mpi  = get_required_var('MPI');
-    if (is_sle('<15')) {
-        $mpi = 'openmpi';
-    } elsif (is_sle('<15-SP2')) {
-        $mpi = 'openmpi2';
-    }
 
     zypper_call("in $mpi");
 


### PR DESCRIPTION
This patch must be re-done as currently it overrides the mpi
value thus all QAM MPI tests will dafault to openmpi(1)(2)

This reverts commit 5b6a563c9a9f051379130b48c76eeb88442f1b29.

False-positive or in fact incorrect test is here as an example:
https://openqa.suse.de/tests/4047377#step/mpi_master/40 
