### PR TITLE
Validate only relevant parts of lvm+resize_root

### DIFF
--- a/lib/Installation/Partitioner/AbstractExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/AbstractExpertPartitionerController.pm
@@ -28,14 +28,14 @@ $args->{raid_level} defines wanted raid level.
 =cut
 sub add_raid();
 
-=head2 accept_changes
+=head2 accept_changes_and_press_next
 
-  accept_changes($self);
+  accept_changes_and_press_next($self);
 
 Accept partitioning setup and proceed to the next page.
 
 =cut
-sub accept_changes();
+sub accept_changes_and_press_next();
 
 =head2 run_expert_partitioner
 

--- a/lib/Installation/Partitioner/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/ExpertPartitionerPage.pm
@@ -19,20 +19,21 @@ use testapi;
 use parent 'Installation::WizardPage';
 
 use constant {
-    EXPERT_PARTITIONER_PAGE    => 'expert-partitioner',
-    SELECTED_HARD_DISK         => 'partitioning_raid-disk_%s-selected',
-    SELECTED_RAID              => 'partitioning_raid-raid-selected',
-    SELECTED_VOLUME_MANAGEMENT => 'volume_management_feature',
-    SELECTED_HARD_DISKS        => 'partitioning_raid-hard_disks-selected',
-    SELECTED_EXISTING_PART     => 'partitioning_existing_part_%s-selected',
-    CLONE_PARTITION            => 'clone_partition',
-    ALL_DISKS_SELECTED         => 'all_disks_selected',
-    PARTITIONS_TAB             => 'partitions_tab_selected',
-    OVERVIEW_TAB               => 'overview_tab_selected',
-    NEW_PARTITION_TABLE_TYPE   => 'new_partition_table_type',
-    SELECTED_CREATE_NEW_TABLE  => 'selected_create_new_table',
-    DELETING_CURRENT_DEVICES   => 'deleting_current_devices',
-    NEW_PARTITION_TYPE         => 'partition-type'
+    EXPERT_PARTITIONER_PAGE            => 'expert-partitioner',
+    SELECTED_HARD_DISK                 => 'partitioning_raid-disk_%s-selected',
+    SELECTED_RAID                      => 'partitioning_raid-raid-selected',
+    SELECTED_CURRENT_VOLUME_MANAGEMENT => 'volume-management_system',                 # current proposal
+    SELECTED_VOLUME_MANAGEMENT         => 'volume_management_feature',                # existing partition
+    SELECTED_HARD_DISKS                => 'partitioning_raid-hard_disks-selected',
+    SELECTED_EXISTING_PART             => 'partitioning_existing_part_%s-selected',
+    CLONE_PARTITION                    => 'clone_partition',
+    ALL_DISKS_SELECTED                 => 'all_disks_selected',
+    PARTITIONS_TAB                     => 'partitions_tab_selected',
+    OVERVIEW_TAB                       => 'overview_tab_selected',
+    NEW_PARTITION_TABLE_TYPE           => 'new_partition_table_type',
+    SELECTED_CREATE_NEW_TABLE          => 'selected_create_new_table',
+    DELETING_CURRENT_DEVICES           => 'deleting_current_devices',
+    NEW_PARTITION_TYPE                 => 'partition-type'
 };
 
 sub new {
@@ -61,6 +62,16 @@ sub _select_system_view_section {
     send_key('alt-s');
 }
 
+=head2 select_item_in_system_view_table
+
+  select_item_in_system_view_table($item);
+
+Selects one of the features of System View in the Expert Partitioner with any of the 
+available options. Each option should find a constant variable representing a needle tag to match.
+Default for C<$item> is to match a hard disk with tag partitioning_raid-disk_%s-selected where this
+will interpolated by the test_data variable of C<existing_partition>.
+=cut
+
 sub select_item_in_system_view_table {
     my ($self, $item) = @_;
     assert_screen(EXPERT_PARTITIONER_PAGE);
@@ -72,11 +83,11 @@ sub select_item_in_system_view_table {
     elsif ($item eq 'volume-management') {
         send_key_until_needlematch(SELECTED_VOLUME_MANAGEMENT, 'down');
     }
+    elsif ($item eq 'current-volume-management') {
+        send_key_until_needlematch(SELECTED_CURRENT_VOLUME_MANAGEMENT, 'down');
+    }
     elsif ($item eq 'hard-disks') {
         send_key_until_needlematch(SELECTED_HARD_DISKS, 'down');
-    }
-    elsif ($item eq 'existing-partition') {
-        send_key_until_needlematch((sprintf SELECTED_EXISTING_PART, $item), "down");
     }
     else {
         send_key_until_needlematch((sprintf SELECTED_HARD_DISK, $item), "down");

--- a/lib/Installation/Partitioner/Libstorage/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/Libstorage/ExpertPartitionerController.pm
@@ -132,10 +132,15 @@ sub add_raid {
     $self->_finish_partition_creation();
 }
 
+sub accept_changes_and_press_next {
+    my ($self) = @_;
+    $self->accept_changes();
+    $self->get_suggested_partitioning_page()->press_next();
+}
+
 sub accept_changes {
     my ($self) = @_;
     $self->get_expert_partitioner_page()->press_accept_button();
-    $self->get_suggested_partitioning_page()->press_next();
 }
 
 

--- a/lib/Installation/Partitioner/LibstorageNG/SuggestedPartitioningPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/SuggestedPartitioningPage.pm
@@ -28,11 +28,35 @@ sub press_guided_setup_button {
     send_key('alt-g');
 }
 
+=head2 select_start_with_existing_partitions
+
+  select_start_with_existing_partitions()
+
+Opens existing partitioning of the Expert Partiotioner from the Suggested Partitioning page .
+
+=cut
+
 sub select_start_with_existing_partitions {
     my ($self) = @_;
     assert_screen($self->SUGGESTED_PARTITIONING_PAGE);
     send_key 'alt-e';
     send_key 'p';
+}
+
+
+=head2 select_start_with_current_partitions
+
+  select_start_with_current_partitions()
+
+Opens current partitioning of the Expert Partiotioner from the Suggested Partitioning page .
+
+=cut
+
+sub select_start_with_current_partitions {
+    my ($self) = @_;
+    assert_screen($self->SUGGESTED_PARTITIONING_PAGE);
+    send_key 'alt-e';
+    send_key 'c';
 }
 
 sub assert_encrypted_partition_without_lvm_shown_in_the_list {

--- a/lib/Installation/Partitioner/LibstorageNG/v3/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v3/ExpertPartitionerController.pm
@@ -43,9 +43,26 @@ sub new {
     }, $class;
 }
 
+=head2 run_expert_partitioner
+
+  run_expert_partitioner([$option]);
+
+Opens the Expert Partiotioner from the Suggested Partitioning page .
+if the C<$option> is given it will open one of the current proposal or existing partition.
+Expected values are [existing|current].
+if none is given the existing partiotion is used as deault.
+
+=cut
 sub run_expert_partitioner {
-    my ($self) = @_;
-    $self->get_suggested_partitioning_page()->select_start_with_existing_partitions();
+    my ($self, $option) = @_;
+    $option //= 'existing';
+    record_info $option;
+    if ($option eq 'current') {
+        $self->get_suggested_partitioning_page()->select_start_with_current_partitions();
+    }
+    else {
+        $self->get_suggested_partitioning_page()->select_start_with_existing_partitions();
+    }
 }
 
 sub add_partition_on_gpt_disk {

--- a/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
@@ -105,6 +105,16 @@ sub add_raid {
     $self->add_raid_partition($args->{partition});
 }
 
+=head2 resize_partition_on_gpt_disk(args)
+
+  resize_partition_on_gpt_disk(args)
+
+Once you have an instance of the page and you are in the Expert Partitioning
+C<resize_partition_on_gpt_disk> can be invoked to resize any partition or hard disk.
+The test_data hash should contains the variables C<disk>, C<existing_partition> and C<part_size>.
+C<disk> is used to select one of the options in the menu, like LVM or Bcache and a needle should match with the C<disk> value included. C<existing_partition> represents the partition or hard disk that you want to resize with the value of C<part_size>.
+=cut
+
 sub resize_partition_on_gpt_disk {
     my ($self, $args) = @_;
     $self->get_expert_partitioner_page()->go_top_in_system_view_table();

--- a/schedule/yast/lvm/lvm+resize_root.yaml
+++ b/schedule/yast/lvm/lvm+resize_root.yaml
@@ -1,0 +1,52 @@
+---
+name: lvm+resize_root
+description: |
+  Select LVM during installation and try to resize
+  the root LV to span more than 40GB which is selected as default.
+  See  bsc#989976, bsc#1000165
+vars:
+  DESKTOP: textmode
+  HDDSIZEGB: 50
+  LVM: 1
+  RESIZE_ROOT_VOLUME: 1
+  SEPARATE_HOME: 0
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/lvm_no_separate_home
+  - installation/partitioning_resize_root
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - locale/keymap_or_locale
+  - console/consoletest_finish
+  - console/validate_modify_existing_partition
+test_data:
+  root:
+    disk: current-volume-management
+    existing_partition: root
+    mount_point: /
+    expert_partitioner_from: current
+    part_size: 45GiB
+    lsblk_expected_size_output: 45G

--- a/tests/installation/partitioning/modify_existing_partition.pm
+++ b/tests/installation/partitioning/modify_existing_partition.pm
@@ -27,7 +27,7 @@ sub run {
         record_info("Edit $part", "$$test_data{$part}->{existing_partition}");
         $partitioner->edit_partition_on_gpt_disk($$test_data{$part});
     }
-    $partitioner->accept_changes();
+    $partitioner->accept_changes_and_press_next();
 }
 
 1;

--- a/tests/installation/partitioning/msdos_partition_table.pm
+++ b/tests/installation/partitioning/msdos_partition_table.pm
@@ -27,7 +27,7 @@ sub run {
             $partitioner->add_partition_msdos({disk => $disk->{name}, partition => $partition});
         }
     }
-    $partitioner->accept_changes();
+    $partitioner->accept_changes_and_press_next();
 }
 1;
 

--- a/tests/installation/partitioning/raid_gpt.pm
+++ b/tests/installation/partitioning/raid_gpt.pm
@@ -41,7 +41,7 @@ sub run {
     foreach my $md (@{$test_data->{mds}}) {
         $partitioner->add_raid($md);
     }
-    $partitioner->accept_changes();
+    $partitioner->accept_changes_and_press_next();
 }
 
 1;

--- a/tests/installation/partitioning/raid_msdos.pm
+++ b/tests/installation/partitioning/raid_msdos.pm
@@ -38,7 +38,7 @@ sub run {
     foreach my $md (@{$test_data->{mds}}) {
         $partitioner->add_raid($md);
     }
-    $partitioner->accept_changes();
+    $partitioner->accept_changes_and_press_next();
 }
 
 1;


### PR DESCRIPTION
Validate only relevant parts of lvm+resize_root
    
    Create scheduler with only relevant modules to validate the scenario
    and make sure that the /root is resized.
    The partitioning_resize_root.pm has been modified to use the Object_Oriented
    framework. Minor changes added. A function to open the current suggestion is added
    and the existing _run_expert_partitioner_ funtion is adjast to make available the choice
    between the latest and the option of _the existing_partition_
    
    Condition of _existing-partition_ and corresponding constant in the _select_item_in_system_view_table_
    removed as it is not used and it does not provide any usability.

- Related ticket: https://progress.opensuse.org/issues/64911
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1365
- Verification run: http://aquarius.suse.cz/tests/2511