### PR TITLE
Increase zypper_call timeout for gcc install in toolchain test

### DIFF
--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -45,7 +45,7 @@ sub run {
     # Create list by removing blank symbols and new lines
     $gcc_packages =~ s/(\R|\s)+/ /g;
     # Install gcc packages
-    zypper_call("in $gcc_packages", timeout => 1200);
+    zypper_call("in $gcc_packages", timeout => 1500);
     # Get lifecycle information for installed toolchain packages
     my $output = script_output "zypper lifecycle $gcc_packages", 300;
     diag($output);


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4124003
