### PR TITLE
Enable gnome installation with /home partition encrypted

### DIFF
--- a/data/autoyast_sle15/autoyast_home_encrypted.xml
+++ b/data/autoyast_sle15/autoyast_home_encrypted.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+    </bootloader>
+    <suse_register>
+      <do_registration config:type="boolean">true</do_registration>
+      <email/>
+      <reg_code>{{SCC_REGCODE}}</reg_code>
+      <install_updates config:type="boolean">true</install_updates>
+      <reg_server>{{SCC_URL}}</reg_server>
+      <addons config:type="list">
+        <addon>
+          <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        </addon>
+        <addon>
+          <name>sle-we</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+          <reg_code>{{SCC_REGCODE_WE}}</reg_code>
+        </addon>
+      </addons>
+    </suse_register>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+    <networking>
+      <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <partitioning config:type="list">
+    <drive>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition>
+          <mount>/swap</mount>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <size>auto</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+          <size>75%</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/home</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <crypt_fs config:type="boolean">true</crypt_fs>
+          <crypt_key>nots3cr3t</crypt_key>
+          <size>20%</size>
+        </partition>
+      </partitions>
+    </drive>
+    </partitioning>
+    <users config:type="list">
+      <user>
+        <fullname>Bernhard M. Wiedemann</fullname>
+        <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+      </user>
+      <user>
+        <encrypted config:type="boolean">false</encrypted>
+        <user_password>nots3cr3t</user_password>
+        <username>root</username>
+      </user>
+    </users>
+    <software>
+      <products config:type="list">
+        <product>SLES</product>
+        <product>sle-we</product>
+      </products>
+      <patterns config:type="list">
+        <pattern>base</pattern>
+        <pattern>enhanced_base</pattern>
+        <pattern>gnome_x11</pattern>
+        </patterns>
+    </software>
+</profile>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -438,7 +438,7 @@ sub adjust_network_conf {
 sub expand_variables {
     my ($profile) = @_;
     # Expand other variables
-    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_URL ARCH LOADER_TYPE NTP_SERVER_ADDRESS);
+    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_REGCODE_WE SCC_URL ARCH LOADER_TYPE NTP_SERVER_ADDRESS);
     # Push more variables to expand from the job setting
     my @extra_vars = push @vars, split(/,/, get_var('AY_EXPAND_VARS', ''));
     if (get_var 'SALT_FORMULAS_PATH') {

--- a/schedule/yast/autoyast_home_encrypted.yaml
+++ b/schedule/yast/autoyast_home_encrypted.yaml
@@ -1,0 +1,75 @@
+---
+name: autoyast_home_encrypted
+description: |
+  Gnome installation with separate /home partition encrypted
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/verify_separate_home
+  - console/validate_encrypt
+  - autoyast/console
+  - autoyast/clone
+  - autoyast/verify_cloned_profile
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  $include: test_data/yast/encryption/encrypt_home.yaml
+  profile:
+    partitioning:
+      - drive:
+          unique_key: device
+          device: /dev/sda
+          partitions:
+            - partition:
+                unique_key: mount
+                mount: swap
+            - partition:
+                unique_key: mount
+                mount: /
+                filesystem: btrfs
+                subvolumes:
+                  - subvolume:
+                      unique_key: path
+                      path: usr/local
+                      copy_on_write: 'true'
+                  - subvolume:
+                      unique_key: path
+                      path: opt
+                      copy_on_write: 'true'
+                  - subvolume:
+                      unique_key: path
+                      path: tmp
+                      copy_on_write: 'true'
+                  - subvolume:
+                      unique_key: path
+                      path: root
+                      copy_on_write: 'true'
+                  - subvolume:
+                      unique_key: path
+                      path: boot/grub2/i386-pc
+                      copy_on_write: 'true'
+                  - subvolume:
+                      unique_key: path
+                      path: boot/grub2/x86_64-efi
+                      copy_on_write: 'true'
+                  - subvolume:
+                      unique_key: path
+                      path: var
+                      copy_on_write: 'false'
+                  - subvolume:
+                      unique_key: path
+                      path: srv
+                      copy_on_write: 'true'
+            - partition:
+                unique_key: partition_nr
+                partition_nr: 1
+            - partition:
+                unique_key: mount
+                mount: /home
+                crypt_key: ENTER KEY HERE
+                crypt_method: luks1
+                filesystem: xfs

--- a/test_data/yast/encryption/encrypt_home.yaml
+++ b/test_data/yast/encryption/encrypt_home.yaml
@@ -1,0 +1,13 @@
+---
+cryptsetup:
+  device_status:
+    message: is active and is in use.
+    properties:
+      type: LUKS1
+      cipher: aes-xts-plain64
+      device: /dev/sda4
+      key_location: dm-crypt
+      mode: read/write
+luks:
+  backup_base_path: /root/bkp_luks_header
+  backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -131,7 +131,8 @@ sub run {
 
     test_ayp_url;
     my $test_data = get_test_suite_data();
-    my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot package-notification nvidia-validation-failed);
+    my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot package-notification nvidia-validation-failed import-untrusted-gpg-key);
+
     my $expected_licenses = get_var('AUTOYAST_LICENSE');
     my @expected_warnings;
     if (defined $test_data->{expected_warnings}) {
@@ -195,6 +196,11 @@ sub run {
         if (match_has_tag('autoyast-boot')) {
             send_key 'ret';    # press enter if grub timeout is disabled, like we have in reinstall scenarios
             last;              # if see grub, we get to the second stage, as it appears after bios-boot which we may miss
+        }
+        elsif (match_has_tag('import-untrusted-gpg-key')) {
+            handle_untrusted_gpg_key;
+            @needles = grep { $_ ne 'import-untrusted-gpg-key' } @needles;
+            next;
         }
         elsif (match_has_tag('prague-pxe-menu') || match_has_tag('qa-net-selection')) {
             @needles       = grep { $_ ne 'prague-pxe-menu' and $_ ne 'qa-net-selection' } @needles;


### PR DESCRIPTION
We perform an AutoYast installation creating a separate partition
for home and we encrypt it. In additional we select Workstation Extension
addon and we install gnome-x11 pattern.
As occurs with encrypted boot partition the installation module stops
after the grub and we handle the decryption in the next module.
We verify the scenario at the end reusing the verify_separate_home
and testing the clone function.


- Related ticket: https://progress.opensuse.org/issues/65172
- Needles: 
- Verification run: http://aquarius.suse.cz/tests/2667
- Test plan: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/180
