### PR TITLE
QAM Azure adjustments

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -43,6 +43,7 @@ sub init {
     $self->SUPER::init();
     $self->vault_create_credentials() unless ($self->key_id);
     $self->az_login();
+    assert_script_run("az account set --subscription " . $self->subscription);
     assert_script_run("export ARM_SUBSCRIPTION_ID=" . $self->subscription);
     assert_script_run("export ARM_CLIENT_ID=" . $self->key_id);
     assert_script_run("export ARM_CLIENT_SECRET=" . $self->key_secret);

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -589,6 +589,7 @@ sub cleanup {
     my ($self) = @_;
     $self->terraform_destroy();
     $self->vault_revoke();
+    assert_script_run "cd";
 }
 
 =head2 stop_instance

--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -32,7 +32,7 @@ sub ssh_interactive_tunnel {
         cmd => "'rm -rf /dev/sshserial; mkfifo -m a=rwx /dev/sshserial; tail -fn +1 /dev/sshserial' | tee /dev/$serialdev ", # Create /dev/sshserial fifo on remote and tail|tee it to /dev/$serialdev on local
         timeout  => 0,    # This will also cause script_run instead of script_output to be used so the test will not wait for the command to end
         no_quote => 1,
-        ssh_opts => "-t -R $upload_port:$upload_host:$upload_port",    # Tunnel the worker port (for downloading from data/ and uploading assets / logs
+        ssh_opts => "-yt -R $upload_port:$upload_host:$upload_port",    # Tunnel the worker port (for downloading from data/ and uploading assets / logs
         username => 'root'
     );
     sleep 3;
@@ -44,7 +44,7 @@ sub ssh_interactive_tunnel {
 
 sub ssh_interactive_join {
     # Open SSH interactive session and check the serial console works
-    type_string("ssh -t sut\n");
+    type_string("ssh -yt sut\n");
     wait_serial("ssh_serial_ready", 90) if (get_var("AUTOINST_URL_HOSTNAME", '') !~ /localhost/);
 
     # Prepare the environment to use the SSH tunnel for upload/download from the worker

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -25,7 +25,7 @@ use warnings;
 use base "consoletest";
 use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
-use utils qw(systemctl exec_and_insert_password zypper_call random_string);
+use utils qw(systemctl exec_and_insert_password zypper_call random_string clear_console);
 use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap);
 
 sub run {
@@ -40,6 +40,9 @@ sub run {
     # 'nc' is not installed by default on JeOS
     if (script_run("which nc")) {
         zypper_call("in netcat-openbsd");
+    }
+    if (script_run("which killall")) {
+        zypper_call("in psmisc");
     }
 
     # Stop the firewall if it's available
@@ -127,6 +130,10 @@ sub run {
 
     # Remove the ~/.ssh folder
     assert_script_run "rm -r ~/.ssh/";
+
+    assert_script_run "killall -u $ssh_testman || true";
+    wait_still_screen 3;
+    clear_console;
 }
 
 sub test_flags {


### PR DESCRIPTION
* There is pernament `--subscription` parameter when using the `az` utility
* The `$provider->cleanup()` has now `assert_script_run` to ensure smooth ending
* While creating / joining the SSH tunnel the parameter `-y` redirects logs to syslog
* All the remaining processes of `sshd.pm` tests are killed so they don't mess up it after

- Related ticket: [pr#64264](https://progress.opensuse.org/issues/64264)
- Verification run: [12-sp4](http://pdostal-server.suse.cz/tests/7959) [15-sp1](http://pdostal-server.suse.cz/tests/7956)
