### PR TITLE
Increase wait_still_screen and timeout to the yast_keyboard

### DIFF
--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -48,7 +48,7 @@ sub run {
 
     # Restore keyboard settings to english-us and verify(enter using german characters).
     if (is_sle('15-sp2+')) {
-        type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 3, timeout => 7);
+        type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 5, timeout => 10);
     }
     else {
         record_soft_failure('bsc#1170292');


### PR DESCRIPTION
test in aarch needs higher values for wait_still_screen.  Consistendly
we have to increase the timeout as well as itdoes not work if the
timeout is lower than the wait_still_screen.

- Related ticket: https://progress.opensuse.org/issues/66292
- Verification run: https://openqa.suse.de/tests/4270099#details
