### PR TITLE
Allow SCC_REGCODE_HPC test setting in ay template

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -436,7 +436,7 @@ sub adjust_network_conf {
 sub expand_variables {
     my ($profile) = @_;
     # Expand other variables
-    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_URL ARCH LOADER_TYPE);
+    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_URL ARCH LOADER_TYPE);
     # Push more variables to expand from the job setting
     my @extra_vars = push @vars, split(/,/, get_var('AY_EXPAND_VARS', ''));
 

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -12,7 +12,7 @@
 # - Get profile from autoyast template
 # - Map version names
 # - Get IP address from system variables
-# - Get values from SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_URL ARCH LOADER_TYPE
+# - Get values from SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_URL ARCH LOADER_TYPE
 # - Modify profile with obtained values and upload new autoyast profile
 # Maintainer: Rodion Iafarov <riafarov@suse.com>
 


### PR DESCRIPTION
Small changes needed as some tests for HPC using autoyast are being prepared.

- Verification run: no test run as this is just cosmetic change; exposing additional var.
