### PR TITLE
Include podman in foreign container test

### DIFF
--- a/tests/console/container_base_images.pm
+++ b/tests/console/container_base_images.pm
@@ -9,6 +9,7 @@
 
 # Summary: Pull and test several base images (alpine, openSUSE, debian, ubuntu, fedora, centos) for their base functionality
 #          Log the test results in container_base_images.txt
+#          Docker or Podman tests can be skipped by setting SKIP_DOCKER_IMAGE_TESTS=1 or SKIP_PODMAN_IMAGE_TESTS=1 in the job
 # Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
 
 use base 'consoletest';
@@ -18,38 +19,53 @@ use testapi;
 use utils;
 use version_utils;
 use containers::common;
+use registration;
+
+sub skip_docker {
+    return check_var("SKIP_DOCKER_IMAGE_TESTS", 1);
+}
+
+sub skip_podman {
+    return ((is_sle and !is_sle('>=15-sp1')) or check_var("SKIP_PODMAN_IMAGE_TESTS", 1));
+}
+
+sub run_image_tests {
+    my $engine = shift;
+    my @images = @_;
+    foreach my $image (@images) {
+        test_container_image($image, 'latest', $engine);
+        script_run("echo 'OK: $engine - $image:latest' >> /var/tmp/container_base_images_log.txt");
+    }
+}
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
-    # Define general test images. Add your docker- or podman-only images here as well if needed
-    my @images        = ('alpine', 'opensuse/leap', 'opensuse/tumbleweed', 'debian', 'ubuntu', 'centos', 'fedora');
-    my @docker_images = ();                                                                                           # Add Docker-only images here
-    my @podman_images = ();                                                                                           # Add Podman-only images here
+    # Define test images here
+    my @docker_images = ('alpine', 'opensuse/leap', 'opensuse/tumbleweed', 'debian', 'ubuntu', 'centos', 'fedora');
+    my @podman_images = ('alpine', 'opensuse/leap', 'opensuse/tumbleweed', 'debian', 'ubuntu', 'centos', 'fedora');
 
     script_run('echo "Container base image tests:" > /var/tmp/container_base_images_log.txt');
     # Run docker tests
-    if (check_var("SKIP_DOCKER_IMAGE_TESTS", 1)) {
+    if (skip_docker) {
         record_info("Skip Docker", "Docker image tests skipped");
         script_run("echo 'INFO: Docker image tests skipped' >> /var/tmp/container_base_images_log.txt");
     } else {
         install_docker_when_needed();
-        foreach my $image (@images, @docker_images) {
-            test_container_image($image, 'latest', 'docker');
-            script_run("echo 'OK: docker - $image:latest' >> /var/tmp/container_base_images_log.txt");
-        }
+        run_image_tests('docker', @docker_images);
         clean_docker_host();
     }
     # Run podman tests
-    if (is_sle || check_var("SKIP_PODMAN_IMAGE_TESTS", 1)) {
+    if (skip_podman) {
         record_info("Skip Podman", "Podman image tests skipped");
         script_run("echo 'INFO: Podman image tests skipped' >> /var/tmp/container_base_images_log.txt");
     } else {
-        zypper_call('in podman podman-cni-config', timeout => 900);
-        foreach my $image (@images, @podman_images) {
-            test_container_image($image, 'latest', 'podman');
-            script_run("echo 'OK: podman - $image:latest' >> /var/tmp/container_base_images_log.txt");
+        # In SLE we need to add the Containers module
+        if (is_sle) {
+            add_suseconnect_product(get_addon_fullname('contm'));
         }
+        zypper_call('in podman podman-cni-config', timeout => 900);
+        run_image_tests('podman', @podman_images);
     }
 }
 
@@ -60,6 +76,9 @@ sub cleanup {
     } else {
         upload_logs("logs.txt");
         script_run("rm logs.txt");
+    }
+    if (!skip_podman and is_sle) {
+        remove_suseconnect_product(get_addon_fullname('contm'));
     }
 }
 


### PR DESCRIPTION
Adds podman to container_base_image test module for SLE.

- Related ticket: https://progress.opensuse.org/issues/67873
- Needles: -
- Verification run: [SLE15-SP1](http://openqa.suse.de/t4335032) | [SLE15](http://openqa.suse.de/t4335033) | [SLE12-SP5](http://openqa.suse.de/t4334984) | [SLE12-SP4](http://openqa.suse.de/t4335034) | [SLE12-SP3](http://openqa.suse.de/t4335035) | [Leap 15.2](http://openqa.opensuse.org/t1295086) | [Tumbleweed](http://openqa.opensuse.org/t1295085)
