### PR TITLE
snapper: Exit terminal based on ncurses param

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -208,10 +208,11 @@ sub y2snapper_clean_and_quit {
     script_run 'snapper -c test delete-config';
     script_run 'rm -rf /test/*';
     script_run "ls";
-    unless (defined($module_name)) {
-        type_string "exit\n";
-        save_screenshot;
-        type_string "exit\n";
+    unless ($ncurses) {
+        type_string "exit\n";    # root
+        wait_still_screen(1);
+        type_string "exit\n";    # user
+        wait_still_screen(1);
     }
 }
 


### PR DESCRIPTION
ncurses does not need to exit tty, but GUI should exit xterm

- Fail: https://openqa.suse.de/tests/4228190#step/yast2_snapper/69
- Verification run:
http://10.100.12.155/tests/15545 ncurses
http://10.100.12.155/tests/15547 gui
