### PR TITLE
Increate timeout in yast2 nfs-client

### DIFF
--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -68,7 +68,7 @@ sub run {
 
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nfs-client');
 
-    assert_screen 'yast2-nfs-client-shares';
+    assert_screen 'yast2-nfs-client-shares', 60;
     send_key 'alt-a';
     assert_screen 'yast2-nfs-client-add';
     type_string get_var('NFSCLIENT') ? '10.0.2.101' : 'localhost';


### PR DESCRIPTION
Increase needle timeout to avoid https://openqa.suse.de/tests/4064268#step/yast2_nfs_client/41 in aarch.
