### PR TITLE
Don't run wpa_supplicant test on JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1694,7 +1694,7 @@ sub load_extra_tests_console {
     loadtest "console/gd";
     loadtest 'console/valgrind'       unless is_sle('<=12-SP3');
     loadtest 'console/sssd_samba'     unless is_sle("<15");
-    loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1'));
+    loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1') || is_jeos);
 }
 
 sub load_extra_tests_sdk {


### PR DESCRIPTION
kernel-default-base does not have the required mac80211_hwsim module.
Fixes #9983

- Verification run: http://10.160.67.86/tests/660