### PR TITLE
Fix zypper_lr_validate on sle15+

### DIFF
--- a/tests/console/zypper_lr_validate.pm
+++ b/tests/console/zypper_lr_validate.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -28,6 +28,7 @@ sub validatelr {
     my $product         = $args->{product};
     my $product_channel = $args->{product_channel} || "";
     my $version         = $args->{version};
+    my $major_version   = substr($args->{version}, 0, 2);
     if (get_var('ZDUP')) {
         $version = "";
     }
@@ -35,46 +36,27 @@ sub validatelr {
         $version .= "-SAP";
     }
     # Live patching and other modules are not per-service pack channel model,
-    # so use major version to validate their repos
-    if ($product eq 'SLE-Live') {
-        $product = 'SLE-Live-Patching';
-        $version = '12';
-    }
+    # so use major version on sle12 to validate their repos
     if ($product eq 'SLE-ASMM') {
         $product = 'SLE-Module-Adv-Systems-Management';
-        $version = '12';
+        $version = $major_version if $major_version eq '12';
     }
     if ($product eq 'SLE-CONTM') {
         $product = 'SLE-Module-Containers';
-        $version = '12';
-    }
-    if ($product eq 'SLE-HPCM') {
-        $product = 'SLE-Module-HPC';
-        $version = '12';
-    }
-    if ($product eq 'SLE-LGM') {
-        $product = 'SLE-Module-Legacy';
-        $version = '12';
-    }
-    if ($product eq 'SLE-PCM') {
-        $product = 'SLE-Module-Public-Cloud';
-        $version = '12';
+        $version = $major_version if $major_version eq '12';
     }
     if ($product eq 'SLE-TCM') {
         $product = 'SLE-Module-Toolchain';
-        $version = '12';
+        $version = $major_version if $major_version eq '12';
     }
     if ($product eq 'SLE-WSM') {
         $product = 'SLE-Module-Web-Scripting';
-        $version = '12';
-    }
-    if ($product eq 'SLE-PHUB') {
-        $product = 'SUSE-PackageHub-';
+        $version = $major_version if $major_version eq '12';
     }
     # LTSS version is included in its product name
     # leave it as empty to match the regex
     if ($product =~ /LTSS/) {
-        $version = '';
+        $version = '' if $major_version eq '12';
     }
     diag "validatelr alias:$alias product:$product cha:$product_channel version:$version";
 
@@ -125,12 +107,11 @@ sub validatelr {
             }
         }
     }
-    run_scripted_command_slow($cmd, slow_type => 2) if defined $cmd;
+    script_output($cmd) if defined $cmd;
 }
 
 sub validate_repos_sle {
     my ($version) = @_;
-    script_run "clear";
 
     # On SLE we follow "SLE Channels Checking Table"
     # (https://wiki.microfocus.net/index.php?title=SLE12_SP2_Channels_Checking_Table)
@@ -139,6 +120,8 @@ sub validate_repos_sle {
     my @addonurl_keys = split(/,/, get_var('ADDONURL', ''));
     my $scc_addon_str = '';
     for my $scc_addon (split(/,/, get_var('SCC_ADDONS', ''))) {
+        # no empty $scc_addon when SCC_ADDONS starts with ,
+        next unless length $scc_addon;
         # The form of LTSS repos is different with other addons
         # For example: SLES12-LTSS-Updates
         if ($scc_addon eq 'ltss') {
@@ -296,11 +279,11 @@ sub validate_repos_sle {
         # For the name of product channel, sle12 uses NVIDIA, sle12sp1 and sp2 use nVidia
         # Consider migration, use regex to match nvidia whether in upper, lower or mixed
         # Skip check AMD/ATI repo since it would be removed from sled12 and sle-we-12, see bsc#984866
-        if ($base_product eq "SLED" || $we) {
+        if ($base_product eq "SLED" || $we && !get_required_var('FLAVOR') =~ /-Updates$|-Incidents/) {
             validatelr(
                 {
                     product         => "SLE-",
-                    product_channel => 'GA-Desktop-[nN][vV][iI][dD][iI][aA]-Driver',
+                    product_channel => 'Desktop-[nN][vV][iI][dD][iI][aA]-Driver',
                     enabled_repo    => 'Yes',
                     uri             => $nvidia_uri,
                     version         => $version
@@ -332,8 +315,7 @@ sub validate_repos {
     my ($version) = @_;
     $version //= get_var('VERSION');
 
-    assert_script_run "zypper lr | tee /dev/$serialdev", 180;
-    script_run "clear";
+    assert_script_run "zypper lr | tee /dev/$serialdev",    180;
     assert_script_run "zypper lr -d | tee /dev/$serialdev", 180;
 
     if (!get_var('STAGING') and is_sle('12-SP1+')) {
@@ -344,7 +326,8 @@ sub validate_repos {
 sub run {
     # ZYPPER_LR is needed for inconsistent migration, test would fail looking for deactivated addon
     set_var 'ZYPPER_LR', 1;
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     validate_repos;
 }
 


### PR DESCRIPTION
-use script_output to speedup validatelr a lot
-do not validate nvidia repo in QAM tests, repo is turned off or removed
-avoid empty scc_addon entry when SCC_ADDONS starts with ,
-fix SCC_ADDONS validatelr on sle15+, was writen for sle12 and not changed since then
-clean console is not needed

- Related ticket:
#10137
https://progress.opensuse.org/issues/66451
- Verification run: 
https://openqa.suse.de/tests/4227526 15sp2 virtio
https://openqa.suse.de/tests/4227527 15sp1 virtio
https://openqa.suse.de/tests/4227425 15sp2
https://openqa.suse.de/tests/4227428 15sp1
all other  tests have been already done in #10137
