### PR TITLE
Unschedule cleanup_before_shutdown from system_performance

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -355,7 +355,8 @@ sub default_desktop {
 }
 
 sub load_shutdown_tests {
-    loadtest("shutdown/cleanup_before_shutdown");
+    # Schedule cleanup before shutdown only in cases the HDD will be published
+    loadtest("shutdown/cleanup_before_shutdown") if get_var('PUBLISH_HDD');
     loadtest "shutdown/shutdown";
 }
 


### PR DESCRIPTION
While the system_performance test suite is meant to detect problems in a
system without all the workarounds we add, this module is only meant to
prepare the system for subsequent boots, which doesn't apply in this
case.

Verification: 
* [SLE](https://openqa.suse.de/tests/4180438)
* [Tumbleweed](http://phobos.suse.de/tests/3856966)