### PR TITLE
Fix wpa_supplicant for jeos

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1694,7 +1694,7 @@ sub load_extra_tests_console {
     loadtest "console/gd";
     loadtest 'console/valgrind'       unless is_sle('<=12-SP3');
     loadtest 'console/sssd_samba'     unless is_sle("<15");
-    loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1'));
+    loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1' || is_jeos));
 }
 
 sub load_extra_tests_sdk {


### PR DESCRIPTION
Fixes regression: test fails on jeos.

Skippes the wpa_supplicant test on jeos, as the required `mac80211_hwsim`
module is not available there.

- Related ticket: https://progress.opensuse.org/issues/55715
- Needles: N/A
- Verification run: [SLE 15-SP1](https://openqa.suse.de/tests/4128321) | [SLE 15](https://openqa.suse.de/tests/4128322) | [Tumbleweed](http://phoenix-openqa.qam.suse.de/tests/517) | [Leap 15.2](http://phoenix-openqa.qam.suse.de/tests/518)
