### PR TITLE
Fail when detecting wrong desktop - 2nd try

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -22,7 +22,7 @@ use warnings;
 use testapi;
 use version_utils qw(is_caasp is_upgrade);
 use Utils::Backends qw(is_remote_backend is_hyperv);
-
+use Test::Assert ':all';
 
 sub ensure_ssh_unblocked {
     if (!get_var('UPGRADE') && is_remote_backend) {
@@ -62,6 +62,29 @@ sub ensure_ssh_unblocked {
     }
 }
 
+sub check_default_target {
+    # Check the systemd target where scenario make it possible
+    return if (is_caasp || is_upgrade || is_hyperv ||
+        get_var('REMOTE_CONTROLLER') || (get_var('BACKEND', '') =~ /spvm|pvm_hmc/));
+    # exclude non-desktop environment and scenarios with edition of package selection (bsc#1167736)
+    return if (!get_var('DESKTOP') || get_var('PATTERNS'));
+
+    # Set expectations
+    my $expected_target = check_var('DESKTOP', 'textmode') ? "multi-user" : "graphical";
+
+    select_console 'install-shell';
+
+    my $target_search = 'default target has been set';
+    # default.target is not yet linked, so we parse logs and assert expectations
+    if (my $log_line = script_output("grep '$target_search' /var/log/YaST2/y2log | tail -1",
+            proceed_on_failure => 1)) {
+        $log_line =~ /$target_search: (?<current_target>.*)/;
+        assert_equals($expected_target, $+{current_target}, "Mismatch in default.target");
+    }
+
+    select_console 'installation';
+}
+
 sub run {
     my ($self) = shift;
     # overview-generation
@@ -79,18 +102,7 @@ sub run {
                 assert_screen 'inst-xen-pattern';
             }
         }
-        ensure_ssh_unblocked;
-        # Check the systemd target, see poo#45020
-        # We need to exclude some scenarios where it doesn't work well
-        return if (is_caasp || is_upgrade || is_hyperv || get_var('REMOTE_CONTROLLER'));
-        if (get_var('DESKTOP')) {
-            my $target = check_var('DESKTOP', 'textmode') ? "multi-user" : "graphical";
-            select_console 'install-shell';
-            # The default.target is not yet linked, so we have to parse the logs.
-            script_run("grep 'target has been set' /var/log/YaST2/y2log |tail -1 |grep --color=auto \"$target\"")
-              && record_info("Warning: no target", "Could not detect the systemd target. Expected was: $target (see poo#49622).");
-            select_console 'installation';
-        }
+        check_default_target;
     }
 }
 


### PR DESCRIPTION
After performing wide search in OSD/O3 to find scenarios where
we were displaying info box about mismatching, now we can die
when detecting wrong desktop and at the same time
improve a bit the validation to assert expected vs actual result.
hmc/pvm_hmc excluded at the moment due to problems switching tty.

- Related ticket: https://progress.opensuse.org/issues/49622

*this is second try after #9882 where now we exclude PATTERNS as well.