### PR TITLE
Should not catch inst-bootmenu in reboot_to_upgrade on s390x

### DIFF
--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -35,7 +35,7 @@ sub run {
     assert_script_run "sync", 300;
     type_string "reboot\n";
     # After remove -f for reboot, we need wait more time for boot menu and avoid exception during reboot caused delay to boot up.
-    assert_screen('inst-bootmenu', 300);
+    assert_screen('inst-bootmenu', 300) unless check_var('ARCH', 's390x');
 }
 
 1;


### PR DESCRIPTION
We shouldn't catch inst-bootmenu in reboot_to_upgrade on s390x since it is different from other ARCHs.

- Related ticket: https://progress.opensuse.org/issues/67228
- Needles: N/A
- Verification run: ttps://openqa.nue.suse.com/tests/4279350#step/version_switch_upgrade_target/5