### PR TITLE
Add clear_console in apache_ssl to avoid uncertain input

### DIFF
--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -11,16 +11,18 @@
 #          calls setup_apache2 with mode = SSL (lib/apachetest.pm)
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#65375
+# Tags: poo#65375, poo#67309
 
 use base "consoletest";
 use testapi;
 use strict;
 use warnings;
 use apachetest;
+use utils 'clear_console';
 
 sub run {
     select_console 'root-console';
+    clear_console;
     setup_apache2(mode => 'SSL');
 }
 


### PR DESCRIPTION
1. Add clear_console before executing zypper install in apache_ssl case
2. Fix it if testflag is fatal=0 in the previous case in s390x

- Related ticket: https://progress.opensuse.org/issues/67309
- Needles: NA
- Verification run: https://openqa.suse.de/tests/4294092
