### PR TITLE
Revert "Modify product name to sle_hpc to remove LTSS for SLEHPC"

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -106,7 +106,7 @@ sub remove_ltss {
     if (get_var('SCC_ADDONS', '') =~ /ltss/) {
         my $scc_addons = get_var_array('SCC_ADDONS');
         record_info 'remove ltss', 'got all updates from ltss channel, now remove ltss and drop it from SCC_ADDONS before migration';
-        if (check_var('SLE_PRODUCT', 'sle_hpc')) {
+        if (check_var('SLE_PRODUCT', 'hpc')) {
             remove_suseconnect_product('SLE_HPC-LTSS');
         } elsif (is_sle('15+') && check_var('SLE_PRODUCT', 'sles')) {
             remove_suseconnect_product('SLES-LTSS');


### PR DESCRIPTION
We need set sle_product as hpc.
Reverts os-autoinst/os-autoinst-distri-opensuse#10492  