### PR TITLE
Fix LTP build dependencies for SLE-12SP2

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -142,18 +142,18 @@ sub install_build_dependencies {
       gcc
       git-core
       kernel-default-devel
-      keyutils-devel
-      libacl-devel
       libaio-devel
-      libcap-devel
       libopenssl-devel
-      libselinux-devel
-      libtirpc-devel
       make
     );
     zypper_call('-t in ' . join(' ', @deps));
 
     my @maybe_deps = qw(
+      keyutils-devel
+      libcap-devel
+      libacl-devel
+      libtirpc-devel
+      libselinux-devel
       gcc-32bit
       kernel-default-devel-32bit
       keyutils-devel-32bit


### PR DESCRIPTION
Some devel libraries are not available on SLE-12SP2 for PPC and s390. Make these libraries optional when building LTP from Git.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - PPC64LE: https://openqa.suse.de/tests/4228161
  - s390x: https://openqa.suse.de/tests/4228162
