### PR TITLE
Add select_console('x11') for libqt5_qtbase

### DIFF
--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -24,6 +24,7 @@ use version_utils 'is_sle';
 use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
 
 sub run {
+    select_console('x11');
     ensure_installed("libqt5-qttools yast2-installation", timeout => 180);
 
     # Test designer-qt5


### PR DESCRIPTION
see https://progress.opensuse.org/issues/66301
verification s390x:
https://openqa.suse.de/tests/4258930#step/libqt5_qtbase/6
