### PR TITLE
Select the right folder since an additional BOOT/ folder is now present

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -566,7 +566,7 @@ sub handle_uefi_boot_disk_workaround {
     save_screenshot;
     wait_screen_change { send_key 'ret' };
     # <sles> or <opensuse>
-    send_key 'up';
+    send_key_until_needlematch 'tianocore-select_opensuse_or_sles', 'up';
     save_screenshot;
     wait_screen_change { send_key 'ret' };
     # efi file


### PR DESCRIPTION
in addition to opensuse/ or sles/ folder

- Related ticket: https://progress.opensuse.org/issues/67204
- Needles: 
  - openSUSE: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/252afff64fe36e2c9dd937eb55224fa116981081
  - SLE: https://openqa.suse.de/tests/4289112
- Verification run: 
  - Leap 15.2 aarch64: https://openqa.opensuse.org/t1278954
  - Leap Tumbleweed aarch64: https://openqa.opensuse.org/t1278955
