### PR TITLE
Install python2 packages to meet POX requirement

### DIFF
--- a/tests/console/openvswitch_ssl.pm
+++ b/tests/console/openvswitch_ssl.pm
@@ -20,7 +20,7 @@ use utils;
 
 sub run {
     select_console 'root-console';
-    zypper_call('in openvswitch');
+    zypper_call('in python openvswitch');    # Install python2 here since pox scripts need python2
 
     # Start openvswitch service
     systemctl('start openvswitch');


### PR DESCRIPTION
For openvswitch_ssl tests, we use https://github.com/noxrepo/pox/tree/eel/pox for some basic verification run, however, this tool needs python2, however python2 is not installed by default.

Hence creating this PR to install the python2 package to make it work.

- Related ticket: https://progress.opensuse.org/issues/68101
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/4357875
