### PR TITLE
HPC: Rasdaemon test extensions

### DIFF
--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -6,12 +6,20 @@
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
-# Summary: rasdaemon may have to be tested on a physical system, as EDAC
-# support may not be available in a VM. To check this, install rasdaemon:
-# zypper in rasdaemon and run ras-mc-ctl --status.
-# If the message returned indicates that there is no EDAC driver loaded,
-# the system does not support it thus not all tests below can be performed
+#
+# Summary: sanity tests of rasdaemon
+#
+# rasdaemon is meant to collect various hardware errors. As such the
+# test for rasdaemon in virtualized env. has very limitted purpose and
+# is meant only as a sanity check for the isolated package.
+#
+# Purpose of this test: this simple module provide only the sanity check
+# to see if:
+# - rasdaemon can be installed and started
+# - ras-mc-ctl can be used to retrive basic information from the
+#   associated database
+# - injected error is correctly recorded
+#
 # Maintainer: Sebastian Chlad <schlad@suse.de>
 # Tags: https://fate.suse.com/318824
 
@@ -21,27 +29,66 @@ use warnings;
 use testapi;
 use utils;
 
+sub inject_error {
+    # load kernel module
+    assert_script_run('modprobe mce-inject');
+    # Inject some software errors
+    script_run('echo 0x9c00410000080f2b > /sys/kernel/debug/mce-inject/status');
+    script_run('echo d5a099a9 > /sys/kernel/debug/mce-inject/addr');
+    script_run('echo 4 > /sys/kernel/debug/mce-inject/bank');
+    script_run('echo 0xdead57ac1ba0babe > /sys/kernel/debug/mce-inject/misc');
+    script_run("echo \"sw\" > /sys/kernel/debug/mce-inject/flags");
+}
+
 sub run {
     my $self = shift;
 
     zypper_call('in rasdaemon');
 
     assert_script_run('! ras-mc-ctl --status');
+
     systemctl('start rasdaemon');
+    systemctl('is-active rasdaemon');
 
     # Validating output of 'ras-mc-ctl --mainboard'
     my $mainboard_output = script_output('ras-mc-ctl --mainboard');
-    die 'Not expected mainboard - ' . $mainboard_output unless $mainboard_output =~ /mainboard/;
+    record_info('INFO', $mainboard_output);
+    die('Not expected mainboard - ' . $mainboard_output)
+      unless ($mainboard_output =~ /mainboard/);
 
-    # Validating output of 'ras-mc-ctl --summary'
+    # Validating output of 'ras-mc-ctl --summary' with assumption that no errors exists
     my $summary_output = script_output('ras-mc-ctl --summary');
-    die 'Not expected summary - ' . $summary_output
-      unless $summary_output =~ /No Memory errors/ && $summary_output =~ /No PCIe AER errors/ && $summary_output =~ /No MCE errors/;
+    record_info('INFO', $summary_output);
 
-    # Validating output of 'ras-mc-ctl --errors'
-    my $error_output = script_output('ras-mc-ctl --errors');
-    die 'Not expected error - ' . $error_output
-      unless $error_output =~ /No Memory errors/ && $error_output =~ /No PCIe AER errors/ && $error_output =~ /No MCE errors/;
+    die('Not expected summary - ' . $summary_output)
+      unless ($summary_output =~ /No Memory errors/
+        && $summary_output =~ /No PCIe AER errors/ && $summary_output =~ /No MCE errors/);
+
+    # Validating output of 'ras-mc-ctl --errors' with assumption that no errors exists
+    my $empty_error_output = script_output('ras-mc-ctl --errors');
+    record_info('INFO', $empty_error_output);
+
+    die('Not expected error - ' . $empty_error_output)
+      unless ($empty_error_output =~ /Memory errors/
+        && $empty_error_output =~ /PCIe AER errors/ && $empty_error_output =~ /No MCE errors/);
+
+    # x86_64 check: Validating output of 'ras-mc-ctl --errors' after MCE error is injected
+    if (check_var('ARCH', 'x86_64') && check_var('VERSION', '15-SP2')) {
+        inject_error();
+        my $error_output = script_output('ras-mc-ctl --errors');
+        record_info('INFO', $error_output);
+
+        die('No MCE event recored - ' . $error_output)
+          unless ($error_output =~ /MCE events/ && $error_output =~ /status=0x9c00410000080f2b/);
+    }
+
+    ##TODO: try to add error injection for ARM
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+    $self->export_logs_basic;
 }
 
 1;


### PR DESCRIPTION
Over the lifecycle of this sanity tests the content was changed with
where some test ideas were removed - namely error injection. This patch
is restoring that original error injection, while it preserves all added
basic sanity checks. Moreover the test description is changed to clearly
indicate what are the limitations for the test, why it does exists as
the openQA test module and what it does.
As such the test for rasdaemon in virtualized env. has very limitted
purpose and is meant only as a sanity check for the isolated package to
see if package is installable and if the daemon itself can run. As the
daemon is run with the -r option it writes data to the databese, so the
test is checking if basic information can be retrived from the db, also
if the injected error can be retrived

- Related ticket: https://progress.opensuse.org/issues/65906
- Verification run:
with modprob and error injection:
SLE15-SP2: https://openqa.suse.de/tests/4152406#step/rasdaemon/66
without calling that error_injection sub():
SLE15: https://openqa.suse.de/tests/4152418