### PR TITLE
Fix turn_off_gnome_screensaver and run once in smoke test

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -350,9 +350,8 @@ sub start_evolution {
     assert_and_click("evolution_wizard-restore-backup-click");
 
     # Move to "Full Name" field and fill it.
-    assert_screen_change {
-        send_key "alt-e";
-    };
+    send_key "alt-e";
+    wait_still_screen(2);
     type_string "SUSE Test";
     # Move to "Email Address" field and fill it.
     assert_screen_change {

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -21,7 +21,6 @@ use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
 use POSIX 'strftime';
 use mm_network;
-use x11utils 'turn_off_gnome_screensaver';
 
 sub post_run_hook {
     my ($self) = @_;
@@ -332,8 +331,6 @@ sub start_evolution {
     # Test setup
     my ($self, $mail_box) = @_;
     mouse_hide(1);
-    # The following is done to make making needles easier.
-    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
 
     # Cleanup past configs  and start Evolution.
     x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"", valid => 0);

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -42,6 +42,7 @@ sub run {
     my $mail_passwd = 'opensuse';
 
     mouse_hide(1);
+    x11_start_program('xterm -e "gsettings set org.gnome.desktop.session idle-delay 0"', valid => 0);
     evolution_wizard($self, $mail_box);
 
     # init time counter


### PR DESCRIPTION
- Fail: remove the not working turn_off_gnome_screensaver
- Verification run:
openSUSE test not found
https://openqa.suse.de/tests/4107102 15sp2
https://openqa.suse.de/tests/4107292 15sp1 virtio
https://openqa.suse.de/tests/4107104 15sp1