### PR TITLE
Extend the timeout for assert screen until the snap-default screen show up

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -260,7 +260,7 @@ sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
     # assert needle to avoid send down key early in grub_test_snapshot.
-    assert_screen 'snap-default' if get_var('OFW');
+    assert_screen('snap-default', 60) if get_var('OFW');
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);


### PR DESCRIPTION
Extend the timeout for assert screen until the snap-default screen show up

- Related ticket: https://progress.opensuse.org/issues/64258
- Verification run: https://openqa.nue.suse.com/tests/4210572#
