### PR TITLE
Increase timeout for qttools being installed

### DIFF
--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -37,7 +37,7 @@ sub run {
     }
     select_console 'x11';
     ensure_unlocked_desktop;
-    ensure_installed("libqt5-qttools yast2-installation");
+    ensure_installed("libqt5-qttools yast2-installation", timeout => 180);
 
     # Test designer-qt5
     x11_start_program('designer-qt5');


### PR DESCRIPTION
Followup https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10178

- Fail: https://openqa.suse.de/tests/4201935#step/libqt5_qtbase/28

