### PR TITLE
Revert "fix online textmode install expertpartitioner key"

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -160,10 +160,6 @@ sub init_cmd {
         $testapi::cmd{sync_without_daemon} = "alt-s";
     }
     ## keyboard cmd vars end
-
-    if (check_var('FLAVOR', 'Online') && check_var('DESKTOP', 'textmode')) {
-        $testapi::cmd{expertpartitioner} = "alt-x";
-    }
 }
 
 =head2 init_desktop_runner


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#9899

DESKTOP=textmode is for desktop, not installer. this broke several tests where we have graphical installer, but we are installing a textmode system, such as this one https://openqa.suse.de/tests/4081136#, or this one https://openqa.suse.de/tests/4080762