### PR TITLE
Remove yast2_network _settings from yast2_gui@s390x

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -71,6 +71,5 @@ conditional_schedule:
                 - yast2_gui/yast2_users
                 - yast2_gui/yast2_datetime
                 - yast2_gui/yast2_hostnames
-                - yast2_gui/yast2_network_settings
                 - yast2_gui/yast2_lan_restart_bridge
                 - yast2_gui/yast2_lan_restart_vlan


### PR DESCRIPTION
The module is failing for the particular arch. Removing until we get into coverage extension of the test suite.