### PR TITLE
Add test for SELinux: restorecon + chcon + chcat

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2349,7 +2349,6 @@ sub load_security_tests_selinux {
 
     # Change SELinux from "permissive" mode to "enforcing" mode for testing
     loadtest "security/selinux/enforcing_mode_setup";
-
     # The following test modules must be run after "enforcing_mode_setup"
     loadtest "security/selinux/semanage_fcontext";
     loadtest "security/selinux/semanage_boolean";
@@ -2358,6 +2357,9 @@ sub load_security_tests_selinux {
     loadtest "security/selinux/audit2allow";
     loadtest "security/selinux/semodule";
     loadtest "security/selinux/setsebool";
+    loadtest "security/selinux/restorecon";
+    loadtest "security/selinux/chcon";
+    loadtest "security/selinux/chcat";
 }
 
 sub load_security_tests_mok_enroll {

--- a/tests/security/selinux/chcat.pm
+++ b/tests/security/selinux/chcat.pm
@@ -1,0 +1,80 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test "# chcat" can change file SELinux security category
+#          NOTE: Since we only focus on minimum policy and this cmd is
+#                for "mls", so this case only do some basic testings.
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#66096, tc#1745369
+
+use base "selinuxtest";
+use power_action_utils "power_action";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self)    = shift;
+    my $test_dir  = "/testdir";
+    my $test_file = "testfile";
+    my $test_user = "root";
+
+    my $systemlow            = "s0";
+    my $systemlow_systemhigh = "s0-s0:c0.c1023";
+    my $systemhigh           = "s0:c0.c1023";
+    my $test_category        = "c0.c1023";
+
+    my $default_category_root       = $systemhigh;
+    my $default_category_commonfile = $systemlow;
+
+    $self->select_serial_terminal;
+
+    # create a testing directory/file
+    $self->create_test_file("$test_dir", "$test_file");
+
+    # test "# chcat -L" can list available categories
+    validate_script_output(
+        "chcat -L",
+        sub {
+            m/
+	    $systemlow\ .*SystemLow.*
+            $systemlow_systemhigh\ .*SystemLow-SystemHigh.*
+            $systemhigh\ .*SystemHigh/sx
+        });
+
+    # test "# chcat [+|-]CATEGORY File" can operate categories on dirs/files
+    # on dirs
+    $self->check_category("$test_dir", "$systemlow");
+    assert_script_run("chcat +${test_category} $test_dir");
+    $self->check_category("$test_dir", "$systemhigh");
+    assert_script_run("chcat -- -${test_category} $test_dir");
+    $self->check_category("$test_dir", "$systemlow");
+    # on files
+    $self->check_category("${test_dir}/${test_file}", "$systemlow");
+    assert_script_run("chcat +${test_category} ${test_dir}/${test_file}");
+    $self->check_category("${test_dir}/${test_file}", "$systemhigh");
+    assert_script_run("chcat -d ${test_dir}/${test_file}");
+    $self->check_category("${test_dir}/${test_file}", "$systemlow");
+
+    # test "# chcat -l" can operate categories on users instead of files
+    validate_script_output("chcat -L -l $test_user", sub { m/${test_user}:\ .*${default_category_root}$/ });
+    assert_script_run("chcat -l -d $test_user");
+    validate_script_output("chcat -L -l $test_user", sub { m/${test_user}:\ .*${systemlow}$/ });
+    assert_script_run("chcat -l +${test_category} $test_user");
+    validate_script_output("chcat -L -l $test_user", sub { m/${test_user}:\ .*${default_category_root}$/ });
+}
+
+1;

--- a/tests/security/selinux/chcon.pm
+++ b/tests/security/selinux/chcon.pm
@@ -1,0 +1,46 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test "# chcon" can change file security context
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#66093, tc#1741289
+
+use base "selinuxtest";
+use power_action_utils "power_action";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self)         = shift;
+    my $test_dir       = "/testdir";
+    my $test_file      = "testfile";
+    my $fcontext_type1 = "etc_t";
+    my $fcontext_type2 = "bin_t";
+
+    $self->select_serial_terminal;
+
+    # create a testing directory/file
+    $self->create_test_file("$test_dir", "$test_file");
+
+    # test "# chcon" can change file security context
+    assert_script_run("chcon -t $fcontext_type1 ${test_dir}/${test_file}");
+    validate_script_output("ls -Z ${test_dir}/${test_file}", sub { m/$fcontext_type1/ });
+    assert_script_run("chcon -t $fcontext_type2 ${test_dir}/${test_file}");
+    validate_script_output("ls -Z ${test_dir}/${test_file}", sub { m/$fcontext_type2/ });
+}
+
+1;

--- a/tests/security/selinux/restorecon.pm
+++ b/tests/security/selinux/restorecon.pm
@@ -1,0 +1,62 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test "# restorecon" to do file system labeling
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#65672, tc#1741291
+
+use base "selinuxtest";
+use power_action_utils "power_action";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self)         = shift;
+    my $test_dir       = "/testdir";
+    my $test_file      = "testfile";
+    my $fcontext_type1 = "etc_t";
+    my $fcontext_type2 = "bin_t";
+
+    $self->select_serial_terminal;
+
+    # create a testing directory/file
+    $self->create_test_file("$test_dir", "$test_file");
+
+    # label system: testing "-R / -P / -V"
+    script_run("restorecon -Rp /",  600);
+    script_run("restorecon -Rp /*", 600);
+    script_run("restorecon -Rv /",  600);
+    script_run("restorecon -Rv /*", 600);
+
+    # clean up in case: remove all local customizations
+    assert_script_run("semanage fcontext -D");
+
+    # add local customizations
+    assert_script_run("semanage fcontext -a -t $fcontext_type1 $test_dir");
+    assert_script_run("semanage fcontext -a -t $fcontext_type2 ${test_dir}/${test_file}");
+
+    # run "# restorecon -R" to label test dir/file
+    assert_script_run("restorecon -R $test_dir");
+    assert_script_run("restorecon -R $test_dir/*");
+    validate_script_output("ls -Zd $test_dir",               sub { m/$fcontext_type1/ });
+    validate_script_output("ls -Z ${test_dir}/${test_file}", sub { m/$fcontext_type2/ });
+
+    # clean up: remove all local customizations
+    assert_script_run("semanage fcontext -D");
+}
+
+1;


### PR DESCRIPTION
Add test for SELinux: restorecon + chcon + chcat
All passed.

- Related ticket:
  https://progress.opensuse.org/issues/65998
  https://progress.opensuse.org/issues/66093
  https://progress.opensuse.org/issues/66096
- Needles: NA
- Verification run: 
  https://openqa.nue.suse.com/tests/4169718# (old)
  https://openqa.nue.suse.com/tests/4181769# (new)

