### PR TITLE
Increase timeout for ltp_init_lvm script

### DIFF
--- a/tests/kernel/ltp_init_lvm.pm
+++ b/tests/kernel/ltp_init_lvm.pm
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
 
-    assert_script_run("prepare_lvm.sh");
+    assert_script_run("prepare_lvm.sh", timeout => 300);
 }
 
 sub test_flags {


### PR DESCRIPTION
`prepare_lvm.sh` may sometimes take slightly longer than 30 seconds to finish which will result in job failure. Increase timeout to allow it to finish gracefully.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - https://openqa.suse.de/tests/4289022
  - https://openqa.suse.de/tests/4289023
