### PR TITLE
Add qdevice script for checking master resource

### DIFF
--- a/data/ha/qdevice_check_master.sh
+++ b/data/ha/qdevice_check_master.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+crm_resource --locate -r promotable-1 2>&1 | grep Master | grep `crm_node -n` >/dev/null 2>&1


### PR DESCRIPTION
I forgot to add this script in my previous PR about qdevice.
We need it for checking where master resource is running, qdevice will give a vote to the node which runs the master resource.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
