### PR TITLE
Disable samba module in ncurses suite

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1400,7 +1400,6 @@ sub load_extra_tests_y2uitest_ncurses {
     unless (is_s390x) {
         loadtest "console/yast2_proxy";
         loadtest "console/yast2_vnc";
-        loadtest "console/yast2_samba";
         # internal nis server in suse network is used, but this is not possible for
         # openqa.opensuse.org
         loadtest "console/yast2_nis" if is_sle;

--- a/schedule/yast/samba_ncurses.yaml
+++ b/schedule/yast/samba_ncurses.yaml
@@ -1,0 +1,8 @@
+name:           samba_ncurses
+description:    >
+    Samba test has to be excluded from ncurses suite until resolution of bsc#1146736. This test suite is to be executed in development groups.
+schedule:
+  - boot/boot_to_desktop
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/yast2_samba


### PR DESCRIPTION
Samba test has to be excluded from ncurses suite until resolution of bsc#1146736 and executed in development groups.

- Related ticket:https://progress.opensuse.org/issues/61780
- Verification run: http://waaa-amazing.suse.cz/tests/12074