### PR TITLE
sles4sap/saptune/mr_test: sap.conf is not shipped in newer sapconf versions

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -267,7 +267,7 @@ sub test_sapconf {
 
     # Scenario 1: sapconf is running and active with sap-netweaver profile.
     # The test shall show, that a running tuned profile or sapconf is not compromised.
-    assert_script_run 'cp /etc/systemd/logind.conf.d/sap.conf{.bak,}';
+    script_run 'cp /etc/systemd/logind.conf.d/sap.conf{.bak,}';
     systemctl "enable --now sapconf";
     systemctl "disable tuned";
     systemctl "start tuned";


### PR DESCRIPTION
sap.conf is not shipped in newer sapconf versions

Fixes sapconf openQA test