### PR TITLE
Add record_info to skip phub in Online medium

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -372,11 +372,18 @@ sub _yast_scc_addons_handler {
 
 sub skip_package_hub_if_necessary {
     my ($addon) = @_;
-    if (is_sle('15-SP2+') && check_var('FLAVOR', 'Full') && $addon eq 'phub') {
-        record_info('Full media: no PHUB', 'Skipping Package Hub, it is not available on offline scenarios - bsc#1157659');
-        return 1;
+    my $skip_package_hub = 0;
+    if (is_sle('15-SP2+') && $addon eq 'phub') {
+        if (check_var('FLAVOR', 'Online')) {
+            record_info('Skip phub', 'For Online medium we need to skip Package Hub registration due to 
+                after registering this module, some packages not supported that comes from openSUSE
+                might conflict not allowing to have a predictable result - bsc#1172074');
+        } elsif (check_var('FLAVOR', 'Full')) {
+            record_info('Skip phub', 'Skipping Package Hub for Full medium due to it is an Online product - bsc#1157659');
+        }
+        $skip_package_hub = 1;
     }
-    return 0;
+    return $skip_package_hub;
 }
 
 sub process_scc_register_addons {


### PR DESCRIPTION
According to bug comment https://bugzilla.suse.com/show_bug.cgi?id=1172074 register phub in Online medium is not predictable, so adding a record_info should help.

- Related ticket: https://progress.opensuse.org/issues/67063
- Verification run: http://rivera-workstation.suse.cz/tests/1227
