### PR TITLE
Fix YAML schedule for extra_tests_gnome

### DIFF
--- a/schedule/functional/extra_tests_gnome.yaml
+++ b/schedule/functional/extra_tests_gnome.yaml
@@ -16,7 +16,7 @@ conditional_schedule:
             'svirt-xen-hvm':
                 - installation/bootloader_svirt
 schedule:
-    - {{bootloader}}
+    - '{{bootloader}}'
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup


### PR DESCRIPTION
Looks like _EXIT_AFTER_SCHEDULE is not always the best way to test these things (https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10106)