### PR TITLE
Don't generate LVM runtest file on SLE-11

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -357,8 +357,12 @@ sub run {
 
     add_custom_grub_entries if (is_sle('12+') || is_opensuse) && !is_jeos;
     setup_network;
-    prepare_ltp_env();
-    assert_script_run('generate_lvm_runfile.sh');
+
+    if (!is_sle('<12')) {
+        prepare_ltp_env();
+        assert_script_run('generate_lvm_runfile.sh');
+    }
+
     upload_runtest_files('/opt/ltp/runtest', $tag);
 
     if (get_var('LTP_COMMAND_FILE')) {


### PR DESCRIPTION
I forgot about SLE-11 when I wrote the LTP LVM support PR so here's the fix.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-11SP3: https://openqa.suse.de/tests/4312253
  - SLE-15SP1: https://openqa.suse.de/tests/4312255
