### PR TITLE
utils::zypper_ar(): Fix repo priority on SLE-11

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -579,14 +579,16 @@ sub zypper_ar {
     my $params       = $args{params}       // '';
     my $no_gpg_check = $args{no_gpg_check} // '';
 
-    $priority     = defined($priority) ? "-p $priority"  : "";
-    $no_gpg_check = $no_gpg_check      ? "--no-gpgcheck" : "";
-    my $cmd_ar  = "--gpg-auto-import-keys ar -f $priority $no_gpg_check $params $url";
+    $no_gpg_check = $no_gpg_check ? "--no-gpgcheck" : "";
+    my $prioarg = defined($priority) && !is_sle('<12') ? "-p $priority" : "";
+    my $cmd_ar  = "--gpg-auto-import-keys ar -f $prioarg $no_gpg_check $params $url";
+    my $cmd_mr  = "mr -p $priority $url";
     my $cmd_ref = "--gpg-auto-import-keys ref";
 
     # repo file
     if (!$name) {
         zypper_call($cmd_ar);
+        zypper_call($cmd_mr) if $priority && is_sle('<12');
         return zypper_call($cmd_ref);
     }
 
@@ -594,6 +596,7 @@ sub zypper_ar {
     my $out = script_output("LC_ALL=C zypper lr $name 2>&1", proceed_on_failure => 1);
     if ($out =~ /Repository.*$name.*not found/i) {
         zypper_call("$cmd_ar $name");
+        zypper_call($cmd_mr) if $priority && is_sle('<12');
         return zypper_call("$cmd_ref --repo $name");
     }
 }


### PR DESCRIPTION
`zypper ar` on SLE-11 has no -p parameter. Priority has to be set using `zypper mr` command after the repo has been added. Priority 0 (reset to default) is also intentionally ignored because SLE-11 doesn't support it.

This fixes install_ltp failures on SLE-11.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-11SP3: https://openqa.suse.de/tests/4172090
  - SLE-15SP1: https://openqa.suse.de/tests/4173283
