### PR TITLE
Implement  FIPS certification for gnutls

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2174,6 +2174,9 @@ sub load_security_tests_crypt_core {
         loadtest "fips/openssl/openssl_fips_cipher";
         loadtest "fips/openssl/dirmngr_setup";
         loadtest "fips/openssl/dirmngr_daemon";    # dirmngr_daemon needs to be tested after dirmngr_setup
+        loadtest "fips/gnutls/gnutls_base_check";
+        loadtest "fips/gnutls/gnutls_server";
+        loadtest "fips/gnutls/gnutls_client";
     }
     loadtest "fips/openssl/openssl_tlsv1_3";
     loadtest "fips/openssl/openssl_pubkey_rsa";

--- a/tests/fips/gnutls/gnutls_base_check.pm
+++ b/tests/fips/gnutls/gnutls_base_check.pm
@@ -1,0 +1,57 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: SLES15SP2 FIPS certification, we need to certify gnutls and libnettle
+#          In this case, will do some base check for gnutls
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#63223, tc#1744099
+
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils 'zypper_call';
+
+sub run {
+    select_console 'root-console';
+
+    # Install the gnutls and openssl apackages
+    zypper_call 'in gnutls openssl';
+
+    # Check the library is in FIPS mode
+    validate_script_output 'gnutls-cli --fips140-mode 2>&1', sub {
+        m/
+            library\sis\sin\sFIPS140-2\smode.*/sx
+    };
+
+    # Lists all ciphers, check the certificate types and double confirm TLS1.3,DTLS1.2 and SSL3.0
+    assert_script_run 'gnutls-cli -l | grep "Certificate types" | grep "CTYPE-X.509"';
+    assert_script_run 'gnutls-cli -l | grep Protocols | grep VERS-SSL3.0 | grep VERS-TLS1.3 | grep VERS-DTLS1.2';
+
+    # Check google's imap server and verify basic function
+    validate_script_output 'echo | gnutls-cli -d 1 imap.gmail.com -p 993', sub {
+        m/
+            Certificate\stype:\sX\.509.*
+            Status:\sThe\scertificate\sis\strusted.*
+            Description:\s\(TLS1\.3\).*
+            Handshake\swas\scompleted.*/sx
+    };
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/fips/gnutls/gnutls_client.pm
+++ b/tests/fips/gnutls/gnutls_client.pm
@@ -1,0 +1,41 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: SLES15SP2 FIPS certification, we need to certify gnutls and libnettle
+#          In this case, will test connecting the GnuTLS server from client
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#63223, tc#1744099
+
+use base "consoletest";
+use testapi;
+use strict;
+use warnings;
+
+sub run {
+    select_console "root-console";
+
+    # Switch to the original folder contains the key/password files
+    my $test_dir = "gnutls";
+    assert_script_run "cd $test_dir";
+    my $user   = "psk_identity";
+    my $passwd = "psk-passwd.txt";
+    my $psk    = script_output "cat $passwd | awk -F : '{print \$2}'";
+
+    # Connect to the server and make sure the handshake
+    validate_script_output "echo |gnutls-cli -p 5556 localhost --pskusername $user --pskkey $psk --priority NORMAL:-KX-ALL:+ECDHE-PSK:+DHE-PSK:+PSK",
+      sub { m/Handshake was completed/ };
+}
+
+1;

--- a/tests/fips/gnutls/gnutls_server.pm
+++ b/tests/fips/gnutls/gnutls_server.pm
@@ -1,0 +1,92 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: SLES15SP2 FIPS certification, we need to certify gnutls and libnettle
+#          In this case, will configure GnuTLS server
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#63223, tc#1744099
+
+use base "consoletest";
+use testapi;
+use strict;
+use warnings;
+
+sub run {
+    select_console "root-console";
+
+    # Create test folder
+    my $test_dir = "gnutls";
+    assert_script_run "mkdir $test_dir && cd $test_dir";
+
+    # Add support for X.509.  First we generate a CA
+    my $pri_ca_key   = "x509-ca-key.pem";
+    my $pri_ca_out   = "x509-ca.pem";
+    my $ca_tmpl      = "ca.tmpl";
+    my $ca_tmpl_cont = <<'EOF';
+cn = GnuTLS test CA
+ca
+cert_signing_key
+EOF
+    assert_script_run "certtool --generate-privkey > $pri_ca_key";
+    assert_script_run "echo '$ca_tmpl_cont' > $ca_tmpl";
+    assert_script_run "certtool --generate-self-signed --load-privkey $pri_ca_key --template $ca_tmpl --outfile $pri_ca_out";
+
+    # Generate a server certificate
+    my $ser_pri_key   = "x509-server-key.pem";
+    my $ser_ca_out    = "x509-server.pem";
+    my $ser_tmpl      = "server.tmpl";
+    my $ser_tmpl_cont = <<'EOF';
+organization = GnuTLS test server
+cn = test.gnutls.org
+tls_www_server
+encryption_key
+signing_key
+dns_name = test.gnutls.org
+EOF
+    assert_script_run "certtool --generate-privkey > $ser_pri_key";
+    assert_script_run "echo '$ser_tmpl_cont' > $ser_tmpl";
+    assert_script_run
+"certtool --generate-certificate --load-privkey $ser_pri_key --load-ca-certificate $pri_ca_out --load-ca-privkey $pri_ca_key --template $ser_tmpl --outfile $ser_ca_out";
+
+    #  Generate a client certificate
+    my $cli_pri_key   = "x509-client-key.pem";
+    my $cli_out       = "x509-client.pem";
+    my $cli_tmpl      = "client.tmpl";
+    my $cli_tmpl_cont = <<'EOF';
+cn = GnuTLS test client
+tls_www_client
+encryption_key
+signing_key
+EOF
+    assert_script_run "certtool --generate-privkey > $cli_pri_key";
+    assert_script_run "echo '$cli_tmpl_cont' > $cli_tmpl";
+    assert_script_run
+"certtool --generate-certificate --load-privkey $cli_pri_key --load-ca-certificate $pri_ca_out --load-ca-privkey $pri_ca_key --template $cli_tmpl --outfile $cli_out";
+
+    # Create password file with psktool
+    my $user   = "psk_identity";
+    my $passwd = "psk-passwd.txt";
+    assert_script_run "psktool -u $user -p $passwd";
+
+    # Start a server with support for PSK. This would require a password file created with psktool
+    type_string "nohup gnutls-serv --http --priority NORMAL:+ECDHE-PSK:+PSK --pskpasswd $passwd&";
+    type_string "\n";
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Description:
SLES15SP2 FIPS certification, we need to certify gnutls and libnettle.
JIRA ID:https://jira.suse.com/browse/SLE-9520

- Related ticket: https://progress.opensuse.org/issues/63223
- Needles: N/A
- Verification run: http://10.67.17.9/tests/155