### PR TITLE
Add totest tag on registry url

### DIFF
--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -53,24 +53,25 @@ sub get_opensuse_registry_prefix {
 # Returns a tuple of image urls and their matching released "stable" counterpart.
 # If empty, no images available.
 sub get_suse_container_urls {
-    my $version    = get_required_var('VERSION');
-    my $dotversion = $version =~ s/-SP/./r;         # 15 -> 15, 15-SP1 -> 15.1
-    $dotversion = "${dotversion}.0" if $dotversion !~ /\./;    # 15 -> 15.0
+    my $version    = shift // get_required_var('VERSION');
+    my $totest     = get_var('CONTAINER_TOTEST', '');        # totest/
+    my $dotversion = $version =~ s/-SP/./r;                  # 15 -> 15, 15-SP1 -> 15.1
+    $dotversion = "${dotversion}.0" if $dotversion !~ /\./;  # 15 -> 15.0
 
     my @image_names  = ();
     my @stable_names = ();
-    if (is_sle(">=12-sp3") && is_sle('<15')) {
+    if (is_sle(">=12-sp3", $version) && is_sle('<15', $version)) {
         my $lowerversion  = lc $version;
         my $nodashversion = $version =~ s/-sp/sp/ir;
         # No aarch64 image
         if (!check_var('ARCH', 'aarch64')) {
-            push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/images/suse/sles${nodashversion}";
+            push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/${totest}images/suse/sles${nodashversion}";
             push @stable_names, "registry.suse.com/suse/sles${nodashversion}";
         }
     }
-    elsif (is_sle(">=15")) {
+    elsif (is_sle(">=15", $version)) {
         my $lowerversion = lc $version;
-        push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/images/suse/sle15:${dotversion}";
+        push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/${totest}images/suse/sle15:${dotversion}";
         push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
     }
     elsif (is_tumbleweed && get_opensuse_registry_prefix) {
@@ -88,7 +89,7 @@ sub get_suse_container_urls {
     elsif (is_leap(">15.0") && check_var('ARCH', 'ppc64le')) {
         # No image set up yet :-(
     }
-    elsif (is_sle("<=12-sp2")) {
+    elsif (is_sle("<=12-sp2", $version)) {
         # No images for old SLE
     }
     else {

--- a/variables.md
+++ b/variables.md
@@ -27,6 +27,7 @@ CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test mo
 CHECK_RELEASENOTES_ORIGIN | boolean | false | Loads `installation/releasenotes_origin` test module.
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
+CONTAINER_TOTEST | string | | The string can be "totest/" or "", depending on the URL of the image in the container image registry. 
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.


### PR DESCRIPTION
In the case of SLE base container images, there is need to test all of
the images on the SUT. In order to achieve this, suse_container_urls
needs to be modified to accept the different image versions.

Also, currently SLE base images are being released using a two step
process, so it is needed to test and pull the images from the registry
that contain "totest" in their path.


- Related ticket: https://progress.opensuse.org/issues/51041
- Needles: No needles
- Verification run: 
without CONTAINER_TOTEST:  http://angmar.suse.de/tests/2303
default usage of get_suse_container_urls(without argument): http://angmar.suse.de/tests/2302   
with argument on get_suse_container_urls: http://angmar.suse.de/tests/2298
   
    tumbleweed: https://openqa.opensuse.org/tests/1294045#step/docker_image/74