### PR TITLE
[virt_autotest] fix virtual_network_utils issue on sles11sp4

### DIFF
--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -90,9 +90,9 @@ sub run_test {
         #Wait for guests attached interface from virtual routed network
         sleep 30;
         my $net1 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed';
-        test_network_interface("$guest", mac => $mac1, gate => $gate1, target => $target1, net => $net1);
+        test_network_interface("$guest", mac => $mac1, gate => $gate1, routed => 1, target => $target1, net => $net1);
         my $net2 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed_clone';
-        test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, target => $target2, net => $net2);
+        test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, routed => 1, target => $target2, net => $net2);
 
         assert_script_run("virsh detach-interface $guest --mac $mac1 $exclusive");
         assert_script_run("virsh detach-interface $guest.clone --mac $mac2 $exclusive");

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -29,6 +29,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run_test {
     my ($self) = @_;
@@ -47,7 +48,7 @@ sub run_test {
     upload_logs "vnet_routed_clone.xml";
     assert_script_run("rm -rf vnet_routed.xml vnet_routed_clone.xml");
 
-    my ($mac1, $mac2, $model1, $model2);
+    my ($mac1, $mac2, $model1, $model2, $affecter, $exclusive);
     my $target1 = '192.168.130.1';
     my $target2 = '192.168.129.1';
     my $gate1   = '192.168.129.1';
@@ -66,21 +67,35 @@ sub run_test {
         assert_script_run("virsh start $guest");
         assert_script_run("virsh start $guest.clone");
 
+        if (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) {
+            $affecter  = "--persistent";
+            $exclusive = "bridge --live --persistent";
+        } else {
+            $affecter  = "";
+            $exclusive = "network --current";
+        }
+
         #figure out that used with virtio as the network device model during
         #attach-interface via virsh worked for all sles guest
         $mac1   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model1 = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
-        assert_script_run("virsh attach-interface $guest network vnet_routed --model $model1 --mac $mac1 --live");
+
+        assert_script_run("virsh attach-interface $guest network vnet_routed --model $model1 --mac $mac1 --live $affecter", 60);
 
         $mac2   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model2 = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
-        assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --model $model2 --mac $mac2 --live");
 
-        test_network_interface("$guest",       mac => $mac1, gate => $gate1, target => $target1, net => "vnet_routed");
-        test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, target => $target2, net => "vnet_routed_clone");
+        assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --model $model2 --mac $mac2 --live $affecter", 60);
 
-        assert_script_run("virsh detach-interface $guest network --mac $mac1 --current");
-        assert_script_run("virsh detach-interface $guest.clone network --mac $mac2 --current");
+        #Wait for guests attached interface from virtual routed network
+        sleep 30;
+        my $net1 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed';
+        test_network_interface("$guest", mac => $mac1, gate => $gate1, target => $target1, net => $net1);
+        my $net2 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed_clone';
+        test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, target => $target2, net => $net2);
+
+        assert_script_run("virsh detach-interface $guest --mac $mac1 $exclusive");
+        assert_script_run("virsh detach-interface $guest.clone --mac $mac2 $exclusive");
 
         assert_script_run("virsh destroy $guest.clone");
         assert_script_run("virsh undefine $guest.clone");

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -44,7 +44,7 @@ sub run_test {
     virt_autotest::virtual_network_utils::ssh_setup();
 
     #Install required packages
-    zypper_call '-t in iproute2 iptables iputils bind-utils sshpass';
+    zypper_call '-t in iproute2 iptables iputils bind-utils sshpass nmap';
 
     #Check with Guest status before libvirt virtual network tests
     virt_autotest::virtual_network_utils::check_guest_status();


### PR DESCRIPTION
Refer to  the following virtual_network_utils failures on sles11sp4, figure out that systemctl cmd do not work on 11sp4 from restart_libvirtd fun under virtual_network_utils pm.
gi-guest_developing-on-host_sles11sp4-kvm-dev
https://openqa.nue.suse.com/tests/4262311
gi-guest_developing-on-host_sles11sp4-xen-dev
https://openqa.nue.suse.com/tests/4262312

This PR fix this virtual_network_utils issue on sles11sp4 vm hosts

- Verification run: 
gi-guest_developing-on-host_sles11sp4-xen-dev
http://10.67.19.82/tests/564
gi-guest_developing-on-host-developing-xen
http://10.67.19.82/tests/566