### PR TITLE
Kernel on virtualization test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2635,6 +2635,10 @@ sub load_hypervisor_tests {
         loadtest 'virtualization/xen/upgrade_guests';         # Upgrade all guests
         loadtest 'virtualization/xen/patch_guests';           # Apply patches to all compatible guests
         loadtest 'virtualization/xen/patch_and_reboot';       # Apply updates and reboot
+
+        loadtest "virt_autotest/login_console";
+        loadtest "virtualization/xen/list_guests";            # List all guests and ensure they are running
+        loadtest "virtualization/xen/kernel";                 # Virtualization kernel functions
     }
 
     if (check_var('VIRT_PART', 'virtmanager')) {
@@ -2708,10 +2712,10 @@ sub load_hypervisor_tests {
 
     if (check_var('VIRT_PART', 'final')) {
         loadtest "virt_autotest/login_console";
-        loadtest "virtualization/xen/smoketest";            # Virtualization smoke test for hypervisor
         loadtest "virtualization/xen/list_guests";          # List all guests and ensure they are running
         loadtest 'virtualization/xen/ssh_final';            # Check that every guest is reachable over SSH
         loadtest 'virtualization/xen/virtmanager_final';    # Check that every guest shows the login screen
+        loadtest "virtualization/xen/smoketest";            # Virtualization smoke test for hypervisor
         loadtest "virtualization/xen/stresstest";           # Perform stress tests on the guests
     }
 }

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -463,7 +463,7 @@ Select the first hard disk.
 
 =cut
 sub select_first_hard_disk {
-    my @tags           = qw(existing-partitions hard-disk-dev-sdb-selected hard-disk-dev-non-sda-selected select-hard-disks-one-selected);
+    my @tags = qw(existing-partitions hard-disk-dev-sdb-selected hard-disk-dev-sdc-selected hard-disk-dev-sdd-selected hard-disk-dev-non-sda-selected select-hard-disks-one-selected);
     my $matched_needle = assert_screen \@tags;
     return if skip_select_first_hard_disk;
     # SUT may have any number disks, only keep the first, unselect all other disks
@@ -478,6 +478,8 @@ sub select_first_hard_disk {
     # Video mode directly matched the sdb-selected needle (old code) or can do the similar (ideal for multiple disks)
     else {
         assert_and_click 'hard-disk-dev-sdb-selected' if match_has_tag('hard-disk-dev-sdb-selected');
+        assert_and_click 'hard-disk-dev-sdc-selected' if match_has_tag('hard-disk-dev-sdc-selected');
+        assert_and_click 'hard-disk-dev-sdd-selected' if match_has_tag('hard-disk-dev-sdd-selected');
         if (match_has_tag('hard-disk-dev-non-sda-selected')) {
             foreach my $tag (grep { $_ =~ /hard-disk-dev-([sv]d[a-z]|pmem[0-9])/ } @{$matched_needle->{needle}->{tags}}) {
                 assert_and_click "$tag-selected";

--- a/lib/virt_autotest/kernel.pm
+++ b/lib/virt_autotest/kernel.pm
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# Summary: virtualization kernel functions
+# Summary: Virtualization kernel functions
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
 package virt_autotest::kernel;
@@ -41,14 +41,14 @@ sub check_virt_kernel {
 
     assert_script_run("$go_to_target uname -a");
     if ($sles_running_version >= 12) {
-        assert_script_run("$go_to_target journalctl -b | tee /tmp/journalctlb$guest$suffix.log");
-        upload_logs("/tmp/journalctlb$guest$suffix.log");
+        assert_script_run("$go_to_target journalctl -b | tee /tmp/journalctl-b-$guest$suffix.log");
+        upload_logs("/tmp/journalctl-b-$guest$suffix.log");
     } else {
-        assert_script_run("$go_to_target dmesg | tee /tmp/dmesg$guest$suffix.log");
-        upload_logs("/tmp/dmesg$guest$suffix.log");
+        assert_script_run("$go_to_target dmesg | tee /tmp/dmesg-$guest$suffix.log");
+        upload_logs("/tmp/dmesg-$guest$suffix.log");
     }
 
-    my $dmesg = "dmesg | grep -i 'fail\\|error\\|segmentation\\|stack' |grep -vi 'acpi\\|ERST\\|bar\\|mouse\\|vesafb\\|thermal\\|Correctable Errors\\|calibration failed\\|PM-Timer\\|dmi\\|irqstacks\\|auto-init\\|TSC ADJUST'";
+    my $dmesg = "dmesg | grep -i 'fail\\|error\\|segmentation\\|stack' |grep -vi 'acpi\\|ERST\\|bar\\|mouse\\|vesafb\\|thermal\\|Correctable Errors\\|calibration failed\\|PM-Timer\\|dmi\\|irqstacks\\|auto-init\\|TSC ADJUST\\|xapic not enabled\\|Firmware\\|missing monitors config'";
     if (script_run("$go_to_target $dmesg") != 1) {
         record_soft_failure "The $guest needs to be checked manually!";
     }

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -73,7 +73,7 @@ sub test_network_interface {
     } else {
         assert_script_run("ssh root\@$guest systemctl restart wickedd wickedd-dhcp4 wicked", 90);
     }
-    assert_script_run("ssh root\@$guest ifup $nic", 90);
+    script_retry("ssh root\@$guest ifup $nic", delay => 30, retry => 3, timeout => 90);
     my $addr = script_output "ssh root\@$guest ip -o -4 addr list $nic | awk \"{print \\\$4}\" | cut -d/ -f1";
 
     # Route our test via the tested interface

--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -719,12 +719,10 @@ sub establish_connection {
         assert_screen "virt-manager_connected";
     }
     elsif (match_has_tag 'virt-manager_not-connected') {
-        assert_and_click 'virt-manager_not-connected';
-        if (!check_screen("virt-manager_connected", 5)) {
+        if (!check_screen("virt-manager_connected", 15)) {
             assert_and_dclick 'virt-manager_not-connected';
+            assert_screen "virt-manager_connected";
         }
-
-        assert_screen "virt-manager_connected";
     }
 }
 

--- a/tests/virtualization/xen/kernel.pm
+++ b/tests/virtualization/xen/kernel.pm
@@ -1,0 +1,39 @@
+# XEN regression tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Test the host kernel
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base 'xen';
+use warnings;
+use strict;
+use virt_autotest::kernel;
+use testapi;
+use utils;
+use qam;
+
+sub run {
+    my $self = shift;
+
+    script_run "zypper lr -d";
+    script_run "rpm -qa > /tmp/rpm-qa.txt";
+    upload_logs("/tmp/rpm-qa.txt");
+
+    check_virt_kernel();
+}
+
+sub post_run_hook {
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virtualization/xen/list_guests.pm
+++ b/tests/virtualization/xen/list_guests.pm
@@ -14,11 +14,15 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use virt_autotest::kernel;
 
 sub run {
-    if (script_run("virsh net-list --all | grep default | grep ' active'", 30) != 0) {
-        assert_script_run "virsh net-start default";
+    my $self = shift;
+
+    if (script_run("virsh net-list --all | grep default | grep ' active'", 90) != 0) {
+        systemctl "restart libvirtd";
+        if (script_run("virsh net-list --all | grep default | grep ' active'", 90) != 0) {
+            assert_script_run "virsh net-start default";
+        }
     }
 
     assert_script_run "virsh list --all", 90;
@@ -39,8 +43,6 @@ sub run {
         script_retry "ping -c3 -W1 $guest", delay => 15, retry => 12;
         assert_script_run "ssh root\@$guest 'hostname -f; uptime'";
     }
-
-    check_virt_kernel();
 }
 
 1;

--- a/tests/virtualization/xen/patch_and_reboot.pm
+++ b/tests/virtualization/xen/patch_and_reboot.pm
@@ -25,18 +25,13 @@ sub run {
 
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));
 
-    check_virt_kernel('', 'before');
+    check_virt_kernel();
     script_run "zypper lr -d";
-    script_run "rpm -qa > /tmp/rpm-qa-before.txt";
-    upload_logs("/tmp/rpm-qa-before.txt");
+    script_run "rpm -qa > /tmp/rpm-qa.txt";
+    upload_logs("/tmp/rpm-qa.txt");
 
     add_test_repositories;
     fully_patch_system;
-
-    check_virt_kernel('', 'after');
-    script_run "zypper lr -d";
-    script_run "rpm -qa > /tmp/rpm-qa-after.txt";
-    upload_logs("/tmp/rpm-qa-after.txt");
 
     # Check that all guests are still running
     script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %xen::guests);

--- a/tests/virtualization/xen/patch_guests.pm
+++ b/tests/virtualization/xen/patch_guests.pm
@@ -33,7 +33,7 @@ sub run {
         if ($host_running_version == $guest_running_version && $host_running_sp == $guest_running_sp) {
             ssh_add_test_repositories "$guest";
 
-            check_virt_kernel($guest, 'before');
+            check_virt_kernel($guest, '-before');
             script_run "ssh root\@$guest zypper lr -d";
             script_run "ssh root\@$guest rpm -qa > /tmp/rpm-qa-$guest-before.txt";
             upload_logs("/tmp/rpm-qa-$guest-before.txt");

--- a/tests/virtualization/xen/ssh_hypervisor_init.pm
+++ b/tests/virtualization/xen/ssh_hypervisor_init.pm
@@ -22,6 +22,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils;
 
 sub run {
     my ($self) = @_;
@@ -47,6 +48,10 @@ sub run {
     # Copy that also for normal user
     assert_script_run "install -o $testapi::username -g users -m 0700 -d /home/$testapi::username/.ssh";
     assert_script_run "install -o $testapi::username -g users -m 0600 ~/.ssh/config ~/.ssh/id_rsa ~/.ssh/id_rsa.pub ~/.ssh/known_hosts /home/$testapi::username/.ssh/";
+
+    my ($sles_running_version, $sles_running_sp) = get_sles_release();
+    zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_" . $sles_running_version . "/SUSE:CA.repo");
+    zypper_call("in ca-certificates-suse");
 }
 
 sub test_flags {


### PR DESCRIPTION
Hello,

 * The `kernel.pm` test module checks the kernel after the hypervisor is patched&rebooted.
 * The `virt-manager` tests should be more robust
 * The `select_first_hard_disk` function works with more than two drives
 * The `ifup` command will not faild when `IN PROGRESS` state is reached

- Needles: [os-autoinst-needles-sles#1374](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1374)
- Verification run: SLE 12 SP5 [XEN](http://openqa.qam.suse.cz/tests/6873#dependencies) [KVM](http://openqa.qam.suse.cz/tests/6927#dependencies) SLE 15 [XEN](http://openqa.qam.suse.cz/tests/6740#dependencies) [KVM](http://openqa.qam.suse.cz/tests/6849#dependencies)
