### PR TITLE
HPC: Use user_settings_root also for hpc-server

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1000,7 +1000,7 @@ sub load_inst_tests {
             loadtest "installation/user_settings" unless check_var('SYSTEM_ROLE', 'hpc-node');
         }
         if (is_sle || get_var("DOCRUN") || get_var("IMPORT_USER_DATA") || get_var("ROOTONLY")) {    # root user
-            loadtest "installation/user_settings_root" unless check_var('SYSTEM_ROLE', 'hpc-server');
+            loadtest "installation/user_settings_root";
         }
         if (get_var('PATTERNS') || get_var('PACKAGES')) {
             loadtest "installation/resolve_dependency_issues";


### PR DESCRIPTION
The product behaviour is changed now and both hpc-server and
compute-node system roles behave the same way, thus the condition
differentiating test for hpc-server system role isn't needed

- Related ticket: https://progress.opensuse.org/issues/65594
- Verification run: https://openqa.suse.de/tests/4129717 (running)
