### PR TITLE
Enable yamllint for schedule and test_data and adjust yaml files accordingly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - echo "requires 'Code::DRY';" >> cpanfile
   - echo "requires 'Regexp::Common';" >> cpanfile
   - echo "requires 'Perl::Tidy', '== 20200110';" >> cpanfile
+  - sudo apt-get -y install yamllint
 install:
   - make prepare
 script:
@@ -42,4 +43,3 @@ deploy:
         branch: master
         condition: "$NEW_DEPLOY_NEEDED = 1 && $TESTS = unit"
     target_branch: gh-pages
-

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+rules:
+  line-length:
+    max: 160
+  document-start: disable
+  indentation:
+    indent-sequences: whatever
+  colons:
+    # Ignore spaces after colons
+    max-spaces-after: -1

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,15 @@ test-compile-changed: os-autoinst/
 
 .PHONY: test-yaml-valid
 test-yaml-valid:
-	export PERL5LIB=${PERL5LIB_} ; tools/test_yaml_valid `git --no-pager diff --diff-filter=d --name-only master | grep 'schedule.*\.yaml'`
+	@# Get list of changed yaml files
+	$(eval YAMLS=$(shell sh -c "git --no-pager diff --diff-filter=dr --name-only master | grep '\(schedule\|test_data\)/.*\.y.\?ml$$'"))
+	if test -n "$(YAMLS)"; then \
+	  export PERL5LIB=${PERL5LIB_} ; tools/test_yaml_valid $(YAMLS);\
+	  which yamllint >/dev/null 2>&1 || echo "Command 'yamllint' not found, can not execute YAML syntax checks";\
+	  yamllint -c .yamllint $(YAMLS);\
+	else \
+	  echo "No yamls modified.";\
+	fi
 
 .PHONY: test-modules-in-yaml-schedule
 test-modules-in-yaml-schedule:

--- a/declarative-schedule-doc.md
+++ b/declarative-schedule-doc.md
@@ -56,7 +56,7 @@ conditional_schedule:
     ...
 
 schedule:
-    - {{module1}}
+    - '{{module1}}'
     - path/to/module/module2
     ...
 test_data:
@@ -105,8 +105,10 @@ For instance, depending on the value of DISTRI setting we can schedule an ordere
 ```
 
 #### schedule
-Refers to a sequence of test modules to be executed in the test suite. For the moment it was chosen this format `{{}}`
+Refers to a sequence of test modules to be executed in the test suite. For the moment it was chosen this format `'{{...}}''`
 to indicate that the module or modules executed at this position is conditional to some variable as described in [conditional_schedule](#conditional_schedule).
+
+NOTE: Please, do not forget to wrap conditional schedule in quotes as `{` and `}` are special symbols and can affect parsing.
 
 **NOTE:**
  - [conditional_schedule](#conditional_schedule) does not allow at the moment to represent complex logic like combination of 'and' or 'or' and it does intend to do it due to potentially it would create the same problem that occurs with main.pm. Other kind of logic like a simple exclusion list could be feasible in the near future, for example "run for all except when this variable value is set to some specific value". Reusing of blocks needs to be re-thinked as well and what would be a readable syntax for this. At the moment if the scenario you intend to migrate has complex conditional logic it would require changes in your test modules.
@@ -177,7 +179,7 @@ test_data:
 ```
 ...
 test_data:
-  $include: 
+  $include:
     - path/to/first_test_data.yaml
     - path/to/second_test_data.yaml
 ```

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration.yaml
@@ -1,18 +1,18 @@
 ---
-name:           allmodules+allpatterns+registration
-description:    >
+name: allmodules+allpatterns+registration
+description: >
   Full Medium installation that covers the following cases:
-     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
-        Scripting, Containers, Desktop Applications);
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
      2. All patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: 'console'
+  SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS:	all
+  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x-zVM.yaml
@@ -1,18 +1,18 @@
 ---
-name:           allmodules+allpatterns+registration@s390x-zVM
-description:    >
+name: allmodules+allpatterns+registration@s390x-zVM
+description: >
   Full Medium installation that covers the following cases:
-     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
-        Scripting, Containers, Desktop Applications);
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
      2. All patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: 'console'
+  SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS:	all
+  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@s390x.yaml
@@ -1,18 +1,18 @@
 ---
-name:           allmodules+allpatterns+registration@s390x
-description:    >
+name: allmodules+allpatterns+registration@s390x
+description: >
   Full Medium installation that covers the following cases:
-     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
-        Scripting, Containers, Desktop Applications);
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
      2. All patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: 'console'
+  SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS:	all
+  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-hyperv.yaml
@@ -1,18 +1,18 @@
 ---
-name:           allmodules+allpatterns+registration@svirt-hyperv
-description:    >
+name: allmodules+allpatterns+registration@svirt-hyperv
+description: >
   Full Medium installation that covers the following cases:
-     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
-        Scripting, Containers, Desktop Applications);
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
      2. All patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: 'console'
+  SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS:	all
+  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-hvm.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-hvm.yaml
@@ -1,18 +1,18 @@
 ---
-name:           allmodules+allpatterns+registration@svirt-xen-hvm
-description:    >
+name: allmodules+allpatterns+registration@svirt-xen-hvm
+description: >
   Full Medium installation that covers the following cases:
-     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
-        Scripting, Containers, Desktop Applications);
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
      2. All patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: 'console'
+  SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS:	all
+  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-pv.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@svirt-xen-pv.yaml
@@ -1,18 +1,18 @@
 ---
-name:           allmodules+allpatterns+registration@svirt-xen-pv
-description:    >
+name: allmodules+allpatterns+registration@svirt-xen-pv
+description: >
   Full Medium installation that covers the following cases:
-     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
-        Scripting, Containers, Desktop Applications);
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
      2. All patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: 'console'
+  SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS:	all
+  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start

--- a/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@uefi.yaml
+++ b/schedule/yast/allmodules+allpatterns+registration/allmodules+allpatterns+registration@uefi.yaml
@@ -1,24 +1,24 @@
 ---
-name:           allmodules+allpatterns+registration@uefi
-description:    >
+name: allmodules+allpatterns+registration@uefi
+description: >
   Full Medium installation that covers the following cases:
-     1. Additional modules enabled using SCC (Legacy, Development Tools, Web and
-        Scripting, Containers, Desktop Applications);
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
      2. All patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
 vars:
-  SCC_REGISTER: 'console'
+  SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS:	all
+  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
-  - installation/scc_registration  
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning

--- a/schedule/yast/autoyast_btrfs.yaml
+++ b/schedule/yast/autoyast_btrfs.yaml
@@ -1,8 +1,9 @@
-name:           autoyast_btrfs
-description:    >
-  Non-default btrfs subvolume structure test for autoyast installation.
-  Verify btrfs in new installation and generation of autoinst.xml.
-  Same as autoyast_btrfs, but with product and and addons defined for SLE15.
+---
+name: autoyast_btrfs
+description: >
+  Non-default btrfs subvolume structure test for autoyast installation. Verify
+  btrfs in new installation and generation of autoinst.xml. Same as autoyast_btrfs,
+  but with product and and addons defined for SLE15.
 vars:
   AUTOYAST: autoyast_sle15/autoyast_btrfs.xml
   AUTOYAST_PREPARE_PROFILE: 1
@@ -23,7 +24,7 @@ schedule:
   - console/system_prepare
   - autoyast/verify_btrfs
   - autoyast/verify_cloned_profile
-test_data:   
+test_data:
   profile:
     partitioning:
       - drive:

--- a/schedule/yast/autoyast_disk_as_md_member.yaml
+++ b/schedule/yast/autoyast_disk_as_md_member.yaml
@@ -1,5 +1,6 @@
-name:           autoyast_disk_as_md_member
-description:    >
+---
+name: autoyast_disk_as_md_member
+description: >
   Test autoyast installation, while using a disk as a MD RAID member
 vars:
   AUTOYAST: autoyast_sle15/autoyast_disk_as_md_member.xml
@@ -22,18 +23,18 @@ schedule:
   - autoyast/verify_disk_as_md_member
   - autoyast/verify_cloned_profile
 test_data:
-  disk: '/dev/md0'
+  disk: /dev/md0
   partitions_count: 2
-  type_part: 'part'
-  raid_level: 'raid1'
+  type_part: part
+  raid_level: raid1
   mount_point:
-    root: '/'
-    data: '/data'
+    root: /
+    data: /data
   profile:
     partitioning:
       - drive:
           unique_key: device
-          device:  /dev/sda
+          device: /dev/sda
       - drive:
           unique_key: device
           device: /dev/md/0
@@ -46,6 +47,6 @@ test_data:
             - partition:
                 unique_key: mount
                 mount: /data
-      - drive:  
+      - drive:
           unique_key: device
           device: /dev/sdb

--- a/schedule/yast/autoyast_disk_as_pv.yaml
+++ b/schedule/yast/autoyast_disk_as_pv.yaml
@@ -1,8 +1,9 @@
-name:           autoyast_disk_as_pv
-description:    >
-  Installation using one disk for booting, second as / partition and third one as volume group. 
-  Partitioning is validated after installation is finished, 
-  then SUT is cloned and generated profile is validated.
+---
+name: autoyast_disk_as_pv
+description: >
+  Installation using one disk for booting, second as / partition and third one
+  as volume group.  Partitioning is validated after installation is finished,  then
+  SUT is cloned and generated profile is validated.
 vars:
   AUTOYAST: autoyast_sle15/autoyast_disk_as_pv.xml
   AUTOYAST_CONFIRM: 1

--- a/schedule/yast/autoyast_eula.yaml
+++ b/schedule/yast/autoyast_eula.yaml
@@ -1,8 +1,9 @@
-name:           autoyast_eula
-description:    >
+---
+name: autoyast_eula
+description: >
   User agreement test, same as autoyast_eula but with modules adjusted for sle15.
   Now expect single license, as content of all licenses is the same and we don't show it.
-  Packages DVD is vanished, using "Full" installer instead. 
+  Packages DVD is vanished, using "Full" installer instead.
 vars:
   AUTOYAST: autoyast_sle15/autoyast_eula.xml
   AUTOYAST_LICENSE: 1

--- a/schedule/yast/autoyast_invalid_default_target.yaml
+++ b/schedule/yast/autoyast_invalid_default_target.yaml
@@ -1,22 +1,21 @@
-name:           autoyast_invalid_default_target
-description:    >
-        Test AutoYaST installation while invalid default target is specified in
-        AutoYaST control file.
-        Covered cases:
-           - Verify that warning message is shown during installation;
-           - Verify that multi-user target is set as default in the case.
-
+---
+name: autoyast_invalid_default_target
+description: >
+  Test AutoYaST installation while invalid default target is specified in AutoYaST
+  control file. Covered cases:
+     - Verify that warning message is shown during installation;
+     - Verify that multi-user target is set as default in the case.
 vars:
-        AUTOYAST: autoyast_sle15/autoyast_invalid_default_target.xml
-        AUTOYAST_PREPARE_PROFILE: 1
+  AUTOYAST: autoyast_sle15/autoyast_invalid_default_target.xml
+  AUTOYAST_PREPARE_PROFILE: 1
 schedule:
-        - autoyast/prepare_profile
-        - installation/isosize
-        - installation/bootloader_start
-        - autoyast/installation
-        - autoyast/console
-        - autoyast/verify_default_target
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/verify_default_target
 test_data:
-  default_target: "multi-user.target"
+  default_target: multi-user.target
   expected_warnings:
     - autoyast-warning-invalid-default-target

--- a/schedule/yast/autoyast_mini_spvm.yaml
+++ b/schedule/yast/autoyast_mini_spvm.yaml
@@ -1,11 +1,12 @@
-name:           autoyast_mini
-description:    >
-    Parent job produces autoyast profile after successful completion.
-    This test uses generated profile to do autoyast installation.
+---
+name: autoyast_mini
+description: >
+  Parent job produces autoyast profile after successful completion. This test
+  uses generated profile to do autoyast installation.
 vars:
-    AUTOYAST: autoyast_sle15/mini_remote.xml
-    AUTOYAST_CONFIRM: 1
-    DESKTOP: textmode
+  AUTOYAST: autoyast_sle15/mini_remote.xml
+  AUTOYAST_CONFIRM: 1
+  DESKTOP: textmode
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start

--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -1,5 +1,6 @@
-name:           autoyast_multi_btrfs
-description:    >
+---
+name: autoyast_multi_btrfs
+description: >
   Test autoyast installation, while using multi-device Btrfs filesystem
 vars:
   ENCRYPT: 1
@@ -10,7 +11,7 @@ schedule:
   - autoyast/installation
   - installation/boot_encrypt
   - installation/first_boot
-  - autoyast/console 
+  - autoyast/console
   - autoyast/clone
   - console/validate_multi_btrfs_partitioning
   - console/validate_encrypt
@@ -72,7 +73,7 @@ test_data:
           device: /dev/vdd
           disklabel: gpt
           partitions:
-            - partition: 
+            - partition:
                 unique_key: partition_nr
                 partition_nr: 1
                 crypt_method: luks1

--- a/schedule/yast/autoyast_nfs_share.yaml
+++ b/schedule/yast/autoyast_nfs_share.yaml
@@ -1,5 +1,6 @@
-name:           autoyast_multi_btrfs
-description:    >
+---
+name: autoyast_multi_btrfs
+description: >
   Test autoyast installation, while using nfs share
 schedule:
   - autoyast/prepare_profile
@@ -7,7 +8,7 @@ schedule:
   - installation/bootloader_start
   - autoyast/installation
   - installation/first_boot
-  - autoyast/console 
+  - autoyast/console
   - autoyast/clone
   - autoyast/verify_cloned_profile
   - autoyast/verify_nfs_share
@@ -21,8 +22,8 @@ test_data:
     - rpcbind
     - rpc-statd
     - nfs
-  services_status: active
   # cloned AutoYaST profile validation
+  services_status: active
   profile:
     partitioning:
       drive:

--- a/schedule/yast/autoyast_reinstall.yaml
+++ b/schedule/yast/autoyast_reinstall.yaml
@@ -1,5 +1,6 @@
-name:           autoyast_reinstall
-description:    >
+---
+name: autoyast_reinstall
+description: >
     Parent job produces autoyast profile after successful completion.
     This test uses generated profile to do autoyast installation.
 schedule:
@@ -38,13 +39,13 @@ conditional_schedule:
       qemu:
         - installation/grub_test
   opensuse_welcome:
-      VERSION:
-        Tumbleweed:
-          - installation/opensuse_welcome
+    VERSION:
+      Tumbleweed:
+        - installation/opensuse_welcome
   inject_registration:
-      DISTRI:
-        sle:
-          - autoyast/prepare_cloned_profile
+    DISTRI:
+      sle:
+        - autoyast/prepare_cloned_profile
 test_data:
   paths:
     - /var/lib/gdm/.bashrc

--- a/schedule/yast/autoyast_resize_luks2.yaml
+++ b/schedule/yast/autoyast_resize_luks2.yaml
@@ -1,5 +1,6 @@
-name:           autoyast_resize_luks2
-description:    >
+---
+name: autoyast_resize_luks2
+description: >
   Test autoyast installation, while resizing encrypted partition using luks2
 vars:
   AUTOYAST: autoyast_sle15/autoyast_resize_luks2.xml
@@ -27,17 +28,16 @@ test_data:
       size: 5G
       luks_type: 2
   profile:
-      partitioning:
-        - drive:
-            unique_key: device
-            device: /dev/vda
-        - drive:
-            unique_key: device
-            device: /dev/vdb
-            disklabel: gpt
-            partitions:
-              - partition:
-                  unique_key: crypt_method
-                  # YaST is only capable of work with luks1
-                  crypt_method: luks1
-                  size: 5368709120
+    partitioning:
+      - drive:
+          unique_key: device
+          device: /dev/vda
+      - drive:
+          unique_key: device
+          device: /dev/vdb
+          disklabel: gpt
+          partitions:
+            - partition:
+                unique_key: crypt_method
+                crypt_method: luks1
+                size: 5368709120

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -1,33 +1,33 @@
 ---
-name:           dud_development_tools
-description:    >
-    Same as dud_sdk, but due to bsc#1080292 we cannot use ISO. 
-    FTP url is used instead. Limitation is that we use x86_64 url, 
-    as cannot create DUD in the runtime, so test cannot be executed on other architectures.
+name: dud_development_tools
+description: >
+  Same as dud_sdk, but due to bsc#1080292 we cannot use ISO.  FTP url is used
+  instead. Limitation is that we use x86_64 url,  as cannot create DUD in the
+  runtime, so test cannot be executed on other architectures.
 vars:
-    DUD: dev_tools.dud
-    DUD_ADDONS: sdk
+  DUD: dev_tools.dud
+  DUD_ADDONS: sdk
 schedule:
-    - installation/isosize
-    - installation/bootloader_start
-    - installation/welcome
-    - installation/accept_license
-    - installation/scc_registration
-    - installation/dud_addon
-    - installation/addon_products_sle
-    - installation/system_role
-    - installation/partitioning
-    - installation/partitioning_finish
-    - installation/installer_timezone
-    - installation/hostname_inst
-    - installation/user_settings
-    - installation/user_settings_root
-    - installation/resolve_dependency_issues
-    - installation/installation_overview
-    - installation/disable_grub_timeout
-    - installation/start_install
-    - installation/await_install
-    - installation/logs_from_installation_system
-    - installation/reboot_after_installation
-    - installation/grub_test
-    - installation/first_boot
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/dud_addon
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm+activate_existing+force_recompute.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing+force_recompute.yaml
@@ -5,10 +5,10 @@ description: >
   partitions activation and that we can re-ecnrypt the disk.
 name: cryptlvm+activate_existing+force_recompute
 vars:
-    ENCRYPT: 1
-    ENCRYPT_ACTIVATE_EXISTING: 1
-    ENCRYPT_FORCE_RECOMPUTE: 1
-    LVM: 1
+  ENCRYPT: 1
+  ENCRYPT_ACTIVATE_EXISTING: 1
+  ENCRYPT_FORCE_RECOMPUTE: 1
+  LVM: 1
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/encryption/cryptlvm+activate_existing+import_users.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing+import_users.yaml
@@ -5,7 +5,7 @@ description: >
   partitions activation and that we can re-ecnrypt the disk.
 name: cryptlvm+activate_existing+import_users
 vars:
-    ENCRYPT_ACTIVATE_EXISTING: 1
+  ENCRYPT_ACTIVATE_EXISTING: 1
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/encryption/cryptlvm+activate_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing.yaml
@@ -4,7 +4,7 @@ description: >
   pre-partitioned disk image to validate encrypted partitions activation.
 name: cryptlvm+activate_existing
 vars:
-    ENCRYPT_ACTIVATE_EXISTING: 1
+  ENCRYPT_ACTIVATE_EXISTING: 1
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/encryption/cryptlvm+activate_existing_dasd.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing_dasd.yaml
@@ -1,13 +1,13 @@
 ---
 description: >
   Conduct installation trying to reuse encrypted partitions (bsc#993247). Using
-  pre-partitioned disk image to validate encrypted partitions activation.
-  For zVM we activate DASD disk which we format in from of the installation and
-  create encrypted partition on it, similarly to powerVM.
+  pre-partitioned disk image to validate encrypted partitions activation. For
+  zVM we activate DASD disk which we format in from of the installation and create
+  encrypted partition on it, similarly to powerVM.
 name: cryptlvm+activate_existing
 vars:
-    ENCRYPT_ACTIVATE_EXISTING: 1
-    FORMAT_DASD: pre_install
+  ENCRYPT_ACTIVATE_EXISTING: 1
+  FORMAT_DASD: pre_install
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/encryption/cryptlvm+activate_existing_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing_spvm.yaml
@@ -1,14 +1,14 @@
 ---
 description: >
   Conduct installation trying to reuse encrypted partitions (bsc#993247). Using
-  pre-partitioned disk image to validate encrypted partitions activation.
-  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
-  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+  pre-partitioned disk image to validate encrypted partitions activation. For
+  spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters module
+  is scheduled and OPT_KERNEL_PARAMS variable is set.
 name: cryptlvm+activate_existing
 vars:
-    OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
-    DESKTOP: textmode
-    ENCRYPT_ACTIVATE_EXISTING: 1
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  DESKTOP: textmode
+  ENCRYPT_ACTIVATE_EXISTING: 1
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -1,14 +1,13 @@
 ---
 description: >
-  Conduct installation cancelling encrypted partitions activation, and
-  creating encrypted lvm setup from scratch.
-  Using pre-partitioned disk image to validate encrypted
-  partitions activation and that we can re-ecnrypt the disk.
+  Conduct installation cancelling encrypted partitions activation, and creating
+  encrypted lvm setup from scratch. Using pre-partitioned disk image to validate
+  encrypted partitions activation and that we can re-ecnrypt the disk.
 name: cryptlvm+activate_existing
 vars:
-    ENCRYPT: 1
-    ENCRYPT_CANCEL_EXISTING: 1
-    LVM: 1
+  ENCRYPT: 1
+  ENCRYPT_CANCEL_EXISTING: 1
+  LVM: 1
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/encryption/cryptlvm_sle_12_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_12_spvm.yaml
@@ -1,14 +1,14 @@
 ---
 description: >
-  Conduct installation with encrypted LVM selected during installation.
-  Generated disk image used in downstream jobs. (crypt-)LVM installations can
-  take longer, especially on non-x86_64 architectures.
-  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
-  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+  Conduct installation with encrypted LVM selected during installation. Generated
+  disk image used in downstream jobs. (crypt-)LVM installations can take longer,
+  especially on non-x86_64 architectures. For spvm we have to disable plymouth,
+  so edit_optional_kernel_cmd_parameters module is scheduled and OPT_KERNEL_PARAMS
+  variable is set.
 name: cryptlvm
 vars:
-    OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
-    DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  DESKTOP: textmode
 schedule:
   - installation/bootloader
   - installation/welcome

--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -1,16 +1,15 @@
 ---
 description: >
-  Conduct installation with encrypted LVM selected during installation.
-  Generated disk image used in downstream jobs. (crypt-)LVM installations can
-  take longer, especially on non-x86_64 architectures.
-  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
-  module is scheduled and OPT_KERNEL_PARAMS variable is set.
-  In comparison to SLE 12 we register the installation and have system roles
-  wizard screen.
+  Conduct installation with encrypted LVM selected during installation. Generated
+  disk image used in downstream jobs. (crypt-)LVM installations can take longer,
+  especially on non-x86_64 architectures. For spvm we have to disable plymouth,
+  so edit_optional_kernel_cmd_parameters module is scheduled and OPT_KERNEL_PARAMS
+  variable is set. In comparison to SLE 12 we register the installation and have
+  system roles wizard screen.
 name: cryptlvm
 vars:
-    OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
-    DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  DESKTOP: textmode
 schedule:
   - installation/bootloader
   - installation/welcome

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -1,7 +1,8 @@
-name:           lvm-encrypt-separate-boot
-description:    >
-  Same as lvm-full-encrypt, but with separate boot not encrypted partition, 
-  only installation to not repeat everything again with small risk.
+---
+name: lvm-encrypt-separate-boot
+description: >
+  Same as lvm-full-encrypt, but with separate boot not encrypted partition, only
+  installation to not repeat everything again with small risk.
 vars:
   UNENCRYPTED_BOOT: 1
   ENCRYPT: 1

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -1,7 +1,8 @@
-name:           lvm-encrypt-separate-boot
-description:    >
-  Same as lvm-full-encrypt, but with separate boot not encrypted partition, 
-  only installation to not repeat everything again with small risk.
+---
+name: lvm-encrypt-separate-boot
+description: >
+  Same as lvm-full-encrypt, but with separate boot not encrypted partition, only
+  installation to not repeat everything again with small risk.
 vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1

--- a/schedule/yast/encryption/lvm_full_encrypt_opensuse.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_opensuse.yaml
@@ -1,7 +1,8 @@
-name:           lvm-encrypt-separate-boot
-description:    >
-  Same as lvm-full-encrypt, but with separate boot not encrypted partition, 
-  only installation to not repeat everything again with small risk.
+---
+name: lvm-encrypt-separate-boot
+description: >
+  Same as lvm-full-encrypt, but with separate boot not encrypted partition,  only
+  installation to not repeat everything again with small risk.
 vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -1,5 +1,6 @@
+---
 name: gpt
-description:    > 
+description: >
   Test installation on a very large hard disk which needs GPT partition format.
 schedule:
   - installation/isosize

--- a/schedule/yast/iscsi/iscsi_normal_auth_backstore_fileio.yaml
+++ b/schedule/yast/iscsi/iscsi_normal_auth_backstore_fileio.yaml
@@ -1,28 +1,30 @@
-name:           iscsi_normal_auth_backstore_fileio
-description:    >
-    iSCSI multimachine test suite with normal authentication, fileIO backstore, simple static network.
+---
+name: iscsi_normal_auth_backstore_fileio
+description: >
+  iSCSI multimachine test suite with normal authentication, fileIO backstore,
+  simple static network.
 test_data:
   common:
-    password: 'susetesting'
+    password: susetesting
   target_conf:
-    backstore_type: 'fileio'
-    backstore: '/root/iscsi-disk'
-    user: 'test_target'
-    name: 'iqn.2016-02.de.openqa'
-    ip: '10.0.2.1/24'
-    id: 'target'
+    backstore_type: fileio
+    backstore: /root/iscsi-disk
+    user: test_target
+    name: iqn.2016-02.de.openqa
+    ip: 10.0.2.1/24
+    id: target
   initiator_conf:
-    ip: '10.0.2.3/24'
-    user: 'test_initiator'
-    id: 'init'
-    name: 'iqn.2016-02.de.openqa'
+    ip: 10.0.2.3/24
+    user: test_initiator
+    id: init
+    name: iqn.2016-02.de.openqa
 conditional_schedule:
-    iscsi:
-        FUNCTION:
-            target:
-                - iscsi/iscsi_server
-            initiator:
-                - iscsi/iscsi_client
+  iscsi:
+    FUNCTION:
+      target:
+        - iscsi/iscsi_server
+      initiator:
+        - iscsi/iscsi_client
 schedule:
-    - boot/boot_to_desktop
-    - '{{iscsi}}'
+  - boot/boot_to_desktop
+  - '{{iscsi}}'

--- a/schedule/yast/iscsi/iscsi_normal_auth_backstore_hdd.yaml
+++ b/schedule/yast/iscsi/iscsi_normal_auth_backstore_hdd.yaml
@@ -1,28 +1,30 @@
-name:           iscsi_normal_auth_backstore_hdd
-description:    >
-    iSCSI multimachine test suite with normal authentication, plain drive backstore, simple static network.
+---
+name: iscsi_normal_auth_backstore_hdd
+description: >
+  iSCSI multimachine test suite with normal authentication, plain drive backstore,
+  simple static network.
 test_data:
   common:
-    password: 'susetesting'
+    password: susetesting
   target_conf:
-    backstore_type: 'hdd'
-    backstore: '/dev/vdb'
-    user: 'test_target'
-    name: 'iqn.2016-02.de.openqa'
-    ip: '10.0.2.1/24'
-    id: 'target'
+    backstore_type: hdd
+    backstore: /dev/vdb
+    user: test_target
+    name: iqn.2016-02.de.openqa
+    ip: 10.0.2.1/24
+    id: target
   initiator_conf:
-    ip: '10.0.2.3/24'
-    user: 'test_initiator'
-    id: 'init'
-    name: 'iqn.2016-02.de.openqa'
+    ip: 10.0.2.3/24
+    user: test_initiator
+    id: init
+    name: iqn.2016-02.de.openqa
 conditional_schedule:
-    iscsi:
-        FUNCTION:
-            target:
-                - iscsi/iscsi_server
-            initiator:
-                - iscsi/iscsi_client
+  iscsi:
+    FUNCTION:
+      target:
+        - iscsi/iscsi_server
+      initiator:
+        - iscsi/iscsi_client
 schedule:
-    - boot/boot_to_desktop
-    - '{{iscsi}}'
+  - boot/boot_to_desktop
+  - '{{iscsi}}'

--- a/schedule/yast/iscsi/iscsi_normal_auth_backstore_lvm.yaml
+++ b/schedule/yast/iscsi/iscsi_normal_auth_backstore_lvm.yaml
@@ -1,28 +1,30 @@
-name:           iscsi_normal_auth_backstore_lvm
-description:    >
-    iSCSI multimachine test suite with normal authentication, lvm backstore, simple static network
+---
+name: iscsi_normal_auth_backstore_lvm
+description: >
+  iSCSI multimachine test suite with normal authentication, lvm backstore, simple
+  static network
 test_data:
   common:
-    password: 'susetesting'
+    password: susetesting
   target_conf:
-    backstore_type: 'lvm'
-    backstore: '/dev/mapper/vg_iscsi-remote_lv'
-    user: 'test_target'
-    name: 'iqn.2016-02.de.openqa'
-    ip: '10.0.2.1/24'
-    id: 'target'
+    backstore_type: lvm
+    backstore: /dev/mapper/vg_iscsi-remote_lv
+    user: test_target
+    name: iqn.2016-02.de.openqa
+    ip: 10.0.2.1/24
+    id: target
   initiator_conf:
-    ip: '10.0.2.3/24'
-    user: 'test_initiator'
-    id: 'init'
-    name: 'iqn.2016-02.de.openqa'
+    ip: 10.0.2.3/24
+    user: test_initiator
+    id: init
+    name: iqn.2016-02.de.openqa
 conditional_schedule:
-    iscsi:
-        FUNCTION:
-            target:
-                - iscsi/iscsi_server
-            initiator:
-                - iscsi/iscsi_client
+  iscsi:
+    FUNCTION:
+      target:
+        - iscsi/iscsi_server
+      initiator:
+        - iscsi/iscsi_client
 schedule:
-    - boot/boot_to_desktop
-    - '{{iscsi}}'
+  - boot/boot_to_desktop
+  - '{{iscsi}}'

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -1,13 +1,12 @@
 ---
 description: >
-  Conduct installation cancelling encrypted partitions activation, and
-  creating non-encrypted lvm setup from scratch.
-  Using pre-partitioned disk image to validate encrypted
-  partitions activation and that we can re-ecnrypt the disk.
+  Conduct installation cancelling encrypted partitions activation, and creating
+  non-encrypted lvm setup from scratch. Using pre-partitioned disk image to validate
+  encrypted partitions activation and that we can re-ecnrypt the disk.
 name: cryptlvm+activate_existing
 vars:
-    ENCRYPT_CANCEL_EXISTING: 1
-    LVM: 1
+  ENCRYPT_CANCEL_EXISTING: 1
+  LVM: 1
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -5,8 +5,8 @@ description: >
   wizard screen.
 name: cryptlvm
 vars:
-    OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
-    DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  DESKTOP: textmode
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -2,14 +2,13 @@
 description: >
   Conduct installation with LVM selected during installation using guided setup.
   For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
-  module is scheduled and OPT_KERNEL_PARAMS variable is set.
-  Also, as of now spvm backend doesn't support x11 tests, hence use textmode.
-  In comparison to SLE 12 we register the installation and have system roles
-  wizard screen.
+  module is scheduled and OPT_KERNEL_PARAMS variable is set. Also, as of now
+  spvm backend doesn't support x11 tests, hence use textmode. In comparison to
+  SLE 12 we register the installation and have system roles wizard screen.
 name: lvm
 vars:
-    OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
-    DESKTOP: textmode
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  DESKTOP: textmode
 schedule:
   - installation/bootloader
   - installation/welcome

--- a/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
@@ -1,33 +1,33 @@
 ---
-  name: lvm+raid1@64bit
-  description: >
-    Validation of partitioning for raid1 on lvm
-    Installation of RAID1 using expert partitioner.
-  vars:
-    RAIDLEVEL: 1
-    LVM: 1
-  test_data:
-    $include: test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
-  schedule :
-    - installation/isosize
-    - installation/bootloader_start
-    - installation/welcome
-    - installation/online_repos
-    - installation/installation_mode
-    - installation/logpackages
-    - installation/system_role
-    - installation/partitioning
-    - installation/partitioning_raid
-    - installation/partitioning_finish
-    - installation/installer_timezone
-    - installation/user_settings
-    - installation/resolve_dependency_issues
-    - installation/installation_overview
-    - installation/disable_grub_timeout
-    - installation/start_install
-    - installation/await_install
-    - installation/logs_from_installation_system
-    - installation/reboot_after_installation
-    - installation/grub_test
-    - installation/first_boot
-    - console/validate_lvm_raid1
+name: lvm+raid1@64bit
+description: >
+  Validation of partitioning for raid1 on lvm Installation of RAID1 using expert
+  partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  $include: test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv-uefi.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv-uefi.yaml
@@ -1,14 +1,14 @@
 ---
-name : lvm +raid1 @64bit
-description : >
-  Validation of partitioning for raid1 on lvm
-  Installation of RAID1 using expert partitioner .
-vars :
-  RAIDLEVEL : 1
-  LVM       : 1
-test_data :
-  $include : test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
-schedule :
+name: lvm +raid1 @64bit
+description: >
+  Validation of partitioning for raid1 on lvm Installation of RAID1 using expert
+  partitioner .
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+schedule:
   - installation/isosize
   - installation/bootloader_hyperv
   - installation/bootloader_uefi

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -1,14 +1,14 @@
 ---
-name : lvm +raid1 @64bit
-description : >
-  Validation of partitioning for raid1 on lvm
-  Installation of RAID1 using expert partitioner .
-vars :
-  RAIDLEVEL : 1
-  LVM       : 1
-test_data :
-  $include : test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
-schedule :
+name: lvm +raid1 @64bit
+description: >
+  Validation of partitioning for raid1 on lvm Installation of RAID1 using expert
+  partitioner .
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  $include: test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+schedule:
   - installation/isosize
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -1,9 +1,10 @@
 ---
-name:           minimal+base@yast-s390x-disk-activation
-description:    >
-  Select a minimal textmode installation by starting with the default and unselecting all patterns
-  except for "base" and "enhanced_base". Not to be confused with the new system role "minimal" introduced with SLE15.
-  Requires disk activation and grub is not displayed due to console reconnection.
+name: minimal+base@yast-s390x-disk-activation
+description: >
+  Select a minimal textmode installation by starting with the default and unselecting
+  all patterns except for "base" and "enhanced_base". Not to be confused with
+  the new system role "minimal" introduced with SLE15. Requires disk activation
+  and grub is not displayed due to console reconnection.
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -37,4 +38,3 @@ schedule:
   - console/orphaned_packages_check
   - console/validate_selected_patterns
   - console/consoletest_finish
-

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -1,7 +1,8 @@
 ---
-name:           modify_existing_partition
-description:    >
-  Installation where we modify some pre-existing partitions. Must depend on some create_hdd test suite.
+name: modify_existing_partition
+description: >
+  Installation where we modify some pre-existing partitions. Must depend on some
+  create_hdd test suite.
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -37,4 +38,3 @@ conditional_schedule:
     BACKEND:
       qemu:
         - installation/grub_test
-

--- a/schedule/yast/msdos.yaml
+++ b/schedule/yast/msdos.yaml
@@ -1,5 +1,5 @@
 ---
-name:           msdos@yast
+name:           msdos
 description:    >
   Test for installation on msdos partition table.
 schedule:
@@ -69,4 +69,3 @@ conditional_schedule:
         - installation/grub_test
 test_data:
   $include: test_data/yast/msdos/msdos.yaml
-

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -7,25 +7,25 @@ vars:
   DESKTOP: gnome
   MULTIPATH: 1
 schedule:
-  -installation/bootloader_start
-  -installation/welcome
-  -installation/accept_license
-  -installation/scc_registration
-  -installation/multipath
-  -installation/addon_products_sle
-  -installation/system_role
-  -installation/partitioning
-  -installation/partitioning_finish
-  -installation/installer_timezone
-  -installation/hostname_inst
-  -installation/user_settings
-  -installation/user_settings_root
-  -installation/resolve_dependency_issues
-  -installation/installation_overview
-  -installation/disable_grub_timeout
-  -installation/start_install
-  -installation/await_install
-  -installation/logs_from_installation_system
-  -installation/reboot_after_installation
-  -installation/grub_test
-  -installation/first_boot
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/multipath
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot

--- a/schedule/yast/nfs/yast2_nfs_v4_server.yaml
+++ b/schedule/yast/nfs/yast2_nfs_v4_server.yaml
@@ -1,7 +1,8 @@
 ---
-name:          yast2_nfs_v4_server
-description:    >
-  Multimachine nfs v4 test, server side. Configures an export with the yast module, and validates that the exported FS is working.  Maintainer jrivrain@suse.com.
+name: yast2_nfs_v4_server
+description: >
+  Multimachine nfs v4 test, server side. Configures an export with the yast module,
+  and validates that the exported FS is working.  Maintainer jrivrain@suse.com.
 schedule:
   - boot/boot_to_desktop
   - console/yast2_nfs4_server

--- a/schedule/yast/raid/raid5_sle_msdos.yaml
+++ b/schedule/yast/raid/raid5_sle_msdos.yaml
@@ -1,5 +1,6 @@
-name:           RAID5_msdos
-description:    >
+---
+name: RAID5_msdos
+description: >
   Configure RAID 5 on the disks with GPT partition tables using Expert Partitioner.
   Creates boot, root and swap partitions on each of the 4 disks and then uses
   them for RAID 5.
@@ -83,29 +84,29 @@ test_data:
       chunk_size: 64
       device_selection_step: 3
       partition:
-          role: operating-system
-          formatting_options:
-            should_format: 1
-          mounting_options:
-            should_mount: 1
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
     - raid_level: 1
       chunk_size: 64
       device_selection_step: 2
       partition:
-          role: data
-          formatting_options:
-            should_format: 1
-            filesystem: ext4
-          mounting_options:
-            should_mount: 1
-            mount_point: '/boot'
+        role: data
+        formatting_options:
+          should_format: 1
+          filesystem: ext4
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot
     - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:
-          role: swap
-          formatting_options:
-            should_format: 1
-            filesystem: swap
-          mounting_options:
-            should_mount: 1
+        role: swap
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/yast/remote_ssh_target.yaml
+++ b/schedule/yast/remote_ssh_target.yaml
@@ -1,8 +1,8 @@
 ---
-name:           remote_ssh_target
-description:    >
-  Boot with ssh=1 parameter and wait for parallel job (remote_ssh_controller) 
-  to install the system.
+name: remote_ssh_target
+description: >
+  Boot with ssh=1 parameter and wait for parallel job (remote_ssh_controller)  to
+  install the system.
 schedule:
   - installation/isosize
   - installation/bootloader

--- a/schedule/yast/remote_vnc_target_opensuse.yaml
+++ b/schedule/yast/remote_vnc_target_opensuse.yaml
@@ -1,8 +1,8 @@
 ---
-name:           remote_vnc_target
-description:    >
-  Boot with vnc=1 parameter and wait for parallel job (remote_vnc_controller) 
-  to install the system.
+name: remote_vnc_target
+description: >
+  Boot with vnc=1 parameter and wait for parallel job (remote_vnc_controller)  to
+  install the system.
 schedule:
   - installation/isosize
   - installation/bootloader

--- a/test_data/yast/btrfs/btrfs_sle_libstorage.yaml
+++ b/test_data/yast/btrfs/btrfs_sle_libstorage.yaml
@@ -1,24 +1,25 @@
+---
 subvolume:
-cow:
-  - /opt
-  - /srv
-  - /tmp
-  - /usr/local
-  - /var/cache
-  - /var/crash
-  - /var/lib/machines
-  - /var/lib/mailman
-  - /var/lib/named
-  - /var/opt
-  - /var/spool
-  - /var/tmp
-  - /.snapshots
-no_cow:
-  - /var/lib/libvirt/images
-  - /var/lib/mariadb
-  - /var/lib/mysql
-  - /var/lib/pgsql
-  - /var/log
-file_system:
- /home: xfs
- /: btrfs
+  cow:
+    - /opt
+    - /srv
+    - /tmp
+    - /usr/local
+    - /var/cache
+    - /var/crash
+    - /var/lib/machines
+    - /var/lib/mailman
+    - /var/lib/named
+    - /var/opt
+    - /var/spool
+    - /var/tmp
+    - /.snapshots
+  no_cow:
+    - /var/lib/libvirt/images
+    - /var/lib/mariadb
+    - /var/lib/mysql
+    - /var/lib/pgsql
+    - /var/log
+  file_system:
+    /home: xfs
+    /: btrfs

--- a/test_data/yast/encryption/default_enc.yaml
+++ b/test_data/yast/encryption/default_enc.yaml
@@ -1,11 +1,12 @@
+---
 cryptsetup:
   device_status:
-      message: 'is active and is in use.'
-      properties:
-        type: 'LUKS1'
-        cipher: 'aes-xts-plain64'
-        key_location: 'dm-crypt'
-        mode: 'read/write'
+    message: is active and is in use.
+    properties:
+      type: LUKS1
+      cipher: aes-xts-plain64
+      key_location: dm-crypt
+      mode: read/write
 luks:
-  backup_base_path: '/root/bkp_luks_header'
+  backup_base_path: /root/bkp_luks_header
   backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'

--- a/test_data/yast/ext4/ext4.yaml
+++ b/test_data/yast/ext4/ext4.yaml
@@ -1,8 +1,9 @@
-  allowed_unpartitioned: 0.00GB
-  partitions:
-    - mnt_point: /
-      fs_type: ext4
-    - mnt_point: /home
-      fs_type: xfs 
-    - mnt_point: [SWAP]
-      fs_type: swap
+---
+allowed_unpartitioned: 0.00GB
+partitions:
+  - mnt_point: /
+    fs_type: ext4
+  - mnt_point: /home
+    fs_type: xfs
+  - mnt_point: '[SWAP]'
+    fs_type: swap

--- a/test_data/yast/ext4/ext4_no_separate_home.yaml
+++ b/test_data/yast/ext4/ext4_no_separate_home.yaml
@@ -1,7 +1,7 @@
-  allowed_unpartitioned: 0.00GB
-  partitions:
-    - mnt_point: /
-      fs_type: ext4
-    - mnt_point: [SWAP]
-      fs_type: swap
-
+---
+allowed_unpartitioned: 0.00GB
+partitions:
+  - mnt_point: /
+    fs_type: ext4
+  - mnt_point: '[SWAP]'
+    fs_type: swap

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle12.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle12.yaml
@@ -11,4 +11,3 @@ raid1:
   disk_to_fail: /dev/vdd2
   level: raid1
   name: /dev/md0
-

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
@@ -11,4 +11,3 @@ raid1:
   disk_to_fail: /dev/sdd2
   level: raid1
   name: /dev/md0
-

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
@@ -11,4 +11,3 @@ raid1:
   disk_to_fail: /dev/xvdd2
   level: raid1
   name: /dev/md0
-

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -11,4 +11,3 @@ raid1:
   disk_to_fail: /dev/sdd2
   level: raid1
   name: /dev/md0
-

--- a/test_data/yast/modify_existing_partition/modify_existing_partition.yaml
+++ b/test_data/yast/modify_existing_partition/modify_existing_partition.yaml
@@ -1,18 +1,20 @@
 ---
-  root:
-    disk: 'vda'
-    existing_partition: 'vda2'
-    mount_point: '/'
-    fs_type: 'ext4'
-    # Sizes should be preferably expressed in human readable binary units (eg GiB) for this test suite:
-    # we use lsblk in validation modules, wich uses human readable binary unit (*ibits).
-    # part_size is the size we input in partitioner, lsblk_expected_size_output is what we'll use for validation.
-    part_size: '11GiB'
-    lsblk_expected_size_output: '11G'
-  swap:
-    disk: 'vda'
-    existing_partition: 'vda3'
-    fs_type: 'swap'
-    skip: 1
-    part_size: '2GiB'
-    lsblk_expected_size_output: '2G'
+root:
+  disk: vda
+  existing_partition: vda2
+  mount_point: /
+  fs_type: ext4
+  # Sizes should be preferably expressed in human readable binary units (eg GiB)
+  # for this test suite: we use lsblk in validation modules, which uses human
+  # readable binary unit (*ibits).
+  # part_size is the size we input in partitioner, lsblk_expected_size_output
+  # is what we'll use for validation.
+  part_size: 11GiB
+  lsblk_expected_size_output: 11G
+swap:
+  disk: vda
+  existing_partition: vda3
+  fs_type: swap
+  skip: 1
+  part_size: 2GiB
+  lsblk_expected_size_output: 2G

--- a/test_data/yast/msdos/msdos.yaml
+++ b/test_data/yast/msdos/msdos.yaml
@@ -1,3 +1,4 @@
+---
 table_type: msdos
 partition_table_disk: vda
 disks:
@@ -13,7 +14,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/'
+          mount_point: /
       - size: 9250Mib
         role: data
         partition_type: primary
@@ -23,14 +24,14 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/home'
-      - size: max 
+          mount_point: /home
+      - size: max
         role: swap
         partition_type: primary
-        validation_flag: 0 
+        validation_flag: 0
         formatting_options:
           should_format: 1
           filesystem: swap
         mounting_options:
           should_mount: 1
-          mount_point: '[SWAP]' 
+          mount_point: '[SWAP]'

--- a/test_data/yast/msdos/msdos_hmc.yaml
+++ b/test_data/yast/msdos/msdos_hmc.yaml
@@ -1,7 +1,8 @@
+---
 table_type: msdos
 partition_table_disk: sda
 disks:
-  - name: sda 
+  - name: sda
     allowed_unpartitioned: 0.00GB
     partitions:
       - size: 8Mib
@@ -18,7 +19,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/'
+          mount_point: /
       - size: 12000Mib
         role: data
         partition_type: primary
@@ -28,7 +29,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/home'
+          mount_point: /home
       - size: max
         role: swap
         partition_type: primary

--- a/test_data/yast/msdos/msdos_hvm.yaml
+++ b/test_data/yast/msdos/msdos_hvm.yaml
@@ -1,3 +1,4 @@
+---
 table_type: msdos
 partition_table_disk: xvdb
 disks:
@@ -13,7 +14,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/'
+          mount_point: /
       - size: 9250Mib
         role: data
         partition_type: primary
@@ -23,15 +24,14 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/home'
+          mount_point: /home
       - size: max
         role: swap
         partition_type: primary
-        validation_flag: 0 
+        validation_flag: 0
         formatting_options:
           should_format: 1
           filesystem: swap
         mounting_options:
           should_mount: 1
           mount_point: '[SWAP]'
-

--- a/test_data/yast/msdos/msdos_hyperv.yaml
+++ b/test_data/yast/msdos/msdos_hyperv.yaml
@@ -1,3 +1,4 @@
+---
 table_type: msdos
 partition_table_disk: sda
 disks:
@@ -13,7 +14,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/'
+          mount_point: /
       - size: 9250Mib
         role: data
         partition_type: primary
@@ -23,15 +24,14 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/home'
+          mount_point: /home
       - size: max
         role: swap
         partition_type: primary
-        validation_flag: 0 
+        validation_flag: 0
         formatting_options:
           should_format: 1
           filesystem: swap
         mounting_options:
           should_mount: 1
           mount_point: '[SWAP]'
-

--- a/test_data/yast/msdos/msdos_ppc64le.yaml
+++ b/test_data/yast/msdos/msdos_ppc64le.yaml
@@ -1,7 +1,8 @@
+---
 table_type: msdos
 partition_table_disk: vda
 disks:
-  - name: vda 
+  - name: vda
     allowed_unpartitioned: 0.00GB
     partitions:
       - size: 8Mib
@@ -18,7 +19,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/'
+          mount_point: /
       - size: 9250Mib
         role: data
         partition_type: primary
@@ -28,11 +29,11 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/home'
+          mount_point: /home
       - size: max
         role: swap
         partition_type: primary
-        validation_flag: 0 
+        validation_flag: 0
         formatting_options:
           should_format: 1
           filesystem: swap

--- a/test_data/yast/msdos/msdos_pv.yaml
+++ b/test_data/yast/msdos/msdos_pv.yaml
@@ -1,3 +1,4 @@
+---
 table_type: msdos
 partition_table_disk: xvdb
 disks:
@@ -13,7 +14,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/'
+          mount_point: /
       - size: 9250Mib
         role: data
         partition_type: primary
@@ -23,7 +24,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/home'
+          mount_point: /home
       - size: max
         role: swap
         partition_type: primary
@@ -34,4 +35,3 @@ disks:
         mounting_options:
           should_mount: 1
           mount_point: '[SWAP]'
-

--- a/test_data/yast/msdos/msdos_s390x.yaml
+++ b/test_data/yast/msdos/msdos_s390x.yaml
@@ -1,3 +1,4 @@
+---
 table_type: msdos
 partition_table_disk: vda
 disks:
@@ -13,7 +14,7 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/'
+          mount_point: /
       - size: 8700Mib
         role: data
         partition_type: primary
@@ -23,11 +24,11 @@ disks:
           filesystem: xfs
         mounting_options:
           should_mount: 1
-          mount_point: '/home'
+          mount_point: /home
       - size: max
         role: swap
         partition_type: primary
-        validation_flag: 0 
+        validation_flag: 0
         formatting_options:
           should_format: 1
           filesystem: swap

--- a/test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+++ b/test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
@@ -1,3 +1,4 @@
+---
 disks:
   - name: vda
     partitions:


### PR DESCRIPTION
After detecting that '!include' is invalid tag, we decided that running yamllint would be beneficial to detect such issues in future. Running the tool on existing profiles has shown multiple issues which we have addressed in this PR. Modified yaml files belong to QSF-Y only.
CI check will validate only files being changed in the PR, meaning that other existing yaml files might contain issues and we leave it to responsible teams to act.

See [poo#64755](https://progress.opensuse.org/issues/64755).