### PR TITLE
Make help menu check in firefox test more robust

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -26,18 +26,8 @@ sub run() {
 
     $self->start_firefox;
     wait_still_screen;
-    # we have poor performance on LIVETEST, use assert_and_click here
-    if (is_tumbleweed && get_var("LIVETEST")) {
-        send_key_until_needlematch('firefox-help-menu', 'alt', 4, 10);    # show menu bar
-        assert_and_click 'firefox-help-menu';
-        assert_and_click 'firefox-help-about';
-    }
-    else {
-        send_key "alt-h";
-        assert_screen 'firefox-help-menu';
-        send_key "a";
-    }
-    assert_screen 'test-firefox-3';
+    send_key_until_needlematch('firefox-help-menu', 'alt-h', 5, 6);
+    send_key_until_needlematch('test-firefox-3',    'a',     5, 6);
 
     # close About
     send_key "alt-f4";


### PR DESCRIPTION
- Fail:
https://progress.opensuse.org/issues/63892
https://openqa.opensuse.org/tests/1296708#step/firefox/10
https://openqa.opensuse.org/tests/1295857#step/firefox/20
https://openqa.opensuse.org/tests/1296447#step/firefox/10
https://openqa.opensuse.org/tests/1296819#step/firefox/10
https://openqa.opensuse.org/tests/1296568
- Verification run:
http://10.100.12.155/tests/16093 TW
https://openqa.opensuse.org/tests/1296971
https://openqa.opensuse.org/tests/1297025
https://openqa.opensuse.org/tests/1296973
https://openqa.opensuse.org/tests/1296975
https://openqa.opensuse.org/tests/1297043 ppc64le
15-SP2
https://openqa.suse.de/tests/4340124 x86_64
https://openqa.suse.de/tests/4340125 ppc64le
https://openqa.suse.de/tests/4340126 s390x
https://openqa.suse.de/tests/4340127 aarch64