### PR TITLE
Support serial port in windows install job

### DIFF
--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -97,8 +97,8 @@ sub run {
 
     # turn off hibernation and fast startup
     $self->open_powershell_as_admin;
-    $self->run_in_powershell(q{REG ADD "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Power" /v HiberbootEnabled /t REG_DWORD /d "0" /f});
-    $self->run_in_powershell('powercfg /hibernate off');
+    $self->run_in_powershell(cmd => q{REG ADD "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Power" /v HiberbootEnabled /t REG_DWORD /d "0" /f});
+    $self->run_in_powershell(cmd => 'powercfg /hibernate off');
 
     # poweroff
     $self->reboot_or_shutdown();


### PR DESCRIPTION
- Related ticket: [[qac][wsl][research] serial vs /dev/tcp](https://progress.opensuse.org/issues/60344)
- Verification run: [windows-10-DVD-x86_64-Build1909-windows_10@windows_uefi_boot](http://kepler.suse.cz/tests/151#step/ms_win_firstboot/54)

Serial line snippet
```
rss num receive queues = 1
Serial Port has been opened...
mZV3jTrue
4e9opTrue
VBLK: shutdown.
VBLK sp_adapter_control: IN ct = 1
	dev = FFFF9C04E7E967E0, irql = 10, cpu 0, op 8, st 1
VBLK virtio_sp_shutdown: doing a reset.
VBLK virtio_sp_shutdown: doing a reset features.
VBLK virtio_sp_shutdown: deleting the queue 0.
VBLK virtio_sp_shutdown: done.
```