### PR TITLE
smt: Increase timeout for smt-repos -m

### DIFF
--- a/tests/smt/smt_server_install.pm
+++ b/tests/smt/smt_server_install.pm
@@ -142,7 +142,7 @@ sub run {
 
     validate_script_output "SUSEConnect --status", sub { m/"identifier":"SLES","version":"12\.5","arch":"x86_64","status":"Registered"/ };
     assert_script_run "smt-repos -o";
-    validate_script_output "smt-repos -m", sub { m/SLES12-SP5-Updates/ };
+    validate_script_output "smt-repos -m", sub { m/SLES12-SP5-Updates/ }, timeout => 200;
 
     assert_script_run "smt-repos -e SLES12-SP5-Updates sle-12-x86_64";
     assert_script_run "smt-repos -e SLES12-SP5-Pool sle-12-x86_64";


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4339004#step/smt_server_install/38
- Verification run: just timeout no need for VR, it's new untested smt test ...
