### PR TITLE
Replace tail to cat for get output of ssh_serial

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -490,7 +490,7 @@ sub init_consoles {
                 hostname => get_required_var('SUT_IP'),
                 password => $testapi::password,
                 user     => 'root',
-                serial   => 'mkfifo /dev/sshserial; tail -fn +1 /dev/sshserial',
+                serial   => 'rm -f /dev/sshserial; mkfifo /dev/sshserial; while true; do cat /dev/sshserial; done',
                 gui      => 1
             });
     }


### PR DESCRIPTION
Testapi::wait_serial: can not get correct msg with pvm_hmc backend, the test result can prove "cat" can handle current scenario but "tail" command not.

- Related ticket: https://progress.opensuse.org/issues/67558
- Needles: na
- Verification run: https://openqa.nue.suse.com/tests/4348934#step/zypper_migration/3
