### PR TITLE
Create br0 interface for untypical SLE-11-SP4 virtulization host

### DIFF
--- a/tests/virtualization/xen/hotplugging.pm
+++ b/tests/virtualization/xen/hotplugging.pm
@@ -35,9 +35,11 @@ sub run_test {
                 record_soft_failure 'bsc#1168124 Bridge network interface hotplugging has to be performed at the beginning.';
                 $self->{test_results}->{$guest}->{"bsc#1168124 Bridge network interface hotplugging has to be performed at the beginning"}->{status} = 'SOFTFAILED';
                 $persistent_config_option = '--persistent' if ($sles_running_version eq '11' && $sles_running_sp eq '4');
+                script_run "brctl addbr br0; ip link set dev br0 up", 60 if ($sles_running_version eq '11' && $sles_running_sp eq '4');
             }
             if (get_var('VIRT_AUTOTEST') && (check_var('SYSTEM_ROLE', 'kvm') || check_var('HOST_HYPERVISOR', 'kvm'))) {
                 $interface_model_option = '--model virtio';
+                script_run "brctl addbr br0; ip link set dev br0 up", 60 if ($sles_running_version eq '11' && $sles_running_sp eq '4');
                 script_run "ssh root\@$guest modprobe acpiphp", 60 if ($guest =~ /^sles-11-sp4.*$/img);
                 record_soft_failure 'bsc#1167828 Bridge network interface br0 hotplugging does not work with this ' . $guest if ($guest =~ /^sles-11-sp4.*$/img);
                 $self->{test_results}->{$guest}->{"bsc#1167828 Bridge network interface br0 hotplugging does not work with this $guest"}->{status} = 'SOFTFAILED' if ($guest =~ /^sles-11-sp4.*$/img);


### PR DESCRIPTION
Untypical SLE-11-SP4 virtualization host installation on openqa.suse.de does not provide br0 which should be available for next up network interface hotplugging test. So create it manually in advance.


- Related ticket: 
   [sles11sp4 kvm](https://openqa.suse.de/tests/4217531)
   [sles11sp4 xen](https://openqa.suse.de/tests/4217536)
- Needles: n/a
- Verification run: 
   [Automation sles11sp4 kvm](http://10.67.133.40/tests/172)
   [Automation sles11sp4 xen](http://10.67.133.40/tests/173)
   [Manual sles11sp4 kvm](https://openqa.suse.de/tests/4217531)
   [Manual sles11sp4 xen](https://openqa.suse.de/tests/4217536)