### PR TITLE
salt: Fix ignored exit code on test.ping call

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -58,9 +58,7 @@ EOF
     assert_script_run("salt-key --accept-all -y");
     # try to ping the minion. If it does not respond on the first try the ping
     # might have gone lost so try more often. Also see bsc#1069711
-    unless (script_run 'salt \'*\' test.ping') {
-        assert_script_run 'for i in {1..7}; do echo "try $i" && salt \'*\' test.ping -t30 && break; done';
-    }
+    assert_script_run 'for i in {1..7}; do echo "try $i" && salt \'*\' test.ping -t30 && break; done';
     systemctl 'stop salt-master salt-minion', timeout => 120;
 }
 


### PR DESCRIPTION
The code was never correct because we got the `script_run` return value
evaluation messed up. See
https://openqa.opensuse.org/tests/1257363#step/salt/20 for an example
where the initial `test.ping` call failed but the the test ignored the
failure and recorded a "passed" result for the test module.

As we do not record a soft_failure here anymore we can just call the
loop without a surrounding condition.

Verification run:


```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10252 https://openqa.opensuse.org/tests/1264363
```

opensuse-Tumbleweed-DVD-x86_64-Build20200511-minimalx@64bit -> https://openqa.opensuse.org/t1264859

Related progress issue: https://progress.opensuse.org/issues/66691