### PR TITLE
Workaround opensuse-welcome failure on Wayland/GNOME

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ our @EXPORT = qw(
   turn_off_kde_screensaver
   turn_off_gnome_screensaver
   turn_off_gnome_suspend
-  untick_welcome_on_next_startup
+  untick_welcome_on_next_startup_and_close
 );
 
 =head1 X11_UTILS
@@ -299,14 +299,15 @@ sub turn_off_gnome_suspend {
     script_run 'gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type \'nothing\'';
 }
 
-=head2 untick_welcome_on_next_startup
+=head2 untick_welcome_on_next_startup_and_close
 
- untick_welcome_on_next_startup();
+ untick_welcome_on_next_startup_and_close();
 
-untick welcome page on next startup.
+untick checkbox "welcome page on next startup" and closes the popup.
+It avoids that the popup is shown on each login.
 
 =cut
-sub untick_welcome_on_next_startup {
+sub untick_welcome_on_next_startup_and_close {
     # Untick box - (Retries may be needed: poo#56024)
     for my $retry (1 .. 5) {
         assert_and_click_until_screen_change("opensuse-welcome-show-on-boot", 5, 5);

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   turn_off_gnome_screensaver
   turn_off_gnome_suspend
   untick_welcome_on_next_startup_and_close
+  workaround_bsc1169203
 );
 
 =head1 X11_UTILS
@@ -321,6 +322,22 @@ sub untick_welcome_on_next_startup_and_close {
         last                                          if check_screen("generic-desktop", timeout => 5);
         die "Unable to close openSUSE Welcome screen" if $retry == 5;
     }
+}
+
+=head2 workaround_bsc1169203
+
+ workaround_bsc1169203
+
+Bad performance on Wayland/GNOME causes opensuse-welcome popup to fail.
+
+=cut
+sub workaround_bsc1169203 {
+    if (check_screen 'opensuse-welcome-started-not-shown-bsc1169203') {
+        assert_and_click('opensuse-welcome-open-title-bar-menu');
+        assert_and_click('opensuse-welcome-quit-app');
+    }
+    x11_start_program('opensuse-welcome');
+    untick_welcome_on_next_startup_and_close();
 }
 
 1;

--- a/schedule/yast/autoyast_reinstall.yaml
+++ b/schedule/yast/autoyast_reinstall.yaml
@@ -10,8 +10,6 @@ schedule:
   - '{{isosize}}'
   - installation/bootloader_start
   - autoyast/installation
-  # On Tumbleweed process Welcome pop-up screen
-  - '{{opensuse_welcome}}'
   - autoyast/console
   - autoyast/login
   - autoyast/verify_imported_users
@@ -38,10 +36,6 @@ conditional_schedule:
     BACKEND:
       qemu:
         - installation/grub_test
-  opensuse_welcome:
-    VERSION:
-      Tumbleweed:
-        - installation/opensuse_welcome
   inject_registration:
     DISTRI:
       sle:

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE Linux GmbH
+# Copyright (C) 2015-2020 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@ use utils;
 use power_action_utils qw(prepare_system_shutdown assert_shutdown_and_restore_system);
 use version_utils qw(is_sle is_caasp is_released);
 use main_common 'opensuse_welcome_applicable';
-use x11utils 'untick_welcome_on_next_startup';
+use x11utils 'untick_welcome_on_next_startup_and_close';
 use Utils::Backends 'is_pvm';
 use scheduler 'get_test_suite_data';
 
@@ -376,7 +376,7 @@ sub run {
             return;
         }
         elsif (match_has_tag('opensuse-welcome')) {
-            return;             # Popup itself is processed in opensuse_welcome module
+            untick_welcome_on_next_startup_and_close();
         }
     }
     # ssh console was activated at this point of time, so need to reset

--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,11 +16,11 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use x11utils 'untick_welcome_on_next_startup';
+use x11utils 'untick_welcome_on_next_startup_and_close';
 
 sub run {
     assert_screen("opensuse-welcome");
-    untick_welcome_on_next_startup;
+    untick_welcome_on_next_startup_and_close;
 }
 
 sub test_flags {

--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -148,7 +148,7 @@ sub run {
     if (opensuse_welcome_applicable) {
         assert_screen 'opensuse-welcome', 120;
         # Close welcome screen
-        untick_welcome_on_next_startup;
+        untick_welcome_on_next_startup_and_close;
     }
     assert_screen "generic-desktop", 120;
     switch_user;

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use x11utils qw(handle_login handle_logout untick_welcome_on_next_startup);
+use x11utils qw(handle_login handle_logout untick_welcome_on_next_startup_and_close);
 use main_common 'opensuse_welcome_applicable';
 
 sub ensure_multi_user_target {
@@ -84,7 +84,7 @@ sub run {
     if (opensuse_welcome_applicable) {
         assert_screen 'opensuse-welcome', 120;
         # Close welcome screen
-        untick_welcome_on_next_startup;
+        untick_welcome_on_next_startup_and_close;
     }
     assert_screen 'generic-desktop', 60;
     # verify correct user is logged in


### PR DESCRIPTION
## Related
- https://bugzilla.opensuse.org/show_bug.cgi?id=1169203
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9450

## Needles
- https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/656

## Verification run
- [aarch64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2437)
- [x86_64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2436)