### PR TITLE
Increase wait time after su -c bash

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -374,7 +374,7 @@ sub script_sudo {
     handle_password_prompt unless ($testapi::username eq 'root');
     if ($wait > 0) {
         if ($prog eq 'bash') {
-            return wait_still_screen(2, 4);
+            return wait_still_screen(4, 8);
         }
         else {
             return wait_serial("$str-\\d+-");


### PR DESCRIPTION
there are too many failures due to following commands being executed while su -c 'bash' didn't finish
I can't simulate same load as is on osd, but I have slow worker (scruffy) which kind of simulates bad performance

- Fail: https://openqa.suse.de/tests/4075634#step/yast2_snapper/24
- Verification run:
http://10.100.12.155/tests/14874
http://10.100.12.155/tests/14876 scruffy