### PR TITLE
Fix boot read_time propagation

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -881,7 +881,7 @@ behave as if the env var NOAUTOLOGIN was set.
 sub wait_boot_past_bootloader {
     my ($self, %args) = @_;
     my $textmode     = $args{textmode};
-    my $ready_time   = $args{ready_time} // (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 500 : 300;
+    my $ready_time   = $args{ready_time} // ((check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 500 : 300);
     my $nologin      = $args{nologin};
     my $forcenologin = $args{forcenologin};
 
@@ -968,7 +968,7 @@ sub wait_boot {
     my ($self, %args) = @_;
     my $bootloader_time = $args{bootloader_time} // 100;
     my $textmode        = $args{textmode};
-    my $ready_time      = $args{ready_time} // (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 500 : 300;
+    my $ready_time      = $args{ready_time} // ((check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 500 : 300);
     my $in_grub         = $args{in_grub} // 0;
 
     die "wait_boot: got undefined class" unless $self;


### PR DESCRIPTION
Fix poo#66188: Missing parentheses around ternary operator caused
incorrect propagation of ready_time variable in Define-or operator.

Incorrect behavior: http://black-bit.suse.cz/tests/4846/

- Related ticket: https://progress.opensuse.org/issues/66188.
- Needles: none
- Verification run:  http://black-bit.suse.cz/tests/4847/

