### PR TITLE
HPC: OpenQA module isosize is used only in SLE15-SP2

### DIFF
--- a/schedule/hpc/create_hdd_hpc_textmode.yaml
+++ b/schedule/hpc/create_hdd_hpc_textmode.yaml
@@ -17,8 +17,12 @@ conditional_schedule:
         - installation/bootloader_uefi
       x86_64:
         - installation/bootloader
+  isosize:
+    VERSION:
+      15-SP2:
+        - installation/isosize
 schedule:
-  - installation/isosize
+  - '{{isosize}}'
   - '{{bootloader}}'
   - installation/welcome
   - installation/accept_license


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/65753
- Verification run: 
SLE15-SP0: https://openqa.suse.de/tests/4224882 (module isosize not loaded)
SLE15-SP2: https://openqa.suse.de/tests/4224883
