### PR TITLE
Increase zypper_call timeout when installing java

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -39,7 +39,7 @@ sub run {
     # java-10-openjdk & java-1_8_0-ibm  -> Legacy
     my $cmd = 'install --auto-agree-with-licenses ';
     $cmd .= (is_sle('15+') || is_leap) ? 'java-11-openjdk* java-1_*' : 'java-*';
-    zypper_call($cmd);
+    zypper_call($cmd, timeout => 1500);
 
     if (script_run 'rpm -q wget') {
         zypper_call 'in wget';


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4117137#step/java/7
- Verification run: https://openqa.suse.de/tests/4119051
