### PR TITLE
Increase needle yast2-sw_single-ui match timeout 

### DIFF
--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -19,7 +19,7 @@ use testapi;
 sub run {
     my $self = shift;
     select_console 'x11';
-    $self->launch_yast2_module_x11('sw_single', match_timeout => 25);
+    $self->launch_yast2_module_x11('sw_single', match_timeout => 50);
     # Accept => Exit, or get to the installation report
     send_key 'alt-a';
     # Installation may take some time


### PR DESCRIPTION
There is a failure here:
https://openqa.suse.de/tests/4330913#step/yast2_software_management/9
because of the short timeout.