### PR TITLE
Use record_soft_fail for bsc#1170037 in cluster init

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -86,7 +86,7 @@ sub run {
     # State of SBD if shared storage SBD is used
     if (!get_var('USE_DISKLESS_SBD')) {
         my $sbd_output = script_output("sbd -d $sbd_device list");
-        record_info('bsc#1170037', 'All nodes not shown by sbd list command', result => 'softfail')
+        record_soft_failure 'bsc#1170037 - All nodes not shown by sbd list command'
           if (get_node_number != (my $clear_count = () = $sbd_output =~ /\sclear\s|\sclear$/g));
     }
 


### PR DESCRIPTION
Use `record_soft_fail()` instead of `record_info('', '', result => 'softfail')` so the entire test is marked as soft failed when bsc#1170037 is present.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A as the only change is a line with `record_soft_fail()` instead of `record_info()`
