### PR TITLE
[virt_autotest] Check with guest disk type before virsh snapshot test

### DIFF
--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -51,6 +51,8 @@ sub run_test {
     my @vm_hostnames_inactive_array = split(/\n+/, $vm_hostnames_inactive);
 
     foreach my $guest (keys %xen::guests) {
+        my $type = check_guest_disk_type($guest);
+        next if ($type == 1);
         record_info "virsh-snapshot", "Creating External Snapshot of guest's disk";
         my $vm_target_dev     = script_output("virsh domblklist $guest --details | awk '/disk/{ print \$3 }'");
         my $pre_snapshot_cmd  = "virsh snapshot-create-as $guest";
@@ -79,7 +81,6 @@ sub run_test {
         record_info "virsh-snapshot", "SKIP - No support to start external snapshot";
         record_info "virsh-snapshot", "SKIP - No support to delete external snapshot";
     }
-
 }
 
 1;

--- a/tests/virt_autotest/virsh_internal_snapshot.pm
+++ b/tests/virt_autotest/virsh_internal_snapshot.pm
@@ -33,6 +33,8 @@ sub run_test {
     return unless check_var("REGRESSION", "qemu-hypervisor") || check_var("SYSTEM_ROLE", "kvm");
 
     foreach my $guest (keys %xen::guests) {
+        my $type = check_guest_disk_type($guest);
+        next if ($type == 1);
         record_info "virsh-snapshot", "Creating Internal Snapshot";
         assert_script_run "virsh snapshot-create-as $guest --name internal-snapshot-$guest-01";
         assert_script_run "virsh snapshot-current $guest | grep internal-snapshot-$guest-01";


### PR DESCRIPTION
RAW as guest disk type do not support snapshot
So, SKIP virsh Snapshot test if guest disk type as RAW

- Verification run: 
gi-guest_developing-on-host_sles15sp2-kvm
http://10.67.19.82/tests/434
gi-guest_developing-on-host_sles11sp4-kvm
http://10.67.19.82/tests/444