### PR TITLE
Increase assert_screen timeout for installation/verify_secure_boot_bios

### DIFF
--- a/tests/installation/verify_secure_boot_bios.pm
+++ b/tests/installation/verify_secure_boot_bios.pm
@@ -19,7 +19,7 @@ use scheduler 'get_test_suite_data';
 
 sub run {
     my $test_data = get_test_suite_data();
-    assert_screen 'linuxrc-start-shell-before-installation', 60;
+    assert_screen 'linuxrc-start-shell-before-installation', 90;
     assert_script_run("bootctl status | grep \"Secure Boot: $test_data->{secure_boot}\"");
     type_string "exit\n";
 }


### PR DESCRIPTION
Due to a recent failure: https://openqa.suse.de/tests/4103035#step/verify_secure_boot_bios/6 
the assert_screen timeout should be increased.