### PR TITLE
Fix serial console, remove duplicity

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -34,7 +34,7 @@ sub run {
     # Configure serial consoles for virtio support
     # poo#18860 Enable console on hvc0 on SLES < 12-SP2
     # poo#44699 Enable console on hvc1 to fix login issues on ppc64le
-    if (get_var('VIRTIO_CONSOLE')) {
+    if (!check_var('VIRTIO_CONSOLE', 0)) {
         if (is_sle('<12-SP2')) {
             add_serial_console('hvc0');
         }

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -19,7 +19,7 @@ use base 'consoletest';
 use testapi;
 use utils;
 use version_utils 'is_sle';
-use serial_terminal 'add_serial_console';
+use serial_terminal 'prepare_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use registration;
 use strict;
@@ -31,17 +31,7 @@ sub run {
 
     ensure_serialdev_permissions;
 
-    # Configure serial consoles for virtio support
-    # poo#18860 Enable console on hvc0 on SLES < 12-SP2
-    # poo#44699 Enable console on hvc1 to fix login issues on ppc64le
-    if (!check_var('VIRTIO_CONSOLE', 0)) {
-        if (is_sle('<12-SP2')) {
-            add_serial_console('hvc0');
-        }
-        elsif (get_var('OFW')) {
-            add_serial_console('hvc1');
-        }
-    }
+    prepare_serial_console;
 
     # Make sure packagekit is not running, or it will conflict with SUSEConnect.
     pkcon_quit unless check_var('DESKTOP', 'textmode');

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -23,7 +23,7 @@ use bootloader_setup qw(add_custom_grub_entries add_grub_cmdline_settings);
 use main_ltp qw(get_ltp_tag loadtest_from_runtest_file);
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
-use serial_terminal 'add_serial_console';
+use serial_terminal 'prepare_serial_console';
 use upload_system_log;
 use version_utils qw(is_jeos is_opensuse is_released is_sle);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x is_x86_64);
@@ -312,11 +312,7 @@ sub run {
         $self->wait_boot;
     }
 
-    # poo#18980
-    if (get_var('OFW') && !check_var('VIRTIO_CONSOLE', 0)) {
-        select_console('root-console');
-        add_serial_console('hvc1');
-    }
+    prepare_serial_console;
 
     $self->select_serial_terminal;
 


### PR DESCRIPTION
Better handling serial console dependencies on ppc64le
- Related ticket: none, but see old tickets:
  - poo#18860 Enable console on hvc0 on SLES < 12-SP2                 
  - poo#44699 Enable console on hvc1 to fix login issues on ppc64le  
- Needles: N/A
- Verification run: 
  - sle-15-SP2-Online-containers_basic@ppc64le https://openqa.suse.de/tests/4318072
  - sle-15-SP2-Online-wicked_advanced_sut@ppc64le https://openqa.suse.de/tests/4318065
  - sle-15-SP2-Online-ppc64le-Build205.1-wicked_advanced_ref@ppc64le https://openqa.suse.de/tests/4318064
  - sle-15-SP2-Online-create_hdd_autoyast_wicked@aarch64 https://openqa.suse.de/tests/4318077
  - sle-15-SP2-Online-create_hdd_autoyast_wicked@ppc64le https://openqa.suse.de/tests/4318073
  - sle-12-SP2-Server-DVD-Incidents-Kernel-install_ltp@ppc64le-virtio https://openqa.suse.de/tests/4318069
  - sle-15-SP2-Online-install_ltp@s390x-kvm-sle15 https://openqa.suse.de/tests/4318067
  -  opensuse-Tumbleweed-install_ltp@ppc64le https://openqa.opensuse.org/tests/1289383
  - sle-12-SP3-Server-DVD-Incidents-Kernel-install_ltp@ppc64le-virtio https://openqa.suse.de/tests/4318070