### PR TITLE
Clean up after packman testing

### DIFF
--- a/tests/console/sqlite3.pm
+++ b/tests/console/sqlite3.pm
@@ -28,7 +28,7 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    zypper_call('install sqlite3 expect');
+    zypper_call('install sqlite3 expect perl');
 
     my $archive = "sqlite3-tests.data";
     assert_script_run(


### PR DESCRIPTION
- Related ticket: [[qac][JeOS] test fails in gpg - configure gpg-agent to use dialog](https://progress.opensuse.org/issues/67999)
- Verification runs: 
   * [tw](http://kepler.suse.cz/tests/550#)
   * [sle15.2](http://kepler.suse.cz/tests/549)
   * [leap15.2](http://kepler.suse.cz/tests/551)
   * [lp15.1](http://kepler.suse.cz/tests/548)
   * [aarch64 sle](https://openqa.suse.de/tests/4351050#)
   * [ppc](https://openqa.suse.de/tests/4351058#)
   * [s390x](https://openqa.suse.de/tests/4351061)