### PR TITLE
Send key to unlock screen

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -112,6 +112,9 @@ sub ensure_unlocked_desktop {
                     assert_screen 'generic-desktop';
                 }
                 else {
+                    # send key to end screenlock
+                    send_key 'esc';
+                    save_screenshot;
                     next;    # most probably screen is locked
                 }
             }


### PR DESCRIPTION
We encounter failed case on consoletest_finish module, the reason behind is lock screen happen, so i add extra key event to unlock screen

- Related ticket: https://progress.opensuse.org/issues/64896
- Needles: n/a
- Verification run: http://openqa.suse.de/t4065895
