### PR TITLE
Fix AutoYaST firstboot: username + remove soft-failure

### DIFF
--- a/schedule/yast/autoyast_y2_firstboot.yaml
+++ b/schedule/yast/autoyast_y2_firstboot.yaml
@@ -2,7 +2,7 @@ name:           autoyast_y2_firstboot
 description:    >
     Smoke test for YaST2 firstboot module
 vars:
-    YAST2_FIRSTBOOT_USERNAME: y2_firstboot_tester
+    YAST2_FIRSTBOOT_USERNAME: firstbootuser
 schedule:
     - autoyast/prepare_profile
     - installation/isosize

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -52,12 +52,7 @@ sub welcome {
 }
 
 sub clock_and_timezone {
-    assert_screen [qw(inst-timezone blank-screen-with-accept-button)];
-    # bsc#1152532 - On Leap15.2, blank screen is appeared sporadically after Welcome
-    if (match_has_tag 'blank-screen-with-accept-button') {
-        record_soft_failure 'bsc#1152532 - Blank Screen is appeared before Clock and Timezone';
-        assert_screen('inst-timezone', 60);
-    }
+    assert_screen 'inst-timezone';
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
 }
 


### PR DESCRIPTION
Fixes in AutoYaST firstboot:
(1) Avoid typing shift for AutoYaST firstboot username.
(2) Remove workaround for blank screen before timezone.

- Related ticket: https://progress.opensuse.org/issues/64598
- Verification run: https://openqa.opensuse.org/tests/overview?build=626.2_jrivera_poo64598&distri=opensuse&version=15.2
