### PR TITLE
HPC: Add multimachine yaml configuration

### DIFF
--- a/schedule/hpc/multi_machine_test.yaml
+++ b/schedule/hpc/multi_machine_test.yaml
@@ -1,0 +1,28 @@
+---
+name: HPC node
+description:    >
+    Maintainer: schlad
+    Create a node for multimachine cluster tests
+vars:
+  DESKTOP: textmode
+  BOOT_HDD_IMAGE: 1
+
+conditional_schedule:
+  bootmenu:
+    ARCH:
+      aarch64:
+        - boot/uefi_bootmenu
+  hpctest:
+    HPC:
+      slurm_master:
+        - hpc/slurm_master
+      slurm_slave:
+        - hpc/slurm_slave
+      slurm_master_backup:
+        - hpc/slurm_master_backup
+
+schedule:
+  - '{{bootmenu}}'
+  - boot/boot_to_desktop
+  - hpc/before_test
+  - '{{hpctest}}'

--- a/schedule/hpc/supportserver.yaml
+++ b/schedule/hpc/supportserver.yaml
@@ -1,0 +1,8 @@
+name:           hpc_supportserver
+description:    >
+    Create a supportserver for multimachine cluster tests
+schedule:
+    - support_server/login
+    - support_server/setup
+    - hpc/barrier_init
+    - support_server/wait_children


### PR DESCRIPTION
OpenQA multimachine HPC tests do rely on installation tests to create
qcow and then boot to that qcow2. For this reason there is only a need
to boot to the image and then load very limited openQA test modules
based on HPC setting provided in the test suite definition. So single
yaml file can replace all current multimachine tests where HPC setting
is used

- Related ticket: https://progress.opensuse.org/issues/65753
- Verification run: tested locally for mm (slurm ALPHA and slurm BETA clusters)
