### PR TITLE
yast_dns_server, Improve to deal with dynamic suse.com ip

### DIFF
--- a/tests/yast2_cmd/yast_dns_server.pm
+++ b/tests/yast2_cmd/yast_dns_server.pm
@@ -72,9 +72,11 @@ sub run {
     zypper_call("in bind-libs",             exitcode => [0, 102, 103, 106]) if is_sle('=12-SP2');
 
     #Forward server and test lookup
+    my $suseip = script_output("dig www.suse.com +short");
+    $suseip =~ s/.*(\d+\.\d+\.\d+\.\d+).*/$1/s;
     $self->cmd_handle("forwarders", "add", ip => "10.0.2.3");
     systemctl("start named.service");
-    validate_script_output('dig @localhost www.suse.com +short', sub { /\Q35.156.53.100\E/ });
+    validate_script_output('dig @localhost www.suse.com +short', sub { /\Q$suseip\E/ });
     $self->cmd_handle("forwarders", "remove", ip => "10.0.2.3");
     record_soft_failure("bsc#1151138") if (systemctl("is-active named.service", ignore_failure => 1));
 


### PR DESCRIPTION
ip address of www.suse.com sometimes changes, which make validation fail. https://openqa.suse.de/tests/4302260#next_previous
solution: Look up the ip first and store into variable. validate with the variable rather than a hard coded ip.

- Related ticket: https://progress.opensuse.org/issues/66134
- Needles: no
- Verification run: 
sles12sp5: http://10.67.17.201/tests/1006
sles12sp4: http://10.67.17.201/tests/1004
sles15: http://10.67.17.201/tests/1005
sles15sp1: http://10.67.17.201/tests/1003