### PR TITLE
Update journalctl calls: show µs timestamp as well

### DIFF
--- a/data/textinfo
+++ b/data/textinfo
@@ -20,6 +20,6 @@ ls -l /etc/ntp* || true
 ps ax
 systemctl --no-pager --full
 rpm -qa | sort
-journalctl -a --no-full -m > /var/log/journal.dump
+journalctl -a --no-full -m -o short-precise > /var/log/journal.dump
 # explicitly ignore exit code as we know files can change in the mean time
 tar cjf /tmp/logs.tar.bz2 --warning=no-file-changed /var/log || true

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -30,7 +30,7 @@ sub enable_and_start {
 
 sub upload_service_log {
     my ($self, $service_name) = @_;
-    script_run("journalctl -u $service_name > /tmp/$service_name");
+    script_run("journalctl -u $service_name -o short-precise > /tmp/$service_name");
     script_run("cat /tmp/$service_name");
     upload_logs("/tmp/$service_name", failok => 1);
 }

--- a/lib/mm_tests.pm
+++ b/lib/mm_tests.pm
@@ -34,7 +34,7 @@ sub configure_static_network {
     configure_default_gateway;
     configure_static_ip($ip);
     configure_static_dns(get_host_resolv_conf());
-    assert_script_run "ping -c 1 10.0.2.2 || journalctl -b --no-pager >/dev/$serialdev";
+    assert_script_run "ping -c 1 10.0.2.2 || journalctl -b --no-pager -o short-precise >/dev/$serialdev";
 }
 
 sub configure_stunnel {

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -47,7 +47,7 @@ sub setup_static_network {
     assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$args{ip}'">/etc/sysconfig/network/ifcfg-$iface);
     assert_script_run 'rcnetwork restart';
     assert_script_run 'ip addr';
-    assert_script_run 'ping -c 1 ' . $args{gw} . '|| journalctl -b --no-pager > /dev/' . $serialdev;
+    assert_script_run 'ping -c 1 ' . $args{gw} . '|| journalctl -b --no-pager -o short-precise > /dev/' . $serialdev;
     assert_script_run('ip -6 addr add ' . $args{ipv6} . ' dev ' . $iface) if (exists($args{ipv6}));
 }
 

--- a/lib/networkdbase.pm
+++ b/lib/networkdbase.pm
@@ -177,7 +177,7 @@ redirected to the host system journal.
 sub export_container_journal {
     my ($self, $machine) = @_;
 
-    assert_script_run("journalctl -M $machine --no-pager -b 0 > /tmp/" . $machine . "_journal.log");
+    assert_script_run("journalctl -M $machine --no-pager -b 0 -o short-precise > /tmp/" . $machine . "_journal.log");
     upload_logs "/tmp/" . $machine . "_journal.log";
 }
 

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -241,7 +241,7 @@ sub start_service {
     clear_console;
 
     # Server is up and running, client can use it now!
-    script_run "( journalctl -fu nfs-server > /dev/$serialdev & )";
+    script_run "( journalctl -fu nfs-server -o short-precise > /dev/$serialdev & )";
     check_nfs_ready($rw, $ro);
 }
 

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -110,7 +110,7 @@ Saves the journal of the systemd unit C<$unit> to C<journal_$unit.log> and uploa
 =cut
 sub save_and_upload_systemd_unit_log {
     my ($self, $unit) = @_;
-    $self->save_and_upload_log("journalctl --no-pager -u $unit", "journal_$unit.log");
+    $self->save_and_upload_log("journalctl --no-pager -u $unit -o short-precise", "journal_$unit.log");
 }
 
 =head2 detect_bsc_1063638
@@ -164,11 +164,11 @@ sub problem_detection {
     clear_console;
 
     # Errors in journal
-    $self->save_and_upload_log("journalctl --no-pager -p 'err'", "journalctl-errors.txt", {screenshot => 1, noupload => 1});
+    $self->save_and_upload_log("journalctl --no-pager -p 'err' -o short-precise", "journalctl-errors.txt", {screenshot => 1, noupload => 1});
     clear_console;
 
     # Tracebacks in journal
-    $self->save_and_upload_log('journalctl | grep -i traceback', "journalctl-tracebacks.txt", {screenshot => 1, noupload => 1});
+    $self->save_and_upload_log('journalctl -o short-precise | grep -i traceback', "journalctl-tracebacks.txt", {screenshot => 1, noupload => 1});
     clear_console;
 
     # Segmentation faults
@@ -406,10 +406,10 @@ This includes C</proc/loadavg>, C<ps axf>, complete journal since last boot, C<d
 =cut
 sub export_logs_basic {
     my ($self) = @_;
-    $self->save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg.txt', {screenshot => 1});
-    $self->save_and_upload_log('ps axf',            '/tmp/psaxf.log',   {screenshot => 1});
-    $self->save_and_upload_log('journalctl -b',     '/tmp/journal.log', {screenshot => 1});
-    $self->save_and_upload_log('dmesg',             '/tmp/dmesg.log',   {screenshot => 1});
+    $self->save_and_upload_log('cat /proc/loadavg',              '/tmp/loadavg.txt', {screenshot => 1});
+    $self->save_and_upload_log('ps axf',                         '/tmp/psaxf.log',   {screenshot => 1});
+    $self->save_and_upload_log('journalctl -b -o short-precise', '/tmp/journal.log', {screenshot => 1});
+    $self->save_and_upload_log('dmesg',                          '/tmp/dmesg.log',   {screenshot => 1});
     $self->tar_and_upload_log('/etc/sysconfig', '/tmp/sysconfig.tar.bz2');
 }
 

--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -46,7 +46,7 @@ sub capture_state {
     script_run("dmesg > /tmp/dmesg_$state.log");
     upload_logs("/tmp/dmesg_$state.log");
     #upload journal
-    script_run("journalctl -b > /tmp/journal_$state.log");
+    script_run("journalctl -b -o short-precise > /tmp/journal_$state.log");
     upload_logs("/tmp/journal_$state.log");
 }
 

--- a/lib/systemd_testsuite_test.pm
+++ b/lib/systemd_testsuite_test.pm
@@ -123,7 +123,7 @@ sub post_fail_hook {
     my ($self) = @_;
     #upload logs from given testname
     $self->tar_and_upload_log('/var/opt/systemd-tests/logs', '/tmp/systemd_testsuite-logs.tar.bz2');
-    $self->save_and_upload_log('journalctl --no-pager -axb', 'journal.log');
+    $self->save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.log');
     upload_logs('/shutdown-log.txt', failok => 1);
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1006,7 +1006,7 @@ sub handle_emergency {
     elsif (match_has_tag('emergency-mode')) {
         type_password;
         send_key 'ret';
-        script_run "journalctl --no-pager > /dev/$serialdev";
+        script_run "journalctl --no-pager -o short-precise > /dev/$serialdev";
         die "hit emergency mode";
     }
 }

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -568,7 +568,7 @@ sub sync_start_of {
         }
     }
     # if we get here means that service failed to start
-    script_run("journalctl -u $service");
+    script_run("journalctl -u $service -o short-precise");
     # we creating this mutex anyway even so we know that we fail to start service
     # to not cause dead-lock
     die("Create mutex failed") unless mutex_create($mutex);

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -507,7 +507,7 @@ sub save_upload_y2logs {
         assert_script_run "save_y2logs $filename", 180;
         upload_logs $filename;
     } else {    # Redirect logs content to serial
-        script_run("journalctl -b --no-pager > /dev/$serialdev");
+        script_run("journalctl -b --no-pager -o short-precise > /dev/$serialdev");
         script_run("dmesg > /dev/$serialdev");
         script_run("cat /var/log/YaST/y2log > /dev/$serialdev");
     }

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -72,7 +72,7 @@ sub initialize_y2lan
       '(WICKED_LOG_LEVEL).*/\1="info"';    # DEBUG configuration for wicked
     assert_script_run 'sed -i -E \'s/' . $debug_conf . '/\' /etc/sysconfig/network/config';
     assert_script_run 'systemctl restart network';
-    type_string "journalctl -f|egrep -i --line-buffered '$query_pattern_for_restart|Reloaded wicked' > journal.log &\n";
+    type_string "journalctl -f -o short-precise|egrep -i --line-buffered '$query_pattern_for_restart|Reloaded wicked' > journal.log &\n";
     clear_journal_log();
 }
 

--- a/tests/console/slp.pm
+++ b/tests/console/slp.pm
@@ -78,10 +78,10 @@ sub post_fail_hook {
 
     upload_logs '/var/log/slpd.log';
     upload_logs '/var/log/zypper.log';
-    $self->save_and_upload_log('journalctl --no-pager',  '/tmp/journal.log',            {screenshot => 1});
-    $self->save_and_upload_log('rpm -ql openslp-server', '/tmp/openslp-server.content', {screenshot => 1});
-    $self->save_and_upload_log('rpm -ql openslp',        '/tmp/openslp.content',        {screenshot => 1});
-    $self->save_and_upload_log('lsmod',                  '/tmp/loaded_modules.txt',     {screenshot => 1});
+    $self->save_and_upload_log('journalctl --no-pager -o short-precise', '/tmp/journal.log',            {screenshot => 1});
+    $self->save_and_upload_log('rpm -ql openslp-server',                 '/tmp/openslp-server.content', {screenshot => 1});
+    $self->save_and_upload_log('rpm -ql openslp',                        '/tmp/openslp.content',        {screenshot => 1});
+    $self->save_and_upload_log('lsmod',                                  '/tmp/loaded_modules.txt',     {screenshot => 1});
 }
 
 1;

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -41,7 +41,7 @@ sub run {
 
     # Workaround network timeout issue during upgrade
     if (get_var('HDDVERSION')) {
-        assert_script_run 'journalctl -b --no-pager > bsc1129385-check-journal.log';
+        assert_script_run 'journalctl -b --no-pager -o short-precise > bsc1129385-check-journal.log';
         my $iscsi_fails = script_run 'grep -q "iscsid: cannot make a connection to" bsc1129385-check-journal.log';
         my $csync_fails = script_run 'grep -q "corosync.service: Failed" bsc1129385-check-journal.log';
         my $pcmk_fails  = script_run 'egrep -q "pacemaker.service.+failed" bsc1129385-check-journal.log';

--- a/tests/microos/journal_check.pm
+++ b/tests/microos/journal_check.pm
@@ -41,7 +41,7 @@ sub run {
     };
     my $master_pattern = "(" . join('|', map { "$_" } values %$bug_pattern) . ")";
 
-    my $journal_output = script_output("journalctl --no-pager -p err | tail -n +2");
+    my $journal_output = script_output("journalctl --no-pager -p err -o short-precise | tail -n +2");
 
     # Find lines which matches to the pattern_bug
     while (my ($bug, $pattern) = each %$bug_pattern) {
@@ -66,7 +66,7 @@ sub run {
     }
 
     # Write full journal output for reference and upload it into Uploaded Logs section in test webUI
-    script_run("journalctl --no-pager > /tmp/full_journal.log");
+    script_run("journalctl --no-pager -o short-precise > /tmp/full_journal.log");
     upload_logs "/tmp/full_journal.log";
 
     # Check for failed systemd services and examine them

--- a/tests/migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/migration/sle12_online_migration/yast2_migration.pm
@@ -283,7 +283,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
-    $self->save_and_upload_log('journalctl -b', '/tmp/journal.log', {screenshot => 1});
+    $self->save_and_upload_log('journalctl -b -o short-precise', '/tmp/journal.log', {screenshot => 1});
     $self->export_logs_desktop;
     $self->SUPER::post_fail_hook;
 }

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -37,7 +37,7 @@ sub system_status {
         iptables   => "iptables -L -n --line-numbers",
         repos      => "zypper repos -u",
         dmesg      => "dmesg",
-        journalctl => "journalctl -xn 100"
+        journalctl => "journalctl -xn 100 -o short-precise"
     );
     foreach my $key (@klst) {
         my $cmd = "echo '=========> $key <=========' >> $log; ";

--- a/tests/rt/kmp_modules.pm
+++ b/tests/rt/kmp_modules.pm
@@ -103,9 +103,9 @@ sub post_fail_hook {
 
     select_console 'log-console';
 
-    $self->save_and_upload_log("dmesg",                 "dmesg.log",        {screenshot => 1});
-    $self->save_and_upload_log("journalctl --no-pager", "journalctl.log",   {screenshot => 1});
-    $self->save_and_upload_log('rpm -qa *-kmp-rt',      "list_of_kmp_rpms", {screenshot => 1});
+    $self->save_and_upload_log("dmesg",                                  "dmesg.log",        {screenshot => 1});
+    $self->save_and_upload_log("journalctl --no-pager -o short-precise", "journalctl.log",   {screenshot => 1});
+    $self->save_and_upload_log('rpm -qa *-kmp-rt',                       "list_of_kmp_rpms", {screenshot => 1});
     if ((script_run 'test -e /var/log/modprobe.out') == 0) {
         upload_logs '/var/log/modprobe.out';
     }

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -100,7 +100,7 @@ sub run {
 
     type_string("cat /var/log/messages >/dev/$serialdev\n");
     # send messages logged during the testsuite runtime to serial
-    type_string("journalctl -f >/dev/$serialdev\n");
+    type_string("journalctl -f -o short-precise >/dev/$serialdev\n");
 
     mutex_create(get_var('SLENKINS_NODE'));
 

--- a/tests/support_server/wait_children.pm
+++ b/tests/support_server/wait_children.pm
@@ -32,7 +32,7 @@ sub run {
 
     select_console 'root-console';
     # We don't need any logs from support server when running on REMOTE_CONTROLLER for remote SLE installation tests
-    type_string("journalctl -f |tee /dev/$serialdev\n") unless (get_var('REMOTE_CONTROLLER'));
+    type_string("journalctl -f -o short-monotonic |tee /dev/$serialdev\n") unless (get_var('REMOTE_CONTROLLER'));
 
     if (check_var("REMOTE_CONTROLLER", "ssh") || check_var("REMOTE_CONTROLLER", "vnc")) {
         mutex_create("installation_done");
@@ -48,7 +48,7 @@ sub run {
         # No messages file in openSUSE which use journal by default
         # Write journal log to /var/log/messages for openSUSE
         if (check_var('DISTRI', 'opensuse')) {
-            script_run 'journalctl -b -x > /var/log/messages', 90;
+            script_run 'journalctl -b -x -o short-precise > /var/log/messages', 90;
         }
         my $log_cmd = "tar cjf /tmp/logs.tar.bz2 /var/log/messages ";
         if (exists $server_roles{qemuproxy} || exists $server_roles{aytest}) {

--- a/tests/transactional/health_check.pm
+++ b/tests/transactional/health_check.pm
@@ -77,7 +77,7 @@ sub run {
 }
 
 sub post_fail_hook {
-    script_run "journalctl -u health-checker > health-checker.log", 60;
+    script_run "journalctl -u health-checker -o short-precise > health-checker.log", 60;
     upload_logs "health-checker.log";
 
     # revert changes to rebootmgr.sh and reboot

--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -169,7 +169,7 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    assert_script_run 'journalctl -b > /tmp/journal', 90;
+    assert_script_run 'journalctl -b -o short-precise > /tmp/journal', 90;
     upload_logs '/tmp/journal';
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
* Ticket: https://progress.opensuse.org/issues/11928
* Verification: http://kazhua.suse.de/tests/25
    * See http://kazhua.suse.de/tests/25/file/textinfo-logs.tar.bz2 --> `/var/log/journal.dump`