### PR TITLE
Add fix in docker test for Tumbleweed failure

### DIFF
--- a/data/containers/app.py
+++ b/data/containers/app.py
@@ -1,12 +1,12 @@
 from flask import Flask, render_template
-import os, sys, json, urllib.request, ssl
+import os, sys, ssl
  
 app = Flask(__name__)
-version = ""
-  
+message = ""
+
 @app.route("/")
 def index():
-    return render_template("index.html", version = version)
+    return render_template("index.html", message = message)
 
 if __name__ == "__main__":
     ctx = ssl.create_default_context()
@@ -19,7 +19,10 @@ if __name__ == "__main__":
         print("Program requires at least one argument!")
         sys.exit()
 
-    request = urllib.request.urlopen(url, context=ctx)
-    data = json.loads(request.read())
-    version = (data["job"]["settings"]["VERSION"])
+    cmd = "curl -I " + url
+    response = os.system(cmd)
+    if response == 0:
+        message = "pass"
+    else:
+        message = "not pass"
     app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))

--- a/data/containers/index.html
+++ b/data/containers/index.html
@@ -1,3 +1,3 @@
 <html>
-    You shall not pass in version: {{ version }}!
+Networking test shall {{ message }}!
 </html>

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -24,9 +24,7 @@ use version_utils;
 
 our @EXPORT = qw(set_up get_vars build_img test_built_img);
 
-our $dir     = '/root/DockerTest/';
-our $id      = '';
-our $version = '';
+our $dir = '/root/DockerTest/';
 
 # Setup environment
 sub set_up() {
@@ -34,14 +32,6 @@ sub set_up() {
     assert_script_run "curl -f -v " . data_url('containers/app.py') . " > $dir/BuildTest/app.py";
     assert_script_run "curl -f -v " . data_url('containers/Dockerfile') . " > $dir/BuildTest/Dockerfile";
     assert_script_run "curl -f -v " . data_url('containers/requirements.txt') . " > $dir/BuildTest/requirements.txt";
-}
-
-# Get job id and version variables
-
-sub get_vars() {
-    my $name = get_var('NAME');
-    $id      = (split('-', $name))[0];
-    $version = get_var('VERSION');
 }
 
 # Build the image
@@ -56,8 +46,8 @@ sub build_img() {
 sub test_built_img() {
     assert_script_run("mkdir /root/templates");
     assert_script_run "curl -f -v " . data_url('containers/index.html') . " > /root/templates/index.html";
-    assert_script_run("docker run -dit -p 8888:5000 -v /root/templates:\/usr/src/app/templates myapp https://openqa.suse.de//api/v1/jobs/${id}");
+    assert_script_run("docker run -dit -p 8888:5000 -v ~/templates:\/usr/src/app/templates myapp www.google.com");
     assert_script_run("docker ps -a");
-    assert_script_run('curl http://localhost:8888/ | grep "You shall not pass in version: ' . $version . '"');
+    assert_script_run('curl http://localhost:8888/ | grep "Networking test shall pass"');
 }
 1;

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -53,6 +53,8 @@ sub test_seccomp {
 
 sub run {
     select_console("root-console");
+    #my $hostnam = autoinst_url();
+    #record_info("$hostnam");
     my $sleep_time = 90 * get_var('TIMEOUT_SCALE', 1);
 
     install_docker_when_needed();
@@ -152,9 +154,6 @@ sub run {
 
     # Set up environment for building a new image
     set_up();
-
-    # Identify current job id and SLE Version
-    get_vars();
 
     # Build the image
     build_img();


### PR DESCRIPTION
Fixes failure in docker test for TW failure.

- Related ticket: https://progress.opensuse.org/issues/67216)
- Needles: N/A
- Verification run: [SLES15sp1](http://10.161.229.247/tests/234#) [SLES15](http://10.161.229.247/tests/235#) [SLES12sp5](http://10.161.229.247/tests/236#) [SLES12sp4](http://10.161.229.247/tests/237#) [SLES12sp3](http://10.161.229.247/tests/238#)

openqa.suse.de : [SLES15sp1](https://openqa.suse.de/tests/4290989#details) [SLES15sp2](https://openqa.suse.de/tests/4291917#details) [SLES15sp2 JeOS](https://openqa.suse.de/tests/4291931#details)
openqa.opensuse.org : [Tumbleweed aarch64](https://openqa.opensuse.org/tests/1281317#) [Tumbleweed x86_64](https://openqa.opensuse.org/tests/1281423#)