### PR TITLE
plasma_browser_integration: Retry pausing the video

### DIFF
--- a/tests/x11/plasma_browser_integration.pm
+++ b/tests/x11/plasma_browser_integration.pm
@@ -54,9 +54,13 @@ sub run {
         last if check_screen('plasma-mpris-pause', 20);
     }
 
-    # Pause using the button in the applet
-    assert_and_click('plasma-mpris-pause');
-    # Verify that the applet noticed that
+    $counter = 3;
+    while ($counter-- > 0) {
+        # Pause using the button in the applet
+        assert_and_click('plasma-mpris-pause');
+        # Verify that the applet noticed that
+        last if check_screen('plasma-mpris-paused', 5);
+    }
     assert_screen('plasma-mpris-paused');
     # Verify that the video is paused and unpause it
     assert_and_click('plasma-browser-integration-video-unpause');


### PR DESCRIPTION
In some cases, clicks to the pause button in the applet appear to get lost
for some reason. Like the code above, retry up to three times.

Fixes https://progress.opensuse.org/issues/64565 (hopefully)

This happens more often in Staging I (Plasma 5.19 Beta), so that's what I used for the verification runs:
http://10.160.67.86/tests/685
http://10.160.67.86/tests/686