### PR TITLE
Remove perlcritic policy ConsistentQuoteLikeWords

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -12,9 +12,6 @@ severity = 1
 [Perl::Critic::Policy::HashKeyQuotes]
 severity = 5
 
-[Perl::Critic::Policy::ConsistentQuoteLikeWords]
-severity = 5
-
 [ControlStructures::ProhibitDeepNests]
 severity = 4
 add_themes = freenode

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ else
 test: unit-test test-static test-compile perlcritic
 endif
 
-PERLCRITIC=PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --quiet --stern --include "strict" --include Perl::Critic::Policy::HashKeyQuote --include Perl::Critic::Policy::ConsistentQuoteLikeWords
+PERLCRITIC=PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --quiet --stern --include "strict" --include Perl::Critic::Policy::HashKeyQuote
 
 .PHONY: perlcritic
 perlcritic: tools/lib/


### PR DESCRIPTION
We are thinking about removing the ConsistentQuoteLikeWords policy from os-autoinst and openQA.

See: https://github.com/os-autoinst/os-autoinst/pull/1375, https://github.com/os-autoinst/openQA/pull/2883

Whenever an import list

    use Foo 'bar`;

gets another item, it has to be changed to

    use Foo qw(bar baz);

But it also has to be changed back if an import item gets removed. That can be quite annoying when developing, and I also wouldn't call this policy "Consistent". Consistent would be to use `qw()` all the time.

The first step would be to remove the policy here, as it is using the module Perl::Critic::Policy::ConsistentQuoteLikeWords  provided by openQA.

What do you think?