### PR TITLE
Wait until is test connected to the smb share

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -109,6 +109,7 @@ sub samba_client_access {
     send_key_until_needlematch("nautilus-connect-to-server", 'tab', 10, 2);
     type_string("smb://$ip");
     send_key "ret";
+    wait_still_screen(2);
 
     # Search the shared dir
     send_key_until_needlematch("nautilus-sharedir-search", 'ctrl-f', 5, 2);


### PR DESCRIPTION
Avoid race where directory search is done on the locations screen, not on smb share as expected

- Fail: https://openqa.suse.de/tests/4190273#step/usr_sbin_smbd/73
- Verification run:  https://openqa.suse.de/tests/4191477