### PR TITLE
Remove yast2_restart _vlan from  yast2_gui@s390x

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -71,4 +71,3 @@ conditional_schedule:
                 - yast2_gui/yast2_users
                 - yast2_gui/yast2_datetime
                 - yast2_gui/yast2_hostnames
-                - yast2_gui/yast2_lan_restart_vlan


### PR DESCRIPTION
Failure of module  due to request of re-login to Gnome after yast2 module is closed:
https://openqa.suse.de/tests/4333403