### PR TITLE
Start installer on Live CD with icon click

### DIFF
--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -25,6 +25,7 @@ use version_utils "is_upgrade";
 use strict;
 use warnings;
 use x11utils 'turn_off_kde_screensaver';
+use Utils::Architectures qw(is_aarch64);
 
 sub send_key_and_wait {
     my ($key, $wait_time) = @_;
@@ -48,7 +49,14 @@ sub run {
         assert_and_click 'live-upgrade';
     }
     else {
-        x11_start_program('xdg-su -c "/usr/sbin/start-install.sh"', target_match => 'maximize');
+        if (is_aarch64) {
+            # On aarch64 there is sporadic issue when "Install" icon is clicked too long,
+            # so that context menu is called instead of opening the wizard.
+            x11_start_program('xdg-su -c "/usr/sbin/start-install.sh"', target_match => 'maximize');
+        }
+        else {
+            assert_and_click 'live-installation';
+        }
     }
     assert_and_click 'maximize';
     mouse_hide;


### PR DESCRIPTION
On all architectures, except aarch64, start Installer Wizard by
clicking on the appropriate icon.

On aarch64 use x11_start_program instead due to sporadic issue when
mouse is hold too long, so that context pop-up is appeared.

The decision to revert the click on icon for other architectures was
made during discussion in PR#10474.

Related ticket: https://progress.opensuse.org/issues/66355
VR: https://openqa.opensuse.org/tests/1301282
