### PR TITLE
Extend time as yast ask reboot needle cannot show on time

### DIFF
--- a/tests/migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/migration/sle12_online_migration/yast2_migration.pm
@@ -262,7 +262,7 @@ sub run {
     send_key "alt-f";
 
     # after migration yast may ask to reboot system
-    if (check_screen("yast2-ask-reboot", 5)) {
+    if (check_screen("yast2-ask-reboot", 20)) {
         # reboot
         send_key "alt-r";
         power_action('reboot', observe => 1, keepconsole => 1);


### PR DESCRIPTION
Extend time as yast ask reboot needle cannot show on time

- Related ticket: https://progress.opensuse.org/issues/66778
- Verification run: https://openqa.nue.suse.com/tests/4274164