### PR TITLE
Increase again timeout for yast2-sw_single-ui needle match

### DIFF
--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -19,7 +19,7 @@ use testapi;
 sub run {
     my $self = shift;
     select_console 'x11';
-    $self->launch_yast2_module_x11('sw_single', match_timeout => 50);
+    $self->launch_yast2_module_x11('sw_single', match_timeout => 100);
     # Accept => Exit, or get to the installation report
     send_key 'alt-a';
     # Installation may take some time


### PR DESCRIPTION
Increased timeout to 100
VR: https://openqa.suse.de/tests/4332900#details