### PR TITLE
Storage: Add initial yaml scheduler

### DIFF
--- a/schedule/storage/blktests.yaml
+++ b/schedule/storage/blktests.yaml
@@ -1,0 +1,20 @@
+name:           blktests
+description:    >
+    Executing blktests, the upstream testsuite
+vars:
+    DESKTOP: textmode
+    VIDEOMODE: text
+    VIRTIO_CONSOLE: 1
+    QEMUCPUS: 4
+    NUMDISKS: 6
+    HDDMODEL_1: virtio-blk
+    HDDMODEL_2: nvme
+    HDDMODEL_3: scsi-disk
+    HDDMODEL_4: nvme
+    HDDMODEL_5: scsi-hd
+    HDDMODEL_6: scsi-hd
+    DUMP_MEMORY_ON_FAIL: 1
+    BOOT_HDD_IMAGE: 1
+schedule:
+    - boot/boot_to_desktop
+    - kernel/blktests

--- a/schedule/storage/blktests_spvm.yaml
+++ b/schedule/storage/blktests_spvm.yaml
@@ -1,0 +1,10 @@
+name:           blktests_spvm
+description:    >
+    Executing blktests, the upstream testsuite
+vars:
+    DESKTOP: textmode
+    BOOT_HDD_IMAGE: 1
+schedule:
+    - installation/bootloader
+    - boot/boot_to_desktop
+    - kernel/blktests


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/64869

Note: proposed as separate yaml files: blktests and blktests_spvm due
to the fact that current runs of blktests are considered 'development' and
due to the fact that tests require very specific SUT set-up, so it might be
clear to keep this in separate yaml for now and merge only after the tests
are considered stable

-- revision 2 --
test suite settings removed from yaml as otherwise it defeats the very
idea of using those for adjusting blktests runs in openQA 

-- edit --
seems, after using some openqa scripts I could do these verification runs:
x86_64: https://openqa.suse.de/tests/4072263
ppc: https://openqa.suse.de/tests/4072274
