### PR TITLE
Containers: pre-install packages during autoyast hdd creation

### DIFF
--- a/data/autoyast_sle15/autoyast_containers_aarch64.xml
+++ b/data/autoyast_sle15/autoyast_containers_aarch64.xml
@@ -102,6 +102,12 @@
     <install_recommended config:type="boolean">true</install_recommended>
     <packages config:type="list">
       <package>iputils</package>
+      <package>runc</package>
+      <package>docker</package>
+      <package>docker-runc</package>
+      <package>zypper-docker</package>
+      <package>podman</package>
+      <package>podman-cni-config</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/autoyast_sle15/autoyast_containers_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_containers_ppc64le.xml
@@ -116,10 +116,12 @@
     <install_recommended config:type="boolean">true</install_recommended>
     <packages config:type="list">
       <package>iputils</package>
-      <package>sles-release</package>
-      <package>sle-module-server-applications-release</package>
-      <package>sle-module-development-tools-release</package>
-      <package>sle-module-basesystem-release</package>
+      <package>runc</package>
+      <package>docker</package>
+      <package>docker-runc</package>
+      <package>zypper-docker</package>
+      <package>podman</package>
+      <package>podman-cni-config</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/autoyast_sle15/autoyast_containers_s390x.xml
+++ b/data/autoyast_sle15/autoyast_containers_s390x.xml
@@ -131,10 +131,12 @@
     <install_recommended config:type="boolean">true</install_recommended>
     <packages config:type="list">
       <package>iputils</package>
-      <package>sles-release</package>
-      <package>sle-module-server-applications-release</package>
-      <package>sle-module-development-tools-release</package>
-      <package>sle-module-basesystem-release</package>
+      <package>runc</package>
+      <package>docker</package>
+      <package>docker-runc</package>
+      <package>zypper-docker</package>
+      <package>podman</package>
+      <package>podman-cni-config</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/autoyast_sle15/autoyast_containers_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_containers_x86_64.xml
@@ -89,10 +89,12 @@
     <install_recommended config:type="boolean">true</install_recommended>
     <packages config:type="list">
       <package>iputils</package>
-      <package>sles-release</package>
-      <package>sle-module-server-applications-release</package>
-      <package>sle-module-development-tools-release</package>
-      <package>sle-module-basesystem-release</package>
+      <package>runc</package>
+      <package>docker</package>
+      <package>docker-runc</package>
+      <package>zypper-docker</package>
+      <package>podman</package>
+      <package>podman-cni-config</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>


### PR DESCRIPTION
Save some time during the tests and to catch package installation errors before hand.

- Related ticket: https://progress.opensuse.org/issues/66583
- Verification runs: 

aarch64  https://openqa.suse.de/tests/4335056
ppc64le  https://openqa.suse.de/tests/4335055
s390x     https://openqa.suse.de/tests/4335054
x86_64   https://openqa.suse.de/tests/4335053

 
