### PR TITLE
LTP/install_ltp: Require libmnl-devel

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -160,6 +160,7 @@ sub install_build_dependencies {
       libacl-devel-32bit
       libaio-devel-32bit
       libcap-devel-32bit
+      libmnl-devel
       libnuma-devel
       libnuma-devel-32bit
       libopenssl-devel-32bit


### PR DESCRIPTION
Needed for LTP release 20200515 (netlink based route tests).
    
libmnl is available since SLE12, just don't require it (if somebody still tests SLE11).

Verification run:
- SLES 15sp2 http://quasar.suse.cz/tests/5183 http://quasar.suse.cz/tests/5183
- various QAM http://quasar.suse.cz/tests/5180 http://quasar.suse.cz/tests/5178 http://quasar.suse.cz/tests/5177
- Tumbleweed http://quasar.suse.cz/tests/5181 http://quasar.suse.cz/tests/5182