### PR TITLE
Add storage test module into test suites

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -778,6 +778,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
             }
             loadtest "virt_autotest/setup_dns_service";
             loadtest "virtualization/xen/hotplugging" if get_var("ENABLE_HOTPLUGGING");
+            loadtest "virtualization/xen/storage"     if get_var("ENABLE_STORAGE");
             loadtest "virt_autotest/virsh_internal_snapshot";
             loadtest "virt_autotest/virsh_external_snapshot";
         }

--- a/tests/virtualization/xen/storage.pm
+++ b/tests/virtualization/xen/storage.pm
@@ -23,9 +23,6 @@ sub run_test {
     my ($self) = @_;
     my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
-    record_info "Default pool";
-    assert_script_run "virsh pool-list --all | grep default | grep active";
-
     record_info "Prepare";
     assert_script_run "mkdir -p /pool_testing";
     assert_script_run "virsh pool-destroy testing || true";


### PR DESCRIPTION
1.Load storage module if desired judging by ENABLE_STORAGE parameter
2.Bypass default pool detection for VIRT_AUTOTEST test suites


- Related ticket: Virtualization Storage Test
- Needles: n/a
- Verification run: 

  - [11sp4/12sp4/12sp5/15sp0/15sp1/15sp2 guest on 15sp2 host KVM](http://10.67.133.40/tests/160)
  - [11sp4/12sp4/12sp5/15sp0/15sp1/15sp2 guest on 15sp2 host XEN](http://10.67.133.40/tests/171)
  - [15sp2 guest on 15sp1 host KVM](http://10.67.133.40/tests/174)
  - [15sp2 guest on 15sp1 host XEN](http://10.67.133.40/tests/175)
  - [15sp2 guest on 15sp0 host KVM](http://10.67.133.40/tests/176)
  - [15sp2 guest on 15sp0 host XEN](http://10.67.133.40/tests/177)
  - [15sp2 guest on 12sp5 host KVM](http://10.67.133.40/tests/178)
  - [15sp2 guest on 12sp5 host XEN](http://10.67.133.40/tests/179)
  - [15sp2 guest on 12sp4 host KVM](http://10.67.133.40/tests/180)
  - [15sp2 guest on 12sp4 host XEN](http://10.67.133.40/tests/181)
  - [15sp2 guest on 11sp4 host KVM](http://10.67.133.40/tests/182)
  - [15sp2 guest on 11sp4 host XEN](http://10.67.133.40/tests/183)
