### PR TITLE
Containers: Skip docker-compose tests

### DIFF
--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -27,6 +27,5 @@ schedule:
     - console/docker_runc
     - console/docker_image
     - '{{docker_base_images}}'
-    - console/docker_compose
     - console/zypper_docker
     - console/coredump_collect


### PR DESCRIPTION
docker-compose package is not part of SLE repos.
It is present in PackageHub, but not for 15-SP2,
only for SP1. We should disable this module
as it's not part of the release.
