### PR TITLE
Add systemd tests 26-34, extend timeout for test 1, 15 and 16, remove binary tests summary needle check

### DIFF
--- a/schedule/systemd/suse_patches-systemd_testsuite.yaml
+++ b/schedule/systemd/suse_patches-systemd_testsuite.yaml
@@ -3,7 +3,7 @@ description:    >
     Maintainer: slindomansilla <slindomansilla@suse.com>
     Modified upstream testsuite to be run as system test.
 conditional_schedule:
-    systemd_testsuite_15SP2ORLATER:
+    systemd_testsuite_if_VERSION:
         VERSION:
             '15.2':
                 - systemd_testsuite/test_16_extend_timeout
@@ -29,6 +29,15 @@ conditional_schedule:
                 - systemd_testsuite/test_20_mainpidgames
                 - systemd_testsuite/test_21_sysusers
                 - systemd_testsuite/test_23_type_exec
+                - systemd_testsuite/test_26_setenv
+                - systemd_testsuite/test_27_stdoutfile
+                - systemd_testsuite/test_28_percentj_wantedby
+                - systemd_testsuite/test_29_udev_id_renaming
+                - systemd_testsuite/test_30_onclockchange
+                - systemd_testsuite/test_31_device_enumeration
+                - systemd_testsuite/test_32_oompolicy
+                - systemd_testsuite/test_33_clean_unit
+                - systemd_testsuite/test_34_dynamicusermigrate
 schedule:
     - boot/boot_to_desktop
     - systemd_testsuite/binary_tests
@@ -47,5 +56,5 @@ schedule:
     - systemd_testsuite/test_14_machine_id
     - systemd_testsuite/test_15_dropin
     - systemd_testsuite/test_22_tmpfiles
-    - '{{systemd_testsuite_15SP2ORLATER}}'
+    - '{{systemd_testsuite_if_VERSION}}'
     - shutdown/shutdown

--- a/tests/systemd_testsuite/binary_tests.pm
+++ b/tests/systemd_testsuite/binary_tests.pm
@@ -22,7 +22,7 @@ sub run {
     # run binary tests
     assert_script_run('cd /var/opt/systemd-tests');
     validate_script_output('./run-tests.sh | tee /tmp/testsuite.log', sub { m/# FAIL:\s*0/ }, timeout => 600);
-    assert_screen("systemd-testsuite-binary-tests-summary");
+    save_screenshot;
     script_run 'clear';
 }
 

--- a/tests/systemd_testsuite/test_01_basic.pm
+++ b/tests/systemd_testsuite/test_01_basic.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-01-BASIC --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-01-BASIC --run 2>&1 | tee /tmp/testsuite.log', 600;
     assert_script_run 'grep "PASS: ...TEST-01-BASIC" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_15_dropin.pm
+++ b/tests/systemd_testsuite/test_15_dropin.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-15-DROPIN --run 2>&1 | tee /tmp/testsuite.log', 120;
+    assert_script_run './run-tests.sh TEST-15-DROPIN --run 2>&1 | tee /tmp/testsuite.log', 600;
     assert_script_run 'grep "PASS: ...TEST-15-DROPIN" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_16_extend_timeout.pm
+++ b/tests/systemd_testsuite/test_16_extend_timeout.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-16-EXTEND-TIMEOUT --run 2>&1 | tee /tmp/testsuite.log', 120;
+    assert_script_run './run-tests.sh TEST-16-EXTEND-TIMEOUT --run 2>&1 | tee /tmp/testsuite.log', 600;
     assert_script_run 'grep "PASS: ...TEST-16-EXTEND-TIMEOUT" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_26_setenv.pm
+++ b/tests/systemd_testsuite/test_26_setenv.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-26-SETENV from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-26-SETENV');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-26-SETENV --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-26-SETENV" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-26-SETENV --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/systemd_testsuite/test_27_stdoutfile.pm
+++ b/tests/systemd_testsuite/test_27_stdoutfile.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-27-STDOUTFILE from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-27-STDOUTFILE');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-27-STDOUTFILE --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-27-STDOUTFILE" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-27-STDOUTFILE --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/systemd_testsuite/test_28_percentj_wantedby.pm
+++ b/tests/systemd_testsuite/test_28_percentj_wantedby.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-28-PERCENTJ-WANTEDBY from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-28-PERCENTJ-WANTEDBY');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-28-PERCENTJ-WANTEDBY --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-28-PERCENTJ-WANTEDBY" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-28-PERCENTJ-WANTEDBY --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/systemd_testsuite/test_29_udev_id_renaming.pm
+++ b/tests/systemd_testsuite/test_29_udev_id_renaming.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-29-UDEV-ID_RENAMING from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-29-UDEV-ID_RENAMING');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-29-UDEV-ID_RENAMING --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-29-UDEV-ID_RENAMING" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-29-UDEV-ID_RENAMING --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/systemd_testsuite/test_30_onclockchange.pm
+++ b/tests/systemd_testsuite/test_30_onclockchange.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-30-ONCLOCKCHANGE from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-30-ONCLOCKCHANGE');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-30-ONCLOCKCHANGE --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-30-ONCLOCKCHANGE" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-30-ONCLOCKCHANGE --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/systemd_testsuite/test_31_device_enumeration.pm
+++ b/tests/systemd_testsuite/test_31_device_enumeration.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-31-DEVICE-ENUMERATION from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-31-DEVICE-ENUMERATION');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-31-DEVICE-ENUMERATION --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-31-DEVICE-ENUMERATION" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-31-DEVICE-ENUMERATION --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/systemd_testsuite/test_32_oompolicy.pm
+++ b/tests/systemd_testsuite/test_32_oompolicy.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-32-OOMPOLICY from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-32-OOMPOLICY');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-32-OOMPOLICY --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-32-OOMPOLICY" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-32-OOMPOLICY --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/systemd_testsuite/test_33_clean_unit.pm
+++ b/tests/systemd_testsuite/test_33_clean_unit.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-33-CLEAN-UNIT from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-33-CLEAN-UNIT');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-33-CLEAN-UNIT --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-33-CLEAN-UNIT" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-33-CLEAN-UNIT --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/systemd_testsuite/test_34_dynamicusermigrate.pm
+++ b/tests/systemd_testsuite/test_34_dynamicusermigrate.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run test executed by TEST-34-DYNAMICUSERMIGRATE from upstream after openSUSE/SUSE patches.
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+
+use base 'systemd_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    #prepare test
+    $self->testsuiteprepare('TEST-34-DYNAMICUSERMIGRATE');
+}
+
+sub run {
+    #run test
+    assert_script_run 'cd /var/opt/systemd-tests';
+    assert_script_run './run-tests.sh TEST-34-DYNAMICUSERMIGRATE --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run 'grep "PASS: ...TEST-34-DYNAMICUSERMIGRATE" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-34-DYNAMICUSERMIGRATE --clean';
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;


### PR DESCRIPTION
Currently only tested for Tumbleweed x86_64

- Verification run: http://emerson.suse.de/tests/2150

- Testsuite package submitted: https://build.opensuse.org/request/show/798910
