### PR TITLE
HPC: Move single-machine HPC tests to yaml scheduler

### DIFF
--- a/schedule/hpc/single_machine_test.yaml
+++ b/schedule/hpc/single_machine_test.yaml
@@ -1,0 +1,30 @@
+---
+name: single machine HPC tests
+description:    >
+     Maintainer: schlad
+     all singe machine HPC tests based loaded based on hpctest
+vars:
+  DESKTOP: textmode
+  PATTERNS: base,minimal
+  SLE_PRODUCT: hpc
+  HDDSIZEGB: 30
+conditional_schedule:
+  bootmenu:
+    ARCH:
+      aarch64:
+        - boot/uefi_bootmenu
+  hpctest:
+    HPC:
+      conman:
+        - hpc/conman
+      powerman:
+        - hpc/powerman
+      genders:
+        - hpc/genders
+      rasdaemon:
+        - hpc/rasdaemon
+schedule:
+  - '{{bootmenu}}'
+  - boot/boot_to_desktop
+  - hpc/before_test
+  - '{{hpctest}}'


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/65753
- Verification run:
**x86_64:**
rasdaemon: https://openqa.suse.de/tests/4172091
powerman: https://openqa.suse.de/tests/4172093
genders: https://openqa.suse.de/tests/4172228
conman: https://openqa.suse.de/tests/4172230
**aarch64:**
rasdaemon: https://openqa.suse.de/tests/4172092
powerman: https://openqa.suse.de/tests/4172094
genders: https://openqa.suse.de/tests/4172229
conman: https://openqa.suse.de/tests/4172231