### PR TITLE
Remove workarounds in yast2 nis mm tests

### DIFF
--- a/data/x11/workaround_ypbind.xml
+++ b/data/x11/workaround_ypbind.xml
@@ -1,9 +1,0 @@
-<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<service>
-  <short>NIS</short>
-  <description>NIS workaround</description>
-  <port protocol=\"tcp\" port=\"111\"/>
-  <port protocol=\"tcp\" port=\"639\"/>
-  <port protocol=\"udp\" port=\"111\"/>
-  <port protocol=\"udp\" port=\"637\"/>
-</service>

--- a/data/x11/workaround_ypserv.xml
+++ b/data/x11/workaround_ypserv.xml
@@ -1,9 +1,0 @@
-<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<service>
-  <short>NIS</short>
-  <description>NIS workaround</description>
-  <port protocol=\"tcp\" port=\"111\"/>
-  <port protocol=\"udp\" port=\"111\"/>
-  <port protocol=\"tcp\" port=\"913\"/>
-  <port protocol=\"udp\" port=\"913\"/>
-</service>


### PR DESCRIPTION
It was somehow decided that we don't support auto-configuration of firewall for nis and nfs, see https://bugzilla.suse.com/show_bug.cgi?id=1083487#c36. Therefore, adding a service file to activate a button that the customer may never see does not make sense : it's a bit like testing an easter egg. Then that does not even work, as shows the next soft failure : we have to stop the firewall despite having quoted "open firewall ports". So the easter egg does not even open the right ports anyway.

- Related ticket: https://progress.opensuse.org/issues/65352
- Needles: 
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1372
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/660

- Verification run: 
TW http://waaa-amazing.suse.cz/tests/12048 http://waaa-amazing.suse.cz/tests/12047
SLE http://waaa-amazing.suse.cz/tests/12044 http://waaa-amazing.suse.cz/tests/12043
