### PR TITLE
userspace_nfs_v4: Increase timeout for tar archive

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -130,7 +130,7 @@ sub run {
 
     # Upload test logs
     my $tarball = "/tmp/qaset.tar.bz2";
-    assert_script_run("tar cjf '$tarball' -C '/var/log/' 'qaset'");
+    assert_script_run("tar cjf '$tarball' -C '/var/log/' 'qaset'", timeout => 300);
     upload_logs($tarball, timeout => 600);
     my $log = $self->system_status();
     upload_logs($log, timeout => 100);


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4324108#step/userspace_nfs_v4/61
- Verification run:
http://10.100.12.155/tests/16069
http://10.100.12.155/tests/16070
http://10.100.12.155/tests/16071