### PR TITLE
Fix 'zypper lifecycle' timeout

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -39,6 +39,10 @@ our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 
 sub run {
     diag('fate#320597: Introduce \'zypper lifecycle\' to provide information about life cycle of individual products and packages');
+    # We add 'zypper ref' here to download and preparse the metadata of packages,
+    # which will make the follow 'zypper lifecycle' runs faster.
+    select_console 'root-console';
+    script_run('zypper ref');
     select_console 'user-console';
     my $overview = script_output('zypper lifecycle', 600);
     die "Missing header line:\nOutput: '$overview'" unless $overview =~ /Product end of support/;


### PR DESCRIPTION
In migration regession tests the  'zypper_lifecycle'  module will timeout.  We need call 'zypper ref' to
make the 'zypper lifecycle' faster.

- Related ticket: https://progress.opensuse.org/issues/66961

- Needles: N/A
- Verification run: 
  http://openqa.suse.de/t4322537 
  http://openqa.suse.de/t4322538
  http://openqa.suse.de/t4322539
  http://openqa.suse.de/t4322540
  http://openqa.suse.de/t4322541
  https://openqa.nue.suse.com/tests/4330025
  https://openqa.nue.suse.com/tests/4330026