### PR TITLE
Move yast2_i test modules to YaST job group

### DIFF
--- a/data/autoyast_sle15/autoyast_containers_s390x.xml
+++ b/data/autoyast_sle15/autoyast_containers_s390x.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-development-tools</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-containers</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
+  <bootloader>
+    <global>
+      <activate>false</activate>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>true</boot_mbr>
+      <boot_root>true</boot_root>
+      <generic_mbr>false</generic_mbr>
+      <timeout config:type="integer">5</timeout>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <second_stage config:type="boolean">false</second_stage>
+    </mode>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <report>
+    <errors>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <warnings>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <yesno_messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <scripts>
+    <chroot-scripts config:type="list">
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <interpreter>shell</interpreter>
+        <source>
+          <![CDATA[
+            #!/bin/sh
+            sed -i 's/splash=silent\ quiet//' /etc/default/grub
+            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
+            sed -i 's/GRUB_CMDLINE_LINUX="/GRUB_CMDLINE_LINUX="plymouth.enable=0\ /' /etc/default/grub
+            grub2-mkconfig -o /boot/grub2/grub.cfg
+            ]]>
+        </source>
+      </script>
+    </chroot-scripts>
+  </scripts>
+  <software>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <packages config:type="list">
+      <package>iputils</package>
+      <package>sles-release</package>
+      <package>sle-module-server-applications-release</package>
+      <package>sle-module-development-tools-release</package>
+      <package>sle-module-basesystem-release</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>minimal_base</pattern>
+    </patterns>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/lib/Installation/Partitioner/FormattingOptionsPage.pm
+++ b/lib/Installation/Partitioner/FormattingOptionsPage.pm
@@ -88,7 +88,7 @@ sub select_filesystem {
     wait_screen_change(sub {
             send_key 'end';
     }, 20);
-    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up');
+    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up', timeout=>5);
 }
 
 # Mounting Options

--- a/lib/Installation/Partitioner/FormattingOptionsPage.pm
+++ b/lib/Installation/Partitioner/FormattingOptionsPage.pm
@@ -88,7 +88,7 @@ sub select_filesystem {
     wait_screen_change(sub {
             send_key 'end';
     }, 20);
-    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up', timeout=>5);
+    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up');
 }
 
 # Mounting Options

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -260,7 +260,7 @@ sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
     # assert needle to avoid send down key early in grub_test_snapshot.
-    assert_screen('snap-default', 60) if get_var('OFW');
+    assert_screen('snap-default', 120) if get_var('OFW');
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -47,6 +47,7 @@ sub test_built_img() {
     assert_script_run("mkdir /root/templates");
     assert_script_run "curl -f -v " . data_url('containers/index.html') . " > /root/templates/index.html";
     assert_script_run("docker run -dit -p 8888:5000 -v ~/templates:\/usr/src/app/templates myapp www.google.com");
+    sleep 5;
     assert_script_run("docker ps -a");
     assert_script_run('curl http://localhost:8888/ | grep "Networking test shall pass"');
 }

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -587,8 +587,6 @@ sub load_jeos_tests {
             loadtest "console/suseconnect_scc";
         }
     }
-    loadtest "jeos/glibc_locale";
-    loadtest "jeos/kiwi_templates" unless (is_leap('<15.2'));
 }
 
 sub installzdupstep_is_applicable {
@@ -1158,6 +1156,10 @@ sub load_consoletests {
             loadtest "console/zypper_ar";
         }
         loadtest "console/zypper_ref";
+    }
+    if (is_jeos) {
+        loadtest "jeos/glibc_locale";
+        loadtest "jeos/kiwi_templates" unless (is_leap('<15.2'));
     }
     loadtest "console/ncurses";
     loadtest "console/yast2_lan" unless is_bridged_networking;

--- a/lib/openscaptest.pm
+++ b/lib/openscaptest.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright (C) 2017-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -70,7 +70,7 @@ sub validate_result {
         assert_script_run "xmllint --noout $xml_args $result_file";
     }
 
-    validate_script_output "cat $result_file", sub { $match };
+    validate_script_output "cat $result_file", sub { $match }, timeout => 300;
     upload_logs($result_file);
 }
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -372,11 +372,18 @@ sub _yast_scc_addons_handler {
 
 sub skip_package_hub_if_necessary {
     my ($addon) = @_;
-    if (is_sle('15-SP2+') && check_var('FLAVOR', 'Full') && $addon eq 'phub') {
-        record_info('Full media: no PHUB', 'Skipping Package Hub, it is not available on offline scenarios - bsc#1157659');
-        return 1;
+    my $skip_package_hub = 0;
+    if (is_sle('15-SP2+') && $addon eq 'phub') {
+        if (check_var('FLAVOR', 'Online')) {
+            record_info('Skip phub', 'For Online medium we need to skip Package Hub registration due to 
+                after registering this module, some packages not supported that comes from openSUSE
+                might conflict not allowing to have a predictable result - bsc#1172074');
+        } elsif (check_var('FLAVOR', 'Full')) {
+            record_info('Skip phub', 'Skipping Package Hub for Full medium due to it is an Online product - bsc#1157659');
+        }
+        $skip_package_hub = 1;
     }
-    return 0;
+    return $skip_package_hub;
 }
 
 sub process_scc_register_addons {

--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -22,7 +22,7 @@ use registration 'get_addon_fullname';
 use Mojo::JSON;
 use List::MoreUtils 'uniq';
 
-my @addons;
+our @addons;
 
 sub suseconnect_ls {
     my ($search) = @_;
@@ -41,8 +41,8 @@ sub check_registered_system {
 sub check_registered_addons {
     my ($addonlist) = @_;
     $addonlist //= get_var('SCC_ADDONS');
-    my @my_addons     = grep { defined $_ && $_ } split(/,/, $addonlist);
-    my @unique_addons = uniq @my_addons;
+    my @addons        = grep { defined $_ && $_ } split(/,/, $addonlist);
+    my @unique_addons = uniq @addons;
     foreach my $addon (@unique_addons) {
         $addon =~ s/(^\s+|\s+$)//g;
         my $name = get_addon_fullname($addon);
@@ -63,7 +63,6 @@ sub check_upgraded_addons {
 sub check_suseconnect {
     my $output = script_output("SUSEConnect -s", 120);
     my @out    = grep { $_ =~ /identifier/ } split(/\n/, $output);
-    @addons = ();
     if (@out) {
         my $json = Mojo::JSON::decode_json($out[0]);
         foreach (@$json) {
@@ -79,23 +78,10 @@ sub check_suseconnect {
     diag "@addons";
 }
 
-sub check_suseconnect_cmd {
-    my $ls_out = script_output("SUSEConnect --list-extensions", 120);
-    diag "$ls_out";
-    my $status_out = script_output("SUSEConnect --status-text", 120);
-    diag "$status_out";
-    for (my $i = 1; $i < @addons; $i = $i + 1) {
-        diag "$addons[$i]";
-        die "$addons[$i] is not existed at SUSEConnect --list-extensions" if ($ls_out     !~ /Deactivate(.*)$addons[$i]/);
-        die "$addons[$i] is not existed at SUSEConnect --status-text"     if ($status_out !~ /$addons[$i]/);
-    }
-}
-
 sub full_registered_check {
     my ($stage) = @_;
     $stage //= '';
     check_suseconnect();
-    check_suseconnect_cmd();
     if ($stage eq 'before') {
         check_registered_system(get_var('ORIGIN_SYSTEM_VERSION'));
         check_registered_addons();

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -22,6 +22,7 @@ use testapi;
 use caasp 'microos_reboot';
 use power_action_utils 'power_action';
 use version_utils qw(is_opensuse is_caasp);
+use utils 'reconnect_mgmt_console';
 
 our @EXPORT = qw(
   process_reboot
@@ -39,10 +40,13 @@ sub process_reboot {
         microos_reboot $trigger;
     } else {
         power_action('reboot', observe => !$trigger, keepconsole => 1);
-
-        # Replace by wait_boot if possible
-        assert_screen 'grub2', 100;
-        send_key 'ret';
+        if (check_var('ARCH', 's390x')) {
+            reconnect_mgmt_console(timeout => 500);
+        } else {
+            # Replace by wait_boot if possible
+            assert_screen 'grub2', 100;
+            send_key 'ret';
+        }
         assert_screen 'linux-login', 200;
 
         # Login & clear login needle

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -539,7 +539,8 @@ sub setup_mail_account {
         type_password $mail_passwd;
         send_key "ret";
     }
-    assert_screen "evolution_mail-max-window";
+    # Μake sure the welcome window is maximized
+    send_key_until_needlematch 'evolution_mail-max-window', 'super-up', 3, 3;
 }
 
 # start clean firefox with one suse.com tab, visit pages which trigger pop-up so they will not pop again
@@ -838,10 +839,6 @@ sub setup_evolution_for_ews {
     assert_screen "evolution_mail-auth";
     type_string "$mail_passwd";
     send_key "ret";
-    if (check_screen "evolution_mail-init-window") {
-        send_key "super-up";
-    }
-    assert_screen "evolution_mail-max-window";
 
     # Make all existing mails as read
     assert_screen "evolution_mail-online", 60;

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -279,15 +279,6 @@ sub check_new_mail_evolution {
     assert_screen "evolution_mail_open_mail";
     send_key "ctrl-w";    # close the mail
     save_screenshot();
-
-    # Delete the message and expunge the deleted item if not used POP3
-    if ($protocol != "POP") {
-        send_key "ctrl-e";
-        if (check_screen "evolution_mail-expunge", 10) {
-            send_key "alt-e";
-        }
-        assert_screen "evolution_mail-ready";
-    }
 }
 
 # get a random string with followed by date, it used in evolution case to get a unique email title.

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -250,7 +250,10 @@ sub check_new_mail_evolution {
     my $mail_passwd = $config->{$i}->{passwd};
     assert_screen "evolution_mail-online", 240;
     assert_and_click "evolution-send-receive";
-    if (check_screen "evolution_mail-auth", 30) {
+    wait_still_screen(2);
+    assert_and_click('evolution_mail-auth-unfocused') if check_screen('evolution_mail-auth-unfocused', 2);
+    assert_screen ['evolution_mail-auth', 'evolution_mail-max-window'];
+    if (match_has_tag "evolution_mail-auth") {
         send_key "alt-a";    #disable keyring option
         send_key "alt-p";
         type_password $mail_passwd;
@@ -520,21 +523,7 @@ sub setup_mail_account {
     send_key "ret";
     assert_screen "evolution_wizard-done";
     send_key "alt-a";
-    if (check_screen "evolution_mail-auth", 30) {
-        if (is_sle('15+')) {
-            send_key "alt-a";    #disable keyring option
-        }
-        else {
-            assert_and_click("disable_keyring_option");
-        }
-        send_key "alt-p";
-        type_password $mail_passwd;
-        send_key "ret";
-    }
-    if (check_screen "evolution_mail-init-window", 30) {
-        send_key "super-up";
-    }
-    if (check_screen "evolution_mail-auth", 30) {
+    if (check_screen "evolution_mail-auth", 5) {
         if (is_sle('15+')) {
             send_key "alt-a";    #disable keyring option
         }
@@ -869,7 +858,7 @@ sub evolution_send_message {
     my $mail_subject = $self->get_dated_random_string(4);
 
     send_key "shift-ctrl-m";
-    if (check_screen "evolution_mail-auth", 30) {
+    if (check_screen "evolution_mail-auth", 5) {
         send_key "alt-a";    #disable keyring option
         send_key "alt-p";
         type_string "$mail_passwd";
@@ -889,7 +878,7 @@ sub evolution_send_message {
     if (check_screen "evolution_mail_send_mail_dialog", 30) {
         send_key "ret";
     }
-    if (check_screen "evolution_mail-auth", 30) {
+    if (check_screen "evolution_mail-auth", 5) {
         send_key "alt-a";    #disable keyring option
         send_key "alt-p";
         type_string "$mail_passwd";

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -384,9 +384,25 @@ sub start_evolution {
         type_string "$mail_box";
     };
     save_screenshot();
-
-    # Finish wizard.
-    assert_and_click('evolution_wizard-identity-next');
+    send_key 'alt-n';
+    if ($mail_box eq 'nooops_test3@aim.com') {
+        assert_screen [qw(evolution_wizard-account-summary evolution_wizard-receiving)];
+        if (match_has_tag 'evolution_wizard-account-summary') {
+            record_info 'found', "$mail_box details resolved";
+            assert_and_click "evolution-option-next";
+            assert_screen 'evolution_wizard-done';
+            send_key 'alt-a';
+            wait_still_screen(1);
+            send_key 'alt-n';
+        }
+        else {
+            record_soft_failure 'poo#67408';
+            send_key 'alt-c';
+        }
+    }
+    else {
+        assert_screen 'evolution_wizard-receiving';
+    }
 }
 
 sub evolution_add_self_signed_ca {
@@ -419,12 +435,6 @@ sub setup_mail_account {
     my $mail_recvport   = $config->{$account}->{$port_key};
 
     $self->start_evolution($mail_box);
-    if (check_screen "evolution_wizard-skip-lookup", 30) {
-        send_key "alt-s";
-    }
-
-    # Reach "Receiving Email" step.
-    assert_screen "evolution_wizard-receiving";
     # Open Server Type screen.
     wait_screen_change {
         send_key "alt-t";

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -497,7 +497,8 @@ sub setup_mail_account {
     wait_still_screen(2);
     send_key "home";
     #change to use mail-server and SSL
-    send_key_until_needlematch "evolution_SSL_wizard-sending-starttls", "down", 5, 1;
+    my $encrypt = get_var('QAM_MAIL_EVOLUTION') ? 'TLS' : 'STARTTLS';
+    send_key_until_needlematch "evolution_SSL_wizard-sending-$encrypt", "down", 5, 1;
     assert_and_click "evolution_wizard-sending-setauthtype";
     assert_and_click "evolution_wizard-sending-setauthtype_login";
     wait_screen_change { send_key 'alt-n' };

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -413,11 +413,12 @@ sub evolution_add_self_signed_ca {
         assert_screen 'evolution_mail_meeting_trust_ca';
         send_key 'alt-a';
         assert_and_click 'evolution_wizard-receiving';
-        wait_screen_change { send_key $self->{next} };    # select "Next" key
-        send_key 'ret';                                   # Go to next page (previous key just selected the key)
+        send_key $cmd{next};    # select "Next" key
+        wait_still_screen(2);
+        send_key 'ret';         # Go to next page (previous key just selected the key)
     }
     else {
-        send_key $self->{next};
+        send_key $cmd{next};
     }
 }
 
@@ -528,7 +529,7 @@ sub setup_mail_account {
     type_string "$mail_user";
     assert_and_click("evolution_wizard-sending_username_filled");
     assert_screen "evolution_wizard-account-summary";
-    send_key $self->{next};
+    send_key $cmd{next};
     send_key "alt-n";
     send_key "ret";
     assert_screen "evolution_wizard-done";

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -506,15 +506,6 @@ sub setup_mail_account {
     wait_still_screen(2);
     send_key "home";
     #change to use mail-server and SSL
-
-    #On TW, need change port manually:
-    if (is_tumbleweed) {
-        wait_screen_change {
-            send_key "alt-p";
-        };
-        type_string "465";
-    }
-
     send_key_until_needlematch "evolution_SSL_wizard-sending-starttls", "down", 5, 1;
     assert_and_click "evolution_wizard-sending-setauthtype";
     assert_and_click "evolution_wizard-sending-setauthtype_login";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1050,6 +1050,26 @@ else {
             loadtest 'network/curl_client';
         }
     }
+    elsif (get_var('QAM_SMT')) {
+        set_var('INSTALLONLY', 1);
+        if (check_var('HOSTNAME', 'server')) {
+            barrier_create('smt_setup',      2);
+            barrier_create('smt_registered', 2);
+            boot_hdd_image;
+            loadtest 'network/setup_multimachine';
+            loadtest 'smt/smt_server';
+        }
+        elsif (check_var('HOSTNAME', 'client1')) {
+            boot_hdd_image;
+            loadtest 'network/setup_multimachine';
+            loadtest 'smt/smt_client1';
+        }
+        else {
+            #default hostname, installation and setting up smt server
+            boot_hdd_image;
+            loadtest 'smt/smt_server_install';
+        }
+    }
     elsif (get_var('QAM_MAIL_THUNDERBIRD')) {
         set_var('INSTALLONLY', 1);
         boot_hdd_image;

--- a/schedule/containers/create_hdd_autoyast.yaml
+++ b/schedule/containers/create_hdd_autoyast.yaml
@@ -2,7 +2,6 @@
 name: create_hdd_autoyast
 vars:
   AUTOYAST: autoyast_sle15/autoyast_containers_%ARCH%.xml
-  AUTOYAST_CONFIRM: 1
   HDDSIZEGB: 30
 schedule:
   - autoyast/prepare_profile

--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -18,6 +18,10 @@ conditional_schedule:
         DISTRI:
             'opensuse':
                 - console/docker_base_images
+    docker_compose:
+        DISTRI:
+            'opensuse':
+                - console/docker_compose
 schedule:
     - '{{bootloader}}'
     - boot/boot_to_desktop
@@ -27,5 +31,6 @@ schedule:
     - console/docker_runc
     - console/docker_image
     - '{{docker_base_images}}'
+    - '{{docker_compose}}'
     - console/zypper_docker
     - console/coredump_collect

--- a/schedule/functional/allpatterns.yaml
+++ b/schedule/functional/allpatterns.yaml
@@ -47,7 +47,6 @@ schedule:
     - console/glibc_sanity
     - console/zypper_in
     - console/zypper_log
-    - console/yast2_i
     - console/yast2_bootloader
     - console/firewall_enabled
     - console/sshd

--- a/schedule/ha/bv/ha_qdevice_node1.yaml
+++ b/schedule/ha/bv/ha_qdevice_node1.yaml
@@ -14,3 +14,4 @@ schedule:
   - ha/watchdog
   - ha/ha_cluster_init
   - ha/qnetd
+  - ha/check_after_reboot

--- a/schedule/ha/bv/ha_qdevice_node2.yaml
+++ b/schedule/ha/bv/ha_qdevice_node2.yaml
@@ -14,3 +14,5 @@ schedule:
   - ha/watchdog
   - ha/ha_cluster_join
   - ha/qnetd
+  - boot/boot_to_desktop
+  - ha/check_after_reboot

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -1,0 +1,35 @@
+---
+description: >
+  Conduct installation cancelling encrypted partitions activation, and creating
+  encrypted lvm setup from scratch. Using pre-partitioned disk image to validate
+  encrypted partitions activation and that we can re-ecnrypt the disk.
+name: cryptlvm+cancel_existing_pvm
+vars:
+  ENCRYPT: 1
+  ENCRYPT_CANCEL_EXISTING: 1
+  LVM: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/encrypted_volume_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm_ignore_existing
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot

--- a/schedule/yast/yast2_ncurses_gnome.yaml
+++ b/schedule/yast/yast2_ncurses_gnome.yaml
@@ -1,50 +1,51 @@
 ---
 name:           yast2_ncurses_gnome
 description:    >
-    Test for yast2 UI, ncurses only. Running on created gnome images
-    which provides both text console for ncurses UI tests as well as
-    the gnome environment for the GUI tests.
+  Test for yast2 UI, ncurses only. Running on created gnome images
+  which provides both text console for ncurses UI tests as well as
+  the gnome environment for the GUI tests.
 schedule:
-    - "{{pre_boot_to_desktop}}"
-    - boot/boot_to_desktop
-    - console/prepare_test_data
-    - console/consoletest_setup
-    - "{{yast_modules}}"
-    - console/coredump_collect
+  - "{{pre_boot_to_desktop}}"
+  - boot/boot_to_desktop
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/yast2_i
+  - "{{yast_modules}}"
+  - console/coredump_collect
 conditional_schedule:
-    pre_boot_to_desktop:
-        ARCH:
-            aarch64:
-                - boot/uefi_bootmenu
-            s390x:
-                - installation/bootloader_start
-    yast_modules:
-        ARCH:
-            x86_64:
-                - console/yast2_rmt
-                - console/yast2_ntpclient
-                - console/yast2_tftp
-                - console/yast2_proxy
-                - console/yast2_vnc
-                - console/yast2_nis
-                - console/yast2_http
-                - console/yast2_ftp
-                - console/yast2_apparmor
-                - console/yast2_lan
-                - console/yast2_lan_hostname
-                - console/yast2_dns_server
-                - console/yast2_nfs_client
-                - console/yast2_snapper_ncurses
-            aarch64:
-                - console/yast2_lan
-            ppc64le:
-                - console/yast2_lan
-            s390x:
-                - console/yast2_rmt
-                - console/yast2_ntpclient
-                - console/yast2_tftp
-                - console/yast2_lan
-                - console/yast2_lan_hostname
-                - console/yast2_dns_server
-                - console/yast2_nfs_client
-                - console/yast2_snapper_ncurses
+  pre_boot_to_desktop:
+    ARCH:
+      aarch64:
+        - boot/uefi_bootmenu
+      s390x:
+        - installation/bootloader_start
+  yast_modules:
+    ARCH:
+      x86_64:
+        - console/yast2_rmt
+        - console/yast2_ntpclient
+        - console/yast2_tftp
+        - console/yast2_proxy
+        - console/yast2_vnc
+        - console/yast2_nis
+        - console/yast2_http
+        - console/yast2_ftp
+        - console/yast2_apparmor
+        - console/yast2_lan
+        - console/yast2_lan_hostname
+        - console/yast2_dns_server
+        - console/yast2_nfs_client
+        - console/yast2_snapper_ncurses
+      aarch64:
+        - console/yast2_lan
+      ppc64le:
+        - console/yast2_lan
+      s390x:
+        - console/yast2_rmt
+        - console/yast2_ntpclient
+        - console/yast2_tftp
+        - console/yast2_lan
+        - console/yast2_lan_hostname
+        - console/yast2_dns_server
+        - console/yast2_nfs_client
+        - console/yast2_snapper_ncurses

--- a/schedule/yast/yast2_ncurses_gnome@svirt-hyperv.yaml
+++ b/schedule/yast/yast2_ncurses_gnome@svirt-hyperv.yaml
@@ -1,0 +1,13 @@
+---
+name:           yast2_ncurses_gnome@svirt-hyperv
+description:    >
+  Test for yast2 UI, ncurses only. Running on created gnome images
+  which provides both text console for ncurses UI tests as well as
+  the gnome environment for the GUI tests.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/yast2_i
+  - console/coredump_collect

--- a/schedule/yast/yast2_ncurses_textmode.yaml
+++ b/schedule/yast/yast2_ncurses_textmode.yaml
@@ -1,17 +1,26 @@
 ---
 name:           yast2_ncurses_textmode
 description:    >
-    Test for yast2 UI, ncurses only. Running on created textmode image.
+  Test for yast2 UI, ncurses only. Running on created textmode image.
 schedule:
-    - "{{pre_boot_to_desktop}}"
-    - boot/boot_to_desktop
-    - console/prepare_test_data
-    - console/consoletest_setup
-    - console/yast2_lan
+  - "{{bootloader_start}}"
+  - boot/boot_to_desktop
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/yast2_lan
+  - "{{yast2_lan_device_settings}}"
 conditional_schedule:
-    pre_boot_to_desktop:
-        ARCH:
-            aarch64:
-                - boot/uefi_bootmenu
-            s390x:
-                - installation/bootloader_start
+  bootloader_start:
+    BACKEND:
+      svirt:
+        - installation/bootloader_start
+  # The test module is temporary excluded on s390x due to the failures.
+  # https://progress.opensuse.org/issues/67603
+  yast2_lan_device_settings:
+    ARCH:
+      aarch64:
+        - console/yast2_lan_device_settings
+      ppc64le:
+        - console/yast2_lan_device_settings
+      x86_64:
+        - console/yast2_lan_device_settings

--- a/schedule/yast/yast2_ncurses_textmode.yaml
+++ b/schedule/yast/yast2_ncurses_textmode.yaml
@@ -8,6 +8,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/yast2_lan
+  - console/yast2_i
   - "{{yast2_lan_device_settings}}"
 conditional_schedule:
   bootloader_start:

--- a/script/yaml_generator/README.md
+++ b/script/yaml_generator/README.md
@@ -1,0 +1,31 @@
+create a virtualenv and install the requirements.txt
+
+run as
+> python3 create_scheduler.py <jobid> <path_to_save> [<openqa_server>]
+
+This will generate the <path_to_save>/template.yaml
+ex:
+> python3 create_scheduler.py 1 /tmp
+or
+> python3 create_scheduler.py 1 /tmp openqa.opensuse.org
+
+If openqa_server is not given, OSD is used by default.
+All the params are positional.
+
+The template.yaml which is generated it has the
+- name
+- description
+- vars
+- schedule
+
+Vars are taken by the suites variables
+test_data are not included
+
+
+Issues to address
+---
+
+- some environment variables are not translated. for example
+> PUBLISH_HDD_1: SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-unregistered.qcow2
+- todo: path should be setup to point to the schedule dir by default 
+- todo: variables from a file

--- a/script/yaml_generator/create_scheduler.py
+++ b/script/yaml_generator/create_scheduler.py
@@ -1,0 +1,79 @@
+import requests
+import sys, os
+from openqa_client.client import OpenQA_Client
+from pathlib import Path
+import re
+import yaml
+
+
+class MyDumper(yaml.Dumper):
+    def increase_indent(self, flow = False, indentless = False):
+        return super(MyDumper, self).increase_indent(flow, False)
+
+    
+def _get_scheduling(jobid, srv):
+    testpage = 'https://%s/tests/%s/file/autoinst-log.txt' % (srv, jobid)
+    ctx = requests.get(testpage, verify=False)
+    regex = re.compile('scheduling\s\w+\stests\/\w+\/\w+\/?\w*')
+    matches = regex.findall(repr(ctx.content))
+    key = 'tests/'
+    job = []
+    for schedule_line in matches:
+        schedule = schedule_line[schedule_line.find(key)+len(key):]
+        job.append(schedule)
+    return job
+
+
+def _get_conf(jobid, srv):
+    client = OpenQA_Client(server='http://%s' % srv)
+    conf = client.openqa_request('GET', 'jobs/%s' % jobid)
+
+    testname = conf['job']['test']
+    jobvars = {}
+    jobvars['name'] = testname
+    suitevars = client.openqa_request('GET', 'test_suites')
+
+    vars_generator = (settings for settings in suitevars['TestSuites'])
+
+    for v in vars_generator:
+        # there are test jobs that the name is modified in job group and is run with
+        # another name than the name in 'TestSuites' ex installer_extended_textmode
+        # Because ususally the name just appends the name we just check if it startswith
+        if testname.startswith(v['name']):
+            jobvars.update(v)
+    return jobvars
+
+
+def _create_template(scheduling, configs, save_to):
+    # there are jobs come back from /test_suites wihtout description
+    if 'description' in configs.keys():
+        description = configs['description'].replace('\n', '')
+    else:
+        description = ""
+    
+    data = {'name': configs['name'],
+            'description': "|\n%s" % description}
+
+    if configs:
+        data['vars'] = {}
+        data['vars'].update({k['key']:k['value'] for k in configs['settings']})
+    data['schedule'] = scheduling
+    # TODO path configuration
+    out = Path(os.path.abspath(os.path.join(save_to, 'template.yaml')))
+
+    with(open(out, 'w')) as out:
+        yaml.dump(data,
+                  stream=out,
+                  default_flow_style=False,
+                  Dumper=MyDumper,
+                  explicit_start=True,
+                  sort_keys=False)
+
+
+if __name__ == '__main__':
+    jobid = sys.argv[1]
+    save_to = sys.argv[2]
+    openqa_server = sys.argv[3] if len(sys.argv) > 3  else 'openqa.suse.de'
+    schd = _get_scheduling(jobid, openqa_server)
+    conf = _get_conf(jobid, openqa_server)
+    _create_template(schd, conf, save_to)

--- a/script/yaml_generator/requirements.txt
+++ b/script/yaml_generator/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.21.0
+PyYAML>=5.3
+openqa-client

--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -11,16 +11,18 @@
 #          calls setup_apache2 with mode = SSL (lib/apachetest.pm)
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#65375
+# Tags: poo#65375, poo#67309
 
 use base "consoletest";
 use testapi;
 use strict;
 use warnings;
 use apachetest;
+use utils 'clear_console';
 
 sub run {
     select_console 'root-console';
+    clear_console;
     setup_apache2(mode => 'SSL');
 }
 

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -39,7 +39,7 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    zypper_call('in clamav');
+    zypper_call('in clamav vim');
     # Initialize and download ClamAV database which needs time
     assert_script_run('freshclam', 700);
 

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -55,8 +55,6 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    #my $hostnam = autoinst_url();
-    #record_info("$hostnam");
     my $sleep_time = 90 * get_var('TIMEOUT_SCALE', 1);
 
     install_docker_when_needed();

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -52,7 +52,9 @@ sub test_seccomp {
 }
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
     #my $hostnam = autoinst_url();
     #record_info("$hostnam");
     my $sleep_time = 90 * get_var('TIMEOUT_SCALE', 1);

--- a/tests/console/docker_base_images.pm
+++ b/tests/console/docker_base_images.pm
@@ -39,7 +39,8 @@ sub test_image {
 }
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
     install_docker_when_needed();
     # Test base images
     test_image('alpine',              'latest');

--- a/tests/console/docker_compose.pm
+++ b/tests/console/docker_compose.pm
@@ -30,7 +30,8 @@ use strict;
 use warnings;
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     install_docker_when_needed;
     add_suseconnect_product(get_addon_fullname('phub')) if is_sle();

--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -26,7 +26,8 @@ use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
 sub run {
-    select_console "root-console";
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     my ($image_names, $stable_names) = get_suse_container_urls();
     my ($plugin, $osversion, $version);

--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -42,6 +42,12 @@ sub run {
             'echo "{ \"insecure-registries\" : [\"registry.suse.de\", \"registry.suse.de:443\", \"registry.suse.de:5000\"] }" > /etc/docker/daemon.json');
         assert_script_run('cat /etc/docker/daemon.json');
         systemctl('restart docker');
+
+        if (get_var('SCC_DOCKER_IMAGE')) {
+            my $regcode = get_var 'SCC_DOCKER_IMAGE';
+            assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{,.bak}";
+            assert_script_run "echo -ne \"$regcode\" > /etc/zypp/credentials.d/SCCcredentials";
+        }
     }
 
     if (check_var("ARCH", "x86_64")) {
@@ -99,6 +105,7 @@ sub run {
         assert_script_run("docker image rm --force $image_names->[$i] refreshed-image");
     }
 
+    assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{.bak,}" if (is_sle() && get_var('SCC_DOCKER_IMAGE'));
     clean_docker_host();
 }
 

--- a/tests/console/docker_runc.pm
+++ b/tests/console/docker_runc.pm
@@ -7,13 +7,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Test docker-runc installation and extended usage
-#    Cover the following aspects of runc:
+# Summary: Test docker-runc and runc installation, and extended usage
+#    Cover the following aspects of docker-runc and runc respectively:
 #      * package can be installed
 #      * create specification files
 #      * run the container
 #      * complete lifecycle (create, start, pause, resume, kill, delete)
-# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
+# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>, George Gkioulis <ggkioulis@suse.com>
 
 use base "consoletest";
 use testapi;
@@ -27,12 +27,12 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    install_docker_when_needed;
+    my @runtimes = ("docker-runc");
+    push @runtimes, "runc" if !is_sle('=15');
 
-    my $runc = 'docker-runc';
-
-    # runC cannot create or extract the root filesystem on its own. Use Docker to create it.
     record_info 'Setup', 'Setup the environment';
+    # runC cannot create or extract the root filesystem on its own. Use Docker to create it.
+    install_docker_when_needed;
 
     # create the rootfs directory
     assert_script_run('mkdir rootfs');
@@ -40,60 +40,27 @@ sub run {
     # export busybox via Docker into the rootfs directory
     assert_script_run('docker export $(docker create busybox) | tar -C rootfs -xvf -');
 
-    # installation of runc package
-    record_info 'Test #1', 'Test: Installation';
-    if (is_caasp) {
-        # runC should be pre-installed
-        die "runC is not pre-installed." if script_run("zypper se -x --provides -i $runc | grep runc");
+    foreach my $runc (@runtimes) {
+        record_info "$runc", "Testing $runc";
+
+        # If not testing docker-runc but docker-runc is installed, uninstall it
+        if ($runc ne "docker-runc" && script_run("which docker-runc") == 0) {
+            zypper_call('rm docker-runc');
+        }
+
+        test_container_runtime($runc);
+
+        # uninstall the tested container runtime
+        zypper_call("rm $runc");
     }
-    else {
-        # SLES/TW
-        zypper_call("in $runc");
-    }
 
-    # create the OCI specification and verify that the template has been created
-    record_info 'Test #2', 'Test: OCI Specification';
-    assert_script_run("$runc spec");
-    assert_script_run('ls -l config.json');
-    script_run('cp config.json config.json.backup');
+    # cleanup
+    assert_script_run("rm -rf rootfs");
 
-    # Modify the configuration to run the container in background
-    assert_script_run("sed -i -e '/\"terminal\":/ s/: .*/: false,/' config.json");
-    assert_script_run("sed -i -e 's/\"sh\"/\"echo\", \"Kalimera\"/' config.json");
+    # install docker and docker-runc if needed
+    install_docker_when_needed;
 
-    # Run (create, start, and delete) the container after it exits
-    record_info 'Test #3', 'Test: Use the run command';
-    assert_script_run("$runc run test1 | grep Kalimera");
-
-    # Restore the default configuration
-    assert_script_run('mv config.json.backup config.json');
-
-    assert_script_run("sed -i -e '/\"terminal\":/ s/: .*/: false,/' config.json");
-    assert_script_run("sed -i -e 's/\"sh\"/\"sleep\", \"120\"/' config.json");
-
-    # Container Lifecycle
-    record_info 'Test #4', 'Test: Create a container';
-    assert_script_run("$runc create test2");
-    assert_script_run("$runc state test2 | grep status | grep created");
-    record_info 'Test #5', 'Test: List containers';
-    assert_script_run("$runc list | grep test2");
-    record_info 'Test #6', 'Test: Start a container';
-    assert_script_run("$runc start test2");
-    assert_script_run("$runc state test2 | grep running");
-    record_info 'Test #7', 'Test: Pause a container';
-    assert_script_run("$runc pause test2");
-    assert_script_run("$runc state test2 | grep paused");
-    record_info 'Test #8', 'Test: Resume a container';
-    assert_script_run("$runc resume test2");
-    assert_script_run("$runc state test2 | grep running");
-    record_info 'Test #9', 'Test: Stop a container';
-    assert_script_run("$runc kill test2 KILL");
-    assert_script_run("$runc state test2 | grep stopped");
-    record_info 'Test #10', 'Test: Delete a container';
-    assert_script_run("$runc delete test2");
-    assert_script_run("! $runc state test2");
-
-    # Cleanup, remove all images
+    # remove leftover containers and images
     clean_docker_host();
 }
 

--- a/tests/console/docker_runc.pm
+++ b/tests/console/docker_runc.pm
@@ -24,7 +24,8 @@ use strict;
 use warnings;
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     install_docker_when_needed;
 

--- a/tests/console/git.pm
+++ b/tests/console/git.pm
@@ -25,10 +25,9 @@ use testapi;
 use utils qw(zypper_call);
 
 sub run {
+    select_console "root-console";
     my $username = $testapi::username;
     my $email    = "you\@example.com";
-    my $self     = shift;
-    $self->select_serial_terminal;
 
     # Create a test repo
     zypper_call("in git-core");

--- a/tests/console/podman.pm
+++ b/tests/console/podman.pm
@@ -31,7 +31,8 @@ use registration;
 use version_utils qw(is_sle is_leap);
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     if (is_sle '>=15') {
         add_suseconnect_product('sle-module-containers');

--- a/tests/console/podman_image.pm
+++ b/tests/console/podman_image.pm
@@ -19,7 +19,8 @@ use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
 sub run {
-    select_console "root-console";
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     my ($image_names, $stable_names) = get_suse_container_urls();
 

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -22,6 +22,7 @@ use version_utils 'is_sle';
 use serial_terminal 'add_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use registration;
+use services::registered_addons;
 use strict;
 use warnings;
 
@@ -87,7 +88,10 @@ sub run {
             diag "SUSEConnect --status-text locked: $out";
         }
         diag "SUSEConnect --status-text: $out";
-        assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'" unless get_var('MEDIA_UPGRADE');
+        if (!get_var('MEDIA_UPGRADE')) {
+            assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'";
+            services::registered_addons::full_registered_check;
+        }
     }
 }
 

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -22,7 +22,6 @@ use version_utils 'is_sle';
 use serial_terminal 'add_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use registration;
-use services::registered_addons;
 use strict;
 use warnings;
 
@@ -88,10 +87,7 @@ sub run {
             diag "SUSEConnect --status-text locked: $out";
         }
         diag "SUSEConnect --status-text: $out";
-        if (!get_var('MEDIA_UPGRADE')) {
-            assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'";
-            services::registered_addons::full_registered_check;
-        }
+        assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'" unless get_var('MEDIA_UPGRADE');
     }
 }
 

--- a/tests/console/validate_lvm_raid1.pm
+++ b/tests/console/validate_lvm_raid1.pm
@@ -88,8 +88,7 @@ sub _check_raid_disks_after_reboot {
         _restore_raid_disk($config, $expected_num_devs);
     }
     else {
-        # Expected behavior is not clear currently. Assuming that the faulty disk shouldn't be automatically reactivated
-        record_soft_failure("bsc#1172203");
+        record_info("Autorecovery", "$config->{raid1}->{disk_to_fail} was automatically recovered after reboot.");
     }
 }
 

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,7 @@
 # "nfs-client"
 # - Disable "recommended packages" and accept install of test package
 # - Remove test package
-# Maintainer: Martin Kravec <mkravec@suse.com>
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use base "y2_module_consoletest";
 use strict;

--- a/tests/console/zypper_docker.pm
+++ b/tests/console/zypper_docker.pm
@@ -25,7 +25,8 @@ use warnings;
 use containers::common;
 
 sub run {
-    select_console("root-console");
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     install_docker_when_needed();
 

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -118,6 +118,7 @@ sub run {
         # QNETD barriers
         barrier_create("QNETD_SERVER_READY_$cluster_name",     $num_nodes + 1);
         barrier_create("QNETD_SERVER_DONE_$cluster_name",      $num_nodes + 1);
+        barrier_create("QNETD_TESTS_DONE_$cluster_name",       $num_nodes + 1);
         barrier_create("SPLIT_BRAIN_TEST_READY_$cluster_name", $num_nodes + 1);
         barrier_create("SPLIT_BRAIN_TEST_DONE_$cluster_name",  $num_nodes + 1);
 

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -31,7 +31,7 @@ sub run {
 
     # We need to be sure to be root and, after fencing, the default console on node01 is not root
     # Only do this on node01, as node02 console is expected to be the root-console
-    if (is_node(1) && !get_var('HDDVERSION')) {
+    if ((is_node(1) && !get_var('HDDVERSION')) || (is_node(2) && check_var('QDEVICE_TEST_ROLE', 'client'))) {
         reset_consoles;
         select_console 'root-console';
     }
@@ -102,6 +102,8 @@ sub run {
     barrier_wait("CHECK_AFTER_REBOOT_END_$cluster_name");
 
     barrier_wait("HAWK_FENCE_$cluster_name") if (check_var('HAWKGUI_TEST_ROLE', 'server'));
+
+    barrier_wait("QNETD_TESTS_DONE_$cluster_name") if (check_var('QDEVICE_TEST_ROLE', 'client'));
 }
 
 1;

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -39,6 +39,9 @@ sub run {
     # in that case
     select_console 'root-console' if (get_var('HDDVERSION'));
 
+    # Remove iptable rules in node 1 when testing qnetd/qdevice in multicast
+    assert_script_run "iptables -F && iptables -X" if (is_node(1) && check_var('QDEVICE_TEST_ROLE', 'client') && !get_var('HA_UNICAST'));
+
     # Workaround network timeout issue during upgrade
     if (get_var('HDDVERSION')) {
         assert_script_run 'journalctl -b --no-pager -o short-precise > bsc1129385-check-journal.log';

--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -93,7 +93,7 @@ sub run {
     }
 
     # Ensure promotable resource is in node 1
-    script_run 'crm resource migrate promotable-1 ' . choose_node(1);
+    script_run 'crm resource migrate promotable-1 ' . choose_node(1) if is_node(1);
 
     # Perform Split Brain test
     barrier_wait("SPLIT_BRAIN_TEST_READY_$cluster_name");
@@ -101,12 +101,14 @@ sub run {
     record_info('Split-brain info', 'Split brain test');
 
     # Stop stonith to prevent fencing of node before our check
-    assert_script_run "crm resource stop stonith-sbd" if (is_node(1));
+    assert_script_run "crm resource stop stonith-sbd" if is_node(1);
 
     # Add firewall rules to provoke a split brain situation and confirm that
     # the qdevice node gives its vote to the node1 (where the master resource is running)
+    # Firewall rules go in both nodes in multicast cluster, and only in node 2 in unicast
     my $partner_ip = is_node(1) ? get_ip(choose_node(2)) : get_ip(choose_node(1));
-    assert_script_run "iptables -A INPUT -s $partner_ip -j DROP; iptables -A OUTPUT -d $partner_ip -j DROP" if (is_node(1) or is_node(2));
+    assert_script_run "iptables -A INPUT -s $partner_ip -j DROP; iptables -A OUTPUT -d $partner_ip -j DROP"
+      if ((is_node(1) and !get_var('HA_UNICAST')) or is_node(2));
     sleep $default_timeout;
 
     if (is_node(2)) {
@@ -128,13 +130,8 @@ sub run {
     # Show cluster status before ending the test
     save_state if (!check_var('QDEVICE_TEST_ROLE', 'qnetd_server'));
 
-    # Cleanup
-    if (is_node(1)) {
-        # Restart stonith. This should fence node 2
-        assert_script_run "crm resource start stonith-sbd";
-        # Remove iptable rules
-        assert_script_run "iptables -F && iptables -X";
-    }
+    # Restart stonith. This should fence node 2
+    assert_script_run "crm resource start stonith-sbd" if is_node(1);
 
     barrier_wait("QNETD_SERVER_DONE_$cluster_name");
 

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -68,6 +68,7 @@ sub check_default_target {
         get_var('REMOTE_CONTROLLER') || (get_var('BACKEND', '') =~ /spvm|pvm_hmc|ipmi/));
     # exclude non-desktop environment and scenarios with edition of package selection (bsc#1167736)
     return if (!get_var('DESKTOP') || get_var('PATTERNS'));
+    return if (get_var 'BSC1167736');
 
     # Set expectations
     my $expected_target = check_var('DESKTOP', 'textmode') ? "multi-user" : "graphical";

--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -31,7 +31,7 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(zypper_call clear_console ensure_serialdev_permissions);
-use version_utils qw(is_opensuse is_sle is_jeos);
+use version_utils qw(is_opensuse is_sle is_tumbleweed);
 use power_action_utils qw(power_action);
 
 ## Define test data
@@ -139,7 +139,9 @@ sub run {
     # 2) ROOT_USES_LANG="ctype"
     select_console('root-console');
     # it is expected that SLE12 has glibc preinstalled
-    zypper_call('in glibc-locale') if (is_sle('15+') || is_opensuse);
+    my @pkgs = qw(glibc-locale);
+    push @pkgs, 'glibc-lang' if (is_tumbleweed);
+    zypper_call("install @pkgs") if (is_sle('15+') || is_opensuse);
 
     my $output = script_output("localectl list-locales | tee -a /dev/$serialdev | grep -E '$lang_new_short\.(UTF-8|utf8)'");
     die "Test locale not found in the available ones" unless ($output =~ $lang_new_short);

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -357,8 +357,12 @@ sub run {
 
     add_custom_grub_entries if (is_sle('12+') || is_opensuse) && !is_jeos;
     setup_network;
-    prepare_ltp_env();
-    assert_script_run('generate_lvm_runfile.sh');
+
+    if (!is_sle('<12')) {
+        prepare_ltp_env();
+        assert_script_run('generate_lvm_runfile.sh');
+    }
+
     upload_runtest_files('/opt/ltp/runtest', $tag);
 
     if (get_var('LTP_COMMAND_FILE')) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -76,6 +76,7 @@ sub install_runtime_dependencies {
       evmctl
       fuse-exfat
       kernel-default-extra
+      lvm2
       net-tools
       net-tools-deprecated
       ntfsprogs

--- a/tests/migration/sle12_online_migration/post_migration.pm
+++ b/tests/migration/sle12_online_migration/post_migration.pm
@@ -26,7 +26,16 @@ sub run {
     zypper_call('lr -u');
 
     # Save output info to logfile
-    my $out = script_output("SUSEConnect --status-text", proceed_on_failure => 1);
+    my $out;
+    my $timeout  = bmwqemu::scale_timeout(30);
+    my $waittime = bmwqemu::scale_timeout(5);
+    while (1) {
+        $out = script_output("SUSEConnect --status-text", proceed_on_failure => 1);
+        last if (($timeout < 0) || ($out !~ /System management is locked by the application with pid/));
+        sleep $waittime;
+        $timeout -= $waittime;
+        diag "SUSEConnect --status-text locked: $out";
+    }
     diag "SUSEConnect --status-text: $out";
     assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'" unless get_var('MEDIA_UPGRADE');
 

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -75,6 +75,8 @@ sub run {
     $instance->run_ssh_command(cmd => 'sudo zypper --no-gpg-checks --gpg-auto-import-keys -q in -y ' . $remote_rpm_path, timeout => 600);
     $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh',                                       timeout => 300);
 
+    record_info('Kernel info', $instance->run_ssh_command(cmd => q(rpm -qa 'kernel*' --qf '%{NAME}\n' | sort | uniq | xargs rpm -qi)));
+
     my $reset_cmd     = $root_dir . '/restart_instance.sh ' . $self->instance_log_args();
     my $log_start_cmd = $root_dir . '/log_instance.sh start ' . $self->instance_log_args();
 

--- a/tests/security/selinux/audit2allow.pm
+++ b/tests/security/selinux/audit2allow.pm
@@ -27,12 +27,11 @@ use version_utils qw(is_sle);
 use registration qw(add_suseconnect_product);
 
 sub run {
-    my ($self)      = @_;
     my $testfile    = "test_file";
     my $test_module = "test_module";
     my $audit_log   = "/var/log/audit/audit.log";
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     assert_script_run("systemctl restart auditd");
 

--- a/tests/security/selinux/chcat.pm
+++ b/tests/security/selinux/chcat.pm
@@ -40,7 +40,7 @@ sub run {
     my $default_category_root       = $systemhigh;
     my $default_category_commonfile = $systemlow;
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # create a testing directory/file
     $self->create_test_file("$test_dir", "$test_file");

--- a/tests/security/selinux/chcon.pm
+++ b/tests/security/selinux/chcon.pm
@@ -31,7 +31,7 @@ sub run {
     my $fcontext_type1 = "etc_t";
     my $fcontext_type2 = "bin_t";
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # create a testing directory/file
     $self->create_test_file("$test_dir", "$test_file");

--- a/tests/security/selinux/enforcing_mode_setup.pm
+++ b/tests/security/selinux/enforcing_mode_setup.pm
@@ -27,7 +27,7 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # make sure SELinux in "permissive" mode
     validate_script_output("sestatus", sub { m/.*Current\ mode:\ .*permissive.*/sx });
@@ -46,7 +46,7 @@ sub run {
 
     power_action("reboot", textmode => 1);
     $self->wait_boot;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     validate_script_output(
         "sestatus",

--- a/tests/security/selinux/fixfiles.pm
+++ b/tests/security/selinux/fixfiles.pm
@@ -28,7 +28,7 @@ sub run {
     my ($self) = shift;
     my $file_output = $selinuxtest::file_output;
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # test `fixfiles check` can print any incorrect file context labels
     assert_script_run("fixfiles check > $file_output 2>&1", timeout => 300);

--- a/tests/security/selinux/fixfiles.pm
+++ b/tests/security/selinux/fixfiles.pm
@@ -31,7 +31,7 @@ sub run {
     $self->select_serial_terminal;
 
     # test `fixfiles check` can print any incorrect file context labels
-    assert_script_run("fixfiles check > $file_output 2>&1");
+    assert_script_run("fixfiles check > $file_output 2>&1", timeout => 300);
 
     # pick up a test file to test
     my $file_info     = script_output("grep -i 'Would relabel' $file_output | tail -1");

--- a/tests/security/selinux/print_se_context.pm
+++ b/tests/security/selinux/print_se_context.pm
@@ -25,10 +25,9 @@ use testapi;
 use utils;
 
 sub run {
-    my ($self) = @_;
     my $testfile = "foo";
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # print security context of file/dir
     assert_script_run("touch $testfile");

--- a/tests/security/selinux/restorecon.pm
+++ b/tests/security/selinux/restorecon.pm
@@ -31,7 +31,7 @@ sub run {
     my $fcontext_type1 = "etc_t";
     my $fcontext_type2 = "bin_t";
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # create a testing directory/file
     $self->create_test_file("$test_dir", "$test_file");

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -25,8 +25,7 @@ use utils;
 use version_utils qw(is_sle is_leap);
 
 sub run {
-    my ($self) = @_;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # program 'sestatus' can be found in policycoreutils pkgs
     zypper_call("in policycoreutils");

--- a/tests/security/selinux/selinux_smoke.pm
+++ b/tests/security/selinux/selinux_smoke.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,8 +30,7 @@ use registration qw(add_suseconnect_product register_product);
 use version_utils "is_sle";
 
 sub run {
-    my ($self) = @_;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # make sure SELinux is "enabled" and in "permissive" mode
     validate_script_output("sestatus", sub { m/SELinux\ status: .*enabled.* Current\ mode: .*permissive/sx });

--- a/tests/security/selinux/semanage_boolean.pm
+++ b/tests/security/selinux/semanage_boolean.pm
@@ -29,7 +29,7 @@ sub run {
     my ($self) = @_;
     my $test_boolean = "fips_mode";
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # list and verify some (not all as it changes often) boolean(s)
     validate_script_output(
@@ -51,7 +51,7 @@ sub run {
     # reboot and check again
     power_action("reboot", textmode => 1);
     $self->wait_boot;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     validate_script_output("semanage boolean -l | grep $test_boolean", sub { m/${test_boolean}.*(on.*,.*on).*Allow.*to.*/ });
 

--- a/tests/security/selinux/semanage_fcontext.pm
+++ b/tests/security/selinux/semanage_fcontext.pm
@@ -36,7 +36,7 @@ sub run {
     my $fcontext_type2        = "bin_t";
     my $fcontext_type3        = "var_t";
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # create a testing directory/file
     $self->create_test_file("$test_dir", "$test_file");

--- a/tests/security/selinux/semodule.pm
+++ b/tests/security/selinux/semodule.pm
@@ -24,10 +24,9 @@ use testapi;
 use utils;
 
 sub run {
-    my ($self) = @_;
     my $test_module = "openvpn";
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # test option "-l": list and verify some (not all as it changes often) standard modules
     validate_script_output(

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,7 +27,7 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # SELinux by default
     validate_script_output("sestatus", sub { m/SELinux status: .*disabled/ });
@@ -39,9 +39,10 @@ sub run {
     assert_script_run("sed -i -e 's/^SELINUX=/#SELINUX=/' /etc/selinux/config");
     assert_script_run("echo 'SELINUX=permissive' >> /etc/selinux/config");
 
+    # reboot the vm and reconnect the console
     power_action("reboot", textmode => 1);
     $self->wait_boot;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     validate_script_output(
         "sestatus",

--- a/tests/security/selinux/setsebool.pm
+++ b/tests/security/selinux/setsebool.pm
@@ -28,7 +28,7 @@ sub run {
     my ($self) = @_;
     my $test_boolean = "fips_mode";
 
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     # list and verify some (not all as it changes often) boolean(s)
     validate_script_output(
@@ -51,7 +51,7 @@ sub run {
     # reboot and check again
     power_action("reboot", textmode => 1);
     $self->wait_boot;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ on/ });
 
@@ -62,7 +62,7 @@ sub run {
     # reboot and check again
     power_action("reboot", textmode => 1);
     $self->wait_boot;
-    $self->select_serial_terminal;
+    select_console "root-console";
 
     validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ on/ });
 }

--- a/tests/smt/smt_client1.pm
+++ b/tests/smt/smt_client1.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: run smt client, register to smt server
+# - Install smt client
+# - Clean SUSEConnect registration
+# - Get registration script and certificate from server
+# - Register
+# - Check registration
+# Maintainer: Katerina Lorenzova <klorenzova@suse.cz>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+
+sub run {
+    select_console 'root-console';
+
+    zypper_call 'in smt-client';
+    assert_script_run 'SUSEConnect --cleanup';
+    assert_script_run 'SUSEConnect --status';
+
+    barrier_wait 'smt_setup';
+    #registration of client
+    assert_script_run 'wget --no-check-certificate https://SERVER/repo/tools/clientSetup4SMT.sh';
+    assert_script_run 'chmod a+x clientSetup4SMT.sh';
+    assert_script_run 'echo y | ./clientSetup4SMT.sh --host https://server --regcert https://server/smt.crt';    #needs yes
+    assert_script_run 'SUSEConnect -p SLES/12.5/x86_64 --url https://server';
+
+    #checking registration
+    validate_script_output 'SUSEConnect --status', sub { m/"identifier":"SLES","version":"12\.5","arch":"x86_64","status":"Registered"/ };
+    assert_script_run 'smt-agent';                                                                               #client is able to ask for jobs
+    validate_script_output 'zypper lr --uri', sub { m/SLES12-SP5-Updates *\| Yes/ };
+    validate_script_output 'zypper lr --uri', sub { m/SLES12-SP5-Pool *\| Yes/ };
+    barrier_wait 'smt_registered';
+}
+1;

--- a/tests/smt/smt_server.pm
+++ b/tests/smt/smt_server.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: run smt server, check client registration
+# - Run basic smt commands
+# - Wait for client registraton
+# - Check client registration
+# Maintainer: Katerina Lorenzova <klorenzova@suse.cz>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+
+sub run {
+    select_console 'root-console';
+
+    assert_script_run 'smt-repos -m';
+    validate_script_output 'SUSEConnect --status', sub { m/"identifier":"SLES","version":"12\.5","arch":"x86_64","status":"Registered"/ };
+    validate_script_output 'smt-repos -o',         sub { m/SLES12-SP5-Updates/ };
+
+    barrier_wait 'smt_setup';
+
+    #time for registration of clients
+
+    barrier_wait 'smt_registered';
+    validate_script_output 'smt-list-registrations', sub { m/client1/ };
+    assert_script_run 'smt-job -l';
+}
+1;

--- a/tests/smt/smt_server_install.pm
+++ b/tests/smt/smt_server_install.pm
@@ -1,0 +1,157 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: installation of smt server
+# - Install smt package
+# - Configure smt server
+# - Use yast certificate to issue correct cert
+# - Mirror repositories
+# Maintainer: Katerina Lorenzova <klorenzova@suse.cz>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mm_network;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    zypper_call 'in -t pattern smt';
+    zypper_call 'in mariadb';
+
+    assert_script_run 'hostnamectl set-hostname server';
+
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'smt-wizard');
+
+    wait_still_screen;
+    wait_screen_change { send_key "alt-f" };
+    wait_screen_change { send_key "alt-u" };
+    type_string "UC5414818";
+    wait_screen_change { send_key "alt-p" };
+    type_string "2c3dff7ee9";
+
+    wait_screen_change { send_key "alt-s" };
+    type_string 'osukup@suse.com';
+    wait_screen_change { send_key "alt-y" };
+    foreach (0 .. 15) {
+        wait_screen_change { send_key "backspace" };
+    }
+    type_string "http://server/";
+    assert_screen "smt_settings";
+
+    wait_screen_change { send_key "alt-t" };
+    assert_screen "smt-test-succ";
+    wait_screen_change { send_key "ret" };
+    wait_screen_change { send_key "alt-n" };
+
+    wait_screen_change { send_key "alt-d" };
+    type_string "susetest";
+    wait_screen_change { send_key "alt-s" };
+    type_string "susetest";
+    wait_screen_change { send_key "alt-n" };
+
+    assert_screen "smt-mariadb";
+    wait_screen_change { send_key "alt-p" };
+    type_string "susetest";
+    wait_screen_change { send_key "alt-a" };
+    type_string "susetest";
+    wait_screen_change { send_key "alt-o" };
+
+    assert_screen "smt-cert";
+    wait_screen_change { send_key "alt-r" };
+
+    assert_screen "smt-ca-passwd";
+    wait_screen_change { send_key "alt-p" };
+    type_string "susetest";
+    wait_screen_change { send_key "alt-n" };
+    type_string "susetest";
+    wait_screen_change { send_key "alt-o" };
+
+    wait_screen_change { send_key "alt-n" };
+    wait_still_screen(7, 45);
+    wait_screen_change(sub { }, 360);
+    $self->clear_and_verify_console;
+
+    #creating smt certificate
+    script_run("yast ca_mgm", timeout => 0);
+    wait_still_screen;
+    assert_screen "smt-yast-ca";
+    wait_screen_change { send_key "alt-e" };
+    type_string "susetest";
+    wait_screen_change { send_key "alt-o" };
+    wait_screen_change { send_key "alt-e" };
+    wait_screen_change { send_key "alt-r" };
+    wait_screen_change { send_key "alt-o" };
+    wait_screen_change { send_key "alt-d" };
+    wait_screen_change { send_key "alt-o" };
+    wait_screen_change { send_key "alt-a" };
+    wait_screen_change { send_key "alt-a" };
+    type_string "server";
+    wait_screen_change { send_key "alt-n" };
+    wait_screen_change { send_key "alt-a" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "ret" };
+    wait_screen_change { send_key "alt-a" };
+    wait_screen_change { send_key "alt-d" };
+    wait_screen_change { send_key "alt-n" };
+    type_string "server";
+    wait_screen_change { send_key "alt-o" };
+    wait_screen_change { send_key "alt-o" };
+    wait_screen_change { send_key "alt-u" };
+    wait_screen_change { send_key "alt-n" };
+    assert_screen "smt-ca-settings";
+    wait_screen_change { send_key "alt-t" };
+    wait_still_screen(3, 45);
+    wait_screen_change { send_key "alt-x" };
+    assert_screen "smt-export-ca";
+    wait_screen_change { send_key "alt-p" };
+    wait_screen_change { send_key "alt-p" };
+    assert_screen "smt-yastca-passwd";
+    type_string "susetest";
+    wait_screen_change { send_key "alt-o" };
+    wait_still_screen;
+    wait_screen_change { send_key "alt-o" };
+    wait_still_screen;
+    wait_screen_change { send_key "alt-o" };
+    wait_screen_change { send_key "alt-f" };
+    $self->clear_and_verify_console;
+
+    #mirroring repos
+    assert_script_run "df -h";    #mirroring needs quite a lot of space
+    save_screenshot;
+
+    validate_script_output "SUSEConnect --status", sub { m/"identifier":"SLES","version":"12\.5","arch":"x86_64","status":"Registered"/ };
+    assert_script_run "smt-repos -o";
+    validate_script_output "smt-repos -m", sub { m/SLES12-SP5-Updates/ };
+
+    assert_script_run "smt-repos -e SLES12-SP5-Updates sle-12-x86_64";
+    assert_script_run "smt-repos -e SLES12-SP5-Pool sle-12-x86_64";
+    validate_script_output "smt-repos -o", sub { m/SLES12-SP5-Updates/ };
+    validate_script_output "smt-repos -o", sub { m/SLES12-SP5-Pool/ };
+
+    assert_script_run "smt-mirror", 16000;
+
+    assert_script_run "df -h";
+    save_screenshot;
+    select_console "x11";
+}
+1;

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -90,9 +90,9 @@ sub run_test {
         #Wait for guests attached interface from virtual routed network
         sleep 30;
         my $net1 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed';
-        test_network_interface("$guest", mac => $mac1, gate => $gate1, target => $target1, net => $net1);
+        test_network_interface("$guest", mac => $mac1, gate => $gate1, routed => 1, target => $target1, net => $net1);
         my $net2 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed_clone';
-        test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, target => $target2, net => $net2);
+        test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, routed => 1, target => $target2, net => $net2);
 
         assert_script_run("virsh detach-interface $guest --mac $mac1 $exclusive");
         assert_script_run("virsh detach-interface $guest.clone --mac $mac2 $exclusive");

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -29,6 +29,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run_test {
     my ($self) = @_;
@@ -47,7 +48,7 @@ sub run_test {
     upload_logs "vnet_routed_clone.xml";
     assert_script_run("rm -rf vnet_routed.xml vnet_routed_clone.xml");
 
-    my ($mac1, $mac2, $model1, $model2);
+    my ($mac1, $mac2, $model1, $model2, $affecter, $exclusive);
     my $target1 = '192.168.130.1';
     my $target2 = '192.168.129.1';
     my $gate1   = '192.168.129.1';
@@ -66,21 +67,35 @@ sub run_test {
         assert_script_run("virsh start $guest");
         assert_script_run("virsh start $guest.clone");
 
+        if (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) {
+            $affecter  = "--persistent";
+            $exclusive = "bridge --live --persistent";
+        } else {
+            $affecter  = "";
+            $exclusive = "network --current";
+        }
+
         #figure out that used with virtio as the network device model during
         #attach-interface via virsh worked for all sles guest
         $mac1   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model1 = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
-        assert_script_run("virsh attach-interface $guest network vnet_routed --model $model1 --mac $mac1 --live");
+
+        assert_script_run("virsh attach-interface $guest network vnet_routed --model $model1 --mac $mac1 --live $affecter", 60);
 
         $mac2   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model2 = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
-        assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --model $model2 --mac $mac2 --live");
 
-        test_network_interface("$guest",       mac => $mac1, gate => $gate1, target => $target1, net => "vnet_routed");
-        test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, target => $target2, net => "vnet_routed_clone");
+        assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --model $model2 --mac $mac2 --live $affecter", 60);
 
-        assert_script_run("virsh detach-interface $guest network --mac $mac1 --current");
-        assert_script_run("virsh detach-interface $guest.clone network --mac $mac2 --current");
+        #Wait for guests attached interface from virtual routed network
+        sleep 30;
+        my $net1 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed';
+        test_network_interface("$guest", mac => $mac1, gate => $gate1, target => $target1, net => $net1);
+        my $net2 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed_clone';
+        test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, target => $target2, net => $net2);
+
+        assert_script_run("virsh detach-interface $guest --mac $mac1 $exclusive");
+        assert_script_run("virsh detach-interface $guest.clone --mac $mac2 $exclusive");
 
         assert_script_run("virsh destroy $guest.clone");
         assert_script_run("virsh undefine $guest.clone");

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -44,7 +44,7 @@ sub run_test {
     virt_autotest::virtual_network_utils::ssh_setup();
 
     #Install required packages
-    zypper_call '-t in iproute2 iptables iputils bind-utils sshpass';
+    zypper_call '-t in iproute2 iptables iputils bind-utils sshpass nmap';
 
     #Check with Guest status before libvirt virtual network tests
     virt_autotest::virtual_network_utils::check_guest_status();

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -88,6 +88,13 @@ sub run {
             }
             assert_script_run('./autogen.sh ',       timeout => 600);
             assert_script_run('make ; make install', timeout => 600);
+        } elsif (my $wicked_repo = get_var('WICKED_REPO')) {
+            zypper_ar($wicked_repo, name => 'wicked_repo', no_gpg_check => 1);
+            zypper_call('in --force -y --from wicked_repo --allow-vendor-change  --allow-downgrade  wicked', log => 1);
+            validate_script_output('zypper ps  --print "%s"', /^\s*$/);
+            if (my $commit_sha = get_var('WICKED_COMMIT_SHA')) {
+                validate_script_output(q(head -n 1 /usr/share/doc/packages/wicked/ChangeLog | awk '{print $2}'), /^$commit_sha$/);
+            }
         }
         if (check_var('WICKED', 'ipv6')) {
             zypper_ar('http://download.suse.de/ibs/home:/wicked-maintainers:/openQA/SLE_15_SP2/', name => 'wicked_maintainers', no_gpg_check => 1, priority => 60);

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -39,7 +39,6 @@ sub run() {
         zypper_call("--gpg-auto-import-keys ref");
         zypper_call("in dovecot", exitcode => [0, 102, 103]);
         zypper_call("rr dovecot_repo");
-        save_screenshot;
     } else {
         if (is_opensuse) {
             # exim is installed by default in openSUSE, but we need postfix

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -96,7 +96,8 @@ sub run() {
     # create test users
     assert_script_run "useradd -m admin";
     assert_script_run "useradd -m nimda";
-    assert_script_run "echo -e 'admin:password123\nnimda:password123' | chpasswd";
+    assert_script_run "echo 'admin:password123' | chpasswd";
+    assert_script_run "echo 'nimda:password123' | chpasswd";
 
     systemctl 'status dovecot';
     systemctl 'status postfix';

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -24,18 +24,6 @@ use testapi;
 use utils;
 use version_utils qw(is_sle is_tumbleweed);
 
-sub evolution_wizard {
-    my ($self, $mail_box) = @_;
-    # Clean and Start Evolution
-    # Follow the wizard to setup mail account
-    $self->start_evolution($mail_box);
-    assert_screen "evolution_wizard-account-summary", 60;
-    assert_and_click "evolution-option-next";
-
-    assert_screen "evolution_wizard-done";
-    send_key "alt-a";
-}
-
 sub run {
     my $self        = shift;
     my $mail_box    = 'nooops_test3@aim.com';
@@ -43,26 +31,7 @@ sub run {
 
     mouse_hide(1);
     x11_start_program('xterm -e "gsettings set org.gnome.desktop.session idle-delay 0"', valid => 0);
-    evolution_wizard($self, $mail_box);
-
-    # init time counter
-    my $time_counter = 0;
-    while (1) {
-        # look for mail authentication window or folders scanning, fail in other situations
-        assert_screen([qw(evolution_smoke-detect-folders-scanning evolution_mail-auth)]);
-        # break loop and continue with test in case of mail authentication window
-        last if (match_has_tag('evolution_mail-auth'));
-        # if evolution still hangs on folders scanning after 10 tries, try another mail provider
-        if ($time_counter == 10) {
-            record_info('Connection problem', "Server is not responding, trying backup email provider.");
-            my $mail_box = 'nooops_test3@gmx.com';
-            evolution_wizard($self, $mail_box);
-            assert_screen "evolution_mail-auth";
-            last;
-        }
-        ++$time_counter;
-        sleep 1;
-    }
+    $self->start_evolution($mail_box);
 
     send_key "super-up" if (check_screen "evolution_mail-init-window", 2);
     if (check_screen "evolution_mail-auth", 5) {

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -33,13 +33,13 @@ sub run {
     x11_start_program('xterm -e "gsettings set org.gnome.desktop.session idle-delay 0"', valid => 0);
     $self->start_evolution($mail_box);
 
-    send_key "super-up" if (check_screen "evolution_mail-init-window", 2);
     if (check_screen "evolution_mail-auth", 5) {
         send_key "alt-a";    #disable keyring option, in SP2 or tumbleweed
         send_key "alt-p";
         type_string "$mail_passwd";
         send_key "ret";
     }
+    send_key "super-up" if (check_screen "evolution_mail-init-window", 2);
     assert_screen "evolution_mail-max-window";
 
     # Help

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -43,14 +43,12 @@ sub run {
     assert_screen "evolution_mail-max-window";
 
     # Help
-    wait_screen_change {
-        send_key "alt-h";
-    };
+    send_key "alt-h";
+    wait_still_screen(2);
     send_key "a";
     assert_screen "evolution_about";
-    wait_screen_change {
-        send_key "esc";
-    };
+    send_key "esc";
+    wait_still_screen(2);
 
     # Exit
     send_key "ctrl-q";

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -1,6 +1,6 @@
 # Evolution tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -64,19 +64,12 @@ sub run {
         sleep 1;
     }
 
-    type_string "$mail_passwd";
-    send_key "ret";
-    if (check_screen "evolution_mail-init-window", 30) {
-        send_key "super-up";
-    }
-    # tumbleweed may pop another auth window
-    if (is_tumbleweed) {
-        if (check_screen "evolution_mail-auth", 30) {
-            send_key "alt-a";    #disable keyring option, in SP2 or tumbleweed
-            send_key "alt-p";
-            type_string "$mail_passwd";
-            send_key "ret";
-        }
+    send_key "super-up" if (check_screen "evolution_mail-init-window", 2);
+    if (check_screen "evolution_mail-auth", 5) {
+        send_key "alt-a";    #disable keyring option, in SP2 or tumbleweed
+        send_key "alt-p";
+        type_string "$mail_passwd";
+        send_key "ret";
     }
     assert_screen "evolution_mail-max-window";
 

--- a/tests/x11/evolution/evolution_timezone_setup.pm
+++ b/tests/x11/evolution/evolution_timezone_setup.pm
@@ -50,17 +50,11 @@ sub run {
     assert_screen "mercator-zoomed-in";
     # Change timezone to Shanghai
     send_key "alt-s";
-    wait_still_screen 3;
-    send_key "ret";
-    if (check_screen "timezone-asia", 30) {
-        send_key "right";
-        send_key_until_needlematch("timezone-shanghai", "up");
-    }
-    else {
-        send_key_until_needlematch("timezone-asia", "down");
-        send_key "right";
-        send_key_until_needlematch("timezone-asia-shanghai", "up");
-    }
+    wait_still_screen(2);
+    send_key_until_needlematch('timezone-asia', 'ret', 10, 2);
+    send_key "right";
+    wait_still_screen(2);
+    send_key_until_needlematch("timezone-shanghai", "up", 20, 1);
     send_key "ret";
     assert_screen "asia-shanghai-timezone-setup";
     send_key "alt-o";

--- a/tests/x11/pidgin/clean_pidgin.pm
+++ b/tests/x11/pidgin/clean_pidgin.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,17 +17,14 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
-use utils 'clear_console';
 
 sub remove_pkg {
     my @packages = qw(pidgin);
     x11_start_program('xterm');
 
     # Remove packages
-    assert_script_sudo "rpm -e @packages";
-    clear_console;
-    type_string "rpm -qa @packages\n";
-    assert_screen "pidgin-pkg-removed";    #make sure pkgs removed.
+    assert_script_sudo "zypper -n rm @packages";
+    assert_script_run "zypper --no-refresh if @packages|grep 'not installed'";
     type_string "exit\n";
 }
 

--- a/tests/x11/plasma_browser_integration.pm
+++ b/tests/x11/plasma_browser_integration.pm
@@ -54,9 +54,13 @@ sub run {
         last if check_screen('plasma-mpris-pause', 20);
     }
 
-    # Pause using the button in the applet
-    assert_and_click('plasma-mpris-pause');
-    # Verify that the applet noticed that
+    $counter = 3;
+    while ($counter-- > 0) {
+        # Pause using the button in the applet
+        assert_and_click('plasma-mpris-pause');
+        # Verify that the applet noticed that
+        last if check_screen('plasma-mpris-paused', 5);
+    }
     assert_screen('plasma-mpris-paused');
     # Verify that the video is paused and unpause it
     assert_and_click('plasma-browser-integration-video-unpause');

--- a/tests/x11/thunderbird/thunderbird_imap.pm
+++ b/tests/x11/thunderbird/thunderbird_imap.pm
@@ -40,7 +40,6 @@ sub run {
 
     mouse_hide(1);
     # clean up and start thunderbird
-    script_run("rm -rf .thunderbir*");
     x11_start_program("xterm -e \"killall -9 thunderbird; find ~ -name *thunderbird | xargs rm -rf;\"", valid => 0);
     my $success = eval { x11_start_program("thunderbird", match_timeout => 300); 1 };
     unless ($success) {

--- a/tests/yast2_cmd/yast_dns_server.pm
+++ b/tests/yast2_cmd/yast_dns_server.pm
@@ -72,9 +72,11 @@ sub run {
     zypper_call("in bind-libs",             exitcode => [0, 102, 103, 106]) if is_sle('=12-SP2');
 
     #Forward server and test lookup
+    my $suseip = script_output("dig www.suse.com +short");
+    $suseip =~ s/.*(\d+\.\d+\.\d+\.\d+).*/$1/s;
     $self->cmd_handle("forwarders", "add", ip => "10.0.2.3");
     systemctl("start named.service");
-    validate_script_output('dig @localhost www.suse.com +short', sub { /\Q35.156.53.100\E/ });
+    validate_script_output('dig @localhost www.suse.com +short', sub { /\Q$suseip\E/ });
     $self->cmd_handle("forwarders", "remove", ip => "10.0.2.3");
     record_soft_failure("bsc#1151138") if (systemctl("is-active named.service", ignore_failure => 1));
 

--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -13,7 +13,7 @@
 # - Set keyboard layout to korean and validate.
 # - Set keyboard layout to german.
 # - Restore keyboard settings to english-us and verify (enter using german characters).
-# Maintainer: Ming Li <mli@suse.com>
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 =head1 Create regression test for keyboard layout and verify
 
@@ -31,12 +31,9 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(zypper_call);
-use version_utils qw(is_sle);
 
 sub run {
-
     select_console("root-console");
-
     # Set keyboard layout to korean and validate.
     zypper_call("in yast2-country", timeout => 480);
     assert_script_run("yast keyboard list");
@@ -47,21 +44,8 @@ sub run {
     assert_script_run("yast keyboard set layout=german");
 
     # Restore keyboard settings to english-us and verify(enter using german characters).
-    if (is_sle('15-sp2+')) {
-        type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 5, timeout => 10);
-    }
-    else {
-        record_soft_failure('bsc#1170292');
-        type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 60, timeout => 130);
-    }
-    save_screenshot;
-
+    type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 40, timeout => 90);
     validate_script_output("yast keyboard summary 2>&1", sub { m/english-us/ }, timeout => 90);
-
-}
-
-sub test_flags {
-    return {always_rollback => 1};
 }
 
 1;

--- a/variables.md
+++ b/variables.md
@@ -113,6 +113,7 @@ RESCUESYSTEM | boolean | false | Indicates rescue system under test.
 ROOTONLY | boolean | false | Request installation to create only the root account, no user account.
 RESET_HOSTNAME| boolean | false | If set to true content of /etc/hostname file will be erased
 SCC_ADDONS | string | | Comma separated list of modules to be enabled using SCC/RMT.
+SCC_DOCKER_IMAGE | string | | The content of /etc/zypp/credentials.d/SCCcredentials used by container-suseconnect-zypp zypper service in SLE base container images
 SELECT_FIRST_DISK | boolean | false | Enables test module to select first disk for the installation. Is used for baremetal machine tests with multiple disks available, including cases when server still has previous installation.
 SEPARATE_HOME | three-state | undef | Used for scheduling the test module where separate `/home` partition should be explicitly enabled (if `1` is set) or disabled (if `0` is set). If not specified, the test module is skipped.
 SES5_CEPH_QA_HEALTH_OK | string | | URL for repo containing ceph-qa-health-ok package.


### PR DESCRIPTION
Added svirt-hyperv schedule for yast2_ncurses_gnome. Need to setup                                                                                                                                                                           
the job group accordingly.

- Related ticket: https://progress.opensuse.org/issues/66856
- Functional group yaml: https://gitlab.suse.de/qsf-u/qa-sle-functional-userspace/-/merge_requests/88
- Verification run: [summary](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%23poo66856&distri=sle&version=15-SP2)
