### PR TITLE
Implement TLS 1.3 enablement for openssl

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2173,6 +2173,7 @@ sub load_security_tests_crypt_core {
         loadtest "fips/openssl/dirmngr_setup";
         loadtest "fips/openssl/dirmngr_daemon";    # dirmngr_daemon needs to be tested after dirmngr_setup
     }
+    loadtest "fips/openssl/openssl_tlsv1_3";
     loadtest "fips/openssl/openssl_pubkey_rsa";
     loadtest "fips/openssl/openssl_pubkey_dsa";
     loadtest "console/openssl_alpn";

--- a/tests/fips/openssl/openssl_tlsv1_3.pm
+++ b/tests/fips/openssl/openssl_tlsv1_3.pm
@@ -1,0 +1,44 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: openssl 1.1.1 supports and negotiates by default the new TLS 1.3 protocol.
+#          Applications that leave everything to the openssl library will automatically
+#          start to negotiate the TLS 1.3 protocol. However, many packages have their
+#          own settings which override the library defaults and these either have to be
+#          recompiled against openssl 1.1.1 or might even need extra patching.
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#64992, tc#1744100
+
+use base "consoletest";
+use testapi;
+use strict;
+use warnings;
+use apachetest;
+
+sub run {
+    select_console 'root-console';
+    setup_apache2(mode => 'SSL');
+
+    # List the supported ciphers and make sure TLSV1.3 is there
+    validate_script_output 'openssl ciphers -v', sub { m/TLSv1\.3.*/xg };
+
+    # Establish a transparent connection to apache server to check the TLS protocol
+    validate_script_output 'echo | openssl s_client -connect localhost:443 2>&1', sub { m/TLSv1\.3.*/xg };
+
+    # Transfer a URL to check the TLS protocol
+    validate_script_output 'curl -Ivvv  https://www.google.com 2>&1', sub { m/TLSv1\.3.*/xg };
+}
+
+1;


### PR DESCRIPTION
This PR is for a new feature test introduced in openssl 1.1.1.
Jira task: https://jira.suse.com/browse/SLE-9297
Description:
"We're upgrading openssl to 1.1.1 in SP2 (SLE-9135).
openssl 1.1.1 supports and negotiates by default the new TLS 1.3 protocol.
Applications that leave everything to the openssl library will automatically start to negotiate the TLS 1.3 protocol"

- Related ticket: https://progress.opensuse.org/issues/64992
- Needles: N/A
- Verification run: http://10.67.17.9/tests/129
