### PR TITLE
publiccloud: Use VM id instead of name for Azure

### DIFF
--- a/data/publiccloud/restart_instance.sh
+++ b/data/publiccloud/restart_instance.sh
@@ -52,7 +52,7 @@ case $PROVIDER in
         aws ec2 reboot-instances  --instance-ids "$INSTANCE_ID"
         ;;
     AZURE)
-        az vm restart -g "$INSTANCE_ID" -n "$INSTANCE_ID" --no-wait
+        az vm restart --ids "$INSTANCE_ID" --no-wait
         ;;
     GCE)
         gcloud compute instances reset "$INSTANCE_ID" --zone "$ZONE"

--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -196,7 +196,7 @@ resource "azurerm_managed_disk" "ssd_disk" {
 
 
 output "vm_name" {
-    value = "${azurerm_virtual_machine.openqa-vm.*.name}"
+    value = "${azurerm_virtual_machine.openqa-vm.*.id}"
 }
 
 data "azurerm_public_ip" "openqa-publicip" {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -204,7 +204,7 @@ sub run_img_proof {
     $cmd .= "--ssh-key-name '" . $args{key_name} . "' " if ($args{key_name});
     $cmd .= '-u ' . $args{user} . ' ' if ($args{user});
     $cmd .= '--ssh-private-key-file "' . $args{instance}->ssh_key . '" ';
-    $cmd .= '--running-instance-id "' . $args{instance}->instance_id . '" ';
+    $cmd .= '--running-instance-id "' . ($args{running_instance_id} // $args{instance}->instance_id) . '" ';
 
     $cmd .= $args{tests};
     record_info("img-proof cmd", $cmd);


### PR DESCRIPTION
In azure a VM can be specified by resource group (rg) plus instance name
or by instance ID.
With this patch we move from rg+name to ID, which make later usage more
easy, but also breaks the implicit assumption that name and rg is always
equal.

- Related ticket: https://progress.opensuse.org/issues/66116
- Verification run: https://openqa.suse.de/t4173399
