### PR TITLE
Add a check for non-deletion of snapshots in transactional

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -31,7 +31,22 @@ our @EXPORT = qw(
   trup_call
   trup_install
   trup_shell
+  get_utt_packages
 );
+
+# Download files needed for transactional update tests
+sub get_utt_packages {
+    # CaaSP needs an additional repo for testing
+    assert_script_run 'curl -O ' . data_url("caasp/utt.repo") unless is_opensuse;
+
+    # Different testfiles for SLE (CaaSP) and openSUSE (Kubic)
+    my $tarball = 'utt-';
+    $tarball .= is_opensuse() ? 'opensuse' : 'sle';
+    $tarball .= '-' . get_required_var('ARCH') . '.tgz';
+
+    assert_script_run 'curl -O ' . data_url("caasp/$tarball");
+    assert_script_run "tar xzvf $tarball";
+}
 
 sub process_reboot {
     my $trigger = shift // 0;

--- a/schedule/yast/transactional_server/transactional_server_snapper.yaml
+++ b/schedule/yast/transactional_server/transactional_server_snapper.yaml
@@ -22,6 +22,7 @@ schedule:
   - console/consoletest_setup
   - console/hostname
   - console/snapper_create_from
+  - transactional/verify_undelete_snapshots
 test_data:
   snapshots:
     - description: 'Snapshot with read-write'

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -22,19 +22,6 @@ use version_utils qw(is_caasp is_staging is_opensuse is_leap);
 use transactional;
 use utils;
 
-# Download files needed for transactional update test
-sub get_utt_packages {
-    # CaaSP needs an additional repo for testing
-    assert_script_run 'curl -O ' . data_url("caasp/utt.repo") unless is_opensuse;
-
-    # Different testfiles for SLE (CaaSP) and openSUSE (Kubic)
-    my $tarball = 'utt-';
-    $tarball .= is_opensuse() ? 'opensuse' : 'sle';
-    $tarball .= '-' . get_required_var('ARCH') . '.tgz';
-
-    assert_script_run 'curl -O ' . data_url("caasp/$tarball");
-    assert_script_run "tar xzvf $tarball";
-}
 
 =head2 check_package
 

--- a/tests/transactional/verify_undelete_snapshots.pm
+++ b/tests/transactional/verify_undelete_snapshots.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that essential snapshots cannot be deleted, see https://jira.suse.com/browse/SLE-3804
+# Maintainer: QA SLE Functional YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use transactional qw(rpmver get_utt_packages trup_call);
+use Test::Assert 'assert_equals';
+
+# Verify that essential snapshots cannot be deleted, see https://jira.suse.com/browse/SLE-3804
+sub run {
+    select_console 'root-console';
+
+    my @snapshots_before = split /\n/, script_output('snapper list --disable-used-space');
+    my $current_snapshot_before;
+    foreach (@snapshots_before) {
+        if ($_ =~ /(?<current_snapshot_before>^\d+)\*/) {
+            $current_snapshot_before = $+{current_snapshot_before};
+            last;
+        }
+    }
+
+    # Create some snapshots with a transactional update snapshot in the middle.
+    record_info "Check undel", "Snapshot #1 - Check that essential snapshots cannot be deleted, 
+                                creates snapshots and installs a package";
+    assert_script_run("snapper create -d \"Disposable snapshot #1\"");
+    get_utt_packages;
+    trup_call "ptf install" . rpmver('security');
+    my $last_snapshot_number = script_output("snapper create -p -d \"Disposable snapshot #2\"");
+
+    my @snapshots_after_update = split /\n/, script_output('snapper list --disable-used-space');
+    my $next_snap_after_update;
+    my $current_snap_after_update;
+    foreach (@snapshots_after_update) {
+        $current_snap_after_update = $+{current_snap} if ($_ =~ /(?<current_snap>^\d+)\-/);
+        $next_snap_after_update    = $+{next_snap}    if ($_ =~ /(?<next_snap>^\d+)\+/);
+    }
+    die('Current snapshot was not marked with -') unless $current_snap_after_update;
+    die('New snapshot not marked with +')         unless $next_snap_after_update;
+    assert_equals($current_snapshot_before, $current_snap_after_update, "Current snapshot number should not change after update");
+
+    my $delete_response = script_output("snapper delete 0-$last_snapshot_number 2>&1");
+    unless ($delete_response =~ /^.*0.*current system\..*$current_snap_after_update.*currently mounted.*\..*$next_snap_after_update.*next to be mounted.*\./s) {
+        die("Unexpected response from snapper delete:\n$delete_response\n");
+    }
+
+    my @snapshots_after = split /\n/, script_output('snapper list --disable-used-space');
+    # number of lines for 3 snapshots +header
+    my $output_lines = 5;
+    die("Incorrect number of snapshots after deletion") if (@snapshots_after != $output_lines);
+}
+
+1;


### PR DESCRIPTION
See https://jira.suse.com/browse/SLE-3804 : for transactional updates, we create a snapshot where we install packages/updates then reboot to it. This snapshot has to be protected as reboot can be planned later, eg after some more timeline snapshots and automatic cleanups.
According to snapper's manpage, "Snapshot 0 cannot be deleted. For btrfs the currently mounted snapshot and the snapshot that will be mounted next time (the btrfs default subvolume) can also not be deleted."
This change verifies it.

- Related tickets: 
https://progress.opensuse.org/issues/43883
- Needles: N/A
- Verification run:
http://waaa-amazing.suse.cz/tests/12381

