### PR TITLE
Add bootloader for s390 and aarch64 on container tests

### DIFF
--- a/schedule/functional/extra_tests_textmode_containers.yaml
+++ b/schedule/functional/extra_tests_textmode_containers.yaml
@@ -2,7 +2,15 @@ name:           extra_tests_textmode_containers
 description:    >
     Maintainer: slindomansilla.
     Extra tests about software in containers module
+conditional_schedule:
+    bootloader:
+        ARCH:
+            aarch64:
+                - boot/uefi_bootmenu
+            s390x:
+                - installation/bootloader_zkvm
 schedule:
+    - '{{bootloader}}'
     - boot/boot_to_desktop
     - console/docker
     - console/docker_runc


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/65070

Verification runs: 
* Aarch64 https://openqa.suse.de/tests/4160085
* s390 https://openqa.suse.de/tests/4160086