### PR TITLE
Add conditional bootloader for extra_tests_gnome_sdk

### DIFF
--- a/schedule/functional/extra_tests_gnome_sdk.yaml
+++ b/schedule/functional/extra_tests_gnome_sdk.yaml
@@ -2,7 +2,20 @@ name:   extra_test_gnome_sdk
 description:    >
     Maintainer: jrauch
     Extra tests about software in sdk on gnome
+conditional_schedule:
+    bootloader:
+        ARCH:
+            'aarch64':
+                - boot/uefi_bootmenu
+            's390x':
+                - installation/bootloader_zkvm
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
 schedule:
+    - '{{bootloader}}'
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup


### PR DESCRIPTION
## Verification runs
- [aarch64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2494) (`_EXIT_AFTER_SCHEDULE=1`)
- [ppc64le-2g](https://openqa.suse.de/tests/4161062) (`_EXIT_AFTER_SCHEDULE=1`)
- [s390x-kvm-sle12](https://openqa.suse.de/tests/4161063) (`_EXIT_AFTER_SCHEDULE=1`)
- [64bit](http://openqa.slindomansilla-vm.qa.suse.de/tests/2493) (`_EXIT_AFTER_SCHEDULE=1`)
- [svirt-xen-hvm](https://openqa.suse.de/tests/4161060) (`_EXIT_AFTER_SCHEDULE=1`)
- [svirt-xen-pv](https://openqa.suse.de/tests/4161061) (`_EXIT_AFTER_SCHEDULE=1`)