### PR TITLE
Add haveged in pc_tools image

### DIFF
--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -99,6 +99,7 @@
             <package>sudo</package>
             <package>wget</package>
             <package>python</package>
+            <package>haveged</package>
         </packages>
     </software>
     <scripts>


### PR DESCRIPTION
Add `haveged` package in Public Cloud image to improve entropy for better generation of random number.

This is to fix sporadic message with terraform:
`crypto/rand: blocked for 60 seconds waiting to read random data from the kernel`

- Related ticket: N/A
- Needles: N/A
- Verification run: TO_BE_DONE

***Note:*** it would have been better to use `rng-tools` in a VM instead of `haveged`, but `rng-tools` seems to be unavailable in default repos of SLE15.