### PR TITLE
[virt_autotest] fix libvirt_routed_virtual_network test failure on sle xen hosts

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -85,6 +85,12 @@ sub test_network_interface {
         assert_script_run("! ssh root\@$addr 'ping -I $nic -c 3 $target' || true", 60);
     }
     save_screenshot;
+
+    # Restore the network interface to the default for the Xen guests
+    if (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) {
+        assert_script_run("ssh root\@$guest 'cd /etc/sysconfig/network/; cp ifcfg-eth0 ifcfg-$nic'");
+    }
+
 }
 
 sub download_network_cfg {

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -71,8 +71,9 @@ sub run_test {
     #Restart libvirtd service
     virt_autotest::virtual_network_utils::restart_libvirtd();
 
+    #Skip restart network service due to bsc#1166570
     #Restart network service
-    virt_autotest::virtual_network_utils::restart_network();
+    #virt_autotest::virtual_network_utils::restart_network();
 
 }
 


### PR DESCRIPTION
Refer to the existed test_network_interface fun, which will be changed the network interface to use DHCP configuration as below:
BOOTPROTO='dhcp'
However, this changed do not worked with libvirt_routed_virtual_network for our Xen guest. 

Also, the current test_network_interface fun do not effect KVM guests as confirmed. So, we just need to take care about Xen guests here.
https://openqa.nue.suse.com/tests/4201185

Moreover,please refer to the following link for more details:
https://openqa.nue.suse.com/tests/4201186#step/libvirt_routed_virtual_network/103

Confirm that our Xen guests required the following network interface configuration, during libvirt_routed_virtual_network: 
BOOTPROTO='dhcp'
STARTMODE='auto'

So, after finished  test_network_interface fun, just restore the test interface configuration here
for Xen guests.

- Verification run: 
  gi-guest_developing-on-host_developing-xen-dev
  http://10.67.19.82/tests/471 
  gi-guest_sles12sp5-on-host_developing-xen-dev
  http://10.67.19.82/tests/473
  gi-guest_sles15sp1-on-host_developing-xen-dev
  http://10.67.19.82/tests/474
  gi-guest_developing-on-host_sles12sp5-xen-dev
  http://10.67.19.82/tests/475
  gi-guest_developing-on-host-developing-kvm
  http://10.67.19.82/tests/469
  gi-guest_developing-on-host_sles12sp5-kvm-dev
  http://10.67.19.82/tests/479