### PR TITLE
Properly cleanup after vagrant tests

### DIFF
--- a/tests/virtualization/vagrant/add_box_libvirt.pm
+++ b/tests/virtualization/vagrant/add_box_libvirt.pm
@@ -47,4 +47,8 @@ sub run() {
     assert_script_run('rm -rf Vagrantfile testfile .vagrant');
 }
 
+sub post_fail_hook() {
+    assert_script_run('rm -rf Vagrantfile testfile .vagrant');
+}
+
 1;

--- a/tests/virtualization/vagrant/add_box_virtualbox.pm
+++ b/tests/virtualization/vagrant/add_box_virtualbox.pm
@@ -39,4 +39,8 @@ sub run() {
     assert_script_run('rm -rf Vagrantfile testfile .vagrant');
 }
 
+sub post_fail_hook() {
+    assert_script_run('rm -rf Vagrantfile testfile .vagrant');
+}
+
 1;

--- a/tests/virtualization/vagrant/sshfs.pm
+++ b/tests/virtualization/vagrant/sshfs.pm
@@ -61,6 +61,13 @@ sub run() {
     #
     assert_script_run('cp $(dirname $(rpm -ql vagrant-sshfs-testsuite|grep testsuite.sh))/Vagrantfile .');
     assert_script_run('$(rpm -ql vagrant-sshfs-testsuite|grep testsuite.sh)', timeout => 1200);
+
+    # cleanup
+    assert_script_run('rm -rf Vagrantfile .vagrant');
+}
+
+sub post_fail_hook() {
+    assert_script_run('rm -rf Vagrantfile .vagrant');
 }
 
 1;


### PR DESCRIPTION
Remove any leftover vagrant files after test runs, should fix issues like the one seen here: https://openqa.opensuse.org/tests/1273695#step/tumbleweed/47

- Related ticket: N/A
- Needles: not required
- Verification run: ~~https://openqa.opensuse.org/tests/1273781~~ https://openqa.opensuse.org/tests/1276968