### PR TITLE
Storage: Extend qa_head_repo with priority option

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -81,7 +81,10 @@ This repository *is* mandatory.
 
 =cut
 sub add_qa_head_repo {
-    zypper_ar(get_required_var('QA_HEAD_REPO'), name => 'qa-head', no_gpg_check => is_sle("<12") ? 0 : 1);
+    my (%args) = @_;
+    my $priority = $args{priority} // 0;
+
+    zypper_ar(get_required_var('QA_HEAD_REPO'), name => 'qa-head', priority => $priority, no_gpg_check => is_sle("<12") ? 0 : 1);
 }
 
 =head2 add_qa_web_repo

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -29,7 +29,9 @@ sub run {
     my $config  = get_required_var('BLK_CONFIG');
     my $device  = get_required_var('BLK_DEVICE_ONLY');
 
-    add_qa_head_repo();
+    #QA repo is added with lower prio in order to avoid possible problems
+    #with some packages provided in both, tested product and qa repo; example: fio
+    add_qa_head_repo(priority => 100);
     zypper_call('in blktests');
 
     my @tests = split(',', $tests);


### PR DESCRIPTION
Some specific tests won't run unless SUT is having required tools
available, like fio. The patch is simply lowering the priority of
the QA repo, so that fio can be installed firstly from the relevant
product repository. Tests like block/006 will run with this patch

- Related ticket: https://progress.opensuse.org/issues/65139
- Verification run (ongoing):
x86_64: https://openqa.suse.de/tests/4073664
ppc: https://openqa.suse.de/tests/4073662

-- edit --
test runs in OSD with the latest patch version:
x86_64: https://openqa.suse.de/tests/4075598
PPC: https://openqa.suse.de/tests/4075599

example of a test using fio and now executed:
block/006 (run null-blk in blocking mode)                    [passed]
    read iops    ...  268615
    runtime      ...  31.178s