### PR TITLE
Storage: Add test description to xunit file

### DIFF
--- a/data/kernel/post_process
+++ b/data/kernel/post_process
@@ -34,7 +34,13 @@ generate_xunit_report() {
 	for file in $(find ./results/$dir -type f)
 	do
 		test_group=$(basename `dirname $file`)
-		test_name=`basename $file`
+
+		if [[ "$line" == "description"* ]]
+		then
+			test_name=${line#'description'}
+		else
+			test_name=`basename $file`
+		fi
 		while IFS= read -r line
 		do
 			if [[ "$line" == "status"* ]]


### PR DESCRIPTION
As the blktests is adding now test description to .out files, we can
have that displayed in the openQA webUI. The patch is simply stripping
the word 'description' from the given line and displayes the reminder
as the test name. In case the .out file has no description, the name
will default to file name

- Related ticket: https://progress.opensuse.org/issues/66319
- Verification run: https://openqa.suse.de/tests/4183340
