### PR TITLE
Containers: wait a bit after killing container in docker_runc

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -98,6 +98,7 @@ sub test_container_runtime {
     assert_script_run("$runc state test2 | grep running");
     record_info 'Test #9', 'Test: Stop a container';
     assert_script_run("$runc kill test2 KILL");
+    sleep 30;
     assert_script_run("$runc state test2 | grep stopped");
     record_info 'Test #10', 'Test: Delete a container';
     assert_script_run("$runc delete test2");
@@ -130,4 +131,3 @@ sub test_container_image {
 }
 
 1;
-


### PR DESCRIPTION
When running kill and checking for status in an automated way we don't leave enough time for the container to perform the operation and OpenQA raises a false negative.
By waiting a bit seconds, we make sure the container has enough time to be destroyed.


failure: https://openqa.suse.de/tests/4345404#step/docker_runc/13
VR: https://openqa.suse.de/tests/4346798#step/docker_runc/23
