### PR TITLE
Move yast2_snapper module to YaST job group

### DIFF
--- a/schedule/functional/allpatterns.yaml
+++ b/schedule/functional/allpatterns.yaml
@@ -67,7 +67,6 @@ schedule:
     - x11/gnome_terminal
     - x11/gedit
     - x11/firefox
-    - x11/yast2_snapper
     - x11/glxgears
     - x11/nautilus
     - x11/desktop_mainmenu

--- a/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
@@ -1,0 +1,28 @@
+---
+name:           yast2_gui
+description:    >
+    Test for yast2 UI, GUI only.
+    Running on created gnome images which provides both text console for ncurses UI tests as well
+    as the gnome environment for the GUI tests.
+vars:
+    BOOTFROM: c
+    HDDSIZEGB: 20
+    SOFTFAIL_BSC1063638: 1
+    VALIDATE_ETC_HOSTS: 1
+schedule:
+    - installation/bootloader_svirt
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/hostname
+    - yast2_gui/yast2_software_management
+    - yast2_gui/yast2_users
+    - yast2_gui/yast2_datetime
+    - yast2_gui/yast2_security
+    - yast2_gui/yast2_bootloader
+    - x11/yast2_snapper
+    - yast2_gui/yast2_hostnames
+    - yast2_gui/yast2_network_settings
+    - yast2_gui/yast2_lan_restart_bridge
+    - yast2_gui/yast2_lan_restart_vlan
+    - yast2_gui/yast2_lan_restart_bond

--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -10,21 +10,67 @@ vars:
     SOFTFAIL_BSC1063638: 1
     VALIDATE_ETC_HOSTS: 1
 schedule:
+    - "{{pre_boot_to_desktop}}"
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup
     - console/hostname
-    - yast2_gui/yast2_control_center
-    - x11/yast2_lan_restart
-    - yast2_gui/yast2_bootloader
-    - yast2_gui/yast2_datetime
-    - yast2_gui/yast2_firewall
-    - yast2_gui/yast2_hostnames
-    - yast2_gui/yast2_lang
-    - yast2_gui/yast2_network_settings
-    - yast2_gui/yast2_software_management
-    - yast2_gui/yast2_users
-    - yast2_gui/yast2_security
-    - yast2_gui/yast2_lan_restart_bridge
-    - yast2_gui/yast2_lan_restart_vlan
-    - yast2_gui/yast2_lan_restart_bond
+    - "{{yast2_modules}}"
+conditional_schedule:
+    pre_boot_to_desktop:
+        ARCH:
+            aarch64:
+                - boot/uefi_bootmenu
+        BACKEND:
+            svirt:
+                - installation/bootloader_start
+    yast2_modules:
+        ARCH:
+            x86_64:
+                - yast2_gui/yast2_control_center
+                - yast2_gui/yast2_software_management
+                - yast2_gui/yast2_security
+                - yast2_gui/yast2_firewall
+                - yast2_gui/yast2_bootloader
+                - x11/yast2_snapper
+                - yast2_gui/yast2_lang
+                - yast2_gui/yast2_users
+                - yast2_gui/yast2_datetime
+                - yast2_gui/yast2_hostnames
+                - yast2_gui/yast2_network_settings
+                - x11/yast2_lan_restart
+                - yast2_gui/yast2_lan_restart_bridge
+                - yast2_gui/yast2_lan_restart_vlan
+                - yast2_gui/yast2_lan_restart_bond
+            aarch64:
+                - yast2_gui/yast2_software_management
+                - yast2_gui/yast2_security
+                - x11/yast2_snapper
+                - yast2_gui/yast2_users
+                - yast2_gui/yast2_datetime
+                - yast2_gui/yast2_hostnames
+                - yast2_gui/yast2_network_settings
+                - yast2_gui/yast2_lan_restart_bridge
+                - yast2_gui/yast2_lan_restart_vlan
+                - yast2_gui/yast2_lan_restart_bond
+            ppc64le:
+                - yast2_gui/yast2_software_management
+                - yast2_gui/yast2_security
+                - x11/yast2_snapper
+                - yast2_gui/yast2_users
+                - yast2_gui/yast2_datetime
+                - yast2_gui/yast2_hostnames
+                - yast2_gui/yast2_network_settings
+                - yast2_gui/yast2_lan_restart_bridge
+                - yast2_gui/yast2_lan_restart_vlan
+                - yast2_gui/yast2_lan_restart_bond
+            s390x:
+                - yast2_gui/yast2_software_management
+                - yast2_gui/yast2_security
+                - x11/yast2_snapper
+                - yast2_gui/yast2_users
+                - yast2_gui/yast2_datetime
+                - yast2_gui/yast2_hostnames
+                - yast2_gui/yast2_network_settings
+                - yast2_gui/yast2_lan_restart_bridge
+                - yast2_gui/yast2_lan_restart_vlan

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -35,6 +35,12 @@ use y2_module_consoletest;
 sub run {
     my $self = shift;
 
+    # Make sure that the module runs on graphical mode
+    unless (check_screen 'generic-desktop', 0) {
+        select_console 'x11';
+        $self->handle_displaymanager_login() if (check_screen 'linux-login', 0);
+    }
+
     # Turn off screensaver
     x11_start_program('xterm');
     turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');

--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -23,7 +23,7 @@ sub run {
     # Accept => Exit, or get to the installation report
     send_key 'alt-a';
     # Installation may take some time
-    assert_screen [qw(sw_single_ui_installation_report generic-desktop)], timeout => 60;
+    assert_screen [qw(sw_single_ui_installation_report generic-desktop)], timeout => 150;
     if (match_has_tag('sw_single_ui_installation_report')) {
         # Press finish
         send_key 'alt-f';

--- a/tests/yast2_gui/yast2_users.pm
+++ b/tests/yast2_gui/yast2_users.pm
@@ -19,7 +19,7 @@ use testapi;
 sub run {
     my $self = shift;
     select_console 'x11';
-    $self->launch_yast2_module_x11('users', match_timeout => 60);
+    $self->launch_yast2_module_x11('users', match_timeout => 100);
     send_key "alt-o";    # OK => Exit
 }
 


### PR DESCRIPTION
Pull request moves module yast2_snapper in YaST job group. The module is added in the schedule of test suite yast2_gui, which schedule is modified so it can be enabled in more architectures. There is a check added in the beginning of yast2_snapper module so that it will be able to run in cases where previous module is leaving system in textmode target.

- Related ticket: https://progress.opensuse.org/issues/66853
- Related PR in YaST job group repo : https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/203
- Related PR in functional job group repo : https://gitlab.suse.de/qsf-u/qa-sle-functional-userspace/-/merge_requests/86
- Verification runs: 
   * Added check of tty for yast2_snapper module: http://falafel.suse.cz/tests/836
   * xen hvm : https://openqa.suse.de/t4322931 - (refspec fails a lot in bootloader_svirt, but posted jobs don't seem to have the same issue)
   * ppc : https://openqa.suse.de/t4323048
   * 64bit : https://openqa.suse.de/t4323047
   * s390 : https://openqa.suse.de/t4323052
   * aarch : https://openqa.suse.de/t4323617

