### PR TITLE
Remove deprecated wireguard-kmp-default and check wireguard kernel module

### DIFF
--- a/tests/network/wireguard.pm
+++ b/tests/network/wireguard.pm
@@ -37,7 +37,10 @@ sub run {
         $remote     = '10.0.2.101';
     }
 
-    zypper_call 'in wireguard-kmp-default wireguard-tools';
+    assert_script_run 'grep -i CONFIG_WIREGUARD /boot/config-$(uname -r)';
+    assert_script_run 'modinfo wireguard';
+
+    zypper_call 'in wireguard-tools';
 
     assert_script_run 'which wg';
     assert_script_run 'umask 077';


### PR DESCRIPTION
Hello,

as I was notified by @pevik the `wireguard-kmp-default` package is no longer present and should be removed.
Luckily, we have the `wireguard` kernel module already included so I am now checking it's availability.

- Verification run: [Tumbleweed](http://pdostal-server.suse.cz/tests/8885)
