### PR TITLE
Add schedule for crypt_no_lvm scenario on powerVM

### DIFF
--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -1,9 +1,11 @@
 ---
 name: crypt_no_lvm
 description: >
-  Test installation with encrypted partitions but without lvm enabled. 
-  This is supported only by storage-ng, hence, do NOT enable test suite on distris without storage-ng.
-  (crypt-)LVM installations can take longer, especially on non-x86_64 architectures. 
+  Test installation with encrypted partitions but without lvm enabled.
+  This is supported only by storage-ng, hence, do NOT enable test suite on
+  distris without storage-ng.
+  Encrypted installations can take longer, especially on non-x86_64
+  architectures.
 vars:
   ENCRYPT: 1
   LVM: 0
@@ -29,4 +31,5 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+  - console/system_prepare
   - console/validate_encrypt

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -1,0 +1,41 @@
+---
+description: >
+  Test installation with encrypted partitions but without lvm enabled.
+  This is supported only by storage-ng, hence, do NOT enable test suite on
+  distris without storage-ng.
+  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+  In comparison to SLE 12 we register the installation and have system roles
+  wizard screen.
+name: cryptlvm
+vars:
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  DESKTOP: textmode
+  ENCRYPT: 1
+  LVM: 0
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_no_lvm
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/system_prepare
+  - console/validate_encrypt


### PR DESCRIPTION
PowerVM requires multiple differences due to backend implementation, so adding new schedule file.

[Verification run](https://openqa.suse.de/tests/4084117).

See [poo#64932](https://progress.opensuse.org/issues/64932).
