### PR TITLE
Implement sssd-samba integration test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1708,7 +1708,8 @@ sub load_extra_tests_console {
     loadtest 'console/osinfo_db' if (is_sle('12-SP3+') && !is_jeos);
     loadtest 'console/libgcrypt' if ((is_sle(">=12-SP4") && (check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk'))) || is_opensuse);
     loadtest "console/gd";
-    loadtest 'console/valgrind' unless is_sle('<=12-SP3');
+    loadtest 'console/valgrind'   unless is_sle('<=12-SP3');
+    loadtest 'console/sssd_samba' unless is_sle("<15");
 }
 
 sub load_extra_tests_sdk {

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -89,4 +89,5 @@ schedule:
     - console/osinfo_db
     - console/zypper_ref
     - console/kdump_and_crash
+    - console/sssd_samba
     - console/coredump_collect

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -63,6 +63,7 @@ schedule:
 - console/libqca2
 - console/gd
 - console/valgrind
+- console/sssd_samba
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -65,6 +65,7 @@ schedule:
 - console/libqca2
 - console/gd
 - console/valgrind
+- console/sssd_samba
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/tests/console/sssd_samba.pm
+++ b/tests/console/sssd_samba.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Integration tests to sssd/samba (version conflicted libwbclient.so.0)
+# Based on https://bugzilla.suse.com/show_bug.cgi?id=1162203
+# The core issue was that samba has it's own version of libwbclient.so.0 but it
+# is already present from winbind, which is not compatible with samba and causes
+# the samba utilities to fail. So, we test to install winbind and then samba
+# and check if smbclient is still working
+#   * Install sssd winbind client
+#   * Install (or force reinstall) samba
+#   * Check if smbclient is still working
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    # Install sssd before samba and separately as we need to check, if the
+    # libwbclient.so.0 module gets overwritten
+    zypper_call 'in sssd-wbclient';
+    # List affected modules before and after installing samba for debugging
+    # purposes in case the test fails (check if the module got overwritten)
+    script_run 'ls -l /usr/lib64/sssd/modules/';
+    script_run 'md5sum /usr/lib64/sssd/modules/libwbclient.so.0';
+    # Perform a force reinstall in case it is already installed to check,
+    # if the modules get overwritten
+    zypper_call 'in samba';
+    script_run 'ls -l /usr/lib64/sssd/modules/';
+    script_run 'md5sum /usr/lib64/sssd/modules/libwbclient.so.0';
+    assert_script_run 'systemctl start smb';
+    # Test if smbclient works
+    assert_script_run 'smbclient -L localhost -N';
+}
+
+1;


### PR DESCRIPTION
Integration test for sssd and samba for SLE15+ and openSUSE products.
Tests for a version conflict in the libwbclient.so module by installing
first sssd-winbind and afterwards samba. It then checks, if
smbclient correctly works and both products can co-exists without breaking.

- Related ticket: https://progress.opensuse.org/issues/64704
- Needles: N/A
- Verification runs: [SLE15-SP1](https://openqa.suse.de/tests/4060091) | [SLE15](https://openqa.suse.de/tests/4060090) | [Tumbleweed](http://phoenix-openqa.qam.suse.de/tests/339) | [Leap 15.2](http://phoenix-openqa.qam.suse.de/tests/340) | [SLE15-SP2](http://phoenix-openqa.qam.suse.de/t351)

`sssd-wbclient` is only available on SLE15+