### PR TITLE
Add HA_SAP_REPO variable for SLES4SAP PC tests

### DIFF
--- a/data/publiccloud/terraform/sap/azure.tfvars
+++ b/data/publiccloud/terraform/sap/azure.tfvars
@@ -106,10 +106,8 @@ drbd_ips = ["10.74.1.21", "10.74.1.22"]
 # Enable drbd cluster
 drbd_enabled = true
 
-# Repository url used to install HA/SAP deployment packages
-# The latest RPM packages can be found at:
-# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
-ha_sap_deployment_repo = "https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_%SLE_VERSION%"
+# HA packages repository
+ha_sap_deployment_repo = "%HA_SAP_REPO%/SLE_%SLE_VERSION%"
 
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"

--- a/data/publiccloud/terraform/sap/ec2.tfvars
+++ b/data/publiccloud/terraform/sap/ec2.tfvars
@@ -60,9 +60,8 @@ hana_cluster_vip = "192.168.1.10"
 # example : host_ips = ["10.0.0.5", "10.0.1.6"]
 host_ips = ["10.0.0.5", "10.0.1.6"]
 
-# Repository url used to install install HA/SAP deployment packages (OS version must be ommited)"
-# Contains the salt formulas
-ha_sap_deployment_repo = "https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_%SLE_VERSION%"
+# HA packages repository
+ha_sap_deployment_repo = "%HA_SAP_REPO%/SLE_%SLE_VERSION%"
 
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"

--- a/data/publiccloud/terraform/sap/gce.tfvars
+++ b/data/publiccloud/terraform/sap/gce.tfvars
@@ -64,8 +64,8 @@ host_ips = ["10.0.0.2", "10.0.0.3"]
 # Local folder where HANA installation master will be mounted
 hana_inst_folder = "/root/hana_inst_media"
 
-# HA packages Repository
-ha_sap_deployment_repo = "https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_%SLE_VERSION%"
+# HA packages repository
+ha_sap_deployment_repo = "%HA_SAP_REPO%/SLE_%SLE_VERSION%"
 
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -330,6 +330,7 @@ sub terraform_apply {
         assert_script_run('cd ' . TERRAFORM_DIR . "/$cloud_name");
         my $sap_media            = get_required_var('HANA');
         my $sap_regcode          = get_required_var('SCC_REGCODE_SLES4SAP');
+        my $ha_sap_repo          = get_required_var('HA_SAP_REPO');
         my $storage_account_name = get_var('STORAGE_ACCOUNT_NAME');
         my $storage_account_key  = get_var('STORAGE_ACCOUNT_KEY');
         my $sle_version          = get_var('FORCED_DEPLOY_REPO_VERSION') ? get_var('FORCED_DEPLOY_REPO_VERSION') : get_var('VERSION');
@@ -342,6 +343,7 @@ sub terraform_apply {
             q(%SCC_REGCODE_SLES4SAP%) => $sap_regcode,
             q(%STORAGE_ACCOUNT_NAME%) => $storage_account_name,
             q(%STORAGE_ACCOUNT_KEY%)  => $storage_account_key,
+            q(%HA_SAP_REPO%)          => $ha_sap_repo,
             q(%SLE_VERSION%)          => $sle_version
         );
         upload_logs(TERRAFORM_DIR . "/$cloud_name/terraform.tfvars", failok => 1);


### PR DESCRIPTION
A new variable needs to be added for SLES4SAP PC tests, as the repository for some HA packages can change.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/4202237
- Verification run: https://openqa.suse.de/t4203835