### PR TITLE
HPC: Use yaml to schedule hpc_installation_server

### DIFF
--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -1,0 +1,53 @@
+---
+name: hpc_installation_server
+description:    >
+     Maintainer: schlad
+     Installation scenario with HPC system role hpc-server.
+vars:
+  DESKTOP: textmode
+  INSTALLONLY: 1
+  PATTERNS: base,minimal
+  SLE_PRODUCT: hpc
+  HDDSIZEGB: 30
+conditional_schedule:
+  bootloader:
+    ARCH:
+      aarch64:
+        - installation/bootloader_uefi
+      x86_64:
+        - installation/bootloader
+  user_settings_root:
+    VERSION:
+      15-SP2:
+        - installation/user_settings_root
+schedule:
+  - installation/isosize
+  - '{{bootloader}}'
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - '{{user_settings_root}}'
+  - installation/resolve_dependency_issues
+  - installation/select_patterns
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
SLE15-SP2 includes a change in the behaviour as the system role is
aligned to standard root password behavior, so that there is no more
root_password_as_first_user set to true. Test scheduler must then
ensure calling of the module to type the root password

- Related ticket: https://progress.opensuse.org/issues/65594
- Verification run: https://openqa.suse.de/tests/4130199

-- updated for ARM and x86_64 --
running checks:
https://openqa.suse.de/tests/4131617
https://openqa.suse.de/tests/4131615