### PR TITLE
Fix NTPD issue when checking the current time after daemon restart

### DIFF
--- a/lib/services/ntpd.pm
+++ b/lib/services/ntpd.pm
@@ -58,7 +58,9 @@ sub check_function {
     assert_script_run("date -s 'Tue Jul 03 10:42:42 2018'");
     assert_script_run("date | grep 2018");
     systemctl("restart ntpd.service");
-    script_retry("date | grep -v 2018", delay => 30, retry => 6);
+    systemctl("status ntpd.service");
+    script_retry('ntpq -pn | grep "^[+\|*]"', delay => 30, retry => 24);
+    assert_script_run("date | grep -v 2018");
 }
 
 # Check ntp service before and after migration.


### PR DESCRIPTION
- Related ticket: [poo#63865](https://progress.opensuse.org/issues/63865)
- Verification run: [SLE12SP4@s390](https://openqa.nue.suse.com/tests/4099001) [SLE15SP1@x86_64](http://pdostal-server.suse.cz/tests/7998)
