### PR TITLE
Fix x3270_ssl launch fail to workaround the Switch Console error

### DIFF
--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -18,13 +18,25 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use power_action_utils 'power_action';
 
 sub run {
+
+    my ($self) = @_;
+
+    # Reboot the system when x11 launch fail to Workaround the Switch Console error
+    # (s390x limitation) s390x does not support snapshot to rollback the lastgood snapshot
+    # This workaround can avoid the blocked test fail from the last case
+    if (check_var('ARCH', 's390x') && check_var('FIPS_ENABLED', 1) && !get_var("FIPS_ENV_MODE")) {
+        power_action('reboot', textmode => 1);
+        $self->wait_boot(bootloader_time => 200);
+    }
+
+    select_console 'root-console';
+
     my $cert_file     = '/tmp/server.cert';
     my $key_file      = '/tmp/server.key';
     my $tracelog_file = '/tmp/x3270-trace.log';
-
-    select_console 'root-console';
 
     # Install x3270
     zypper_call "install x3270";


### PR DESCRIPTION
Description:
The x3270_ssl x11 launch fail due to the firefox_nss test fail previously. The problem only happened in s390x ARCH with Kernel Mode in FIPS. 

1. Reboot the system when x11 launch fail Switch Console error in s390x
2. The workaround can avoid the blocked test fail from the last case
Error run: https://openqa.suse.de/tests/4146477

- Related ticket: https://progress.opensuse.org/issues/65570
- Needles: NA
- Verification run: 
   Kernel Mode: https://openqa.suse.de/t4158090
   ENV Mode: https://openqa.suse.de/t4158091