### PR TITLE
Adjust username in y2_firstboot

### DIFF
--- a/schedule/yast/yast2_firstboot.yaml
+++ b/schedule/yast/yast2_firstboot.yaml
@@ -3,7 +3,7 @@ name:           yast2_fistboot
 description:    >
     Smoke test for YaST2 firstboot module
 vars:
-    YAST2_FIRSTBOOT_USERNAME: y2_firstboot_tester
+    YAST2_FIRSTBOOT_USERNAME: firstbootuser
 schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data


### PR DESCRIPTION
Adjust username to avoid to press `shift` when typing user creation in yast2_firstboot.
Similar fix was done for openSUSE.
