### PR TITLE
Validate YAML schedules against JSON Schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,14 @@ test-compile-changed: os-autoinst/
 
 .PHONY: test-yaml-valid
 test-yaml-valid:
-	@# Get list of changed yaml files
-	$(eval YAMLS=$(shell sh -c "git --no-pager diff --diff-filter=dr --name-only master | grep '\(schedule\|test_data\)/.*\.y.\?ml$$'"))
-	if test -n "$(YAMLS)"; then \
-	  export PERL5LIB=${PERL5LIB_} ; tools/test_yaml_valid $(YAMLS);\
+	@# Get list of changed yaml files. We only want to lint changed files for
+	@# now because yamllint complains about a lot of existing files
+	$(eval YAMLS=$(shell sh -c "git ls-files schedule/ test_data/ | grep '/.*\.y.\?ml$$'"))
+	export PERL5LIB=${PERL5LIB_} ; tools/test_yaml_valid $(YAMLS);\
+	$(eval CHANGED_YAMLS=$(shell sh -c "git --no-pager diff --diff-filter=dr --name-only master | grep '\(schedule\|test_data\)/.*\.y.\?ml$$'"))
+	if test -n "$(CHANGED_YAMLS)"; then \
 	  which yamllint >/dev/null 2>&1 || echo "Command 'yamllint' not found, can not execute YAML syntax checks";\
-	  yamllint -c .yamllint $(YAMLS);\
+	  yamllint -c .yamllint $(CHANGED_YAMLS);\
 	else \
 	  echo "No yamls modified.";\
 	fi

--- a/cpanfile
+++ b/cpanfile
@@ -61,5 +61,5 @@ on 'test' => sub {
   requires 'Test::MockObject';
   requires 'Test::More', '0.88';
   requires 'Test::Warnings';
-  requires 'Test::YAML::Valid';
+  requires 'JSON::Validator';
 };

--- a/t/schema/Schedule-1.yaml
+++ b/t/schema/Schedule-1.yaml
@@ -1,0 +1,70 @@
+$id: Schedule-1.yaml
+$schema: http://json-schema.org/draft-04/schema#
+description: >
+    YAML schedules define the list of test modules to be executed by a given
+    job. It also allows setting variables that will affect the job to be
+    executed in the end.
+type: object
+additionalProperties: false
+required:
+# Every file should have a description, but we are not there yet
+#- description
+- name
+- schedule
+
+properties:
+
+  name:
+    type: string
+
+  description:
+    oneOf:
+    - type: string
+    - type: 'null'  # Some files have a description without a value
+
+  schedule:
+    type: array
+    items:
+      type: string
+
+  vars:
+    type: object
+    description: Additional test variables to be set
+    additionalProperties: false
+    patternProperties:
+      "^[A-Z_+]+[A-Z0-9_]*$":
+        oneOf:
+        - type: string
+        - type: number
+
+  test_data:
+    additionalProperties: false
+    type: object
+    patternProperties:
+      # Ideally we should load includes before validating
+      # but since test_data can contain pretty much every structure
+      # we can leave it like that for now
+      "^\\$include$":
+        type: string
+      "^([a-zA-Z0-9_]+)$":
+        oneOf:
+        - type: string
+        - type: number
+        - type: object
+        - type: array
+
+  conditional_schedule:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^[a-zA-Z0-9_]+$":
+        type: object
+        additionalProperties: false
+        patternProperties:
+          '^[A-Z][A-Z0-9_]+$':
+            type: object
+            patternProperties:
+              "^[a-zA-Z0-9_]+$":
+                type: array
+                items:
+                  type: string

--- a/tools/test_yaml_valid
+++ b/tools/test_yaml_valid
@@ -1,7 +1,34 @@
 #!/usr/bin/env perl
+use strict;
+use warnings;
+use FindBin '$Bin';
 use Test::More;
-use Test::YAML::Valid qw(-Tiny);
+use YAML::PP;
+use JSON::Validator;
 
-pass("No yaml files modified") unless @ARGV;
-yaml_file_ok($_, $_) for @ARGV;
+my $schema_file = "$Bin/../t/schema/Schedule-1.yaml";
+my $validator = JSON::Validator->new;
+$validator = eval { $validator->load_and_validate_schema($schema_file) };
+if (my $err = $@) {
+    diag $err;
+    BAIL_OUT("Schema $schema_file invalid");
+}
+
+pass("Nothing to do") unless @ARGV;
+for my $file (@ARGV) {
+    my $data = eval { YAML::PP::LoadFile($file) };
+    if (my $err = $@) {
+        fail("$file has invalid yaml syntax");
+        diag "Error: $err";
+    }
+    else {
+        pass("$file has valid yaml syntax");
+    }
+    if ($file =~ m{schedule/}) {
+        my @errors = $validator->validate($data);
+        is(scalar @errors, 0, "$file passes schema validation")
+            or diag @errors;
+    }
+}
+
 done_testing();


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/66230

This makes sure that the schedule files contain the correct structure.

Otherwise it can happen that it contains things like:

    schedule:
    - {{foo}}

Which is valid YAML, but it's actually a YAML mapping, short for:

    schedule:
    - { { foo: null }: null }

and it must be quoted.
The JSON Schema validation will make sure it is always a string.

Please see the TODO item in `t/schema/Schedule-1.yaml`. Maybe we should make sure that every schedule file contains a description.