### PR TITLE
Fix script timeout issue on openscap and selinux

### DIFF
--- a/lib/openscaptest.pm
+++ b/lib/openscaptest.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -70,7 +70,7 @@ sub validate_result {
         assert_script_run "xmllint --noout $xml_args $result_file";
     }
 
-    validate_script_output "cat $result_file", sub { $match };
+    validate_script_output "cat $result_file", sub { $match }, timeout => 300;
     upload_logs($result_file);
 }
 

--- a/tests/security/selinux/fixfiles.pm
+++ b/tests/security/selinux/fixfiles.pm
@@ -31,7 +31,7 @@ sub run {
     $self->select_serial_terminal;
 
     # test `fixfiles check` can print any incorrect file context labels
-    assert_script_run("fixfiles check > $file_output 2>&1");
+    assert_script_run("fixfiles check > $file_output 2>&1", timeout => 300);
 
     # pick up a test file to test
     my $file_info     = script_output("grep -i 'Would relabel' $file_output | tail -1");


### PR DESCRIPTION
Fix script timeout issue on openscap and selinux
All are pass.

- Related ticket:
  https://progress.opensuse.org/issues/67306
  https://progress.opensuse.org/issues/67270
- Needles: NA
- Verification run:
  http://openqa.nue.suse.com/tests/4301191
  http://openqa.nue.suse.com/tests/4301192