### PR TITLE
LTP: Mark TCONF properly

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -227,7 +227,8 @@ sub record_ltp_result {
         $export_details->{test}->{result} = 'PASS';
     }
     elsif ($results->{conf}) {
-        $details->{result} = 'unk';
+        $details->{result}                = 'skip';
+        $self->{result}                   = 'skip';
         $export_details->{test}->{result} = 'CONF';
     }
     else {


### PR DESCRIPTION
This will change tests ending with TCONF as "skipped" with blue border,
instead of "passed", with gray border ('unk'). Previously was TCONF
hidden as TPASS, so easily overlooked.

Verification run: http://quasar.suse.cz/tests/5255#step/evm_overlay/8
(previously: http://quasar.suse.cz/tests/5253#step/evm_overlay/8)