### PR TITLE
Check for test.ping output

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -61,6 +61,7 @@ EOF
     unless (script_run 'salt \'*\' test.ping') {
         assert_script_run 'for i in {1..7}; do echo "try $i" && salt \'*\' test.ping -t30 && break; done';
     }
+    assert_screen 'True'
     systemctl 'stop salt-master salt-minion', timeout => 120;
 }
 


### PR DESCRIPTION
Adding a check for the test.ping output. Otherwise this could fail silently.

I have no clue if this works at all, but we need a check because this has failed silently and broke TW: https://openqa.opensuse.org/tests/1257363#step/salt/20


- Related ticket: https://progress.opensuse.org/issues/66691
- Verification run: I have no personal instance.