### PR TITLE
Fix selecting the keyboard layout for en_US in jeos/firstrun

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -70,9 +70,10 @@ sub run {
 
     my $lang = is_sle('15+') ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
 
-    my %keylayout_key = ('en_US' => 'e', 'de_DE' => 'd');
     # For 'en_US' pick 'en_US', for 'de_DE' select 'de_DE'
     my %locale_key = ('en_US' => 'e', 'de_DE' => 'd');
+    # For 'en_US' pick 'us', for 'de_DE' select 'de'
+    my %keylayout_key = ('en_US' => 'u', 'de_DE' => 'd');
     # For 'en_US' pick 'UTC', for 'de_DE' select 'Europe/Berlin'
     my %tz_key = ('en_US' => 'u', 'de_DE' => 'e');
 


### PR DESCRIPTION
It's 'us', not 'en_US', so press 'u'.
Also adjust the order to match the wizard dialogs.

This failed for TW as due to a graphical glitch it had to press the key: https://openqa.opensuse.org/tests/1243493#step/firstrun/3

Verification run: http://10.160.67.86/t661