### PR TITLE
Enable Online tests to use Full medium as mirror

### DIFF
--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -1,0 +1,33 @@
+---
+name: gnome_install_from_source
+description: >
+   Install default system using the gnome desktop
+   using a remote repository over http or https or samba.
+   Scenario is thought to use Online medium to boot
+   and Full medium for remote repositories.
+vars:
+  DESKTOP: gnome
+  NETBOOT: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_mirror_repos

--- a/tests/console/validate_mirror_repos.pm
+++ b/tests/console/validate_mirror_repos.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate that mirror used for installation is added as a repo in the installed system.
+#
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use Test::Assert ':all';
+
+sub run {
+    select_console 'root-console';
+
+    my $method     = uc get_required_var('INSTALL_SOURCE');
+    my $mirror_src = get_required_var("MIRROR_$method");
+    $mirror_src .= '?ssl_verify=no' if ($method eq 'HTTPS');
+
+    my $output   = script_output('zypper lr --uri');
+    my $sle_prod = uc get_var('SLE_PRODUCT') . get_var('VERSION');
+    $output =~ /
+        \d\s+\|                 # #
+        \s+$sle_prod.*\s+\|     # Alias
+        \s+$sle_prod.*\s+\|     # Name
+        \s+Yes\s+\|             # Enabled
+        \s+\(r\s+\)\s+Yes\s+\|  # GPG Check
+        \s+Yes\s+\|             # Refresh
+        \s+(?<uri>.*)           # URI
+    /x;
+    assert_equals($mirror_src, $+{uri},
+        "Repository on the installed system does not match mirror for installation");
+}
+
+1;


### PR DESCRIPTION
Enable certain Online scenarios to use Full medium as mirror.

Moving the scenario to Full Medium and just updating the ISO does not requires code changes. On the other hand keeping the scenarios in Online and updating the mirrors cannot be done without adding other condition [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/installation/addon_products_sle.pm#L182) so I chose better first option for this case.

- Related ticket: https://progress.opensuse.org/issues/65331
- Job group MR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/169
- Verification run: [gnome_*](https://openqa.suse.de/tests/overview?arch=&machine=&modules=validate_mirror_repos&distri=sle&version=15-SP2&build=178.1&groupid=96#)