### PR TITLE
Fix openqa_review failing missing python2

### DIFF
--- a/tests/console/openqa_review.pm
+++ b/tests/console/openqa_review.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,7 @@ use testapi;
 use utils;
 
 sub run {
-    zypper_call('in python-openqa_review');
+    zypper_call('in python3-openqa_review');
     assert_script_run 'openqa-review --help';
 }
 


### PR DESCRIPTION
After python2 is in the process of being removed from openSUSE
Tumbleweed we can simply move to the python3 package variant.

Verification run: https://openqa.opensuse.org/tests/1243636#step/openqa_review/1

Related progress issue: https://progress.opensuse.org/issues/65986