### PR TITLE
Fix transactional update  for SLE

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -167,7 +167,7 @@ sub trup_shell {
 # In general automated services will make sure that they don't block each other,
 # but this does not apply when manual triggering of the script.
 sub ensure_rollback_service_not_running {
-    for (1 .. 12) {
+    for (1 .. 24) {
         my $output = script_output("systemctl show -p SubState --value rollback.service");
         $output =~ '^(start|running)$' ? sleep 10 : last;
     }

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -79,7 +79,7 @@ sub run {
 
     script_run "rebootmgrctl set-strategy off";
 
-    if (get_var('BETA')) {
+    if (is_opensuse && get_var('BETA')) {
         record_info 'Remove pkgs', 'Remove preinstalled packages on Leap BETA';
         trup_call "pkg remove update-test-[^t]*";
         process_reboot 1;


### PR DESCRIPTION
Fix transactional update for SLE regarding condition introduced [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10205/files#diff-8a69ff131c89016f6556304348fc42d9R82) and also adjust timeout.

- Verification run: [sle-15-SP2-Online-x86_64-Build190.2-transactional_server_helper_apps@64bit ](https://openqa.suse.de/tests/4227409)