### PR TITLE
Small public cloud fices - timeouts, debug output, logs in place

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -207,7 +207,7 @@ sub ssh_add_suseconnect_product {
     $arch    //= '${CPU}';
     $params  //= '';
     $retry   //= 0;                 # run SUSEConnect a 2nd time to workaround the gpg error due to missing repo key on 1st run
-    $timeout //= 180;
+    $timeout //= 300;
 
     my $result = script_run("ssh $remote sudo SUSEConnect -p $name/$version/$arch $params", $timeout);
     if ($result != 0 && $retry) {

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -27,6 +27,7 @@ sub run {
 
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) unless get_var('MAINT_TEST_REPO');
     my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
+    assert_script_run('touch /tmp/repos.list.txt');
 
     my $ret = 0;
     for my $maintrepo (@repos) {

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -24,7 +24,7 @@ sub run {
     my ($self, $args) = @_;
     select_console 'root-console';
 
-    assert_script_run("hostname -f");
+    script_run("hostname -f");
     assert_script_run("uname -a");
 
     assert_script_run("cat /etc/os-release");
@@ -49,6 +49,9 @@ sub run {
     assert_script_run("rpm -qa > /tmp/rpm.list.txt");
     upload_logs('/tmp/rpm.list.txt');
     upload_logs('/var/log/zypper.log');
+
+    assert_script_run("SUSEConnect --status-text");
+    zypper_call("lr");
 }
 
 1;

--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -26,7 +26,7 @@ sub run {
 
     select_console 'tunnel-console';
 
-    $args->{my_instance}->run_ssh_command(cmd => "sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'), timeout => 180) unless (get_var('FLAVOR') =~ 'On-Demand');
+    $args->{my_instance}->run_ssh_command(cmd => "sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'), timeout => 420) unless (get_var('FLAVOR') =~ 'On-Demand');
 
     for my $addon (@addons) {
         if (is_sle('<15') && $addon =~ /tcm|wsm|contm|asmm|pcm/) {


### PR DESCRIPTION
Hello, here is what I did:
 * Increased SCC registration command timeout
 * Ensured `/tmp/repos.list.txt` even when no repos are transfered
 * Executed `SUSEConnect --status-text` and `zypper lr` for debugging purposes

- Verification run: [GCE](http://pdostal-server.suse.cz/tests/8892) [AZURE](http://pdostal-server.suse.cz/tests/8875) [EC2](http://pdostal-server.suse.cz/tests/8873)
