### PR TITLE
Fix soft-failure for missing nfs firewalld config

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -21,7 +21,7 @@ sub server_configure_network {
     setup_static_mm_network('10.0.2.101/24');
 
     if (is_sle('15+') || is_opensuse) {
-        record_soft_failure 'boo#1130093 No firewalld service for nfs-kernel-server';
+        record_soft_failure 'boo#1083486 No firewalld service for nfs-kernel-server';
         disable_and_stop_service('firewalld');
     }
 }


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1130093 is resolved as
duplicate of https://bugzilla.suse.com/show_bug.cgi?id=1083486 which is
correct bug reference.