### PR TITLE
LTP: Use unique ASSET_31 for runtest file

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -80,7 +80,7 @@ sub parse_runtest_file {
 
 sub loadtest_from_runtest_file {
     my $namelist           = get_var('LTP_COMMAND_FILE');
-    my $archive            = shift || get_required_var('ASSET_1');
+    my $archive            = shift || get_required_var('ASSET_31');
     my $unpack_path        = './runtest-files';
     my $cmd_pattern        = get_var('LTP_COMMAND_PATTERN') || '.*';
     my $cmd_exclude        = get_var('LTP_COMMAND_EXCLUDE') || '$^';


### PR DESCRIPTION
There is ASSET_1 (and ASSET_2) already used on test suite
create_hdd_textmode.  They're defined in test module (not in the test
suite), and it got propagated to child jobs: install_ltp and then to
actual LTP tests, although these define ASSET_1 in test suites.

Thus use unique number ASSET_31 (really bad solution, but asset
inheritance don't give us better solution).

Fixes: 1e035ddb4 ("LTP: Use ASSET_1 as runtest file archive full path")

Verification run: http://quasar.suse.cz/tests/5079
