### PR TITLE
Stabilize KDE live installation on aarch64

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -68,7 +68,7 @@ sub handle_livecd_screenlock {
             send_key 'tab';
             send_key 'ret';
         }
-        last unless check_screen qw(screenlock blackscreen), 20;
+        last unless check_screen([qw(screenlock blackscreen)], 20);
         die "Failed to unlock screen within multiple retries" if $_ == $retries;
     }
     save_screenshot;

--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -48,7 +48,7 @@ sub run {
         assert_and_click 'live-upgrade';
     }
     else {
-        assert_and_click 'live-installation';
+        x11_start_program('xdg-su -c "/usr/sbin/start-install.sh"', target_match => 'maximize');
     }
     assert_and_click 'maximize';
     mouse_hide;


### PR DESCRIPTION
The PR adds the required steps to stabilize Tumbleweed installation using Live CD on aarch64.

Changes introduced:
1. live_installation test module sporadically failed on aarch64 because when clicking on "Installation" icon on Desktop, the mouse button was hold too long and popup appeared instead of opening the application. The PR changes the click with `x11_start_program`, which also allows to open the app but without relying on click;
2. await_install failed because black screen appeared after some time without activity. The PR just adjusts the existing approach with mouse moving from time to time. As shown from 4 verification runs, this is effective and fixes the issue;
3. Legacy `sub handle_livecd_screenlock` seems to be not effective with the current product, but it is still left (maybe temporary), just to not broke existing tests that potentially may use it (e.g. on x64). Though, the way how `check_screen` is used here was changed. As previously it used array in function arguments instead of arrayref, that is required by function definition;
4. Also, `QEMURAM=4096` `QEMUCPUS=4` `TIMEOUT_SCALE=4` were added to Test Suite settings.

- Related ticket: https://progress.opensuse.org/issues/66355
- Verification runs:
https://openqa.opensuse.org/tests/1293429
https://openqa.opensuse.org/tests/1293430
https://openqa.opensuse.org/tests/1293431
https://openqa.opensuse.org/tests/1293432
