### PR TITLE
Validate boot in JeOS images

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -65,6 +65,7 @@ our @EXPORT = qw(
   remove_grub_cmdline_settings
   replace_grub_cmdline_settings
   mimic_user_to_import
+  tianocore_disable_secureboot
 );
 
 our $zkvm_img_path = "/var/lib/libvirt/images";
@@ -878,6 +879,33 @@ sub tianocore_enter_menu {
         send_key 'f2';
         sleep 0.1;
     }
+}
+
+sub tianocore_disable_secureboot {
+    my $basetest = shift;
+
+    assert_screen 'grub2';
+    send_key 'c';
+    sleep 2;
+    type_string "exit\n";
+    assert_screen 'tianocore-mainmenu';
+    # Select 'Boot manager' entry
+    send_key_until_needlematch('tianocore-devicemanager', 'down', 5, 5);
+    send_key 'ret';
+    send_key_until_needlematch('tianocore-devicemanager-sb-conf', 'down', 5, 5);
+    send_key 'ret';
+    send_key_until_needlematch('tianocore-devicemanager-sb-conf-attempt-sb', 'down', 5, 5);
+    send_key 'spc';
+    assert_screen 'tianocore-devicemanager-sb-conf-changed';
+    send_key 'ret';
+    assert_screen 'tianocore-devicemanager-sb-conf-attempt-sb';
+    send_key 'f10';
+    assert_screen 'tianocore-bootmanager-save-changes';
+    send_key 'Y';
+    send_key_until_needlematch 'tianocore-devicemanager',  'esc';
+    send_key_until_needlematch 'tianocore-mainmenu-reset', 'down';
+    send_key 'ret';
+    $basetest->wait_grub;
 }
 
 sub tianocore_select_bootloader {

--- a/lib/jeos.pm
+++ b/lib/jeos.pm
@@ -1,0 +1,51 @@
+# Copyright (C) 2015-2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package jeos;
+use Mojo::Base qw(Exporter);
+use testapi;
+use utils qw(ensure_serialdev_permissions);
+use power_action_utils qw(power_action);
+use Utils::Backends qw(is_hyperv);
+use version_utils qw(is_sle is_tumbleweed is_leap);
+use bootloader_setup qw(change_grub_config grep_grub_settings grub_mkconfig set_framebuffer_resolution set_extrabootparams_grub_conf);
+
+our @EXPORT = qw(expect_mount_by_uuid set_grub_gfxmode reboot_image);
+
+sub expect_mount_by_uuid {
+    return (is_hyperv || is_sle('>=15-sp2') || is_tumbleweed || is_leap('>=15.2'));
+}
+
+sub reboot_image {
+    my ($self, $msg) = @_;
+    power_action('reboot', textmode => 1);
+    record_info('reboot', $msg);
+    $self->wait_boot;
+    $self->select_serial_terminal;
+    ensure_serialdev_permissions;
+}
+
+# Set GRUB_GFXMODE to 1024x768
+sub set_grub_gfxmode {
+    change_grub_config('=.*', '=1024x768', 'GRUB_GFXMODE=');
+    change_grub_config('^#',  '',          'GRUB_GFXMODE');
+    change_grub_config('=.*', '=-1',       'GRUB_TIMEOUT') unless check_var('VIRSH_VMM_TYPE', 'linux');
+    grep_grub_settings('^GRUB_GFXMODE=1024x768$');
+    set_framebuffer_resolution;
+    set_extrabootparams_grub_conf;
+    grub_mkconfig;
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -585,7 +585,8 @@ sub load_jeos_tests {
             loadtest "console/suseconnect_scc";
         }
 
-        replace_opensuse_repos_tests if is_repo_replacement_required;
+        replace_opensuse_repos_tests      if is_repo_replacement_required;
+        loadtest 'console/verify_efi_mok' if get_var('MOK_VERBOSITY');
     }
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -88,6 +88,7 @@ our @EXPORT = qw(
   create_btrfs_subvolume
   file_content_replace
   ensure_ca_certificates_suse_installed
+  is_efi_boot
 );
 
 =head1 SYNOPSIS
@@ -1686,6 +1687,11 @@ sub ensure_ca_certificates_suse_installed {
         zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_$distversion/SUSE:CA.repo");
         zypper_call("in ca-certificates-suse");
     }
+}
+
+# non empty */sys/firmware/efi/* must exist in UEFI mode
+sub is_efi_boot {
+    return !!script_output('test -d /sys/firmware/efi/ && ls -A /sys/firmware/efi/', proceed_on_failure => 1);
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -891,8 +891,7 @@ elsif (get_var('LIBSOLV_INSTALLCHECK')) {
 elsif (get_var("EXTRATEST")) {
     boot_hdd_image;
     load_extra_tests();
-    loadtest "console/coredump_collect" unless (check_var('EXTRATEST', 'wicked') || get_var('PUBLIC_CLOUD'));
-
+    loadtest "console/coredump_collect" unless (check_var('EXTRATEST', 'wicked') || get_var('PUBLIC_CLOUD') || is_jeos);
 }
 elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_installation";

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -1,0 +1,68 @@
+---
+description: 'Main JeOS test suite. Maintainer: qa-c@suse.de'
+name: 'jeos-main'
+conditional_schedule:
+    bootloader:
+        MACHINE:
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+            'svirt-hyperv-uefi':
+                - installation/bootloader_hyperv
+                - installation/bootloader_uefi
+            'uefi-virtio-vga':
+                - installation/bootloader_uefi
+    efi:
+        MOK_VERBOSITY:
+            '1':
+                - console/verify_efi_mok
+schedule:
+    - '{{bootloader}}'
+    - jeos/firstrun
+    - jeos/record_machine_id
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - jeos/grub2_gfxmode
+    - jeos/diskusage
+    - jeos/build_key
+    - console/suseconnect_scc
+    - '{{efi}}'
+    - jeos/glibc_locale
+    - console/check_network
+    - console/system_state
+    - console/consoletest_setup
+    - locale/keymap_or_locale
+    - console/apache
+    - console/dns_srv
+    - console/postgresql_server
+    - console/shibboleth
+    - console/apache_ssl
+    - console/apache_nss
+    - console/hostname
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - console/yast2_lan
+    - console/curl_https
+    - console/glibc_sanity
+    - update/zypper_up
+    - console/console_reboot
+    - console/zypper_in
+    - console/yast2_i
+    - console/yast2_bootloader
+    - console/vim
+    - console/firewall_enabled
+    - console/gpt_ptable
+    - console/kdump_disabled
+    - console/slp
+    - console/sshd_running
+    - console/sshd
+    - console/ssh_cleanup
+    - console/mtab
+    - console/mysql_srv
+    - console/rsync
+    - console/zypper_lifecycle
+    - console/repo_orphaned_packages_check
+    - console/orphaned_packages_check
+    - console/consoletest_finish

--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -1,0 +1,274 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Check EFI boot in images or after OS installation
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use utils qw(zypper_call is_efi_boot);
+use version_utils qw(is_leap is_opensuse is_sle);
+use Utils::Backends qw(is_hyperv is_svirt_except_s390x);
+use jeos qw(reboot_image set_grub_gfxmode);
+use constant {
+    SYSFS_EFI_BITS      => '/sys/firmware/efi/fw_platform_size',
+    FSTAB               => '/etc/fstab',
+    GRUB_DEFAULT        => '/etc/default/grub',
+    GRUB_CFG            => '/boot/grub2/grub.cfg',
+    SYSCONFIG_BOOTLADER => '/etc/sysconfig/bootloader'
+};
+
+sub get_expected_efi_settings {
+    my $settings      = {};
+    my $efi_rec_label = (is_opensuse() ? (lc get_var('DISTRI')) : 'sles');
+    my $efi_exec      = $efi_rec_label . '/grubx64.efi';
+
+    if (!get_var('DISABLE_SECUREBOOT', 0)) {
+        $efi_exec = $efi_rec_label . '/shim.efi';
+        $efi_rec_label .= '-secureboot';
+    }
+    $settings->{exec}  = '/EFI/' . $efi_exec;
+    $settings->{label} = $efi_rec_label;
+
+    return $settings;
+}
+sub efibootmgr_current_boot {
+    my $ebm_raw = script_output 'efibootmgr --verbose';
+    my $h       = {};
+
+    ($h->{bootid}) = $ebm_raw =~ /^BootCurrent:\s+(\d+)/m;
+    die("Missing BootCurrent: in efibootmgr output") unless (defined($h->{bootid}));
+
+    if ($ebm_raw =~ /^(Boot$h->{bootid}\*\s+(.+)\s+(\S+\([^\)]+\)\/?)+.*|Boot$h->{bootid}\*\s+(.+))$/m) {
+        $h->{label} = $2 // $4;
+    }
+    die("Missing label in Boot$h->{bootid} entry") unless (exists($h->{label}) or defined($h->{label}));
+
+    ($h->{exec}) = $ebm_raw =~ /^Boot$h->{bootid}\*.*File\(([^\)]+)\).*/m;
+    if (defined($h->{exec})) {
+        $h->{exec} =~ s'\\'/'g;
+    }
+
+    return $h;
+}
+
+sub check_efi_state {
+    is_efi_boot or die "Image did not boot in UEFI mode!\n";
+    my $expected = shift;
+
+    # check UEFI firmware bitness
+    validate_script_output 'cat ' . SYSFS_EFI_BITS, sub { $_ == 64 };
+
+    # check SecureBoot according to efivars
+    # get data from efivars
+    # {8be4df61-93ca-11d2-aa0d-00e098032b8c} {global} efi_guid_global EFI Global Variable
+    # save only the first capture
+    my ($efi_guid_global, undef) = script_output('efivar --list-guids') =~ /\{((\w+-){4}\w+)\}.*\s+efi_guid_global\s+/;
+    diag "Found efi guid=$efi_guid_global";
+    diag('Expected state of SecureBoot: ' . get_var('DISABLE_SECUREBOOT', 0) ? 'Disabled' : 'Enabled');
+    validate_script_output
+      "od --address-radix=n --format=u1 /sys/firmware/efi/vars/SecureBoot-$efi_guid_global/data",
+      sub { $_ == !get_var('DISABLE_SECUREBOOT', 0) };
+
+    # get current boot information from efibootmgr
+    my $efi = efibootmgr_current_boot;
+
+    diag("Found:\nlabel=$efi->{label}\nexecutable=$efi->{exec}");
+    diag("Expected:\nlabel=$expected->{label}\nexecutable=$expected->{exec}");
+
+    if (exists $expected->{exec} && defined $expected->{exec}) {
+        record_info "Expected", "EFI executable: $expected->{exec} ( $expected->{label} )";
+        if (exists $efi->{exec} && defined $efi->{exec}) {
+            ($efi->{exec} eq $expected->{exec} && $efi->{label} eq $expected->{label}) or die "System booted using unexpected efi binary\n";
+        } else {
+            die "No efi executable found!";
+        }
+        record_info "Found", "EFI executable: $efi->{exec} ( $efi->{label} )";
+    } else {
+        record_info "Fallback", "EFI label: $efi->{label}";
+        return;
+    }
+
+    return if (get_var('DISABLE_SECUREBOOT', 0));
+
+    my $issuer_regex = is_opensuse() ? qr/^\s+issuer:\s+\/CN=openSUSE Secure Boot CA/ :
+      qr/^\s+issuer:\s+\/CN=SUSE Linux Enterprise Secure Boot CA/;
+    diag("Verifying shim's certificate");
+    (grep /$issuer_regex/, split /\n/, script_output "sbverify --list $expected->{mount}/$efi->{exec}") or
+      die "No SUSE/openSUSE certificate has been found in sbverify's output";
+    assert_script_run 'openssl x509 -in $(rpm -ql shim | grep crt) -inform DER -text -out shim.crt';
+    assert_script_run "sbverify --cert shim.crt $expected->{mount}/$efi->{exec}";
+
+    if (script_run "cat /proc/keys | tee -a /dev/$serialdev | grep asym") {
+        if (is_leap('=15.1')) {
+            record_soft_failure('boo#1170896 - secureboot keys not found in /proc/keys');
+        } else {
+            die "No asymetric keys in keyring";
+        }
+    }
+}
+
+sub check_mok {
+    my $state = !get_var('DISABLE_SECUREBOOT', 0) ? qr/^SecureBoot\senabled$/ : qr/^SecureBoot\sdisabled$/;
+    # check SecureBoot according to MOK
+    diag('Expected regex used to verify SecureBoot: ' . $state);
+    validate_script_output 'mokutil --sb-state', $state;
+
+    my $new_mok_keys = script_output('mokutil --list-new', proceed_on_failure => 1);
+    if ($new_mok_keys =~ /MokNew is empty/) {
+        record_info 'MOK updates', 'No new certificates are expected to be enrolled';
+    } elsif ($new_mok_keys =~ /^Failed.*MokNew:.*directory/) {
+        record_soft_failure('bsc#1170889 -  mokutil: Failed to read MokNew');
+    } else {
+        die "No new boot certificates are expected";
+    }
+
+    my $rc = script_run('mokutil --list-enrolled | grep ' . (is_sle() ? 'O=SUSE' : 'O=openSUSE'));
+    die "Unexpected certificate has been enrolled!\n" if ($rc && !get_var('DISABLE_SECUREBOOT', 0));
+
+    unless (script_run 'test -f /boot/efi/EFI/mock.der') {
+        assert_script_run 'mokutil --list-enrolled | grep CN=MOCK';
+        assert_script_run 'mokutil --delete /boot/efi/EFI/mock.der --root-pw';
+        assert_script_run 'rm /boot/efi/EFI/mock.der';
+        assert_script_run 'mokutil --list-delete | grep CN=MOCK';
+    }
+}
+
+sub virtualized_block_type {
+    my $backend        = join('_', grep { $_ } (get_required_var('BACKEND'), get_var('VIRSH_VMM_FAMILY')));
+    my $blk_dev_driver = {
+        qemu         => 'virtblk',
+        svirt_xen    => 'xvd',
+        svirt_hyperv => 'scsi'
+    };
+
+    return $blk_dev_driver->{$backend};
+}
+
+sub get_esp_from_parted {
+    my @parted_data = split /\n/, script_output 'parted --list --machine --script';
+    # return a the first element (drive or partition number) from parted's output
+    my $extract_from_parted = sub { return (split /:/, shift())[0] };
+    # locate drive record_info
+    # old dos partition table is not supported in JeOS
+    my $vbt = virtualized_block_type();
+    my ($drive_raw_record) = grep(/gpt/ && /$vbt/, @parted_data) or die "No gpt table found!\n";
+
+    # find possible boot partitions in JeOS image
+    my $boot_esp->{drive} = $extract_from_parted->($drive_raw_record);
+    map {
+        $boot_esp->{part_no}   = $extract_from_parted->($_);
+        $boot_esp->{partition} = $boot_esp->{drive} . $boot_esp->{part_no};
+    } grep(/boot,\s?esp/, @parted_data);
+
+    assert_script_run "parted --script $boot_esp->{drive} align-check optimal $boot_esp->{part_no}";
+
+    return $boot_esp;
+}
+
+sub verification {
+    my ($self, $msg, $expected, $setup) = @_;
+
+    $setup->()                if ($setup && ref($setup) eq 'CODE');
+    $self->reboot_image($msg) if ($msg);
+    check_efi_state $expected;
+    check_mok;
+}
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    my $esp_details = get_esp_from_parted;
+    die "Image did not boot in UEFI mode!\n"
+      unless ($esp_details && is_efi_boot && get_required_var('UEFI'));
+
+    my $pkgs = 'efivar mokutil';
+    $pkgs .= ' dosfstools' if (is_leap('<15.2') || is_sle('<15-sp2'));
+    unless (get_var('DISABLE_SECUREBOOT', 0)) {
+        # temporary hack for sle, due to missing sbsigntools package
+        if (is_sle) {
+            (my $version = get_var('VERSION')) =~ s/-/_/g;
+            $version =~ s/SP3/SP2/g;
+            zypper_call("ar -p 101 --refresh --no-gpgcheck http://download.opensuse.org/repositories/Base:/System/SLE_$version/ sb_signtools");
+        }
+        $pkgs .= ' sbsigntools';
+    }
+    zypper_call "in $pkgs";
+
+    # store ESP's file system and mount point
+    my ($efi_p_fs, $efi_p_mp) = split(/\s+/,
+        script_output 'df --output=fstype,target,source --local | grep ' . $esp_details->{partition});
+    ($efi_p_fs && $efi_p_mp && $esp_details->{partition}) or die "No mounted ESP partition was not found!\n";
+
+    record_info "esp [$esp_details->{partition}]", "\nFilesystem [$efi_p_fs],\nMountPoint [$efi_p_mp]";
+
+    # run fs check on ESP
+    assert_script_run "umount $efi_p_mp";
+    assert_script_run "fsck.vfat -tvV $esp_details->{partition}";
+    assert_script_run "mount $efi_p_mp";
+
+    my $exp_data = get_expected_efi_settings;
+    $exp_data->{mount} = $efi_p_mp;
+    ## default efi boot, no restart, but set gfxmode before reboot
+    $self->verification(undef, undef, sub {
+            set_grub_gfxmode;
+            assert_script_run('grub2-script-check --verbose ' . GRUB_CFG);
+        }
+    );
+    ## Test efi without secure boot
+    if (get_var('DISABLE_SECUREBOOT')) {
+        $self->verification('After grub2-install', $exp_data, sub {
+                assert_script_run('sed -ie s/SECURE_BOOT=.*/SECURE_BOOT=no/ ' . SYSCONFIG_BOOTLADER);
+                assert_script_run "grub2-install --efi-directory=$efi_p_mp --target=x86_64-efi $esp_details->{drive}";
+                assert_script_run('grub2-mkconfig -o ' . GRUB_CFG);
+            }
+        );
+    } else {
+        ## Test efi with secure boot
+        # enable verbosity in shim
+        assert_script_run 'mokutil --set-verbosity true';
+        $self->verification('After shim-install', $exp_data, sub {
+                assert_script_run('shim-install --config-file=' . GRUB_CFG);
+                assert_script_run('grub2-mkconfig -o ' . GRUB_CFG);
+            }
+        );
+        $self->verification('Import mock key to MOK', $exp_data, sub {
+                assert_script_run 'openssl req -new -x509 -newkey rsa:2048 -sha256 -keyout key.asc -out cert.pem -nodes -days 666 -subj "/CN=MOCK/"';
+                assert_script_run 'openssl x509 -in cert.pem -outform der -out /boot/efi/EFI/mock.der';
+                assert_script_run 'mokutil --import /boot/efi/EFI/mock.der --root-pw';
+                assert_script_run 'mokutil --list-new';
+            }
+        );
+    }
+
+    ## Keep previous configuration
+    $self->verification('After pbl reinit', $exp_data, sub {
+            my $state = !get_var('DISABLE_SECUREBOOT', 0) ? 'yes' : 'no';
+            assert_script_run(q|egrep "SECURE_BOOT=['\"]?| . $state . q|[\"']?" | . SYSCONFIG_BOOTLADER);
+            assert_script_run 'update-bootloader --reinit';
+        }
+    );
+
+    unless (get_var('DISABLE_SECUREBOOT', 0)) {
+        zypper_call 'rm sbsigntools';
+        zypper_call 'rr sb_signtools' if is_sle;
+    }
+}
+
+sub post_fail_hook {
+    select_console('root-console');
+
+    upload_logs(GRUB_DEFAULT,        log_name => 'etc_default_grub.txt');
+    upload_logs(GRUB_CFG,            log_name => 'grub.cfg');
+    upload_logs(SYSCONFIG_BOOTLADER, log_name => 'etc_sysconfig_bootloader.txt');
+    upload_logs(FSTAB,               log_name => 'fstab.txt');
+}
+
+1;

--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -212,8 +212,11 @@ sub run {
     hyperv_cmd("$ps Set-VMProcessor $name -Count $cpucount");
 
     if (get_var('UEFI')) {
-        hyperv_cmd("$ps Set-VMFirmware $name -EnableSecureBoot off")                                                        if $winserver eq '2012';
-        hyperv_cmd("$ps Set-VMFirmware $name -EnableSecureBoot On -SecureBootTemplate 'MicrosoftUEFICertificateAuthority'") if $winserver eq '2016';
+        if ($winserver eq '2012' || get_var('DISABLE_SECUREBOOT')) {
+            hyperv_cmd("$ps Set-VMFirmware $name -EnableSecureBoot Off");
+        } else {
+            hyperv_cmd("$ps Set-VMFirmware $name -EnableSecureBoot On -SecureBootTemplate 'MicrosoftUEFICertificateAuthority'");
+        }
         if (check_var('BOOTFROM', 'c')) {
             hyperv_cmd($ps . ' "' . "\$hd = Get-VMHardDiskDrive $name; Set-VMFirmware $name -BootOrder \$hd" . '"');
         }

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -80,6 +80,9 @@ sub run {
         send_key "ret";
         assert_screen "bootloader-grub2", $bootloader_timeout;
     }
+    if (get_var('DISABLE_SECUREBOOT') && (get_var('BACKEND') eq 'qemu')) {
+        $self->tianocore_disable_secureboot;
+    }
     if (get_var("QEMUVGA") && get_var("QEMUVGA") ne "cirrus") {
         sleep 5;
     }

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -17,11 +17,8 @@ use testapi;
 use version_utils qw(is_sle is_tumbleweed is_leap is_opensuse);
 use Utils::Architectures qw(is_aarch64 is_x86_64);
 use Utils::Backends 'is_hyperv';
+use jeos qw(expect_mount_by_uuid);
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);
-
-sub expect_mount_by_uuid {
-    return (is_hyperv || is_sle('>=15-sp2') || is_tumbleweed || is_leap('>=15.2'));
-}
 
 sub post_fail_hook {
     assert_script_run('timedatectl');

--- a/tests/jeos/grub2.pm
+++ b/tests/jeos/grub2.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'type_string_very_slow';
-use bootloader_setup qw(uefi_bootmenu_params get_hyperv_fb_video_resolution);
+use bootloader_setup qw(uefi_bootmenu_params get_hyperv_fb_video_resolution tianocore_disable_secureboot);
 
 sub run {
     my $self = shift;
@@ -34,6 +34,7 @@ sub run {
         $counter++;
     } while ((!check_screen('grub2', 1)) && ($counter < 10));
     $self->wait_grub(in_grub => 1, bootloader_time => 10);
+    $self->tianocore_disable_secureboot if (get_var('DISABLE_SECUREBOOT') && (get_var('BACKEND') eq 'qemu'));
     uefi_bootmenu_params;
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
         type_string_very_slow(get_hyperv_fb_video_resolution);

--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -14,20 +14,15 @@
 # Summary: Set GRUB_GFXMODE to 1024x768
 # Maintainer: Michal Nowak <mnowak@suse.com>
 
-use base "opensusebasetest";
-use strict;
-use warnings;
+use Mojo::Base qw(opensusebasetest);
 use testapi;
-use bootloader_setup qw(change_grub_config grep_grub_settings grub_mkconfig set_framebuffer_resolution set_extrabootparams_grub_conf);
+use jeos qw(set_grub_gfxmode);
 
 sub run {
-    change_grub_config('=.*', '=1024x768', 'GRUB_GFXMODE=');
-    change_grub_config('^#',  '',          'GRUB_GFXMODE');
-    change_grub_config('=.*', '=-1',       'GRUB_TIMEOUT') unless check_var('VIRSH_VMM_TYPE', 'linux');
-    grep_grub_settings('^GRUB_GFXMODE=1024x768$');
-    set_framebuffer_resolution;
-    set_extrabootparams_grub_conf;
-    grub_mkconfig;
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    set_grub_gfxmode;
 }
 
 sub test_flags {

--- a/variables.md
+++ b/variables.md
@@ -33,6 +33,7 @@ DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xf
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.
 DEV_IMAGE | boolean | false | This setting is used to set veriables properly when SDK or Development-Tools are required.
 DISABLE_ONLINE_REPOS | boolean | false | Enables `installation/disable_online_repos` test module, relevant for openSUSE only. Test module explicitly disables online repos not to be used during installation.
+DISABLE_SECUREBOOT | boolean | false | Disable secureboot in firmware of the SUT or in hypervisor's guest VM settings
 DISABLE_SLE_UPDATES | boolean | false | Disables online updates for the installation. Is true if `QAM_MINIMAL` is true for SLE.
 DISTRI | string | | Defines distribution. Possible values: `sle`, `opensuse`, `casp`, `caasp`, `microos`.
 DOCRUN | boolean | false |
@@ -89,6 +90,7 @@ MACHINE | string | | Define machine name which defines worker specific configura
 MEDIACHECK | boolean | false | Enables `installation/mediacheck` test module.
 MEMTEST | boolean | false | Enables `installation/memtest` test module.
 MIRROR_{protocol} | string | | Specify source address
+MOK_VERBOSITY | boolean | false | Enable verbosity feature of shim. Requires preinstalled `mokutil`.
 MOZILLATEST |||
 NAME | string | | Name of the test run including distribution, build, machine name and job id.
 NET | boolean | false | Indicates net installation.


### PR DESCRIPTION
- Related ticket: [[qac][JeOS] extend jeos testing to validate UEFI boot with secure boot](https://progress.opensuse.org/issues/64445)
- [osd needles - MOK](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1393)
- [o3 needles - MOK manager](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/672)
- Verification runs:
   * sle15sp3
      * [w/ sb](http://kepler.suse.cz/tests/1617)
      * [w/o sb](http://kepler.suse.cz/tests/1606)
   * sle15sp2
      * [w/ sb@svirt-hyperv-uefi](http://kepler.suse.cz/tests/839#step/verify_efi_mok/1)
      * [w/o sb@svirt-hyperv-uefi](http://kepler.suse.cz/tests/830#step/verify_efi_mok/1)
      * [w/ sb](http://kepler.suse.cz/tests/837#step/verify_efi_mok/1)
      * [w/o sb](http://kepler.suse.cz/tests/835#step/verify_efi_mok/1)
   * sle15sp1
      * [w/ sb](http://kepler.suse.cz/tests/1618)
      * [w/o sb](http://kepler.suse.cz/tests/1607)
   * tumbleweed
     * [w/ sb](http://kepler.suse.cz/tests/906#step/verify_efi_mok/1)
     * [w/o sb](http://kepler.suse.cz/tests/904#step/verify_efi_mok/1)
   * leap15.2
     * [w/ sb](http://kepler.suse.cz/tests/902#step/verify_efi_mok/1)
     * [w/o sb](http://kepler.suse.cz/tests/903#step/verify_efi_mok/1)
   * leap15.1
     * [w/ sb](http://kepler.suse.cz/tests/1593#step/verify_efi_mok/1)
     * [w/o sb](http://kepler.suse.cz/tests/1594#step/verify_efi_mok/1)