### PR TITLE
Introduce Transactional Update DUP test

### DIFF
--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -32,6 +32,10 @@ sub load_boot_from_disk_tests {
     loadtest 'microos/networking';
 }
 
+sub load_tdup_tests {
+    loadtest 'transactional/tdup';
+}
+
 sub load_feature_tests {
     # Feature tests for Micro OS operating system
     loadtest 'microos/libzypp_config';
@@ -71,6 +75,7 @@ sub load_installation_tests {
         # Full list of installation test-modules can be found at 'main_common.pm'
         load_inst_tests unless get_var 'BOOT_HDD_IMAGE';
         load_boot_from_disk_tests;
+        load_tdup_tests             if (get_var 'TDUP');
         loadtest 'console/regproxy' if is_regproxy_required;
         load_feature_tests          if (check_var 'EXTRA', 'FEATURES');
         loadtest 'shutdown/shutdown';
@@ -82,6 +87,7 @@ sub load_installation_tests {
 #######################
 if (get_var 'STACK_ROLE') {
     load_boot_from_disk_tests;
+    load_tdup_tests      if (get_var 'TDUP');
     load_feature_tests() if (check_var 'EXTRA', 'FEATURES');
     loadtest 'shutdown/shutdown';
 }

--- a/tests/transactional/tdup.pm
+++ b/tests/transactional/tdup.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: To a transactional-update dup and reboot the node
+# Maintainer: Richard Brown <rbrown@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use transactional;
+use utils;
+
+sub run {
+    select_console 'root-console';
+
+    zypper_call 'mr --all --disable';
+
+    my $defaultrepo;
+    if (get_var('SUSEMIRROR')) {
+        $defaultrepo = "http://" . get_var("SUSEMIRROR");
+    }
+    else {
+        die "No SUSEMIRROR variable set";
+    }
+
+    my $nr = 1;
+    foreach my $r (split(/,/, get_var('ZDUPREPOS', $defaultrepo))) {
+        zypper_call("--no-gpg-checks ar \"$r\" repo$nr");
+        $nr++;
+    }
+
+    zypper_call '--gpg-auto-import-keys ref';
+
+    trup_call 'dup';
+
+    process_reboot 1;
+
+}
+
+1;


### PR DESCRIPTION
Add Transactional Update DUP tests for MicroOS and Kubic so we can test the distro for the next snapshot

- Needles: None
- Verification run: https://openqa.opensuse.org/tests/1266362#
