### PR TITLE
Remove grub_test in btrfs_sle_libgstorage-ng

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
-  - installation/grub_test
   - installation/first_boot
   - console/validate_no_cow_attribute
   - console/verify_separate_home


### PR DESCRIPTION
After fixing first_boot in #10223, run is failed, because it didn't
catch GRUB.

The commit removes grub_test module, as it is not needed for the test,
as grub timeout is enabled and test just waits for first boot to be shown.

- Related ticket: https://progress.opensuse.org/issues/65891
- Verification run: https://openqa.suse.de/tests/4251940