### PR TITLE
Trigger failed when encounter conflict during 11sp4 patch

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1649,8 +1649,17 @@ sub handle_patch_11sp4_zvm {
     while ($out) {
         if ($out =~ $zypper_patch_conflict) {
             save_screenshot;
-            send_key "3";
-            send_key "ret";
+            if (check_var("BREAK_DEPS", '1')) {
+                send_key "3";
+                send_key "ret";
+            }
+            elsif (check_var("WORKAROUND_DEPS", '1')) {
+                send_key "2";
+                send_key "ret";
+            }
+            else {
+                die 'Dependency problems';
+            }
         }
         elsif ($out =~ $zypper_continue) {
             save_screenshot;


### PR DESCRIPTION
Trigger failed when encounter conflict during 11sp4 patch:

- Related ticket: https://progress.opensuse.org/issues/66760
- Needles: na
- Verification run: 
http://openqa.suse.de/t4227230 with BREAK_DEPS=1
http://openqa.suse.de/t4227227 without BREAK_DEPS
http://openqa.suse.de/tests/4233453 with WORKAROUND_DEPS =1