### PR TITLE
Remove -f for reboot in patch_sle

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -66,9 +66,8 @@ sub patching_sle {
             assert_script_run 'sync', 600;
             # Open gdm debug info for poo#45236, this issue happen sometimes in openqa env
             script_run('sed -i s/#Enable=true/Enable=true/g /etc/gdm/custom.conf');
-            # Workaround for test failed of the reboot operation need to wait some jobs done
-            # Add '-f' to force the reboot to avoid the test be blocked here
-            type_string "reboot -f\n";
+            # Remove '-f' for reboot for poo#65226
+            type_string "reboot\n";
             $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 300, nologin => $nologin);
             # Setup again after reboot
             $self->setup_sle();


### PR DESCRIPTION
Originally, we add '-f' for reboot to avoid the timeout issue for wait_boot, force reboot won't wait sync and services stopped, it will shorten the time to boot up. While force to reboot in patch_sle may have potential risk for file system, we need remove '-f' for reboot cmd.  
The '-f' option to 'reboot' in 'patch_sle' is not the proper way to reboot, there may be some corner cases where this operation will potentially lead   to problems. Detail see bsc#1167756.

- Related ticket: https://progress.opensuse.org/issues/65226
- Needles: N/A
- Verification run: 
     HPC migration test: http://openqa.nue.suse.com/tests/4092683
     Media migration test: http://openqa.nue.suse.com/tests/4092684
    