### PR TITLE
container_base_images: Do not manupulate with SLE modules and remove post_* modules

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -123,6 +123,7 @@ sub test_container_image {
     assert_script_run("$runtime container create --name '$container' '$image' /bin/sh -c '$smoketest'");
     assert_script_run("$runtime container start '$container'");
     assert_script_run("$runtime container logs '$container' > '/var/tmp/container_$container'");
+    assert_script_run("$runtime wait '$container'", 90);
     assert_script_run("$runtime container rm '$container'");
     assert_script_run("grep \"`uname -r`\" '/var/tmp/container_$container'");
     assert_script_run("grep \"Heartbeat from $image\" '/var/tmp/container_$container'");


### PR DESCRIPTION
This is a fix of #10465:

- Related ticket: [poo#67978](https://progress.opensuse.org/issues/67978)
- Verification run: [SLE 12 SP3](http://pdostal-server.suse.cz/tests/8918) [SLE 12 SP4](http://pdostal-server.suse.cz/tests/8924#) [SLE 12 SP5](http://pdostal-server.suse.cz/tests/8920#) [SLE 15 SP1](http://pdostal-server.suse.cz/tests/8894) [openSUSE Leap 15.2](http://pdostal-server.suse.cz/tests/8921)
