### PR TITLE
Adopt FIPS testing into Maintenance TestRepo tests

### DIFF
--- a/schedule/qam/common/qam-security-fips.yml
+++ b/schedule/qam/common/qam-security-fips.yml
@@ -1,0 +1,23 @@
+---
+name: qam-security-fips
+vars:
+    FIPS_ENABLED: 1
+    SECURITY_TEST: crypt_web
+
+schedule:
+- boot/boot_to_desktop
+- console/consoletest_setup
+- fips/fips_setup
+- fips/openssl/openssl_pubkey_rsa
+- fips/openssl/openssl_pubkey_dsa
+- fips/openssh/openssh_fips
+- console/sshd
+- console/ssh_pubkey
+- console/ssh_cleanup
+- console/curl_https
+- console/apache_ssl
+- console/cryptsetup
+- security/dm_crypt
+- fips/curl_fips_rc4_seed
+- fips/mozilla_nss/apache_nssfips
+- fips/mozilla_nss/firefox_nss


### PR DESCRIPTION
Adopt FIPS testing into QAM Maintenance TestRepo tests.  Nothing changed but and added a yaml schedule file.
How to schedule:
1. Create a new testsuite ""mau-extratests-security-fips" of which the settings are all  the same as "mau-extratests-desktop" and add "YAML_SCHEDULE=schedule/qam/common/qam-security-fips.yml"
2. Place mau-extratests-security-fips in scenarios where mau-extratests-desktop is in job group in TEST REPO.

- Related ticket: https://progress.opensuse.org/issues/63403
- Needles: no
- Verification run: 
sles15: http://10.67.17.201/tests/974
sles12sp5: http://10.67.17.201/tests/975
sles12sp3: http://10.67.17.201/tests/971
