### PR TITLE
LTP: Fix path to nsswitch.conf on openSUSE

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -144,7 +144,7 @@ EOF
         script_run('netstat -nap');
 
         script_run('cat /etc/resolv.conf');
-        script_run('cat /etc/nsswitch.conf');
+        script_run('f=/etc/nsswitch.conf; [ ! -f $f ] && f=/usr$f; cat $f');
         script_run('cat /etc/hosts');
 
         # hostname (getaddrinfo_01)

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -274,7 +274,7 @@ sub setup_network {
     script_run('touch /var/lib/dhcp6/db/dhcpd6.leases');
 
     # echo/echoes, getaddrinfo_01
-    assert_script_run('sed -i \'s/^\(hosts:\s+files\s\+dns$\)/\1 myhostname/\' /etc/nsswitch.conf');
+    assert_script_run('f=/etc/nsswitch.conf; [ ! -f $f ] && f=/usr$f; sed -i \'s/^\(hosts:\s+files\s\+dns$\)/\1 myhostname/\' $f');
 
     foreach my $service (qw(auditd dnsmasq nfs-server rpcbind vsftpd)) {
         if (!is_jeos && is_sle('12+') || is_opensuse) {


### PR DESCRIPTION
Recent glibc version on openSUSE started to use /usr/etc/ directory
instead of /etc for nsswitch.conf (following change in netcfg package).
This breaks installation on openSUSE:

`sed: can't read /etc/nsswitch.conf: No such file or directory`

https://build.opensuse.org/package/view_file/Base:System/glibc/glibc.changes?expand=1

Mon May 18 12:25:49 UTC 2020 - Andreas Schwab <schwab@suse.de>

- glibc-nsswitch-usr.diff: read /usr/etc/nsswitch.conf if
  /etc/nsswitch.conf does not exist
- Install default nsswitch.conf in /usr/etc
- Don't install gai.conf in /etc

Verification run:
- http://quasar.suse.cz/tests/5206 (Tumbleweed fix)
verify that there is no regression:
- http://quasar.suse.cz/tests/5208 (15sp2)
- http://quasar.suse.cz/tests/5212 http://quasar.suse.cz/tests/5210 http://quasar.suse.cz/tests/5205 (few QAM)
