### PR TITLE
Check SUSEConnect --status-text and save output info to logfile

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -72,9 +72,11 @@ sub run {
     }
 
     # Save output info to logfile
-    my $out = script_output("SUSEConnect --status-text", proceed_on_failure => 1);
-    diag "SUSEConnect --status-text: $out";
-    assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'" unless get_var('MEDIA_UPGRADE');
+    if (is_sle) {
+        my $out = script_output("SUSEConnect --status-text", proceed_on_failure => 1);
+        diag "SUSEConnect --status-text: $out";
+        assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'" unless get_var('MEDIA_UPGRADE');
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Check SUSEConnect --status-text and save output info to logfile

- Related ticket: https://progress.opensuse.org/issues/65211
- Verification run:
https://openqa.nue.suse.com/tests/4096510#
https://openqa.nue.suse.com/tests/4096511#
