### PR TITLE
Improve sbd test by checking node count in output

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -53,7 +53,11 @@ sub run {
     exec_csync;
 
     # State of SBD if shared storage SBD is used
-    assert_script_run "sbd -d $sbd_device list" unless (get_var('USE_DISKLESS_SBD'));
+    if (!get_var('USE_DISKLESS_SBD')) {
+        my $sbd_output = script_output("sbd -d $sbd_device list");
+        record_info('bsc#1170037', 'All nodes not shown by sbd list command', result => 'softfail')
+          if (get_node_number != (my $clear_count = () = $sbd_output =~ /\sclear\s|\sclear$/g));
+    }
 
     # Check if the multicast port is correct (should be 5405 or 5407 by default)
     assert_script_run "grep -Eq '^[[:blank:]]*mcastport:[[:blank:]]*(5405|5407)[[:blank:]]*' $corosync_conf";


### PR DESCRIPTION
This PR improves our sbd output checking by comparing the number of nodes and number of clear status in the output.
It also adds a softail for bsc#1170037 (sbd not started in joined nodes).

- Related ticket: N/A
- Needles: N/A
- Verification run: 
15SP2: 
[Alpha node1](http://1a102.qa.suse.de/tests/4266) and [Alpha node2](http://1a102.qa.suse.de/tests/4267) using build without sbd issue.
[Alpha node1](http://1a102.qa.suse.de/tests/4269) and [Alpha node2](http://1a102.qa.suse.de/tests/4270) using build with the sbd issue.

