### PR TITLE
Remove LTP asset name sanitization

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -307,7 +307,6 @@ sub get_ltp_tag {
             $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
         }
     }
-    $tag =~ s/[^a-zA-Z0-9_@.]+/-/g;
     return $tag;
 }
 


### PR DESCRIPTION
The unique tag for LTP runfile tarball must contain unmodified job variable values, otherwise the `ASSET_1` variable in child LTP jobs will expand to a wrong filename.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - https://openqa.suse.de/tests/4107302
  - https://openqa.suse.de/tests/4107303
