### PR TITLE
Change yast migration to do migration on powerVM

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -980,6 +980,11 @@ sub wait_boot {
     # shutting down or booting up
     $self->{in_wait_boot} = 1;
 
+    # for powerVM, it need switch console, it need wait longer time to
+    # get grub page. After we get grub page, the workflow will be same
+    # as others
+    $self->wait_grub(bootloader_time => $bootloader_time) if is_pvm;
+
     # Reset the consoles after the reboot: there is no user logged in anywhere
     reset_consoles;
     select_console('sol', await_console => 0) if check_var('BACKEND', 'ipmi');

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -19,6 +19,7 @@ use power_action_utils 'power_action';
 use version_utils qw(is_desktop_installed is_sles4sap);
 use migration;
 use qam;
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -28,6 +29,7 @@ sub run {
     fully_patch_system;
     remove_ltss;
     power_action('reboot', keepconsole => 1, textmode => 1);
+    reconnect_mgmt_console if is_pvm;
 
     # Do not attempt to log into the desktop of a system installed with SLES4SAP
     # being prepared for upgrade, as it does not have an unprivileged user to test


### PR DESCRIPTION
Change yast migration to do migration on powerVM

- Related ticket: https://progress.opensuse.org/issues/64833
- Verification run:  
http://openqa.suse.de/t4358358
http://openqa.suse.de/t4358359