### PR TITLE
Move yast2 lan tests to YaST job group

### DIFF
--- a/schedule/functional/allpatterns.yaml
+++ b/schedule/functional/allpatterns.yaml
@@ -42,7 +42,6 @@ schedule:
     - console/zypper_lr
     - console/zypper_ref
     - console/ncurses
-    - console/yast2_lan
     - console/curl_https
     - console/salt
     - console/glibc_sanity

--- a/schedule/yast/yast2_ncurses_gnome.yaml
+++ b/schedule/yast/yast2_ncurses_gnome.yaml
@@ -1,0 +1,43 @@
+---
+name:           yast2_ncurses_gnome
+description:    >
+    Test for yast2 UI, ncurses only. Running on created gnome images
+    which provides both text console for ncurses UI tests as well as
+    the gnome environment for the GUI tests.
+schedule:
+    - "{{pre_boot_to_desktop}}"
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - "{{yast_modules}}"
+    - console/coredump_collect
+conditional_schedule:
+    pre_boot_to_desktop:
+        ARCH:
+            aarch64:
+                - boot/uefi_bootmenu
+            s390x:
+                - installation/bootloader_start
+    yast_modules:
+        ARCH:
+            x86_64:
+                - console/yast2_rmt
+                - console/yast2_ntpclient
+                - console/yast2_tftp
+                - console/yast2_proxy
+                - console/yast2_vnc
+                - console/yast2_nis
+                - console/yast2_http
+                - console/yast2_ftp
+                - console/yast2_apparmor
+                - console/yast2_lan
+                - console/yast2_lan_hostname
+                - console/yast2_dns_server
+                - console/yast2_nfs_client
+                - console/yast2_snapper_ncurses
+            aarch64:
+                - console/yast2_lan
+            ppc64le:
+                - console/yast2_lan
+            s390x:
+                - console/yast2_lan

--- a/schedule/yast/yast2_ncurses_textmode.yaml
+++ b/schedule/yast/yast2_ncurses_textmode.yaml
@@ -1,0 +1,17 @@
+---
+name:           yast2_ncurses_textmode
+description:    >
+    Test for yast2 UI, ncurses only. Running on created textmode image.
+schedule:
+    - "{{pre_boot_to_desktop}}"
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/yast2_lan
+conditional_schedule:
+    pre_boot_to_desktop:
+        ARCH:
+            aarch64:
+                - boot/uefi_bootmenu
+            s390x:
+                - installation/bootloader_start


### PR DESCRIPTION
Move yast2 lan tests to YaST job group trying to match the closer test coverage to the existing one and therefore excluding this test module from the default schedule of main.pm  mechanism for latest product to have more control on its maintenance. 

Currently in functional group when the module is schedule in other architecture than x86_64 we are just opening it, so with this change we can apply the detailed check for aarch64 and ppc64le. For s390x after creating a few needles there are still [failures](https://openqa.suse.de/tests/4214814#step/yast2_lan/37) so there it is enabled just the current light check.

- Related ticket: https://progress.opensuse.org/issues/66212
- YaST Job group MR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/191
- Userspace Job group MR: https://gitlab.suse.de/qsf-u/qa-sle-functional-userspace/-/merge_requests/80
- Verification run: [yast2_ncurses_*](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=191.1&groupid=96&modules=yast2_lan)
