### PR TITLE
Always force reboot in shell as patching is done in shell

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -51,7 +51,8 @@ sub run {
     assert_script_run('rpm -ql --changelog kernel-default >/tmp/kernel_changelog.log');
     upload_logs('/tmp/kernel_changelog.log');
 
-    power_action('reboot');
+    # DESKTOP can be gnome, but patch is happening in shell, thus always force reboot in shell
+    power_action('reboot', textmode => 1);
     $self->wait_boot(bootloader_time => 150);
 }
 


### PR DESCRIPTION
DESKTOP can equal gnome e.g. in qam-gnome test, but patch_and_reboot is always done
in shell, switching to GUI and doing reboot there does just unnecessarily delay reboot action

- Fail: https://openqa.suse.de/tests/4256927#step/consoletest_setup/2
- Verification run:
https://openqa.suse.de/tests/4257621
https://openqa.suse.de/tests/4257835
https://openqa.suse.de/tests/4257836
https://openqa.suse.de/tests/4257624