### PR TITLE
Removes the wait_screen_change from select_filesystem

### DIFF
--- a/lib/Installation/Partitioner/FormattingOptionsPage.pm
+++ b/lib/Installation/Partitioner/FormattingOptionsPage.pm
@@ -85,10 +85,8 @@ sub select_filesystem {
     return if $skip;
     assert_screen(FORMATTING_OPTIONS_PAGE);
     send_key($self->{filesystem_shortcut});
-    wait_screen_change(sub {
-            send_key 'end';
-    }, 20);
-    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up');
+    send_key 'end', wait_screen_change => 1;
+    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up', 20, 5);
 }
 
 # Mounting Options


### PR DESCRIPTION
Increase the timeout of the send_key_until_needlematch is one thing                                                                                                                                                                          
that does not really made any difference IMO. I removed the wait_screen_change                                                                                                                                                               
because the send_key does this internal anyway

- Related ticket: https://progress.opensuse.org/issues/67384
- Verification run: [@svirt-xen-pv](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%23poo67384_fs_selection_issue&distri=sle&version=15-SP2)