### PR TITLE
Change IP for suse.com in yast_dns_server test

### DIFF
--- a/tests/yast2_cmd/yast_dns_server.pm
+++ b/tests/yast2_cmd/yast_dns_server.pm
@@ -74,7 +74,7 @@ sub run {
     #Forward server and test lookup
     $self->cmd_handle("forwarders", "add", ip => "10.0.2.3");
     systemctl("start named.service");
-    validate_script_output('dig @localhost www.suse.com +short', sub { /\Q35.157.181.240\E/ });
+    validate_script_output('dig @localhost www.suse.com +short', sub { /\Q35.156.53.100\E/ });
     $self->cmd_handle("forwarders", "remove", ip => "10.0.2.3");
     record_soft_failure("bsc#1151138") if (systemctl("is-active named.service", ignore_failure => 1));
 


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4257941#step/yast_dns_server/13
- Verification run: https://openqa.suse.de/tests/4258890