### PR TITLE
Fix assets handling for AY tests without modifications

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -630,10 +630,16 @@ sub autoyast_boot_params {
         $autoyast_args .= "$proto://10.0.2.1/";
         $autoyast_args .= 'data/' if $ay_var !~ /^aytests\//;
         $autoyast_args .= $ay_var;
+    } elsif ($ay_var =~ /^ASSET_\d+$/) {
+        # In case profile is uploaded as an ASSET we need just filename
+        $ay_var = basename(get_required_var($ay_var));
+        $autoyast_args .= autoinst_url("/assets/other/$ay_var");
     } elsif ($ay_var !~ /^slp$|:\/\//) {
-        $autoyast_args .= data_url($ay_var);    # Getting profile from the worker as openQA asset
+        # Getting profile from the worker as openQA asset
+        $autoyast_args .= data_url($ay_var);
     } else {
-        $autoyast_args .= $ay_var;              # Getting profile by direct url or slp
+        # Getting profile by direct url or slp
+        $autoyast_args .= $ay_var;
     }
     push @params, split ' ', $autoyast_args;
     return @params;


### PR DESCRIPTION
We have fixed problem with assets for the jobs where we inject something to the profile, but still have issue when we simply use profile from the parent job.

See [poo#64961](https://progress.opensuse.org/issues/64961).

[Verification run](https://openqa.opensuse.org/tests/1228862#).