### PR TITLE
yast2_control_center: do not use wait_still_screen after search

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -40,9 +40,6 @@ sub search {
         send_key 'backspace';
     }
     wait_screen_change { type_string $name; } if $name;
-    # After typing some icons get detected before it's filetered
-    # Adding extra sync point before trying to click
-    wait_still_screen 3;
 }
 
 sub start_addon_products {


### PR DESCRIPTION
The idea of this was to await the search result filter to have happened before
then clicking the right module to start.

The problem though is that the control_center has a blinking cursor in the search field
and wait_still_screen can never succeed (it always waits for the 30s timeout)

We're better off to create larger needles (e.g including the category header) and then define
a click area for assert_and_click to have proper coordinates

- Related ticket: https://progress.opensuse.org/issues/66295
- Needles: To be seen
- Verification run: https://openqa.opensuse.org/tests/1250100
