### PR TITLE
Fix yaml parsing issues

### DIFF
--- a/schedule/qam/QR/15-SP1/zfcp.yaml
+++ b/schedule/qam/QR/15-SP1/zfcp.yaml
@@ -7,24 +7,24 @@ vars:
   DESKTOP: gnome
   MULTIPATH: 1
 schedule:
-  -installation/bootloader_start
-  -installation/welcome
-  -installation/accept_license
-  -installation/disk_activation
-  -installation/multipath
-  -installation/scc_registration
-  -installation/addon_products_sle
-  -installation/system_role
-  -installation/partitioning
-  -installation/partitioning_finish
-  -installation/installer_timezone
-  -installation/user_settings
-  -installation/user_settings_root
-  -installation/installation_overview
-  -installation/disable_grub_timeout
-  -installation/start_install
-  -installation/await_install
-  -installation/logs_from_installation_system
-  -installation/reboot_after_installation
-  -boot/reconnect_mgmt_console
-  -installation/first_boot
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/disk_activation
+  - installation/multipath
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot

--- a/schedule/yast/autoyast_btrfs.yaml
+++ b/schedule/yast/autoyast_btrfs.yaml
@@ -29,7 +29,7 @@ test_data:
     partitioning:
       - drive:
           unique_key: enable_snapshots
-          enable_snapshots: true
+          enable_snapshots: 'true'
           partitions:
             - partition:
                 unique_key: mount
@@ -43,15 +43,15 @@ test_data:
                   - subvolume:
                       unique_key: path
                       path: usr/local
-                      copy_on_write: true
+                      copy_on_write: 'true'
                   - subvolume:
                       unique_key: path
                       path: opt
-                      copy_on_write: true
+                      copy_on_write: 'true'
                   - subvolume:
                       unique_key: path
                       path: tmp
-                      copy_on_write: false
+                      copy_on_write: 'false'
             - partition:
                 unique_key: mount
                 mount: /var/log

--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -66,7 +66,7 @@ test_data:
           partitions:
             - partition:
                 unique_key: create
-                create: false
+                create: 'false'
           type: CT_DISK
       - drive:
           unique_key: device
@@ -85,7 +85,7 @@ test_data:
             data_raid_level: raid0
             metadata_raid_level: raid1
           disklabel: none
-          enable_snapshots: false
+          enable_snapshots: 'false'
           partitions:
             - partition:
                 unique_key: label
@@ -95,31 +95,31 @@ test_data:
                 subvolumes:
                   - subvolume:
                       unique_key: path
-                      copy_on_write: true
+                      copy_on_write: 'true'
                       path: tmp
                   - subvolume:
                       unique_key: path
-                      copy_on_write: true
+                      copy_on_write: 'true'
                       path: usr/local
                   - subvolume:
                       unique_key: path
-                      copy_on_write: true
+                      copy_on_write: 'true'
                       path: home
                   - subvolume:
                       unique_key: path
-                      copy_on_write: true
+                      copy_on_write: 'true'
                       path: root
                   - subvolume:
                       unique_key: path
-                      copy_on_write: true
+                      copy_on_write: 'true'
                       path: srv
                   - subvolume:
                       unique_key: path
-                      copy_on_write: false
+                      copy_on_write: 'false'
                       path: var
                   - subvolume:
                       unique_key: path
-                      copy_on_write: true
+                      copy_on_write: 'true'
                       path: opt
                 subvolumes_prefix: '@'
           type: CT_BTRFS

--- a/schedule/yast/autoyast_nfs_share.yaml
+++ b/schedule/yast/autoyast_nfs_share.yaml
@@ -33,7 +33,7 @@ test_data:
         partitions:
           - partition:
               unique_key: mount
-              create: false
+              create: 'false'
               mount: /test
         type: CT_NFS
     services-manager:

--- a/schedule/yast/autoyast_non_secure_boot.yaml
+++ b/schedule/yast/autoyast_non_secure_boot.yaml
@@ -27,4 +27,4 @@ test_data:
   profile:
     bootloader:
       global:
-        secure_boot: false
+        secure_boot: 'false'

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -7,24 +7,24 @@ vars:
   DESKTOP: gnome
   MULTIPATH: 1
 schedule:
-  -installation/bootloader_start
-  -installation/welcome
-  -installation/accept_license
-  -installation/disk_activation
-  -installation/scc_registration
-  -installation/multipath
-  -installation/addon_products_sle
-  -installation/system_role
-  -installation/partitioning
-  -installation/partitioning_finish
-  -installation/installer_timezone
-  -installation/user_settings
-  -installation/user_settings_root
-  -installation/installation_overview
-  -installation/disable_grub_timeout
-  -installation/start_install
-  -installation/await_install
-  -installation/logs_from_installation_system
-  -installation/reboot_after_installation
-  -boot/reconnect_mgmt_console
-  -installation/first_boot
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/disk_activation
+  - installation/scc_registration
+  - installation/multipath
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot


### PR DESCRIPTION
* After changing yaml parsing library to YAML::PP, booleans that do
not have quotes are parsed as 1 and 0. (e.g. fail: https://openqa.suse.de/tests/4171266)

  The PR adds quotes for the booleans, that has to be parsed as
  text.

* Also, YAML:PP does not parse array items if '-' is not followed by space.

  The PR fixes the issue by adding the required spaces.