### PR TITLE
Configure serial line for WSL and Windows

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -758,6 +758,7 @@ sub activate_console {
             # s390 zkvm uses a remote ssh session which is root by default so
             # search for that and su to user later if necessary
             push(@tags, 'text-logged-in-root') if get_var('S390_ZKVM');
+            push(@tags, 'wsl-linux-prompt')    if (get_var('FLAVOR') eq 'WSL');
             # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet,
             # or premature typing of credentials on sle15+
             my $stilltime = is_sle('15+') ? 5 : 1;
@@ -773,6 +774,9 @@ sub activate_console {
             }
             elsif (match_has_tag('text-logged-in-root')) {
                 ensure_user($user);
+            }
+            elsif (match_has_tag('wsl-linux-prompt')) {
+                return;
             }
         }
         assert_screen "text-logged-in-$user", 60;
@@ -871,7 +875,7 @@ sub console_selected {
     $args{tags}          //= $console;
     $args{ignore}        //= qr{sut|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary};
 
-    if ($args{tags} =~ $args{ignore} || !$args{await_console}) {
+    if ($args{tags} =~ $args{ignore} || !$args{await_console} || (get_var('FLAVOR') eq 'WSL')) {
         set_var('CONSOLE_JUST_ACTIVATED', 0);
         return;
     }

--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -58,14 +58,17 @@ sub run_in_powershell {
     my $rc_hash = testapi::hashed_string $args{cmd};
 
     type_string $args{cmd}, max_interval => 125;
+
     if (exists $args{code} && (ref $args{code} eq 'CODE')) {
         wait_screen_change(sub { send_key 'ret' }, 10);
         $args{code}->();
     } else {
         type_string ';$port.WriteLine(\'' . $rc_hash . '\' + $?)', max_interval => 125;
         wait_screen_change(sub { send_key 'ret' }, 10);
-        wait_serial "${rc_hash}True", timeout => (exists $args{timeout}) ? $args{timeout} : 30;
+        wait_serial("${rc_hash}True", timeout => (exists $args{timeout}) ? $args{timeout} : 30) or
+          die "Expected string (${rc_hash}True) was not found on serial";
     }
+
     send_key 'ctrl-l';
 }
 

--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -121,9 +121,6 @@ sub run {
         send_key 'alt-f';
         # Back to CLI
         assert_screen 'wsl-linux-prompt';
-        wait_screen_change { type_string 'exit' };
-        send_key 'ret';
-        save_screenshot;
     } else {
         #1) skip registration, we cannot register against proxy SCC
         assert_and_click 'window-max';
@@ -138,11 +135,17 @@ sub run {
         sleep 2;
         send_key 'ret';
         assert_screen 'wsl-image-ready-prompt', 120;
-        wait_screen_change { type_string 'exit' };
-        send_key 'ret';
-        sleep 2;
-        save_screenshot;
     }
+
+    unless (get_var('SCC_REGISTER', 0)) {
+        become_root;
+    }
+
+    assert_script_run 'cd ~';
+    if (script_run "zypper ps") {
+        record_soft_failure 'bsc#1170256 - [Build 3.136] zypper ps is missing lsof package';
+    }
+
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [[qac][wsl][research] serial vs /dev/tcp](https://progress.opensuse.org/issues/60344)
- <del>[osd](https://gitlab.suse.de/mloviska/os-autoinst-needles-sles/-/merge_requestsnew?merge_request%5Bsource_branch%5D=wsl_console_root_needles)</del>
- [o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/667)
- Verification runs: 
   * [opensuse-Tumbleweed-WSL-x86_64-Build20200523.5.71-wsl-main@uefi_win](http://kepler.suse.cz/tests/163)
   * [sle-15-SP2-WSL-x86_64-Build3.194-wsl-main+register@windows_uefi_boot](http://kepler.suse.cz/tests/164)
   * [opensuse-15.2-WSL-x86_64-Build20.73-wsl-main@uefi_win](http://kepler.suse.cz/tests/169#)
