### PR TITLE
[virt_autotest] fix up issue for restore_guests func

### DIFF
--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -52,9 +52,9 @@ sub run_test {
     #Prepare Guests
     foreach my $guest (keys %xen::guests) {
         #Archive deployed Guests
+        #NOTE: Keep Archive deployed Guests for restore_guests func
         assert_script_run("virsh dumpxml $guest > /tmp/$guest.xml");
         upload_logs "/tmp/$guest.xml";
-        assert_script_run("rm -rf /tmp/$guest.xml");
         #Start installed Guests
         assert_script_run("virsh start $guest", 60);
         #Wait for forceful boot up guests


### PR DESCRIPTION
Refer to test results from the latest osd_dev, there was automation issue for restore_guests func

Root Cause: 
Delete the Archive deployed Guests under libvirt_virtual_network_init, which do block restore_guests func to define guest from Archive deployed Guests. 

- Verification run: 
[sles15sp2 guest on sles15sp2 host KVM](https://openqa.nue.suse.com/tests/4322661)

