### PR TITLE
Check unused modules for changed files only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-spec:
 	tools/update_spec --check
 
 .PHONY: test-static
-test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files detect-nonexistent-testdata test-unused-modules test-soft_failure-no-reference test-spec test-invalid-syntax
+test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files detect-nonexistent-testdata test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax
 .PHONY: test
 ifeq ($(TESTS),compile)
 test: test-compile
@@ -126,11 +126,16 @@ PERLCRITIC=PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --quiet --stern -
 perlcritic: tools/lib/
 	${PERLCRITIC} $$(git ls-files -- '*.p[ml]' ':!:data/')
 
-.PHONY: test-unused-modules
-test-unused-modules:
+.PHONY: test-unused-modules-changed
+test-unused-modules-changed:
+	@echo "[make] Unused modules check called over modified/new files only. For a full run use make test-unused-modules-full"
 	tools/detect_unused_modules `git diff --name-only --diff-filter=d $$(git merge-base master HEAD) | grep '^tests/*'`
 	tools/detect_unused_modules `git diff --unified=0 $$(git merge-base master HEAD) products/* | grep -oP "^-.*loadtest.*[\"']\K[^\"'].+(?=[\"'])"`
 	tools/detect_unused_modules `git diff --unified=0 $$(git merge-base master HEAD) schedule/* | grep -oP "^-\s+- [\"']?\K.*(?=[\"']?)" | grep -v '{{'`
+
+.PHONY: test-unused-modules
+test-unused-modules:
+	tools/detect_unused_modules
 
 .PHONY: test-deleted-renamed-referenced-files
 test-deleted-renamed-referenced-files:

--- a/Makefile
+++ b/Makefile
@@ -129,13 +129,13 @@ perlcritic: tools/lib/
 .PHONY: test-unused-modules-changed
 test-unused-modules-changed:
 	@echo "[make] Unused modules check called over modified/new files only. For a full run use make test-unused-modules-full"
-	tools/detect_unused_modules `git diff --name-only --diff-filter=d $$(git merge-base master HEAD) | grep '^tests/*'`
-	tools/detect_unused_modules `git diff --unified=0 $$(git merge-base master HEAD) products/* | grep -oP "^-.*loadtest.*[\"']\K[^\"'].+(?=[\"'])"`
-	tools/detect_unused_modules `git diff --unified=0 $$(git merge-base master HEAD) schedule/* | grep -oP "^-\s+- [\"']?\K.*(?=[\"']?)" | grep -v '{{'`
+	tools/detect_unused_modules -m `git diff --name-only --diff-filter=d $$(git merge-base master HEAD) | grep '^tests/*'`
+	tools/detect_unused_modules -m `git diff --unified=0 $$(git merge-base master HEAD) products/* | grep -oP "^-.*loadtest.*[\"']\K[^\"'].+(?=[\"'])"`
+	tools/detect_unused_modules -m `git diff --unified=0 $$(git merge-base master HEAD) schedule/* | grep -oP "^-\s+- [\"']?\K.*(?=[\"']?)" | grep -v '{{'`
 
 .PHONY: test-unused-modules
 test-unused-modules:
-	tools/detect_unused_modules
+	tools/detect_unused_modules -a
 
 .PHONY: test-deleted-renamed-referenced-files
 test-deleted-renamed-referenced-files:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,9 @@ perlcritic: tools/lib/
 
 .PHONY: test-unused-modules
 test-unused-modules:
-	tools/detect_unused_modules
+	tools/detect_unused_modules `git diff --name-only --diff-filter=d $$(git merge-base master HEAD) | grep '^tests/*'`
+	tools/detect_unused_modules `git diff --unified=0 $$(git merge-base master HEAD) products/* | grep -oP "^-.*loadtest.*[\"']\K[^\"'].+(?=[\"'])"`
+	tools/detect_unused_modules `git diff --unified=0 $$(git merge-base master HEAD) schedule/* | grep -oP "^-\s+- [\"']?\K.*(?=[\"']?)" | grep -v '{{'`
 
 .PHONY: test-deleted-renamed-referenced-files
 test-deleted-renamed-referenced-files:

--- a/tools/detect_unused_modules
+++ b/tools/detect_unused_modules
@@ -1,9 +1,11 @@
 #!/bin/sh -e
 
-for test in $(git ls-files "*tests/*.pm") ; do
+MODULES="${@}"
+
+for test in $MODULES ; do
     t=$(echo $test | sed -e 's@tests/.*/@@' -e 's@\.pm$@@')
     t_dir=$(echo $test | sed -e 's@tests/\(.*\)/.*$@\1@')
-    git grep -E "(- $t_dir/$t|loadtest.*$t|load_testdir.*$t_dir|^use (base )?\"?$t\"?)" | grep -qv ".(pm|yaml):\s*#" || echo $test
+    git grep -E "(- $t_dir/$t|loadtest.*$t|load_testdir.*$t_dir|^use (base )?\"?$t\"?)" | grep -qv ".(pm|yaml):\s*#" || echo "$test module is not used in any schedule"
 done | \
     # Whitelist
 

--- a/tools/detect_unused_modules
+++ b/tools/detect_unused_modules
@@ -1,6 +1,39 @@
 #!/bin/sh -e
 
-MODULES="${@}:=$(git ls-files "*tests/*.pm")"
+usage="Detect test modules usage in the schedules, inluding main.pm and yaml schedules.
+
+Usage: $(basename "$0") { -a | -m [modules] } | -h
+
+    -h|--help                 show this help text
+    -a|--all                  check all test modules
+    -m|--modules [modules]    check provided list"
+
+if [ $# -eq 0 ]; then
+    echo "$usage"
+    exit 1
+fi
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            echo "$usage"
+            exit
+            ;;
+        -a|--all)
+            MODULES=$(git ls-files "*tests/*.pm")
+            break
+            ;;
+        -m|--modules)
+            shift
+            MODULES=${@}
+            break
+            ;;
+        *)
+            echo "$usage"
+            exit 1
+            ;;
+    esac
+done
 
 for test in $MODULES ; do
     t=$(echo $test | sed -e 's@tests/.*/@@' -e 's@\.pm$@@')

--- a/tools/detect_unused_modules
+++ b/tools/detect_unused_modules
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-MODULES="${@}"
+MODULES="${@}:=$(git ls-files "*tests/*.pm")"
 
 for test in $MODULES ; do
     t=$(echo $test | sed -e 's@tests/.*/@@' -e 's@\.pm$@@')


### PR DESCRIPTION
We always run this check for all modules in the repo, which takes around
5 minutes. However, we can just check files which are changed in the
repo.

For that we have 3 cases:
1. Module is added or renamed
2. Last usage is removed from main.pm
3. Last usage is removed from any schedule file

With this change, we get modules from each of the group and verify if
they are used anywhere else and fail CI check in case it's not.

See [poo#64688](https://progress.opensuse.org/issues/64688).

Running time is down to 3 minutes from 11 minutes:
![image](https://user-images.githubusercontent.com/28305643/82453810-4a05bb80-9ab1-11ea-88db-8a1f77a94e1a.png)
![image](https://user-images.githubusercontent.com/28305643/82453838-5558e700-9ab1-11ea-97b6-290e6f99ad34.png)


* Detection after removal from `main.pm`: https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/jobs/689230802#L1324
* Detection after removal from yaml schedule: https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/jobs/689233617#L1325
* Detection of adding new module which is not used in any schedule: https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/jobs/689241959#L1326
