### PR TITLE
enhance performance cases past fail hook

### DIFF
--- a/tests/kernel_performance/run_perf_case.pm
+++ b/tests/kernel_performance/run_perf_case.pm
@@ -80,6 +80,11 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
+    script_run("dmesg > /tmp/dmesg.log");
+    upload_logs "/tmp/dmesg.log";
+    upload_logs "/var/log/messages";
+    my $screenlog = script_output("ls -rt /var/log/qaset/calls | tail -n 1");
+    upload_logs "/var/log/qaset/calls/$screenlog";
 }
 
 sub test_flags {


### PR DESCRIPTION
enhance performance cases past fail hook

- Related ticket: https://trello.com/c/VqPwUF8a/607-p1-ph039-can-not-got-ip-during-ci-acceptance-testing
- Needles: N/A
- Verification run: http://10.67.129.4/tests/12242#downloads
