### PR TITLE
Handle disabled display within ensure_unlocked_desktop

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -121,7 +121,7 @@ sub ensure_unlocked_desktop {
                 }
                 else {
                     diag("Next loop ($counter), Generic desktop didn't match");
-                    record_soft_failure('bsc#1168979') if is_aarch64;
+                    record_info('Screen seems frozen', 'Might be consequence of bsc#1168979') if is_aarch64;
                     next;    # most probably screen is locked
                 }
             }


### PR DESCRIPTION
As a consequence of bsc#1168979 and possibly boo#1168992 when the SUT's
power saving kicks in, the screen buffer is not properly updated once it
comes back, causing openQA to see the wrong screen, upon a keypress the
SUT ends up believing that it should expect i.e generic desktop, when in
reality the screen is turned off (because again, the power saving mode
is just kicking in), this causes openQA to detect the wrong screen and
fail the test, when actually the system is still working.

Matching the guest disabled display screen, helps us to detect these
situations, avoiding entering into the wrong loop (see
https://openqa.opensuse.org/tests/1259244#step/consoletest_finish/13)

Sometimes the screenbuffer does not refresh, to workaround this
issue we now send 'Shift' to the SUT

Test is simply logging into user console, waiting for either 600 or 300 
seconds and then switching back, only to find (sometimes, when the time is 
600 secs) a screen with old buffer data (that matches generic desktop)

See: https://progress.opensuse.org/issues/64812

Verifications: https://openqa.suse.de/tests/overview?groupid=96&build=foursixnine_189.1&distri=sle&version=15-SP2&flavor=black-display-workaround-now-finally-really-finally