### PR TITLE
HPC: Add basic autoyast installation test

### DIFF
--- a/data/autoyast_sle15/autoyast_hpc_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_hpc_x86_64.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-web-scripting</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-hpc</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-development-tools</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-python2</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/vda</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <timeout config:type="integer">1</timeout>
+      <append>splash=verbose</append>
+    </global>
+  </bootloader>
+  <scripts>
+    <chroot-scripts config:type="list">
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <interpreter>shell</interpreter>
+        <source>
+          <![CDATA[
+            #!/bin/sh
+            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
+            sed -i 's/splash=silent\ quiet//' /etc/default/grub
+            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
+            grub2-mkconfig -o /boot/grub2/grub.cfg
+            ]]>
+        </source>
+      </script>
+    </chroot-scripts>
+  </scripts>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <disklabel>msdos</disklabel>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <mountby config:type="symbol">device</mountby>
+          <filesystem config:type="symbol">swap</filesystem>
+          <mount>swap</mount>
+        </partition>
+        <partition>
+          <mountby config:type="symbol">device</mountby>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+        </partition>
+      </partitions>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <software>
+    <products config:type="list">
+      <product>SLE_HPC</product>
+    </products>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <packages config:type="list">
+      <package>sle-module-server-applications-release</package>
+      <package>sle-module-development-tools-release</package>
+      <package>sle-module-basesystem-release</package>
+      <package>sle-module-basesystem-release</package>
+      <package>sle-module-web-scripting-release</package>
+      <package>sle-module-hpc-release</package>
+      <package>sle-module-python2-release</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>minimal_base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>enhanced_base</pattern>
+      <pattern>ofed</pattern>
+      <pattern>hpc_compute_node</pattern>
+      <pattern>hpc_development_node</pattern>
+      <pattern>hpc_libraries</pattern>
+      <pattern>hpc_workload_server</pattern>
+    </patterns>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/schedule/hpc/installation_autoyast.yaml
+++ b/schedule/hpc/installation_autoyast.yaml
@@ -1,0 +1,12 @@
+---
+name: hpc_installation_autoyast
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_hpc_%ARCH%.xml
+  AUTOYAST_CONFIRM: 1
+  HDDSIZEGB: 30
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
For long there was no specific sanity check whether using autoyast hpc
profile would result in a working system. This commit provides basic
checks for such test scenario, using all hpc patterns as well as the
ofed pattern

- Related ticket: https://progress.opensuse.org/issues/55034
