### PR TITLE
Add support for LVM stress tests in LTP

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -1,0 +1,48 @@
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: LTP helper functions
+# Maintainer: Martin Doucha <mdoucha@suse.cz>
+
+package LTP::utils;
+
+use base Exporter;
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT = qw(prepare_ltp_env);
+
+# Set up basic shell environment for running LTP tests
+sub prepare_ltp_env {
+    my $ltp_env = get_var('LTP_ENV');
+
+    assert_script_run('export LTPROOT=/opt/ltp; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
+
+    # setup for LTP networking tests
+    assert_script_run("export PASSWD='$testapi::password'");
+
+    my $block_dev = get_var('LTP_BIG_DEV');
+    if ($block_dev && get_var('NUMDISKS') > 1) {
+        assert_script_run("lsblk -la; export LTP_BIG_DEV=$block_dev");
+    }
+
+    if ($ltp_env) {
+        $ltp_env =~ s/,/ /g;
+        script_run("export $ltp_env");
+    }
+
+    assert_script_run('cd $LTPROOT/testcases/bin');
+}

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -115,6 +115,10 @@ sub loadtest_from_runtest_file {
         loadtest 'create_junkfile_ltp';
     }
 
+    if (get_var('LTP_COMMAND_FILE') =~ m/lvm\.local/) {
+        loadtest 'ltp_init_lvm';
+    }
+
     mkdir($unpack_path, 0755);
     my $tar = Archive::Tar->new();
     $tar->read($archive) || die "tar read failed $? $!";

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -28,6 +28,7 @@ use upload_system_log;
 use version_utils qw(is_jeos is_opensuse is_released is_sle);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x is_x86_64);
 use Utils::Systemd qw(systemctl disable_and_stop_service);
+use LTP::utils;
 
 sub add_we_repo_if_available {
     # opensuse doesn't have extensions
@@ -355,6 +356,8 @@ sub run {
 
     add_custom_grub_entries if (is_sle('12+') || is_opensuse) && !is_jeos;
     setup_network;
+    prepare_ltp_env();
+    assert_script_run('generate_lvm_runfile.sh');
     upload_runtest_files('/opt/ltp/runtest', $tag);
 
     if (get_var('LTP_COMMAND_FILE')) {

--- a/tests/kernel/ltp_init_lvm.pm
+++ b/tests/kernel/ltp_init_lvm.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Initialize LVM volume groups for LTP LVM tests
+# Maintainer: Martin Doucha <mdoucha@suse.cz>
+
+use 5.018;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+
+sub run {
+    my ($self) = @_;
+
+    assert_script_run("prepare_lvm.sh");
+}
+
+sub test_flags {
+    return {
+        fatal     => 1,
+        milestone => 1,
+    };
+}
+
+=head1 Configuration
+
+This test module is activated when LTP_COMMAND_FILE is set to lvm.local
+
+=cut
+
+1;


### PR DESCRIPTION
New LTP release includes a redesigned set of LVM tests. This PR adds the test environment setup needed to run those tests.

- Related ticket: https://progress.opensuse.org/issues/15680
- Needles: N/A
- Verification runs:
  - 12SP4@x86_64 install_ltp: https://openqa.suse.de/tests/4266045
  - 12SP4@x86_64 ltp_lvm: https://openqa.suse.de/tests/4266134
  - 12SP4@ppc64le install_ltp: https://openqa.suse.de/tests/4269158
  - 12SP4@ppc64le ltp_lvm: https://openqa.suse.de/tests/4269200
  - 15SP1@x86_64 install_ltp: https://openqa.suse.de/tests/4266046
  - 15SP1@x86_64 ltp_lvm: https://openqa.suse.de/tests/4266135
  - 15SP1@ppc64le install_ltp: https://openqa.suse.de/tests/4269159
  - 15SP1@ppc64le ltp_lvm: https://openqa.suse.de/tests/4269201