### PR TITLE
Replace soft failure from module validate_lvm_raid1

### DIFF
--- a/tests/console/validate_lvm_raid1.pm
+++ b/tests/console/validate_lvm_raid1.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: RAID1 on LVM partition validation
-# Maintainer: Yiannis Bonatakis <ybonatakis@suse.com>
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use strict;
 use warnings;
@@ -25,20 +25,14 @@ sub run {
 
     select_console 'root-console';
 
-    my $config = get_test_suite_data();
-    $config->{expected_num_devs} = scalar @{$config->{disks}};
-    # actual_num_devs is used to get the number of the disks in raid
-    # as we move in and out a disk during the test. This is because
-    # after the reboot sle15 can recover the missing disk and we need
-    # to compare with the expected_num_devs
-    my $actual_num_devs = $config->{expected_num_devs};
+    my $config            = get_test_suite_data();
+    my $expected_num_devs = scalar @{$config->{disks}};
     _check_lvm_partitioning($config);
-    _check_raid1_partitioning($config, $actual_num_devs);
-    _remove_raid_disk($config, $actual_num_devs);
+    _check_raid1_partitioning($config, $expected_num_devs);
+    _remove_raid_disk($config, $expected_num_devs);
     _reboot();
     $self->wait_boot;
-    _check_raid_disks_after_reboot($config, $actual_num_devs);
-    _restore_raid_disk($config);
+    _check_raid_disks_after_reboot($config, $expected_num_devs);
 }
 
 sub _check_lvm_partitioning {
@@ -51,12 +45,12 @@ sub _check_lvm_partitioning {
 }
 
 sub _check_raid1_partitioning {
-    my ($config, $actual_num_devs) = @_;
+    my ($config, $expected_num_devs) = @_;
     record_info("raid1 name", $config->{raid1}->{name});
     assert_script_run 'mdadm --detail ' . $config->{lvm}->{pvname};
     assert_script_run 'grep \'md0 : active ' . $config->{raid1}->{level} . '\' /proc/mdstat';
     my $active_devs = script_output("mdadm --detail " . $config->{raid1}->{name} . " |grep \"Active Devices\" |awk '{ print \$4 }'");
-    assert_equals($active_devs, $actual_num_devs, "Active devices are different");
+    assert_equals($active_devs, $expected_num_devs, "Active devices are different");
 
     for (@{$config->{disks}}) {
         my $line = script_output "mdadm --detail " . $config->{raid1}->{name} . " | awk '{ if((/$_/) && (\$5 ~ /active/) && (\$6 ~ /sync/)) {print}}'";
@@ -65,15 +59,15 @@ sub _check_raid1_partitioning {
 }
 
 sub _remove_raid_disk {
-    my ($config, $actual_num_devs) = @_;
+    my ($config, $expected_num_devs) = @_;
     assert_script_run "mdadm --manage $config->{raid1}->{name} --set-faulty $config->{raid1}->{disk_to_fail}";
-    $actual_num_devs--;
+    $expected_num_devs--;
     my $active_devs = script_output("mdadm --detail " . $config->{raid1}->{name} . " |grep \"Active Devices\" |awk '{ print \$4 }'");
-    assert_equals($actual_num_devs, $active_devs, "Active devices are different after set faulty device");
+    assert_equals($expected_num_devs, $active_devs, "Active devices are different after set faulty device");
 
     assert_script_run 'mdadm --manage ' . $config->{raid1}->{name} . ' --remove ' . $config->{raid1}->{disk_to_fail};
-    script_retry "mdadm --detail " . $config->{raid1}->{name} . " | grep 'Active Devices : 3'";
-    my $removedDisk = script_output "mdadm --detail " . $config->{raid1}->{name} . " | awk '{ if((\$4 == " . $actual_num_devs . ") && (\$5 ~ /removed/)) {print}}'";
+    script_retry "mdadm --detail " . $config->{raid1}->{name} . " | grep 'Active Devices : $expected_num_devs'";
+    my $removedDisk = script_output "mdadm --detail " . $config->{raid1}->{name} . " | awk '{ if((\$4 == " . $expected_num_devs . ") && (\$5 ~ /removed/)) {print}}'";
     assert_not_null($removedDisk, "$removedDisk should have been removed");
 }
 
@@ -83,29 +77,27 @@ sub _reboot {
 }
 
 sub _check_raid_disks_after_reboot {
-    my ($config, $actual_num_devs) = @_;
+    my ($config, $expected_num_devs) = @_;
     record_info('get state after reboot');
     select_console 'root-console';
 
     assert_script_run 'mdadm --detail ' . $config->{raid1}->{name};
     my $active_devs = script_output("mdadm --detail " . $config->{raid1}->{name} . " |grep \"Active Devices\" |awk '{ print \$4 }'");
-    # if the number of disk in raid1 list are not the same report a soft failure
-    if ($active_devs != $config->{actual_num_devs}) {
-        record_soft_failure 'bsc#1150370 - disk is restored during the booting' if is_sle('>=15');
+    # if the deactivated disk is not reactivated after reboot, run _restore_raid_disk
+    unless ($active_devs == $expected_num_devs) {
+        _restore_raid_disk($config, $expected_num_devs);
     }
     else {
-        assert_equals($actual_num_devs, $active_devs, "Active devices should be still " . $config->{expected_num_devs});
+        # Expected behavior is not clear currently. Assuming that the faulty disk shouldn't be automatically reactivated
+        record_soft_failure("bsc#1172203");
     }
 }
 
 sub _restore_raid_disk {
-    my ($config) = @_;
-    my $active_devs = script_output("mdadm --detail " . $config->{raid1}->{name} . " |grep \"Active Devices\" |awk '{ print \$4 }'");
-    if ($active_devs != $config->{expected_num_devs}) {
-        assert_script_run 'mdadm --manage ' . $config->{raid1}->{name} . ' --add ' . $config->{raid1}->{disk_to_fail};
-        script_retry "mdadm --detail $config->{raid1}->{name} | grep 'Active Devices : $config->{expected_num_devs}'";
-        assert_script_run 'mdadm --detail ' . $config->{raid1}->{name};
-    }
+    my ($config, $expected_num_devs) = @_;
+    assert_script_run 'mdadm --manage ' . $config->{raid1}->{name} . ' --add ' . $config->{raid1}->{disk_to_fail};
+    script_retry "mdadm --detail $config->{raid1}->{name} | grep 'Active Devices : $expected_num_devs'";
+    assert_script_run 'mdadm --detail ' . $config->{raid1}->{name};
 }
 
 1;


### PR DESCRIPTION
After rejection as Invalid of [bug#1150370](https://bugzilla.suse.com/show_bug.cgi?id=1150370) the soft failure should be removed and the validation expectations changed. 
After speaking with some people with more expertise, I opened [bug#1172203](https://bugzilla.suse.com/show_bug.cgi?id=1172203) and added soft failure when disk is recovered automatically after reboot (both in SLE and OpenSUSE).

- Related ticket: https://progress.opensuse.org/issues/67060
- Verification runs: 
sle Manual reactivation: http://falafel.suse.cz/tests/808
opensuse Automatic reactivation: http://falafel.suse.cz/tests/809