### PR TITLE
Wait longer for apparmor configuration screen to appear

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -52,7 +52,7 @@ sub run {
         send_key 'alt-l';
     }
 
-    assert_screen([qw(yast2_apparmor_disabled yast2_apparmor_enabled)], 10);
+    assert_screen([qw(yast2_apparmor_disabled yast2_apparmor_enabled)]);
     if (match_has_tag 'yast2_apparmor_disabled') {
         send_key 'alt-e';
         assert_screen 'yast2_apparmor_enabled';


### PR DESCRIPTION
After additional apparmor packages are installed there is again visible yast2_apparmor screen, but the installed packages are still bein installed. When this whole installation process is done, then apparmor configuration screen, where can be apparmor enabled, will appear. This can take more than 10 seconds, thus use default assert_screen timeout.

- Fail: https://openqa.suse.de/tests/4190371#step/yast2_apparmor/9
- Verification run: https://openqa.suse.de/tests/4193824
