### PR TITLE
Exclude deleted yaml schedule files from CI check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-yaml-valid:
 
 .PHONY: test-modules-in-yaml-schedule
 test-modules-in-yaml-schedule:
-	export PERL5LIB=${PERL5LIB_} ; tools/detect_nonexistent_modules_in_yaml_schedule `git diff --name-only --exit-code $$(git merge-base master HEAD) | grep '^schedule/*'`
+	export PERL5LIB=${PERL5LIB_} ; tools/detect_nonexistent_modules_in_yaml_schedule `git diff --diff-filter=d --name-only --exit-code $$(git merge-base master HEAD) | grep '^schedule/*'`
 
 .PHONY: test-metadata
 test-metadata:


### PR DESCRIPTION
[Ci check failed](https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/jobs/667754773?utm_medium=notification&utm_source=github_status) when yaml scheduling files were removed in PR.

The PR fixes the issue by excluding deleted yaml scheduling files with the appropriate filter.