### PR TITLE
Fix yaml profiles for QR 15-SP1

### DIFF
--- a/schedule/qam/QR/15-SP1/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/qam/QR/15-SP1/btrfs_sle_libstorage-ng.yaml
@@ -1,0 +1,92 @@
+name:           btrfs_libstorage-ng
+description:    >
+  Validate default installation with btrfs and Libstorage NG.
+vars:
+  DESKTOP: gnome
+  FILESYSTEM: btrfs
+schedule:
+  # Called on BACKEND: qemu
+  - '{{isosize}}'
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  # Called only on BACKEND: s390x
+  - '{{disk_activation}}'
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  # Called on all, except BACKEND: s390x
+  - '{{hostname_inst}}'
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  # Called on BACKEND: s390x, svirt
+  - '{{reconnect_mgmt_console}}'
+  # Called on BACKEND: qemu
+  - '{{grub_test}}'
+  - installation/first_boot
+  - '{{check_resume}}'
+  - console/validate_no_cow_attribute
+  # On all the backends except s390x, /home is located on a separate partition
+  - '{{validate_home_partition}}'
+conditional_schedule:
+  isosize:
+    BACKEND:
+      qemu:
+        - installation/isosize
+  disk_activation:
+    BACKEND:
+      s390x:
+        - installation/disk_activation
+  reconnect_mgmt_console:
+    BACKEND:
+      s390x:
+        - boot/reconnect_mgmt_console
+      svirt:
+        - boot/reconnect_mgmt_console
+  grub_test:
+    BACKEND:
+      qemu:
+        - installation/grub_test
+  hostname_inst:
+    BACKEND:
+      qemu:
+        - installation/hostname_inst
+      svirt:
+        - installation/hostname_inst
+  validate_home_partition:
+    BACKEND:
+      qemu:
+        - console/verify_separate_home
+        - console/validate_file_system
+      svirt:
+        - console/verify_separate_home
+        - console/validate_file_system
+      s390x:
+        - console/verify_no_separate_home
+test_data:
+  device: vda
+  table_type: gpt
+  subvolume:
+    cow:
+      - /root
+      - /tmp
+      - /usr/local
+      - /.snapshots
+      - /srv
+      - /opt
+    no_cow:
+      - /var
+  file_system:
+    /home: xfs
+    /: btrfs

--- a/schedule/qam/QR/15-SP1/zfcp.yaml
+++ b/schedule/qam/QR/15-SP1/zfcp.yaml
@@ -1,0 +1,30 @@
+name:           zfcp
+description:    >
+  Test installation on machine with zfcp multipath disk.
+  Only tests succesful detection of multipath and installation.
+  No functional testing of multipath itself.
+vars:
+  DESKTOP: gnome
+  MULTIPATH: 1
+schedule:
+  -installation/bootloader_start
+  -installation/welcome
+  -installation/accept_license
+  -installation/disk_activation
+  -installation/multipath
+  -installation/scc_registration
+  -installation/addon_products_sle
+  -installation/system_role
+  -installation/partitioning
+  -installation/partitioning_finish
+  -installation/installer_timezone
+  -installation/user_settings
+  -installation/user_settings_root
+  -installation/installation_overview
+  -installation/disable_grub_timeout
+  -installation/start_install
+  -installation/await_install
+  -installation/logs_from_installation_system
+  -installation/reboot_after_installation
+  -boot/reconnect_mgmt_console
+  -installation/first_boot


### PR DESCRIPTION
-schedule/qam/QR/15-SP1/btrfs_sle_libstorage-ng.yaml
 resume= change on s390x has been requested for 12-SP5 poo#53888
-schedule/qam/QR/15-SP1/zfcp.yaml
 multipath pop-up does appear after disk activation on scc registration

- Fail:
https://progress.opensuse.org/issues/53888
https://openqa.suse.de/tests/4088458#step/check_resume/7
https://progress.opensuse.org/issues/62342
https://openqa.suse.de/tests/4088466#step/scc_registration/5
- Verification run: 
https://openqa.suse.de/tests/4092703 zfcp
https://openqa.suse.de/tests/4092790 btrfs_libstorage-ng