### PR TITLE
Wait longer for yast2-kdump-restart-info pop-up

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -145,7 +145,7 @@ sub activate_kdump {
     }
     send_key('alt-o');
     if ($expect_restart_info == 1) {
-        assert_screen('yast2-kdump-restart-info');
+        assert_screen('yast2-kdump-restart-info', 200);
         send_key('alt-o');
     }
     wait_serial("$module_name-0", 240) || die "'yast2 kdump' didn't finish";


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4170590#step/kdump_and_crash/39
- Verification run: https://openqa.suse.de/tests/4173328 job cancelled, too long queue