### PR TITLE
Handle node 2 fencing in qnetd split brain scenario

### DIFF
--- a/schedule/ha/bv/ha_qdevice_node1.yaml
+++ b/schedule/ha/bv/ha_qdevice_node1.yaml
@@ -14,3 +14,4 @@ schedule:
   - ha/watchdog
   - ha/ha_cluster_init
   - ha/qnetd
+  - ha/check_after_reboot

--- a/schedule/ha/bv/ha_qdevice_node2.yaml
+++ b/schedule/ha/bv/ha_qdevice_node2.yaml
@@ -14,3 +14,5 @@ schedule:
   - ha/watchdog
   - ha/ha_cluster_join
   - ha/qnetd
+  - boot/boot_to_desktop
+  - ha/check_after_reboot

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -118,6 +118,7 @@ sub run {
         # QNETD barriers
         barrier_create("QNETD_SERVER_READY_$cluster_name",     $num_nodes + 1);
         barrier_create("QNETD_SERVER_DONE_$cluster_name",      $num_nodes + 1);
+        barrier_create("QNETD_TESTS_DONE_$cluster_name",       $num_nodes + 1);
         barrier_create("SPLIT_BRAIN_TEST_READY_$cluster_name", $num_nodes + 1);
         barrier_create("SPLIT_BRAIN_TEST_DONE_$cluster_name",  $num_nodes + 1);
 

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -31,7 +31,7 @@ sub run {
 
     # We need to be sure to be root and, after fencing, the default console on node01 is not root
     # Only do this on node01, as node02 console is expected to be the root-console
-    if (is_node(1) && !get_var('HDDVERSION')) {
+    if ((is_node(1) && !get_var('HDDVERSION')) || (is_node(2) && check_var('QDEVICE_TEST_ROLE', 'client'))) {
         reset_consoles;
         select_console 'root-console';
     }
@@ -102,6 +102,8 @@ sub run {
     barrier_wait("CHECK_AFTER_REBOOT_END_$cluster_name");
 
     barrier_wait("HAWK_FENCE_$cluster_name") if (check_var('HAWKGUI_TEST_ROLE', 'server'));
+
+    barrier_wait("QNETD_TESTS_DONE_$cluster_name") if (check_var('QDEVICE_TEST_ROLE', 'client'));
 }
 
 1;

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -39,6 +39,9 @@ sub run {
     # in that case
     select_console 'root-console' if (get_var('HDDVERSION'));
 
+    # Remove iptable rules in node 1 when testing qnetd/qdevice in multicast
+    assert_script_run "iptables -F && iptables -X" if (is_node(1) && check_var('QDEVICE_TEST_ROLE', 'client') && !get_var('HA_UNICAST'));
+
     # Workaround network timeout issue during upgrade
     if (get_var('HDDVERSION')) {
         assert_script_run 'journalctl -b --no-pager -o short-precise > bsc1129385-check-journal.log';

--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -93,7 +93,7 @@ sub run {
     }
 
     # Ensure promotable resource is in node 1
-    script_run 'crm resource migrate promotable-1 ' . choose_node(1);
+    script_run 'crm resource migrate promotable-1 ' . choose_node(1) if is_node(1);
 
     # Perform Split Brain test
     barrier_wait("SPLIT_BRAIN_TEST_READY_$cluster_name");
@@ -101,12 +101,14 @@ sub run {
     record_info('Split-brain info', 'Split brain test');
 
     # Stop stonith to prevent fencing of node before our check
-    assert_script_run "crm resource stop stonith-sbd" if (is_node(1));
+    assert_script_run "crm resource stop stonith-sbd" if is_node(1);
 
     # Add firewall rules to provoke a split brain situation and confirm that
     # the qdevice node gives its vote to the node1 (where the master resource is running)
+    # Firewall rules go in both nodes in multicast cluster, and only in node 2 in unicast
     my $partner_ip = is_node(1) ? get_ip(choose_node(2)) : get_ip(choose_node(1));
-    assert_script_run "iptables -A INPUT -s $partner_ip -j DROP; iptables -A OUTPUT -d $partner_ip -j DROP" if (is_node(1) or is_node(2));
+    assert_script_run "iptables -A INPUT -s $partner_ip -j DROP; iptables -A OUTPUT -d $partner_ip -j DROP"
+      if ((is_node(1) and !get_var('HA_UNICAST')) or is_node(2));
     sleep $default_timeout;
 
     if (is_node(2)) {
@@ -128,13 +130,8 @@ sub run {
     # Show cluster status before ending the test
     save_state if (!check_var('QDEVICE_TEST_ROLE', 'qnetd_server'));
 
-    # Cleanup
-    if (is_node(1)) {
-        # Restart stonith. This should fence node 2
-        assert_script_run "crm resource start stonith-sbd";
-        # Remove iptable rules
-        assert_script_run "iptables -F && iptables -X";
-    }
+    # Restart stonith. This should fence node 2
+    assert_script_run "crm resource start stonith-sbd" if is_node(1);
 
     barrier_wait("QNETD_SERVER_DONE_$cluster_name");
 


### PR DESCRIPTION
With upcoming fixes to bsc#1170037, the split brain test with qdevice/qnetd will require to handle the fencing of node 2 when the split brain scenario is introduced by the test code. This PR
introduces changes in the job schedules and test modules so the node 2 test is able to handle the fence, and also to verify the cluster status after fencing.

Additionally, STONITH is being temporarily disabled to allow the test to verify the expected
configuration of qdevice/qnetd during the split brain scenario, and then enabled to allow the cluster to handle the split brain automatically via a fence.

Support was also added for multicast vs unicast cluster configuration: when the cluster is configured over multicast, test code will need to add iptables rules in both nodes to properly cause a split brain failure on which to test qnetd/qdevice functionality; in this scenario, iptables rules must be removed manually from node 1 after node 2 is fenced

On the other hand, when the cluster is configured over unicast, iptables rules to cause a split brain failure are only needed in one node (test does this in node 2).

Both in unicast or multicast configuration, the fence action on node 2 clears the iptables rules from node 2, so there is no need to explicitly remove them.

Also part of this commit:
- Ensure promotable resource runs in node 1 so qnetd selects this node during the split brain failure.
- Make qnetd server wait until testing finishes in cluster nodes

-----

- Related ticket: N/A
- Needles: N/A
- Verification run (multicast): [node 1](http://mango.suse.de/tests/2455), [node 2](http://mango.suse.de/tests/2456), [qnetd server](http://mango.suse.de/tests/2457) & [support server](http://mango.suse.de/tests/2454)
- Verification run (unicast): [node 1](http://mango.suse.de/tests/2459), [node 2](http://mango.suse.de/tests/2460), [qnetd server](http://mango.suse.de/tests/2461), [support server](http://mango.suse.de/tests/2458)
- Verification run (regression, alpha cluster): [node 1](http://mango.suse.de/tests/2463), [node 2](http://mango.suse.de/tests/2464) & [support server](http://mango.suse.de/tests/2462) (Regression test is failing due to bsc#1169581. Notice it clears all modules modified in this PR)