### PR TITLE
Close broken opensuse-welcome window and restart it

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(
   handle_login
   handle_logout
   handle_relogin
+  handle_welcome_screen
   select_user_gnome
   turn_off_kde_screensaver
   turn_off_gnome_screensaver
@@ -333,6 +334,22 @@ Kill broken opensuse-welcome window and restart it properly to workaround boo#11
 sub workaround_boo1170586 {
     x11_start_program('killall /usr/bin/opensuse-welcome', target_match => 'generic-desktop');
     x11_start_program('opensuse-welcome');
+}
+
+=head2 handle_welcome_screen
+
+ handle_welcome_screen([timeout => $timeout]);
+
+openSUSE Welcome window should be auto-launched.
+Disable auto-launch on next boot and close application.
+Also handle workarounds when needed.
+
+=cut
+sub handle_welcome_screen {
+    my (%args) = @_;
+    assert_screen([qw(opensuse-welcome opensuse-welcome-boo1170586)], $args{timeout});
+    workaround_boo1170586 if match_has_tag("opensuse-welcome-boo1170586");
+    untick_welcome_on_next_startup;
 }
 
 1;

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   turn_off_gnome_screensaver
   turn_off_gnome_suspend
   untick_welcome_on_next_startup
+  workaround_boo1170586
 );
 
 =head1 X11_UTILS
@@ -320,6 +321,18 @@ sub untick_welcome_on_next_startup {
         last                                          if check_screen("generic-desktop", timeout => 5);
         die "Unable to close openSUSE Welcome screen" if $retry == 5;
     }
+}
+
+=head2 workaround_boo1170586
+
+ workaround_boo1170586();
+
+Kill broken opensuse-welcome window and restart it properly to workaround boo#1170586.
+
+=cut
+sub workaround_boo1170586 {
+    x11_start_program('killall /usr/bin/opensuse-welcome', target_match => 'generic-desktop');
+    x11_start_program('opensuse-welcome');
 }
 
 1;

--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -16,10 +16,11 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use x11utils 'untick_welcome_on_next_startup';
+use x11utils qw(untick_welcome_on_next_startup workaround_boo1170586);
 
 sub run {
-    assert_screen("opensuse-welcome");
+    assert_screen([qw(opensuse-welcome opensuse-welcome-boo1170586)]);
+    workaround_boo1170586 if match_has_tag("opensuse-welcome-boo1170586");
     untick_welcome_on_next_startup;
 }
 

--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -16,12 +16,10 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use x11utils qw(untick_welcome_on_next_startup workaround_boo1170586);
+use x11utils 'handle_welcome_screen';
 
 sub run {
-    assert_screen([qw(opensuse-welcome opensuse-welcome-boo1170586)]);
-    workaround_boo1170586 if match_has_tag("opensuse-welcome-boo1170586");
-    untick_welcome_on_next_startup;
+    handle_welcome_screen;
 }
 
 sub test_flags {

--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -145,11 +145,7 @@ sub run {
     assert_screen "testUser-login-dm";
     type_string "$pwd4newUser\n";
     # Handle welcome screen, when needed
-    if (opensuse_welcome_applicable) {
-        assert_screen 'opensuse-welcome', 120;
-        # Close welcome screen
-        untick_welcome_on_next_startup;
-    }
+    handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
     assert_screen "generic-desktop", 120;
     switch_user;
     send_key "esc";

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use x11utils qw(handle_login handle_logout untick_welcome_on_next_startup);
+use x11utils qw(handle_login handle_logout handle_welcome_screen);
 use main_common 'opensuse_welcome_applicable';
 
 sub ensure_multi_user_target {
@@ -81,11 +81,7 @@ sub run {
     # Make sure screen changed before calling handle_login function (for slow workers)
     wait_still_screen;
     handle_login($user, 1);
-    if (opensuse_welcome_applicable) {
-        assert_screen 'opensuse-welcome', 120;
-        # Close welcome screen
-        untick_welcome_on_next_startup;
-    }
+    handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
     assert_screen 'generic-desktop', 60;
     # verify correct user is logged in
     x11_start_program('xterm');


### PR DESCRIPTION
to workaround boo#1170586

- Related ticket: https://progress.opensuse.org/issues/66176
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/d78876a9056223f2ac3f5776bdf00567ea550650
- Verification run: 
  * aarch64 create_hdd_gnome: https://openqa.opensuse.org/t1259161
  * x86_64 create_hdd_gnome: https://openqa.opensuse.org/t1259156
  * x86_64 extra_tests_on_gnome: https://openqa.opensuse.org/t1259158
