### PR TITLE
Handle case when we fail to calculate checksum separately

### DIFF
--- a/lib/data_integrity_utils.pm
+++ b/lib/data_integrity_utils.pm
@@ -40,7 +40,7 @@ sub get_image_digest {
 
     my $digest;
     if (check_var('BACKEND', 'svirt')) {
-        $digest = console('svirt')->get_cmd_output("sha256sum $image_path");
+        $digest = console('svirt')->run_cmd("sha256sum $image_path");
         # On Hyper-V the hash starts with '\'
         my $start = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 1 : 0;
         $digest = substr $digest, $start, 64;    # extract SHA256 from the output
@@ -71,6 +71,10 @@ sub verify_checksum {
         my $image_path = get_required_var $image;
         $image_path = $dir_path . basename($image_path) if $dir_path;
         my $digest = get_image_digest($image_path);
+        unless ($digest) {
+            $error .= "Failed to calculate checksum for $image localted in: $image_path\n";
+            next;
+        }
         if ($checksum eq $digest) {
             diag("$image OK", "$image_path: OK");
         } else {


### PR DESCRIPTION
Currently we have sporadic issues when we cannot calculate digest. This
triggers removal of the image, which might affect other jobs.
With this change we will remove iso only if checksum was calculated on
hyper-v side and it doesn't match expected value.

[Verification run](https://openqa.suse.de/tests/4233799).
NOTE: we have issues on hyper-v currently, this PR only helps to reach `welcome` module as of now, as installer fails to start.