### PR TITLE
Fix systemd test suite repo

### DIFF
--- a/lib/systemd_testsuite_test.pm
+++ b/lib/systemd_testsuite_test.pm
@@ -41,9 +41,8 @@ sub testsuiteinstall {
             $qa_testsuite_repo = 'https://download.opensuse.org/repositories/devel:/openSUSE:/QA:/' . $sub_project;
         }
         else {
-            my $version_with_service_pack    = get_required_var('VERSION');
-            my $version_without_service_pack = substr($version_with_service_pack, 0, index($version_with_service_pack, '-'));
-            $qa_testsuite_repo = "http://download.suse.de/ibs/QA:/Head:/SLE$version_without_service_pack/SLE-$version_with_service_pack/";
+            my $version_with_service_pack = get_required_var('VERSION');
+            $qa_testsuite_repo = "http://download.suse.de/ibs/QA:/Head/SLE-$version_with_service_pack/";
         }
         die '$qa_testsuite_repo is not set' unless ($qa_testsuite_repo);
     }


### PR DESCRIPTION
## Description

- Before it was http://download.suse.de/ibs/QA:/Head/SLE15/SLE-15-SP2/
- Now it is http://download.suse.de/ibs/QA:/Head/SLE-15-SP2/

## Related
- failed test: https://openqa.suse.de/tests/4081392#step/binary_tests/12

## Verification run

- http://openqa.slindomansilla-vm.qa.suse.de/tests/2397#step/binary_tests/14 (the package is missing because it doesn't build, but @tblume is working on it. See https://build.suse.de/package/show/QA:Head/systemd-v234-testsuite)
