### PR TITLE
Fix suseconnect_scc packages list to register

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -43,9 +43,7 @@ sub run {
 
     # add modules
     if (is_sle '15+') {
-        foreach (split(',', $registration::SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')} . ",$scc_addons")) {
-            add_suseconnect_product("sle-module-" . lc($registration::SLE15_MODULES{$_}));
-        }
+        register_addons_cmd;
     }
     # Check that repos actually work
     zypper_call('refresh');


### PR DESCRIPTION
The Desktop module needs to be register before the Development. There is already code which acts on it.
After this i removed the PackageHub module which we do not support
official.

ADDITIONAL: SCC_ADDONS=base,legacy,serverapp,sdk,script,contm ahs been added to the test_suite

- Related ticket: https://progress.opensuse.org/issues/66913
- Verification run: http://aquarius.suse.cz/tests/2686#
[VRs](https://openqa.suse.de/tests/overview?version=15-SP2&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2310342)
[uefi](https://openqa.suse.de/tests/4266619)