### PR TITLE
Switch to user-console only on default us keyboar layout

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -23,7 +23,7 @@ use utils 'ensure_serialdev_permissions';
 
 sub run {
     my ($self) = @_;
-    select_console('user-console');
+    select_console('user-console') unless get_var('INSTALL_KEYBOARD_LAYOUT');
     my $expected = get_var('INSTALL_KEYBOARD_LAYOUT', 'us');
     # Feature of switching keyboard during installation is not ready yet,
     # so if another language is used it needs to be verfied that the needle represents properly


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/67249
- Verification run: http://10.100.12.155/tests/15829#step/keymap_or_locale/2