### PR TITLE
systemd-qa-tests: add binary journal log upload

### DIFF
--- a/lib/systemd_testsuite_test.pm
+++ b/lib/systemd_testsuite_test.pm
@@ -123,8 +123,9 @@ sub post_fail_hook {
     my ($self) = @_;
     $self->SUPER::post_fail_hook();
     #upload logs from given testname
-    $self->tar_and_upload_log('/var/opt/systemd-tests/logs', '/tmp/systemd_testsuite-logs.tar.bz2');
-    $self->save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.log');
+    $self->tar_and_upload_log('/var/opt/systemd-tests/logs',       '/tmp/systemd_testsuite-logs.tar.bz2');
+    $self->tar_and_upload_log('/var/log/journal /run/log/journal', 'binary-journal-log.tar.bz2');
+    $self->save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.txt');
     upload_logs('/shutdown-log.txt', failok => 1);
 }
 


### PR DESCRIPTION
The binary format is much more powerful for a deeper analysis.
One can easily inspect all logs emitted by the containers running on the
system, filter messages, change the ouput format, etc...
Still the text representation should stay as well to be able to take a
direct look from within the browser.

- Verification run: http://knopfler.arch.suse.de/tests/56#downloads
