### PR TITLE
Fix docker_compose.pm for aarch64 and docker* on JeOS

### DIFF
--- a/data/containers/docker-compose.yml
+++ b/data/containers/docker-compose.yml
@@ -1,63 +1,31 @@
 version: "3.3"
 services:
 
-  redis:
-    image: redis:alpine
-    ports:
-      - "6379"
-    networks:
-      - frontend
-    restart: on-failure
-
-  db:
-    image: postgres:9.4
-    volumes:
-      - db-data:/var/lib/postgresql/data
+  nginx:
+    image: nginx
     networks:
       - backend
+    volumes:
+      - www:/usr/share/nginx/html
     restart: on-failure
-    environment:
-      - POSTGRES_PASSWORD=nots3cr3t
 
-  vote:
-    image: dockersamples/examplevotingapp_vote:before
+  haproxy:
+    image: haproxy
+    volumes:
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     ports:
-      - "5000:80"
+      - "8080:80"
     networks:
+      - backend
       - frontend
     depends_on:
-      - redis
+      - nginx
     restart: on-failure
-
-  result:
-    image: dockersamples/examplevotingapp_result:before
-    ports:
-      - "5001:80"
-    networks:
-      - backend
-    depends_on:
-      - db
-    restart: on-failure
-
-  worker:
-    image: dockersamples/examplevotingapp_worker
-    networks:
-      - frontend
-      - backend
-    restart: on-failure
-
-  visualizer:
-    image: dockersamples/visualizer:stable
-    ports:
-      - "8080:8080"
-    stop_grace_period: 1m30s
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
 
 networks:
   frontend:
   backend:
 
 volumes:
-  db-data:
+  www:
 

--- a/data/containers/haproxy.cfg
+++ b/data/containers/haproxy.cfg
@@ -1,0 +1,15 @@
+defaults
+  mode http
+  maxconn 5000
+
+  timeout connect 5s
+  timeout client  20s
+  timeout server  20s
+
+frontend public
+  bind *:80
+  default_backend apps
+
+backend apps
+  server nginx nginx:80 check
+

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -33,10 +33,8 @@ sub install_docker_when_needed {
     }
     else {
         if (script_run("which docker") != 0) {
-            if (is_sle() && script_run("SUSEConnect --status-text") != 0) {
-                cleanup_registration();
-                register_product();
-                add_suseconnect_product("sle-module-containers", substr(get_required_var('VERSION'), 0, 2));
+            if (is_sle() && script_run("SUSEConnect --status-text | grep Containers") != 0) {
+                add_suseconnect_product("sle-module-containers");
             }
 
             # docker package can be installed

--- a/tests/console/docker_compose.pm
+++ b/tests/console/docker_compose.pm
@@ -10,7 +10,14 @@
 # Summary: Test docker-compose installation
 #    Cover the following aspects of docker-compose:
 #      * package can be installed
-# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
+#      * Required images can be pulled
+#      * All containers can be executed
+#      * Both internal and external volumes can be attached
+#      * Various networks can be created - the containers can communicate through
+#      * Single commands can be executed inside of running container
+#      * Exposed ports are accessible from outside of a container
+#      * Logs can be retrieved
+# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>, Pavel Dostal <pdostal@suse.cz>
 
 
 use base "consoletest";
@@ -27,29 +34,48 @@ sub run {
 
     install_docker_when_needed;
     add_suseconnect_product(get_addon_fullname('phub')) if is_sle();
-    zypper_call("in nmap")                              if (script_run("which nmap") != 0);
 
     record_info 'Test #1', 'Test: Installation';
     zypper_call("in docker-compose");
     assert_script_run 'docker-compose --version';
 
+    # Prepare docker-compose.yml and haproxy.cfg
     assert_script_run 'mkdir -p dcproject; cd dcproject';
     assert_script_run("wget " . data_url("containers/docker-compose.yml") . " -O docker-compose.yml");
-    assert_script_run 'docker-compose pull',  600;
+    assert_script_run("wget " . data_url("containers/haproxy.cfg") . " -O haproxy.cfg");
+
+    assert_script_run 'docker-compose pull', 600;
+
+    # Start all containers in background
+    # Wait for still screen so we sure everything is stable
     assert_script_run 'docker-compose up -d', 120;
+    wait_still_screen stilltime => 15, timeout => 180;
+
     assert_script_run 'docker-compose ps';
     assert_script_run 'docker-compose top';
-    assert_script_run 'curl -s http://127.0.0.1:5001/ | grep Result';
-    assert_script_run 'curl -s http://127.0.0.1:8080/ | grep Visualizer';
-    assert_script_run 'curl -s http://127.0.0.1:5000/ | grep "Cats vs Dogs!"';
-    assert_script_run 'nmap 127.0.0.1 -p 5432 | grep closed';
+
+    # Send HTTP request to haproxy - it should be proxied to nginx
+    assert_script_run 'curl -s http://127.0.0.1:8080/ | grep "Welcome to nginx!"';
+
+    # Change the index.html in nginx /usr/share/nginx/html volume a check it
+    assert_script_run 'docker-compose exec nginx /bin/sh -c "echo \"Hello\" > /usr/share/nginx/html/index.html"';
+    assert_script_run 'curl -s http://127.0.0.1:8080/ | grep "Hello"';
+
     assert_script_run 'docker-compose logs > logs.txt';
     upload_logs "logs.txt";
+
     assert_script_run 'docker-compose down', 180;
     assert_script_run 'cd';
 
     remove_suseconnect_product(get_addon_fullname('phub')) if is_sle();
     clean_docker_host();
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    assert_script_run 'docker-compose logs > logs.txt';
+    upload_logs 'logs.txt';
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
 * Fix `docker_compose.pm` so used images are compatible for all required architectures.
 * Fix `install_docker_when_needed()` as it was failing on [SLE15SP2JeOS](https://openqa.suse.de/tests/4260685#step/docker/11) since 8dd611b202f16bb41acde71f0ffbc9dfbd0694cd.

- Followup to: #10289
- Related ticket: [poo#67018](https://progress.opensuse.org/issues/67018)
- Verification run: [Tumbleweed@x86_64](http://pdostal-server.suse.cz/tests/8607) [Tumbleweed@aarch64](https://openqa.opensuse.org/tests/1273574) [Tumbleweed@ppc64le](https://openqa.opensuse.org/tests/1273768) [openSUSE15.1JeOS](https://openqa.opensuse.org/tests/1273742#step/force_scheduled_tasks/18) [SLE12-SP3@x86_64](http://pdostal-server.suse.cz/tests/8602) [SLE12SP4@x86_64](http://pdostal-server.suse.cz/tests/8609) [SLE12SP5@x86_64](http://pdostal-server.suse.cz/tests/8608) [SLE15@x86_64](http://pdostal-server.suse.cz/tests/8612) [SLE15SP1@x86_64](http://pdostal-server.suse.cz/tests/8611) [SLE15SP2@HyperV](https://openqa.nue.suse.com/tests/4264985#)
