### PR TITLE
Fix race condition for yast_keyboard

### DIFF
--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -13,7 +13,7 @@
 # - Set keyboard layout to korean and validate.
 # - Set keyboard layout to german.
 # - Restore keyboard settings to english-us and verify (enter using german characters).
-# Maintainer: Ming Li <mli@suse.com>
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 =head1 Create regression test for keyboard layout and verify
 
@@ -31,12 +31,9 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(zypper_call);
-use version_utils qw(is_sle);
 
 sub run {
-
     select_console("root-console");
-
     # Set keyboard layout to korean and validate.
     zypper_call("in yast2-country", timeout => 480);
     assert_script_run("yast keyboard list");
@@ -47,21 +44,8 @@ sub run {
     assert_script_run("yast keyboard set layout=german");
 
     # Restore keyboard settings to english-us and verify(enter using german characters).
-    if (is_sle('15-sp2+')) {
-        type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 5, timeout => 10);
-    }
-    else {
-        record_soft_failure('bsc#1170292');
-        type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 60, timeout => 130);
-    }
-    save_screenshot;
-
+    type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 40, timeout => 90);
     validate_script_output("yast keyboard summary 2>&1", sub { m/english-us/ }, timeout => 90);
-
-}
-
-sub test_flags {
-    return {always_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
When the `yast keyboard set` runs it executes loadkeys for all the tty.
when the type_string run the last command has not finished apparently.
And this explains why when the module runs successful the error about the
ttyS0 does not appear. increasing the type_string seems to work
but it doesnt seem the right solution. But also replacing the type_string
with the assert_script_run is problematic as the language in the device
has changed and the commands inside the assert_script_run are localed
as german characters.

- Related ticket: https://progress.opensuse.org/issues/66292
- Verification run: 
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=b10n1k%2Fos-autoinst-distri-opensuse%23fix_poo66292

