### PR TITLE
Add addon-module-ftp and addon-module-http schedulers

### DIFF
--- a/schedule/yast/addon-module-ftp.yaml
+++ b/schedule/yast/addon-module-ftp.yaml
@@ -1,0 +1,43 @@
+---
+name: addon-module-ftp
+description: |
+  Test verifies that adding addon using ftp works fine.  We just perform installation
+  here. Using HA here, related ticket: https://progress.opensuse.org/issues/25896
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - '{{hostname_inst}}'
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - '{{grub}}'
+  - installation/first_boot
+conditional_schedule:
+  hostname_inst:
+    BACKEND:
+      qemu:
+        - installation/hostname_inst
+      svirt:
+        - installation/hostname_inst
+  grub:
+    BACKEND:
+      qemu:
+        - installation/grub_test
+      svirt:
+        - boot/reconnect_mgmt_console
+      pvm_hmc:
+        - boot/reconnect_mgmt_console
+        - installation/grub_test

--- a/schedule/yast/addon-module-http.yaml
+++ b/schedule/yast/addon-module-http.yaml
@@ -1,0 +1,43 @@
+---
+name: addon-module-http
+description: |
+  Test verifies that adding addon using http works fine. We just perform installation
+  here. Using HA here, related ticket: https://progress.opensuse.org/issues/25896
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - '{{hostname_inst}}'
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - '{{grub}}'
+  - installation/first_boot
+conditional_schedule:
+  hostname_inst:
+    BACKEND:
+      qemu:
+        - installation/hostname_inst
+      svirt:
+        - installation/hostname_inst
+  grub:
+    BACKEND:
+      qemu:
+        - installation/grub_test
+      svirt:
+        - boot/reconnect_mgmt_console
+      pvm_hmc:
+        - boot/reconnect_mgmt_console
+        - installation/grub_test


### PR DESCRIPTION
Create scheduling for archs including hmc-single-disk machine for
powerVM


- Related ticket: https://progress.opensuse.org/issues/67879
- JobGroup: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/211
- Verification run: [summary](https://openqa.suse.de/tests/overview?version=15-SP2&build=b10n1k%2Fos-autoinst-distri-opensuse%2367879_addon_modules&distri=sle)
