### PR TITLE
Public Cloud: storage test fix with wait_for_guestregister()

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -273,7 +273,7 @@ sub create_instances {
     my @vms = $self->terraform_apply(%args);
     foreach my $instance (@vms) {
         record_info("INSTANCE $instance->{instance_id}", Dumper($instance));
-        $instance->check_ssh_port() if ($args{check_connectivity});
+        $instance->wait_for_ssh() if ($args{check_connectivity});
     }
     return @vms;
 }

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -123,7 +123,7 @@ sub run {
 
     # Provision the instance
     my $instance = $provider->create_instance(check_connectivity => 0);
-    $startup_timings->{ssh_access} = $instance->check_ssh_port(timeout => 300);
+    $startup_timings->{ssh_access} = $instance->wait_for_ssh(timeout => 300);
 
     my ($systemd_analyze, $systemd_blame) = do_systemd_analyze($instance);
     $startup_timings->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));

--- a/tests/publiccloud/ssh_interactive_init.pm
+++ b/tests/publiccloud/ssh_interactive_init.pm
@@ -24,7 +24,7 @@ sub run {
     # Create public cloud instance
     my $provider = $self->provider_factory();
     my $instance = $provider->create_instance(check_connectivity => 0);
-    $instance->check_ssh_port(timeout => 300);
+    $instance->wait_for_ssh(timeout => 300);
     $args->{my_provider} = $provider;
     $args->{my_instance} = $instance;
 
@@ -82,4 +82,3 @@ sub test_flags {
 }
 
 1;
-

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -72,11 +72,12 @@ sub run {
 
     my $provider = $self->provider_factory();
     my $instance = $provider->create_instance(use_extra_disk => {size => $disk_size, type => $disk_type});
+    $instance->wait_for_guestregister();
 
     $tags->{os_kernel_release} = $instance->run_ssh_command(cmd => 'uname -r');
     $tags->{os_kernel_version} = $instance->run_ssh_command(cmd => 'uname -v');
 
-    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . $reg_code,                timeout => 600) if $reg_code;
+    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . $reg_code,                timeout => 600) if (get_required_var('FLAVOR') =~ m/BYOS/);
     $instance->run_ssh_command(cmd => 'sudo zypper --gpg-auto-import-keys -q in -y fio', timeout => 600);
 
     my $block_device = '/dev/' . $instance->run_ssh_command(cmd => 'lsblk|grep ' . $disk_size . '|cut -f 1 -d " "');


### PR DESCRIPTION
Storage perf tests are failing since we are running a ssh command right after port 22 is open, we should wait. Similar to run_ltp test.

- Related ticket: https://progress.opensuse.org/issues/65115

GCE:                          http://fromm.arch.suse.de/tests/627
GCE-BYOS:               http://fromm.arch.suse.de/tests/628
GCE-CHOST-BYOS: http://fromm.arch.suse.de/tests/629
