### PR TITLE
[WIP] Fix ASSET_ path issue in prepare_cloned_profile

### DIFF
--- a/tests/autoyast/prepare_cloned_profile.pm
+++ b/tests/autoyast/prepare_cloned_profile.pm
@@ -21,7 +21,7 @@ use autoyast qw(inject_registration expand_variables upload_profile);
 
 sub run {
     # Get path in the worker
-    my $path = get_var('ASSETDIR') . '/other/' . get_var('ASSET_1');
+    my $path = get_var('ASSET_1');
     record_info('path', $path);
 
     # Read content of file


### PR DESCRIPTION
The ASSET variables have full path now. So getting only the variable
    from ASSET and use only the name fixes the problem

- Verification run: TBD
