### PR TITLE
update conditional schedule for TW modules

### DIFF
--- a/schedule/systemd/suse_patches-systemd_testsuite.yaml
+++ b/schedule/systemd/suse_patches-systemd_testsuite.yaml
@@ -5,22 +5,6 @@ description:    >
 conditional_schedule:
     systemd_testsuite_if_VERSION:
         VERSION:
-            '15.2':
-                - systemd_testsuite/test_16_extend_timeout
-                - systemd_testsuite/test_17_udev_wants
-                - systemd_testsuite/test_18_failureaction
-                - systemd_testsuite/test_19_delegate
-                - systemd_testsuite/test_20_mainpidgames
-                - systemd_testsuite/test_21_sysusers
-                - systemd_testsuite/test_23_type_exec
-            '15-SP2':
-                - systemd_testsuite/test_16_extend_timeout
-                - systemd_testsuite/test_17_udev_wants
-                - systemd_testsuite/test_18_failureaction
-                - systemd_testsuite/test_19_delegate
-                - systemd_testsuite/test_20_mainpidgames
-                - systemd_testsuite/test_21_sysusers
-                - systemd_testsuite/test_23_type_exec
             'Tumbleweed':
                 - systemd_testsuite/test_16_extend_timeout
                 - systemd_testsuite/test_17_udev_wants


### PR DESCRIPTION
It seems that older perl modules need some quotes in the conditional schedule call in the yaml file.
Otherwise I get the following error:

-->
loadtest needs a script below /var/lib/openqa/cache/emerson.suse.de/tests/opensuse - tests/HASH(0x75e7018).pm is not
[2020-04-29T09:07:19.950 CEST] [debug] error on tests/HASH(0x75e7018).pm: Invalid version format (non-numeric data) at (eval 1442) line 1, near "package HASH"
syntax error at (eval 1442) line 1, near "package HASH("
BEGIN not safe after errors--compilation aborted at (eval 1442) line 1.

error on tests/HASH(0x75e7018).pm: Invalid version format (non-numeric data) at (eval 1442) line 1, near "package HASH"
syntax error at (eval 1442) line 1, near "package HASH("
BEGIN not safe after errors--compilation aborted at (eval 1442) line 1.
--<

- test error: http://emerson.suse.de/tests/2158/file/autoinst-log.txt
- Verification run Tumbleweed: http://emerson.suse.de/tests/2163
- Verification run SLES15SP2:  http://knopfler.arch.suse.de/tests/30