### PR TITLE
Skip duplicate 'generic-desktop' checks

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -933,6 +933,8 @@ sub wait_boot_past_bootloader {
         last if $ret;
         $timeout -= $check_interval;
     }
+    # if we reached a logged in desktop we are done here
+    return 1 if match_has_tag('generic-desktop') || match_has_tag('opensuse-welcome');
     # the last check after previous intervals must be fatal
     assert_screen \@tags, $check_interval;
     handle_emergency_if_needed;

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -25,7 +25,7 @@ use mm_network;
 sub post_run_hook {
     my ($self) = @_;
 
-    assert_screen('generic-desktop');
+    assert_screen('generic-desktop') unless match_has_tag('generic-desktop');
 }
 
 sub dm_login {

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -28,5 +28,8 @@ sub run {
 sub test_flags {
     return {fatal => 1, milestone => 1};
 }
+
+# 'generic-desktop' already checked in wait_boot_past_bootloader
+sub post_run_hook {}
 
 1;

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -30,6 +30,6 @@ sub test_flags {
 }
 
 # 'generic-desktop' already checked in wait_boot_past_bootloader
-sub post_run_hook {}
+sub post_run_hook { }
 
 1;

--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -25,5 +25,8 @@ sub run {
 sub test_flags {
     return {milestone => 1};
 }
+
+# 'generic-desktop' already checked in wait_boot_past_bootloader
+sub post_run_hook {}
 
 1;

--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -27,6 +27,6 @@ sub test_flags {
 }
 
 # 'generic-desktop' already checked in wait_boot_past_bootloader
-sub post_run_hook {}
+sub post_run_hook { }
 
 1;


### PR DESCRIPTION
* Skip duplicate 'generic-desktop' check in bootup
* Skip duplicate 'generic-desktop' check in first_boot+opensuse_welcome
* Only look for 'generic-desktop' in post_run_hook if necessary

Verification run: https://openqa.opensuse.org/t1263069