### PR TITLE
Use serial terminal in TPM2 tests

### DIFF
--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_ecdsa_operation.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_ecdsa_operation.pm
@@ -26,7 +26,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # ECDSA operations
     # There is an known issue bsc#1159508

--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_info.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_info.pm
@@ -26,7 +26,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Retrieve the Engine informations
     validate_script_output "openssl engine -t -c tpm2tss", sub {

--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_random_data.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_random_data.pm
@@ -26,7 +26,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Random data
     validate_script_output "openssl rand -engine tpm2tss -hex 10  2>&1", sub { m/engine\s\"tpm2tss\"\sset/ };

--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_rsa_operation.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_rsa_operation.pm
@@ -26,7 +26,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # RSA operations
     # RSA decrypt

--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_self_sign.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_self_sign.pm
@@ -26,7 +26,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Self Signed certificate generate operation
     my $test_dir = "tpm2_engine_self_sign";

--- a/tests/security/tpm2/tpm2_env_setup.pm
+++ b/tests/security/tpm2/tpm2_env_setup.pm
@@ -26,8 +26,8 @@ use utils 'zypper_call';
 use power_action_utils "power_action";
 
 sub run {
-    my ($self) = @_;
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Add user tss, tss is the default user to start tpm2.0 service
     my $user   = "tss";
@@ -56,7 +56,7 @@ EOF
     # Reboot the node to make the changes take effect
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);
-    select_console "root-console";
+    $self->select_serial_terminal;
 
     # Start the emulator
     assert_script_run "su - tss -c '/usr/lib/ibmtss/tpm_server&'";

--- a/tests/security/tpm2/tpm2_tools/tpm2_tools_auth.pm
+++ b/tests/security/tpm2/tpm2_tools/tpm2_tools_auth.pm
@@ -25,7 +25,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Modify authorization for a loadable transient object
     my $test_dir = "tpm2_tools_auth";

--- a/tests/security/tpm2/tpm2_tools/tpm2_tools_encrypt.pm
+++ b/tests/security/tpm2/tpm2_tools/tpm2_tools_encrypt.pm
@@ -25,7 +25,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Write/Read data to/from a Non-Volatile (NV) index
     my $test_dir  = "tpm2_tools_encrypt";

--- a/tests/security/tpm2/tpm2_tools/tpm2_tools_self_contain_tool.pm
+++ b/tests/security/tpm2/tpm2_tools/tpm2_tools_self_contain_tool.pm
@@ -25,7 +25,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Display PCR values
     validate_script_output "systemctl status tpm2-abrmd.service", sub { m/Active:\sactive/ };

--- a/tests/security/tpm2/tpm2_tools/tpm2_tools_sign_verify.pm
+++ b/tests/security/tpm2/tpm2_tools/tpm2_tools_sign_verify.pm
@@ -25,7 +25,8 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # Sign and verify with the TPM using the endorsement hierarchy
     my $test_dir = "tpm2_tools_sign_verify";


### PR DESCRIPTION
They are used just on intel qemu, so we don't have to bother about
ppc64le fixes (using prepare_serial_console, which is needed on old SLES
for QAM + adjusting cmdline ppc64le for s390x).

- Related ticket: N/A
- Needles: N/A
- Verification run: http://quasar.suse.cz/tests/5309 (9 min, vs. 15 min the original setup http://quasar.suse.cz/tests/5306)
