### PR TITLE
Create a passwordless ssh key in HA cluster

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -75,6 +75,9 @@ sub run {
     # Ensure that ntp service is activated/started
     activate_ntp;
 
+    # Generate ssh key
+    gen_root_ssh_key;
+
     # Configure SBD_DELAY_START to yes
     # This may be necessary if your cluster nodes reboot so fast that the
     # other nodes are still waiting in the fence acknowledgement phase.

--- a/tests/ha/remove_node.pm
+++ b/tests/ha/remove_node.pm
@@ -40,7 +40,14 @@ sub remove_state_join {
     is_node(2) ? script_run("$crm_mon_cmd", $default_timeout) : save_state;
 
     # Second node needs to be reintegrated
-    assert_script_run("$join_cmd $node_01", 2 * $join_timeout) if is_node(2);
+    if (is_node(2)) {
+        type_string "$join_cmd $node_01 ; echo ha-cluster-join-finished-\$? > /dev/$serialdev\n";
+        if (check_screen('ha-cluster-join-password', 5)) {
+            type_password;
+            send_key 'ret';
+        }
+        wait_serial("ha-cluster-join-finished-0", 2 * $join_timeout);
+    }
 
     # Synchronize all the nodes after the join
     barrier_wait("JOIN_NODE_BY_" . "$method" . "_DONE_" . "$cluster_name");

--- a/tests/ha/yast_cluster_init.pm
+++ b/tests/ha/yast_cluster_init.pm
@@ -79,8 +79,7 @@ sub run {
     save_state;
 
     # Generate ssh key
-    assert_script_run 'ssh-keygen -f /root/.ssh/id_rsa -N ""';
-    assert_script_run 'cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys';
+    gen_root_ssh_key;
 
     # Signal that the cluster stack is initialized
     barrier_wait("CLUSTER_INITIALIZED_$cluster_name");

--- a/tests/ha/yast_cluster_join.pm
+++ b/tests/ha/yast_cluster_join.pm
@@ -28,10 +28,7 @@ sub run {
     barrier_wait("CLUSTER_INITIALIZED_$cluster_name");
 
     # Configure ssh key to enable ssh passwordless
-    add_to_known_hosts($node_to_join);
-    assert_script_run "ls -altr /root/";
-    exec_and_insert_password("scp root\@$node_to_join:/root/.ssh/* /root/.ssh/");
-    assert_script_run "ssh root\@$node_to_join 'ssh-keyscan -H $hostname >> /root/.ssh/known_hosts'";
+    get_root_ssh_key $node_to_join;
 
     # Wait until all the nodes have ssh key configured
     barrier_wait("SSH_KEY_CONFIGURED_$cluster_name");


### PR DESCRIPTION
Before bsc#1169581 crmsh used the default ssh root key (or created one) for the HA connection. Crmsh now uses a dedicated key for this.

As some tests need to do some passwordless ssh connections we now need to generate a pair. This was already done before in HA YaST test.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/4281321#step/netweaver_network/11
- Verification run: TBD?