### PR TITLE
Add support for virtualized InfiniBand testing

### DIFF
--- a/data/kernel/mlx5_sriov.sh
+++ b/data/kernel/mlx5_sriov.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -ex
+
+inc_guid(){
+        echo 16o$((0x$1 + 1))p | dc
+}
+format_guid(){
+        echo $1 | sed -e 's/\([0-9A-F][0-9A-F]\)/\1:/g' -e 's/:$//'
+}
+list_pci_vfs(){
+        lspci -D | grep Mellano | grep Virtual | awk '{ print $1}'
+}
+N_VFS=4
+
+echo $N_VFS > /sys/class/infiniband/mlx5_0/device/sriov_numvfs
+echo $N_VFS > /sys/class/infiniband/mlx5_1/device/sriov_numvfs
+
+# Basic IPoIB
+ip addr del 192.168.20.1/24 dev ib0 || true
+ip addr add 192.168.20.1/24 dev ib0
+
+#Make sure everything is bound first
+for pci_id in $(list_pci_vfs); do
+        echo $pci_id > /sys/bus/pci/drivers/mlx5_core/bind 2>/dev/null || true
+done
+
+BASE_GUID=$((ibstat mlx5_0; ibstat mlx5_1 ) | grep "Node GUID:" | awk '{ print $NF}' | sort  | tail -1 | sed -e s/0x//)
+GUID=$(inc_guid $BASE_GUID)
+for ibIf in ib0 ib1; do
+        for i in $(seq 0 $(expr $N_VFS - 1)); do
+                CLEAN_GUID=$(format_guid $GUID)
+                GUID=$(inc_guid $GUID)
+                ip link set $ibIf vf $i state auto
+                ip link set $ibIf vf $i port_guid $CLEAN_GUID
+                ip link set $ibIf vf $i node_guid $CLEAN_GUID
+        done
+        ip link set $ibIf up
+done
+for pci_id in $(list_pci_vfs); do
+        echo $pci_id > /sys/bus/pci/drivers/mlx5_core/unbind
+        echo $pci_id > /sys/bus/pci/drivers/mlx5_core/bind
+done

--- a/schedule/kernel/ibtest-kvm-master.yaml
+++ b/schedule/kernel/ibtest-kvm-master.yaml
@@ -1,0 +1,41 @@
+name:           ibtest-kvm-master
+description:    >
+    The master node for the infiniband testsuite (hpc-testing) in kvm
+vars:
+    DESKTOP: textmode
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/home:/MMoese:/branches:/devel:/tools/SLE_12_SP4/home:MMoese:branches:devel:tools.repo
+    BAREMETAL_SUPPORT_SERVER: http://baremetal-support.qa.suse.de:8080
+    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
+    GRUB_TIMEOUT: 300
+    IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
+    IBTEST_ROLE: IBTEST_MASTER
+    IPXE: 1
+    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+    PATTERNS: base,minimal
+    SCC_ADDONS: sdk
+    VM_HOST_1: 10.162.2.93
+    VM_HOST_2: 10.162.2.94
+schedule:
+    - kernel/ibtests_barriers
+    - installation/ipxe_install
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/reboot_after_installation
+    - kernel/mlx5_sriov
+    - kernel/ibtests_kvm
+    - kernel/ibtests

--- a/schedule/kernel/ibtest-kvm-slave.yaml
+++ b/schedule/kernel/ibtest-kvm-slave.yaml
@@ -1,0 +1,38 @@
+name:           ibtest-kvm-slave
+description:    >
+    The slave node for the infiniband testsuite (hpc-testing)
+vars:
+    DESKTOP: textmode
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/home:/MMoese:/branches:/devel:/tools/SLE_12_SP4/home:MMoese:branches:devel:tools.repo
+    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
+    GRUB_TIMEOUT: 300
+    IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
+    IBTEST_ROLE: IBTEST_SLAVE
+    IPXE: 1
+    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+    PARALLEL_WITH: ibtests-kvm-master
+    PATTERNS: base,minimal
+    SCC_ADDONS: sdk
+schedule:
+    - kernel/ibtests_barriers
+    - installation/ipxe_install
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/reboot_after_installation
+    - kernel/mlx5_sriov
+    - kernel/ibtests

--- a/tests/kernel/ibtests_kvm.pm
+++ b/tests/kernel/ibtests_kvm.pm
@@ -1,0 +1,132 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify installation starts and is in progress
+# Maintainer: Michael Moese <mmoese@suse.de>
+use strict;
+use warnings;
+use base 'opensusebasetest';
+
+use testapi;
+use bmwqemu;
+use utils;
+
+use HTTP::Tiny;
+
+my @vm_ips;
+
+sub create_vms {
+    my $self = shift;
+
+    my $distri = get_required_var('DISTRI');
+    my $ver    = get_required_var('VERSION');
+
+    $ver =~ tr/-//;    # remove the - in the string
+    my $os_variant = $distri . $ver;
+
+    my @vfns = split(' ', script_output('lspci -D | grep Mellanox | grep Virtual | awk \'{ print $1}\''));
+
+    my $vm_count = get_var('VM_COUNT', '1');
+    my $vm_mem   = get_var('VM_MEM',   '2048');
+    my $vm_vcpu  = get_var('VM_VCPU',  '2');
+    my $virtinst_parm = "--os-type=Linux --os-variant=$os_variant --ram=$vm_mem --vcpus=$vm_vcpu --graphics=none --network network=default --import --noautoconsole --noreboot";
+
+    my $count = 0;
+    my @vm_ips;
+
+    foreach (@vfns) {
+        my $libvirt_nodedev = $_;
+        $libvirt_nodedev =~ tr/:./_/;
+        my $img = "/var/lib/libvirt/images/vm_$_.qcow2";
+        assert_script_run("qemu-img create -f qcow2 -o backing_file=/var/lib/libvirt/images/master.qcow2 $img");
+
+        # create the machine, but don't run it yet - otherwise virt-install
+        # will wait for the installation to finish, but we don't perform an
+        # installation here.
+        assert_script_run(
+            "virt-install --name vm_$_ --description \"vm for $_\" --disk path=$img --host-device=pci_$libvirt_nodedev $virtinst_parm "
+        );
+        assert_script_run("virsh start vm_$_");
+        sleep(120);
+        assert_script_run("virsh console vm_$_");
+        type_string("root\n");
+        type_password;
+        send_key("ret");
+        my $str = script_output('ip addr show dev eth0 | grep "inet "');
+        type_string("\c]");
+        $str =~ s/^\s+//;
+        my @ip = split(/[\s,\/]/, $str);
+        push(@vm_ips, $ip[1]);
+
+        $count = $count + 1;
+        last if $count == $vm_count;
+    }
+}
+
+sub run {
+    my $self = shift;
+    # those IP's represent the host machines that we start the VM's on
+    my $host1 = get_required_var('VM_HOST_1');
+    my $host2 = get_required_var('VM_HOST_2');
+
+    my $arch        = get_required_var('ARCH');
+    my $build       = get_required_var('BUILD');
+    my $distri      = get_required_var('DISTRI');
+    my $flavor      = get_required_var('FLAVOR');
+    my $version     = get_required_var('VERSION');
+    my $http_server = get_required_var('BAREMETAL_SUPPORT_SERVER');
+
+    my $test = get_var('GET_IMAGE_FROM_TEST', 'create_hdd_textmode');
+
+    my $url      = "$http_server/v1/latest_job/$arch/$distri/$flavor/$version/$test";
+    my $response = HTTP::Tiny->new->request('GET', $url);
+    my $jobid    = $response->{content};
+
+    my $openqa_host = get_required_var('MIRROR_HTTP');
+    $openqa_host =~ m|^( .*?\. [^/]+ )|x;
+
+    $self->select_serial_terminal;
+
+    # make sure we have a ssh key
+    script_run('[ ! -f /root/.ssh/id_rsa] && ssh-keygen -b 2048 -t rsa -q -N "" -f /root/.ssh/id_rsa');
+
+    # start the VM's for each host
+    foreach ($host1, $host2) {
+        script_run("/usr/bin/clear");
+        exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$_");
+        assert_script_run("scp /root/id_rsa root@$_/.ssh/id_rsa");
+        assert_script_run("scp /root/id_rsa.pub root@$_/.ssh/id_rsa.pub");
+        assert_script_run("ssh root@$_");
+
+        # we need openqa2vm, so lets add the repo
+        zypper_ar('https://download.opensuse.org/repositories/home:/czerw:/openqa2vm/openSUSE_Leap_15.1/home:czerw:openqa2vm.repo', no_gpg_check => 1);
+
+        # make sure we install the requirements: kvm, libvirt, qemu, virt-install, openqa2vm, expect and dependencies
+        zypper_call('in libvirt virt-install openqa2vm, expect');
+
+        systemctl('enable --now libvirt');
+        script_run('virsh net-start default');
+        script_run('sysctl -w net.ipv4.ip_forward=1');
+
+        # fetch the image from openQA
+        assert_script_run("openqa2vm -f $openqa_host -p $jobid");
+        my $path  = "/var/tmp/openqa2vm/$openqa_host/$jobid/";
+        my $image = script_output("ls $path/$distri-$version-$arch-$build-*.qcow2");
+        script_run("mv $image /var/lib/libvirt/master.qcow2");
+        script_run("rm -f $image");
+
+        create_vms();
+        script_run("exit");
+    }
+    set_var('IBTEST_IP1', $vm_ips[0]);
+    set_var('IBTEST_IP2', $vm_ips[1]);
+
+}
+
+1;

--- a/tests/kernel/mlx5_sriov.pm
+++ b/tests/kernel/mlx5_sriov.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Configure SR-IOV for Mellanox ConnectX-5
+# Maintainer: Michael Moese <mmoese@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    $self->select_serial_terminal;
+
+    # ensure ib_ipoib is loaded
+    assert_script_run('modprobe ib_ipoib');
+    zypper_call('in infiniband-diags bc');
+    save_screenshot;
+
+    script_run('wget --quiet ' . data_url('kernel/mlx5_sriov.sh') . ' -O mlx5_sriov.sh');
+    save_screenshot;
+    script_run('chmod +x mlx5_sriov.sh');
+    save_screenshot;
+    script_run('./mlx5_sriov.sh');
+    save_screenshot;
+}
+
+1;


### PR DESCRIPTION
Configure a defined number of virtual functions for the Mellanox
ConnectX-5 cards we have for InfiniBand testing.

This is a work in progress, what is missing:
 - creating virtual machines with passthrough of virtual functions
 - testing, testing, testing

- Related ticket: https://progress.opensuse.org/issues/63754
- Verification run: pending+
