### PR TITLE
Move LTP whitelist check to run_ltp::run_post_fail()

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -69,7 +69,7 @@ sub override_known_failures {
 
         bmwqemu::diag("Failure in LTP:$suite:$test is known, overriding to softfail");
         $self->{result} = 'softfail';
-        record_soft_failure($cond->{message}) if exists $cond->{message};
+        $self->record_soft_failure_result($cond->{message}) if exists $cond->{message};
         return 1;
     }
 

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -79,6 +79,7 @@ sub run {
             revision    => get_var('BUILD'),
             flavor      => get_var('FLAVOR'),
             arch        => get_var('ARCH'),
+            backend     => get_var('BACKEND'),
             kernel      => '',
             libc        => '',
             gcc         => '',


### PR DESCRIPTION
The current LTP whitelist check doesn't support whitelisting kernel warnings which have been recently turned into hard OpenQA errors. Serial console output gets checked for kernel errors and warnings after `run_ltp::run()` exits so whitelisting has to be done in one of the post-fail methods.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-12SP1: https://openqa.suse.de/tests/4079377 (kernel warning + regular fails)
  - SLE-15SP1: https://openqa.suse.de/tests/4079376 (module timeout)