### PR TITLE
Fix login failure ppc64le virtio console in quota.pm

### DIFF
--- a/tests/console/quota.pm
+++ b/tests/console/quota.pm
@@ -60,6 +60,7 @@ sub run {
     #enable quota
     assert_script_run "quotaon /tmp/quota";
     # run user to use all quota
+    ensure_serialdev_permissions;
     select_console 'user-console';
     assert_script_run 'cd /tmp/quota/test-directory';
     assert_script_run 'touch first_file';


### PR DESCRIPTION
Add call to ensure_serialdev_permissions
to solve https://progress.opensuse.org/issues/67318
because reboot triggered by journalctl since
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10335

- Related ticket: https://progress.opensuse.org/issues/67318
- Needles: none
- Verification run: https://openqa.opensuse.org/t1281303  <= quota test passed (ignore ipv6 failure that is not related problem)
