### PR TITLE
Add sap hana cluster test in qam

### DIFF
--- a/schedule/qam/common/qam-sles4sap_hana_node01.yml
+++ b/schedule/qam/common/qam-sles4sap_hana_node01.yml
@@ -1,0 +1,23 @@
+name:           qam-sles4sap_hana_node01
+description:    >
+  Deploy a first HANA node to set up a cluster test.
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - sles4sap/patterns
+  - ha/ha_cluster_init
+  - sles4sap/hana_install
+  - sles4sap/hana_cluster
+  - sles4sap/sap_suse_cluster_connector
+  - ha/fencing
+  - boot/boot_to_desktop
+  - ha/check_after_reboot
+  - ha/check_logs

--- a/schedule/qam/common/qam-sles4sap_hana_node02.yml
+++ b/schedule/qam/common/qam-sles4sap_hana_node02.yml
@@ -1,0 +1,21 @@
+name:           qam-sles4sap_hana_node02
+description:    >
+  Deploy a second HANA node to set up a cluster test.
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - sles4sap/patterns
+  - ha/ha_cluster_join
+  - sles4sap/hana_install
+  - sles4sap/hana_cluster
+  - ha/fencing
+  - ha/check_after_reboot
+  - ha/check_logs

--- a/schedule/qam/common/qam-sles4sap_hana_supportserver.yml
+++ b/schedule/qam/common/qam-sles4sap_hana_supportserver.yml
@@ -1,0 +1,8 @@
+name:           qam-sles4sap_hana_supportserver.yml
+description:    >
+  Deploy a supportserver for hana cluster.
+schedule:
+  - support_server/login
+  - support_server/setup
+  - ha/barrier_init
+  - support_server/wait_children


### PR DESCRIPTION
This PR adds a new test in QAM for daily SAP tests.
This is a MM test which configures two HANA nodes and put them in cluster with System Replication.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1362
- Verification run: 
15-SP1: [Hana node 1](http://1a102.qa.suse.de/tests/3752) & [Hana node 2](http://1a102.qa.suse.de/tests/3753)
Older SLE versions will be tested later on.
