### PR TITLE
Add QAM SAP regression tests

### DIFF
--- a/schedule/qam/15-SP1/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/15-SP1/qam-create_hdd_sles4sap_gnome.yml
@@ -7,6 +7,7 @@ schedule:
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
+  - '{{update_test_repo}}'
   - installation/addon_products_sle
   - installation/system_role
   - installation/sles4sap_product_installation_mode
@@ -30,3 +31,8 @@ schedule:
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/15-SP2/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/15-SP2/qam-create_hdd_sles4sap_gnome.yml
@@ -7,6 +7,7 @@ schedule:
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
+  - '{{update_test_repo}}'
   - installation/addon_products_sle
   - installation/system_role
   - installation/sles4sap_product_installation_mode
@@ -30,3 +31,8 @@ schedule:
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/15/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/15/qam-create_hdd_sles4sap_gnome.yml
@@ -7,6 +7,7 @@ schedule:
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
+  - '{{update_test_repo}}'
   - installation/addon_products_sle
   - installation/system_role
   - installation/sles4sap_product_installation_mode
@@ -30,3 +31,8 @@ schedule:
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/common/qam-sles4sap_scc_gnome_hana_wizard.yml
+++ b/schedule/qam/common/qam-sles4sap_scc_gnome_hana_wizard.yml
@@ -1,0 +1,10 @@
+name:           qam-sles4sap_scc_gnome_hana_wizard
+description:    >
+  Deploy a HANA instance on top of gnome image using wizard.
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/wizard_hana_install
+  - sles4sap/hana_test


### PR DESCRIPTION
This PR adds the possibility to execute SAP regression tests for QAM incident.
I added a `conditional_schedule` in the YAML files for loading the `add_update_test_repo` when we are in a QAM incident situation, for adding QAM update repos.
A HANA wizard test (qam-sles4sap_scc_gnome_hana_wizard.yml) is also added but not used yet.

- Related ticket: N/A
- Needles: N/A
- Verification run:
With QAM_INCI variable, `add_update_test_repo` is well loaded:
[15SP1-test](http://1a102.qa.suse.de/tests/4301)
[15GA-test](http://1a102.qa.suse.de/tests/4327)
Without QAM_INCI variable, `add_update_test_repo` is not loaded:
[15SP1-test](http://1a102.qa.suse.de/tests/4306)
[15GA-test](http://1a102.qa.suse.de/tests/4328)
