### PR TITLE
Remove un-necessary line in nis_server

### DIFF
--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -82,7 +82,6 @@ sub nis_server_configuration {
 sub nfs_server_configuration {
     # NFS Server Configuration
     assert_screen 'nfs-server-configuration';
-    send_key 'alt-f';                            # open port in firewall
     send_key 'alt-s';                            # start nfs server
     send_key 'alt-m';                            # NFSv4 domain name field
     type_string $setup_nis_nfs_x11{nfs_domain};


### PR DESCRIPTION
We don't need to select this as we are disabling firewalld

- Verification run:
http://waaa-amazing.suse.cz/tests/12101
