### PR TITLE
HPC: Select openmpi version

### DIFF
--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Provide functionality for hpc tests.
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+package hpc::utils;
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+
+sub get_mpi() {
+    my $mpi = get_required_var('MPI');
+
+    if ($mpi eq 'openmpi3') {
+        if (is_sle('<15')) {
+            $mpi = 'openmpi';
+        } elsif (is_sle('<15-SP2')) {
+            $mpi = 'openmpi2';
+        }
+    }
+
+    return $mpi;
+}
+
+1;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -13,6 +13,7 @@
 # Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
 
 use base 'hpcbase';
+use base 'hpc::utils';
 use strict;
 use warnings;
 use testapi;
@@ -23,7 +24,7 @@ use version_utils 'is_sle';
 
 sub run {
     my $self          = shift;
-    my $mpi           = get_required_var('MPI');
+    my $mpi           = $self->get_mpi();
     my $mpi_c         = 'simple_mpi.c';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -11,6 +11,7 @@
 # Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
 
 use base 'hpcbase';
+use base 'hpc::utils';
 use strict;
 use warnings;
 use testapi;
@@ -19,7 +20,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    my $mpi  = get_required_var('MPI');
+    my $mpi  = $self->get_mpi();
 
     zypper_call("in $mpi");
 


### PR DESCRIPTION
A function is introduced to select openmpi, openmpi2 and openmpi3
depending on the SLE version.

- Related ticket: https://progress.opensuse.org/issues/65133
- Needles: No needles
- Verification run:
sle-12-sp3 (openmpi): http://angmar.suse.de/tests/1630#step/mpi_master/2
sle-12-sp4 (openmpi): http://angmar.suse.de/tests/1634#step/mpi_master/2
sle-12-sp5 (openmpi): http://angmar.suse.de/tests/1638#step/mpi_master/2
sle-15 (openmpi2): http://angmar.suse.de/tests/1642#step/mpi_master/8
sle-15-sp1 (openmpi2):  http://angmar.suse.de/tests/1646#step/mpi_master/8
sle-15-sp1 (openmpi3): http://angmar.suse.de/tests/1662#step/mpi_master/8

other mpis not overwritten:
sle-12-sp5(mvapich2): http://angmar.suse.de/tests/1650#step/mpi_master/2