### PR TITLE
Storage: Install tools required by blktests

### DIFF
--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -32,6 +32,9 @@ sub run {
     add_qa_head_repo();
     zypper_call('in blktests');
 
+    #install test specific tools
+    zypper_call('in fio blktrace');
+
     my @tests = split(',', $tests);
     assert_script_run('cd /usr/lib/blktests');
 


### PR DESCRIPTION
Some specific tests won't run unless SUT is having those tools
available. The patch is simply adding fio and blktrace needed for
tests: block/002 and 006 as well as well as nvme/010-014

- Related ticket: tbd
- Verification run: tbd
