### PR TITLE
Remove soft fail from validate_lvm_raid1

### DIFF
--- a/tests/console/validate_lvm_raid1.pm
+++ b/tests/console/validate_lvm_raid1.pm
@@ -88,8 +88,7 @@ sub _check_raid_disks_after_reboot {
         _restore_raid_disk($config, $expected_num_devs);
     }
     else {
-        # Expected behavior is not clear currently. Assuming that the faulty disk shouldn't be automatically reactivated
-        record_soft_failure("bsc#1172203");
+        record_info("Autorecovery", "$config->{raid1}->{disk_to_fail} was automatically recovered after reboot.");
     }
 }
 


### PR DESCRIPTION
Looks like the opinions on the matter are divided. Mdadm maintainer stated that consistent behavior after reboot, regarding raid resync would be considered as a feature request. He also mentioned that he might consider doing some changes but it would take a long time, so I am removing the soft failure from module validate_lvm_raid1

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1172203
- Verification run: http://falafel.suse.cz/tests/833