### PR TITLE
Containers: use serial terminal optinally for the tests

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -52,7 +52,9 @@ sub test_seccomp {
 }
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
     #my $hostnam = autoinst_url();
     #record_info("$hostnam");
     my $sleep_time = 90 * get_var('TIMEOUT_SCALE', 1);

--- a/tests/console/docker_base_images.pm
+++ b/tests/console/docker_base_images.pm
@@ -39,7 +39,8 @@ sub test_image {
 }
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
     install_docker_when_needed();
     # Test base images
     test_image('alpine',              'latest');

--- a/tests/console/docker_compose.pm
+++ b/tests/console/docker_compose.pm
@@ -30,7 +30,8 @@ use strict;
 use warnings;
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     install_docker_when_needed;
     add_suseconnect_product(get_addon_fullname('phub')) if is_sle();

--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -26,7 +26,8 @@ use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
 sub run {
-    select_console "root-console";
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     my ($image_names, $stable_names) = get_suse_container_urls();
     my ($plugin, $osversion, $version);

--- a/tests/console/docker_runc.pm
+++ b/tests/console/docker_runc.pm
@@ -24,7 +24,8 @@ use strict;
 use warnings;
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     install_docker_when_needed;
 

--- a/tests/console/podman.pm
+++ b/tests/console/podman.pm
@@ -31,7 +31,8 @@ use registration;
 use version_utils qw(is_sle is_leap);
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     if (is_sle '>=15') {
         add_suseconnect_product('sle-module-containers');

--- a/tests/console/podman_image.pm
+++ b/tests/console/podman_image.pm
@@ -19,7 +19,8 @@ use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
 sub run {
-    select_console "root-console";
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     my ($image_names, $stable_names) = get_suse_container_urls();
 

--- a/tests/console/zypper_docker.pm
+++ b/tests/console/zypper_docker.pm
@@ -25,7 +25,8 @@ use warnings;
 use containers::common;
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     install_docker_when_needed();
 


### PR DESCRIPTION
Using this option we gain 2 things:
1) Execution time reduced more than half.
2) Everything is logged to serial_termina.txt

It is possible to disable it by setting VIRTIO_CONSOLE=0.
- Related ticket: https://progress.opensuse.org/issues/67531
- Verification runs: 
      - VIRTIO_CONSOLE=0: http://fromm.arch.suse.de/tests/942 (~29 min)
      - VIRTIO_CONSOLE=1: http://fromm.arch.suse.de/tests/941 (~12 min)
