### PR TITLE
Remove -f for reboot in reboot_to_upgrade

### DIFF
--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -33,7 +33,7 @@ sub run {
         set_var('BOOT_HDD_IMAGE', 0) unless check_var('ARCH', 'aarch64');
     }
     assert_script_run "sync", 300;
-    type_string "reboot -f\n";
+    type_string "reboot\n";
 }
 
 1;


### PR DESCRIPTION
The '-f' option to 'reboot' in 'reboot_to_upgrade' is not the proper way to reboot, there may be some corner cases where this operation will potentially lead to problems. Detail see bsc#1166042.

- Related ticket: https://progress.opensuse.org/issues/67012
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/4255866#