### PR TITLE
Cleanup timeline snapshots after it's disabled

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -68,6 +68,7 @@ sub y2snapper_adding_new_snapper_conf {
     assert_script_run("btrfs subvolume create /test");
     assert_script_run("snapper -c test create-config /test");
     assert_script_run('sed -i \'/^TIMELINE_CREATE/ s/yes/no/\' /etc/snapper/configs/test');
+    assert_script_run('snapper cleanup timeline');
 }
 
 =head2 y2snapper_create_snapshot


### PR DESCRIPTION
Timeline snapshot can be created before disabling it, following aseert_screen is expecting empty snapshot list, created snapshot is deleted in y2snapper_show_changes_and_delete

- Related ticket: https://progress.opensuse.org/issues/60767
- Verification run:
http://10.100.12.155/tests/15088#step/yast2_snapper/34
http://10.100.12.155/tests/15088#step/yast2_snapper/34