### PR TITLE
Containers: replace wget by curl to download files from data dir

### DIFF
--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Basic functions for testing docker
-# Maintainer: Anna Minou <anna.minou@suse.de>
+# Maintainer: Anna Minou <anna.minou@suse.de>, qa-c@suse.de
 
 package containers::docker;
 
@@ -24,21 +24,16 @@ use version_utils;
 
 our @EXPORT = qw(set_up get_vars build_img test_built_img);
 
-my $dir     = '';
-my $id      = '';
-my $version = '';
+our $dir     = '/root/DockerTest/';
+our $id      = '';
+our $version = '';
 
 # Setup environment
 sub set_up() {
-    $dir = "/root/DockerTest";
-    assert_script_run("mkdir $dir");
-    assert_script_run("cd $dir");
-    assert_script_run("mkdir BuildTest");
-    assert_script_run("cd BuildTest");
-    assert_script_run("wget --quiet " . data_url('containers/app.py'));
-    assert_script_run("wget --quiet " . data_url('containers/Dockerfile'));
-    assert_script_run("wget --quiet " . data_url('containers/requirements.txt'));
-    assert_script_run("cd ..");
+    assert_script_run("mkdir -p $dir/BuildTest");
+    assert_script_run "curl -f -v " . data_url('containers/app.py') . " > $dir/BuildTest/app.py";
+    assert_script_run "curl -f -v " . data_url('containers/Dockerfile') . " > $dir/BuildTest/Dockerfile";
+    assert_script_run "curl -f -v " . data_url('containers/requirements.txt') . " > $dir/BuildTest/requirements.txt";
 }
 
 # Get job id and version variables
@@ -51,6 +46,7 @@ sub get_vars() {
 
 # Build the image
 sub build_img() {
+    assert_script_run("cd $dir");
     assert_script_run("docker pull python:3", timeout => 300);
     assert_script_run("docker build -t myapp BuildTest");
     assert_script_run("docker images| grep myapp");
@@ -58,11 +54,9 @@ sub build_img() {
 
 # Run the built image
 sub test_built_img() {
-    assert_script_run("cd");
-    assert_script_run("mkdir templates");
-    assert_script_run("cd templates");
-    assert_script_run("wget --quiet " . data_url('containers/index.html'));
-    assert_script_run("docker run -dit -p 8888:5000 -v ~/templates:\/usr/src/app/templates myapp https://openqa.suse.de//api/v1/jobs/${id}");
+    assert_script_run("mkdir /root/templates");
+    assert_script_run "curl -f -v " . data_url('containers/index.html') . " > /root/templates/index.html";
+    assert_script_run("docker run -dit -p 8888:5000 -v /root/templates:\/usr/src/app/templates myapp https://openqa.suse.de//api/v1/jobs/${id}");
     assert_script_run("docker ps -a");
     assert_script_run('curl http://localhost:8888/ | grep "You shall not pass in version: ' . $version . '"');
 }


### PR DESCRIPTION
Some images don't install wget by default, like JeOS.[1] 
We can achieve the same by using curl which is by default
installed and works out of the box without needing to install
wget.

[1] https://openqa.suse.de/tests/4279592#step/docker/97