### PR TITLE
LTP: Add dependencies for net.tcp_cmds

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -107,32 +107,30 @@ sub install_debugging_tools {
 
 sub install_runtime_dependencies_network {
     my @deps;
-    # utils
-    @deps = qw(
-      ethtool
-      iptables
-      psmisc
-      tcpdump
-    );
-    zypper_call('-t in ' . join(' ', @deps));
-
-    # clients
     @deps = qw(
       dhcp-client
-      telnet
-    );
-    zypper_call('-t in ' . join(' ', @deps));
-
-    # services
-    @deps = qw(
       dhcp-server
+      diffutils
       dnsmasq
+      ethtool
+      iptables
       nfs-kernel-server
+      psmisc
       rpcbind
       rsync
+      telnet
+      tcpdump
       vsftpd
     );
     zypper_call('-t in ' . join(' ', @deps));
+
+    my @maybe_deps = qw(
+      telnet-server
+      xinetd
+    );
+    for my $dep (@maybe_deps) {
+        script_run('zypper -n -t in ' . $dep . ' | tee');
+    }
 }
 
 sub install_build_dependencies {


### PR DESCRIPTION
telnet-server and xinetd are "maybe_deps" because they are available
only Tumbleweed (not on SLES).

Also merge 3 arrays used for zypper_call() which speedup executing a bit
(calling zypper_call() only once instead of 3 times).

This code is not run as the default, so it's just mirroring changes in
package.

Verification run:
- SLE 15 SP2 http://quasar.suse.cz/tests/4970
- Tumbleweed http://quasar.suse.cz/tests/4971
- sle-12-SP5-Server-DVD-Incidents-Kernel (QAM) http://quasar.suse.cz/tests/4977

NOTE: for QAM has been installing from git broken for some time (not affected by this change), but it's not used anyway:
- sle-15-Server-DVD-Incidents-Kernel
http://quasar.suse.cz/tests/4975/file/serial_terminal.txt
Problem: conflicting requests
 Solution 1: remove lock to allow installation of kernel-default-devel-4.12.14-150.47.1.x86_64[Basesystem_Module_15_x86_64:SLE-Module-Basesystem15-Updates]
 Solution 2: do not ask to install a solvable providing kernel-default-devel.x86_64 = 4.12.14-150.47.1