### PR TITLE
Click authenticate in PolicyKit authentication dialog

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -30,7 +30,7 @@ Base class implementation of distribution class necessary for testapi
 =cut
 
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
-use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_screenshot
+use testapi qw(send_key %cmd assert_screen check_screen check_var click_lastmatch get_var save_screenshot
   match_has_tag set_var type_password type_string wait_serial $serialdev
   mouse_hide send_key_until_needlematch record_info record_soft_failure
   wait_still_screen wait_screen_change get_required_var diag);
@@ -318,9 +318,9 @@ sub ensure_installed {
         last unless @tags;
         assert_screen(\@tags, timeout => $args{timeout});
         last if (match_has_tag('pkcon-finished'));
-        if (match_has_tag('Policykit')) {
+        if (match_has_tag('Policykit-authenticate')) {
             type_password;
-            send_key 'ret';
+            click_lastmatch;
             @tags = grep { $_ ne 'Policykit' } @tags;
             @tags = grep { $_ ne 'Policykit-behind-window' } @tags;
             next;


### PR DESCRIPTION
Up to GNOME 3.36, the PolKit auth dialog started with 'authenticate'
having the focus. for users with a password that is ok, as no harm
can happen by wrongly 'just' hitting enter.

From GNOME 3.36 on, the default is to 'cancel' the auth request, so
that the user can't just 'press away an auth dialog without thought',
since the following actions could have a negative impact on the system.

So instead of pressing 'ret' after typing the password (blank password),
we explicitly click using the mouse.

- Related ticket: https://progress.opensuse.org/issues/66083
- Needles: One needle required - PolicyKit-authenticate
  Same needle as the old 'PolicyKit' but with click regions on the 'Authenticate button' set
- Verification run: https://openqa.opensuse.org/tests/1271245 (in progress)
