### PR TITLE
Add create_hdd_gnome_wicked test suite

### DIFF
--- a/schedule/yast/create_hdd_gnome_wicked.yaml
+++ b/schedule/yast/create_hdd_gnome_wicked.yaml
@@ -1,0 +1,9 @@
+name:           create_hdd_gnome_wicked
+description:    >
+  Boots into installed gnome system, switches to wicked.
+  Used as base job for other jobs, that require wicked to be running.
+schedule:
+  - boot/boot_to_desktop
+  - console/switch_to_wicked
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/tests/console/switch_to_wicked.pm
+++ b/tests/console/switch_to_wicked.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Switch from NetworkManager to wicked.
+# Maintainer: QA SLE Functional YaST <qa-sle-yast@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+    assert_script_run 'systemctl disable NetworkManager --now';
+    assert_script_run 'systemctl enable wicked --now';
+    assert_script_run qq{systemctl status wickedd.service | grep \"active \(running\)\"};
+}
+
+1;


### PR DESCRIPTION
The commit adds test module to switch to wicked and the appropriate yaml schedule.

- Related ticket: https://progress.opensuse.org/issues/64731
- Verification run: http://10.163.2.111/tests/1349

After merging, I have to add the update Test Suite settings:
  - create `create_hdd_gnome_wicked` with variables:
      PUBLISH_HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-gnome-wicked@%MACHINE%.qcow2
  PUBLISH_PFLASH_VARS=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-gnome-wicked@%MACHINE%-uefi-vars.qcow2
  - update `yast2_ui_devel` to use the published image;
  - update `nis_(client|server)` to use the published images.