### PR TITLE
Add test module to check MicroOS image partition resizing

### DIFF
--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -21,6 +21,10 @@ sub is_regproxy_required {
     return check_var('SYSTEM_ROLE', 'kubeadm');
 }
 
+sub is_image_flavor {
+    return get_required_var('FLAVOR') =~ /-Image$/;
+}
+
 sub load_boot_from_dvd_tests {
     loadtest 'installation/bootloader_uefi' if (get_var("UEFI"));
     loadtest 'installation/bootloader' unless (get_var("UEFI"));
@@ -39,6 +43,7 @@ sub load_tdup_tests {
 sub load_feature_tests {
     # Feature tests for Micro OS operating system
     loadtest 'microos/libzypp_config';
+    loadtest 'microos/image_checks' if is_image_flavor;
     loadtest 'microos/one_line_checks';
     loadtest 'microos/services_enabled';
     load_transactional_role_tests;

--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run simple image specific checks
+# Maintainer: Fabian Vogt <fvogt@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+
+    # Disk which /var resides on
+    my $disk = script_output 'lsblk -rnoPKNAME $(findmnt -nrvoSOURCE /var)';
+
+    # Verify that openQA resized the disk image
+    my $disksize = script_output "sfdisk --show-size /dev/$disk";
+    die "Disk not bigger than the default size, got $disksize KiB" unless $disksize > (20 * 1024 * 1024);
+
+    # Verify that there is no unpartitioned space left
+    validate_script_output("sfdisk --list-free /dev/$disk", qr/Unpartitioned space .* 0 sectors/);
+
+    # Verify that the filesystem mounted at /var grew beyond the default 5GiB
+    my $varsize = script_output "findmnt -rnboSIZE -T/var";
+    die "/var did not grow, got $varsize B" unless $varsize > (5 * 1024 * 1024 * 1024);
+}
+
+1;


### PR DESCRIPTION
Requires `HDDSIZEGB_1=30`.

Verification run: http://10.160.67.86/tests/703

~http://10.160.67.86/tests/672~

~WIP because the product is currently broken. Fix is pending (https://build.opensuse.org/request/show/805239)~