### PR TITLE
clamav: ensure vim is installed

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -39,7 +39,7 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    zypper_call('in clamav');
+    zypper_call('in clamav vim');
     # Initialize and download ClamAV database which needs time
     assert_script_run('freshclam', 700);
 


### PR DESCRIPTION
Ensure that vim is installed before using it, since there was some time when the test errored out because of it ("Can't access file /usr/bin/vim"), even though the test currently runs again fine.

- Related ticket: https://progress.opensuse.org/issues/65591
- Verification runs (limited, because only modifies installed packages):
15 SP1: https://openqa.suse.de/tests/4279586
Leap 15.2: https://openqa.opensuse.org/tests/1278438
