### PR TITLE
Check if SUSEConnect command includes all expected addons info for migration

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -22,6 +22,7 @@ use version_utils 'is_sle';
 use serial_terminal 'add_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use registration;
+use services::registered_addons 'full_registered_check';
 use strict;
 use warnings;
 
@@ -75,7 +76,7 @@ sub run {
     }
 
     # Save output info to logfile
-    if (is_sle) {
+    if (is_sle && get_required_var('FLAVOR') =~ /Migration/) {
         my $out;
         my $timeout  = bmwqemu::scale_timeout(30);
         my $waittime = bmwqemu::scale_timeout(5);
@@ -87,7 +88,10 @@ sub run {
             diag "SUSEConnect --status-text locked: $out";
         }
         diag "SUSEConnect --status-text: $out";
-        assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'" unless get_var('MEDIA_UPGRADE');
+        if (!get_var('MEDIA_UPGRADE')) {
+            assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'";
+            services::registered_addons::full_registered_check;
+        }
     }
 }
 


### PR DESCRIPTION
Check if SUSEConnect command includes all expected addons info
Background: Before we only check SUSEConnect -s command includes all expected addons registration information. Now we need add SUSEConnect --list-extensions and SUSEConnect --status-text command also includes all expected addon information. As we have check each addons at SUSEConnect -s command. Now we just need compare addon information between SUSEConnect -s and SUSEConnect --list-extensions & SUSEConnect --staus-text command. If those two command includes all addons which SUSEConnect -s included. We will get all expected addons information.

    Related ticket: https://progress.opensuse.org/issues/66826
Verification run:https://openqa.nue.suse.com/tests/4315290#step/system_prepare/22
function case: https://openqa.nue.suse.com/tests/4315214#step/system_prepare/10
