### PR TITLE
LTP: Reuse UEFI_baremetal_basic to install LTP

### DIFF
--- a/schedule/kernel/install_ltp_uefi_baremetal.yaml
+++ b/schedule/kernel/install_ltp_uefi_baremetal.yaml
@@ -1,14 +1,17 @@
 name:          UEFI_baremetal_basic
 description:    >
-    basic installation testing on baremetal UEFI
+    basic installation testing on baremetal UEFI + install LTP
 vars:
     AUTOYAST_PREPARE_PROFILE: 1
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_UEFI: 1
     SCC_ADDONS: sdk
+    LTP_BAREMETAL: 1
+    INSTALL_LTP: from_repo
 schedule:
     - autoyast/prepare_profile
     - installation/ipxe_install
     - console/suseconnect_scc
     - toolchain/install
+    - kernel/install_ltp


### PR DESCRIPTION
`LTP_BAREMETAL=1` is needed to not wait on boot in install_ltp.pm (could
be also detected by `IPXE`, because both install_ltp_baremetal_mlx and
this aarch64 baremetal test which define `INSTALL_LTP` also define `IPXE`,
but it's safer not depend on it).

Also rename to reflect current purpose (requires to rename both
`YAML_SCHEDULE` in the testsuite
and the name in job group setup.

- Related ticket: https://progress.opensuse.org/issues/58466
- Verification run: https://openqa.suse.de/tests/4260009
