### PR TITLE
HPC: Move HPC installation tests to yaml scheduler

### DIFF
--- a/schedule/hpc/create_hdd_hpc_textmode.yaml
+++ b/schedule/hpc/create_hdd_hpc_textmode.yaml
@@ -1,0 +1,51 @@
+---
+name: create_hdd_hpc_textmode
+description:    >
+     Maintainer: schlad
+     Rudimentary installation scenario for creating qcow2
+     required by other HPC tests
+vars:
+  DESKTOP: textmode
+  INSTALLONLY: 1
+  PATTERNS: base,minimal
+  SLE_PRODUCT: hpc
+  HDDSIZEGB: 30
+conditional_schedule:
+  bootloader:
+    ARCH:
+      aarch64:
+        - installation/bootloader_uefi
+      x86_64:
+        - installation/bootloader
+schedule:
+  - installation/isosize
+  - '{{bootloader}}'
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/no_separate_home
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/select_patterns
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -1,0 +1,53 @@
+---
+name: hpc_installation_node_dev
+description:    >
+     Maintainer: schlad
+     Installation scenario with HPC system role hpc-node and hpc-dev
+vars:
+  DESKTOP: textmode
+  INSTALLONLY: 1
+  PATTERNS: base,minimal
+  SLE_PRODUCT: hpc
+  HDDSIZEGB: 30
+conditional_schedule:
+  bootloader:
+    ARCH:
+      aarch64:
+        - installation/bootloader_uefi
+      x86_64:
+        - installation/bootloader
+  systemrole_dev:
+    HPC:
+      installation_dev:
+        - installation/user_settings
+schedule:
+  - installation/isosize
+  - '{{bootloader}}'
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - '{{systemrole_dev}}'
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/select_patterns
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/65753
- verification runs:

**create_hdd_hpc_textmode:**
**x86_64:** https://openqa.suse.de/tests/4174295
**aarch64:** https://openqa.suse.de/tests/4178064
**hpc_installation_node:**
**x86_64:** https://openqa.suse.de/tests/4178047
**aarch64:** https://openqa.suse.de/tests/4178048
**hpc_installation_dev**
**x86_64:** https://openqa.suse.de/tests/4178037
**aarch64:** https://openqa.suse.de/tests/4178036