### PR TITLE
Reschedule the yast2_cmd test

### DIFF
--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -20,11 +20,11 @@ schedule:
   - boot/boot_to_desktop
   - yast2_cmd/yast_rdp
   - yast2_cmd/yast_timezone
+  - '{{yast_keyboard}}'
   - yast2_cmd/yast_ftp_server
   - yast2_cmd/yast_nfs_server
   - yast2_cmd/yast_nfs_client
   - yast2_cmd/yast_tftp_server
   - yast2_cmd/yast_lan
   - yast2_cmd/yast_users
-  - '{{yast_keyboard}}'
   - yast2_cmd/yast_sysconfig

--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -60,4 +60,8 @@ sub run {
 
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
A workaround for the failure of yast_keyboard


- Related ticket: https://progress.opensuse.org/issues/66292
- Verification run: 
https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2310366&distri=sle&version=15-SP2