### PR TITLE
Update gfx handling in grub 2.04 in JeOS15.1

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -334,7 +334,7 @@ sub uefi_bootmenu_params {
       :         send_key 'e';
     # Kiwi in TW uses grub2-mkconfig instead of the custom kiwi config
     # Locate gfxpayload parameter and update it
-    if (is_jeos && (is_tumbleweed || is_sle('>=15-sp2') || is_leap('>=15.2'))) {
+    if (is_jeos && (is_tumbleweed || is_sle('>=15-sp1') || is_leap('>=15.2'))) {
         for (1 .. 3) { send_key "down"; }
         send_key "end";
         # delete "keep" word


### PR DESCRIPTION
- Related ticket: [[JeOS][qu3 15.1] test fails in grub2 - adapt gfx handling according to grub 2.04 used in sle15sp2, leap15.2 and TW](https://progress.opensuse.org/issues/65187)

* Vr:
* https://openqa.suse.de/t4079208

