### PR TITLE
Wait for firefox to exit to avoid 'already running' pop-up

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -641,6 +641,7 @@ sub restart_firefox {
     # exit firefox properly
     wait_still_screen 2;
     $self->exit_firefox_common;
+    assert_script_run('time wait $(pidof firefox)');
     type_string "$cmd\n";
     type_string "firefox $url >>firefox.log 2>&1 &\n";
     $self->firefox_check_default;


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4202787#step/firefox_smoke/34
- Verification run:
http://10.100.12.155/tests/15457#step/firefox_smoke/25
https://openqa.suse.de/tests/4203816 15-SP2 x11
https://openqa.suse.de/tests/4203817 15-SP2 wayland
https://openqa.suse.de/tests/4203818 15-SP1 SLED
https://openqa.suse.de/tests/4203819 15-SP1 SLES