### PR TITLE
firefox: Use CZ mirror to test protocols and content

### DIFF
--- a/tests/x11/firefox/firefox_extcontent.pm
+++ b/tests/x11/firefox/firefox_extcontent.pm
@@ -30,7 +30,7 @@ sub run {
     my ($self) = @_;
 
     $self->start_firefox_with_profile;
-    $self->firefox_open_url('http://mirror.bej.suse.com/dist/install/SLP/SLE-12-SP3-Server-GM/x86_64/dvd1/');
+    $self->firefox_open_url('http://mirror.suse.cz/install/SLP/SLE-12-SP5-Server-GM/x86_64/DVD1/');
 
     assert_screen('firefox-extcontent-pageloaded');
 

--- a/tests/x11/firefox/firefox_urlsprotocols.pm
+++ b/tests/x11/firefox/firefox_urlsprotocols.pm
@@ -32,7 +32,7 @@ sub run {
     my %sites_url = (
         http  => "http://httpbin.org/html",
         https => "https://www.google.com/",
-        ftp   => "ftp://mirror.bej.suse.com/",
+        ftp   => "ftp://mirror.suse.cz/",
         local => "file:///usr/share/w3m/w3mhelp.html"
     );
 


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4313313
- Verification run: http://10.100.12.155/tests/16068