### PR TITLE
Add btrfsmaintenance test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1799,6 +1799,7 @@ sub load_extra_tests_filesystem {
                 loadtest "console/btrfs_send_receive";
             }
         }
+        loadtest "console/btrfsmaintenance";
     }
     loadtest 'console/snapper_undochange';
     loadtest 'console/snapper_create';

--- a/schedule/qam/12-SP1/mau-filesystem.yaml
+++ b/schedule/qam/12-SP1/mau-filesystem.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-filesystem
-description: Filesystem tests on Maintenance prepared image 
+description: Filesystem tests on Maintenance prepared image
 vars:
   COLLECT_COREDUMPS: '1'
 schedule:

--- a/schedule/qam/12-SP2/mau-filesystem.yaml
+++ b/schedule/qam/12-SP2/mau-filesystem.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-filesystem
-description: Filesystem tests on Maintenance prepared image 
+description: Filesystem tests on Maintenance prepared image
 vars:
   COLLECT_COREDUMPS: '1'
 schedule:
@@ -13,6 +13,7 @@ schedule:
 - console/lvm
 - console/btrfs_autocompletion
 - console/btrfs_qgroups
+- console/btrfsmaintenance
 - console/snapper_cleanup
 - console/btrfs_send_receive
 - console/snapper_undochange

--- a/schedule/qam/12-SP3/mau-filesystem.yaml
+++ b/schedule/qam/12-SP3/mau-filesystem.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-filesystem
-description: Filesystem tests on Maintenance prepared image 
+description: Filesystem tests on Maintenance prepared image
 vars:
   COLLECT_COREDUMPS: '1'
 schedule:
@@ -13,6 +13,7 @@ schedule:
 - console/lvm
 - console/btrfs_autocompletion
 - console/btrfs_qgroups
+- console/btrfsmaintenance
 - console/snapper_cleanup
 - console/btrfs_send_receive
 - console/snapper_undochange

--- a/schedule/qam/12-SP4/mau-filesystem.yaml
+++ b/schedule/qam/12-SP4/mau-filesystem.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-filesystem
-description: Filesystem tests on Maintenance prepared image 
+description: Filesystem tests on Maintenance prepared image
 vars:
   COLLECT_COREDUMPS: '1'
 schedule:
@@ -13,6 +13,7 @@ schedule:
 - console/lvm
 - console/btrfs_autocompletion
 - console/btrfs_qgroups
+- console/btrfsmaintenance
 - console/snapper_cleanup
 - console/btrfs_send_receive
 - console/snapper_undochange

--- a/schedule/qam/12-SP5/mau-filesystem.yaml
+++ b/schedule/qam/12-SP5/mau-filesystem.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-filesystem
-description: Filesystem tests on Maintenance prepared image 
+description: Filesystem tests on Maintenance prepared image
 vars:
   COLLECT_COREDUMPS: '1'
 schedule:
@@ -15,6 +15,7 @@ schedule:
 - console/btrfs_qgroups
 - console/snapper_cleanup
 - console/btrfs_send_receive
+- console/btrfsmaintenance
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm

--- a/schedule/qam/15-SP1/mau-filesystem.yaml
+++ b/schedule/qam/15-SP1/mau-filesystem.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-filesystem
-description: Filesystem tests on Maintenance prepared image 
+description: Filesystem tests on Maintenance prepared image
 vars:
   COLLECT_COREDUMPS: '1'
 schedule:
@@ -16,6 +16,7 @@ schedule:
 - console/btrfs_qgroups
 - console/snapper_cleanup
 - console/btrfs_send_receive
+- console/btrfsmaintenance
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm

--- a/schedule/qam/15/mau-filesystem.yaml
+++ b/schedule/qam/15/mau-filesystem.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-filesystem
-description: Filesystem tests on Maintenance prepared image 
+description: Filesystem tests on Maintenance prepared image
 vars:
   COLLECT_COREDUMPS: '1'
 schedule:
@@ -15,6 +15,7 @@ schedule:
 - console/btrfs_qgroups
 - console/snapper_cleanup
 - console/btrfs_send_receive
+- console/btrfsmaintenance
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm

--- a/tests/console/btrfsmaintenance.pm
+++ b/tests/console/btrfsmaintenance.pm
@@ -1,0 +1,79 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Check btrfsmaintenance for functionality
+# - run btrfs-balance.sh and btrfs-scrub.sh
+# - Check if btrfsmaintenance-refresh.service is present and started properly
+# - Check if btrfs-scrub is scheduled
+# - Check if btrfs-balance is scheduled
+# - Checks for btrfs-related cron jobs after uninstalling btrfsmaintenance
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+
+sub btrfs_service_unavailable {
+    my $service = $_[0];
+    # Check if the given btrfs service (e.g. scrub or balance) is enabled in one of the following methods:
+    # - via btrfsmaintenance-refresh.service
+    # - via a systemd timer service
+    # - or if known as a timer
+    if (script_run("systemctl status btrfsmaintenance-refresh.service | grep -E -v 'uninstall|none' | grep $service") == 0) {
+        record_info("btrfs-$service", "btrfs-$service enabled via btrfsmaintenance-refresh.service");
+        return 0;
+    } elsif (script_run("systemctl is-enabled btrfs-$service.timer") == 0) {
+        record_info("btrfs-$service", "btrfs-$service enabled via btrfs-$service.timer");
+        return 0;
+    } elsif (script_run("systemctl list-timers --all | grep btrfs-$service") == 0) {
+        record_info("btrfs-$service", "btrfs-$service found in list-timers");
+        return 0;
+    } else {
+        record_info("btrfs-$service", "btrfs-$service is not enabled");
+        return 1;
+    }
+}
+
+sub run {
+    # Preparation
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    if (script_run('mount | grep btrfs') != 0) {
+        record_info("btrfs-maintenance", "No btrfs volume mounted");
+    }
+    # Run balance and scrub
+    assert_script_run('/usr/share/btrfsmaintenance/btrfs-balance.sh', timeout => 300);
+    assert_script_run('/usr/share/btrfsmaintenance/btrfs-scrub.sh ',  timeout => 300);
+    assert_script_run('systemctl restart btrfsmaintenance-refresh.service');
+    assert_script_run("systemctl is-enabled btrfsmaintenance-refresh");
+    # Check if btrfs-scrub and btrfs-balance are (somehow) enabled (results only in a info write)
+    if (!is_sle('<15')) {
+        die("btrfs-scrub service not active")   if btrfs_service_unavailable("scrub");
+        die("btrfs-balance service not active") if btrfs_service_unavailable("balance");
+    }
+    # Check for crontab remnants of btrfsmaintenance after uninstall (see https://bugzilla.suse.com/show_bug.cgi?id=1159891)
+    zypper_call 'remove btrfsmaintenance';
+    if (script_run("crontab -l") == 0 && script_run('crontab -l | grep btrfs') == 0) {
+        script_run('crontab -l | grep btrfs > /var/tmp/btrfs_cron_remnants.txt');
+        upload_logs('/var/tmp/btrfs_cron_remnants.txt');
+        upload_logs("/etc/sysconfig/btrfsmaintenance", log_name => "sysconfig.txt");
+        record_info("btrfsmaintenance", "crontab - btrfs remnants detected");
+        die "btrfsmaintenance script failed";
+    }
+}
+
+sub post_run_hook {
+    # Ensure btrfsmaintenance is installed
+    zypper_call 'in btrfsmaintenance';
+}
+1;


### PR DESCRIPTION
Tests `btrfsmaintenance` for functionality. Tests also if removing
btrfsmaintenance leaves behind remnants in crontab
(see https://bugzilla.suse.com/show_bug.cgi?id=1159891).

- Related ticket: https://progress.opensuse.org/issues/65606
- Needles: N/A
- Verification run: [SLE15-SP1](https://openqa.suse.de/tests/4209246) | [SLE15](https://openqa.suse.de/tests/4209247) | [SLE12-SP5](https://openqa.suse.de/tests/4209248) | [SLE12-SP4](https://openqa.suse.de/tests/4209249) | [SLE12-SP3](https://openqa.suse.de/tests/4209250) | [SLE12-SP2](https://openqa.suse.de/tests/4209251) | [SLE12-SP1](https://openqa.suse.de/tests/4209252) | [Leap 15.2](http://phoenix-openqa.qam.suse.de/tests/836) | [Tumbleweed](http://phoenix-openqa.qam.suse.de/tests/837) | [SLE15-SP2  x86_64](https://openqa.suse.de/tests/4209255) | [SLE15-SP2 ppc64le](https://openqa.suse.de/tests/4209256)