### PR TITLE
Use virtio console in patch_and_reboot

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -27,16 +27,11 @@ use utils;
 use testapi;
 use qam;
 use Utils::Backends 'use_ssh_serial_console';
+use power_action_utils qw(power_action);
 
 sub run {
     my $self = shift;
-
-    if (check_var('BACKEND', 'ipmi')) {
-        use_ssh_serial_console;
-    }
-    else {
-        select_console 'root-console';
-    }
+    $self->select_serial_terminal;
 
     pkcon_quit unless check_var('DESKTOP', 'textmode');
 
@@ -49,9 +44,7 @@ sub run {
     assert_script_run('rpm -ql --changelog kernel-default >/tmp/kernel_changelog.log');
     upload_logs('/tmp/kernel_changelog.log');
 
-    console('root-ssh')->kill_ssh if check_var('BACKEND', 'ipmi');
-    type_string "reboot\n";
-
+    power_action('reboot');
     $self->wait_boot(bootloader_time => 150);
 }
 


### PR DESCRIPTION
Patch & reboot is done approx. 5 times faster

- Verification run: 
http://10.100.12.155/tests/15603#step/patch_and_reboot/1 x86_64
https://openqa.suse.de/tests/4238466 s390x defualt
https://openqa.suse.de/tests/4239349 s390x trying with VIRTIO_CONSOLE=1
