### PR TITLE
Containers: fix autoyast installation for s390x

### DIFF
--- a/schedule/containers/create_hdd_autoyast.yaml
+++ b/schedule/containers/create_hdd_autoyast.yaml
@@ -1,11 +1,25 @@
 ---
 name: create_hdd_autoyast
+description:    >
+    Maintainer: qa-c@suse.de.
+    HDD creation for container tests in product QA
 vars:
-  AUTOYAST: autoyast_sle15/autoyast_containers_%ARCH%.xml
-  HDDSIZEGB: 30
+    AUTOYAST: autoyast_sle15/autoyast_containers_%ARCH%.xml
+    HDDSIZEGB: 30
+conditional_schedule:
+    grub_set_bootargs:
+        ARCH:
+            's390x':
+                - shutdown/grub_set_bootargs
+    svirt_upload_assets:
+        ARCH:
+            's390x':
+                - shutdown/svirt_upload_assets
 schedule:
-  - autoyast/prepare_profile
-  - installation/bootloader_start
-  - autoyast/installation
-  - shutdown/cleanup_before_shutdown
-  - shutdown/shutdown
+    - autoyast/prepare_profile
+    - installation/bootloader_start
+    - autoyast/installation
+    - '{{grub_set_bootargs}}'
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown
+    - '{{svirt_upload_assets}}'


### PR DESCRIPTION
Before, the test was passing but not publishing the qcow2

- Related ticket: https://progress.opensuse.org/issues/66583
- Verification runs:
aarch64: https://openqa.suse.de/tests/4323693
ppc64le: https://openqa.suse.de/tests/4323616
s390x: https://openqa.suse.de/tests/4323421
x86_64: https://openqa.suse.de/tests/4323614
