### PR TITLE
Fix heuristic script permissions for split brain test

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -116,9 +116,10 @@ sub run {
         barrier_create("CTDB_DONE_$cluster_name", $num_nodes + 1);
 
         # QNETD barriers
-        barrier_create("QNETD_SERVER_READY_$cluster_name", $num_nodes + 1);
-        barrier_create("QNETD_SERVER_DONE_$cluster_name",  $num_nodes + 1);
-        barrier_create("SPLIT_BRAIN_TEST_$cluster_name",   $num_nodes + 1);
+        barrier_create("QNETD_SERVER_READY_$cluster_name",     $num_nodes + 1);
+        barrier_create("QNETD_SERVER_DONE_$cluster_name",      $num_nodes + 1);
+        barrier_create("SPLIT_BRAIN_TEST_READY_$cluster_name", $num_nodes + 1);
+        barrier_create("SPLIT_BRAIN_TEST_DONE_$cluster_name",  $num_nodes + 1);
 
         # Create barriers for multiple tests
         foreach my $fs_tag ('LUN', 'CLUSTER_MD', 'DRBD_PASSIVE', 'DRBD_ACTIVE') {


### PR DESCRIPTION
Fix heuristic script permissions for split brain test and add additional checks in the test, including:

1. Moving the split brain check into its own section within the test module separated by barriers
2. Execution of the iptables commands in both nodes
3. Check the promotable resource is still working in the master during the split brain test

- Related ticket: N/A
- Needles: N/A
- Verification run: [node 1](http://mango.suse.de/tests/2373), [node 2](http://mango.suse.de/tests/2374), [qnetd server](http://mango.suse.de/tests/2375), [support server](http://mango.suse.de/tests/2372)
