### PR TITLE
New Kernel livepatch installation checks

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+package klp;
+
+use warnings;
+use strict;
+
+use Exporter 'import';
+
+use testapi;
+use utils;
+use version_utils 'is_sle';
+
+our @EXPORT = qw(
+  install_klp_product
+);
+
+sub install_klp_product {
+    my $arch    = get_required_var('ARCH');
+    my $version = get_required_var('VERSION');
+    my $release_override;
+    my $lp_product;
+    my $lp_module;
+    if ($version eq '12') {
+        $release_override = '-d';
+    }
+    if (!is_sle('>=12-SP3')) {
+        $version = '12';
+    }
+    # SLE15 has different structure of modules and products than SLE12
+    if (is_sle('15+')) {
+        $lp_product = 'sle-module-live-patching';
+        $lp_module  = 'SLE-Module-Live-Patching';
+    }
+    else {
+        $lp_product = 'sle-live-patching';
+        $lp_module  = 'SLE-Live-Patching';
+    }
+
+    #install kgraft product
+    zypper_call("ar http://download.suse.de/ibs/SUSE/Products/$lp_module/$version/$arch/product/ kgraft-pool");
+    zypper_call("ar $release_override http://download.suse.de/ibs/SUSE/Updates/$lp_module/$version/$arch/update/ kgraft-update");
+    zypper_call("ref");
+    zypper_call("in -l -t product $lp_product", exitcode => [0, 102, 103]);
+    zypper_call("mr -e kgraft-update");
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -259,6 +259,7 @@ sub is_ltp_test {
 sub is_kernel_test {
     return is_ltp_test() ||
       (get_var('QA_TEST_KLP_REPO')
+        || get_var('INSTALL_KLP_PRODUCT')
         || get_var('INSTALL_KOTD')
         || get_var('VIRTIO_CONSOLE_TEST')
         || get_var('BLKTESTS')

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -89,6 +89,10 @@ sub load_kernel_tests {
         loadtest_kernel 'boot_ltp';
         loadtest_kernel 'qa_test_klp';
     }
+    elsif (get_var('INSTALL_KLP_PRODUCT')) {
+        loadtest_kernel 'boot_ltp';
+        loadtest_kernel 'install_klp_product';
+    }
     elsif (get_var('VIRTIO_CONSOLE_TEST')) {
         loadtest_kernel 'virtio_console';
         loadtest_kernel 'virtio_console_long_output';

--- a/tests/kernel/install_klp_product.pm
+++ b/tests/kernel/install_klp_product.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This module installs the kernel livepatching product and
+#          verifies the installation.
+# Maintainer: Nicolai Stange <nstange@suse.de>
+
+use 5.018;
+use warnings;
+use strict;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use klp;
+use power_action_utils 'power_action';
+
+sub run {
+    my $self = shift;
+    my $kver;
+    my $kflavor;
+
+    my $output = script_output('uname -r');
+    if ($output =~ /^([0-9]+([-.][0-9a-z]+)*)-([a-z][a-z0-9]*)/i) {
+        $kver    = $1;
+        $kflavor = $3;
+    }
+    else {
+        die "Failed to parse 'uname -r' output: '$output'";
+    }
+
+    install_klp_product();
+    my $klp_pkg = find_installed_klp_pkg($kver, $kflavor);
+    if (!$klp_pkg) {
+        die "No installed kernel livepatch package for current kernel found";
+    }
+
+    verify_klp_pkg_patch_is_active($klp_pkg);
+    verify_klp_pkg_installation($klp_pkg);
+
+    # Reboot and check that the livepatch gets loaded again.
+    power_action('reboot', textmode => 1);
+    $self->wait_boot;
+    $self->select_serial_terminal;
+    verify_klp_pkg_patch_is_active($klp_pkg);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -193,7 +193,6 @@ sub prepare_kgraft {
         #disable kgraf-test-repo for while
         zypper_call("mr -d $cur_repo");
 
-        fully_patch_system;
         foreach my $pkg (@$pkgs) {
             my $cur_klp_pkg = is_klp_pkg($pkg);
             if ($cur_klp_pkg && $$cur_klp_pkg{kflavor} eq 'default') {
@@ -212,6 +211,8 @@ sub prepare_kgraft {
     if (!$incident_klp_pkg) {
         die "No kernel livepatch package found";
     }
+
+    fully_patch_system;
 
     my $kversion       = zypper_search(q(-s -x kernel-default));
     my $wanted_version = right_kversion($kversion, $incident_klp_pkg);

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -19,6 +19,7 @@ use utils;
 use version_utils 'is_sle';
 use qam;
 use kernel 'remove_kernel_packages';
+use klp;
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
 use Utils::Backends 'use_ssh_serial_console';
@@ -178,33 +179,8 @@ sub install_lock_kernel {
 
 sub prepare_kgraft {
     my ($repo, $incident_id) = @_;
-    my $arch    = get_required_var('ARCH');
-    my $version = get_required_var('VERSION');
-    my $release_override;
-    my $lp_product;
-    my $lp_module;
-    if ($version eq '12') {
-        $release_override = '-d';
-    }
-    if (!is_sle('>=12-SP3')) {
-        $version = '12';
-    }
-    # SLE15 has different structure of modules and products than SLE12
-    if (is_sle('15+')) {
-        $lp_product = 'sle-module-live-patching';
-        $lp_module  = 'SLE-Module-Live-Patching';
-    }
-    else {
-        $lp_product = 'sle-live-patching';
-        $lp_module  = 'SLE-Live-Patching';
-    }
 
-    #install kgraft product
-    zypper_call("ar http://download.suse.de/ibs/SUSE/Products/$lp_module/$version/$arch/product/ kgraft-pool");
-    zypper_call("ar $release_override http://download.suse.de/ibs/SUSE/Updates/$lp_module/$version/$arch/update/ kgraft-update");
-    zypper_call("ref");
-    zypper_call("in -l -t product $lp_product", exitcode => [0, 102, 103]);
-    zypper_call("mr -e kgraft-update");
+    install_klp_product;
 
     #add repository with tested patch
     my @repos = split(",", $repo);

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -279,6 +279,8 @@ sub update_kgraft {
         elsif (!klp_pkg_eq($installed_klp_pkg, $incident_klp_pkg)) {
             die "Unexpected kernel livepatch package installed after update";
         }
+
+        verify_klp_pkg_installation($incident_klp_pkg);
     }
 }
 

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -180,8 +180,6 @@ sub install_lock_kernel {
 sub prepare_kgraft {
     my ($repo, $incident_id) = @_;
 
-    install_klp_product;
-
     #add repository with tested patch
     my $incident_klp_pkg;
     my @all_pkgs;
@@ -217,6 +215,8 @@ sub prepare_kgraft {
     my $kversion       = zypper_search(q(-s -x kernel-default));
     my $wanted_version = right_kversion($kversion, $incident_klp_pkg);
     install_lock_kernel($wanted_version);
+
+    install_klp_product;
 
     if (check_var('REMOVE_KGRAFT', '1') && @all_pkgs) {
         my $pversion = join(' ', map { $$_{name} } @all_pkgs);

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -280,6 +280,7 @@ sub update_kgraft {
             die "Unexpected kernel livepatch package installed after update";
         }
 
+        verify_klp_pkg_patch_is_active($incident_klp_pkg);
         verify_klp_pkg_installation($incident_klp_pkg);
     }
 }
@@ -331,6 +332,7 @@ sub run {
             power_action('reboot', textmode => 1);
 
             boot_to_console($self);
+            verify_klp_pkg_patch_is_active($incident_klp_pkg);
         }
 
         kgraft_state;

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -183,30 +183,43 @@ sub prepare_kgraft {
     install_klp_product;
 
     #add repository with tested patch
+    my $incident_klp_pkg;
+    my @all_pkgs;
     my @repos = split(",", $repo);
     while (my ($i, $val) = each(@repos)) {
-        zypper_call("ar $val kgraft-test-repo-$i");
-
-        my $kversion = zypper_search(q(-s -x kernel-default));
-        my $pkgs     = zypper_search("-s -t package -r kgraft-test-repo-$i");
-
+        my $cur_repo = "kgraft-test-repo-$i";
+        zypper_call("ar $val $cur_repo");
+        my $pkgs = zypper_search("-s -t package -r $cur_repo");
         #disable kgraf-test-repo for while
-        zypper_call("mr -d kgraft-test-repo-$i");
+        zypper_call("mr -d $cur_repo");
 
         fully_patch_system;
         foreach my $pkg (@$pkgs) {
-            my $incident_klp_pkg = is_klp_pkg($pkg);
-            if ($incident_klp_pkg && $$incident_klp_pkg{kflavor} eq 'default') {
-                my $wanted_version = right_kversion($kversion, $incident_klp_pkg);
-                install_lock_kernel($wanted_version);
-                last;
+            my $cur_klp_pkg = is_klp_pkg($pkg);
+            if ($cur_klp_pkg && $$cur_klp_pkg{kflavor} eq 'default') {
+                if ($incident_klp_pkg) {
+                    die "Multiple kernel live patch packages found: \"$$incident_klp_pkg{name}-$$incident_klp_pkg{version}\" and \"$$cur_klp_pkg{name}-$$cur_klp_pkg{version}\"";
+                }
+                else {
+                    $incident_klp_pkg = $cur_klp_pkg;
+                }
             }
         }
 
-        my $pversion = join(' ', map { $$_{name} } @$pkgs);
-        if (check_var('REMOVE_KGRAFT', '1')) {
-            zypper_call("rm " . $pversion);
-        }
+        push @all_pkgs, @$pkgs;
+    }
+
+    if (!$incident_klp_pkg) {
+        die "No kernel livepatch package found";
+    }
+
+    my $kversion       = zypper_search(q(-s -x kernel-default));
+    my $wanted_version = right_kversion($kversion, $incident_klp_pkg);
+    install_lock_kernel($wanted_version);
+
+    if (check_var('REMOVE_KGRAFT', '1') && @all_pkgs) {
+        my $pversion = join(' ', map { $$_{name} } @all_pkgs);
+        zypper_call("rm " . $pversion);
     }
 
     power_action('reboot', textmode => 1);


### PR DESCRIPTION
Implement some sanity checks to be run after kernel livepatch package installation.

Tested locally on SLE12-SP3, SLE12-SP5 and SLE15-SP1.

Highlevel overview:
- Cleanup existing kernel livepatch incident related code in update_kernel.pm.
- Make update_kernel.pm verify the kernel livepatch package installation (initrd updated, uname -v changed, etc.). Note that this takes effect for kernel livepatch incidents only.
- Implement the new kernel/install_klp_product.pm, which does the same, but for the initial livepatches submitted alongside regular kernel MUs.

- Related ticket: None AFAIK, requested internally by @lpechacek
- Needles: No needles update needed.
- Verification run: Only locally, unfortunately, as I don't have access to a public instance. Also, actual pending incidents would be required and currently there aren't any.