### PR TITLE
publiccloud: Adjust  threshold

### DIFF
--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -46,10 +46,25 @@ our $default_azure_analyze_thresholds = {
     overall   => 180,
 };
 
+our $default_azure_BYOS_analyze_thresholds = {
+    %{$default_analyze_thresholds},
+    userspace => 100,
+};
+
+our $default_ec2_analyze_thresholds = {
+    %{$default_analyze_thresholds},
+    userspace => 90,
+};
+
 our $default_gce_BYOS_analyze_thresholds = {
     %{$default_analyze_thresholds},
     userspace => 40,
     overall   => 60,
+};
+
+our $default_gce_analyze_thresholds = {
+    %{$default_analyze_thresholds},
+    userspace => 80,
 };
 
 our $default_blame_thresholds = {
@@ -62,11 +77,11 @@ our $default_blame_thresholds = {
 our $thresholds_by_flavor = {
     # Azure
     'Azure-BYOS' => {
-        analyze => $default_analyze_thresholds,
+        analyze => $default_azure_BYOS_analyze_thresholds,
         blame   => $default_blame_thresholds,
     },
     'Azure-CHOST-BYOS' => {
-        analyze => $default_analyze_thresholds,
+        analyze => $default_azure_BYOS_analyze_thresholds,
         blame   => $default_blame_thresholds,
     },
     'Azure-Basic' => {
@@ -89,12 +104,12 @@ our $thresholds_by_flavor = {
         blame   => $default_blame_thresholds,
     },
     'EC2-HVM' => {
-        analyze => $default_analyze_thresholds,
+        analyze => $default_ec2_analyze_thresholds,
         blame   => $default_blame_thresholds,
     },
 
     'EC2-HVM-ARM' => {
-        analyze => $default_analyze_thresholds,
+        analyze => $default_ec2_analyze_thresholds,
         blame   => $default_blame_thresholds,
     },
 
@@ -105,7 +120,7 @@ our $thresholds_by_flavor = {
 
     # GCE
     GCE => {
-        analyze => $default_analyze_thresholds,
+        analyze => $default_gce_analyze_thresholds,
         blame   => $default_blame_thresholds,
     },
     'GCE-BYOS' => {


### PR DESCRIPTION
Adjust boot timings thresholds for userspace:

```
                            min        max        avg       threshold           
Azure-BYOS/15-SP2        1.09 min  1.97 min    1.41 min   => 100s               
Azure-CHOST-BYOS/15-SP2  1.16 min  1.44 min    1.34 min   => 100s               
EC2-HVM/15-SP2           54.06 s   1.27 min    1.02 min   => 90s                
EC2-HVM-ARM/15-SP2       41 s      1.44 min    1.15 min   => 90s                
GCE/15-SP2               59.20 s   1.18 min    1.10 min   => 80s  
```

Azure-BYOS: http://s.qa.suse.de/ew2a
EC2-HVM-ARM: http://s.qa.suse.de/up0v
EC2-HVM: http://s.qa.suse.de/bGcx
GCE: http://s.qa.suse.de/lxoc

- Related ticket: https://progress.opensuse.org/issues/56462