### PR TITLE
WIP: exclude libqt5_qtbase from svirt-xen-pv and s390x

### DIFF
--- a/schedule/functional/extra_tests_gnome_sdk.yaml
+++ b/schedule/functional/extra_tests_gnome_sdk.yaml
@@ -1,5 +1,6 @@
-name:   extra_test_gnome_sdk
-description:    >
+---
+name: extra_test_gnome_sdk
+description: >
     Maintainer: jrauch
     Extra tests about software in sdk on gnome
 conditional_schedule:
@@ -14,10 +15,21 @@ conditional_schedule:
                 - installation/bootloader_svirt
             'svirt-xen-hvm':
                 - installation/bootloader_svirt
+    libqt5_qtbase:
+        ARCH:
+            'aarch64':
+                - x11/libqt5_qtbase
+            'x86_64':
+                - x11/libqt5_qtbase
+            'ppc64le':
+                - x11/libqt5_qtbase
+        MACHINE:
+            'svirt-xen-hvm':
+                - x11/libqt5_qtbase
 schedule:
     - '{{bootloader}}'
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup
-    - x11/libqt5_qtbase
+    - '{{libqt5_qtbase}}'
     - console/coredump_collect


### PR DESCRIPTION
for svirt-xen-pv we have a product issue, remove form test till
https://bugzilla.suse.com/show_bug.cgi?id=1171869 got fixed.
it has never worked for s390x, so remove from schedule.
see https://progress.opensuse.org/issues/66301
