### PR TITLE
xfstests: Longer upload log wait time

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -463,15 +463,15 @@ sub run {
     save_tmp_file('status.log', $status_log_content);
     my $local_file = "/tmp/opt_logs.tar.gz";
     script_run("tar zcvf $local_file --absolute-names /opt/log/");
-    script_run("NUM=0; while [ ! -f $local_file ]; do sleep 10; NUM=\$(( \$NUM + 1 )); if [ \$NUM -gt 5 ]; then break; fi; done");
+    script_run("NUM=0; while [ ! -f $local_file ]; do sleep 20; NUM=\$(( \$NUM + 1 )); if [ \$NUM -gt 10 ]; then break; fi; done");
     my $tar_content = script_output("cat $local_file");
     save_tmp_file('opt_logs.tar.gz', $tar_content);
+    send_key 'ctrl-c';
     script_run('clear');
 }
 
 sub post_fail_hook {
     my ($self) = shift;
-    $self->SUPER::post_fail_hook;
     # Collect executed test logs
     script_run 'tar zcvf /tmp/opt_logs.tar.gz --absolute-names /opt/log/';
     upload_logs '/tmp/opt_logs.tar.gz';


### PR DESCRIPTION
Test will die in waiting upload log sometimes in spvm. e.g. https://openqa.suse.de/tests/3998437#step/run/4401
Before the waiting time is 60s, this PR extend wait time to 200s.
And tests may fail by some unexpected input in `script_run('clear')`, then add a ctrl-c to clear input before it.

And spvm has a login issue in post_fail_hook, and logs in SUPER::post_fail_hook is not needed in this tests so, delete that function and leave upload xfstests logs.

- Related ticket: https://progress.opensuse.org/issues/64559
- VR: http://openqa.suse.de/tests/4108817