### PR TITLE
Type su -c 'bash' slower to avoid typo

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -366,7 +366,7 @@ sub script_sudo {
         $prog = "$prog; echo $str-\$?- > /dev/$testapi::serialdev" unless $prog eq 'bash';
     }
     type_string "clear\n";    # poo#13710
-    type_string "su -c \'$prog\'\n";
+    type_string "su -c \'$prog\'\n", max_interval => 125;
     handle_password_prompt unless ($testapi::username eq 'root');
     if ($wait > 0) {
         if ($prog eq 'bash') {

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -45,6 +45,8 @@ sub run {
 
     # Start an xterm as root
     x11_start_program('xterm');
+    # Wait before typing to avoid typos
+    wait_still_screen(5);
     become_root;
     script_run "cd";
     $self->y2snapper_adding_new_snapper_conf;


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4094798#step/yast2_snapper/24
- Verification run:
https://openqa.suse.de/tests/4098584
https://openqa.suse.de/tests/4098585