### PR TITLE
prepare_tools: Fix python package conflicts and upgrade to SLE 15 SP1

### DIFF
--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -30,18 +30,6 @@
                 <ask_user config:type="boolean">false</ask_user>
                 <selected config:type="boolean">true</selected>
             </listentry>
-            <listentry>
-                <media_url>https://download.opensuse.org/repositories/devel:/languages:/python:/backports/SLE_15/</media_url>
-                <product>python_devel</product>
-                <alias>Python Devel</alias>
-                <product_dir>/</product_dir>
-                <priority config:type="integer">20</priority>
-                <ask_on_error config:type="boolean">false</ask_on_error>
-                <confirm_license config:type="boolean">false</confirm_license>
-                <name>Python Devel</name>
-                <ask_user config:type="boolean">false</ask_user>
-                <selected config:type="boolean">true</selected>
-            </listentry>
         </add_on_products>
     </add-on>
     <suse_register>
@@ -52,22 +40,22 @@
         <addons config:type="list">
             <addon>
                 <name>sle-module-basesystem</name>
-                <version>15</version>
+                <version>{{VERSION}}</version>
                 <arch>x86_64</arch>
             </addon>
             <addon>
                 <name>sle-module-public-cloud</name>
-                <version>15</version>
+                <version>{{VERSION}}</version>
                 <arch>x86_64</arch>
             </addon>
             <addon>
                 <name>sle-module-development-tools</name>
-                <version>15</version>
+                <version>{{VERSION}}</version>
                 <arch>x86_64</arch>
             </addon>
             <addon>
                 <name>sle-module-legacy</name>
-                <version>15</version>
+                <version>{{VERSION}}</version>
                 <arch>x86_64</arch>
             </addon>
         </addons>

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -72,6 +72,7 @@ resource "google_compute_instance" "openqa" {
     zone         = var.region
 
     boot_disk {
+        device_name = "${var.name}-${element(random_id.service.*.hex, count.index)}"
         initialize_params {
             image = var.image_id
         }

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -169,7 +169,7 @@ sub create_ssh_key {
     $args{ssh_private_key_file} //= '/root/.ssh/id_rsa';
     if (script_run('test -f ' . $args{ssh_private_key_file}) != 0) {
         assert_script_run('SSH_DIR=`dirname ' . $args{ssh_private_key_file} . '`; mkdir -p $SSH_DIR');
-        assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ' . $args{ssh_private_key_file});
+        assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -m pem -f ' . $args{ssh_private_key_file});
     }
 }
 

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -64,8 +64,8 @@ sub run {
         }
     }
 
-    # Install prerequesite packages
-    zypper_call('-q in python-xml python3-devel python3-pip python3-virtualenv python3-img-proof python3-img-proof-tests');
+    # Install prerequesite packages test
+    zypper_call('-q in python3-pip python3-virtualenv python3-img-proof python3-img-proof-tests');
     record_info('python', script_output('python --version'));
 
     # Install AWS cli
@@ -93,7 +93,7 @@ sub run {
     record_info('img-proof', script_output('img-proof --version'));
 
     # Install Terraform from repo
-    zypper_call('ar https://download.opensuse.org/repositories/systemsmanagement:/terraform/SLE_15/systemsmanagement:terraform.repo');
+    zypper_call('ar https://download.opensuse.org/repositories/systemsmanagement:/terraform/SLE_15_SP1/systemsmanagement:terraform.repo');
     zypper_call('--gpg-auto-import-keys -q in terraform');
     record_info('Terraform', script_output('terraform -v'));
 


### PR DESCRIPTION
Due to usage of devel:languages:python on SLE we got into package
dependencies issue. Because devel:languages:python was actually
not needed leftover was decided to simply drop it.
Also some minor changes needed to be able to use SLE 15 SP1
as source image.

- Verification run: 
http://autobot.qa.suse.de/tests/701
GCE img-proof - http://autobot.qa.suse.de/tests/736
GCE ltp - http://autobot.qa.suse.de/tests/737
EC2 boottime - http://autobot.qa.suse.de/tests/739
EC2 img-proof - http://autobot.qa.suse.de/tests/741
EC ltp syscalls - http://autobot.qa.suse.de/tests/740
Azure img-proof - http://autobot.qa.suse.de/tests/742
Azure boottime - http://autobot.qa.suse.de/tests/744
Azure ltp syscall - http://autobot.qa.suse.de/tests/743

