### PR TITLE
Improve handling of crm node list output

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -333,12 +333,8 @@ sub check_cluster_state {
     assert_script_run "$crm_mon_cmd";
     assert_script_run "$crm_mon_cmd | grep -i 'no inactive resources'" if is_sle '12-sp3+';
     assert_script_run 'crm_mon -1 | grep \'partition with quorum\'';
-    if (is_sle('=12-sp2')) {
-        assert_script_run q/crm_mon -s | grep "$(crm node list | wc -l).*nodes online"/;
-    }
-    else {
-        assert_script_run q/crm_mon -s | grep "$(crm node list | grep -c ': member') nodes online"/;
-    }
+    # In older versions, node names in crm node list output are followed by ": normal". In newer ones by ": member"
+    assert_script_run q/crm_mon -s | grep "$(crm node list | egrep -c ': member|: normal') nodes online"/;
     # As some options may be deprecated, test shouldn't die on 'crm_verify'
     if (get_var('HDDVERSION')) {
         script_run 'crm_verify -LV';


### PR DESCRIPTION
Output of `crm node list` is not uniform among different versions.

On newer systems, the command will output something like this:

```
1c079(178397007): member
	maintenance=off
linux-m59g(178397190): member
```

While in older versions, output is like this:

```
s390vsl158(178363294): normal
s390vsl159(178363295): normal
```

Previous workaround in the test code would count total lines from the output if the version of SLES is 12-SP2 or earlier, and count lines matching with `: member` when **VERSION** is 12-SP3 or newer. This workaround is effective when configuring basic HA resources (sbd, dlm, clvm, cluster_md, drbd, etc), but fails in HanaSR tests in 12-SP2 as output is like this:

```
hana-node01(167772688): normal
        hana_ha1_op_mode=logreplay lpa_ha1_lpt=1585671225 hana_ha1_vhost=hana-node01 hana_ha1_site=NODE1 hana_ha1_srmode=sync
hana-node02(167772687): normal
        lpa_ha1_lpt=30 hana_ha1_op_mode=logreplay hana_ha1_vhost=hana-node02 hana_ha1_remoteHost=hana-node01 hana_ha1_site=NODE2 hana_ha1_srmode=sync
```

This PR fixes the issue by always counting the lines matching either `: member` or `: normal` in the output of `crm node list`.

- Related ticket: N/A
- Needles: N/A
- Verification runs: [12-SP2 node1](http://mango.suse.de/tests/2250#step/check_after_reboot/23) & [12-SP2 node2](http://mango.suse.de/tests/2251#step/check_after_reboot/16); [15-SP2 node1](http://mango.suse.de/tests/2243#step/check_after_reboot/29) & [15-SP2 node2](http://mango.suse.de/tests/2244#step/check_after_reboot/22)
