### PR TITLE
Improve error detection for zypper_call and add_suseconnect_product

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -189,6 +189,9 @@ sub add_suseconnect_product {
             record_soft_failure 'bsc#1124318 - Fail to get module repo metadata - running the command again as a workaround';
         }
         assert_script_run("SUSEConnect -p $name/$version/$arch $params", $timeout);
+    } elsif ($result && !$retry) {
+        die "SUSEConnect failed activating module $name with exit code (see log output): $result.";
+
     }
 }
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -191,7 +191,6 @@ sub add_suseconnect_product {
         assert_script_run("SUSEConnect -p $name/$version/$arch $params", $timeout);
     } elsif ($result && !$retry) {
         die "SUSEConnect failed activating module $name with exit code (see log output): $result.";
-
     }
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -500,7 +500,7 @@ sub zypper_call {
     $IN_ZYPPER_CALL = 1;
     # Retrying workarounds
     my $ret;
-    my $search_conflicts = 'awk \'BEGIN {print "Processing Record - ",NR; group=0}
+    my $search_conflicts = 'awk \'BEGIN {print "Processing conflicts - ",NR; group=0}
                     /Solverrun finished with an ERROR/,/statistics/{ print group"|", 
                     $0; if ($0 ~ /statistics/ ){ print "EOL"; group++ }; }\'\
                     /var/log/zypper.log


### PR DESCRIPTION
While working on adding AI/ML to SLE15, I came across these two problems:

* `add_suseconnect_product` was not failing if the call to `SUSEConnect` failed, hence giving us a false positive, here's how it looks now: http://phobos.suse.de/tests/3856979#step/tflite2/33
* `zypper_call` now will report package conflicts detected http://phobos.suse.de/tests/3856984#step/tflite2/34