### PR TITLE
Add a workaround for bsc#1167736

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -68,6 +68,7 @@ sub check_default_target {
         get_var('REMOTE_CONTROLLER') || (get_var('BACKEND', '') =~ /spvm|pvm_hmc|ipmi/));
     # exclude non-desktop environment and scenarios with edition of package selection (bsc#1167736)
     return if (!get_var('DESKTOP') || get_var('PATTERNS'));
+    return if (get_var 'BSC1167736');
 
     # Set expectations
     my $expected_target = check_var('DESKTOP', 'textmode') ? "multi-user" : "graphical";


### PR DESCRIPTION
Workaround for [bsc#1167736](https://bugzilla.suse.com/show_bug.cgi?id=1167736) - [Build 163.11] Default target is set to graphical if VNC is used during installation

- Related ticket: https://progress.opensuse.org/issues/65301