### PR TITLE
update partitioning_specific_disk.pm to deal with warning popup

### DIFF
--- a/tests/installation/partitioning_specific_disk.pm
+++ b/tests/installation/partitioning_specific_disk.pm
@@ -82,6 +82,9 @@ sub run {
     send_key(is_storage_ng() ? 'alt-n' : 'alt-f');
     assert_screen 'expert-partitioner-finish';
     send_key 'alt-a';
+    if (check_screen("expert-partitioner-Warning_popup", 5)) {
+        send_key 'alt-y';
+    }
 }
 
 1;


### PR DESCRIPTION
If no SWAP partition on machine, the expert partitioner will popup a warning, then send a alt+y.

- Verification run: 10.67.134.217/tests/9616#
