### PR TITLE
Fix fail in firefox_nss: send_key not take effect

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -48,7 +48,9 @@ sub run {
     type_string "Passwords";    # Search "Passwords" section
     send_key "tab";             # Hide blinking cursor in the search box
     wait_still_screen 2;
-    send_key "alt-shift-u";     # Use a master password
+    # Use a master password
+    send_key_until_needlematch("firefox-use-a-master-password", "tab", 20, 1);
+    send_key "spc";
     assert_screen('firefox-passwd-master_setting');
 
     type_string $fips_password;
@@ -65,12 +67,16 @@ sub run {
     send_key "tab";
     wait_still_screen 2;
 
-    send_key "alt-shift-d";        # Device Manager
+    # Device Manager
+    send_key_until_needlematch("firefox-security-devices", "tab", 20, 1);
+    send_key "spc";
     assert_screen "firefox-device-manager";
 
-    send_key "alt-shift-f";        # Enable FIPS mode
+    # Enable FIPS mode
+    send_key_until_needlematch("firefox-enable-fips", "tab", 20, 1);
+    send_key "spc";
     assert_screen "firefox-confirm-fips_enabled";
-    send_key "esc";                # Quit device manager
+    send_key "esc";    # Quit device manager
 
     quit_firefox;
     assert_screen "generic-desktop";
@@ -91,7 +97,9 @@ sub run {
     type_string "certificates";    # Search "Certificates" section
     send_key "tab";
     wait_still_screen 2;
-    send_key "alt-shift-d";        # Device Manager
+    # Device Manager
+    send_key_until_needlematch("firefox-security-devices", "tab", 20, 1);
+    send_key "spc";
     assert_screen "firefox-device-manager";
     assert_screen "firefox-confirm-fips_enabled";
 


### PR DESCRIPTION
Fix fail in firefox_nss: `send_key "alt-shift-?"` did not take effect on s390 arch, we chose "tab" as a workaround.
All failed modules are tracked by known issues, introduced no new issue.

- Related ticket: ttps://progress.opensuse.org/issues/65567
- Needles: NA (all are pushed to gitlab via openQA)
- Verification run: 
  http://openqa.nue.suse.com/tests/4117933 (ker_mode s390x)((firefox_nss fail)
  http://openqa.nue.suse.com/tests/4117850 (env_mode s390x) (firefox_nss pass)
  http://openqa.nue.suse.com/tests/4117934 (ker_mode x86)(firefox_nss fail)
  http://openqa.nue.suse.com/tests/4117935 (env_mode x86) (firefox_nss pass)
