### PR TITLE
salt: Adapt timeout to sum of retries

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -58,7 +58,8 @@ EOF
     assert_script_run("salt-key --accept-all -y");
     # try to ping the minion. If it does not respond on the first try the ping
     # might have gone lost so try more often. Also see bsc#1069711
-    assert_script_run 'for i in {1..7}; do echo "try $i" && salt \'*\' test.ping -t30 && break; done';
+    assert_script_run 'for i in {1..7}; do echo "try $i" && salt \'*\' test.ping -t30 && break; done', timeout => 300;
+
     systemctl 'stop salt-master salt-minion', timeout => 120;
 }
 


### PR DESCRIPTION
The script_run exit code evaluation was fixed with dc785a89f but the
timeout was never adjusted to the sum of internal timeouts within the
salt commands with retries.