### PR TITLE
Use wait_still_screen for reliable wait before typing password

### DIFF
--- a/tests/smt/smt_server_install.pm
+++ b/tests/smt/smt_server_install.pm
@@ -52,7 +52,8 @@ sub run {
     wait_screen_change { send_key "alt-t" };
     assert_screen "smt-test-succ";
     wait_screen_change { send_key "ret" };
-    wait_screen_change { send_key "alt-n" };
+    send_key "alt-n";
+    wait_still_screen(2);
 
     wait_screen_change { send_key "alt-d" };
     type_string "susetest";


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4331182#step/smt_server_install/20
- Verification run: 