### PR TITLE
Increase timeout value for snap-default

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -260,7 +260,7 @@ sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
     # assert needle to avoid send down key early in grub_test_snapshot.
-    assert_screen('snap-default', 60) if get_var('OFW');
+    assert_screen('snap-default', 120) if get_var('OFW');
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);


### PR DESCRIPTION
We need wait more time for the tag of snap-default, sometimes 60s is not enough for ppc64le, so adjust it to 120s.

- Related ticket: https://progress.opensuse.org/issues/67375
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/4303598#
