### PR TITLE
Don't change the working directory in evolution_prepare_servers

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -74,7 +74,7 @@ sub run() {
         $dovecot_path = "/usr/share/doc/packages/dovecot";
     }
 
-    assert_script_run "cd $dovecot_path;bash mkcert.sh";
+    assert_script_run "(cd $dovecot_path; bash mkcert.sh)";
 
     # configure postfix
     assert_script_run "postconf -e 'smtpd_use_tls = yes'";


### PR DESCRIPTION
This breaks succeeding tests.

See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10390

Verification run: http://10.160.67.86/tests/680
