### PR TITLE
Use the same conditional schedule for bootloader

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -5,14 +5,14 @@ description:    >
 conditional_schedule:
     bootloader:
         ARCH:
-            aarch64:
+            'aarch64':
                 - boot/uefi_bootmenu
-            s390x:
+            's390x':
                 - installation/bootloader_zkvm
         MACHINE:
-            svirt-xen-pv:
+            'svirt-xen-pv':
                 - installation/bootloader_svirt
-            svirt-xen-hvm:
+            'svirt-xen-hvm':
                 - installation/bootloader_svirt
     lshw:
         ARCH:

--- a/schedule/functional/extra_tests_textmode_containers.yaml
+++ b/schedule/functional/extra_tests_textmode_containers.yaml
@@ -5,10 +5,15 @@ description:    >
 conditional_schedule:
     bootloader:
         ARCH:
-            aarch64:
+            'aarch64':
                 - boot/uefi_bootmenu
-            s390x:
+            's390x':
                 - installation/bootloader_zkvm
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
 schedule:
     - '{{bootloader}}'
     - boot/boot_to_desktop

--- a/schedule/functional/extra_tests_textmode_mod_desktop.yaml
+++ b/schedule/functional/extra_tests_textmode_mod_desktop.yaml
@@ -5,14 +5,14 @@ description:    >
 conditional_schedule:
     bootloader:
         ARCH:
-            aarch64:
+            'aarch64':
                 - boot/uefi_bootmenu
-            s390x:
+            's390x':
                 - installation/bootloader_zkvm
         MACHINE:
-            svirt-xen-pv:
+            'svirt-xen-pv':
                 - installation/bootloader_svirt
-            svirt-xen-hvm:
+            'svirt-xen-hvm':
                 - installation/bootloader_svirt
     tests_requiring_soundcard:
         ARCH:

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -5,10 +5,15 @@ description:    >
 conditional_schedule:
     bootloader:
         ARCH:
-            aarch64:
+            'aarch64':
                 - boot/uefi_bootmenu
-            s390x:
+            's390x':
                 - installation/bootloader_zkvm
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
 schedule:
     - '{{bootloader}}'
     - boot/boot_to_desktop

--- a/schedule/functional/extra_tests_textmode_sdk.yaml
+++ b/schedule/functional/extra_tests_textmode_sdk.yaml
@@ -1,0 +1,21 @@
+name:           extra_tests_textmode_phub
+description:    >
+    Maintainer: slindomansilla.
+    Extra tests about software in Software Development Kit module on textmode
+conditional_schedule:
+    bootloader:
+        ARCH:
+            'aarch64':
+                - boot/uefi_bootmenu
+            's390x':
+                - installation/bootloader_zkvm
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - console/gdb
+    - console/coredump_collect


### PR DESCRIPTION
## Verification runs

- [aarch64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2496) (`_EXIT_AFTER_SCHEDULE`)
- [ppc64le](https://openqa.suse.de/tests/4162200) (`_EXIT_AFTER_SCHEDULE`)
- [s390x](https://openqa.suse.de/tests/4162201) (`_EXIT_AFTER_SCHEDULE`)
- [x86_64](https://openqa.suse.de/tests/4162202) (`_EXIT_AFTER_SCHEDULE`)