### PR TITLE
Add validation step that checks the version of the updated binaries

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -17,12 +17,12 @@ use Exporter;
 
 use testapi;
 use utils;
-use List::Util 'max';
+use JSON;
+use List::Util qw(max first);
 use version_utils 'is_sle';
 
 our @EXPORT
-  = qw(capture_state check_automounter is_patch_needed add_test_repositories ssh_add_test_repositories remove_test_repositories advance_installer_window get_patches check_patch_variables);
-
+  = qw(capture_state check_automounter is_patch_needed add_test_repositories ssh_add_test_repositories remove_test_repositories advance_installer_window get_patches check_patch_variables query_smelt  get_incident_packages get_packagebins_in_modules);
 use constant ZYPPER_PACKAGE_COL    => 1;
 use constant OLD_ZYPPER_STATUS_COL => 4;
 use constant ZYPPER_STATUS_COL     => 5;
@@ -175,5 +175,46 @@ sub check_patch_variables {
         die("Missing INCIDENT_PATCH or INCIDENT_ID");
     }
 }
+
+sub query_smelt {
+    my $graphql = $_[0];
+    my $api_url = "--request POST https://smelt.suse.de/graphql/";
+    my $header  = '--header "Content-Type: application/json"';
+    my $data    = qq( --data '{"query": "$graphql"}');
+    return qx(curl $api_url $header $data 2>/dev/null );
+}
+
+sub get_incident_packages {
+    my $mr        = $_[0];
+    my $gql_query = "{incidents(incidentId: $mr){edges{node{incidentpackagesSet{edges{node{package{name}}}}}}}}";
+    my $graph     = JSON->new->utf8->decode(query_smelt($gql_query));
+    my @nodes     = @{$graph->{data}{incidents}{edges}[0]{node}{incidentpackagesSet}{edges}};
+    my @packages  = map { $_->{node}{package}{name} } @nodes;
+    return @packages;
+}
+
+sub get_packagebins_in_modules {
+    # This function uses the term package in the way that SMELT uses it. Not as
+    # an rpm but as a set of binaries that receive varying levels of support and are
+    # in different modules.
+    my ($self) = @_;
+    my ($package_name, $module_ref) = ($self->{package_name}, $self->{modules});
+    my $response = qx(curl "https://smelt.suse.de/api/v1/basic/maintained/$package_name/" 2>/dev/null);
+    my $graph    = JSON->new->utf8->decode($response);
+    # Get the modules to which this package provides binaries.
+    my @existing_modules = grep { exists($graph->{$_}) } @{$module_ref};
+    my @arr;
+    foreach my $m (@existing_modules) {
+        # The refs point to a hash of hashes. We only care about the value with
+        # the codestream key. The Update key is different for every SLE
+        # Codestream so instead of maintaining a LUT we just use a regex for it.
+        my $upd_key = first { m/Update\b/ } keys %{$graph->{$m}};
+        push(@arr, @{$graph->{$m}{$upd_key}});
+    }
+    # Return a hash of hashes, hashed by name. The values are hashes with the keys 'name', 'supportstatus' and
+    # 'package'.
+    return map { $_->{name} => $_ } @arr;
+}
+
 
 1;


### PR DESCRIPTION
Query SMELT for the binaries that are expected to be installed and or updated and check if they did and how.
Also devel packages are also now installed.

- Related ticket: [poo#67357](https://progress.opensuse.org/issues/67357)
- Verification runs: [Run showing expected failure](http://apappas-openqa.qam.suse.de/tests/202#step/update_install/93)
- New Runs (24.06): [Run showing expected failure](http://apappas-openqa.qam.suse.de/tests/283)
  - [12SP2](http://apappas-openqa.qam.suse.de/tests/285) [12SP3](http://apappas-openqa.qam.suse.de/tests/280) [12SP4](http://apappas-openqa.qam.suse.de/tests/281) [12SP5](http://apappas-openqa.qam.suse.de/tests/284) [15SP1](http://apappas-openqa.qam.suse.de/tests/279) [15SP2](http://apappas-openqa.qam.suse.de/tests/282)
