### PR TITLE
LTP: Use ASSET_1 as runtest file archive path

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -39,7 +39,6 @@ our @EXPORT = qw(
   chromiumstep_is_applicable
   consolestep_is_applicable
   default_desktop
-  get_ltp_tag
   gnomestep_is_applicable
   guiupdates_is_applicable
   have_scc_repos
@@ -266,22 +265,6 @@ sub is_kernel_test {
         || get_var('TRINITY')
         || get_var('NUMA_IRQBALANCE')
         || get_var('TUNED'));
-}
-
-sub get_ltp_tag {
-    my $tag = get_var('LTP_RUNTEST_TAG');
-
-    if (!defined $tag) {
-        if (defined get_var('HDD_1')) {
-            $tag = get_var('PUBLISH_HDD_1');
-            $tag = get_var('HDD_1') if (!defined $tag);
-            $tag = basename($tag);
-        } else {
-            $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
-        }
-    }
-    $tag =~ s/[^a-zA-Z0-9_@.]+/-/g;
-    return $tag;
 }
 
 # Isolate the loading of LTP tests because they often rely on newer features

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -18,13 +18,13 @@
 package main_ltp;
 use base 'Exporter';
 use Exporter;
-use testapi qw(check_var get_var);
+use testapi qw(check_var get_required_var get_var);
 use autotest;
 use Archive::Tar;
 use utils;
 use LTP::TestInfo 'testinfo';
 use File::Basename 'basename';
-use main_common qw(boot_hdd_image get_ltp_tag load_bootloader_s390x load_kernel_baremetal_tests);
+use main_common qw(boot_hdd_image load_bootloader_s390x load_kernel_baremetal_tests);
 use 5.018;
 use Utils::Backends 'is_pvm';
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
@@ -80,9 +80,8 @@ sub parse_runtest_file {
 
 sub loadtest_from_runtest_file {
     my $namelist           = get_var('LTP_COMMAND_FILE');
-    my $path               = shift || get_var('ASSETDIR') . '/other';
+    my $archive            = shift || get_required_var('ASSET_1');
     my $unpack_path        = './runtest-files';
-    my $tag                = get_ltp_tag();
     my $cmd_pattern        = get_var('LTP_COMMAND_PATTERN') || '.*';
     my $cmd_exclude        = get_var('LTP_COMMAND_EXCLUDE') || '$^';
     my $test_result_export = {
@@ -97,7 +96,7 @@ sub loadtest_from_runtest_file {
 
     mkdir($unpack_path, 0755);
     my $tar = Archive::Tar->new();
-    $tar->read("$path/runtest-files-$tag.tar.gz") || die "tar read failed $? $!";
+    $tar->read($archive) || die "tar read failed $? $!";
     $tar->setcwd($unpack_path);
     $tar->extract() || die "tar extract failed $? $!";
 

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -20,7 +20,6 @@ use testapi;
 use registration;
 use utils;
 use bootloader_setup qw(add_custom_grub_entries add_grub_cmdline_settings);
-use main_common 'get_ltp_tag';
 use main_ltp 'loadtest_from_runtest_file';
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
@@ -298,6 +297,22 @@ sub setup_network {
     }
 }
 
+sub get_ltp_tag {
+    my $tag = get_var('LTP_RUNTEST_TAG');
+
+    if (!defined $tag) {
+        if (defined get_var('HDD_1')) {
+            $tag = get_var('PUBLISH_HDD_1');
+            $tag = get_var('HDD_1') if (!defined $tag);
+            $tag = basename($tag);
+        } else {
+            $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
+        }
+    }
+    $tag =~ s/[^a-zA-Z0-9_@.]+/-/g;
+    return $tag;
+}
+
 sub run {
     my $self       = shift;
     my $inst_ltp   = get_var 'INSTALL_LTP';
@@ -361,7 +376,7 @@ sub run {
 
     if (get_var('LTP_COMMAND_FILE')) {
         # This assumes that current working directory is the worker's pool dir
-        loadtest_from_runtest_file('assets_public');
+        loadtest_from_runtest_file("assets_public/runtest-files-$tag.tar.gz");
     }
 
     is_jeos && zypper_call 'in system-user-bin system-user-daemon';

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -191,7 +191,6 @@ curl --form upload=\@\$archive --form target=assets_public $aiurl/upload_asset/\
 }
 
 sub install_from_git {
-    my ($tag)       = @_;
     my $url         = get_var('LTP_GIT_URL', 'https://github.com/linux-test-project/ltp');
     my $rel         = get_var('LTP_RELEASE');
     my $timeout     = (is_aarch64 || is_s390x) ? 7200 : 1440;
@@ -246,7 +245,6 @@ sub add_ltp_repo {
 }
 
 sub install_from_repo {
-    my ($tag) = @_;
     my $pkg = get_var('LTP_PKG', (want_stable && is_sle) ? 'qa_test_ltp' : 'ltp');
 
     zypper_call("in --recommends $pkg");
@@ -354,14 +352,14 @@ sub run {
 
         # bsc#1024050 - Watch for Zombies
         script_run('(pidstat -p ALL 1 > /tmp/pidstat.txt &)');
-        install_from_git($tag);
+        install_from_git();
 
         install_runtime_dependencies_network;
         install_debugging_tools;
     }
     else {
         add_ltp_repo;
-        install_from_repo($tag);
+        install_from_repo();
     }
 
     $grub_param .= ' console=hvc0'     if (get_var('ARCH') eq 'ppc64le');


### PR DESCRIPTION
Use ASSET_1 as runtest file archive path

instead of using `ASSETDIR` + `/other` (i.e. `/var/lib/openqa/share/factory/other`),
which does not require to have mounted NFS `/var/lib/openqa/share` on
workers (which was often problematic on o3, see poo#63373, poo#51743).

This requires:
1) commit in openQA
d5c17138e ("Rewrite asset list generation for cache service")

2) and (obviously) to add `ASSET_1=runtest-files-%HDD_1%.tar.gz` to all
testsuites that have `LTP_COMMAND_FILE` (and which use `HDD_1`; for other
e.g. IPMI on osd and s390x on o3 it needs to use
`ASSET_1=runtest-files-%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%.tar.gz`)
This is the path set up by get_ltp_tag().

Also move `get_ltp_tag()` from `main_common.pm` into `install_ltp.pm` as it's
now used only there.

\+ cleanup in second commit.

Verification run: 
* SLE15-SP2 normal tests: http://quasar.suse.cz/tests/5066 http://quasar.suse.cz/t5067
* Tumbleweed normal tests: http://quasar.suse.cz/tests/5061 http://quasar.suse.cz/tests/5064
* JeOS (install OS, `INSTALL_LTP` with `LTP_COMMAND_FILE`): http://quasar.suse.cz/tests/5058
* `INSTALL_LTP` with `LTP_COMMAND_FILE`: http://quasar.suse.cz/tests/5056