### PR TITLE
Increase timeout for wpa_supplicant test

### DIFF
--- a/tests/console/wpa_supplicant.pm
+++ b/tests/console/wpa_supplicant.pm
@@ -46,7 +46,7 @@ sub run {
     assert_script_run 'curl -v -o wpa_supplicant-test.zip ' . data_url('wpa_supplicant/wpa_supplicant-test.zip');
     assert_script_run 'unzip wpa_supplicant-test.zip';
     record_info('Info', 'Running wpa_supplicant_test.sh');
-    assert_script_run('bash -x ./wpa_supplicant_test.sh', timeout => 300);
+    assert_script_run('bash -x ./wpa_supplicant_test.sh', timeout => 600);
     # unregister SDK
     if (is_sle && !main_common::is_updates_tests()) {
         remove_suseconnect_product(get_addon_fullname('phub'));


### PR DESCRIPTION
We noticed in at least [one case](https://openqa.opensuse.org/tests/1248934#step/wpa_supplicant/17) a timeout failure. This commit
increases the timeout for the test script to increase the robustness
of the test case

- Related ticket: https://progress.opensuse.org/issues/66280
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/4183120
