### PR TITLE
Fix failing dclick and speedup libreoffice test

### DIFF
--- a/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
+++ b/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
@@ -38,17 +38,17 @@ sub run {
     # navigate to the python samples item
     assert_screen 'ooffice-writer-mymacros';
     send_key 'down';
-    assert_and_dclick 'ooffice-writer-libreofficemacros';
-    send_key_until_needlematch 'ooffice-python-samples', 'down';
+    assert_and_click 'ooffice-writer-libreofficemacros';
+    wait_still_screen(2);
+    type_string "python\n";
 
-    # expand python samples and navigate to table sample
-    # In Libreoffice 6.3 send_key 'right'; doesn't work
-    # So use assert_and_dclick instead
-    assert_and_dclick 'ooffice-python-samples';
-    send_key_until_needlematch 'ooffice-table-sample', 'down';
+    assert_and_click 'ooffice-python-samples';
+    wait_still_screen(2);
+    send_key_until_needlematch 'ooffice-table-sample', 'down', 5, 1;
+    send_key 'tab';
 
     # run create table
-    assert_and_click 'ooffice-run-create-table';
+    send_key 'ret';
     assert_screen 'ooffice-verify-table';
 
     # exit ooffice-writer without saving created table


### PR DESCRIPTION
-use assert_and_click with updated needle clicking on the arrow to expand
-type python to get faster to the pythonSamples
-on python samples navigate and run the macro with keys

- Related ticket: https://progress.opensuse.org/issues/64989
- Fail on 15sp2: https://openqa.suse.de/tests/4065249#step/libreoffice_pyuno_bridge_no_evolution_dep/67
- Verification run:
http://10.100.12.155/tests/14851 15sp1
http://10.100.12.155/tests/14852 15sp2
http://10.100.12.155/tests/14853 15sp2 virtio
multiple full tests of three tests above, due to 6k+ scheduled jobs in o.s.d, not running tests there
http://10.100.12.155/tests
