### PR TITLE
Fix azure ssh_interactive_init and add PRG new IP

### DIFF
--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -60,7 +60,7 @@ resource "aws_security_group" "basic_sg" {
         from_port   = 0
         to_port     = 0
         protocol    = "-1"
-        cidr_blocks = ["213.151.95.130/32", "195.135.220.0/22"]
+        cidr_blocks = ["213.151.95.130/32", "195.135.220.0/22", "195.250.132.144/29"]
     }
 
     egress {

--- a/tests/publiccloud/ssh_interactive_init.pm
+++ b/tests/publiccloud/ssh_interactive_init.pm
@@ -23,8 +23,8 @@ sub run {
 
     # Create public cloud instance
     my $provider = $self->provider_factory();
-    my $instance = $provider->create_instance(check_connectivity => 0);
-    $instance->wait_for_ssh(timeout => 300);
+    my $instance = $provider->create_instance(check_connectivity => 1);
+    $instance->wait_for_guestregister();
     $args->{my_provider} = $provider;
     $args->{my_instance} = $instance;
 
@@ -43,7 +43,7 @@ sub run {
     assert_script_run("chown -R " . $testapi::username . " /home/" . $testapi::username . "/.ssh/");
 
     # configure ssh server, allow root and password login
-    $instance->run_ssh_command(cmd => 'hostname -f');
+    $instance->run_ssh_command(cmd => 'hostname');
     $instance->run_ssh_command(cmd => 'sudo sed -i "s/PasswordAuthentication/#PasswordAuthentication/" /etc/ssh/sshd_config; echo "PasswordAuthentication no" | sudo tee -a /etc/ssh/sshd_config');
     $instance->run_ssh_command(cmd => 'sudo sed -i "s/ChallengeResponseAuthentication/#ChallengeResponseAuthentication/" /etc/ssh/sshd_config; echo "ChallengeResponseAuthentication no" | sudo tee -a /etc/ssh/sshd_config');
     $instance->run_ssh_command(cmd => 'echo -e "' . $testapi::password . '\n' . $testapi::password . '" | sudo passwd root');


### PR DESCRIPTION
Hello,

 * this is `ssh_interactive_init` hostname fix
 * SUSE PRG office has new IP range

- Related ticket: [poo#65621](https://progress.opensuse.org/issues/65621)
- Verification run: [SLE 12 SP4 Azure](http://pdostal-server.suse.cz/tests/8343) [SLE 15 SP1 Azure](http://pdostal-server.suse.cz/tests/8347) [SLE 12 SP4 Amazon](http://pdostal-server.suse.cz/tests/8345) [SLE 15 SP1 Google](http://pdostal-server.suse.cz/tests/8346)
