### PR TITLE
Fix x3270_ssl launch error and needles mismatch

### DIFF
--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -1,16 +1,17 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
+#
 # Testopia Case#1595207 - FIPS: x3270
-
 # Summary: x3270 for SSL support testing, with openssl s_server running on local system
-# Maintainer: Wnereiz <wnereiz@eienteiland.org>
+#
+# Maintainer: Ben Chou <bchou@suse.com>
+# Tags: poo#65570, poo#65615
 
 use base "x11test";
 use strict;
@@ -32,10 +33,10 @@ sub run {
     type_string
 "openssl req -new -x509 -newkey rsa:2048 -keyout $key_file -days 3560 -out $cert_file -nodes -subj \"/C=CN/ST=BJ/L=BJ/O=SUSE/OU=QA/CN=suse/emailAddress=test\@suse.com\" 2>&1 | tee /dev/$serialdev\n";
 
-    wait_serial "writing new private", 120 || die "openssl req output doesn't match";
+    wait_serial "writing new private", 60 || die "openssl req output doesn't match";
 
     #Workaround for avoiding missing charactors in following commands
-    for (1 ... 20) {
+    for (1 ... 3) {
         send_key "ret";
     }
 
@@ -51,11 +52,12 @@ sub run {
 
     #Launch x3270
     type_string "x3270 -trace -tracefile $tracelog_file L:localhost:8443\n";
-    assert_screen 'x3270_fips_launched';
+    assert_screen 'x3270_fips_launched_with_TLS_SSL';
 
-    for (1 ... 3) {
-        send_key "alt-f4";
-    }
+    # Exit and back to generic desktop
+    send_key "ctrl-c";
+    send_key "alt-tab";
+    send_key "ctrl-c";
     assert_screen 'generic-desktop';
 
     #Terminate openssl s_server
@@ -69,10 +71,12 @@ sub run {
     #Clean
     script_run "rm -f $tracelog_file $cert_file $key_file";
 
-    #Exit and return to x11
-    send_key "ctrl-d";
-    send_key "ctrl-d";
+    # Return to x11
     select_console 'x11';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
1. Refine x3270_ssl test case to avoid the launch error
2. Add a new needle for x3270_ssl with TLS/SSL

- Related ticket: 
  https://progress.opensuse.org/issues/65615
  https://progress.opensuse.org/issues/65570
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1366 [merged]
- Verification run: 
  - http://10.163.2.52/tests/590 [localhost : x3270_ssl]
  - https://openqa.suse.de/tests/4142741 [OSD x86_64 : x3270_ssl]
  - https://openqa.suse.de/tests/4142745 [OSD s390x : x3270_ssl]
