### PR TITLE
Execute suseconnect -s when test failed

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -38,6 +38,7 @@ sub upload_service_log {
 sub post_fail_hook {
     my ($self) = @_;
     $self->select_serial_terminal;
+    script_run("SUSEConnect --status-text");
     script_run("journalctl -o short-precise > /tmp/journal.log");
     script_run('cat /tmp/journal.log');
     upload_logs('/tmp/journal.log', failok => 1);

--- a/tests/hpc/before_test.pm
+++ b/tests/hpc/before_test.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -41,12 +41,6 @@ sub run {
         zypper_call("--gpg-auto-import-keys ref");
         zypper_call 'up';
     }
-
-    my $out = script_output('SUSEConnect -s', 30, proceed_on_failure => 1);
-    assert_script_run('SUSEConnect --cleanup', 200) if $out =~ /Error: Invalid system credentials/s;
-
-    # list registration status for ease of investigating in case the test fails
-    record_info('INFO', script_output("SUSEConnect --status-text"));
 }
 
 sub test_flags {


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4120843#step/before_test/44
- Verification run: https://openqa.suse.de/tests/4121789#step/before_test/41 added die to fail test
