### PR TITLE
Unschedule keyboard_layout_gdm for s390x

### DIFF
--- a/schedule/functional/extra_tests_gnome.yaml
+++ b/schedule/functional/extra_tests_gnome.yaml
@@ -23,6 +23,14 @@ conditional_schedule:
                 - x11/user_defined_snapshot
             'x86_64':
                 - x11/user_defined_snapshot
+    keyboard_layout_gdm:
+        ARCH:
+            'aarch64':
+                - x11/keyboard_layout_gdm
+            'ppc64le':
+                - x11/keyboard_layout_gdm
+            'x86_64':
+                - x11/keyboard_layout_gdm
 schedule:
     - '{{bootloader}}'
     - boot/boot_to_desktop
@@ -33,7 +41,7 @@ schedule:
     - x11/remote_desktop/vino_screensharing_available
     - x11/rrdtool_x11
     - x11/yast2_lan_restart
-    - x11/keyboard_layout_gdm
+    - '{{keyboard_layout_gdm}}'
     - console/yast2_lan_device_settings
     - console/check_default_network_manager
     - console/coredump_collect


### PR DESCRIPTION
On s390x we are using the svirt backend which creates a direct VNC connection to the SUT
which is not affected by keyboard layout settings.

Ticket: https://progress.opensuse.org/issues/66847
Verification: https://openqa.suse.de/t4257190