### PR TITLE
Storage: Extend blktests test module

### DIFF
--- a/data/kernel/post_process
+++ b/data/kernel/post_process
@@ -1,52 +1,69 @@
 #!/bin/bash
+
+check_for_errors() {
+
 ERROR=0
 
-for file in $(find ./results -type f);
-do
-	while IFS= read -r line
+for file in $(find ./results/$1 -type f);
 	do
-		if [[ "$line" == *"exit_status"* ]]
-		then
-			if [[ "$line" == *"1"* ]]
+		while IFS= read -r line
+		do
+			if [[ "$line" == *"exit_status"* ]]
 			then
-				ERROR=1
-			fi
-		elif [[ "$line" == "status"* ]]
-		then
-			if [[ "$line" == *"fail"* ]]
+				if [[ "$line" == *"1"* ]]
+				then
+					ERROR=1
+				fi
+			elif [[ "$line" == "status"* ]]
 			then
-				ERROR=1
+				if [[ "$line" == *"fail"* ]]
+				then
+					ERROR=1
+				fi
 			fi
-		fi
-	done < "$file"
-done
+		done < "$file"
+	done
+}
 
-echo "<testsuite errors=\"$ERROR\" name=\"_blktests\">" > ./results.xml
+generate_xunit_report() {
+	dir=${1}
+	results=${dir}_results.xml
+	check_for_errors $dir
+	echo "<testsuite errors=\"$ERROR\" name=\"$dir\">" > ./$results
 
-for file in $(find ./results -type f)
-do
-	while IFS= read -r line
+	for file in $(find ./results/$dir -type f)
 	do
-		if [[ "$line" == "status"* ]]
-		then
-			if [[ "$line" == *"pass"* ]]
+		test_group=$(basename `dirname $file`)
+		test_name=`basename $file`
+		while IFS= read -r line
+		do
+			if [[ "$line" == "status"* ]]
 			then
-				echo "<testcase name=\"$file\">" >> ./results.xml
-				echo "<system-out>" >> ./results.xml
-				echo "</system-out>" >> ./results.xml
-				echo "</testcase>" >> ./results.xml
-			elif [[ "$line" == *"fail"* ]]
-			then
-				echo "<testcase errors=\"1\" name=\"$file\">" >> ./results.xml
-				echo "<system-out>" >> ./results.xml
-				echo "</system-out>" >> ./results.xml
-				echo "</testcase>" >> ./results.xml
-			elif [[ "$line" == *"not run"* ]]
-			then
-				echo "not run: $file"
+				if [[ "$line" == *"pass"* ]]
+				then
+					echo "<testcase name=\"${test_group}::${test_name}\">" >> ./$results
+					echo "</testcase>" >> ./$results
+				elif [[ "$line" == *"fail"* ]]
+				then
+					echo "<testcase errors=\"1\" name=\"${test_group}::${test_name}\">" >> ./$results
+					#failure_message=`cat dirname ${file}.bad`
+					failure_message=`head -10 dirname ${file}.*`
+					echo "<failure message=\"$failure_message\">" >> ./$results
+					echo "</failure>" >> ./$results
+					echo "</testcase>" >> ./$results
+				elif [[ "$line" == *"not run"* ]]
+				then
+					echo "not run: $file"
+				fi
 			fi
-		fi
-	done < "$file"
-done
+		done < "$file"
+	done
 
-echo "</testsuite>" >> ./results.xml
+	echo "</testsuite>" >> ./$results
+}
+
+for dir in ./results/*
+do
+        dir=`basename $dir`
+        generate_xunit_report $dir
+done


### PR DESCRIPTION
Allow basic config preparation through test setting: BLK_DEVICE_ONLY
so that multiple, defined devices could be tested. If BLK_DEVICE_ONLY
is equal 'none', the blktests will behave as the default upstream test
suite with no TEST_DEVS defined. For each defined block device, the
results will be pushed to corresponding xunit file and then rendered
accordingly in the openQA WebUI. Failed test cases will print error
message

Related ticket:
https://progress.opensuse.org/issues/65139
https://progress.opensuse.org/issues/65145

Test runs:
x86_64: https://openqa.suse.de/tests/4126534
PowerPC: https://openqa.suse.de/tests/4126548
https://openqa.suse.de/tests/4126583