### PR TITLE
Remove obsoleted test module

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -89,5 +89,4 @@ schedule:
     - console/osinfo_db
     - console/zypper_ref
     - console/kdump_and_crash
-    - console/sssd_samba
     - console/coredump_collect


### PR DESCRIPTION
The package sssd-wbclient was removed from SLE15-SP2

- Related tickets:
  - Bug: https://bugzilla.suse.com/show_bug.cgi?id=1162203
  - Bug driven feature: https://bugzilla.suse.com/show_bug.cgi?id=1169657
  - Invalid bug: https://bugzilla.suse.com/show_bug.cgi?id=1169884
