### PR TITLE
Add a fix for sporadic failure in nis test

### DIFF
--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -17,7 +17,7 @@ use warnings;
 use testapi;
 use lockapi 'mutex_lock';
 use utils;
-use version_utils qw(is_opensuse is_sle);
+use version_utils 'is_opensuse';
 use mm_network 'setup_static_mm_network';
 use y2_module_guitest '%setup_nis_nfs_x11';
 use x11utils 'turn_off_gnome_screensaver';
@@ -98,7 +98,10 @@ sub nfs_shares_tab {
     send_key 'alt-o';          # OK
     assert_screen 'nis-client-fw-opened';
     send_key 'alt-f';          # finish
-    if (check_screen 'disable_auto_login_popup') { send_key 'ret' }
+    if (is_opensuse) {
+        assert_screen 'disable_auto_login_popup';
+        send_key "alt-y";
+    }
 }
 
 sub setup_verification {

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -20,7 +20,6 @@ use mmapi 'wait_for_children';
 use utils;
 use mm_network 'setup_static_mm_network';
 use y2_module_guitest '%setup_nis_nfs_x11';
-use version_utils 'is_sle';
 use x11utils 'turn_off_gnome_screensaver';
 use y2_module_consoletest;
 use scheduler 'get_test_suite_data';


### PR DESCRIPTION
Fixes this: https://openqa.opensuse.org/tests/1225940#step/nis_client/62 : if for some reason the needle did not match, it does not look obvious what went wrong. I wanted to avoid using "if is_opensuse" but I don't see another way to make clear what is happening. I also thought of just "wait_screen_change { send_key_ret }" but again we would not really know what happened if it does not work.

- Related ticket: https://progress.opensuse.org/issues/9900
- Verification run: 
sle: http://waaa-amazing.suse.cz/tests/11977
tw: http://waaa-amazing.suse.cz/tests/11975
