### PR TITLE
Reboot after reverting lang test setup

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -587,7 +587,8 @@ sub load_jeos_tests {
             loadtest "console/suseconnect_scc";
         }
     }
-    loadtest "jeos/glibc_locale" if is_sle('15+') && get_var('JEOSINSTLANG');
+    loadtest "jeos/glibc_locale";
+    loadtest "jeos/kiwi_templates" unless (is_leap('<15.2'));
 }
 
 sub installzdupstep_is_applicable {

--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -32,12 +32,15 @@ use warnings;
 use testapi;
 use utils qw(zypper_call clear_console ensure_serialdev_permissions);
 use version_utils qw(is_opensuse is_sle is_jeos);
-use power_action_utils 'power_action';
+use power_action_utils qw(power_action);
 
 ## Define test data
 my $suse_lang_conf = '/etc/sysconfig/language';
 my %lc_data        = (en_US => 'en_US.UTF-8', de_DE => 'de_DE.UTF-8');
-my %test_lang_data = (en_US => 'For bug reporting', de_DE => 'Eine Anleitung zum Melden');
+my %test_data_lang = (
+    en_US => 'For bug reporting instructions, please see:',
+    de_DE => 'Eine Anleitung zum Melden von Programmfehlern finden Sie hier:'
+);
 
 sub change_locale {
     # if there is no new language to be set, let's return
@@ -72,25 +75,26 @@ sub change_locale {
 }
 
 sub test_users_locale {
-    my $rc_lc_udpated   = shift;
-    my $ldd_help_string = shift;
+    my $rc_lc_udpated            = shift;
+    my $ldd_help_string_expected = shift;
 
     record_info('Check', "Verifying $rc_lc_udpated->{RC_LANG}");
     ## Let's repeat the whole user login process again
     reset_consoles;
     select_console('user-console', ensure_tty_selected => 0, skip_setterm => 1);
 
-    foreach my $line (split(/\n/, script_output("locale"))) {
-        next if ($line =~ /^LC_ALL= *$/);
-        diag "\nExpected = $rc_lc_udpated->{RC_LANG}\n";
-        ($line =~ $rc_lc_udpated->{RC_LANG}) or die "Unexpected locale setting $line!\n";
-    }
+    assert_script_run("locale | tee -a /dev/$serialdev | grep $rc_lc_udpated->{RC_LANG}",
+        fail_message => "Expected LANG ($rc_lc_udpated->{RC_LANG}) has not been found!");
 
-    my $lang_new_short          = substr($rc_lc_udpated->{RC_LANG}, 0, 5);
-    my $ldd_help_string_updated = script_output("ldd --help | grep '^" . $test_lang_data{$lang_new_short} . "'");
-    diag "\nOriginal = $ldd_help_string\nUpdated = $ldd_help_string_updated";
-    record_info('glibc string', $ldd_help_string_updated);
-    ($ldd_help_string ne $ldd_help_string_updated) or die "glibc strings do not differ!\n";
+    my $ldd_help_string_updated = script_output "ldd --help";
+    if ($ldd_help_string_updated =~ /([A-Z]\w+\s.*\w:)/) {
+        $ldd_help_string_updated = $1;
+    } else {
+        die "Test string not found in *ldd* output\n";
+    }
+    record_info('Compare ldd', "\nExpected = $ldd_help_string_expected\nGot = $ldd_help_string_updated");
+
+    ($ldd_help_string_expected eq $ldd_help_string_updated) or die "Unexpected locale settings, glibc test strings are not the same!\n";
     type_string("exit\n");
 
     return $ldd_help_string_updated;
@@ -100,12 +104,12 @@ sub run {
     my ($self) = @_;
     # C<$lang_ref> denotes what kind of lang setting is expected from test suite perspective
     # sle15+ does not enable locale change during firstboot
-    my $lang_ref = (is_sle('15+'))                                            ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
-    my $lang_new = ((get_required_var('TEST') =~ /de_DE/) && (is_sle('<15'))) ? 'en_US' : 'de_DE';
+    my $lang_ref         = get_var('JEOSINSTLANG', 'en_US');
+    my $lang_new_short   = ((get_required_var('TEST') =~ /de_DE/) && (is_sle('<15'))) ? 'en_US' : 'de_DE';
     my $rc_expected_data = {
         ROOT_USES_LANG => 'ctype',
         RC_LC_ALL      => qr/^ *$/,
-        RC_LANG        => (is_sle('15+')) ? qr/^ *$/ : $lc_data{$lang_ref}
+        RC_LANG        => (is_sle('15+') || is_opensuse) ? qr/^ *$/ : $lc_data{$lang_ref}
     };
 
     ## Retrieve user's $LANG env variable after JeOS firstboot
@@ -119,8 +123,8 @@ sub run {
     die "User's language variable is set to $lang_booted, expected $lc_data{$lang_ref}!" if ($lc_data{$lang_ref} ne $lang_booted);
 
     ## Check glibc locale, should be the same as in firstrun module
-    my $original_glibc_string = script_output("ldd --help | grep '^" . $test_lang_data{$lang_booted_short} . "'");
-    record_info('glibc string', $original_glibc_string);
+    my $original_glibc_string = script_output("ldd --help | grep '^" . $test_data_lang{$lang_booted_short} . "'");
+    record_info('Original', $original_glibc_string);
     type_string("exit\n");
 
     ## Check system wide locale configuration; general notes
@@ -135,68 +139,75 @@ sub run {
     # 2) ROOT_USES_LANG="ctype"
     select_console('root-console');
     # it is expected that SLE12 has glibc preinstalled
-    zypper_call('in glibc-locale') if (is_sle('15+'));
+    zypper_call('in glibc-locale') if (is_sle('15+') || is_opensuse);
 
-    my $output = script_output("localectl list-locales | grep $lang_new.utf8");
-    die "Test locale not found in the available ones" unless ($output =~ $lang_new);
+    my $output = script_output("localectl list-locales | tee -a /dev/$serialdev | grep -E '$lang_new_short\.(UTF-8|utf8)'");
+    die "Test locale not found in the available ones" unless ($output =~ $lang_new_short);
 
     # Parse and evaluate /etc/sysconfig/language
     die 'SUSE language config file is missing!' if (script_run("test -f $suse_lang_conf") != 0);
-    my %rc_lc_setup = map {
+    my %rc_lc_defaults = map {
         s/["']//g;
         s/\s+//g;
         my ($k, $v) = split(/=/, $_, 2);
         ($k => $v);
     } grep { /^\w+(_\w+)+/ } split(/\n/, script_output("cat $suse_lang_conf"));
 
-    my $record_info_result = ($rc_lc_setup{RC_LC_ALL} =~ /^ *$/);
+    my $record_info_result = ($rc_lc_defaults{RC_LC_ALL} =~ /^ *$/);
     my $total_result += $record_info_result;
     record_info('LC_ALL',
-        "Expected to be empty\nRC_LC_ALL = $rc_lc_setup{RC_LC_ALL}\n",
+        "Expected to be empty\nRC_LC_ALL = $rc_lc_defaults{RC_LC_ALL}\n",
         result => $record_info_result ? 'ok' : 'fail'
     );
 
-    $record_info_result = ($rc_lc_setup{RC_LANG} =~ $rc_expected_data->{RC_LANG});
+    $record_info_result = ($rc_lc_defaults{RC_LANG} =~ $rc_expected_data->{RC_LANG});
     $total_result += $record_info_result;
     record_info('LANG',
-        "Expected to be $rc_expected_data->{RC_LANG}\nRC_LANG = $rc_lc_setup{RC_LANG}\n",
+        "Expected to be $rc_expected_data->{RC_LANG}\nRC_LANG = $rc_lc_defaults{RC_LANG}\n",
         result => $record_info_result ? 'ok' : 'fail'
     );
 
-    $record_info_result = ($rc_lc_setup{ROOT_USES_LANG} eq $rc_expected_data->{ROOT_USES_LANG});
+    $record_info_result = ($rc_lc_defaults{ROOT_USES_LANG} eq $rc_expected_data->{ROOT_USES_LANG});
     $total_result += $record_info_result;
     record_info('ROOT_USES_LANG',
-        "Expected to be \'ctype\'\nROOT_USES_LANG = $rc_lc_setup{ROOT_USES_LANG}\n",
+        "Expected to be \'ctype\'\nROOT_USES_LANG = $rc_lc_defaults{ROOT_USES_LANG}\n",
         result => $record_info_result ? 'ok' : 'fail'
     );
 
-    $record_info_result = ($rc_lc_setup{RC_LC_MESSAGES} =~ $rc_expected_data->{RC_LANG});
+    $record_info_result = ($rc_lc_defaults{RC_LC_MESSAGES} =~ $rc_expected_data->{RC_LANG});
     $total_result += $record_info_result;
     record_info('LANG == LC_MESSAGES',
-        "Expected to be the same\nRC_LANG=$rc_lc_setup{RC_LANG}\nLC_MESSAGES=$rc_lc_setup{RC_LC_MESSAGES}\n",
+        "Expected to be the same\nRC_LANG=$rc_lc_defaults{RC_LANG}\nLC_MESSAGES=$rc_lc_defaults{RC_LC_MESSAGES}\n",
         result => $record_info_result ? 'ok' : 'fail'
     );
 
-    $self->result('fail') unless ($total_result);
+    if ($total_result % 4) {
+        $self->result('fail');
+        diag("Number of failed checks: " . $total_result % 4 . "\n");
+    }
 
-    my $rc_lc_changed        = change_locale($lc_data{$lang_new}, \%rc_lc_setup);
-    my $updated_glibc_string = test_users_locale($rc_lc_changed, $original_glibc_string);
-
-    ## Reboot and double check if the locale settings haven't changed
+    ## Modify default locale, verify new setup, reboot and repeat verification
+    my $rc_lc_changed        = change_locale($lc_data{$lang_new_short}, \%rc_lc_defaults);
+    my $updated_glibc_string = test_users_locale($rc_lc_changed, $test_data_lang{$lang_new_short});
     power_action('reboot', textmode => 1);
     record_info('Rebooting', "Expected locale set=$rc_lc_changed->{RC_LANG}");
     $self->wait_boot;
     select_console('root-console', skip_set_standard_prompt => 1, skip_setterm => 1);
     ensure_serialdev_permissions;
-    (test_users_locale($rc_lc_changed, $original_glibc_string) eq $updated_glibc_string) or die "Locale has changed after reboot!\n";
+    (test_users_locale($rc_lc_changed, $test_data_lang{$lang_new_short}) eq $updated_glibc_string) or die "Locale has changed after reboot!\n";
 
-    if ($lang_new eq 'de_DE') {
-        # Revert changes back to english
-        $updated_glibc_string = test_users_locale(change_locale($lang_booted, $rc_lc_changed), $updated_glibc_string);
-    }
+    return if (is_sle('<15'));
 
+    ## Revert locales to default and verify
+    my $rc_lc_reverted        = change_locale($lang_booted_short, $rc_lc_changed);
+    my $reverted_glibc_string = test_users_locale($rc_lc_reverted, $test_data_lang{$lang_ref});
+    power_action('reboot', textmode => 1);
+    record_info('Rebooting', "Expected locale set=$rc_lc_reverted->{RC_LANG}");
+    $self->wait_boot;
+    select_console('root-console');
+    ensure_serialdev_permissions;
+    (test_users_locale($rc_lc_reverted, $test_data_lang{$lang_ref}) eq $original_glibc_string) or die "Locale has changed after reboot!\n";
     reset_consoles;
-    ($updated_glibc_string =~ /$test_lang_data{en_US}/) or die "Exit locale settings have not been changed to english!\n";
 }
 
 1;

--- a/tests/jeos/kiwi_templates.pm
+++ b/tests/jeos/kiwi_templates.pm
@@ -19,7 +19,7 @@ use utils qw(zypper_call);
 
 sub run {
     select_console 'root-console';
-    my $rpm = (is_sle('<15-SP2') or is_leap('<15.2')) ? 'kiwi-templates-SLES15-JeOS' : 'kiwi-templates-JeOS';
+    my $rpm = is_sle('<15-SP2') ? 'kiwi-templates-SLES15-JeOS' : 'kiwi-templates-JeOS';
     zypper_call "in $rpm";
     assert_script_run "rpm -ql $rpm";
 }


### PR DESCRIPTION
- Related ticket: [[qac][JeOS] test fails in consoletest_setup - add restart after last locale update in glibc_locale.pm](https://progress.opensuse.org/issues/67159)
- Verification runs:
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build14.49-jeos-main_intel_image@64bit-virtio-vga](http://kepler.suse.cz/tests/286#step/glibc_locale/1)
   * [sle-15-SP2-JeOS-for-MS-HyperV-x86_64-Build14.49-jeos-main_hyperv_image@svirt-hyperv](http://kepler.suse.cz/tests/285#step/glibc_locale/1)
   * [tw - failed](http://kepler.suse.cz/tests/288#step/glibc_locale/1)
   * [leap15.2](http://kepler.suse.cz/tests/289#step/glibc_locale/1)
   * [leap15.1](http://kepler.suse.cz/tests/290#step/glibc_locale/1)
   * [sle12sp5](http://kepler.suse.cz/tests/287)

