### PR TITLE
Introduce guest restart functionality

### DIFF
--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -66,7 +66,7 @@ sub run_test {
 
         record_info "virsh-snapshot", "Creating Live External Snapshot of guest's memory and disk state";
         #required guests as running status to create Live External Snapshot
-        script_run("virsh start $_") foreach (@vm_hostnames_inactive_array);
+        assert_script_run("virsh start $_") foreach (@vm_hostnames_inactive_array);
         my $pre_esnapshot_cmd = "virsh snapshot-create-as $guest";
         my $live_es_memspec   = "snapshot=external,file=/var/lib/libvirt/images/$guest.memspec";
         $pre_esnapshot_cmd = $pre_esnapshot_cmd . " --live ";

--- a/tests/virtualization/xen/hotplugging.pm
+++ b/tests/virtualization/xen/hotplugging.pm
@@ -127,6 +127,11 @@ sub run_test {
         }
     }
 
+    #Workaround to drop all live provisions of all vm guests
+    if (get_var('VIRT_AUTOTEST') && (check_var('SYSTEM_ROLE', 'kvm') || check_var('HOST_HYPERVISOR', 'kvm')) && (($sles_running_version eq '12' and $sles_running_sp eq '5') || ($sles_running_version eq '15' and $sles_running_sp eq '1'))) {
+        record_info "Reboot All Guests", "Mis-handling of live and config provisions by other test modules may have negative impact on 12-SP5 and 15-SP1 KVM scenarios due to bsc#1171946. So here is the workaround to drop all live provisions by rebooting all vm guests.";
+        perform_guest_restart;
+    }
 }
 
 1;


### PR DESCRIPTION
1.New subroutine perform_guest_restart in virt_utils module
2.Restart all guests on 12-SP5 and 15-SP1 KVM host to workaround bsc#1171946
3.Use assert_script_run to start guests after external offline snapshot to validate guests well-being

- Related ticket: 
  * [openQA failure 1](https://openqa.suse.de/tests/4261967#step/virsh_external_snapshot/1)   
  * [openQA failure 2](https://openqa.suse.de/tests/4262093#step/virsh_external_snapshot/41)
- Needles: n/a
- Verification run: 
  * [15sp2 on 12sp5 KVM](http://10.67.133.40/tests/206)
  * [15sp2 on 15sp1 KVM](http://10.67.133.40/tests/205)
  * Additional runs to verify new subroutine perform_guest_restart:
    * [Pass guest list into perform_guest_restart](http://10.67.133.40/tests/204)
    * [Use customized timeout value to restart guest](http://10.67.133.40/tests/203)
    * [Restart guest on remote host](http://10.67.133.40/tests/201)
    * Also confirmed other SLES releases(including 11-SP4 KVM&XEN) have the same virsh usage

