### PR TITLE
Add restart to workaround bsc#1170014

### DIFF
--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -47,8 +47,13 @@ sub run {
 
     assert_script_run('! ras-mc-ctl --status');
 
+    # Try to start rasdaemon. May need a restart on aarch64.
     systemctl('start rasdaemon');
-    systemctl('is-active rasdaemon');
+    if (systemctl('is-active rasdaemon', ignore_failure => 1)) {
+        systemctl('restart rasdaemon');
+        record_soft_failure('bsc#1170014 rasdaemon service needed to be restarted.');
+        script_retry("systemctl is-active rasdaemon", retry => 9, timeout => 10, delay => 1);
+    }
 
     # Validating output of 'ras-mc-ctl --mainboard'
     my $mainboard_output = script_output('ras-mc-ctl --mainboard');


### PR DESCRIPTION
Restarts daemon on is-active failing. This is a bit suspicious, but I am adding the change as discussed.

- Related ticket: [66424](https://progress.opensuse.org/issues/66424)
- Verification runs: 
  - x86: [12sp2](http://apappas-openqa.qam.suse.de/tests/251) [12sp3](http://apappas-openqa.qam.suse.de/tests/257) [12sp4](http://apappas-openqa.qam.suse.de/tests/261) [12sp5](http://apappas-openqa.qam.suse.de/tests/263) [15sp0](http://apappas-openqa.qam.suse.de/tests/253) [15sp1](http://apappas-openqa.qam.suse.de/tests/259)
  - aarch64: [12sp3](https://openqa.suse.de/t4322681) [12sp4](https://openqa.suse.de/t4322679) [12sp5]( https://openqa.suse.de/t4322680) [15sp0](https://openqa.suse.de/tests/4322682) [15sp1](https://openqa.suse.de/tests/4322678)
The SLE12 runs on aarch64 are failing due to SCC error. SLE15 runs pass and show that the restart is successful.