### PR TITLE
Disable screensaver module; openqa: Simplify webui/test_results

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1471,6 +1471,7 @@ sub load_extra_tests_texlive {
 }
 
 sub load_extra_tests_openqa_bootstrap {
+    loadtest 'x11/disable_screensaver';
     if (get_var 'BOOTSTRAP_CONTAINER') {
         loadtest 'openqa/install/openqa_bootstrap_container';
     }

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -34,6 +34,7 @@ our @EXPORT = qw(
   handle_relogin
   handle_welcome_screen
   select_user_gnome
+  turn_off_screensaver
   turn_off_kde_screensaver
   turn_off_gnome_screensaver
   turn_off_gnome_suspend
@@ -310,6 +311,21 @@ Disable suspend in gnome. To be called from a command prompt, for example an xte
 =cut
 sub turn_off_gnome_suspend {
     script_run 'gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type \'nothing\'';
+}
+
+=head2 turn_off_screensaver
+
+ turn_off_screensaver();
+
+Turns off the screensaver depending on desktop environment
+
+=cut
+sub turn_off_screensaver {
+    return turn_off_kde_screensaver if check_var('DESKTOP', 'kde');
+    die "Unsupported desktop '" . get_var('DESKTOP', '') . "'" unless check_var('DESKTOP', 'gnome');
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver;
+    script_run 'exit', 0;
 }
 
 =head2 untick_welcome_on_next_startup

--- a/tests/x11/disable_screensaver.pm
+++ b/tests/x11/disable_screensaver.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Disable screensaver depending on desktop environment
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use x11utils 'turn_off_screensaver';
+
+sub run {
+    select_console 'x11';
+    turn_off_screensaver;
+}
+
+1;


### PR DESCRIPTION
This simplifies the code, gets rid of "brute-force refreshing" with
pressing 'f5' repeatedly as well as speeds up the test.by about one
minute.

EDIT: Verification run: ~~https://openqa.opensuse.org/1259293~~

```
$ for i in https://openqa.opensuse.org/tests/1262098 https://openqa.opensuse.org/tests/1259200; do openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10220 $i; done
```

* opensuse-Tumbleweed-DVD-x86_64-Build20200509-openqa_bootstrap@64bit -> https://openqa.opensuse.org/t1263314
* *opensuse-Tumbleweed-DVD-aarch64-Build20200506-openqa_bootstrap@aarch64 -> https://openqa.opensuse.org/t1263315
