### PR TITLE
Add IOMMU commandline options to autoyast profile

### DIFF
--- a/data/autoyast_sle15/autoyast_mlx_con5.xml
+++ b/data/autoyast_sle15/autoyast_mlx_con5.xml
@@ -24,7 +24,7 @@
   <bootloader>
     <global>
       <activate config:type="boolean">true</activate>
-      <append>console=ttyS1,115200 noquiet crashkernel=172M,high crashkernel=72M,low</append>
+      <append>console=ttyS1,115200 noquiet crashkernel=172M,high crashkernel=72M,low intel_iommu=on iommu=pt pci=realloc</append>
       <gfxmode>auto</gfxmode>
       <boot_mbr>true</boot_mbr>
       <hiddenmenu>false</hiddenmenu>


### PR DESCRIPTION
In the future, we plan for virtualized testing with our mlx_con5
machines. As one preparing step, we need to enable a few command line
options to enable the IOMMU.
The option pci=realloc is usually only needed when we have a buggy BIOS.
Until it is possible to update the firmware on sonic and tails we should
just go with this option.