### PR TITLE
Add basic Workload Memory Protection test for SLES for SAP Applications with SAP HANA

### DIFF
--- a/data/sles4sap/sap.slice
+++ b/data/sles4sap/sap.slice
@@ -1,0 +1,2 @@
+[Service]
+Slice=sap.slice

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -18,6 +18,7 @@ use utils 'zypper_call';
 
 our @EXPORT = qw(
   $instance_password
+  $systemd_cgls_cmd
   ensure_serialdev_permissions_for_sap
   fix_path
   set_ps_cmd
@@ -44,6 +45,7 @@ our $sid;
 our $instance;
 our $ps_cmd;
 our $instance_password = get_var('INSTANCE_PASSWORD', 'Qwerty_123');
+our $systemd_cgls_cmd  = 'systemd-cgls --no-pager -u sap.slice';
 
 =head2 ensure_serialdev_permissions_for_sap
 
@@ -109,7 +111,7 @@ sub user_change {
     # We need to change the 'serial_term_prompt' value for 'wait_serial'
     my $serial_term_prompt = "$sapadmin> ";
     type_string(qq/PS1="$serial_term_prompt"\n/);
-    wait_serial(qr/PS1="$serial_term_prompt"/);
+    wait_serial(qr/PS1="$serial_term_prompt"/) if testapi::is_serial_terminal;
     $testapi::distri->{serial_term_prompt} = "$serial_term_prompt";
 }
 

--- a/schedule/sles4sap/sles4sap_wmp_hana_node1.yaml
+++ b/schedule/sles4sap/sles4sap_wmp_hana_node1.yaml
@@ -1,0 +1,45 @@
+---
+name: sles4sap_wmp_hana_node1
+description: >
+  SAP HANA and HanaSR test on SLES for SAP Applications with Workload Memory Protection
+vars:
+  AUTOMATED_REGISTER: 'false'
+  BOOT_HDD_IMAGE: '1'
+  DM_NEEDS_USERNAME: '1'
+  HA_CLUSTER: '1'
+  HA_CLUSTER_INIT: '1'
+  HDDSIZEGB_2: '131'
+  HDD_SCC_REGISTERED: '1'
+  HOSTNAME: '%CLUSTER_NAME%-node01'
+  INSTANCE_ID: '00'
+  INSTANCE_IP_CIDR: '10.0.2.200/24'
+  INSTANCE_SID: HA1
+  INSTANCE_TYPE: HDB
+  NUMDISKS: '2'
+  QEMU_DISABLE_SNAPSHOTS: '1'
+  TIMEOUT_SCALE: '3'
+  USE_SUPPORT_SERVER: '1'
+  VIRTIO_CONSOLE: '0'
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - sles4sap/patterns
+  - sles4sap/hana_install
+  - sles4sap/wmp_setup
+  - ha/ha_cluster_init
+  - sles4sap/hana_cluster
+  - sles4sap/sap_suse_cluster_connector
+  - sles4sap/wmp_basic_test
+  - ha/fencing
+  - boot/boot_to_desktop
+  - ha/check_after_reboot
+  - ha/check_logs
+  - sles4sap/wmp_basic_test

--- a/schedule/sles4sap/sles4sap_wmp_hana_node1.yaml
+++ b/schedule/sles4sap/sles4sap_wmp_hana_node1.yaml
@@ -20,6 +20,7 @@ vars:
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
   VIRTIO_CONSOLE: '0'
+  WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop
   - ha/wait_barriers

--- a/schedule/sles4sap/sles4sap_wmp_hana_node2.yaml
+++ b/schedule/sles4sap/sles4sap_wmp_hana_node2.yaml
@@ -1,0 +1,43 @@
+---
+name: sles4sap_wmp_hana_node2
+description: >
+  SAP HANA and HanaSR test on SLES for SAP Applications with Workload Memory Protection
+vars:
+  AUTOMATED_REGISTER: 'false'
+  BOOT_HDD_IMAGE: '1'
+  DM_NEEDS_USERNAME: '1'
+  HA_CLUSTER: '1'
+  HA_CLUSTER_JOIN: '%CLUSTER_NAME%-node01'
+  HDDSIZEGB_2: '131'
+  HDD_SCC_REGISTERED: '1'
+  HOSTNAME: '%CLUSTER_NAME%-node02'
+  INSTANCE_ID: '00'
+  INSTANCE_IP_CIDR: '10.0.2.200/24'
+  INSTANCE_SID: HA1
+  INSTANCE_TYPE: HDB
+  NUMDISKS: '2'
+  QEMU_DISABLE_SNAPSHOTS: '1'
+  TIMEOUT_SCALE: '3'
+  USE_SUPPORT_SERVER: '1'
+  VIRTIO_CONSOLE: '0'
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - sles4sap/patterns
+  - sles4sap/hana_install
+  - sles4sap/wmp_setup
+  - ha/ha_cluster_join
+  - sles4sap/hana_cluster
+  - sles4sap/wmp_basic_test
+  - ha/fencing
+  - ha/check_after_reboot
+  - ha/check_logs
+  - sles4sap/wmp_basic_test

--- a/schedule/sles4sap/sles4sap_wmp_hana_node2.yaml
+++ b/schedule/sles4sap/sles4sap_wmp_hana_node2.yaml
@@ -20,6 +20,7 @@ vars:
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
   VIRTIO_CONSOLE: '0'
+  WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop
   - ha/wait_barriers

--- a/tests/sles4sap/wmp_basic_test.pm
+++ b/tests/sles4sap/wmp_basic_test.pm
@@ -1,0 +1,75 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run Workload Memory Protection basic test
+# Maintainer: Alvaro Carvajal <acarvajal@suse.de>
+
+use base "sles4sap";
+use testapi;
+use utils qw(zypper_call file_content_replace);
+use version_utils qw(is_sle);
+use strict;
+use warnings;
+
+sub run {
+    my ($self)     = @_;
+    my $testname   = 'wmp_basic_tests';
+    my $logdir     = '/root/wmp_logs';
+    my $sapsvc     = '/usr/sap/sapservices';
+    my @testphases = qw(initial takeover takeback);
+
+    # WMP is a feature of SLES for SAP Applications 15+. Skip test in older systems
+    if (is_sle('<15')) {
+        record_info 'WMP', 'WMP is only available in SLES for SAP Applications 15+';
+        return;
+    }
+
+    # Download python test script in HOME directory only if it has not been downloaded before
+    if (script_run "ls -d /root/$testname") {
+        assert_script_run 'cd /root';
+        my $wmp_test_repo = "https://gitlab.suse.de/lpalovsky/$testname/-/archive/master/$testname-master.tar.gz";
+        my $ret           = script_run "curl -k $wmp_test_repo | tar -zxvf -";
+        record_info 'Download failed', "Could not download $testname script", result => 'fail' unless (defined $ret and $ret == 0);
+        assert_script_run "mv -i $testname-master $testname";
+        zypper_call 'in python3-psutil python3-PyYAML';
+        file_content_replace("/root/$testname/config/config.yml", '^log_path: .*' => "log_path: '$logdir/'",
+            '^sapservices_path: .*' => "sapservices_path: '$sapsvc'");
+    }
+
+    # Run script
+    my $current_test = get_var('WMP_PHASE', $testphases[0]);
+    $current_test = $testphases[0] unless (grep /^$current_test$/, @testphases);
+    type_string "cd /root/$testname\n";
+    my $out = script_output "python3 check_process.py -n $current_test 2>&1";
+    die "$testname failed with error [$out]" if ($out =~ /ERROR:/);
+    my ($index) = grep { $testphases[$_] eq $current_test } (0 .. $#testphases);
+    $index = ($index == $#testphases) ? $#testphases : ($index + 1);
+    set_var('WMP_PHASE', $testphases[$index]);
+    type_string "cd -\n";
+
+    # Upload results
+    assert_script_run "tar -zcvf /tmp/$current_test.tar.gz $logdir/*$current_test*";
+    upload_logs("/tmp/$current_test.tar.gz", failok => 1);
+    # Check results file for current test was created and then upload its results
+    assert_script_run "ls $logdir/*_$current_test.results";
+    # Wrap ls output with extra characters so we can get actual filename with a regexp
+    my $results = script_output "echo \"FILE=`ls $logdir/*_$current_test.results`\"";
+    $results =~ m/FILE=(.+)_$current_test.results/;
+    $results = "${1}_${current_test}.results";
+    parse_extra_log(IPA => $results);
+
+    # Check sap.slice
+    assert_script_run $sles4sap::systemd_cgls_cmd;
+}
+
+sub test_flags {
+    return {milestone => 1};
+}
+
+1;

--- a/tests/sles4sap/wmp_setup.pm
+++ b/tests/sles4sap/wmp_setup.pm
@@ -1,0 +1,73 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Prepare system for Workload Memory Protection basic test
+# Maintainer: Alvaro Carvajal <acarvajal@suse.de>
+
+use base "sles4sap";
+use testapi;
+use utils qw(zypper_call);
+use Utils::Systemd qw(systemctl);
+use version_utils qw(is_sle);
+use bootloader_setup qw(add_grub_cmdline_settings);
+use hacluster qw(get_hostname);
+use strict;
+use warnings;
+
+sub run {
+    my ($self) = @_;
+
+    # WMP is a feature of SLES for SAP Applications 15+. Skip test in older systems
+    if (is_sle('<15')) {
+        record_info 'WMP', 'WMP is only available in SLES for SAP Applications 15+';
+        return;
+    }
+
+    # Install sapwmp package
+    zypper_call 'in sapwmp';
+
+    # Create slice cgroup
+    my $systemd_path  = '/etc/systemd/system';
+    my $sap_slice_cfg = 'sap.slice';
+    assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/$sap_slice_cfg -o /tmp/$sap_slice_cfg";
+    assert_script_run "mv -i /tmp/$sap_slice_cfg $systemd_path/$sap_slice_cfg";
+    assert_script_run "cat $systemd_path/$sap_slice_cfg";
+    systemctl('daemon-reload');
+
+    # Add cgroup capture program to startup profile
+    my $sid         = get_required_var('INSTANCE_SID');
+    my $instance_id = get_required_var('INSTANCE_ID');
+    my $hostname    = get_hostname;
+    my $profile     = "/usr/sap/${sid}/SYS/profile/${sid}_HDB${instance_id}_${hostname}";
+    assert_script_run 'echo "# all programs spawned below will be put in dedicated cgroup" >> ' . $profile;
+    assert_script_run 'echo "Execute_20 = local /usr/lib/sapwmp/sapwmp-capture -a" >> ' . $profile;
+    assert_script_run "tail $profile";
+
+    # Setup cgroup kernel parameter, reboot and verify system boots with parameter configured
+    add_grub_cmdline_settings('systemd.unified_cgroup_hierarchy=1', update_grub => 1);
+    $self->reboot;
+    my $out = script_output 'cat /proc/cmdline';
+    die 'Failed to boot with systemd.unified_cgroup_hierarchy set' unless ($out =~ /systemd\.unified_cgroup_hierarchy\=1/);
+
+    # Start & test HANA installation
+    $self->set_sap_info($sid, $instance_id);
+    $self->set_ps_cmd('HDB');
+    $self->user_change;
+    $self->test_start;
+    $self->reset_user_change;
+
+    # Check sap.slice
+    assert_script_run $sles4sap::systemd_cgls_cmd;
+}
+
+sub test_flags {
+    return {milestone => 1};
+}
+
+1;

--- a/tests/sles4sap/wmp_setup.pm
+++ b/tests/sles4sap/wmp_setup.pm
@@ -57,7 +57,7 @@ sub run {
 
     # Start & test HANA installation
     $self->set_sap_info($sid, $instance_id);
-    $self->set_ps_cmd('HDB');
+    $self->set_ps_cmd(get_required_var('INSTANCE_TYPE'));
     $self->user_change;
     $self->test_start;
     $self->reset_user_change;


### PR DESCRIPTION
This PR adds a Workload Memory Protection basic test using an [external python script](https://gitlab.suse.de/lpalovsky/wmp_basic_tests) on top of the existing HanaSR cluster test for SLES for SAP Applications.

Included are the YAML schedule configuration files.

To add this into a YAML job group configuration, use the following:

```
    - sles4sap_wmp_hana_node01:
        machine: 64bit-sap
        testsuite: '-'
        settings:
          CLUSTER_NAME: hana
          HANA: 'nfs://path/to/hana/%ARCH%'
          HDD_1: 'SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2'
          MAX_JOB_TIME: '20000'
          NICTYPE: tap
          PARALLEL_WITH: sles4sap_wmp_hana_supportserver
          SLE_PRODUCT: sles4sap
          WORKER_CLASS: tap
          YAML_SCHEDULE: schedule/sles4sap/sles4sap_wmp_hana_node1.yaml
    - sles4sap_wmp_hana_node02:
        machine: 64bit-sap
        testsuite: '-'
        settings:
          CLUSTER_NAME: hana
          HANA: 'nfs://path/to/hana/%ARCH%'
          HDD_1: 'SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2'
          MAX_JOB_TIME: '20000'
          NICTYPE: tap
          PARALLEL_WITH: sles4sap_wmp_hana_supportserver
          SLE_PRODUCT: sles4sap
          WORKER_CLASS: tap
          YAML_SCHEDULE: schedule/sles4sap/sles4sap_wmp_hana_node2.yaml
    - sles4sap_wmp_hana_supportserver:
        machine: 64bit-sap
        testsuite: sles4sap_hana_supportserver
        settings:
          MAX_JOB_TIME: '20000'
          QEMUVGA: ''
```

- Related ticket: N/A
- Needles: N/A
- Verification run: [node 1](http://mango.suse.de/tests/2684), [node 2](http://mango.suse.de/tests/2685), [support server](http://mango.suse.de/tests/2683)
