### PR TITLE
Fix zypper_extend in Tumbleweed JeOS

### DIFF
--- a/tests/console/zypper_extend.pm
+++ b/tests/console/zypper_extend.pm
@@ -104,12 +104,13 @@ sub run {
     zypper_call 'renamerepo "packman" Packman';
 
     #Remove a repository
-    zypper_call 'rr packman';
+    zypper_call 'rr Packman';
 
     #Verify whether all dependencies are fulfilled
     zypper_call 'verify';
 
     #Identify processes and services using deleted files
+    zypper_call 'in lsof';
     zypper_call 'ps';
 
     #List all applicable patches:


### PR DESCRIPTION
Fix zypper_extend in Tumbleweed for aarch64

- Related ticket: https://progress.opensuse.org/issues/67981
- Needles: N/A
- Verification run: [Tumbleweed JeOS](https://openqa.opensuse.org/tests/1301261) [SLE15sp1](http://10.161.229.247/tests/361) [SLE15](http://10.161.229.247/tests/362) [SLE12sp5](http://10.161.229.247/tests/363) [SLE12sp4](http://10.161.229.247/tests/364) [SLE12sp2](http://10.161.229.247/tests/365)
