### PR TITLE
Modify product name to sle_hpc to remove LTSS for SLEHPC

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -106,7 +106,7 @@ sub remove_ltss {
     if (get_var('SCC_ADDONS', '') =~ /ltss/) {
         my $scc_addons = get_var_array('SCC_ADDONS');
         record_info 'remove ltss', 'got all updates from ltss channel, now remove ltss and drop it from SCC_ADDONS before migration';
-        if (check_var('SLE_PRODUCT', 'hpc')) {
+        if (check_var('SLE_PRODUCT', 'sle_hpc')) {
             remove_suseconnect_product('SLE_HPC-LTSS');
         } elsif (is_sle('15+') && check_var('SLE_PRODUCT', 'sles')) {
             remove_suseconnect_product('SLES-LTSS');


### PR DESCRIPTION
The hpc product name is wrong. In openQA flavor the product name is sle_hpc, need to modify it to sle_hpc in code too. Otherwise, it would go wrong when removing SLE_HPC_LTSS before migration.

- Related ticket: https://progress.opensuse.org/issues/67843
- Verification run: 
  - https://openqa.nue.suse.com/tests/4334958#step/zypper_patch/9
  - https://openqa.nue.suse.com/tests/4334959#step/patch_sle/116
  - https://openqa.nue.suse.com/tests/4334972#step/patch_sle/77
  - https://openqa.nue.suse.com/tests/4334971#step/patch_sle/132
