### PR TITLE
SR-IOV Ethernet devices pci passthrough automation

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -106,14 +106,17 @@ sub setup_console_in_grub {
             # autoballoning is disabled since sles15sp1 beta2. we use default dom0_ram which is '10% of total ram + 1G'
             # while for older release, bsc#1107572 "This dom0 memory amount works well with hosts having 4 to 8 Gigs of RAM"
             # considering of one SUT in OSD with 4G ram only, we set dom0_mem=2G
-            my $dom0_mem_options = "";
+            my $dom0_options = "";
             if (is_sle('<=12-SP4') || is_sle('=15')) {
-                $dom0_mem_options = "dom0_mem=2048M,max:2048M";
+                $dom0_options = "dom0_mem=2048M,max:2048M";
+            }
+            if (get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH")) {
+                $dom0_options .= " iommu=on";
             }
             $cmd
               = "sed -ri '/multiboot/ "
               . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
-              . "/multiboot/ s/\$/ $dom0_mem_options console=com2,115200 log_lvl=all guest_loglvl=all sync_console $com_settings/;}; "
+              . "/multiboot/ s/\$/ $dom0_options console=com2,115200 log_lvl=all guest_loglvl=all sync_console $com_settings/;}; "
               . "' $grub_cfg_file";
             assert_script_run($cmd);
             save_screenshot;

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -1,0 +1,88 @@
+# SUSE's openQA tests
+#
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: virtualization test utilities.
+# Maintainer: Julie CAO <jcao@suse.com>
+
+package virt_autotest::utils;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use utils;
+use testapi;
+
+our @EXPORT
+  = qw(is_fv_guest is_pv_guest is_xen_host is_kvm_host check_host check_guest print_cmd_output_to_file);
+
+#return 1 if it is a fv guest judging by name
+#feel free to extend to support more cases
+sub is_fv_guest {
+    my $guest = shift;
+    return $guest =~ /\bfv\b/ || $guest =~ /\bhvm\b/;
+}
+
+#return 1 if it is a pv guest judging by name
+#feel free to extend to support more cases
+sub is_pv_guest {
+    my $guest = shift;
+    return $guest =~ /\bpv\b/;
+}
+
+#return 1 if test is expected to run on KVM hypervisor
+sub is_kvm_host {
+    return check_var("SYSTEM_ROLE", "kvm") || check_var("HOST_HYPERVISOR", "kvm");
+}
+
+#return 1 if test is expected to run on XEN hypervisor
+sub is_xen_host {
+    return get_var("XEN") || check_var("SYSTEM_ROLE", "xen") || check_var("HOST_HYPERVISOR", "xen");
+}
+
+#check host to make sure it works well
+#welcome everybody to extend this function
+sub check_host {
+
+}
+
+#check guest to make sure it works well
+#welcome everybody to extend this function
+sub check_guest {
+    my $vm = shift;
+
+    #check if guest is still alive
+    validate_script_output "virsh domstate $vm", sub { /running/ };
+
+    #TODO: other checks like checking journals from guest
+    #need check the oops bug
+
+}
+
+#ammend the output of the command to an existing log file
+#passing guest name or an remote IP as the 3rd parameter if running command in a remote machine
+sub print_cmd_output_to_file {
+    my ($cmd, $file, $machine) = @_;
+
+    $cmd = "ssh root\@$machine \"" . $cmd . "\"" if $machine;
+    script_run "echo -e \"\n# $cmd\" >> $file";
+    script_run "$cmd >> $file";
+
+}
+
+1;

--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -143,6 +143,7 @@ sub post_fail_hook {
     #(caller(0))[3] can help pass calling subroutine name into called subroutine
     $self->junit_log_provision((caller(0))[3]) if get_var("VIRT_AUTOTEST");
     virt_utils::upload_supportconfig_log;
+    $self->upload_coredumps;
     #(caller(0))[0] can help pass calling package name into called subroutine
     virt_utils::upload_virt_logs("/var/log/libvirt", (caller(0))[0] . "-libvirt-logs");
     $self->SUPER::post_fail_hook;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -779,8 +779,9 @@ elsif (get_var("VIRT_AUTOTEST")) {
                 loadtest "virt_autotest/libvirt_isolated_virtual_network";
             }
             loadtest "virt_autotest/setup_dns_service";
-            loadtest "virtualization/xen/hotplugging" if get_var("ENABLE_HOTPLUGGING");
-            loadtest "virtualization/xen/storage"     if get_var("ENABLE_STORAGE");
+            loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH");
+            loadtest "virtualization/xen/hotplugging"                   if get_var("ENABLE_HOTPLUGGING");
+            loadtest "virtualization/xen/storage"                       if get_var("ENABLE_STORAGE");
             loadtest "virt_autotest/virsh_internal_snapshot";
             loadtest "virt_autotest/virsh_external_snapshot";
         }

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -1,0 +1,406 @@
+# SUSE's openQA tests
+
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: A test to pass SR-IOV Ethernet VFs to guest via libvirt. Both KVM & XEN hosts are supported.
+# Test environment: one or more Ethernet card with SR-IOV features in host machine as a secondary network card;
+#                   hvm or pv domains defined in the host, and they are ssh accessible from host.
+# Test flow:
+#    - search the SR-IOV Ethernet cards installed in host.
+#    - enable 8 vfs for each of them. 8 is set fixed, other values work as well.
+#    - choose one of the vfs randomly and pass it thru to the domain.
+#    - choose another vf randomly and pass it thru to the domain. Set $passthru_vf_count to other values in case you'd like to pass thru more vfs.
+#    - reboot the domain.
+#    - unplug the first vf from domain; then unplug all the others.
+#    - for each of the plugging/unplugging step above, check domain network status and host&guest status.
+# Maintainer: Julie CAO <JCao@suse.com>
+
+use base "virt_feature_test_base";
+use strict;
+use warnings;
+use utils;
+use testapi;
+use xen;
+use set_config_as_glue;
+use virt_autotest::utils;
+use virt_autotest::virtual_network_utils qw(save_guest_ip test_network_interface);
+use virt_utils qw(upload_virt_logs);
+
+sub run_test {
+    my $self = shift;
+
+    #set up ssh, packages and iommu on host
+    prepare_host();
+
+    #clean up test logs
+    my $log_dir = "/tmp/sriov_pcipassthru";
+    script_run "[ -d $log_dir ] && rm -rf $log_dir; mkdir -p $log_dir";
+
+    #get the SR-IOV device BDF and interface
+    my @host_pfs;
+    @host_pfs = find_sriov_ethernet_devices();
+    if (@host_pfs == ()) {
+        $self->{test_results}->{host}->{"Error: there is no SR-IOV ethernet devices in the host!"}->{status} = 'FAILED';
+        return 1;
+    }
+    record_info("Find SR-IOV devices", "@host_pfs");
+
+    #get/set nessisary variables for test
+    my $gateway = script_output "ip r s | grep 'default via' | cut -d ' ' -f3";
+    set_var("SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH", 1);    #to differenciate virtual network tests
+
+    # enable 8 vfs for the SR-IOV device on host
+    my @host_vfs = enable_vf(@host_pfs);
+    record_info("VFs enabled", "@host_vfs");
+
+    foreach my $guest (keys %xen::guests) {
+
+        record_info("Test $guest");
+        prepare_guest($guest);
+        save_network_device_status_logs($log_dir, $guest, "1-initial");
+
+        #passthrough 2 vf ethernet devices from host
+        my @vfs               = ();
+        my $passthru_vf_count = 2;    #the number of vfs to be passed through to guests
+        for (my $i = 0; $i < $passthru_vf_count; $i++) {
+
+            my %vf;
+
+            #detach the vf from host
+            $vf{host_bdf} = $host_vfs[int(rand($#host_vfs + 1))];
+            for (my $j = 0; $j < $i; $j++) {
+                if ($vf{host_bdf} eq $vfs[$j]->{host_bdf}) {
+                    $vf{host_bdf} = $host_vfs[int(rand($#host_vfs + 1))];
+                    $j = 0;
+                }
+            }
+            $vf{host_id} = detach_vf_from_host($vf{host_bdf});
+
+            #add the vf to the list of passthrough devices
+            push @vfs, \%vf;
+
+            #plug the vf in guest
+            plugin_device($guest, $vfs[$i]);
+
+            #upload test specific logs
+            save_network_device_status_logs($log_dir, $guest, $i + 2 . "-after_hotplug_$vfs[$i]->{host_id}");
+
+            #check the networking of the plugged interface
+            #use br123 as ssh connection
+            test_network_interface($guest, gate => $gateway, mac => $vfs[$i]->{vm_mac}, net => 'br123');
+
+        }
+
+        #reboot the guest
+        record_info("VM reboot", "$guest");
+        script_run "ssh root\@$guest 'reboot'";    #don't use assert_script_run, or may fail on xen guests
+        save_network_device_status_logs($log_dir, $guest, $passthru_vf_count + 2 . '-after_guest_reboot');
+        script_retry("nmap $guest -PN -p ssh | grep open", delay => 10, retry => 18, die => 1);
+
+        #check again the networking inside vm
+        for (my $i = 0; $i < $passthru_vf_count; $i++) {
+            test_network_interface($guest, gate => $gateway, mac => $vfs[$i]->{vm_mac}, net => 'br123');
+        }
+
+        #unplug the first vf from vm
+        unplug_vf_from_vm($guest, $vfs[0]);
+        assert_script_run("virsh nodedev-reattach $vfs[0]->{host_id}", 60);
+        record_info("Reattach VF to host", "vm=$guest \nvf=$vfs[0]->{host_id}");
+        save_network_device_status_logs($log_dir, $guest, $passthru_vf_count + 3 . "-after_hot_unplug_$vfs[$0]->{host_id}");
+
+        #check host and guest to make sure they work well
+        check_host();
+        check_guest($guest);
+
+        #check again the remaining vf(s) inside vm
+        for (my $i = 1; $i < $passthru_vf_count; $i++) {
+            test_network_interface($guest, gate => $gateway, mac => $vfs[$i]->{vm_mac}, net => 'br123');
+        }
+        set_var("SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH", 0);    #turn off the flag in case of affecting other tests
+
+        #unplug the remaining vf(s) from vm
+        for (my $i = 1; $i < $passthru_vf_count; $i++) {
+            unplug_vf_from_vm($guest, $vfs[$i]);
+            assert_script_run("virsh nodedev-reattach $vfs[$i]->{host_id}", 60);
+            record_info("Reattach VF to host", "vm=$guest \nvf=$vfs[$i]->{host_id}");
+            save_network_device_status_logs($log_dir, $guest, $passthru_vf_count + 3 + $i . "-after_hot_unplug_$vfs[$i]->{host_id}");
+        }
+        script_run "lspci | grep Ethernet";
+        save_screenshot;
+
+        #check host and guest to make sure they work well
+        check_host();
+        check_guest($guest);
+
+    }
+
+    #upload network device related logs
+    upload_virt_logs($log_dir, "logs.tar.gz");
+}
+
+
+#set up ssh, packages and iommu on host
+sub prepare_host {
+
+    #install required packages on host
+    zypper_call '-t in pciutils nmap';    #to run 'lspci' and 'nmap' command
+
+    #check IOMMU on XEN is enabled
+    if (is_xen_host()) {
+        assert_script_run "xl dmesg | grep IOMMU | grep -i enabled";
+    }
+}
+
+
+#get the BDF the PF device on host
+sub find_sriov_ethernet_devices {
+
+    #get the BDF of the ethernet devices with SR-IOV
+    my $nic_devices = script_output "lspci | grep Ethernet | grep -v 'Virtual Function' | cut -d ' ' -f1";
+    my @nic_devices = split("\n", $nic_devices);
+    my @sriov_devices;
+    foreach (@nic_devices) {
+        if ((script_run "lspci -v -s $_ | grep -q 'SR-IOV'") == 0) {
+            push @sriov_devices, $_;
+        }
+    }
+    return @sriov_devices;
+}
+
+#enable 8 virtual functions for the specified physical functions of the SR-IOV network device
+sub enable_vf {
+    my @pfs = @_;
+
+    # get the network device drivers
+    my @drivers = ();
+    my $driver  = "";
+    foreach my $pf (@pfs) {
+        $driver = script_output "lspci -v -s $pf | sed -n '/Kernel modules/p' | sed 's/.*Kernel modules: *//'";
+        push @drivers, $driver if (!grep /^$driver$/, @drivers);
+    }
+
+    #set max_vfs and reload driver
+    #should not enable vf repeatedly, so skip enabling in local test for debugging
+    foreach my $driver (@drivers) {
+        assert_script_run("[ `lsmod | grep $driver | wc -l` -gt 0 ] && rmmod $driver", 60);
+        assert_script_run("modprobe --first-time $driver max_vfs=8",                   60);
+    }
+
+    #bring up the SR-IOV device
+    foreach my $pf (@pfs) {
+        my $nic = script_output "ls -l /sys/class/net |grep $pf | awk '{print \$9}'";
+        assert_script_run "echo \"BOOTPROTO='dhcp'\nSTARTMODE='manual'\" > /etc/sysconfig/network/ifcfg-$nic";
+        assert_script_run("ifup $nic", 60);    #about 15s
+    }
+
+    my $vf_devices = script_output "lspci | grep Ethernet | grep \"Virtual Function\" | cut -d ' ' -f1";
+    my @vfs        = split("\n", $vf_devices);
+
+}
+
+
+#set up guest test environment
+sub prepare_guest {
+    my $vm = shift;
+
+    assert_script_run "virsh dumpxml $vm > $vm.xml";
+    script_run "virsh destroy $vm";
+    assert_script_run "virsh undefine $vm";
+
+    #extra process for XEN hypervisor
+    if (is_xen_host()) {
+
+        #enable pci-passthrough and set model for pv guest.
+        #refer to bug #1167217 for the reason
+        my $passthru_xml = "<passthrough state='on'/>";
+        my $e820_xml     = "";
+        if (is_pv_guest($vm)) {
+            $e820_xml = "<e820_host state='on'/>";
+        }
+        if (script_run("grep '<features>' $vm.xml") == 0) {
+            assert_script_run "sed -i \"/<features>/a\\<xen>\\n$passthru_xml\\n$e820_xml\\n</xen>\" $vm.xml";
+        }
+        else {
+            assert_script_run "sed -i \"/<domain /a\\<features>\\n<xen>\\n$passthru_xml\\n$e820_xml\\n</xen>\\n</features>\" $vm.xml";
+        }
+
+        #disable memory ballooning for fv guest as it is not supported
+        if (is_fv_guest($vm)) {
+            assert_script_run "sed -i '/<currentMemory/d' $vm.xml";
+        }
+
+    }
+
+    #add pcie controllers to support hotplugging more SR-IOV Ethernet vf devices
+    my $controller_xml = "<controller type='pci' model='pcie-root-port'/>";
+    assert_script_run "sed -i \"/<devices>/a\\$controller_xml\\n$controller_xml\\n$controller_xml\" $vm.xml";
+    assert_script_run "virsh define $vm.xml";
+    assert_script_run "virsh start $vm";
+
+    #passwordless access to guest
+    save_guest_ip($vm, name => "br123");    #get the guest ip via key words in 'virsh domiflist'
+
+}
+
+
+#detach a specified vf Ethernet device from host
+sub detach_vf_from_host {
+    my $device_bdf = shift;
+
+    #change to device id in libvirt
+    $device_bdf =~ s/[:\.]/_/g;
+    my $device_id = script_output "virsh nodedev-list | grep $device_bdf";
+
+    #detach from host
+    assert_script_run "virsh nodedev-detach $device_id";
+    record_info("Detach VF from host", "$device_id");
+
+    return $device_id;
+}
+
+
+#plugin a device to vm via libvirt
+sub plugin_device {
+    my ($vm, $vf) = @_;
+
+    #get neccessary device config from host
+    my $host_device_xml = script_output "virsh nodedev-dumpxml $vf->{host_id}";
+    $host_device_xml =~ /\<domain\>(\w+)\<\/domain\>.*\<bus\>(\w+)\<\/bus\>.*\<slot\>(\w+)\<\/slot\>.*\<function\>(\w+)\<\/function\>/s;
+    my ($dev_domain, $dev_bus, $dev_slot, $dev_func) = ($1, $2, $3, $4);
+
+    #'virsh attach-interface' can plug the network device to guest with the BDF in commandline without a seperate device xml file
+    #but the SUSE document use 'virsh attach-device', so the test follows it
+    #create the device xml to passthrough to vm
+    my $vf_host_addr_xml = "<address type='pci' domain='$dev_domain' bus='$dev_bus' slot='$dev_slot' function='$dev_func'/>";
+    assert_script_run("echo \"<interface type='hostdev'>\n  <source>\n    $vf_host_addr_xml\n  </source>\n</interface>\" > $vf->{host_id}.xml", 60);
+    upload_logs("$vf->{host_id}.xml");
+
+    #attach device to vm
+    assert_script_run "virsh -d 1 attach-device $vm $vf->{host_id}.xml --persistent";
+
+    #get the mac address and bdf by parsing the domain xml
+    #tips: there may be multiple interfaces and multiple hostdev devices in the guest
+    my $nics_count = script_output "virsh dumpxml $vm | grep -c \"<interface.*type='hostdev'\"";
+    my $devs_xml   = script_output "virsh dumpxml $vm | sed -n \"/<interface.*type='hostdev'/,/<\\/devices/p\"";
+    $vf->{host_id} =~ /pci_([a-z\d]+)_([a-z\d]+)_([a-z\d]+)_([a-z\d]+)/;
+    my ($dom, $bus, $slot, $func) = ($1, $2, $3, $4);    #these are different with those in host_devices.xml
+    for (my $i = 0; $i < $nics_count; $i++) {
+        $devs_xml =~ /\<interface.*?type='hostdev'.*?\<\/interface\>/s;    #minimal match
+        my $nic_xml = $&;
+        if ($nic_xml =~ /domain='(0x)?$dom' +bus='(0x)?$bus' +slot='(0x)?$slot' +function='(0x)?$func'/) {
+
+            #get the vf xml in vm config file for later unplugging to use
+            $vf->{vm_xml} = $nic_xml;
+
+            #get mac address
+            $nic_xml =~ /\<mac.*address='(.*)'/;
+            $vf->{vm_mac} = $1;
+
+            #get bdf for guests on KVM
+            $nic_xml =~ s/\<source.*\<\/source\>//s;
+            if ($nic_xml =~ /bus='(\w+)'.*slot='(\w+)'.*function='(\w+)'/) {
+                my ($bus, $slot, $func) = ($1, $2, $3);
+                $vf->{vm_bdf} = $bus . ":" . $slot . "." . $func;
+            }
+            else {
+
+                #have to get bdf by other means for guests on XEN
+                $vf->{vm_bdf} = script_output "ssh root\@$vm \"if [ -e /sys/devices/pci-0/pci????:?? ]; then grep -H '$vf->{vm_mac}' /sys/devices/pci-0/*/*/net/*/address | cut -d '/' -f6; else grep -H '$vf->{vm_mac}' /sys/devices/*/*/net/*/address | cut -d '/' -f5; fi\"";
+            }
+            last;
+
+        }
+        else {
+            $devs_xml =~ s/\<interface.*?type='hostdev'.*?\<\/interface\>//s;
+        }
+    }
+
+    #print the vf device
+    $vf->{vm_bdf} =~ /[a-z\d]+:[a-z\d]+[.:][a-z\d]+/;    #bdf has different format in guests on KVM and XEN
+    assert_script_run "ssh root\@$vm \"lspci -vvv -s $vf->{vm_bdf}\"";
+    $vf->{vm_nic} = script_output "ssh root\@$vm \"grep '$vf->{vm_mac}' /sys/class/net/*/address | cut -d'/' -f5 | head -n1\"";
+    record_info("VF plugged to vm", "$vf->{host_id} \nGuest: $vm\nbdf='$vf->{vm_bdf}'   mac_addrss='$vf->{vm_mac}'   nic='$vf->{vm_nic}'");
+
+}
+
+
+#unplug the vf device from guest
+sub unplug_vf_from_vm {
+    my ($vm, $vf) = @_;
+
+    #bring the nic down
+    script_run("ssh root\@$vm 'ifdown $vf->{vm_nic}'", 60);
+
+    #detach vf from guest
+    my $vf_xml_file = "vf_in_vm.xml";
+    assert_script_run "echo \"$vf->{vm_xml}\" > $vf_xml_file";
+    assert_script_run("virsh detach-device $vm $vf_xml_file --persistent", 60);
+
+    #check if the nic is removed from vm
+    validate_script_output "ssh root\@$vm \"ip l show $vf->{vm_nic}\"", sub { /does not exist/ };
+
+    record_info("VF unpluged from vm", "$vf->{host_id} \nGuest: $vm \nbdf='$vf->{vm_bdf}'   mac='$vf->{vm_mac}'   nic='$vf->{vm_nic}'");
+
+}
+
+#print logs for debugging
+sub save_network_device_status_logs {
+    my ($log_dir, $vm, $test_step) = @_;
+
+    #vm configuration file
+    script_run "virsh dumpxml $vm > $log_dir/${vm}_${test_step}.xml";
+
+    my $log_file = "log.txt";
+    script_run "echo `date` > $log_file";
+
+    #list domain interface
+    print_cmd_output_to_file("virsh domiflist $vm", $log_file);
+
+    #save udev rules from guest
+    script_run "echo -e \"\n# ssh root\@$vm 'cat /etc/udev/rules.d/'\" >> $log_file";
+    if ((script_run "ssh root\@$vm 'ls /etc/udev/rules.d/'") == 0) {
+        script_run "[ -d rules.d/ ] && rm -rf rules.d/; scp -r root\@$vm:/etc/udev/rules.d/ .; ls rules.d/ >> $log_file; cat rules.d/* >> $log_file";
+    }
+
+    #list pci devices in guest
+    print_cmd_output_to_file("lspci",     $log_file, $vm);
+    print_cmd_output_to_file("ip l show", $log_file, $vm);
+
+    script_run "mv $log_file $log_dir/${vm}_${test_step}_network_device_status.txt";
+
+}
+
+sub post_fail_hook {
+    my $self = shift;
+
+    my $log_dir = "/tmp/sriov_pcipassthru";
+
+    diag("Module sriov_network_card_pci_passthrough post fail hook starts.");
+    my $vm_types           = "sles|win";
+    my $get_vm_hostnames   = "virsh list  --all | grep -E \"${vm_types}\" | awk \'{print \$2}\'";
+    my $vm_hostnames       = script_output($get_vm_hostnames, 30, type_command => 0, proceed_on_failure => 0);
+    my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
+    foreach (@vm_hostnames_array)
+    {
+        save_network_device_status_logs($log_dir, $_, "9_post_fail_hook");
+    }
+
+    upload_virt_logs($log_dir, "logs.tar.gz");
+    $self->SUPER::post_fail_hook;
+
+}
+
+1;

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -140,6 +140,7 @@ sub run_test {
     if ($upload_virt_log_flag eq "yes") {
         upload_virt_logs($log_dir, $compressed_log_name);
         virt_utils::upload_supportconfig_log;
+        $self->upload_coredumps;
     }
 
     if ($upload_guest_assets_flag eq "yes") {

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -343,9 +343,9 @@ sub compress_single_qcow2_disk {
 sub upload_supportconfig_log {
     my $datetab = script_output("date '+%Y%m%d%H%M%S'");
     script_run("cd;supportconfig -t . -B supportconfig.$datetab", 600);
-    script_run("tar zcvfP nts_supportconfig.$datetab.tar.gz nts_supportconfig.$datetab");
-    upload_logs("nts_supportconfig.$datetab.tar.gz");
-    script_run("rm -rf nts_supportconfig.*");
+    script_run("tar zcvfP supportconfig.$datetab.tar.gz *supportconfig.$datetab");
+    upload_logs("supportconfig.$datetab.tar.gz");
+    script_run("rm -rf *supportconfig.*");
     save_screenshot;
 }
 

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -55,6 +55,14 @@ sub enable_debug_logging {
     }
     save_screenshot;
 
+    # enable qemu core dumps
+    my $qemu_conf_file = "/etc/libvirt/qemu.conf";
+    if (!script_run "ls $qemu_conf_file") {
+        script_run "sed -i '/max_core *=/{h;s/^[# ]*max_core *=.*\$/max_core = \"unlimited\"/};\${x;/^\$/{s//max_core = \"unlimited\"/;H};x}' $qemu_conf_file";
+        script_run "grep max_core $qemu_conf_file";
+    }
+    save_screenshot;
+
 }
 
 sub get_version_for_daily_build_guest {


### PR DESCRIPTION
SR-IOV pci passthrough is a new function test began with sles15sp2. 
 - suse doc(there is a bit of difference between sles15sp2 and sles15sp1): https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-libvirt-config-virsh.html#sec-libvirt-config-io 
 - test procedure(not follow strictly): https://confluence.suse.com/pages/viewpage.action?pageId=379748391

Some implementation status:
 - 1:The test support both KVM and XEN. 

 - 2: Support sles15sp2 guests on sles15sp2 host only. sles12sp5 on sles15sp2 KVM should be supported but just do one verification run. Plan to support more matrix on next release.

 - 3: Defined some general functions in lib/virt_auto/utils.pm and only implemented part of them. Welcome everyone to extend them.

 - 4: There is a bug has not been fixed for KVM, so the test on KVM is expected to fail near the end. the bug: bsc#1166567  [SR-IOV][kvm]guest vm crash after detaching a vf network device

 - 5: The bug for XEN was fixed and just had a complete verification run on XEN. Bug 1172052 - [XEN][SR-IOV]hotplug in a vf Ethernet device to domU via virsh but MAC address changed after domU's first reboot

 - 6: coredump is enabled in this PR as well.

 - 7: The pending issue which fail to bring an NIC up in the guest after repeated tests has been resolved or gotten around, to run test on a fresh vm disk file.

 - 8: emply supportconfig tarball issue in OSD has been fixed along with this PR as well.

Verification run: 

 - sles15sp2 guest on sles15sp2 kvm host (including coredump):http://10.67.133.97/tests/212(test is expected to fail due to bsc#1166567. coredump is published)

 - sles15sp2 PV & FV guests on sles15sp2 XEN host: http://10.67.133.97/tests/229


@alice-suse @xguo @waynechen55 @pdostal
