### PR TITLE
Remove setting of IPXE_CONSOLE from schedule

### DIFF
--- a/schedule/kernel/uefi_baremetal_basic.yaml
+++ b/schedule/kernel/uefi_baremetal_basic.yaml
@@ -4,7 +4,6 @@ description:    >
 vars:
     AUTOYAST_PREPARE_PROFILE: 1
     IPXE: 1
-    IPXE_CONSOLE: console=ttyS0,115200
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_UEFI: 1
     SCC_ADDONS: sdk


### PR DESCRIPTION
We get the entire screen output properly using only the default values.
When we override the defaults, we don't see the installer in the IPMI
console.