### PR TITLE
Allow remove or rename of YAML scheduling files

### DIFF
--- a/tools/detect_nonexistent_modules_in_yaml_schedule
+++ b/tools/detect_nonexistent_modules_in_yaml_schedule
@@ -18,6 +18,7 @@ YAML schedule file.
 =cut
 sub parse_modules_in_schedule {
     my ($schedule_file_path) = @_;
+    return () unless (-f $schedule_file_path);
     my $schedule = YAML::Tiny::LoadFile($schedule_file_path);
     my @scheduled;
     for my $module (@{$schedule->{schedule}}) {


### PR DESCRIPTION
If I'm not wrong, it's not possible to rename or remove YAML scheduling files.
This PR adds a code line to allow this it.

This is a [PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9908) where I'm trying to rename and remove files and it fails.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
With the new code, [Travis is happy](https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/builds/667748189?utm_source=github_status&utm_medium=notification)

