### PR TITLE
Disable hostname set by DHCP since it overwrite manual value - poo#66775

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -65,6 +65,17 @@ sub run {
     }
 
     assert_screen 'test-yast2_lan-1';
+
+    # Do not set hostname via DHCP - poo#66775
+    # This is already the default on SLE, so change it for openSUSE only
+    if (is_opensuse) {
+        send_key "tab";
+        assert_screen 'yast2_lan-set-hostname-via-dhcp-selected';
+        send_key 'down';
+        send_key_until_needlematch("yast2_lan-set-hostname-via-dhcp-NO-selected", "up", 5);
+        send_key "ret";
+    }
+
     close_yast2_lan;
     wait_still_screen;
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/66775
- Needles: 
  - yast2_lan-set-hostname-via-dhcp-selected: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/417e03ea06bc271a94b2bf5cb494e86a438222ca
  - yast2_lan-set-hostname-via-dhcp-NO-selected: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/54638714d2012ab577157ef380c3a536a08b5eaf
- Verification run: https://openqa.opensuse.org/t1272278