### PR TITLE
Avoid failures on assert_screen when the system is under heavy load

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -45,7 +45,7 @@ sub handle_password_prompt {
     $console //= '';
 
     return if get_var("LIVETEST") || get_var('LIVECD');
-    assert_screen "password-prompt";
+    assert_screen("password-prompt", 60);
     if ($console eq 'hyperv-intermediary') {
         type_string get_required_var('VIRSH_GUEST_PASSWORD');
     }

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -40,7 +40,7 @@ our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 sub run {
     diag('fate#320597: Introduce \'zypper lifecycle\' to provide information about life cycle of individual products and packages');
     select_console 'user-console';
-    my $overview = script_output 'zypper lifecycle', 300;
+    my $overview = script_output('zypper lifecycle', 600);
     die "Missing header line:\nOutput: '$overview'" unless $overview =~ /Product end of support/;
     die "Missing link to lifecycle page:\nOutput: '$overview'"
       if $overview =~ /n\/a/ && $overview !~ qr{\*\) See https://www.suse.com/lifecycle for latest information};

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -76,9 +76,15 @@ END_SCRIPT
         assert_script_run(q{echo 'ForwardToConsole=yes' >> /etc/systemd/journald.conf});
         assert_script_run(q{echo 'MaxLevelConsole=debug' >> /etc/systemd/journald.conf});
         assert_script_run(qq{echo 'TTYPath=/dev/$serialdev' >> /etc/systemd/journald.conf});
-        assert_script_run(q{systemctl restart systemd-journald});
+        # Before updating this value again, check the system logs
+        assert_script_run(q{systemctl restart systemd-journald}, 120);
     }
 }
 
-1;
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->SUPER::post_fail_hook;
+    $self->save_and_upload_systemd_unit_log('systemd-journald');
+}
 
+1;


### PR DESCRIPTION
Helps avoiding failing too much when the host is under load, as the call might take a long time to complete, and password prompt that also might take a bit to show up

Verification https://openqa.suse.de/tests/4180443