### PR TITLE
Change autoyast profile url check, not to fail test

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -519,9 +519,11 @@ EOF
 sub test_ayp_url {
     my $ayp_url = get_var('AUTOYAST');
     if ($ayp_url =~ /^http/) {
-        die "Autoyast profile url $ayp_url is unreachable " unless head($ayp_url);
-        record_info("ayp ok", "Autoyast profile url reachable");
+        if (head($ayp_url)) {
+            record_info("ayp url ok", "Autoyast profile url $ayp_url is reachable");
+        } else {
+            record_info("Failure", "Autoyast profile url $ayp_url is unreachable");
+        }
     }
 }
-
 1;


### PR DESCRIPTION
It has occurred on my local machine that the check does not function properly. Changing the autoyast profile check from failing the installation module, to just recording the failure will help monitor if this failure happens on more local machines, without causing issues.

- Related ticket: https://progress.opensuse.org/issues/64325
- Verification run: http://falafel.suse.cz/tests/701#step/installation/1
