### PR TITLE
Fix HANA test without user and add consoletest_setup for sshxterm

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2112,6 +2112,7 @@ sub load_common_x11 {
     elsif (check_var("REGRESSION", "other")) {
         loadtest "boot/boot_to_desktop";
         loadtest "x11/window_system";
+        loadtest "console/consoletest_setup";
         load_x11_other();
     }
     elsif (check_var("REGRESSION", "firefox")) {

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -43,7 +43,7 @@ sub run {
 
     # copy and add root key into authorized_keys and public key into known_hosts of both root and user
     # $user is not created or used, like LIVECD or ROOTONLY tests
-    if (get_var('ROOTONLY') || get_var('LIVECD')) {
+    if (get_var('ROOTONLY') || get_var('LIVECD') || get_var('HANA')) {
         assert_script_run('mkdir -pv ~/.ssh');
         assert_script_run('touch ~/.ssh/{authorized_keys,known_hosts}');
         assert_script_run('chmod 600 ~/.ssh/*');


### PR DESCRIPTION
- Related ticket: #10288
- Verification run: 
http://10.100.12.155/tests/15739
http://10.100.12.155/tests/15748
http://10.100.12.155/tests/15751 VIRTIO
https://openqa.suse.de/tests/4264691#step/consoletest_setup/35 VIRTIO
https://openqa.suse.de/tests/4264693