### PR TITLE
[RFC] Add stale bot, to close pull requests automatically

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - notready
+  - WIP
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+  If it's still needed, you can add labels `WIP` or `notready` to it
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This Pull Request has been automatically closed as it didn't have any
+  activity in the last 97 days. Thank you.


### PR DESCRIPTION
Since we tend to have a lot of PR's that go unattended for quite some time, there's
always the thought of having something that is automatically closing these that can be
considered as `stale` every now and then. By using [probot/stale](https://github.com/probot/stale) we can automate said process, and in case somebody doesn't want their PR to be closed, these special cases can also be labeled as `notready` or `WIP`.

For now the lead time would be 90 days to mark the PR as stale, and 7 more days before definitely closing it.

Related ticket: https://progress.opensuse.org/issues/47441

Note: The app still needs to be enabled (I'll do it post merge)