### PR TITLE
Fix ipxe

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -77,8 +77,8 @@ sub set_bootscript {
     my $arch        = get_required_var('ARCH');
     my $autoyast    = get_required_var('AUTOYAST');
 
-    my $kernel  = get_required_var('MIRROR_HTTP') . '/boot/$arch/loader/linux';
-    my $initrd  = get_required_var('MIRROR_HTTP') . '/boot/$arch/loader/initrd';
+    my $kernel  = get_required_var('MIRROR_HTTP') . "/boot/$arch/loader/linux";
+    my $initrd  = get_required_var('MIRROR_HTTP') . "/boot/$arch/loader/initrd";
     my $install = get_required_var('MIRROR_NFS');
     my $cmdline_extra;
 


### PR DESCRIPTION
Fix quoting in ipxe_install
    
When changing to support dynamic ARCHes, the quoting would have to be changed as well, which was forgotten. 
This fix is needed to allow correct execution.
