### PR TITLE
Force use of the matching repo in live_installation

### DIFF
--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -34,6 +34,13 @@ sub send_key_and_wait {
 }
 
 sub run {
+    if (get_netboot_mirror) {
+        select_console 'install-shell';
+        # Force use of the matching repo
+        assert_script_run("sed -i'' 's#ZyppRepoURL:.*\$#ZyppRepoURL: " . get_netboot_mirror . "#g' /usr/sbin/start-install.sh");
+        select_console 'x11';
+    }
+
     # stop packagekit, root password is not needed on live system
     x11_start_program('systemctl stop packagekit.service', target_match => 'generic-desktop');
     turn_off_kde_screensaver;


### PR DESCRIPTION
The live installer does not have any mechanism to specify the installation
repository URL, so get creative and patch it...

Verification runs:
15.1 kde_live_installation: http://10.160.67.86/tests/659
TW kde_live_upgrade_leap_15.0: http://10.160.67.86/tests/658
TW kde_live_installation: http://10.160.67.86/tests/657

The TW runs use the openQA hosted repo while the Leap test uses d.o.o, as expected.