### PR TITLE
Change location for containers schedule

### DIFF
--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -1,6 +1,6 @@
 name:           extra_tests_textmode_containers
 description:    >
-    Maintainer: slindomansilla.
+    Maintainer: jalausuch@suse.com, qa-c@suse.de.
     Extra tests about software in containers module
 conditional_schedule:
     bootloader:


### PR DESCRIPTION
Containers tests have changed ownership to QAC team.
Therefore, we would like to have that schedule under
our own schedule directory.

Related ticket: https://progress.opensuse.org/issues/66538
