### PR TITLE
Improve tigervnc test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1489,7 +1489,7 @@ sub load_extra_tests_desktop {
     if (check_var('DISTRI', 'sle')) {
         loadtest 'x11/disable_screensaver';
         # start extra x11 tests from here
-        loadtest 'x11/vnc_two_passwords';
+        loadtest 'x11/vnc_two_passwords' unless is_sle("<=12-SP2");
         # TODO: check why this is not called on opensuse
         # poo#35574 - Excluded for Xen PV as it was never passed due to the fail while interacting with grub.
         loadtest 'x11/user_defined_snapshot' unless is_s390x || (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'));
@@ -1503,6 +1503,7 @@ sub load_extra_tests_desktop {
                 # 42.2 feature - not even on Tumbleweed
                 loadtest "x11/gdm_session_switch";
             }
+            loadtest 'x11/vnc_two_passwords';
             loadtest "x11/seahorse";
             # only scheduled on gnome and was developed only for gnome but no
             # special reason should prevent it to be scheduled in another DE.


### PR DESCRIPTION
This tests the functionality of tigervnc (`vncserver` and `vncviewer`) by establishing a vnc session to `vncserver` on localhost and checks for a working desktop there. It also adds a check for bsc [1171519] (revealed during development of this test)

This commit also brings the `vnc_two_password` test to openSUSE Tumbleweed and Leap.

- Related ticket: https://progress.opensuse.org/issues/53381
- Needles: [openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/662) and [SLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1376)
- Verification runs: 
- - [Tumbleweed](http://phoenix-openqa.qam.suse.de/tests/1146) (`vnc_two_password` passes)
- - [SLE15-SP1](phoenix-openqa.qam.suse.de/tests/1141)
- - [SLE15](http://phoenix-openqa.qam.suse.de/tests/1142)
- - [SLE12-SP5](http://phoenix-openqa.qam.suse.de/tests/1143)
- - [SLE12-SP4](http://phoenix-openqa.qam.suse.de/tests/1144)
- - [SLE12-SP3](http://phoenix-openqa.qam.suse.de/tests/1145) (`vnc_two_password` passes)
- - [Leap 15.2](http://phoenix-openqa.qam.suse.de/tests/1147) (`vnc_two_password` passes)