### PR TITLE
cleanup_needles: Fix ternary operator evaluation

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -33,7 +33,7 @@ sub cleanup_needles {
     for my $distri (qw(opensuse microos)) {
         unregister_needle_tags("ENV-DISTRI-$distri") unless check_var('DISTRI', $distri);
     }
-    unregister_needle_tags('ENV-LIVECD-' . get_var('LIVECD') ? 0 : 1);
+    unregister_needle_tags('ENV-LIVECD-' . (get_var('LIVECD') ? 0 : 1));
     for my $wm (qw(mate lxqt enlightenment awesome)) {
         remove_desktop_needles($wm) unless check_var('DE_PATTERN', $wm);
     }


### PR DESCRIPTION
?: (ternary operator) has lower preference than . (string concatenation), thus it must be wrapped in brackets.

man perlop is your friend :)

Fixes: ad30e6b02 ("main_common: Simplify some conditions")

- Related ticket: N/A
- Needles: N/A
- Verification run: 
  - old run http://quasar.suse.cz/tests/5294/file/autoinst-log.txt has
`Use of uninitialized value in concatenation (.) or string at /var/lib/openqa/share/tests/opensuse/products/opensuse/main.pm line 36.`
  - fixed run http://quasar.suse.cz/tests/5295/file/autoinst-log.txt doesn't have it