### PR TITLE
[WIP][virt_autotest] change timeout setting for save_guest_ip func

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -48,7 +48,7 @@ sub save_guest_ip {
         script_run "sed -i '/$guest/d' /etc/hosts";
         assert_script_run "virsh domiflist $guest";
         my $mac_guest = script_output("virsh domiflist $guest | grep $name | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"");
-        script_retry "journalctl --no-pager | grep DHCPACK | grep $mac_guest | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", delay => 90, retry => 9, timeout => 90;
+        script_retry "journalctl --no-pager | grep DHCPACK | grep $mac_guest | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", delay => 120, retry => 12, timeout => 120;
         my $gi_guest = script_output("journalctl --no-pager | grep DHCPACK | grep $mac_guest | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"");
         assert_script_run "echo '$gi_guest $guest # virtualization' >> /etc/hosts";
         assert_script_run "ping -c3 $guest";


### PR DESCRIPTION
Debug new failures from osd libvirt_routed_virtual_network on xen hosts
  gi-guest_developing-on-host_developing-xen-dev
  gi-guest_developing-on-host_sles12sp5-xen-dev
  gi-guest_sles12sp5-on-host_developing-xen-dev
  gi-guest_sles15sp1-on-host_developing-xen-dev
  gi-guest_developing-on-host_sles12sp4-xen-dev
  gi-guest_developing-on-host_sles15-xen-dev
  gi-guest_developing-on-host_sles15sp1-xen-dev

Figure out the existed timeout setting was not enough to get ip add
for Xen guest used with virtual routed network via save_guest_ip func

So, change the existed timeout setting from 90 to 120 for save_guest_ip func

- Verification run: 
  sles15sp2 xen host
  http://10.67.19.82/tests/448