### PR TITLE
Make hotplugging module spin

### DIFF
--- a/tests/virtualization/xen/hotplugging.pm
+++ b/tests/virtualization/xen/hotplugging.pm
@@ -22,37 +22,67 @@ use version_utils;
 sub run_test {
     my ($self) = @_;
     my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
+    my ($sles_running_version, $sles_running_sp) = get_sles_release;
+
+    my %mac = ();
+    record_info "Virtual network", "Adding virtual network interface";
+    foreach my $guest (keys %xen::guests) {
+        $mac{$guest} = '00:16:3f:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
+        unless ($guest =~ m/hvm/i && is_sle('<=12-SP2') && check_var("XEN", "1")) {
+            my $persistent_config_option = '';
+            my $interface_model_option   = '';
+            if (get_var('VIRT_AUTOTEST') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) {
+                record_soft_failure 'bsc#1168124 Bridge network interface hotplugging has to be performed at the beginning.';
+                $self->{test_results}->{$guest}->{"bsc#1168124 Bridge network interface hotplugging has to be performed at the beginning"}->{status} = 'SOFTFAILED';
+                $persistent_config_option = '--persistent' if ($sles_running_version eq '11' && $sles_running_sp eq '4');
+            }
+            if (get_var('VIRT_AUTOTEST') && (check_var('SYSTEM_ROLE', 'kvm') || check_var('HOST_HYPERVISOR', 'kvm'))) {
+                $interface_model_option = '--model virtio';
+                script_run "ssh root\@$guest modprobe acpiphp", 60 if ($guest =~ /^sles-11-sp4.*$/img);
+                record_soft_failure 'bsc#1167828 Bridge network interface br0 hotplugging does not work with this ' . $guest if ($guest =~ /^sles-11-sp4.*$/img);
+                $self->{test_results}->{$guest}->{"bsc#1167828 Bridge network interface br0 hotplugging does not work with this $guest"}->{status} = 'SOFTFAILED' if ($guest =~ /^sles-11-sp4.*$/img);
+            }
+            script_retry "ssh root\@$guest ip l | grep " . $xen::guests{$guest}->{macaddress}, delay => 60, retry => 3, timeout => 60;
+            assert_script_run "virsh attach-interface --domain $guest --type bridge ${interface_model_option} --source br0 --mac " . $mac{$guest} . " --live " . ${persistent_config_option};
+            assert_script_run "virsh domiflist $guest | grep br0";
+            assert_script_run "ssh root\@$guest cat /proc/uptime | cut -d. -f1", 60;
+            script_retry "ssh root\@$guest ip l | grep " . $mac{$guest}, delay => 60, retry => 3, timeout => 60;
+            assert_script_run "virsh detach-interface $guest bridge --mac " . $mac{$guest};
+        } else {
+            record_soft_failure 'bsc#959325 - Live NIC attachment on <=12-SP2 Xen hypervisor with HVM guests does not work correctly.';
+        }
+    }
 
     # TODO:
     my $lsblk = 0;
     record_info "Disk", "Adding another raw disk";
     assert_script_run "mkdir -p /var/lib/libvirt/images/add/";
     assert_script_run "qemu-img create -f raw /var/lib/libvirt/images/add/$_.raw 10G" foreach (keys %xen::guests);
+    my $domblk_target = '';
     if (check_var('XEN', '1')) {
-        script_run "virsh detach-disk $_ xvdz", 240 foreach (keys %xen::guests);
-        assert_script_run "virsh attach-disk --domain $_ --source /var/lib/libvirt/images/add/$_.raw --target xvdz" foreach (keys %xen::guests);
-        assert_script_run "virsh domblklist $_ | grep xvdz"                                                         foreach (keys %xen::guests);
-        foreach my $guest (keys %xen::guests) {
-            $lsblk = script_run "ssh root\@$guest lsblk | grep xvdz", 60;
-            record_soft_failure("lsblk failed - please check the output manually") if $lsblk != 0;
-        }
-        assert_script_run "ssh root\@$_ lsblk" foreach (keys %xen::guests);
-        assert_script_run "virsh detach-disk $_ xvdz", 240 foreach (keys %xen::guests);
+        $domblk_target = 'xvdz';
     } else {
-        script_run "virsh detach-disk $_ vdz", 240 foreach (keys %xen::guests);
-        assert_script_run "virsh attach-disk --domain $_ --source /var/lib/libvirt/images/add/$_.raw --target vdz" foreach (keys %xen::guests);
-        assert_script_run "virsh domblklist $_ | grep vdz"                                                         foreach (keys %xen::guests);
-        foreach my $guest (keys %xen::guests) {
-            $lsblk = script_run "ssh root\@$guest lsblk | grep vdz", 60;
-            record_soft_failure("lsblk failed - please check the output manually") if $lsblk != 0;
-        }
-        assert_script_run "ssh root\@$_ lsblk" foreach (keys %xen::guests);
-        assert_script_run "virsh detach-disk $_ vdz", 240 foreach (keys %xen::guests);
+        $domblk_target = 'vdz';
     }
+    script_run "virsh detach-disk $_ ${domblk_target}", 240 foreach (keys %xen::guests);
+    assert_script_run "virsh attach-disk --domain $_ --source /var/lib/libvirt/images/add/$_.raw --target ${domblk_target}" foreach (keys %xen::guests);
+    assert_script_run "virsh domblklist $_ | grep ${domblk_target}"                                                         foreach (keys %xen::guests);
+    foreach my $guest (keys %xen::guests) {
+        $lsblk = script_run "ssh root\@$guest lsblk | grep ${domblk_target}", 60;
+        record_soft_failure("lsblk failed - please check the output manually") if $lsblk != 0;
+        $self->{test_results}->{$guest}->{"lsblk failed - please check the output manually (ssh root\@$guest lsblk | grep ${domblk_target})"}->{status} = 'SOFTFAILED' if (get_var('VIRT_AUTOTEST') && ($lsblk != 0));
+    }
+    assert_script_run "ssh root\@$_ lsblk" foreach (keys %xen::guests);
+    assert_script_run "virsh detach-disk $_ ${domblk_target}", 240 foreach (keys %xen::guests);
 
     # TODO:
     record_info "CPU", "Changing the number of CPUs available";
     foreach my $guest (keys %xen::guests) {
+        if (get_var('VIRT_AUTOTEST') && (check_var('SYSTEM_ROLE', 'kvm') || check_var('HOST_HYPERVISOR', 'kvm')) && ($sles_running_version eq '11' && $sles_running_sp eq '4')) {
+            record_soft_failure 'bsc#1169065 vCPU hotplugging does no work on SLE 11-SP4 KVM host.';
+            $self->{test_results}->{$guest}->{"bsc#1169065 vCPU hotplugging does no work on SLE 11-SP4 KVM host"}->{status} = 'SOFTFAILED';
+            next;
+        }
         unless ($guest =~ m/hvm/i) {
             # The guest should have 2 CPUs after the installation
             assert_script_run "virsh vcpucount $guest | grep current | grep live", 90;
@@ -61,13 +91,23 @@ sub run_test {
             assert_script_run "virsh setvcpus --domain $guest --count 3 --live";
             sleep 5;
             assert_script_run "virsh vcpucount $guest | grep current | grep live | grep 3";
-            script_retry "ssh root\@$guest nproc", delay => 60, retry => 3, timeout => 60;
+            if (get_var('VIRT_AUTOTEST') && (check_var('SYSTEM_ROLE', 'kvm') || check_var('HOST_HYPERVISOR', 'kvm')) && ($sles_running_version eq '15' && $sles_running_sp eq '2')) {
+                my $vcpu_nproc = script_retry "ssh root\@$guest nproc", delay => 60, retry => 3, timeout => 60, die => 0;
+                record_soft_failure 'bsc#1170026 vCPU hotplugging damages this guest ' . $guest if ($vcpu_nproc != 0);
+                $self->{test_results}->{$guest}->{"bsc#1170026 vCPU hotplugging damages this guest $guest"}->{status} = 'SOFTFAILED' if ($vcpu_nproc != 0);
+            } else {
+                script_retry "ssh root\@$guest nproc", delay => 60, retry => 3, timeout => 60;
+            }
         }
     }
 
     # TODO:
     record_info "Memory", "Changing the amount of memory available";
     foreach my $guest (keys %xen::guests) {
+        if (get_var('VIRT_AUTOTEST') && ($sles_running_version lt '12' or ($sles_running_version eq '12' and $sles_running_sp lt '3'))) {
+            record_info('Skip memory hotplugging on outdated before-12-SP3 SLES product because immature memory handling situations');
+            last;
+        }
         unless ($guest =~ m/hvm/i) {
             assert_script_run "virsh dommemstat $guest";
             assert_script_run "ssh root\@$guest free", 60;
@@ -85,21 +125,6 @@ sub run_test {
         }
     }
 
-    my %mac = ();
-    record_info "Virtual network", "Adding virtual network interface";
-    foreach my $guest (keys %xen::guests) {
-        $mac{$guest} = '00:16:3f:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
-        unless ($guest =~ m/hvm/i && is_sle('<=12-SP2') && check_var("XEN", "1")) {
-            script_retry "ssh root\@$guest ip l | grep " . $xen::guests{$guest}->{macaddress}, delay => 60, retry => 3, timeout => 60;
-            assert_script_run "virsh attach-interface --domain $guest --type bridge --source br0 --mac " . $mac{$guest} . " --live";
-            assert_script_run "virsh domiflist $guest | grep br0";
-            assert_script_run "ssh root\@$guest cat /proc/uptime | cut -d. -f1", 60;
-            script_retry "ssh root\@$guest ip l | grep " . $mac{$guest}, delay => 60, retry => 3, timeout => 60;
-            assert_script_run "virsh detach-interface $guest bridge --mac " . $mac{$guest};
-        } else {
-            record_soft_failure 'bsc#959325 - Live NIC attachment on <=12-SP2 Xen hypervisor with HVM guests does not work correctly.';
-        }
-    }
 }
 
 1;


### PR DESCRIPTION
1.Introduce get_sles_release subroutine in version_utils. So other modules can derive sles version and service pack on any machine runs SLES

2.Tweak hotplugging module in order to cater for virtualization openQA automation run:
  a) Make bridge network interface hotplugging happens at the beginning because of bsc#1168124
  b) Introduce --persistent option on SLE 11-SP4 xen host, because it only supports hotplugging with both of --live and --persistent options
  c) Add --model virtio option to bridge network interface hotplugging on KVM host. Although virtio is default model, it should be specified explicitly
  d) Hotplugging to SLE 11-SP4 guest on SLE 11-SP4 KVM host needs loading acpiphp module manually because bsc#1167828
  e) Add junit log softfailure item for disk hotplugging to ensure junit log displays the same visual effect as test module itself
  f) SLE 11-SP4 KVM host can not do vCPU hotplugging because bsc#1169065
  g) Performing vCPU hotplugging for 11-SP4 guest on 15-SP2 KVM host may fail due to  bsc#1170026
  h) Memory hotplugging will not happen if machine runs SLES older than SLE 12-SP3 because potential legacy memory ballooning or handling issue
  i) Remove duplicate code in disk hotplugging section by introducing  $domblk_target variable to differentiate xen from kvm

3.The original purpose and usage of this module are preserved  after all these changes have been made. So it still can be executed and used as before.





- Related ticket: Hotplugging openQA automation
- Needles: n/a
- Verification run:
  - [15-sp2 guest on 11-sp4 host kvm](http://10.67.133.40/tests/110)
  - [15-sp2 guest on 11-sp4 host xen](http://10.67.133.40/tests/90)
  - [15-sp2 guest on 12-sp4 host kvm](http://10.67.133.40/tests/75)
  - [15-sp2 guest on 12-sp4 host xen](http://10.67.133.40/tests/76)
  - [15-sp2 guest on 12-sp5 host kvm](http://10.67.133.40/tests/72)
  - [15-sp2 guest on 12-sp5 host xen](http://10.67.133.40/tests/74)
  - [15-sp2 guest on 15 host kvm](http://10.67.133.40/tests/82)
  - [15-sp2 guest on 15 host xen](http://10.67.133.40/tests/81)
  - [15-sp2 guest on 15-sp1 host kvm](http://10.67.133.40/tests/78)
  - [15-sp2 guest on 15-sp1 host xen](http://10.67.133.40/tests/77)
  - [11-sp4/12-sp4/12-sp5/15/15-sp1/15-sp2 guest on 15-sp2 host kvm](http://10.67.133.40/tests/64)
  - [11-sp4/12-sp4/12-sp5/15/15-sp1/15-sp2 guest on 15-sp2 host xen](http://10.67.133.40/tests/55)