### PR TITLE
Enable and start chronyd if SUT is SLE

### DIFF
--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -51,6 +51,7 @@ schedule:
 - console/rpcbind
 - sysauth/sssd
 - console/timezone
+- console/ntp_client
 - console/procps
 - '{{lshw}}'
 - console/kmod

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -53,6 +53,7 @@ schedule:
 - console/rpcbind
 - sysauth/sssd
 - console/timezone
+- console/ntp_client
 - console/procps
 - '{{lshw}}'
 - console/kmod

--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -13,11 +13,17 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
 
     assert_script_run 'timedatectl';
+
+    if (is_sle) {
+        systemctl 'enable chronyd';
+        systemctl 'start chronyd';
+    }
 
     # ensure that ntpd is neither installed nor enabled nor active
     systemctl 'is-active ntpd',  expect_false => 1;


### PR DESCRIPTION
A chrony regression was caused by a mozilla-nss update. 
The chrony daemon needs to be enabled and started if the system is sle. 

- Related ticket: https://progress.opensuse.org/issues/65531
- Needles: No needles
- Verification run: 
15: http://angmar.suse.de/tests/1982#step/ntp_client/28
15.sp1: http://angmar.suse.de/tests/1983#step/ntp_client/28