### PR TITLE
Add new qdevice ha test

### DIFF
--- a/schedule/ha/bv/ha_qdevice_node1.yaml
+++ b/schedule/ha/bv/ha_qdevice_node1.yaml
@@ -1,0 +1,16 @@
+name:           ha_qdevice_node1
+description:    >
+  Create a 2 nodes cluster with qdevice/qnetd
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/qnetd

--- a/schedule/ha/bv/ha_qdevice_node2.yaml
+++ b/schedule/ha/bv/ha_qdevice_node2.yaml
@@ -1,0 +1,16 @@
+name:           ha_qdevice_node2
+description:    >
+  Create a 2 nodes cluster with qdevice/qnetd
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/qnetd

--- a/schedule/ha/bv/ha_qnetd_server.yaml
+++ b/schedule/ha/bv/ha_qnetd_server.yaml
@@ -1,0 +1,11 @@
+name:           ha_qnetd_server
+description:    >
+    Create a qnetd server for testing qnetdevice (corosync quorum feature)
+schedule:
+    - boot/boot_to_desktop
+    - console/system_prepare
+    - console/consoletest_setup
+    - console/check_os_release
+    - console/hostname
+    - ha/firewall_disable
+    - ha/qnetd

--- a/schedule/ha/bv/ha_supportserver.yaml
+++ b/schedule/ha/bv/ha_supportserver.yaml
@@ -1,0 +1,8 @@
+name:           ha_supportserver
+description:    >
+    Create a supportserver for multi machines tests
+schedule:
+    - support_server/login
+    - support_server/setup
+    - ha/barrier_init
+    - support_server/wait_children

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -115,6 +115,11 @@ sub run {
         barrier_create("CTDB_INIT_$cluster_name", $num_nodes + 1);
         barrier_create("CTDB_DONE_$cluster_name", $num_nodes + 1);
 
+        # QNETD barriers
+        barrier_create("QNETD_SERVER_READY_$cluster_name", $num_nodes + 1);
+        barrier_create("QNETD_SERVER_DONE_$cluster_name",  $num_nodes + 1);
+        barrier_create("SPLIT_BRAIN_TEST_$cluster_name",   $num_nodes + 1);
+
         # Create barriers for multiple tests
         foreach my $fs_tag ('LUN', 'CLUSTER_MD', 'DRBD_PASSIVE', 'DRBD_ACTIVE') {
             barrier_create("VG_INIT_${fs_tag}_$cluster_name",             $num_nodes);

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -16,6 +16,29 @@ use warnings;
 use testapi;
 use lockapi;
 use hacluster;
+use utils qw(zypper_call exec_and_insert_password);
+
+sub is_qdevice {
+    if (get_var('QDEVICE')) {
+        wait_serial(qr/Password:\s*$/i);
+        type_password;
+        send_key 'ret';
+    }
+}
+
+sub cluster_init {
+    my ($init_method, $fencing_opt, $unicast_opt, $qdevice_opt) = @_;
+
+    if ($init_method eq 'ha-cluster-init') {
+        type_string "ha-cluster-init -y $fencing_opt $unicast_opt $qdevice_opt; echo ha-cluster-init-finished-\$? > /dev/$serialdev\n";
+        is_qdevice;
+    }
+    elsif ($init_method eq 'crm-debug-mode') {
+        type_string "crm -dR cluster init -y $fencing_opt $unicast_opt $qdevice_opt ; echo ha-cluster-init-finished-\$? > /dev/$serialdev\n";
+        is_qdevice;
+        die "Cluster initialization failed" if (!wait_serial("ha-cluster-init-finished-0", $join_timeout));
+    }
+}
 
 sub run {
     # Validate cluster creation with ha-cluster-init tool
@@ -26,17 +49,25 @@ sub run {
     my $unicast_opt   = get_var("HA_UNICAST") ? '-u' : '';
     my $quorum_policy = 'stop';
     my $fencing_opt   = "-s $sbd_device";
+    my $qdevice_opt;
+
+    # Qdevice configuration
+    if (get_var('QDEVICE')) {
+        zypper_call 'in corosync-qdevice';
+        my $qnet_node_host = choose_node(3);
+        $qdevice_opt = "--qnetd-hostname=" . get_ip($qnet_node_host);
+        barrier_wait("QNETD_SERVER_READY_$cluster_name");
+    }
 
     # Ensure that ntp service is activated/started
     activate_ntp;
 
-    # If we failed to initialize the cluster, trying again but in debug mode
-    # Note: the default timeout need to be increase because it can takes time to join the cluster
     # Initialize the cluster with diskless or shared storage SBD (default)
     $fencing_opt = '-S' if (get_var('USE_DISKLESS_SBD'));
-    if (script_run "ha-cluster-init -y $fencing_opt $unicast_opt", $join_timeout) {
-        assert_script_run "crm -dR cluster init -y $fencing_opt $unicast_opt", $join_timeout;
-    }
+    cluster_init('ha-cluster-init', $fencing_opt, $unicast_opt, $qdevice_opt);
+
+    # If we failed to initialize the cluster with 'ha-cluster-init', trying again with crm in debug mode
+    cluster_init('crm-debug-mode', $fencing_opt, $unicast_opt, $qdevice_opt) if (!wait_serial("ha-cluster-init-finished-0", $join_timeout));
 
     # Signal that the cluster stack is initialized
     barrier_wait("CLUSTER_INITIALIZED_$cluster_name");
@@ -46,7 +77,7 @@ sub run {
     barrier_wait("NODE_JOINED_$cluster_name");
 
     # We need to configure the quorum policy according to the number of nodes
-    $quorum_policy = 'ignore' if (get_node_number == 2);
+    $quorum_policy = 'ignore' if (get_node_number == 2) && !get_var('QDEVICE');
     assert_script_run "crm configure property no-quorum-policy=$quorum_policy";
 
     # Execute csync2 to synchronise the configuration files

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -16,10 +16,17 @@ use warnings;
 use testapi;
 use lockapi;
 use hacluster;
+use utils 'zypper_call';
 
 sub run {
     my $cluster_name = get_cluster_name;
     my $node_to_join = get_node_to_join;
+
+    # Qdevice configuration
+    if (get_var('QDEVICE')) {
+        zypper_call 'in corosync-qdevice';
+        barrier_wait("QNETD_SERVER_READY_$cluster_name");
+    }
 
     # Ensure that ntp service is activated/started
     activate_ntp;

--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -1,0 +1,113 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test qdevice/qnetd
+# qdevice/qnetd is a supported feature since 15-SP1
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use hacluster;
+use version_utils 'is_sle';
+use utils qw(systemctl file_content_replace zypper_call);
+
+sub qdevice_status {
+    my ($expected_status) = @_;
+    my $num_nodes         = get_required_var('NUM_NODES');
+    my $quorum_status_cmd = 'crm corosync status quorum';
+    my $qnetd_status_cmd  = 'crm corosync status qnetd';
+    my $output;
+
+    $num_nodes-- if ($expected_status eq 'stopped');
+
+    # Check qdevice status
+    script_run "$qnetd_status_cmd";
+
+    $output = script_output("$quorum_status_cmd");
+
+    # Check split brain situation
+    if ($expected_status eq 'split-brain') {
+        die "Unexpected output for split-brain situation" unless ($output =~ /Activity blocked/);
+        return;
+    }
+
+    my @regexps = map { $_ . ($num_nodes + 1) } ('Expected votes:\s+', 'Highest expected:\s+', 'Total votes:\s+');
+    push @regexps, 'Quorum:\s+' . $num_nodes;
+
+    push @regexps, 'Flags:\s+Quorate\s+Qdevice' if ($expected_status eq 'started');
+    push @regexps, 'Flags:\s+2Node\s+Quorate'   if ($expected_status eq 'stopped');
+
+    die "Qdevice membership information does not match expected info" if ($expected_status eq 'started' and $output !~ /\s+0\s+1\s+Qdevice/);
+    die "Qdevice membership information shown when stopped"           if ($expected_status eq 'stopped' and $output =~ /\s+0\s+1\s+Qdevice/);
+
+    foreach my $exp (@regexps) { die "Unexpected output. Output does not match [$exp]" unless ($output =~ /$exp/) }
+}
+
+sub run {
+    my $cluster_name  = get_cluster_name;
+    my $qdevice_check = "/etc/corosync/qdevice/check_master.sh";
+
+    if (check_var('QDEVICE_TEST_ROLE', 'qnetd_server')) {
+        zypper_call 'in corosync-qnetd';
+        barrier_wait("QNETD_SERVER_READY_$cluster_name");
+    }
+    else {
+        assert_script_run "curl -f -v " . autoinst_url . "/data/ha/qdevice_check_master.sh -o $qdevice_check";
+    }
+
+    if (is_node(1)) {
+        my $qnet_node_host = choose_node(3);
+        my $qnet_node_ip   = get_ip($qnet_node_host);
+        my $node2_ip       = get_ip(choose_node(2));
+
+        # Add a promotable resource to check if the current node is hosting
+        # master instance of the resource. If so, this cluster partition
+        # is preferred to be given the vote from qnetd.
+        assert_script_run "EDITOR=\"sed -ie '\$ a primitive stateful-1 ocf:pacemaker:Stateful'\" crm configure edit";
+        assert_script_run "EDITOR=\"sed -ie '\$ a clone promotable-1 stateful-1 meta promotable=true'\" crm configure edit";
+        save_state;
+
+        # Qdevice should be started
+        qdevice_status('started');
+
+        # Remove qdevice
+        assert_script_run "crm cluster remove --qdevice -y";
+        # Qdevice should be stopped
+        qdevice_status('stopped');
+
+        # Add qdevice to a running cluster with heuristic check
+        assert_script_run "crm cluster init qdevice --qnetd-hostname=$qnet_node_ip -y --qdevice-heuristics=/etc/corosync/qdevice/check_master.sh --qdevice-heuristics-mode=on";
+        # Qdevice should be started again
+        qdevice_status('started');
+
+        # Add firewall rules to provoke a split brain situation and confirm that
+        # the qdevice node gives its vote to the node1 (where the master resource is running)
+        record_info('Split-brain info', 'Split brain test');
+        assert_script_run "iptables -A INPUT -s $node2_ip -j DROP; iptables -A OUTPUT -d $node2_ip -j DROP";
+        sleep $default_timeout;
+    }
+
+    barrier_wait("SPLIT_BRAIN_TEST_$cluster_name");
+
+    # Activity must be blocked in node2 due to split brain situation
+    if (is_node(2)) {
+        record_info('Split-brain check', 'Check if activity is blocked');
+        qdevice_status('split-brain');
+    }
+
+    # Show cluster status before ending the test
+    save_state if (!check_var('QDEVICE_TEST_ROLE', 'qnetd_server'));
+
+    barrier_wait("QNETD_SERVER_DONE_$cluster_name");
+}
+
+1;


### PR DESCRIPTION
This PR adds a new test about qdevice/qnetd.
It configures qdevice and net and forces a split-brain-test to confirm that quorum is working.
I will add a fencing test later because now, we are facing to this [bug](https://bugzilla.suse.com/show_bug.cgi?id=1170037).

- Related ticket: N/A
- Needles: N/A
- Verification run:
[ha_qdevice_node1](http://1a102.qa.suse.de/tests/4213)
[ha_qdevice_node2](http://1a102.qa.suse.de/tests/4214)
[ha_qnetd_server](http://1a102.qa.suse.de/tests/4215)
- Regression tests:
Two nodes cluster: 
[ha_alpha_node01](http://1a102.qa.suse.de/tests/4223)
[ha_alpha_node02](http://1a102.qa.suse.de/tests/4224)
Diskless SBD and 3 nodes cluster:
[ha_delta_node01](http://1a102.qa.suse.de/tests/4134)
[ha_delta_node02](http://1a102.qa.suse.de/tests/4135)
[ha_delta_node03](http://1a102.qa.suse.de/tests/4136)
3 nodes cluster with SBD:
[ha_gamma_node01](http://1a102.qa.suse.de/tests/4226)
[ha_gamma_node02](http://1a102.qa.suse.de/tests/4227)
[ha_gamma_node03](http://1a102.qa.suse.de/tests/4228)