### PR TITLE
Don't add serverapp and wsm modules in php7_mysql test

### DIFF
--- a/tests/console/php7_mysql.pm
+++ b/tests/console/php7_mysql.pm
@@ -35,10 +35,6 @@ use apachetest;
 
 sub run {
     select_console 'root-console';
-    if (is_sle) {
-        add_suseconnect_product(get_addon_fullname('serverapp'));
-        add_suseconnect_product(get_addon_fullname('wsm'));
-    }
     setup_apache2(mode => 'PHP7');
     # install requirements
     zypper_call "in php7-mysql mysql sudo";


### PR DESCRIPTION
They are already there as part of the test setup

- Related ticket: https://progress.opensuse.org/issues/66895
- Verification run:
http://10.100.12.155/tests/15604 12sp2
http://10.100.12.155/tests/15605 15
http://10.100.12.155/tests/15606 15sp2