### PR TITLE
Run SUSEConnect --status-text more than once up to a timeout after Online Migration

### DIFF
--- a/tests/migration/sle12_online_migration/post_migration.pm
+++ b/tests/migration/sle12_online_migration/post_migration.pm
@@ -26,7 +26,16 @@ sub run {
     zypper_call('lr -u');
 
     # Save output info to logfile
-    my $out = script_output("SUSEConnect --status-text", proceed_on_failure => 1);
+    my $out;
+    my $timeout  = bmwqemu::scale_timeout(30);
+    my $waittime = bmwqemu::scale_timeout(5);
+    while (1) {
+        $out = script_output("SUSEConnect --status-text", proceed_on_failure => 1);
+        last if (($timeout < 0) || ($out !~ /System management is locked by the application with pid/));
+        sleep $waittime;
+        $timeout -= $waittime;
+        diag "SUSEConnect --status-text locked: $out";
+    }
     diag "SUSEConnect --status-text: $out";
     assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'" unless get_var('MEDIA_UPGRADE');
 


### PR DESCRIPTION
Similar to #10164, we have seen tests fail in s390x after online migration of SLES+HA to 15-SP2, with `SUSEConnect --status-text` failing as System Management blocked by another process.

#10164 introduced a fix for this problem for offline upgrades in `tests/console/system_prepare`, this introduces the same change in `tests/migration/sle12_online_migration/post_migration`.

- Related ticket: https://openqa.suse.de/tests/4291008#step/post_migration/4
- Needles: N/A
- Verification run: [x86_64](https://openqa.suse.de/t4291935), [s390x](https://openqa.suse.de/t4292439)
