### PR TITLE
Need wait more time to reboot the system

### DIFF
--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -53,7 +53,7 @@ sub run {
             type_string("/sbin/reboot\n");
 
             reset_consoles;
-            $self->wait_boot(textmode => 1);
+            $self->wait_boot(textmode => 1, bootloader_time => 200);
 
             select_console('root-console');
         }


### PR DESCRIPTION
Need wait more time to reboot the system.
Background: We checked the log https://openqa.nue.suse.com/tests/4094592/file/autoinst-log.txt, it cannot boot to text mode in 100s. So we need extend the time to wait the system ready.

- Related ticket: https://progress.opensuse.org/issues/61880
- Verification run: https://openqa.nue.suse.com/tests/4098984#