### PR TITLE
Docker: allow the container to bring up http service

### DIFF
--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -47,6 +47,7 @@ sub test_built_img() {
     assert_script_run("mkdir /root/templates");
     assert_script_run "curl -f -v " . data_url('containers/index.html') . " > /root/templates/index.html";
     assert_script_run("docker run -dit -p 8888:5000 -v ~/templates:\/usr/src/app/templates myapp www.google.com");
+    sleep 5;
     assert_script_run("docker ps -a");
     assert_script_run('curl http://localhost:8888/ | grep "Networking test shall pass"');
 }


### PR DESCRIPTION
Running the command right after spawning the container
might not give enough time to check the functionality.
I did some tests and it takes around 1 second until the
service is up.

```
Running command after sleeping 0 seconds..
curl http://localhost:8888/;
curl: (52) Empty reply from server

Running command after sleeping 1 seconds..
curl http://localhost:8888/; 
<html>
Networking test shall pass!
</html>

Running command after sleeping 2 seconds..
curl http://localhost:8888/; 
<html>
Networking test shall pass!
</html>
```

VR: http://fromm.arch.suse.de/tests/926#  (with small modification to run only that part of the code)
