### PR TITLE
Revert console connection to serial terminal for git test

### DIFF
--- a/tests/console/git.pm
+++ b/tests/console/git.pm
@@ -25,9 +25,10 @@ use testapi;
 use utils qw(zypper_call);
 
 sub run {
-    select_console "root-console";
     my $username = $testapi::username;
     my $email    = "you\@example.com";
+    my $self     = shift;
+    $self->select_serial_terminal;
 
     # Create a test repo
     zypper_call("in git-core");


### PR DESCRIPTION
As per PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10434
It is not so nice to change the test logic which is already there without getting approved with original contributor.  and at the same time, we found another workaround to by pass the issue via modifying the test suite configuration.  So I created this new PR to revert the change for git test

- Related ticket: https://progress.opensuse.org/issues/67801
- Needles:N/A
- Verification run: http://openqa.nue.suse.com/tests/4322918#
