### PR TITLE
Remove milestone testflag to avoid test not-clean snapshot

### DIFF
--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -25,7 +25,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -99,7 +99,7 @@ sub post_run_hook {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -159,7 +159,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/console/links_https.pm
+++ b/tests/console/links_https.pm
@@ -34,7 +34,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/console/lynx_https.pm
+++ b/tests/console/lynx_https.pm
@@ -34,7 +34,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/console/openvswitch_ssl.pm
+++ b/tests/console/openvswitch_ssl.pm
@@ -77,7 +77,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/console/ssh_cleanup.pm
+++ b/tests/console/ssh_cleanup.pm
@@ -23,7 +23,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/console/ssh_pubkey.pm
+++ b/tests/console/ssh_pubkey.pm
@@ -52,7 +52,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -139,7 +139,7 @@ sub run {
 }
 
 sub test_flags {
-    return get_var('PUBLIC_CLOUD') ? {milestone => 0, no_rollback => 1} : {milestone => 1, fatal => 0};
+    return get_var('PUBLIC_CLOUD') ? {milestone => 0, no_rollback => 1} : {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -108,7 +108,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/fips/openssl/dirmngr_daemon.pm
+++ b/tests/fips/openssl/dirmngr_daemon.pm
@@ -75,7 +75,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -65,7 +65,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;


### PR DESCRIPTION
**Description**
1. Remove milestone=1 test flag from 12 test cases
2. Avoid testing under not-clean snapshot once the previous fail
------
### Test Suite (Impacted)
**group 1:  fips_ker_mode_tests_crypt_core**
- openssl_fips_alglist
- dirmngr_daemon
- sshd
- ssh_pubkey
- ssh_cleanup

**group 2. fips_ker_mode_tests_crypt_tool**
- gpg 
- clamav
- openvswitch_ssl

**group 3. fips_ker_mode_tests_crypt_web**
- links_https
- lynx_https 
- apache_ssl

**group 4. fips_ker_mode_tests_crypt_x11_s390x**
- firefox_nss
------

- Related ticket: https://progress.opensuse.org/issues/65375
- Needles: NA
- Verification run: 
   1. [**fips_ker_mode_tests_crypt_core**](https://openqa.suse.de/t4204189)
   2. [**fips_ker_mode_tests_crypt_tool**](https://openqa.suse.de/t4204685)
   3. [**fips_ker_mode_tests_crypt_web**](https://openqa.suse.de/t4204852)
   4. [**fips_ker_mode_tests_crypt_x11_s390x**](https://openqa.suse.de/t4204980)
