### PR TITLE
Containers: Create autoyast HDD with btrfs instead of ext4

### DIFF
--- a/data/autoyast_sle15/autoyast_containers_aarch64.xml
+++ b/data/autoyast_sle15/autoyast_containers_aarch64.xml
@@ -86,7 +86,7 @@
         <partition>
           <mountby config:type="symbol">device</mountby>
           <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">ext4</filesystem>
+          <filesystem config:type="symbol">btrfs</filesystem>
           <format config:type="boolean">true</format>
           <fstopt>defaults</fstopt>
           <mount>/</mount>

--- a/data/autoyast_sle15/autoyast_containers_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_containers_ppc64le.xml
@@ -99,7 +99,7 @@
         <partition>
           <mountby config:type="symbol">device</mountby>
           <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">ext4</filesystem>
+          <filesystem config:type="symbol">btrfs</filesystem>
           <format config:type="boolean">true</format>
           <fstopt>defaults</fstopt>
           <mount>/</mount>

--- a/data/autoyast_sle15/autoyast_containers_s390x.xml
+++ b/data/autoyast_sle15/autoyast_containers_s390x.xml
@@ -104,6 +104,26 @@
       </script>
     </chroot-scripts>
   </scripts>
+  <partitioning config:type="list">
+   <drive>
+     <device>/dev/disk/by-path/ccw-0.0.0000</device>
+     <disklabel>gpt</disklabel>
+     <initialize config:type="boolean">true</initialize>
+     <partitions config:type="list">
+       <partition>
+         <mountby config:type="symbol">device</mountby>
+         <filesystem config:type="symbol">swap</filesystem>
+         <mount>swap</mount>
+       </partition>
+       <partition>
+         <mountby config:type="symbol">device</mountby>
+         <filesystem config:type="symbol">btrfs</filesystem>
+         <mount>/</mount>
+       </partition>
+     </partitions>
+     <use>all</use>
+   </drive>
+ </partitioning>
   <software>
     <products config:type="list">
       <product>SLES</product>

--- a/data/autoyast_sle15/autoyast_containers_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_containers_x86_64.xml
@@ -75,7 +75,7 @@
         </partition>
         <partition>
           <mountby config:type="symbol">device</mountby>
-          <filesystem config:type="symbol">ext4</filesystem>
+          <filesystem config:type="symbol">btrfs</filesystem>
           <mount>/</mount>
         </partition>
       </partitions>


### PR DESCRIPTION
We got the requirement or recommendation to test base container
on btrfs from developers. This will allow us some extended
docker features.

- Related ticket: https://progress.opensuse.org/issues/66583
- Verification runs:
x86_64:    https://openqa.suse.de/tests/4326151#step/installation/4
aarch64:  https://openqa.suse.de/tests/4326149#step/installation/5
ppc64le:  https://openqa.suse.de/tests/4326139#step/installation/5
s390x:     https://openqa.suse.de/tests/4330467#