### PR TITLE
Unschedule container tests from textmode suite

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -88,9 +88,5 @@ schedule:
     - console/aaa_base
     - console/osinfo_db
     - console/zypper_ref
-    - console/docker
-    - console/docker_runc
-    - console/docker_image
-    - console/zypper_docker
     - console/kdump_and_crash
     - console/coredump_collect


### PR DESCRIPTION
It is already present in extra_tests_textmode_containers

- Related ticket: https://progress.opensuse.org/issues/57290