### PR TITLE
MicroOS 15.2 test fixes

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -347,6 +347,10 @@ sub uefi_bootmenu_params {
         for (1 .. 10) { send_key "down"; }
     }
     else {
+        if (is_caasp) {
+            # skip healthchecker lines
+            for (1 .. 5) { send_key "down"; }
+        }
         for (1 .. 2) { send_key "down"; }
         send_key "end";
         # delete "keep" word
@@ -362,6 +366,9 @@ sub uefi_bootmenu_params {
         }
         sleep 5;
         for (1 .. 4) { send_key "down"; }
+        if (is_caasp) {
+            for (1 .. 7) { send_key "down"; }
+        }
     }
 
     send_key "end";

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -86,7 +86,7 @@ if (get_var 'STACK_ROLE') {
     loadtest 'shutdown/shutdown';
 }
 else {
-    load_boot_from_dvd_tests;
+    load_boot_from_dvd_tests unless get_var 'BOOT_HDD_IMAGE';
     if (get_var 'SYSTEM_ROLE') {
         load_installation_tests;
     }

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -60,7 +60,7 @@ sub check_package {
         my ($in_ver, $in_rel) = split '-', $in_vr;
         my ($up_ver, $up_rel) = split '-', script_output("rpm -q --qf '%{V}-%{R}' $package");
 
-        $up_rel =~ s/lp// if is_leap;
+        $up_rel =~ s/lp\d+\.(?:mo\.)?//;
         $in_ver = version->declare($in_ver);
         $in_rel = version->declare($in_rel);
         $up_ver = version->declare($up_ver);
@@ -79,7 +79,7 @@ sub run {
 
     script_run "rebootmgrctl set-strategy off";
 
-    if (is_leap && get_var('BETA')) {
+    if (get_var('BETA')) {
         record_info 'Remove pkgs', 'Remove preinstalled packages on Leap BETA';
         trup_call "pkg remove update-test-[^t]*";
         process_reboot 1;


### PR DESCRIPTION
Fixes booting and transactional_update for MicroOS on 15.2.

Removes the need for #10161 for MicroOS

- Related ticket: https://progress.opensuse.org/issues/66200
- Verification run: http://tortuga.suse.de/tests/54
  http://tortuga.suse.de/tests/55
  http://tortuga.suse.de/tests/56