### PR TITLE
libqt5_qtbase: Increase timeout for gcc qt being installed

### DIFF
--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -55,7 +55,7 @@ sub run {
     send_key "alt-f4";                           # close program
 
     # Compile an application and run it, check that exits with 0
-    ensure_installed "gcc gcc-c++ libQt5Core-devel libQt5Gui-devel libQt5Network-devel libQt5Widgets-devel", timeout => 180;
+    ensure_installed "gcc gcc-c++ libQt5Core-devel libQt5Gui-devel libQt5Network-devel libQt5Widgets-devel", timeout => 400;
 
     x11_start_program('xterm');
     assert_script_run 'cd data';


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4214151#step/libqt5_qtbase/56