### PR TITLE
[WIP] Adapt samba settings for 389-ds

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -20,14 +20,13 @@ use version_utils qw(is_sle is_leap is_tumbleweed is_opensuse);
 use yast2_widget_utils 'change_service_configuration';
 
 my %ldap_directives = (
-    fqdn                => 'openqa.ldaptest.org',
-    dir_instance        => 'openqatest',
-    dir_suffix          => 'dc=ldaptest,dc=org',
-    dn_container        => 'dc=ldaptest,dc=org',
-    dir_manager_dn      => 'cn=root',
-    dir_manager_passwd  => 'openqatest',
-    ca_cert_pem         => '/root/samba_ca_cert.pem',
-    srv_cert_key_pkcs12 => '/root/samba_server_cert.p12'
+ fqdn => "openqa.ldaptest.org",
+ instance_name => "openqatest",
+ suffix => "dc=ldaptest,dc=org",
+ dm_pass => "openqatest",
+ dm_pass_repeat => "openqatest",
+ tls_ca => "/root/samba_ca_cert.pem",
+ tls_p12 => "/root/samba_server_cert.p12"
 );
 
 my %samba_directives = (


### PR DESCRIPTION
The 389-ds ui in yast-auth-server was recently updated to change from openldap -> 389-ds, but then to update the 389-ds module to work with the 389 project's new instance helper tools. This has resulted in a change in the ui which has broken openqa tests in bz https://bugzilla.suse.com/show_bug.cgi?id=1146736

   Related ticket: https://progress.opensuse.org/issues/61780
   Needles: n/a
   Verification run:
   with original PR from january https://openqa.opensuse.org/tests/1264949
   after rebase
   on TW http://waaa-amazing.suse.cz/tests/12051
   and SLE http://waaa-amazing.suse.cz/tests/12052

