### PR TITLE
Add autoyast test for yast2-ntp-client systemd timers

### DIFF
--- a/data/autoyast_sle15/autoyast_systemd_timesync.xml
+++ b/data/autoyast_sle15/autoyast_systemd_timesync.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <!-- minimal autoyast profile -->
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email />
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+  </bootloader>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+      <ntp_server>
+        <address>{{NTP_SERVER_ADDRESS}}</address>
+        <iburst config:type="boolean">true</iburst>
+        <offline config:type="boolean">false</offline>
+      </ntp_server>
+    </ntp_servers>
+    <ntp_sync>1</ntp_sync>
+  </ntp-client>
+  <software>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>enhanced_base</pattern>
+      <pattern>yast2_basis</pattern>
+    </patterns>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+</profile>
+

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -436,7 +436,7 @@ sub adjust_network_conf {
 sub expand_variables {
     my ($profile) = @_;
     # Expand other variables
-    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_URL ARCH LOADER_TYPE);
+    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_URL ARCH LOADER_TYPE NTP_SERVER_ADDRESS);
     # Push more variables to expand from the job setting
     my @extra_vars = push @vars, split(/,/, get_var('AY_EXPAND_VARS', ''));
 

--- a/schedule/yast/autoyast_systemd_timesync.yaml
+++ b/schedule/yast/autoyast_systemd_timesync.yaml
@@ -1,0 +1,29 @@
+name:       autoyast_systemd_timesync
+description:   >
+  Test performs autoyast installation where profile dictates that ntp is configured for one time synchronization.
+  Following, checks for the use of systemd timesync instead of cron, validates configuration and functionality.
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_systemd_timesync.xml
+  AUTOYAST_PREPARE_PROFILE: 1
+  NTP_SERVER_ADDRESS: cz.pool.ntp.org
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/clone
+  - autoyast/verify_cloned_profile
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/verify_systemd_timesync
+test_data:
+  profile:
+    ntp-client:
+      ntp_servers:
+        ntp_server:
+          address: cz.pool.ntp.org
+      ntp_sync: 1

--- a/tests/console/verify_systemd_timesync.pm
+++ b/tests/console/verify_systemd_timesync.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that systemd timer is used for time synchronization.
+#          - Check if yast-timer configuration file exists and contains expected values.
+#          - Check configured time synchronization server address.
+#          - Check the message logs for "One time synchronization" occurrence.
+# Maintainer: Sofia Syrianidou <ssyrianidou@suse.com>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+sub run {
+    my $test_data = get_test_suite_data();
+    select_console 'root-console';
+
+    record_info("Check configuration", "Check if file /etc/systemd/system/yast-timesync.timer exists and has expected configuration.");
+    assert_script_run('ls /etc/systemd/system/yast-timesync.timer');
+    my $conf_file = script_output("cat /etc/systemd/system/yast-timesync.timer");
+    $conf_file =~ /OnUnitActiveSec=(?<interval>\S+)min/;
+    my $expected_interval = $test_data->{profile}->{'ntp-client'}->{ntp_sync};
+    assert_equals($expected_interval, $+{interval}, "The interval in yast-timesync configuration file is not the expected one.");
+
+    record_info("Check server", "Check if the configured time synchronization server is the expected one.");
+    my $expected_server = $test_data->{profile}->{'ntp-client'}->{ntp_servers}->{ntp_server}->{address};
+    my $chrony_conf     = script_output("cat /etc/chrony.conf");
+    $chrony_conf =~ /(\R|^)pool\s(?<server>\S+)/;
+    assert_equals($expected_server, $+{server});
+
+    record_info("Check sync", "Check if the use of systemd timers can be spotted in the journal logs as expected.");
+    # The first "One time synchronization" is not happening immediately after boot. In order to make sure that first sync
+    # has already happened before checking the logs, the following loop will check the logs repeatedly until logs are found
+    # or uptime minutes are more that OnBootSec+1 ( +1 due to timers inaccuracy ).
+    $conf_file =~ /OnBootSec=(?<onbootsec>\S+)min/;
+    my $uptime;
+    my $not_synced = 1;
+    {
+        do {
+            $not_synced = script_run("journalctl -u yast-timesync | grep \"Started One time sync configured by YaST\"");
+            last unless ($not_synced);
+            $uptime = script_output("uptime | cut -c19,20");
+            script_run("echo \"Waiting 10 seconds before rechecking logs for One time synchronization\"");
+            sleep 10;
+        } while ($uptime <= ($+{onbootsec} + 1));
+    }
+    die "One time synchronization was not spotted in the journal logs as expected" if $not_synced;
+}
+
+1;


### PR DESCRIPTION
yast2-ntp-client is using systemd timers instead of cron, when configured to perform one time synchronization. This test verifies that particular function works as configured.

- Related ticket: https://progress.opensuse.org/issues/61946
- http://falafel.suse.cz/tests/631