### PR TITLE
Fix docker_compose and debug docker_image

### DIFF
--- a/data/containers/docker-compose.yml
+++ b/data/containers/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       - db-data:/var/lib/postgresql/data
     networks:
       - backend
+    restart: on-failure
+    environment:
+      - POSTGRES_PASSWORD=nots3cr3t
 
   vote:
     image: dockersamples/examplevotingapp_vote:before

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -52,8 +52,8 @@ sub install_docker_when_needed {
 }
 
 sub clean_docker_host {
-    assert_script_run('docker stop $(docker ps -q)') if script_output('docker ps -q | wc -l') != '0';
-    assert_script_run('docker system prune -a -f');
+    assert_script_run('docker stop $(docker ps -q)', 180) if script_output('docker ps -q | wc -l') != '0';
+    assert_script_run('docker system prune -a -f',   180);
 }
 
 1;

--- a/tests/console/docker_compose.pm
+++ b/tests/console/docker_compose.pm
@@ -27,6 +27,7 @@ sub run {
 
     install_docker_when_needed;
     add_suseconnect_product(get_addon_fullname('phub')) if is_sle();
+    zypper_call("in nmap")                              if (script_run("which nmap") != 0);
 
     record_info 'Test #1', 'Test: Installation';
     zypper_call("in docker-compose");
@@ -34,10 +35,14 @@ sub run {
 
     assert_script_run 'mkdir -p dcproject; cd dcproject';
     assert_script_run("wget " . data_url("containers/docker-compose.yml") . " -O docker-compose.yml");
-    assert_script_run 'docker-compose pull';
-    assert_script_run 'docker-compose up -d';
+    assert_script_run 'docker-compose pull',  600;
+    assert_script_run 'docker-compose up -d', 120;
     assert_script_run 'docker-compose ps';
     assert_script_run 'docker-compose top';
+    assert_script_run 'curl -s http://127.0.0.1:5001/ | grep Result';
+    assert_script_run 'curl -s http://127.0.0.1:8080/ | grep Visualizer';
+    assert_script_run 'curl -s http://127.0.0.1:5000/ | grep "Cats vs Dogs!"';
+    assert_script_run 'nmap 127.0.0.1 -p 5432 | grep closed';
     assert_script_run 'docker-compose logs > logs.txt';
     upload_logs "logs.txt";
     assert_script_run 'docker-compose down', 180;


### PR DESCRIPTION
 * The `db` container has now in `docker_compose.yml` all its variables.
 * The `container-suseconnect-zypp` binary is now triggered so we can debug it.
 * Some timeouts were addressed.

- Related ticket: [poo#66754](https://progress.opensuse.org/issues/66754)
- Verification run: [SLE 12 SP3](http://pdostal-server.suse.cz/tests/8602), [SLE 12 SP5](http://pdostal-server.suse.cz/tests/8603), [SLE 15](http://pdostal-server.suse.cz/tests/8605#live), [Tumbleweed](http://pdostal-server.suse.cz/tests/8602#step/docker_image/35)
