### PR TITLE
openqa: Prevent double check of same screen

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -776,8 +776,10 @@ sub activate_console {
             }
         }
         assert_screen "text-logged-in-$user", 60;
-        $self->set_standard_prompt($user, skip_set_standard_prompt => $args{skip_set_standard_prompt});
-        assert_screen $console;
+        unless ($args{skip_set_standard_prompt}) {
+            $self->set_standard_prompt($user, skip_set_standard_prompt => $args{skip_set_standard_prompt});
+            assert_screen $console;
+        }
     }
     elsif ($type =~ /^(virtio-terminal|sut-serial)$/) {
         serial_terminal::login($user, $self->{serial_term_prompt});

--- a/tests/openqa/osautoinst/start_test.pm
+++ b/tests/openqa/osautoinst/start_test.pm
@@ -25,7 +25,7 @@ sub run {
 last_tw_build=\$(openqa-client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-$arch-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
 echo "Last Tumbleweed build on openqa.opensuse.org: \$last_tw_build"
 [ ! -z \$last_tw_build ]
-zypper -n in jq
+command -v jq >/dev/null || zypper -n in jq
 job_id=\$(openqa-client --host $openqa_url --json-output jobs get version=Tumbleweed scope=relevant arch=$arch build=\$last_tw_build flavor=NET latest=1 | jq '.jobs | .[] | select(.test == "$ttest") | .id')
 echo "Job Id: \$job_id"
 [ ! -z \$job_id  ]

--- a/tests/openqa/webui/dashboard.pm
+++ b/tests/openqa/webui/dashboard.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018-2019 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,11 +23,7 @@ sub run {
     x11_start_program("firefox http://localhost", timeout => 60, valid => 0);
     # starting from git might take a bit longer to get and generated assets
     # workaround for poo#19798, basically doubles the timeout
-    if ((check_screen 'openqa-dashboard', 180) == undef) {
-        record_info 'ff took to long to start';
-    }
-    #wait few minutes for ff to start and then fail the test
-    assert_screen 'openqa-dashboard', 360;
+    assert_screen 'openqa-dashboard', 600;
 }
 
 sub test_flags {


### PR DESCRIPTION
Just a record_info for a slow firefox will not trigger any action
different than just a long timeout does.