### PR TITLE
docker_image: Switch from downloaded container-diff tool to packaged

### DIFF
--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -51,8 +51,7 @@ sub run {
     }
 
     if (check_var("ARCH", "x86_64")) {
-        assert_script_run('curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64', 240);
-        assert_script_run('chmod +x container-diff-linux-amd64 && mv container-diff-linux-amd64 /usr/local/bin/container-diff');
+        zypper_call("install container-diff");
     }
 
     for my $i (0 .. $#$image_names) {


### PR DESCRIPTION
docker_image: Switch from downloaded container-diff tool to packaged

- Related ticket: https://progress.opensuse.org/issues/58019 (and for currently happening unrelated failures https://progress.opensuse.org/issues/66754)
- Verification runs:
Tumbleweed: https://openqa.opensuse.org/tests/1266994 - install https://openqa.opensuse.org/tests/1266994#step/docker_image/10
15 SP1: https://openqa.suse.de/tests/4233495 - install https://openqa.suse.de/tests/4233495#step/docker_image/26
12 SP5: https://openqa.suse.de/tests/4233467 - install https://openqa.suse.de/tests/4233467#step/docker_image/24
12 SP4: https://openqa.suse.de/tests/4233466 - install https://openqa.suse.de/tests/4233466#step/docker_image/24
12 SP3: https://openqa.suse.de/tests/4233465 - install https://openqa.suse.de/tests/4233465#step/docker_image/24
