### PR TITLE
[WIP]Fix partitioning_specific_disk.pm for format issue

### DIFF
--- a/tests/installation/partitioning_specific_disk.pm
+++ b/tests/installation/partitioning_specific_disk.pm
@@ -38,6 +38,8 @@ sub format_partition {
     wait_still_screen 3;
     send_key 'ret';
     send_key(is_storage_ng() ? 'alt-f' : 'alt-s');
+    send_key 'home';
+    wait_still_screen 3;
     send_key_until_needlematch("expert-partitioner-$filesystem",
         "down", 20, 1);
     send_key 'ret';


### PR DESCRIPTION
The original filesystem is selected by default in filesystem list.
Thus format perhaps failed if format a partition as new type.

For example, format a xfs partition as btrfs. But btrfs at above of xfs.
So fixed by send Home key at first.

- Verification run: http://mitigations.qa2.suse.asia/tests/9629#step/partitioning_specific_disk/6