### PR TITLE
WIP add soft_fail_data with bugref '1169881' and let die if grub not …

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -683,7 +683,7 @@ sub reconnect_s390 {
         select_console('svirt');
         save_svirt_pty;
 
-        wait_serial('GNU GRUB', 180) || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
+        wait_serial('GNU GRUB', 180) || die 'Could not find GRUB screen and could not boot';
         grub_select;
 
         type_line_svirt '', expect => $login_ready, timeout => $ready_time + 100, fail_message => 'Could not find login prompt';

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use utils;
 use testapi;
+use Utils::Architectures 'is_s390x';
 use version_utils qw(is_sle is_opensuse is_vmware);
 use Carp 'croak';
 
@@ -299,6 +300,10 @@ sub power_action {
     # Sometimes QEMU CD-ROM pop-up is displayed on shutdown, see bsc#1137230
     if (is_opensuse && check_screen 'qemu-cd-rom-authentication-required') {
         $soft_fail_data = {bugref => 'bsc#1137230', soft_timeout => 60, timeout => $shutdown_timeout *= 5};
+    }
+    # sometimes s390x with backend svirt needs more time to shutdown or encouter kernel panic, see bsc#1169881
+    if (is_s390x && check_var('BACKEND', 'svirt')) {
+        $soft_fail_data = {bugref => '1169881', soft_timeout => 90, timeout => $shutdown_timeout *= 3};
     }
     # no need to redefine the system when we boot from an existing qcow image
     # Do not redefine if autoyast or s390 zKVM reboot, as did initial reboot already


### PR DESCRIPTION
…reached

see https://progress.opensuse.org/issues/65474

veification partly for "not find GRUB screen":
https://openqa.suse.de/tests/4141066#step/kdump_and_crash/86

