### PR TITLE
Fix script logic issue & add error handling for tpm2_engine test

### DIFF
--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_self_sign.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_self_sign.pm
@@ -43,7 +43,14 @@ expect \"Organization Name (eg, company) \\[Internet Widgits Pty Ltd\\]:\"; send
 expect \"Organizational Unit Name (eg, section) \\[\\]:\"; send \"QA\\r\";
 expect \"Common Name (e.g. server FQDN or YOUR name) \\[\\]:\"; send \"richard\\r\";
 expect \"Email Address \\[\\]:\"; send \"richard.fan\@suse.com\\r\";
-tpm2_engine.pm'";
+expect {
+    \"error\" {
+      exit 139
+   }
+   eof {
+       exit 0
+   }
+}'";
     assert_script_run "ls |grep $crt_file";
     assert_script_run "cd";
 }


### PR DESCRIPTION
There is an issue with wrong parameter within "expect" script. at the same time, add some error handling.

- Related ticket: https://progress.opensuse.org/issues/65220
- Needles: N/A
- Verification run: http://10.67.17.9/tests/124
