### PR TITLE
Use virtio console when possible to speedup extratests

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -106,7 +106,7 @@ Returns true if the current instance is using ttys
 =cut
 
 sub has_ttys {
-    return ((get_var('BACKEND', '') !~ /ipmi|s390x|spvm|pvm_hmc/) && !get_var('S390_ZKVM') && !(check_var('BACKEND', 'generalhw') && !defined(get_var('GENERAL_HW_VNC_IP'))));
+    return ((get_var('BACKEND', '') !~ /ipmi|s390x|spvm|pvm_hmc/) && !get_var('S390_ZKVM') && !(check_var('BACKEND', 'generalhw') && !defined(get_var('GENERAL_HW_VNC_IP'))) && !get_var('PUBLIC_CLOUD'));
 }
 
 =head2 has_serial_over_ssh

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1724,7 +1724,7 @@ sub load_extra_tests_docker {
 sub load_extra_tests_prepare {
     # setup $serialdev permission and so on
     loadtest "console/prepare_test_data";
-    loadtest "console/consoletest_setup" unless get_var('PUBLIC_CLOUD');
+    loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
 }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1407,6 +1407,7 @@ sub load_extra_tests_y2uitest_ncurses {
         loadtest "console/yast2_ftp";
         loadtest "console/yast2_apparmor";
         loadtest "console/yast2_lan";
+        loadtest "console/yast2_lan_device_settings";
     }
     # TODO https://progress.opensuse.org/issues/20200
     # softfail record #bsc1049433 for samba and xinetd
@@ -1460,6 +1461,8 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest "console/yast2_nis" if is_sle;
     loadtest "console/yast2_ftp";
     loadtest "console/yast2_tftp";
+    # We cannot change network device settings as rely on ssh/vnc connection to the machine
+    loadtest "console/yast2_lan_device_settings" unless (is_s390x() || get_var('PUBLIC_CLOUD'));
 }
 
 sub load_extra_tests_texlive {
@@ -1635,8 +1638,8 @@ sub load_extra_tests_console {
     loadtest "console/syslog";
     loadtest "console/ntp_client" if (!is_sle || is_jeos);
     loadtest "console/mta" unless is_jeos;
-    # We cannot change network device settings as rely on ssh/vnc connection to the machine
-    loadtest "console/yast2_lan_device_settings" unless (is_s390x() || get_var('PUBLIC_CLOUD'));
+    # part of load_extra_tests_y2uitest_ncurses & load_extra_tests_y2uitest_cmd except jeos
+    loadtest "console/yast2_lan_device_settings" if is_jeos;
     loadtest "console/check_default_network_manager";
     loadtest "console/ipsec_tools_h2h" if get_var("IPSEC");
     loadtest "console/git";

--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -94,8 +94,8 @@ sub login {
         die 'Failed to wait for password prompt' unless wait_serial(qr/Password:\s*$/i);
         type_password;
         type_string("\n");
-        die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
     }
+    die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
     type_string(qq/PS1="$serial_term_prompt"\n/);
     wait_serial(qr/PS1="$serial_term_prompt"/);
     # TODO: Send 'tput rmam' instead/also

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -80,7 +80,6 @@ our @EXPORT = qw(
   set_hostname
   show_tasks_in_blocked_state
   svirt_host_basedir
-  prepare_ssh_localhost_key_login
   disable_serial_getty
   script_retry
   script_run_interactive
@@ -1392,35 +1391,6 @@ Return C<VIRSH_OPENQA_BASEDIR> or fall back to C</var/lib>.
 =cut
 sub svirt_host_basedir {
     return get_var('VIRSH_OPENQA_BASEDIR', '/var/lib');
-}
-
-=head2 prepare_ssh_localhost_key_login
-
- prepare_ssh_localhost_key_login($source_user);
-
-Add the SSH key of C<$source_user> to the C<.ssh/authorized_keys> file of root.
-
-=cut
-sub prepare_ssh_localhost_key_login {
-    my ($source_user) = @_;
-    # in case localhost is already inside known_hosts
-    if (script_run('test -e ~/.ssh/known_hosts') == 0) {
-        assert_script_run('ssh-keygen -R localhost');
-    }
-
-    # generate ssh key
-    if (script_run('! test -e ~/.ssh/id_rsa') == 0) {
-        assert_script_run('ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa');
-    }
-
-    # add key to authorized_keys of root
-    if ($source_user eq 'root') {
-        assert_script_run('cat ~/.ssh/id_rsa.pub | tee -a ~/.ssh/authorized_keys');
-    }
-    else {
-        assert_script_sudo('mkdir -p /root/.ssh');
-        assert_script_sudo("cat /home/$source_user/.ssh/id_rsa.pub | tee -a /root/.ssh/authorized_keys");
-    }
 }
 
 =head2 script_retry

--- a/schedule/qam/12-SP1/mau-extratests.yaml
+++ b/schedule/qam/12-SP1/mau-extratests.yaml
@@ -17,7 +17,6 @@ schedule:
 - console/cron
 - console/syslog
 - console/mta
-- console/yast2_lan_device_settings
 - console/check_default_network_manager
 - console/git
 - console/cups

--- a/schedule/qam/12-SP2/mau-extratests.yaml
+++ b/schedule/qam/12-SP2/mau-extratests.yaml
@@ -18,7 +18,6 @@ schedule:
 - console/cron
 - console/syslog
 - console/mta
-- console/yast2_lan_device_settings
 - console/check_default_network_manager
 - console/git
 - console/cups

--- a/schedule/qam/12-SP2/mau-extratests.yaml
+++ b/schedule/qam/12-SP2/mau-extratests.yaml
@@ -15,7 +15,6 @@ schedule:
 - console/libvorbis
 - console/command_not_found
 - console/openssl_alpn
-- console/autoyast_removed
 - console/cron
 - console/syslog
 - console/mta

--- a/schedule/qam/12-SP3/mau-extratests.yaml
+++ b/schedule/qam/12-SP3/mau-extratests.yaml
@@ -15,10 +15,10 @@ schedule:
 - console/libvorbis
 - console/command_not_found
 - console/openssl_alpn
-- console/autoyast_removed
 - console/cron
 - console/syslog
 - console/mta
+- console/vsftpd
 - console/yast2_lan_device_settings
 - console/check_default_network_manager
 - console/git

--- a/schedule/qam/12-SP3/mau-extratests.yaml
+++ b/schedule/qam/12-SP3/mau-extratests.yaml
@@ -19,7 +19,6 @@ schedule:
 - console/syslog
 - console/mta
 - console/vsftpd
-- console/yast2_lan_device_settings
 - console/check_default_network_manager
 - console/git
 - console/cups

--- a/schedule/qam/12-SP4/mau-extratests.yaml
+++ b/schedule/qam/12-SP4/mau-extratests.yaml
@@ -16,10 +16,10 @@ schedule:
 - console/libvorbis
 - console/command_not_found
 - console/openssl_alpn
-- console/autoyast_removed
 - console/cron
 - console/syslog
 - console/mta
+- console/vsftpd
 - console/check_default_network_manager
 - console/git
 - console/cups

--- a/schedule/qam/12-SP4/mau-extratests.yaml
+++ b/schedule/qam/12-SP4/mau-extratests.yaml
@@ -74,6 +74,5 @@ conditional_schedule:
         - console/aplay
         - console/soundtouch
         - console/wavpack
-        - console/yast2_lan_device_settings
         - console/gdb
 ...

--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -16,10 +16,10 @@ schedule:
 - console/libvorbis
 - console/command_not_found
 - console/openssl_alpn
-- console/autoyast_removed
 - console/cron
 - console/syslog
 - console/mta
+- console/vsftpd
 - console/check_default_network_manager
 - console/git
 - console/cups

--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -73,6 +73,5 @@ conditional_schedule:
         - console/aplay
         - console/soundtouch
         - console/wavpack
-        - console/yast2_lan_device_settings
         - console/gdb
 ...

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -20,7 +20,6 @@ schedule:
 - console/syslog
 - console/mta
 - console/vsftpd
-- '{{yast2_lan_device_settings}}'
 - console/check_default_network_manager
 - console/git
 - console/cups
@@ -76,10 +75,6 @@ conditional_schedule:
       x86_64:
         - console/aplay
         - console/wavpack
-  yast2_lan_device_settings:
-    ARCH:
-      x86_64:
-        - console/yast2_lan_device_settings
   lshw:
     ARCH:
       x86_64:

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -16,10 +16,10 @@ schedule:
 - console/libvorbis
 - console/command_not_found
 - console/openssl_alpn
-- console/autoyast_removed
 - console/cron
 - console/syslog
 - console/mta
+- console/vsftpd
 - '{{yast2_lan_device_settings}}'
 - console/check_default_network_manager
 - console/git

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -20,7 +20,6 @@ schedule:
 - console/syslog
 - console/mta
 - console/vsftpd
-- '{{yast2_lan_device_settings}}'
 - console/check_default_network_manager
 - console/git
 - console/cups
@@ -78,10 +77,6 @@ conditional_schedule:
       x86_64:
         - console/aplay
         - console/wavpack
-  yast2_lan_device_settings:
-    ARCH:
-      x86_64:
-        - console/yast2_lan_device_settings
   lshw:
     ARCH:
       x86_64:

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -16,10 +16,10 @@ schedule:
 - console/libvorbis
 - console/command_not_found
 - console/openssl_alpn
-- console/autoyast_removed
 - console/cron
 - console/syslog
 - console/mta
+- console/vsftpd
 - '{{yast2_lan_device_settings}}'
 - console/check_default_network_manager
 - console/git

--- a/tests/console/aaa_base.pm
+++ b/tests/console/aaa_base.pm
@@ -1,6 +1,6 @@
 # SUSE"s openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -30,7 +30,9 @@ use warnings;
 use testapi;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
+
     #create work dir
     assert_script_run "mkdir /tmp/aaa_base_test ; cd /tmp/aaa_base_test; touch test-file.txt ; mkdir test_dir";
 

--- a/tests/console/ca_certificates_mozilla.pm
+++ b/tests/console/ca_certificates_mozilla.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,8 @@ use testapi;
 use utils 'zypper_call';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     zypper_call 'in ca-certificates-mozilla openssl';
     assert_script_run('echo "x" | openssl s_client -connect static.opensuse.org:443 | grep "Verify return code: 0"');
 }

--- a/tests/console/check_default_network_manager.pm
+++ b/tests/console/check_default_network_manager.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,8 @@ use utils;
 use version_utils;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     zypper_call('in systemd-network', exitcode => [0, 104]);
 

--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,8 +22,7 @@ use main_common 'is_desktop';
 
 sub run {
     my ($self) = @_;
-
-    select_console 'root-console';
+    $self->select_serial_terminal;
 
     my %checker = ();
     $checker{VERSION}    = get_required_var('VERSION');

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -36,7 +36,9 @@ sub scan_and_parse {
 }
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
+
     zypper_call('in clamav');
     # Initialize and download ClamAV database which needs time
     assert_script_run('freshclam', 700);

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -11,31 +11,57 @@
 # Summary: console test pre setup, performing actions required to run tests
 # which are supposed to be reverted e.g. stoping and disabling packagekit and so on
 # Permanent changes are now executed in system_prepare module
-# - Save screenshot
+# - Setup passwordless & questionless ssh login to localhost 127.0.0.1 ::1
 # - Disable/stop serial-getty service
 # - Disable mail notifications system-wide
+# - Enable pipefail system-wide
 # - Disable/stop packagekit service
-# - Enable pipefail
+# - Check console font
+
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "consoletest";
 use testapi;
 use utils qw(check_console_font disable_serial_getty);
-use Utils::Backends qw(has_ttys use_ssh_serial_console);
-use Utils::Systemd 'disable_and_stop_service';
+use Utils::Backends qw(has_ttys);
+use Utils::Systemd qw(disable_and_stop_service systemctl);
 use strict;
 use warnings;
 
+
 sub run {
     my $self = shift;
-    # let's see how it looks at the beginning
-    save_screenshot;
-    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    my $user = $testapi::username;
+    $self->select_serial_terminal;
+
+    systemctl('start sshd');
+
+    # generate ssh key and use same key for root and bernhard
+    if (script_run('! test -e ~/.ssh/id_rsa') == 0) {
+        assert_script_run('ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa');
+    }
+
+    # copy and add root key into authorized_keys and public key into known_hosts of both root and user
+    # $user is not created or used, like LIVECD or ROOTONLY tests
+    if (get_var('ROOTONLY') || get_var('LIVECD')) {
+        assert_script_run('mkdir -pv ~/.ssh');
+        assert_script_run('touch ~/.ssh/{authorized_keys,known_hosts}');
+        assert_script_run('chmod 600 ~/.ssh/*');
+        assert_script_run('cat ~/.ssh/id_rsa.pub | tee -a ~/.ssh/authorized_keys');
+        assert_script_run("ssh-keyscan localhost 127.0.0.1 ::1 | tee -a ~/.ssh/known_hosts");
+    }
+    else {
+        assert_script_run("mkdir -pv ~/.ssh ~$user/.ssh");
+        assert_script_run("cp ~/.ssh/id_rsa ~$user/.ssh/id_rsa");
+        assert_script_run("touch ~{,$user}/.ssh/{authorized_keys,known_hosts}");
+        assert_script_run("chmod 600 ~{,$user}/.ssh/*");
+        assert_script_run("chown bernhard ~$user/.ssh/*");
+        assert_script_run("cat ~/.ssh/id_rsa.pub | tee -a ~{,$user}/.ssh/authorized_keys");
+        assert_script_run("ssh-keyscan localhost 127.0.0.1 ::1 | tee -a ~{,$user}/.ssh/known_hosts");
+    }
 
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt
     disable_serial_getty;
-    # init
-    check_console_font if has_ttys();
 
     # Prevent mail notification messages to show up in shell and interfere with running console tests
     script_run 'echo "unset MAILCHECK" >> /etc/bash.bashrc.local';
@@ -43,7 +69,8 @@ sub run {
     script_run '. /etc/bash.bashrc.local';
     disable_and_stop_service('packagekit.service', mask_service => 1);
 
-    $self->clear_and_verify_console;
+    # init
+    check_console_font if has_ttys();
 }
 
 sub post_fail_hook {

--- a/tests/console/coredump_collect.pm
+++ b/tests/console/coredump_collect.pm
@@ -1,7 +1,7 @@
 
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use testapi;
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
+    $self->select_serial_terminal;
     $self->upload_coredumps;
 }
 

--- a/tests/console/cron.pm
+++ b/tests/console/cron.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,8 @@ use testapi;
 use utils;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # check if cronie is installed, enabled and running
     assert_script_run 'rpm -q cronie';

--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -189,7 +189,8 @@ sub test8 {
 }
 
 sub run {
-    select_console("root-console");
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Check Service State, enable it if necessary, set default zone to public
     pre_test;

--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -30,16 +30,14 @@ sub test1 {
     record_info 'Test #1', 'Test: Stop firewalld, then start it';
     systemctl('stop firewalld');
     systemctl('start firewalld');
-
-    # Check Service State, enable it if necessary
-    record_info 'Check Service State';
-    assert_script_run("if ! systemctl is-active -q firewalld | grep -q -i 'inactive'; then systemctl start firewalld; fi");
+    # wait until iptables -L can print rules, max 10 seconds
+    assert_script_run('timeout 10 bash -c "until iptables -L IN_public_allow; do sleep 1;done"');
 }
 
 # Test #2 - Temporary Rules
 sub test2 {
     record_info 'Test #2', 'Test Temporary Rules';
-    script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+    assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
 
     # Check if it's tumbleweed or Leap/SLE and run the correct test accordingly
     if (is_tumbleweed) {
@@ -79,7 +77,7 @@ sub test2 {
 sub test3 {
     # Test Permanent Rules
     record_info 'Test #3', 'Test Permanent Rules';
-    script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+    assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
 
     assert_script_run("firewall-cmd --zone=public --permanent --add-port=25/tcp");
     assert_script_run("firewall-cmd --zone=public --permanent --add-service=pop3");
@@ -116,8 +114,8 @@ sub test3 {
 # Test #4 - Test Rules using Masquerading
 sub test4 {
     record_info 'Test #4', 'Test Rules using Masquerading';
-    script_run("iptables -t nat -L PRE_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_pre.txt");
-    script_run("iptables -t nat -L POST_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_post.txt");
+    assert_script_run("iptables -t nat -L PRE_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_pre.txt");
+    assert_script_run("iptables -t nat -L POST_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_post.txt");
 
     assert_script_run("firewall-cmd --zone=public --add-masquerade");
     assert_script_run("firewall-cmd --zone=public --add-forward-port=port=2222:proto=tcp:toport=22");
@@ -134,8 +132,8 @@ sub test4 {
 # Test #5 - Test ipv4 family addresses with rich rules
 sub test5 {
     record_info 'Test #5", "Test ipv4 family addresses with rich rules';
-    script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_allow.txt");
-    script_run("iptables -L IN_public_deny --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_deny.txt");
+    assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_allow.txt");
+    assert_script_run("iptables -L IN_public_deny --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_deny.txt");
 
     assert_script_run("firewall-cmd --zone=public --permanent --add-rich-rule 'rule family=\"ipv4\" source address=192.168.200.0/24 accept'");
     assert_script_run("firewall-cmd --zone=public --permanent --add-rich-rule 'rule family=\"ipv4\" source address=192.168.201.0/24 drop'");
@@ -165,7 +163,7 @@ sub test6 {
 # Test #7 - Create a rule using --timeout and verifying if the rule vanishes after the specified period
 sub test7 {
     record_info 'Test #7', 'Create a rule using timeout';
-    script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+    assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
 
     assert_script_run("firewall-cmd --zone=public --add-service=smtp --timeout=30");
 

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -36,7 +36,9 @@ sub wait_serial_or_die {
 
 
 sub run {
-    select_console("root-console");
+    my $self = shift;
+    $self->select_serial_terminal;
+
     zypper_call('in gcc glibc-devel gdb');    #Install test dependencies.
 
     #Test Case 1

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -42,7 +42,7 @@ sub run {
     #Test Case 1
     assert_script_run("curl -O " . data_url('gdb/test1.c'));
     assert_script_run("gcc -g -std=c99 test1.c -o test1");
-    type_string("gdb test1 >/dev/$serialdev\n");
+    type_string("gdb test1 | tee /dev/$serialdev\n");
     wait_serial_or_die("GNU gdb");
     #Needed because colour codes mess up the output on $serialdev
     type_string("set style enabled 0\n");
@@ -56,7 +56,7 @@ sub run {
     #Test Case 2
     assert_script_run("curl -O " . data_url('gdb/test2.c'));
     assert_script_run("gcc -g -std=c99  test2.c -o test2");
-    type_string("gdb test2 > /dev/$serialdev\n");
+    type_string("gdb test2 | tee /dev/$serialdev\n");
     wait_serial_or_die(qr/GNU gdb/);
     type_string("set style enabled 0\n");
     type_string("run\n");
@@ -72,14 +72,12 @@ sub run {
     wait_serial_or_die("Inferior");
     type_string("y\n");
 
-
     #Test 3
     assert_script_run("curl -O " . data_url('gdb/test3.c'));
     assert_script_run("gcc -g -std=c99 test3.c -o test3");
     script_run("./test3 & echo 'this is a workaround'");
     assert_script_run("pidof test3");    #Make sure the process was launched.
-    type_string('gdb -p $(pidof test3)' . " > /dev/$serialdev");
-    type_string("\n");
+    type_string("gdb -p \$(pidof test3) | tee /dev/$serialdev\n");
     wait_serial_or_die("Attaching to process", 10);
     type_string("set style enabled 0\n");
     type_string("break test3.c:9\n");

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -1,7 +1,7 @@
 
 # SUSE's openQA tests
 #
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,9 +23,6 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
-use version_utils;
-use Utils::Architectures;
-use registration;
 
 
 sub wait_serial_or_die {
@@ -39,12 +36,7 @@ sub wait_serial_or_die {
 
 
 sub run {
-    #Setup console for text feedback.
     select_console("root-console");
-    if (is_sle('=12-SP5') && is_aarch64()) {
-        register_product;
-        add_suseconnect_product 'sle-sdk';
-    }
     zypper_call('in gcc glibc-devel gdb');    #Install test dependencies.
 
     #Test Case 1
@@ -99,9 +91,6 @@ sub run {
     type_string("y\n");
     type_string("y\n");                  #Workaround to handle sshserial behavior
     assert_script_run("pkill -9 test3");
-    if (is_sle('=12-SP5') && is_aarch64()) {
-        cleanup_registration;
-    }
 }
 
 1;

--- a/tests/console/git.pm
+++ b/tests/console/git.pm
@@ -29,8 +29,6 @@ sub run {
     my $email    = "you\@example.com";
     select_console "root-console";
 
-    prepare_ssh_localhost_key_login 'root';
-
     # Create a test repo
     zypper_call("in git-core");
     assert_script_run("mkdir -p repos/qa1;cd repos/qa1");
@@ -45,9 +43,6 @@ sub run {
 
     # Clone repo via ssh
     script_run("git clone ssh://localhost:/root/repos/qa0 qa2 | tee /dev/$serialdev", 0);
-    assert_screen("input-yes");
-    type_string("yes\n");
-    assert_screen 'root-console';
 
     # Push update via ssh
     assert_script_run("cd ~/repos/qa2;echo \"Update\" >> README");

--- a/tests/console/git.pm
+++ b/tests/console/git.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,10 +22,9 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils;
+use utils qw(zypper_call);
 
 sub run {
-
     my $username = $testapi::username;
     my $email    = "you\@example.com";
     select_console "root-console";
@@ -45,7 +44,6 @@ sub run {
     assert_script_run("cd ~/repos;git clone --bare qa1 qa0");
 
     # Clone repo via ssh
-    type_string("clear\n");
     script_run("git clone ssh://localhost:/root/repos/qa0 qa2 | tee /dev/$serialdev", 0);
     assert_screen("input-yes");
     type_string("yes\n");
@@ -54,9 +52,7 @@ sub run {
     # Push update via ssh
     assert_script_run("cd ~/repos/qa2;echo \"Update\" >> README");
     assert_script_run("git add README;git commit  -m \"Update README\"");
-    type_string("clear\n");
     script_run("git push ssh://localhost:/root/repos/qa0 | tee /dev/$serialdev", 0);
-    assert_screen 'root-console';
 
     # git clone via https protocol
     assert_script_run("cd ~;git clone -q https://github.com/os-autoinst/os-autoinst-distri-example");

--- a/tests/console/git.pm
+++ b/tests/console/git.pm
@@ -27,7 +27,8 @@ use utils qw(zypper_call);
 sub run {
     my $username = $testapi::username;
     my $email    = "you\@example.com";
-    select_console "root-console";
+    my $self     = shift;
+    $self->select_serial_terminal;
 
     # Create a test repo
     zypper_call("in git-core");

--- a/tests/console/journalctlLevels.pm
+++ b/tests/console/journalctlLevels.pm
@@ -20,7 +20,7 @@ use warnings;
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
+    $self->select_serial_terminal;
 
     record_info("INFO", "Logs all level0 severity types");
     assert_script_run "wget --quiet " . data_url('journalctl_levels/test.sh') . " -O test.sh";

--- a/tests/console/kmod.pm
+++ b/tests/console/kmod.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -24,7 +24,8 @@ use testapi;
 use utils 'zypper_call';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Test modinfo command
     assert_script_run("OUT=\"\$(modinfo ip_set)\"");

--- a/tests/console/krb5.pm
+++ b/tests/console/krb5.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,7 +23,9 @@ use warnings;
 use testapi;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
+
     zypper_call 'in krb5 krb5-server krb5-client';
 
     #Get the script that creates the kerberus server:

--- a/tests/console/krb5.pm
+++ b/tests/console/krb5.pm
@@ -68,6 +68,9 @@ sub run {
     script_run "mkdir -p /run/user/`id -u tester`/krb5cc";
     script_run "chown tester:users /run/user/`id -u tester`/krb5cc";
 
+    # avoid failures in virtio-console due to unexpected PS1
+    assert_script_run('echo "PS1=\'# \'" >> ~tester/.bashrc') if check_var('VIRTIO_CONSOLE', '1');
+
     #confirm we have no existing kinit tickets cache:
     script_run 'su - tester', 0;
     type_string "klist 2> /tmp/krb5\n";

--- a/tests/console/lshw.pm
+++ b/tests/console/lshw.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,8 @@ use testapi;
 use utils;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     zypper_call('in lshw libxml2-tools');
 

--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -20,7 +20,8 @@ use registration qw(add_suseconnect_product register_product);
 
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     if (is_sle) {
         assert_script_run 'source /etc/os-release';

--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -46,7 +46,6 @@ sub run {
         return;
     }
     validate_script_output 'machinery --help', sub { m/machinery - A systems management toolkit for Linux/ }, 100;
-    prepare_ssh_localhost_key_login 'root';
     if (get_var('ARCH') =~ /aarch64|ppc64le/ && \
         script_run("machinery inspect localhost | grep 'no machinery-helper for the remote system architecture'", 300) == 0) {
         record_soft_failure 'boo#1125785 - no machinery-helper for this architecture.';

--- a/tests/console/mdadm.pm
+++ b/tests/console/mdadm.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,8 @@ use strict;
 use warnings;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     assert_script_run 'wget ' . data_url('qam/mdadm.sh');
     if (is_sle('<15')) {

--- a/tests/console/mta.pm
+++ b/tests/console/mta.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -37,7 +37,7 @@ sub run {
     # test email transmission
     assert_script_run 'echo "FOOBAR123" | mail root';
     assert_script_run 'postqueue -p';
-    script_run 'cat /var/mail/root';
+    assert_script_run 'until postqueue -p|grep "Mail queue is empty";do sleep 1;done';
     assert_script_run 'grep FOOBAR123 /var/mail/root';
 }
 

--- a/tests/console/mta.pm
+++ b/tests/console/mta.pm
@@ -18,7 +18,8 @@ use testapi;
 use utils;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     assert_script_run '! rpm -q exim';
 

--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,8 @@ use utils;
 use version_utils 'is_sle';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     assert_script_run 'timedatectl';
 

--- a/tests/console/openvswitch.pm
+++ b/tests/console/openvswitch.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -26,7 +26,8 @@ use warnings;
 use utils;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     zypper_call('in openvswitch-switch iputils', timeout => 300);
 

--- a/tests/console/osinfo_db.pm
+++ b/tests/console/osinfo_db.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,7 +22,8 @@ use testapi;
 use utils;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     #install osdbinfo packages
     zypper_call 'in osinfo-db libosinfo';

--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -29,7 +29,8 @@ use utils;
 use version_utils qw(is_leap is_sle);
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     die "This test module is not enabled for openSUSE Leap yet" if is_leap();
     my $version = get_required_var('VERSION');

--- a/tests/console/perf.pm
+++ b/tests/console/perf.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,9 @@ use testapi;
 use utils 'zypper_call';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
+
     # test 1
     # Installing and testing options -a -d -p
     zypper_call 'in perf';

--- a/tests/console/rpm.pm
+++ b/tests/console/rpm.pm
@@ -1,6 +1,6 @@
 # SUSE's Apache regression test
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -31,10 +31,11 @@ use utils 'zypper_call';
 use File::Basename 'basename';
 
 sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
     my $dir_prefix = '/tmp/';
     my @test_pkgs  = map { $dir_prefix . $_ } qw(openqa_rpm_test-1.0-0.noarch.rpm aaa_base.rpm);
 
-    select_console 'root-console';
     # Download dummy test packages
     # wget is not present in opensuse-15.1
     assert_script_run("curl -o ${dir_prefix}openqa_rpm_test-1.0-0.noarch.rpm " . autoinst_url . "/data/rpm/openqa_rpm_test-1.0-0.noarch.rpm");

--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -24,14 +24,14 @@ use utils;
 use version_utils qw(is_opensuse is_sle is_jeos);
 
 sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
     # try to install rsync if the test does not run on JeOS
     if (!is_jeos) {
-        select_console 'root-console';
         zypper_call('-t in rsync', dumb_term => 1);
     }
 
     # create the folders and files that will be synced
-    select_console('root-console');
     assert_script_run('mkdir /tmp/rsync_test_folder_a');
     assert_script_run('mkdir /tmp/rsync_test_folder_b');
     assert_script_run('echo rsync_test > /tmp/rsync_test_folder_a/rsync_test_file');

--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -11,7 +11,6 @@
 # - Install rsync (if not jeos)
 # - Create two test directories and populate with files, scripts and compressed
 # files
-# - Create a ssh key and copy to root authorized_keys
 # - Run "rsync -avzr /tmp/rsync_test_folder_a/ root@localhost:/tmp/rsync_test_folder_b; echo $? > /tmp/rsync_return_code.txt"
 # - Check the operation return code and md5sum from files transfered
 # Maintainer: Ciprian Cret <ccret@suse.com>
@@ -43,20 +42,8 @@ sub run {
     my $md5_initial_sh   = script_output('md5sum /tmp/rsync_test_folder_a/rsync_test_sh.sh');
     my $md5_initial_tar  = script_output('md5sum /tmp/rsync_test_folder_a/rsync_test_tar.tar');
 
-    prepare_ssh_localhost_key_login 'root';
-
     type_string("rsync -avzr /tmp/rsync_test_folder_a/ root\@localhost:/tmp/rsync_test_folder_b; echo \$\? > /tmp/rsync_return_code.txt\n");
-
-    if (is_jeos || is_sle) {
-        assert_screen('remote-ssh-login');
-    }
-    elsif (is_opensuse) {
-        assert_screen('accept-ssh-host-key');
-    }
-    type_string('yes');
-    send_key('ret');
-    assert_screen('rsync');
-    assert_script_run('$(exit $(cat /tmp/rsync_return_code.txt))');
+    assert_script_run('time sync');
 
     # keep the md5 hash value of the synced file and folder
     my $md5_synced_file = script_output('md5sum /tmp/rsync_test_folder_b/rsync_test_file');

--- a/tests/console/slp.pm
+++ b/tests/console/slp.pm
@@ -1,6 +1,6 @@
 # SUSE's openSLP regression test
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -25,7 +25,7 @@ use Utils::Systemd 'disable_and_stop_service';
 
 sub run {
     my ($self) = @_;
-    select_console 'root-console';
+    $self->select_serial_terminal;
 
     # Let's install slpd
     zypper_call 'in openslp-server';

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -108,8 +108,9 @@ sub run {
     assert_script_run "ssh -4v $ssh_testman\@localhost bash -c 'whoami | grep $ssh_testman'";
 
     # Port forwarding (bsc#1131709 bsc#1133386)
-    assert_script_run "( ssh -vv -L 4242:localhost:22 $ssh_testman\@localhost sleep 9999 & )";
-    assert_script_run "( ssh -vv -R 0.0.0.0:5252:localhost:22 $ssh_testman\@localhost sleep 9999 & )";
+    assert_script_run "( ssh -NL 4242:localhost:22 $ssh_testman\@localhost & )";
+    assert_script_run "( ssh -NR 0.0.0.0:5252:localhost:22 $ssh_testman\@localhost & )";
+    assert_script_run 'until ss -tulpn|egrep "4242|5252";do sleep 1;done';
     assert_script_run "ssh-keyscan -p 4242 localhost >> ~/.ssh/known_hosts";
     assert_script_run "ssh-keyscan -p 5252 localhost >> ~/.ssh/known_hosts";
 
@@ -135,7 +136,7 @@ sub run {
 
     assert_script_run "killall -u $ssh_testman || true";
     wait_still_screen 3;
-    clear_console;
+    clear_console if !is_serial_terminal;
 }
 
 sub test_flags {

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -32,7 +32,7 @@ use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap);
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
+    $self->select_serial_terminal;
 
     # new user to test sshd
     my $ssh_testman        = "sshboy";

--- a/tests/console/sshfs.pm
+++ b/tests/console/sshfs.pm
@@ -20,7 +20,9 @@ use testapi;
 use utils;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
+
     zypper_call('in sshfs');
     script_run('cd /var/tmp ; mkdir mnt ; sshfs localhost:/ mnt', 0);
     assert_script_run('zypper -n in xdelta3', fail_message => 'rpm/zypper calls statfs and might stumble over fuse fs');

--- a/tests/console/sshfs.pm
+++ b/tests/console/sshfs.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,11 +22,7 @@ use utils;
 sub run {
     select_console 'root-console';
     zypper_call('in sshfs');
-    prepare_ssh_localhost_key_login 'root';
     script_run('cd /var/tmp ; mkdir mnt ; sshfs localhost:/ mnt', 0);
-    assert_screen 'accept-ssh-host-key';
-    type_string "yes\n";    # trust ssh host key
-    assert_screen 'sshfs-accepted';
     assert_script_run('zypper -n in xdelta3', fail_message => 'rpm/zypper calls statfs and might stumble over fuse fs');
     assert_script_run('rpm -e xdelta3');
     assert_script_run('diff <(ls mnt) <(ls /)', fail_message => 'Listings should be the same from real and mounted root');

--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,8 @@ use warnings;
 use testapi;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     assert_script_run "rm -rf nts_* scc_* ||:";
     assert_script_run "supportconfig -t . -B test", 800;

--- a/tests/console/suse_module_tools.pm
+++ b/tests/console/suse_module_tools.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,7 +22,8 @@ use utils 'zypper_call';
 use version_utils qw(is_sle is_tumbleweed);
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Find a random module available on the system
     # Get a list of all modules

--- a/tests/console/sysctl.pm
+++ b/tests/console/sysctl.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,8 @@ use warnings;
 use testapi;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     assert_script_run 'sysctl -w vm.swappiness=59';
     validate_script_output 'cat /proc/sys/vm/swappiness', sub { m/^59$/ };
 }

--- a/tests/console/syslog.pm
+++ b/tests/console/syslog.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,7 +23,8 @@ use utils;
 use version_utils;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     my $test_log_msg = 'Test Log Message FOOBAR123';
     assert_script_run "logger $test_log_msg";

--- a/tests/console/sysstat.pm
+++ b/tests/console/sysstat.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2018 SUSE LLC
+# Copyright 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -25,7 +25,8 @@ use warnings;
 use testapi;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     zypper_call 'in sysstat';
     script_run 'rm -rf /var/log/sa/sa*';
     systemctl 'start sysstat.service';

--- a/tests/console/unzip.pm
+++ b/tests/console/unzip.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -24,8 +24,8 @@ use testapi;
 use utils 'zypper_call';
 
 sub run {
-    # Preparation
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     zypper_call 'in wget unzip';
     assert_script_run 'mkdir -p /tmp/unzip-test/ && pushd /tmp/unzip-test';
 

--- a/tests/console/vsftpd.pm
+++ b/tests/console/vsftpd.pm
@@ -30,7 +30,6 @@ use warnings;
 use utils 'zypper_call';
 
 sub run {
-    my $password = $testapi::password;
     select_console 'root-console';
     zypper_call 'in vsftpd expect';
     # export slenkins variables
@@ -39,11 +38,6 @@ sub run {
     # hosts entry for ssh-copy-id with expect
     assert_script_run 'echo "$SERVER server" >>/etc/hosts';
     assert_script_run 'echo "$CLIENT client" >>/etc/hosts';
-    # copy ssh keys on server and client
-    assert_script_run 'ssh-keygen -f /root/.ssh/id_rsa -N ""';
-    assert_script_run "expect -c 'spawn ssh-copy-id client;expect \"yes\";send \"yes\\r\";expect \"Password\";send \"$password\\r\";interact'";
-    assert_script_run "expect -c 'spawn ssh-copy-id server;expect \"yes\";send \"yes\\r\";interact'";
-    assert_script_run "expect -c 'spawn ssh-copy-id 127.0.0.1;expect \"yes\";send \"yes\\r\";interact'";
     # extract vsftpd testsuite in /tmp/vsftpd
     assert_script_run 'cd /tmp';
     assert_script_run 'wget ' . data_url('qam/vsftpd.tar.gz');

--- a/tests/console/vsftpd.pm
+++ b/tests/console/vsftpd.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018-2019 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -27,7 +27,6 @@ use base 'consoletest';
 use testapi;
 use strict;
 use warnings;
-use lockapi qw(barrier_create barrier_wait);
 use utils 'zypper_call';
 
 sub run {
@@ -49,7 +48,7 @@ sub run {
     assert_script_run 'cd /tmp';
     assert_script_run 'wget ' . data_url('qam/vsftpd.tar.gz');
     assert_script_run 'tar xzfv vsftpd.tar.gz';
-    assert_script_run 'bash run.sh | tee run.log', 300;
+    assert_script_run 'bash run.sh |& tee run.log', 300;
     upload_logs('run.log');
 }
 

--- a/tests/console/vsftpd.pm
+++ b/tests/console/vsftpd.pm
@@ -30,7 +30,9 @@ use warnings;
 use utils 'zypper_call';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
+
     zypper_call 'in vsftpd expect';
     # export slenkins variables
     assert_script_run 'export SERVER=127.0.0.1';

--- a/tests/console/wavpack.pm
+++ b/tests/console/wavpack.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -30,8 +30,8 @@ use version_utils 'is_sle';
 use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
 
 sub run {
-    # setup
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     # development module needed for dependencies, released products are tested with sdk module
     if (is_sle() && !main_common::is_updates_tests()) {
         cleanup_registration;

--- a/tests/console/zypper_extend.pm
+++ b/tests/console/zypper_extend.pm
@@ -1,6 +1,6 @@
 #SUSE"s openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -37,12 +37,12 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils;
+use utils qw(zypper_call);
 use version_utils 'is_sle';
 
 sub run {
-    select_console 'root-console';
-
+    my $self = shift;
+    $self->select_serial_terminal;
 
     #Search for a package (star
     zypper_call 'se star';

--- a/tests/console/zypper_info.pm
+++ b/tests/console/zypper_info.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -52,7 +52,8 @@ sub test_package_output {
 }
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # check for zypper info
     test_package_output;

--- a/tests/console/zypper_ref.pm
+++ b/tests/console/zypper_ref.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,7 +22,9 @@ use utils qw(zypper_call zypper_enable_install_dvd);
 use version_utils 'is_sle';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
+
     zypper_enable_install_dvd;
     zypper_call '--gpg-auto-import-keys ref';
 }

--- a/tests/console/zziplib.pm
+++ b/tests/console/zziplib.pm
@@ -1,6 +1,6 @@
 # SUSE"s openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -29,7 +29,9 @@ use version_utils 'is_sle';
 
 sub run {
     my $filezip = "files.zip";
-    select_console "root-console";
+    my $self    = shift;
+    $self->select_serial_terminal;
+
     # development module needed for dependencies, released products are tested with sdk module
     if (!main_common::is_updates_tests()) {
         cleanup_registration;

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -26,7 +26,9 @@ use utils;
 use version_utils qw(is_sle is_jeos is_opensuse);
 
 sub run() {
-    select_console('root-console');
+    my $self = shift;
+    $self->select_serial_terminal;
+
     pkcon_quit;
 
     if (check_var('SLE_PRODUCT', 'sled') || get_var('DOVECOT_REPO')) {

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -1,6 +1,6 @@
 # Evolution tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -93,21 +93,8 @@ sub run() {
 
     # create test users
     assert_script_run "useradd -m admin";
-    script_run "passwd admin", 0;    # set user's password
-    type_password "password123";
-    wait_still_screen(1);
-    send_key 'ret';
-    type_password "password123";
-    wait_still_screen(1);
-    send_key 'ret';
-
     assert_script_run "useradd -m nimda";
-    script_run "passwd nimda", 0;    # set user's password
-    type_password "password123";
-    send_key 'ret';
-    type_password "password123";
-    send_key 'ret';
-    save_screenshot;
+    assert_script_run "echo -e 'admin:password123\nnimda:password123' | chpasswd";
 
     systemctl 'status dovecot';
     systemctl 'status postfix';

--- a/tests/x11/exiv2.pm
+++ b/tests/x11/exiv2.pm
@@ -96,6 +96,7 @@ sub run {
     script_run "eog 20190201_154421.jpg", 0;
     assert_screen "exiv2_rename_test";
     send_key 'alt-f4';
+    wait_still_screen(1);
 
     #check exiv2 preview feature, which extracts a image preview from the file.
     assert_script_run "exiv2 -ep1 20190201_154421.jpg";
@@ -103,6 +104,7 @@ sub run {
     script_run "eog 20190201_154421-preview1.jpg", 0;
     assert_screen "exiv2_test_preview";
     send_key 'alt-f4';
+    wait_still_screen(1);
 
     # clean-up
     assert_script_run "rm 20190201_154421.jpg";

--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,7 +10,6 @@
 
 # Summary: Ensure ssh X-forwarding is working
 # - Launch xterm
-# - Create ssh keys for user and add to root authorized_keys
 # - Run "SSH_AUTH_SOCK=0 ssh -XC root@localhost xterm"
 # - Check if another xterm opened
 # - Check for "If you can see this text ssh-X-forwarding is working"
@@ -27,14 +26,7 @@ sub run {
     my ($self) = @_;
     mouse_hide(1);
     x11_start_program('xterm');
-    prepare_ssh_localhost_key_login $username;
-    # add SSH_AUTH_SOCK=0 to fix 'sign_and_send_pubkey: signing failed: agent refused operation'
-    type_string("SSH_AUTH_SOCK=0 ssh -XC root\@localhost xterm\n");
-    assert_screen([qw(ssh-xterm-host-key-authentication ssh-second-xterm)]);
-    # if ssh asks for authentication of the key accept it
-    if (match_has_tag('ssh-xterm-host-key-authentication')) {
-        type_string "yes\n";
-    }
+    type_string("ssh -XC root\@localhost xterm\n");
     assert_screen "ssh-second-xterm";
     $self->set_standard_prompt();
     $self->enter_test_text('ssh-X-forwarding', cmd => 1);


### PR DESCRIPTION
- Related ticket: #10137 
  Fixed serial_terminal on passwordles login on LIVECD, changed passwordless setup in
  consoltest_setup on opensuse without bernhard user (get_var('ROOTONLY') || get_var('LIVECD'))
  and sshd is not using passwordless setup done in consoltest_setup.
- Verification run:
https://openqa.suse.de/tests/4257161 15-SP1 extratests
https://openqa.suse.de/tests/4256927 12-SP5 s390x
15-SP2
https://openqa.suse.de/tests/4256216 staging gnome
https://openqa.suse.de/tests/4256217 staging minimal-base
https://openqa.suse.de/tests/4256219 extra_tests_textmode x86_64
https://openqa.suse.de/tests/4256220 extra_tests_textmode s390x
https://openqa.suse.de/tests/4256221 extra_tests_textmode ppc64le
https://openqa.suse.de/tests/4257148 extra_tests_textmode aarch64
TW
https://openqa.opensuse.org/tests/1272652 gnome_live i686
https://openqa.opensuse.org/tests/1272653 gnome_live x86_64
https://openqa.opensuse.org/tests/1272654 jeos_extra x86_64
https://openqa.opensuse.org/tests/1272860 extra_tests_in_textmode x86_64
https://openqa.opensuse.org/tests/1272656 gnome x86_64
https://openqa.opensuse.org/tests/1272657 kde x86_64
https://openqa.opensuse.org/tests/1272658 rootonly x86_64
https://openqa.opensuse.org/tests/1272659 kde-live x86_64
https://openqa.opensuse.org/tests/1272660 xfce-live x86_64
https://openqa.opensuse.org/tests/1271322 jeos-extra aarch64
There is big queue on aarch64 and nothing changed for aarch64 since previous version
15.1
https://openqa.opensuse.org/tests/1273585 krypton-live