### PR TITLE
Fix SAP on Public Cloud tests

### DIFF
--- a/tests/publiccloud/sles4sap.pm
+++ b/tests/publiccloud/sles4sap.pm
@@ -135,7 +135,7 @@ sub fence_node {
 sub run {
     my ($self)        = @_;
     my $timeout       = bmwqemu::scale_timeout(60);
-    my @cluster_types = split(' ', get_required_var('CLUSTER_TYPES'));
+    my @cluster_types = split(',', get_required_var('CLUSTER_TYPES'));
 
     $self->select_serial_terminal;
 


### PR DESCRIPTION
We should use `CLUSTER_TYPES=drbd,hana` syntax instead of `CLUSTER_TYPES="drbd hana"`.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/t4190084