### PR TITLE
Fix detect_unused_modules when file is renamed or removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,9 @@ perlcritic: tools/lib/
 .PHONY: test-unused-modules-changed
 test-unused-modules-changed:
 	@echo "[make] Unused modules check called over modified/new files only. For a full run use make test-unused-modules-full"
-	tools/detect_unused_modules -m `git diff --name-only --diff-filter=d $$(git merge-base master HEAD) | grep '^tests/*'`
-	tools/detect_unused_modules -m `git diff --unified=0 $$(git merge-base master HEAD) products/* | grep -oP "^-.*loadtest.*[\"']\K[^\"'].+(?=[\"'])"`
-	tools/detect_unused_modules -m `git diff --unified=0 $$(git merge-base master HEAD) schedule/* | grep -oP "^-\s+- [\"']?\K.*(?=[\"']?)" | grep -v '{{'`
+	tools/detect_unused_modules -m `git --no-pager diff --name-only --diff-filter=d $$(git merge-base master HEAD) | grep '^tests/*'`
+	tools/detect_unused_modules -m `git --no-pager diff --unified=0 $$(git merge-base master HEAD) products/* | grep -oP "^-.*loadtest.*[\"']\K[^\"'].+(?=[\"'])"`
+	tools/detect_unused_modules -m `git --no-pager diff --unified=0 $$(git merge-base master HEAD) schedule/* | grep -oP "^-\s+- [\"']?\K.*(?=[\"']?)" | grep -v '{{'`
 
 .PHONY: test-unused-modules
 test-unused-modules:

--- a/tools/detect_unused_modules
+++ b/tools/detect_unused_modules
@@ -36,6 +36,10 @@ while [ "$#" -gt 0 ]; do
 done
 
 for test in $MODULES ; do
+    # Don't check non-existing modules it as it was either renamed or removed
+    if [ -z `git ls-files "*$test*"` ]; then
+        continue
+    fi
     t=$(basename $test | sed -e 's@\.pm$@@')
     t_dir=$(dirname $test | sed -e 's@tests/\(.*\)$@\1@')
     git grep -E "(- $t_dir/$t|loadtest.*$t|load_testdir.*$t_dir|^use (base )?\"?$t\"?)" | grep -qv ".(pm|yaml):\s*#" || echo "$test module is not used in any schedule"


### PR DESCRIPTION
Script throws false negatives if module was removed from the schedule
and renamed or completely removed. To avoid this, we now check if file
exists before reporting it as unused module.
