### PR TITLE
Enlarger the timeout for assert screen yast2-migration-target-list-se…

### DIFF
--- a/tests/migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/migration/sle12_online_migration/yast2_migration.pm
@@ -204,7 +204,7 @@ sub run {
     }
     assert_screen 'yast2-migration-target';
     send_key "alt-p";                                       # focus on the item of possible migration targets
-    assert_screen 'yast2-migration-target-list-selected', 20;
+    assert_screen 'yast2-migration-target-list-selected', 60;
     send_key_until_needlematch 'migration-target-' . get_var("VERSION"), 'down', 20, 3;
     send_key "alt-n";
     assert_screen ['yast2-migration-installupdate', 'yast2-migration-proposal'], 500;


### PR DESCRIPTION
Enlarger the timeout for assert screen yast2-migration-target-list-selected

- Related ticket: https://progress.opensuse.org/issues/66829
- Needles: na
- Verification run: http://openqa.suse.de/t4236120
