### PR TITLE
networkd: Specify grep as a required package to be installed

### DIFF
--- a/tests/networkd/networkd_init.pm
+++ b/tests/networkd/networkd_init.pm
@@ -38,7 +38,7 @@ sub run {
     my $pkg_repo            = get_var('MIRROR_HTTP', 'dvd:/?devices=/dev/sr0');
     my $release_pkg         = 'openSUSE-release';
     my $systemd_network_pkg = (is_tumbleweed) ? 'systemd-network' : '';
-    my $pkgs_to_install     = "systemd $systemd_network_pkg shadow zypper $release_pkg vim iproute2 iputils";
+    my $pkgs_to_install     = "systemd $systemd_network_pkg shadow zypper $release_pkg vim iproute2 iputils grep";
 
     $self->setup_nspawn_container("node1", $pkg_repo, $pkgs_to_install);
     $self->setup_nspawn_container("node2", $pkg_repo, $pkgs_to_install);


### PR DESCRIPTION
The test code explicitly calls grep and it is thus our responsibility
to ensure the tool to be present.

In the past, grep used to be pulled in by every package that had %fillup_prereq
defined in the preamble (in the specific case of the networkd container, this
used to the case for issue-generator). With the fillup_prereq macro being adjusted
to the current situation, diffutils, and as a result grep (required by diffutils)
are no longer present in the dep chain

- Related ticket: https://progress.opensuse.org/issues/66373
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1254286
