### PR TITLE
Containers: move SLE base image specific test to a new section

### DIFF
--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -14,7 +14,15 @@ conditional_schedule:
                 - installation/bootloader_svirt
             'svirt-xen-hvm':
                 - installation/bootloader_svirt
-    docker_base_images:
+    podman_image:
+        DISTRI:
+            'opensuse':
+                - containers/podman_image
+    docker_image:
+        DISTRI:
+            'opensuse':
+                - containers/docker_image
+    container_base_images:
         DISTRI:
             'opensuse':
                 - containers/container_base_images
@@ -26,11 +34,11 @@ schedule:
     - '{{bootloader}}'
     - boot/boot_to_desktop
     - containers/podman
-    - containers/podman_image
+    - '{{podman_image}}'
     - containers/docker
     - containers/docker_runc
-    - containers/docker_image
-    - '{{docker_base_images}}'
+    - '{{docker_image}}'
+    - '{{container_base_images}}'
     - '{{docker_compose}}'
     - containers/zypper_docker
     - console/coredump_collect

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -1,0 +1,21 @@
+name:           sle_image_on_sle_host
+description:    >
+    Maintainer: jalausuch@suse.com, qa-c@suse.de.
+    Extra tests about software in containers module
+conditional_schedule:
+    bootloader:
+        ARCH:
+            'aarch64':
+                - boot/uefi_bootmenu
+            's390x':
+                - installation/bootloader_zkvm
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - containers/podman_image
+    - containers/docker_image


### PR DESCRIPTION
`docker_image` and `podman_image` are testing the SLE base image.
This schedule separates the other test covering other images from the PM requirements we have to test SLE base image.

