### PR TITLE
nautilus-open_ftp: behave more like a user would

### DIFF
--- a/tests/x11/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11/gnomecase/nautilus_open_ftp.pm
@@ -9,11 +9,6 @@
 # without any warranty.
 
 # Summary: Test nautilus open ftp
-# - Launch nautilus
-# - Inside nautilus, open "ftp://ftp.suse.com" and check
-# - Send "SHIFT-F10" and check
-# - Umount ftp
-# - Close nautilus
 # Maintainer: Oliver Kurz <okurz@suse.de>
 # Tags: tc#1436143
 
@@ -31,15 +26,10 @@ sub run {
     assert_screen 'nautilus-ftp-login';
     send_key 'ret';
     assert_screen 'nautilus-ftp-suse-com';
-    if (is_sle('12-SP2+') || is_tumbleweed) {
-        assert_and_click 'unselected-pub';
-        assert_and_click 'ftp-path-selected';
-        wait_still_screen(2);
-    }
-    send_key 'shift-f10';
+    assert_and_click('ftp-path-selected', button => 'right');
     assert_screen 'nautilus-ftp-rightkey-menu';
     # unmount ftp
-    send_key 'alt-u';
+    assert_and_click 'nautilus-unmount';
     assert_screen 'nautilus-launched';
     send_key 'ctrl-w';
 }


### PR DESCRIPTION
Most users won't click an item in the location bar and then chose to perform
the action (in this case unmount) using a keyboard shortcut.
It's much more realistic for the user to click 'unmount' in this case.

This fixes the test insofar as Nautilus 3.36.2 fixed an earlier broken behavior:
  When a user selected Location 1, scrolled 60% down, then selected Location 2,
  it could happen that the newly loaded Location 2 showed at 60% scrolled down
  Newly, nautilus scrolls to the top, which in turn has the side effect that
  the focus is back in the files area, so alt-f10 would not trigger the menu
  on the item this test expects it to happen on

- Related ticket: https://progress.opensuse.org/issues/66331
- Needles: 
- Verification run: https://openqa.opensuse.org/tests/1251228
