### PR TITLE
Add validation of yast2 NIS configuration functionality

### DIFF
--- a/schedule/yast/nis/nis_client.yaml
+++ b/schedule/yast/nis/nis_client.yaml
@@ -5,3 +5,7 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - x11/nis_client
+  - x11/nis_client_validate
+test_data:
+  nis_domain: nis.openqa.suse.de
+  username: nis_user

--- a/schedule/yast/nis/nis_server_sle.yaml
+++ b/schedule/yast/nis/nis_server_sle.yaml
@@ -5,5 +5,22 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - x11/nis_server
+  - x11/nis_server_validate
 test_data:
   maps: 11
+  nis_domain: nis.openqa.suse.de
+  nfs_domain: nfs.openqa.suse.de
+  username: nis_user
+  password: nots3cr3t
+  map_names:
+    - auto
+    - ethers
+    - group
+    - hosts
+    - netgroup
+    - networks
+    - passwd
+    - protocols
+    - rpc
+    - services
+    - shadow

--- a/schedule/yast/nis/nis_server_tw.yaml
+++ b/schedule/yast/nis/nis_server_tw.yaml
@@ -5,5 +5,19 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - x11/nis_server
+  - x11/nis_server_validate
 test_data:
   maps: 8
+  nis_domain: nis.openqa.suse.de
+  nfs_domain: nfs.openqa.suse.de
+  username: nis_user
+  password: nots3cr3t
+  map_names:
+    - auto
+    - group
+    - hosts
+    - netgroup
+    - passwd
+    - printcap
+    - rpc
+    - shadow

--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -15,7 +15,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
-use lockapi 'mutex_lock';
+use lockapi;
 use utils;
 use version_utils 'is_opensuse';
 use mm_network 'setup_static_mm_network';
@@ -121,15 +121,15 @@ sub run {
     # we have to stop the firewall, see bsc#999873 and bsc#1083487#c36
     systemctl 'stop ' . $self->firewall;
 
-    mutex_lock('nis_ready');    # wait for NIS server setup
+    mutex_wait('nis_nfs_server_ready');    # wait for server setup
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nis');
     setup_nis_client($server_ip);
-    mutex_lock('nfs_ready');    # wait for NFS server setup
     nfs_settings_tab();
     nfs_shares_tab($server_ip);
     wait_serial("$module_name-0", 360) || die "'yast2 nis client' didn't finish";
     setup_verification();
-    type_string "killall xterm\n";    # game over -> xterm
+    mutex_create('nis_nfs_client_ready');
+    type_string "killall xterm\n";         # game over -> xterm
 }
 
 1;

--- a/tests/x11/nis_client_validate.pm
+++ b/tests/x11/nis_client_validate.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate YaST configuration functionality for NIS
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_suite_data';
+use lockapi 'mutex_wait';
+use x11utils 'turn_off_gnome_screensaver';
+use utils 'systemctl';
+
+sub run {
+    my ($self) = @_;
+    my $test_data = get_test_suite_data();
+
+    x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
+    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
+    become_root;
+
+    assert_script_run "ls /etc/yp.conf",              fail_message => "File /etc/yp.conf doesn't exist";
+    assert_script_run "grep \"ypserv\" /etc/yp.conf", fail_message => "\"ypserv\" was not found in /etc/yp.conf";
+    assert_script_run "grep \"$test_data->{nis_domain}\" /etc/defaultdomain",
+      fail_message => "\"$test_data->{nis_domain}\" was not found in /etc/defaultdomain";
+    mutex_wait('nis_user_ready');
+    assert_script_run "ypmatch $test_data->{username} passwd",
+      fail_message => "New nis user is not visible from NIS client";
+    # In order for the client to use nis users, nscd needs to be restarted.
+    systemctl "restart nscd";
+    assert_script_run "grep -r netgroup /etc/nsswitch.conf | grep nis",
+      fail_message => "nsswitch.conf was not modified properly by NIS configuration";
+    assert_script_run "su - $test_data->{username} -c 'pwd | grep $test_data->{username}'",
+      fail_message => "Home directory of new NIS user is not the expected one";
+    assert_script_run "su - $test_data->{username} -c 'echo \"nis works\" > some_random_file'",
+      fail_message => "Cannot write in home directory of new NIS user from NIS client";
+    assert_script_run "su - $test_data->{username} -c 'grep \"nis works\" some_random_file'",
+      fail_message => "Failed to verify writability to home directory of new NIS user from NIS client";
+    type_string "killall xterm\n";
+}
+
+1;

--- a/tests/x11/nis_server_validate.pm
+++ b/tests/x11/nis_server_validate.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate YaST configuration functionality for NIS
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_suite_data';
+use lockapi 'mutex_create';
+use x11utils 'turn_off_gnome_screensaver';
+use mmapi 'wait_for_children';
+
+sub run {
+    my ($self) = @_;
+    my $test_data = get_test_suite_data();
+
+    x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
+    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
+    become_root;
+
+    assert_script_run "grep \"$test_data->{nfs_domain}\" /etc/idmapd.conf",
+      fail_message => "Nfs domain was not found in idmapd.conf";
+    assert_script_run "grep \"$test_data->{nis_domain}\" /etc/defaultdomain",
+      fail_message => "Nis domain was not found in defaultdomain";
+    foreach my $map (@{$test_data->{map_names}}) {
+        assert_script_run "find /var/yp/$test_data->{nis_domain}/ -name $map*",
+          fail_message => "$map was not found in /var/yp/$test_data->{nis_domain}/";
+    }
+    assert_script_run "useradd $test_data->{username} -p $test_data->{password}",
+      fail_message => "Failed to add user $test_data->{username}";
+    assert_script_run "cd /var/yp/",
+      fail_message => "Failed to switch to directory /var/yp/";
+    assert_script_run "make",
+      fail_message => "Failed to make Makefile in /var/yp/";
+    assert_script_run "chown $test_data->{username}:users /home/$test_data->{username}/",
+      fail_message => "Failed to change ownership of /home/$test_data->{username}/";
+    mutex_create('nis_user_ready');
+    wait_for_children;
+    type_string "killall xterm\n";
+}
+
+1;


### PR DESCRIPTION
For multi-machine NIS test (nis_server, nis_client) validation modules are added that verify the NIS functionality.

- Related ticket: https://progress.opensuse.org/issues/67126
- SLE VRs: 
    - server - > https://openqa.suse.de/tests/4383987
      client  - > https://openqa.suse.de/tests/4383988

- opesuse VRs: 
    - server - > https://openqa.opensuse.org/tests/1307284
       client - > https://openqa.opensuse.org/tests/1307285
