### PR TITLE
Add check for autoyast profile url reachability before installation

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -27,6 +27,7 @@ use version_utils 'is_sle';
 use registration qw(scc_version get_addon_fullname);
 use File::Copy 'copy';
 use File::Path 'make_path';
+use LWP::Simple 'head';
 
 use xml_utils;
 
@@ -39,6 +40,7 @@ our @EXPORT = qw(
   upload_profile
   inject_registration
   init_autoyast_profile
+  test_ayp_url
   validate_autoyast_profile
 );
 
@@ -507,6 +509,19 @@ EOF
     return $profile;
 }
 
+=head2 test_ayp_url
 
+ test_ayp_url();
+
+ Test if the autoyast profile url is reachable, before the autoyast installation begins.
+
+=cut
+sub test_ayp_url {
+    my $ayp_url = get_var('AUTOYAST');
+    if ($ayp_url =~ /^http/) {
+        die "Autoyast profile url $ayp_url is unreachable " unless head($ayp_url);
+        record_info("ayp ok", "Autoyast profile url reachable");
+    }
+}
 
 1;

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -642,6 +642,8 @@ sub autoyast_boot_params {
         $autoyast_args .= $ay_var;
     }
     push @params, split ' ', $autoyast_args;
+    $autoyast_args =~ /autoyast=(?<url>\S+)/;
+    set_var('AUTOYAST', $+{url});
     return @params;
 }
 

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -45,6 +45,7 @@ use main_common 'opensuse_welcome_applicable';
 use x11utils 'untick_welcome_on_next_startup';
 use Utils::Backends 'is_pvm';
 use scheduler 'get_test_suite_data';
+use autoyast 'test_ayp_url';
 
 my $confirmed_licenses = 0;
 my $stage              = 'stage1';
@@ -128,8 +129,8 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
+    test_ayp_url;
     my $test_data = get_test_suite_data();
-
     my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot package-notification nvidia-validation-failed);
     my $expected_licenses = get_var('AUTOYAST_LICENSE');
     my @expected_warnings;

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -112,9 +112,11 @@ sub prepare_parmfile {
     if (get_var('AUTOYAST')) {
         if (get_var('AUTOYAST_PREPARE_PROFILE')) {
             $params .= " autoyast=" . shorten_url(get_var('AUTOYAST'));
+            set_var('AUTOYAST', shorten_url(get_var('AUTOYAST')));
         }
         else {
             $params .= " autoyast=" . shorten_url(data_url(get_var('AUTOYAST')));
+            set_var('AUTOYAST', shorten_url(data_url(get_var('AUTOYAST'))));
         }
     }
     return split_lines($params);

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -40,6 +40,7 @@ sub set_svirt_domain_elements {
         if (my $autoyast = get_var('AUTOYAST')) {
             $autoyast = data_url($autoyast) if $autoyast !~ /^slp$|:\/\//;
             $cmdline .= " autoyast=" . $autoyast;
+            set_var('AUTOYAST', $autoyast);
         }
 
         $cmdline .= ' ' . get_var("EXTRABOOTPARAMS") if get_var("EXTRABOOTPARAMS");


### PR DESCRIPTION
In case of autoyast installation, openqa tests will try to reach the autoyast profile during installation. If the profile is not reachable, the test will continue for several minutes. The autoyast profile check implemented here, will cause failure that will stop the test earlier.

- Related ticket: https://progress.opensuse.org/issues/64325
- Verification run:  
64bit  : https://openqa.suse.de/t4182147
ppc64: https://openqa.suse.de/t4182144
s390  : https://openqa.suse.de/t4182074

