### PR TITLE
[virt_autotest] Fix host_bridge_virtual_network failure

### DIFF
--- a/data/virt_autotest/vm_host_bridge_final.sh
+++ b/data/virt_autotest/vm_host_bridge_final.sh
@@ -8,7 +8,7 @@ echo -e $interface >/etc/sysconfig/network/ifcfg-$ACTIVE_NET
 cat /etc/sysconfig/network/ifcfg-$ACTIVE_NET
 rm -rf /etc/sysconfig/network/ifcfg-$BRIDGE_INF*
 if [[ $VERSION_ID =~ '11' ]]; then
-    service libvirtd restart
+    service network restart
 else
     systemctl restart network.service
 fi

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -62,7 +62,7 @@ sub run_test {
 
         assert_script_run("virsh attach-interface $guest network vnet_isolated --model $model --mac $mac --live $affecter", 60);
 
-        my $net = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen') && is_sle('=11-sp4')) ? 'netfront' : 'vnet_isolated';
+        my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_isolated';
         test_network_interface($guest, mac => $mac, gate => $gate, isolated => 1, net => $net);
 
         assert_script_run("virsh detach-interface $guest --mac $mac $exclusive");
@@ -74,6 +74,9 @@ sub run_test {
 
     #Restore Guest systems
     virt_autotest::virtual_network_utils::restore_guests();
+
+    #After finished all virtual network test, need to restore file /etc/hosts from backup
+    virt_autotest::virtual_network_utils::hosts_restore();
 
     #Skip restart network service due to bsc#1166570
     #Restart network service

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -64,7 +64,8 @@ sub run_test {
 
         assert_script_run("virsh attach-interface $guest network vnet_nated --model $model --mac $mac --live $affecter", 60);
 
-        test_network_interface($guest, mac => $mac, gate => $gate, net => "vnet_nated");
+        my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_nated';
+        test_network_interface($guest, mac => $mac, gate => $gate, net => $net);
 
         assert_script_run("virsh detach-interface $guest --mac $mac $exclusive");
     }

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -89,9 +89,9 @@ sub run_test {
 
         #Wait for guests attached interface from virtual routed network
         sleep 30;
-        my $net1 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed';
+        my $net1 = is_sle('=11-sp4') ? 'br123' : 'vnet_routed';
         test_network_interface("$guest", mac => $mac1, gate => $gate1, routed => 1, target => $target1, net => $net1);
-        my $net2 = (is_sle('=11-sp4') && (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen'))) ? 'netfront' : 'vnet_routed_clone';
+        my $net2 = is_sle('=11-sp4') ? 'br123' : 'vnet_routed_clone';
         test_network_interface("$guest.clone", mac => $mac2, gate => $gate2, routed => 1, target => $target2, net => $net2);
 
         assert_script_run("virsh detach-interface $guest --mac $mac1 $exclusive");

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,11 +37,18 @@ use version_utils 'is_sle';
 sub run_test {
     my ($self) = @_;
 
+    #Need to reset up environemt - br123 for virt_atuo test due to after
+    #finished guest installation to trigger cleanup step on sles11sp4 vm hosts
+    virt_autotest::virtual_network_utils::restore_standalone() if (is_sle('=11-sp4'));
+
     #Enable libvirt debug log
     virt_autotest::virtual_network_utils::enable_libvirt_log();
 
     #VM HOST SSH SETUP
     virt_autotest::virtual_network_utils::ssh_setup();
+
+    #Backup file /etc/hosts before virtual network testing
+    virt_autotest::virtual_network_utils::hosts_backup();
 
     #Install required packages
     zypper_call '-t in iproute2 iptables iputils bind-utils sshpass nmap';


### PR DESCRIPTION
Refer to the osd results about virtual network on sles11sp4 host, figure out the following different both local worker and osd worker:

- After finished guest installation on osd sles11sp4 worker successfully , there will be trigger cleanup script on sles11sp4 vm host due to boot up guest without br123 virtual network interface issue 

- There was not created br0 host bridge as default on osd s11sp4 worker

This PR do some enhancement to support virtual network on sles11sp4 vm hosts.

Verification run:
guest sles15sp2 on host sles11sp4 kvm
http://10.67.19.82/tests/600

guest sles15sp2 on host sles11sp4 xen
http://10.67.19.82/tests/595

guest sles15sp2 on host sles15sp2 kvm
http://10.67.19.82/tests/601

guest sles15sp2 on host sles15sp2 xen
http://10.67.19.82/tests/597
