### PR TITLE
Fix autoyast profile handling when used as an asset

### DIFF
--- a/tests/autoyast/prepare_cloned_profile.pm
+++ b/tests/autoyast/prepare_cloned_profile.pm
@@ -21,7 +21,7 @@ use autoyast qw(inject_registration expand_variables upload_profile);
 
 sub run {
     # Get path in the worker
-    my $path = get_var('ASSETDIR') . '/other/' . get_var('ASSET_1');
+    my $path = get_required_var(get_required_var('AUTOYAST'));
     record_info('path', $path);
 
     # Read content of file


### PR DESCRIPTION
Due to changes in openQA we now need to upload assets with unique name
of the files as openQA doesn't handle this anymore. Also, ASSET_*
variables are now expanded to the full path of the asset and do not
require any further guessing of the path.

See [poo#65229](https://progress.opensuse.org/issues/65229).

[Verification run](https://openqa.suse.de/tests/4090875#).
