### PR TITLE
Change location for containers schedule

### DIFF
--- a/data/containers/docker-compose.yml
+++ b/data/containers/docker-compose.yml
@@ -1,0 +1,60 @@
+version: "3.3"
+services:
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379"
+    networks:
+      - frontend
+    restart: on-failure
+
+  db:
+    image: postgres:9.4
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    networks:
+      - backend
+
+  vote:
+    image: dockersamples/examplevotingapp_vote:before
+    ports:
+      - "5000:80"
+    networks:
+      - frontend
+    depends_on:
+      - redis
+    restart: on-failure
+
+  result:
+    image: dockersamples/examplevotingapp_result:before
+    ports:
+      - "5001:80"
+    networks:
+      - backend
+    depends_on:
+      - db
+    restart: on-failure
+
+  worker:
+    image: dockersamples/examplevotingapp_worker
+    networks:
+      - frontend
+      - backend
+    restart: on-failure
+
+  visualizer:
+    image: dockersamples/visualizer:stable
+    ports:
+      - "8080:8080"
+    stop_grace_period: 1m30s
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+networks:
+  frontend:
+  backend:
+
+volumes:
+  db-data:
+

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -1,0 +1,60 @@
+# Copyright (C) 2015-2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package containers::common;
+
+use base Exporter;
+use Exporter;
+use strict;
+use warnings;
+use testapi;
+use registration;
+use utils qw(zypper_call systemctl);
+use version_utils qw(is_sle is_caasp);
+
+our @EXPORT = qw(install_docker_when_needed clean_docker_host);
+
+sub install_docker_when_needed {
+    if (is_caasp) {
+        # Docker should be pre-installed in MicroOS
+        die 'Docker is not pre-installed.' if zypper_call('se -x --provides -i docker');
+    }
+    else {
+        if (script_run("which docker") != 0) {
+            if (is_sle() && script_run("SUSEConnect --status-text") != 0) {
+                cleanup_registration();
+                register_product();
+                add_suseconnect_product("sle-module-containers", substr(get_required_var('VERSION'), 0, 2));
+            }
+
+            # docker package can be installed
+            zypper_call('in docker', timeout => 900);
+        }
+    }
+
+    # docker daemon can be started
+    systemctl('enable docker') if systemctl('is-enabled docker', ignore_failure => 1);
+    systemctl('start docker')  if systemctl('is-active docker',  ignore_failure => 1);
+    systemctl('status docker');
+    assert_script_run('docker info');
+}
+
+sub clean_docker_host {
+    assert_script_run('docker stop $(docker ps -q)') if script_output('docker ps -q | wc -l') != '0';
+    assert_script_run('docker system prune -a -f');
+}
+
+1;
+

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1712,6 +1712,7 @@ sub load_extra_tests_docker {
     loadtest "console/docker_runc";
     if (is_sle(">=12-sp3")) {
         loadtest "console/docker_image";
+        loadtest "console/docker_compose" if is_sle('15+');
     }
     if (is_opensuse) {
         loadtest "console/docker_image";

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -171,6 +171,7 @@ sub wait_for_ssh
     my ($self, %args) = @_;
     $args{timeout}            //= 600;
     $args{proceed_on_failure} //= 0;
+    $args{username}           //= $self->username();
     my $start_time = time();
 
     # Check port 22
@@ -181,7 +182,7 @@ sub wait_for_ssh
 
     # Check ssh command
     while ((my $duration = time() - $start_time) < $args{timeout}) {
-        return $duration if ($self->run_ssh_command(cmd => 'echo test', proceed_on_failure => 1, quiet => 1) eq 'test');
+        return $duration if ($self->run_ssh_command(cmd => 'echo test', proceed_on_failure => 1, quiet => 1, username => $args{username}) eq 'test');
         sleep 1;
     }
 
@@ -202,7 +203,8 @@ reachable anymore. The second one is the estimated bootup time.
 sub softreboot
 {
     my ($self, %args) = @_;
-    $args{timeout} //= 600;
+    $args{timeout}  //= 600;
+    $args{username} //= $self->username();
 
     my $duration;
 
@@ -213,11 +215,11 @@ sub softreboot
 
     # wait till ssh disappear
     while (($duration = time() - $start_time) < $args{timeout}) {
-        last unless (defined($self->wait_for_ssh(timeout => 1, proceed_on_failure => 1)));
+        last unless (defined($self->wait_for_ssh(timeout => 1, proceed_on_failure => 1, username => $args{username})));
     }
     my $shutdown_time = time() - $start_time;
     die("Waiting for system down failed!") unless ($shutdown_time < $args{timeout});
-    my $bootup_time = $self->wait_for_ssh(timeout => $args{timeout} - $shutdown_time);
+    my $bootup_time = $self->wait_for_ssh(timeout => $args{timeout} - $shutdown_time, username => $args{username});
     return ($shutdown_time, $bootup_time);
 }
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -43,7 +43,6 @@ our @EXPORT = qw(
   get_addon_fullname
   rename_scc_addons
   is_module
-  install_docker_when_needed
   verify_scc
   investigate_log_empty_license
   register_addons_cmd
@@ -878,28 +877,6 @@ sub rename_scc_addons {
         push @addons_new, defined $addons_map{$i} ? $addons_map{$i} : $i;
     }
     set_var('SCC_ADDONS', join(',', @addons_new));
-}
-
-sub install_docker_when_needed {
-    if (is_caasp) {
-        # Docker should be pre-installed in MicroOS
-        die 'Docker is not pre-installed.' if zypper_call('se -x --provides -i docker');
-    }
-    else {
-        if (is_sle('<15')) {
-            assert_script_run('zypper se docker || zypper -n ar -f http://download.suse.de/ibs/SUSE:/SLE-12:/Update/standard/SUSE:SLE-12:Update.repo', timeout => 600);
-        }
-        elsif (is_sle) {
-            add_suseconnect_product('sle-module-containers');
-        }
-        # docker package can be installed
-        zypper_call('in docker', timeout => 900);
-    }
-
-    # docker daemon can be started
-    systemctl('start docker');
-    systemctl('status docker');
-    assert_script_run('docker info');
 }
 
 sub verify_scc {

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -313,15 +313,15 @@ sub ensure_installed {
     testapi::assert_script_run('systemctl is-active -q packagekit || (systemctl unmask -q packagekit ; systemctl start -q packagekit)');
     type_string "exit\n";
     $self->script_run("pkcon install -yp $pkglist; echo pkcon-status-\$? | tee /dev/$testapi::serialdev", 0);
-    my @tags = qw(Policykit Policykit-behind-window pkcon-finished);
+    my @tags = qw(PolicyKit-authenticate Policykit-behind-window pkcon-finished);
     while (1) {
         last unless @tags;
         assert_screen(\@tags, timeout => $args{timeout});
         last if (match_has_tag('pkcon-finished'));
-        if (match_has_tag('Policykit-authenticate')) {
+        if (match_has_tag('PolicyKit-authenticate')) {
             type_password;
             click_lastmatch;
-            @tags = grep { $_ ne 'Policykit' } @tags;
+            @tags = grep { $_ ne 'PolicyKit-authenticate' } @tags;
             @tags = grep { $_ ne 'Policykit-behind-window' } @tags;
             next;
         }

--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -1,6 +1,6 @@
 name:           extra_tests_textmode_containers
 description:    >
-    Maintainer: slindomansilla.
+    Maintainer: jalausuch@suse.com, qa-c@suse.de
     Extra tests about software in containers module
 conditional_schedule:
     bootloader:

--- a/schedule/functional/allpatterns.yaml
+++ b/schedule/functional/allpatterns.yaml
@@ -42,7 +42,6 @@ schedule:
     - console/zypper_lr
     - console/zypper_ref
     - console/ncurses
-    - console/yast2_lan
     - console/curl_https
     - console/salt
     - console/glibc_sanity

--- a/schedule/functional/extra_tests_textmode_containers.yaml
+++ b/schedule/functional/extra_tests_textmode_containers.yaml
@@ -18,6 +18,7 @@ schedule:
     - '{{bootloader}}'
     - boot/boot_to_desktop
     - console/podman
+    - console/podman_image
     - console/docker
     - console/docker_runc
     - console/docker_image

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
-  - installation/grub_test
   - installation/first_boot
   - console/validate_no_cow_attribute
   - console/verify_separate_home

--- a/schedule/yast/yast2_ncurses_gnome.yaml
+++ b/schedule/yast/yast2_ncurses_gnome.yaml
@@ -1,0 +1,43 @@
+---
+name:           yast2_ncurses_gnome
+description:    >
+    Test for yast2 UI, ncurses only. Running on created gnome images
+    which provides both text console for ncurses UI tests as well as
+    the gnome environment for the GUI tests.
+schedule:
+    - "{{pre_boot_to_desktop}}"
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - "{{yast_modules}}"
+    - console/coredump_collect
+conditional_schedule:
+    pre_boot_to_desktop:
+        ARCH:
+            aarch64:
+                - boot/uefi_bootmenu
+            s390x:
+                - installation/bootloader_start
+    yast_modules:
+        ARCH:
+            x86_64:
+                - console/yast2_rmt
+                - console/yast2_ntpclient
+                - console/yast2_tftp
+                - console/yast2_proxy
+                - console/yast2_vnc
+                - console/yast2_nis
+                - console/yast2_http
+                - console/yast2_ftp
+                - console/yast2_apparmor
+                - console/yast2_lan
+                - console/yast2_lan_hostname
+                - console/yast2_dns_server
+                - console/yast2_nfs_client
+                - console/yast2_snapper_ncurses
+            aarch64:
+                - console/yast2_lan
+            ppc64le:
+                - console/yast2_lan
+            s390x:
+                - console/yast2_lan

--- a/schedule/yast/yast2_ncurses_textmode.yaml
+++ b/schedule/yast/yast2_ncurses_textmode.yaml
@@ -1,0 +1,17 @@
+---
+name:           yast2_ncurses_textmode
+description:    >
+    Test for yast2 UI, ncurses only. Running on created textmode image.
+schedule:
+    - "{{pre_boot_to_desktop}}"
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/yast2_lan
+conditional_schedule:
+    pre_boot_to_desktop:
+        ARCH:
+            aarch64:
+                - boot/uefi_bootmenu
+            s390x:
+                - installation/bootloader_start

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -27,7 +27,7 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use registration;
+use containers::common;
 use version_utils qw(is_sle is_leap);
 
 sub test_seccomp {
@@ -100,10 +100,10 @@ sub run {
     die("error: missing container $container_name") unless ($output_containers =~ m/$container_name/);
 
     # containers state can be saved to a docker image
-    my $exit_code = script_run("docker container exec $container_name zypper -n in curl", 300);
+    my $exit_code = script_run("docker container exec $container_name zypper -n in curl", 600);
     if ($exit_code) {
         record_info('poo#40958 - curl install failure, try with force-resolution.');
-        my $output = script_output("docker container exec $container_name zypper in --force-resolution -y -n curl", 300);
+        my $output = script_output("docker container exec $container_name zypper in --force-resolution -y -n curl", 600);
         die('error: curl not installed in the container') unless ($output =~ m/Installing: curl.*done/);
     }
     assert_script_run("docker container commit $container_name tw:saved");

--- a/tests/console/docker_compose.pm
+++ b/tests/console/docker_compose.pm
@@ -15,29 +15,36 @@
 
 use base "consoletest";
 use testapi;
+use registration;
 use utils;
+use version_utils 'is_sle';
+use containers::common;
 use strict;
 use warnings;
-
-# Setup the required testing environment
-sub setup {
-    # install the docker package if it's not already installed
-    zypper_call('in docker');
-
-    # make sure docker daemon is running
-    systemctl('start docker');
-    systemctl('status docker');
-}
 
 sub run {
     select_console("root-console");
 
-    record_info 'Setup', 'Setup the environment';
-    setup;
+    install_docker_when_needed;
+    add_suseconnect_product(get_addon_fullname('phub')) if is_sle();
 
     record_info 'Test #1', 'Test: Installation';
     zypper_call("in docker-compose");
     assert_script_run 'docker-compose --version';
+
+    assert_script_run 'mkdir -p dcproject; cd dcproject';
+    assert_script_run("wget " . data_url("containers/docker-compose.yml") . " -O docker-compose.yml");
+    assert_script_run 'docker-compose pull';
+    assert_script_run 'docker-compose up -d';
+    assert_script_run 'docker-compose ps';
+    assert_script_run 'docker-compose top';
+    assert_script_run 'docker-compose logs > logs.txt';
+    upload_logs "logs.txt";
+    assert_script_run 'docker-compose down', 180;
+    assert_script_run 'cd';
+
+    remove_suseconnect_product(get_addon_fullname('phub')) if is_sle();
+    clean_docker_host();
 }
 
 1;

--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -21,7 +21,7 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use registration qw(add_suseconnect_product install_docker_when_needed cleanup_registration register_product);
+use containers::common;
 use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
@@ -29,14 +29,6 @@ sub run {
     select_console "root-console";
 
     my ($image_names, $stable_names) = get_suse_container_urls();
-
-    if (is_sle) {
-        if (script_run("SUSEConnect --status-text") != 0) {
-            cleanup_registration();
-            register_product();
-            add_suseconnect_product("sle-module-containers", substr(get_required_var('VERSION'), 0, 2));
-        }
-    }
 
     install_docker_when_needed();
 
@@ -95,6 +87,8 @@ sub run {
         # Remove the image again to save space
         assert_script_run("docker image rm --force $image_names->[$i] refreshed-image");
     }
+
+    clean_docker_host();
 }
 
 1;

--- a/tests/console/docker_runc.pm
+++ b/tests/console/docker_runc.pm
@@ -19,7 +19,7 @@ use base "consoletest";
 use testapi;
 use utils;
 use version_utils qw(is_caasp is_sle);
-use registration;
+use containers::common;
 use strict;
 use warnings;
 
@@ -93,7 +93,7 @@ sub run {
     assert_script_run("! $runc state test2");
 
     # Cleanup, remove all images
-    assert_script_run("docker rmi --force busybox");
+    clean_docker_host();
 }
 
 1;

--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -52,7 +52,7 @@ sub run {
     my $systemd_tasks_cmd = 'echo "Triggering systemd timed service $i" && systemctl start $i';
     $systemd_tasks_cmd .= ' && systemctl mask $i.{service,timer}' unless get_var('SOFTFAIL_BSC1063638');
     assert_script_run(
-'for i in $(systemctl list-units --type=timer --state=active --no-legend | sed -e \'s/\(\S\+\)\.timer\s.*/\1/\'); do ' . $systemd_tasks_cmd . '; done', 600);
+'for i in $(systemctl list-units --type=timer --state=active --no-legend | sed -e \'s/\(\S\+\)\.timer\s.*/\1/\'); do ' . $systemd_tasks_cmd . '; done', 1000);
     record_soft_failure 'bsc#1063638 - review I/O scheduling parameters of btrfsmaintenance' if (time - $before) > 60 && get_var('SOFTFAIL_BSC1063638');
     # Disable cron jobs on older SLE12 by symlinking them to /bin/true
     if (!get_var('SOFTFAIL_BSC1063638') && script_run("! [ -d /usr/share/btrfsmaintenance/ ]")) {

--- a/tests/console/podman_image.pm
+++ b/tests/console/podman_image.pm
@@ -36,6 +36,12 @@ sub run {
         zypper_call "in apparmor-parser";
     }
 
+    if (is_sle() && script_run('rpm -qi ca-certificates-suse') == 1) {
+        my $distversion = get_required_var("VERSION") =~ s/-SP/_SP/r;    # 15 -> 15, 15-SP1 -> 15_SP1
+        zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_$distversion/SUSE:CA.repo");
+        zypper_call("in ca-certificates-suse");
+    }
+
     for my $i (0 .. $#$image_names) {
         # Load the image
         assert_script_run("podman pull $image_names->[$i]", 900);

--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -43,9 +43,9 @@ sub run {
     upload_asset $ay_profile_path;
 
     unless (is_opensuse) {
-        # As developement_tools are not build for staging, we will attempt to get the package from the factory repo
+        # As developement_tools are not build for staging, we will attempt to get the package
         # otherwise MODULE_DEVELOPMENT_TOOLS should be used
-        my $uri = (is_staging) ? "http://download.opensuse.org/tumbleweed/repo/oss/" : get_ftp_uri();
+        my $uri = get_ftp_uri();
         zypper_call "ar -c $uri devel-repo";
     }
     zypper_call '--gpg-auto-import-keys ref';
@@ -70,7 +70,13 @@ sub run {
 }
 
 sub get_ftp_uri {
-    my $devel_repo = get_required_var(is_sle('>=15') ? get_repo_var_name("MODULE_DEVELOPMENT_TOOLS") : 'REPO_SLE_SDK');
+    my $devel_repo;
+    if (is_staging) {
+        $devel_repo = uc(get_required_var('DISTRI')) . '-' . get_required_var('VERSION') .
+          '-Module-Development-Tools-POOL-' . get_required_var('ARCH') . '-CURRENT-Media1';
+    } else {
+        $devel_repo = get_required_var(is_sle('>=15') ? get_repo_var_name("MODULE_DEVELOPMENT_TOOLS") : 'REPO_SLE_SDK');
+    }
     return "$utils::OPENQA_FTP_URL/" . $devel_repo;
 }
 

--- a/tests/console/zypper_docker.pm
+++ b/tests/console/zypper_docker.pm
@@ -22,7 +22,7 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use registration;
+use containers::common;
 
 sub run {
     select_console("root-console");
@@ -48,6 +48,8 @@ sub run {
     assert_script_run("zypper-docker list-patches-container tmp_container", timeout => 600);
     # apply all the updates to a new_image
     assert_script_run("zypper-docker update --auto-agree-with-licenses $testing_image new_image", timeout => 900);
+
+    clean_docker_host();
 }
 
 1;


### PR DESCRIPTION
Containers tests have changed ownership to QAC team.
Therefore, we would like to have that schedule under
our own schedule directory.

- Related ticket: https://progress.opensuse.org/issues/66538
