### PR TITLE
Revert "Containers: Skip docker-compose tests"

### DIFF
--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -27,5 +27,6 @@ schedule:
     - console/docker_runc
     - console/docker_image
     - '{{docker_base_images}}'
+    - console/docker_compose
     - console/zypper_docker
     - console/coredump_collect


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#10387

https://scc.suse.com/packages?name=SUSE%20Linux%20Enterprise%20Server&version=15.2&arch=x86_64&query=docker-compose&module=

`docker-compose` is contained in packagehub for sle15-sp2.