### PR TITLE
Repeat send_key ctrl-c and wait for closing xev in vnc_two_passwords.pm

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -26,6 +26,7 @@ use strict;
 use warnings;
 use testapi;
 use x11utils 'ensure_unlocked_desktop';
+use Utils::Architectures 'is_ppc64le';
 
 # Any free display
 my $display = ':37';
@@ -104,6 +105,12 @@ sub run {
 
         # Close xev
         send_key 'ctrl-c';
+        if (is_ppc64le) {
+            # repeat send_key because we have sporadic performance issue on ppc64le
+            # and wait a little more time for closing xev
+            send_key 'ctrl-c';
+            wait_still_screen 20;
+        }
 
         # Check if xev recorded events or not - RO/RW mode
         if ($opt->{change}) {


### PR DESCRIPTION
we experienced sporadic performance issue on ppc64le. Repeat send_key 'ctrl-c' (close xev)
can help.

see https://progress.opensuse.org/issues/64568
verifications, no single failure over 100 runs
https://openqa.suse.de/tests/4092676
