### PR TITLE
Assert boot menu after reboot

### DIFF
--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -34,6 +34,8 @@ sub run {
     }
     assert_script_run "sync", 300;
     type_string "reboot\n";
+    # After remove -f for reboot, we need wait more time for boot menu and avoid exception during reboot caused delay to boot up.
+    assert_screen('inst-bootmenu', 300);
 }
 
 1;


### PR DESCRIPTION
After remove -f for reboot, we need wait more time for boot menu and avoid exception during reboot caused delay to boot up.

- Related ticket: https://progress.opensuse.org/issues/67102
- Needles: N/A
- Verification run: 
http://openqa.nue.suse.com/tests/4268745#step/reboot_to_upgrade/4
http://openqa.nue.suse.com/tests/4268870#step/reboot_to_upgrade/4
http://openqa.nue.suse.com/tests/4268871#step/reboot_to_upgrade/4
http://openqa.nue.suse.com/tests/4269120#step/reboot_to_upgrade/4