### PR TITLE
Add docker tests to publiccloud

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1709,13 +1709,13 @@ sub load_extra_tests_docker {
 
     if (is_leap('15.1+') || is_tumbleweed) {
         loadtest 'containers/podman';
-        loadtest "containers/podman_image";
+        loadtest "containers/podman_image" unless is_public_cloud;
     }
 
     loadtest "containers/docker";
     loadtest "containers/docker_runc";
     loadtest "containers/container_base_images";
-    loadtest "containers/docker_image" if (is_sle(">=12-sp3") || is_opensuse);
+    loadtest "containers/docker_image" if (!is_public_cloud && (is_sle(">=12-sp3") || is_opensuse));
     loadtest "containers/docker_compose" unless is_sle('<15');
     loadtest "containers/zypper_docker";
 }
@@ -2801,7 +2801,8 @@ sub load_publiccloud_tests {
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         loadtest "publiccloud/instance_overview";
         load_extra_tests_prepare();
-        load_extra_tests_console();
+        load_extra_tests_docker() if (get_var('PUBLIC_CLOUD_CONTAINERS'));
+        load_extra_tests_console() unless (get_var('PUBLIC_CLOUD_CONTAINERS'));
         loadtest "publiccloud/ssh_interactive_end", run_args => $args;
     }
     elsif (get_var('PUBLIC_CLOUD_LTP')) {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -48,6 +48,7 @@ use constant {
           is_storage_ng
           is_using_system_role
           is_using_system_role_first_flow
+          is_public_cloud
           requires_role_selection
           check_version
           get_sles_release
@@ -576,3 +577,11 @@ sub get_sles_release {
     return $sles_version, $sles_service_pack;
 }
 
+=head2 is_public_cloud
+
+Returns true if PUBLIC_CLOUD is set to 1
+=cut
+
+sub is_public_cloud {
+    return get_var('PUBLIC_CLOUD');
+}


### PR DESCRIPTION
Adds the docker test suite to public cloud tests.

- Related ticket: https://progress.opensuse.org/issues/66370
- Needles: N/A
- Verification run: [SLE15-SP1-az](http://openqa.suse.de/t4359690) | [SLE15-SP1 ec2](http://openqa.suse.de/t4359691) | [SLE15-SP1 gce](http://openqa.suse.de/t4359692) | [SLE12-SP4 az](http://openqa.suse.de/t4359693) | [SLE12-SP4 ec2](http://openqa.suse.de/t4359694) | [SLE12-SP4 gce](http://openqa.suse.de/t4359695)
