### PR TITLE
Fix wrong variable name in the schedule introduced by 3baeb0e

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -356,7 +356,7 @@ sub default_desktop {
 
 sub load_shutdown_tests {
     # Schedule cleanup before shutdown only in cases the HDD will be published
-    loadtest("shutdown/cleanup_before_shutdown") if get_var('PUBLISH_HDD');
+    loadtest("shutdown/cleanup_before_shutdown") if get_var('PUBLISH_HDD_1');
     loadtest "shutdown/shutdown";
 }
 


### PR DESCRIPTION
PUBLISH_HDD variable doesn't exists, instead it's a combination of
PUBLISH_HDD_+NUMDISK, where 1 corresponds to the root disk of the SUT