### PR TITLE
wireguard: Use virtio console

### DIFF
--- a/tests/network/wireguard.pm
+++ b/tests/network/wireguard.pm
@@ -21,7 +21,9 @@ use lockapi;
 use mmapi 'wait_for_children';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+
+    $self->select_serial_terminal;
     barrier_wait 'SETUP_DONE';
 
     my ($vpn_local, $vpn_remote, $remote);


### PR DESCRIPTION
For ppc64le it'd require some additional setup (see doc at `select_serial_terminal()`), but that's not run atm.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/4324985 (failed due poo#67816, but serial console is working)