### PR TITLE
Test runc alongside docker_runc

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -55,8 +55,6 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    #my $hostnam = autoinst_url();
-    #record_info("$hostnam");
     my $sleep_time = 90 * get_var('TIMEOUT_SCALE', 1);
 
     install_docker_when_needed();

--- a/tests/console/docker_runc.pm
+++ b/tests/console/docker_runc.pm
@@ -7,13 +7,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Test docker-runc installation and extended usage
-#    Cover the following aspects of runc:
+# Summary: Test docker-runc and runc installation, and extended usage
+#    Cover the following aspects of docker-runc and runc respectively:
 #      * package can be installed
 #      * create specification files
 #      * run the container
 #      * complete lifecycle (create, start, pause, resume, kill, delete)
-# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
+# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>, George Gkioulis <ggkioulis@suse.com>
 
 use base "consoletest";
 use testapi;
@@ -27,12 +27,12 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    install_docker_when_needed;
+    my @runtimes = ("docker-runc");
+    push @runtimes, "runc" if !is_sle('=15');
 
-    my $runc = 'docker-runc';
-
-    # runC cannot create or extract the root filesystem on its own. Use Docker to create it.
     record_info 'Setup', 'Setup the environment';
+    # runC cannot create or extract the root filesystem on its own. Use Docker to create it.
+    install_docker_when_needed;
 
     # create the rootfs directory
     assert_script_run('mkdir rootfs');
@@ -40,60 +40,27 @@ sub run {
     # export busybox via Docker into the rootfs directory
     assert_script_run('docker export $(docker create busybox) | tar -C rootfs -xvf -');
 
-    # installation of runc package
-    record_info 'Test #1', 'Test: Installation';
-    if (is_caasp) {
-        # runC should be pre-installed
-        die "runC is not pre-installed." if script_run("zypper se -x --provides -i $runc | grep runc");
+    foreach my $runc (@runtimes) {
+        record_info "$runc", "Testing $runc";
+
+        # If not testing docker-runc but docker-runc is installed, uninstall it
+        if ($runc ne "docker-runc" && script_run("which docker-runc") == 0) {
+            zypper_call('rm docker-runc');
+        }
+
+        test_container_runtime($runc);
+
+        # uninstall the tested container runtime
+        zypper_call("rm $runc");
     }
-    else {
-        # SLES/TW
-        zypper_call("in $runc");
-    }
 
-    # create the OCI specification and verify that the template has been created
-    record_info 'Test #2', 'Test: OCI Specification';
-    assert_script_run("$runc spec");
-    assert_script_run('ls -l config.json');
-    script_run('cp config.json config.json.backup');
+    # cleanup
+    assert_script_run("rm -rf rootfs");
 
-    # Modify the configuration to run the container in background
-    assert_script_run("sed -i -e '/\"terminal\":/ s/: .*/: false,/' config.json");
-    assert_script_run("sed -i -e 's/\"sh\"/\"echo\", \"Kalimera\"/' config.json");
+    # install docker and docker-runc if needed
+    install_docker_when_needed;
 
-    # Run (create, start, and delete) the container after it exits
-    record_info 'Test #3', 'Test: Use the run command';
-    assert_script_run("$runc run test1 | grep Kalimera");
-
-    # Restore the default configuration
-    assert_script_run('mv config.json.backup config.json');
-
-    assert_script_run("sed -i -e '/\"terminal\":/ s/: .*/: false,/' config.json");
-    assert_script_run("sed -i -e 's/\"sh\"/\"sleep\", \"120\"/' config.json");
-
-    # Container Lifecycle
-    record_info 'Test #4', 'Test: Create a container';
-    assert_script_run("$runc create test2");
-    assert_script_run("$runc state test2 | grep status | grep created");
-    record_info 'Test #5', 'Test: List containers';
-    assert_script_run("$runc list | grep test2");
-    record_info 'Test #6', 'Test: Start a container';
-    assert_script_run("$runc start test2");
-    assert_script_run("$runc state test2 | grep running");
-    record_info 'Test #7', 'Test: Pause a container';
-    assert_script_run("$runc pause test2");
-    assert_script_run("$runc state test2 | grep paused");
-    record_info 'Test #8', 'Test: Resume a container';
-    assert_script_run("$runc resume test2");
-    assert_script_run("$runc state test2 | grep running");
-    record_info 'Test #9', 'Test: Stop a container';
-    assert_script_run("$runc kill test2 KILL");
-    assert_script_run("$runc state test2 | grep stopped");
-    record_info 'Test #10', 'Test: Delete a container';
-    assert_script_run("$runc delete test2");
-    assert_script_run("! $runc state test2");
-
-    # Cleanup, remove all images
+    # remove leftover containers and images
     clean_docker_host();
 }
 


### PR DESCRIPTION
The runc runtime environment was not tested on related products.
The docker_runc test now also tests the runc package, with the
same tests that are performed for the docker-runc package.

- Related ticket: https://progress.opensuse.org/issues/67267
- Needles: No needles
- Verification run: 
12-sp3: http://angmar.suse.de/tests/2250#step/docker_runc/165
12-sp4: http://angmar.suse.de/tests/2251#step/docker_runc/165
12-sp5: http://angmar.suse.de/tests/2257#step/docker_runc/165
15-sp1: http://angmar.suse.de/tests/2258#step/docker_runc/165
15-sp2: http://angmar.suse.de/tests/2255#step/docker_runc/165
15-sp2 JEOS: http://angmar.suse.de/tests/2254#step/docker_runc/165
tumbleweed: http://angmar.suse.de/tests/2256#step/docker_runc/163

and also runc NOT tested in sle 15 since it is not available:
http://angmar.suse.de/tests/2259
