### PR TITLE
Remove yast2_lan_restart_bridge from yast2_gui@s390x

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -71,5 +71,4 @@ conditional_schedule:
                 - yast2_gui/yast2_users
                 - yast2_gui/yast2_datetime
                 - yast2_gui/yast2_hostnames
-                - yast2_gui/yast2_lan_restart_bridge
                 - yast2_gui/yast2_lan_restart_vlan


### PR DESCRIPTION
The s390x is full of surprising failures that were not occurring during VRs. Another module removed from schedule "yast2_lan_restart_bridge"