### PR TITLE
Fix and cleanup libqt5_qtbase

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1487,6 +1487,7 @@ sub load_extra_tests_openqa_bootstrap {
 sub load_extra_tests_desktop {
     return unless any_desktop_is_applicable;
     if (check_var('DISTRI', 'sle')) {
+        loadtest 'x11/disable_screensaver';
         # start extra x11 tests from here
         loadtest 'x11/vnc_two_passwords';
         # TODO: check why this is not called on opensuse
@@ -1545,7 +1546,6 @@ sub load_extra_tests_desktop {
         }
         # We cannot change network device settings as rely on ssh/vnc connection to the machine
         loadtest "console/yast2_lan_device_settings" unless is_s390x();
-        loadtest "console/check_default_network_manager";
     }
 }
 

--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -24,19 +24,6 @@ use version_utils 'is_sle';
 use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
 
 sub run {
-    my $self = shift;
-
-    # Install required packages
-    # designer-qt5 is in package libqt5-qttools, yast release notes in yast2-installation
-    # SDK needs to be added for 12
-    if (is_sle('<=12-SP5')) {
-        select_console 'root-console';
-        cleanup_registration;
-        register_product;
-        add_suseconnect_product(get_addon_fullname('sdk'));
-    }
-    select_console 'x11';
-    ensure_unlocked_desktop;
     ensure_installed("libqt5-qttools yast2-installation", timeout => 180);
 
     # Test designer-qt5
@@ -65,10 +52,6 @@ sub run {
     assert_script_run 'make';
     assert_script_run './libqt5-qtbase';
     type_string "exit\n";
-}
-
-sub post_fail_hook {
-    my ($self) = @_;
 }
 
 1;


### PR DESCRIPTION
-turn off screensaver at beginning
-remove duplicate check_default_network_manager test from desktop extratests
-sdk does need to be added, it's already there

- Fail: https://openqa.suse.de/tests/4232782#step/libqt5_qtbase/56
- Verification run:
http://10.100.12.155/tests/15560 12sp4
http://10.100.12.155/tests/15554 12sp5
http://10.100.12.155/tests/15556 15sp1