### PR TITLE
Add conditional bootloader to extra_tests_gnome

### DIFF
--- a/schedule/functional/extra_tests_gnome.yaml
+++ b/schedule/functional/extra_tests_gnome.yaml
@@ -3,7 +3,20 @@ description:    >
     Maintainer: asmorodskyi, okurz.
     Extra tests for software in desktop applications which were designed to run on gnome
     VNC_STALL_THRESHOLD is needed for xen svirt to don't turn off the scrreen after default 4 sec
+conditional_schedule:
+    bootloader:
+        ARCH:
+            'aarch64':
+                - boot/uefi_bootmenu
+            's390x':
+                - installation/bootloader_zkvm
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
 schedule:
+    - {{bootloader}}
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup


### PR DESCRIPTION
## Verification run

- [aarch64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2499) (`_EXIT_AFTER_SCHEDULE=1`)
- [ppc64le](https://openqa.suse.de/tests/4167604) (`_EXIT_AFTER_SCHEDULE=1`)
- [s390x](https://openqa.suse.de/tests/4167605) (`_EXIT_AFTER_SCHEDULE=1`)
- [x86_64](http://openqa.slindomansilla-vm.qa.suse.de/tests/2500) (`_EXIT_AFTER_SCHEDULE=1`)
- [xen-hvm](https://openqa.suse.de/tests/4167606) (`_EXIT_AFTER_SCHEDULE=1`)
- [xen-pv](https://openqa.suse.de/tests/4167607) (`_EXIT_AFTER_SCHEDULE=1`)