### PR TITLE
Add workaround for s390x FIPS tests suspend after testing failed

### DIFF
--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -1,15 +1,17 @@
 # SUSE's Apache+SSL tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
+#
 # Summary: Enable SSL module on Apache2 server
-# - calls setup_apache2 with mode = SSL (lib/apachetest.pm)
+#          calls setup_apache2 with mode = SSL (lib/apachetest.pm)
+#
 # Maintainer: Ben Chou <bchou@suse.com>
+# Tags: poo#65375
 
 use base "consoletest";
 use testapi;
@@ -20,6 +22,10 @@ use apachetest;
 sub run {
     select_console 'root-console';
     setup_apache2(mode => 'SSL');
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -1,12 +1,12 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
+#
 # Summary: check freshclam and clamscan against some fake virus samples
 # - refresh the database using freshclam
 # - change user vscan to root in clamd.conf (clamd runs as root)
@@ -14,8 +14,9 @@
 # - check that clamscan is able to recognize a fake vim virus
 # - check that clamscan is able to recognize an EICAR virus pdf, txt and zip format
 # - check that clamdscan is able to recognize an EICAR virus pdf, txt and zip format
+#
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: TC1595169, poo#46880
+# Tags: TC1595169, poo#46880, poo#65375
 
 use base "consoletest";
 use strict;
@@ -95,6 +96,10 @@ sub run {
 
 sub post_run_hook {
     assert_script_run("swapoff /var/lib/swap/swapfile") if is_jeos && !(is_opensuse && check_var('ARCH', 'aarch64'));
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,9 @@
 # - Sign test file
 # - Check test file signature
 # - Cleanup
+#
 # Maintainer: Petr Cervinka <pcervinka@suse.com>, Ben Chou <bchou@suse.com>
+# Tags: poo#65375
 
 use base "consoletest";
 use strict;
@@ -154,6 +156,10 @@ sub run {
     foreach my $len ('1024', '2048', '3072', '4096') {
         gpg_test($len, $gpg_version);
     }
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/console/links_https.pm
+++ b/tests/console/links_https.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,8 +15,9 @@
 #
 # Summary: Test with "FIPS" installed and enabled, the WWW browser "links"
 #          can access https web pages successfully.
+#
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#52289, tc#1621467
+# Tags: poo#52289, tc#1621467, poo#65375
 
 use base "consoletest";
 use strict;
@@ -30,6 +31,10 @@ sub run {
     setup_web_browser_env();
     zypper_call("--no-refresh --no-gpg-checks in links");
     run_web_browser_text_based("links", undef);
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/console/lynx_https.pm
+++ b/tests/console/lynx_https.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,8 +15,9 @@
 #
 # Summary: Test with "FIPS" installed and enabled, the WWW browser "lynx"
 #          can access https web pages successfully.
+#
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#52292, tc#1621466
+# Tags: poo#52292, tc#1621466, poo#65375
 
 use base "consoletest";
 use strict;
@@ -30,6 +31,10 @@ sub run {
     setup_web_browser_env();
     zypper_call("--no-refresh --no-gpg-checks in lynx");
     run_web_browser_text_based("lynx", "-accept_all_cookies");
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/console/openvswitch_ssl.pm
+++ b/tests/console/openvswitch_ssl.pm
@@ -1,15 +1,16 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
+#
 # Summary: The test to connect openvswitch to openflow with SSL enabled
+#
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: TC1595181
+# Tags: TC1595181, poo#65375
 
 use base "consoletest";
 use strict;
@@ -73,6 +74,10 @@ sub run {
 
     # Stop pox
     assert_script_run "ps aux|grep '[p]ox.py'|awk '{print \$2}'|xargs kill";
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/console/ssh_cleanup.pm
+++ b/tests/console/ssh_cleanup.pm
@@ -1,26 +1,29 @@
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
+#
+# Summary: Cleanup ssh test user to prevent the user showing up in
+#          displaymanager and confusing other tests
+#          - If user sshboy exists, remove the user
+#
+# Maintainer: Oliver Kurz <okurz@suse.de>
+# Tags: poo#65375
 
 use base "consoletest";
 use strict;
 use warnings;
 use testapi;
 
-# Summary: Cleanup ssh test user to prevent the user showing up in
-#  displaymanager and confusing other tests
-# - If user sshboy exists, remove the user
-# Maintainer: Oliver Kurz <okurz@suse.de>
 sub run {
     select_console 'root-console';
     assert_script_run('getent passwd sshboy > /dev/null && userdel -fr sshboy');
 }
 
 sub test_flags {
-    return {milestone => 1};
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/console/ssh_pubkey.pm
+++ b/tests/console/ssh_pubkey.pm
@@ -1,6 +1,6 @@
 # SUSE's openssh tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,9 @@
 #    openssh will refuse to work with any non-approved
 #    algorithm in fips mode, just like blowfish cipher
 #    or MD5 hash.
+#
 # Maintainer: Ben Chou <bchou@suse.com>
+# Tags: poo#65375
 
 use base "consoletest";
 use strict;
@@ -47,6 +49,10 @@ sub run {
     # Verify ssh without password
     script_run("ssh -v $ssh_testman\@localhost -t echo LOGIN_SUCCESSFUL", 0);
     assert_screen "ssh-login-ok";
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,9 @@
 #   * Utilities ssh-keygen and ssh-copy-id are used
 #   * Local and remote port forwarding are tested
 #   * The SCP is tested by copying various files
+#
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
+# Tags: poo#65375
 
 use warnings;
 use base "consoletest";
@@ -137,7 +139,7 @@ sub run {
 }
 
 sub test_flags {
-    return get_var('PUBLIC_CLOUD') ? {milestone => 0, no_rollback => 1} : {milestone => 1};
+    return get_var('PUBLIC_CLOUD') ? {milestone => 0, no_rollback => 1} : {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -6,12 +6,13 @@
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
+#
 # Case #1560076 - FIPS: Firefox Mozilla NSS
-
+#
 # Summary: FIPS mozilla-nss test for firefox : firefox_nss
+#
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tag: poo#47018, poo#58079
+# Tag: poo#47018, poo#58079, poo#65375
 
 use base "x11test";
 use strict;
@@ -96,6 +97,10 @@ sub run {
 
     quit_firefox;
     assert_screen "generic-desktop";
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/fips/openssl/dirmngr_daemon.pm
+++ b/tests/fips/openssl/dirmngr_daemon.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
 # Summary: Test dirmngr daemon and valid/revoked certificate
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#52430, poo#52937, tc#1729313
+# Tags: poo#52430, poo#52937, tc#1729313, poo#65375
 
 use base "consoletest";
 use strict;
@@ -72,6 +72,10 @@ sub run {
 
     # Test Dirmngr daemon
     $self->dirmngr_daemon();
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;

--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -1,6 +1,6 @@
 # openssl fips test
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -11,7 +11,7 @@
 #                 while system is working in fips mode
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#44831
+# Tags: poo#44831, poo#65375
 
 use base "consoletest";
 use testapi;
@@ -62,6 +62,10 @@ sub run {
           sub { m/^Invalid Pubkey: 0$/ };
     }
 
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
 }
 
 1;


### PR DESCRIPTION
**Description**
1. Refine 12 FIPS test cases were failed in s390x arch
2. Add test_flag to workaround the test suspend if test failed (The problem will not be reproduced in x86_64, and there will be no regression after adding the test_flag)
------
### Test Suite (Impacted)
**group 1:  fips_env_mode_tests_crypt_core**
- openssl_fips_alglist
- dirmngr_daemon
- sshd
- ssh_pubkey
- ssh_cleanup

**group 2. fips_env_mode_tests_crypt_tool**
- gpg 
- clamav
- openvswitch_ssl

**group 3. fips_env_mode_tests_crypt_web**
- links_https
- lynx_https 
- apache_ssl

**group 4. fips_env_mode_tests_crypt_x11_s390x**
- firefox_nss
------

- Related ticket: https://progress.opensuse.org/issues/65375
- Needles: NA
- Verification run:  [Test failed in s390x but it'll not suspend the whole run and skip rest of cases.]


 
  1. [**fips_env_mode_tests_crypt_core**](https://openqa.suse.de/tests/4105849)
   2. [**fips_env_mode_tests_crypt_tool**](https://openqa.suse.de/tests/4105864)
   3. [**fips_env_mode_tests_crypt_web**](https://openqa.suse.de/tests/4106225)
   4. [**fips_env_mode_tests_crypt_x11_s390x**](https://openqa.suse.de/tests/4105866)

