### PR TITLE
sles4sap/saptune/mr_test: Adapt sapconf test for bsc#1139176 fix

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -268,6 +268,8 @@ sub test_sapconf {
     # Scenario 1: sapconf is running and active with sap-netweaver profile.
     # The test shall show, that a running tuned profile or sapconf is not compromised.
     script_run 'cp /etc/systemd/logind.conf.d/sap.conf{.bak,}';
+    # Otherwise sapconf will fail to start. See bsc#1139176
+    assert_script_run "tuned-adm off" if is_sle('>=15');
     systemctl "enable --now sapconf";
     systemctl "disable tuned";
     systemctl "start tuned";


### PR DESCRIPTION
Fixes sapconf mr_test test.

The developer (Angela) told me that a similar fix for sapconf on SLES 12 is not planned.

Verification run: http://ix64hae1001.qa.suse.de/tests/2129