### PR TITLE
Deduplicate tests/containers/*_image.pm

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use version_utils;
 
-our @EXPORT = qw(build_container_image build_with_zypper_docker build_with_sle2docker);
+our @EXPORT = qw(build_container_image build_with_zypper_docker build_with_sle2docker test_opensuse_based_image perform_container_diff);
 
 # Build any container image using a basic Dockerfile
 sub build_container_image {
@@ -52,6 +52,67 @@ sub build_with_zypper_docker {
 
 # Build a sle image using sle2docker
 sub build_with_sle2docker {
+}
+
+# Testing openSUSE based images
+sub test_opensuse_based_image {
+    my $image = $_[0];
+    my ($name, $tag) = split(/:/, $image);
+    $tag //= 'latest';
+
+    my $runtime = $_[1] //= "docker";
+
+    my $distri  = $_[2] //= get_required_var("DISTRI");
+    my $version = $_[3] //= get_required_var("VERSION");
+
+    # It is the right version
+    if ($distri eq 'sle') {
+        my $pretty_version = $version =~ s/-SP/ SP/r;
+        validate_script_output("$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'", sub { /PRETTY_NAME="SUSE Linux Enterprise Server $pretty_version"/ });
+
+        if (is_sle('=12-SP3', $version)) {
+            my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect';
+            assert_script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin'";
+        } else {
+            my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
+            assert_script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin -v'";
+            script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lp'", 420;
+            script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lm'", 420;
+        }
+    } else {
+        validate_script_output qq{$runtime container run --rm $image cat /etc/os-release}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
+    }
+    # zypper lr
+    assert_script_run("$runtime run --rm $image zypper lr -s", 120);
+    # zypper ref
+    assert_script_run("$runtime run --name refreshed $image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
+    # Commit the image
+    assert_script_run("$runtime commit refreshed refreshed-image", 120);
+    # Remove it
+    assert_script_run("$runtime rm refreshed", 120);
+    # Verify the image works
+    assert_script_run("$runtime run --rm refreshed-image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
+}
+
+sub perform_container_diff {
+    my $first  = $_[0];
+    my $second = $_[1];
+
+    # The container-diff is available only for x86_64 architecture
+    # The registry.suse.de is not accessible from PC instances
+    return unless check_var('ARCH', 'x86_64');
+
+    zypper_call("install container-diff") if (script_run("which container-diff") != 0);
+
+    # container-diff
+    my $image_file = $first =~ s/\/|:/-/gr;
+    if (script_run("docker pull $second", 600) == 0) {
+        assert_script_run("container-diff diff daemon://$first daemon://$second --type=rpm --type=file --type=history > /tmp/container-diff-$image_file.txt", 300);
+        upload_logs("/tmp/container-diff-$image_file.txt");
+        assert_script_run("docker image rm $second");
+    } else {
+        record_soft_failure("Could not compare $first to $second as $second could not be downloaded");
+    }
 }
 
 1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -85,6 +85,7 @@ our @EXPORT = qw(
   script_run_interactive
   create_btrfs_subvolume
   file_content_replace
+  ensure_ca_certificates_suse_installed
 );
 
 =head1 SYNOPSIS
@@ -1629,4 +1630,21 @@ sub assert_file_content {
     my ($param, $value) = @_;
     assert_script_run("cat $param | grep $value");
 }
+
+=head2 ensure_ca_certificates_suse_installed
+    ensure_ca_certificates_suse_installed();
+
+This functions checks if ca-certificates-suse is installed and if it is not it adds the repository and installs it.
+
+=cut
+
+sub ensure_ca_certificates_suse_installed {
+    return unless is_sle;
+    if (script_run('rpm -qi ca-certificates-suse') == 1) {
+        my $distversion = get_required_var("VERSION") =~ s/-SP/_SP/r;    # 15 -> 15, 15-SP1 -> 15_SP1
+        zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_$distversion/SUSE:CA.repo");
+        zypper_call("in ca-certificates-suse");
+    }
+}
+
 1;

--- a/tests/containers/container_base_images.pm
+++ b/tests/containers/container_base_images.pm
@@ -33,7 +33,7 @@ sub run_image_tests {
     my $engine = shift;
     my @images = @_;
     foreach my $image (@images) {
-        test_container_image($image, 'latest', $engine);
+        test_container_image($image, $engine);
         script_run("echo 'OK: $engine - $image:latest' >> /var/tmp/container_base_images_log.txt");
     }
 }
@@ -63,7 +63,7 @@ sub run {
     } else {
         install_docker_when_needed();
         run_image_tests('docker', @docker_images);
-        clean_docker_host();
+        clean_container_host('docker');
     }
     # Run podman tests
     if (skip_podman) {
@@ -71,8 +71,9 @@ sub run {
         script_run("echo 'INFO: Podman image tests skipped' >> /var/tmp/container_base_images_log.txt");
     } else {
         # In SLE we need to add the Containers module
-        zypper_call('in podman podman-cni-config', timeout => 900);
+        install_podman_when_needed();
         run_image_tests('podman', @podman_images);
+        clean_container_host('podman');
     }
 }
 

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -69,7 +69,7 @@ sub run {
     assert_script_run 'cd';
 
     remove_suseconnect_product(get_addon_fullname('phub')) if is_sle();
-    clean_docker_host();
+    clean_container_host('docker');
 }
 
 sub post_fail_hook {

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -22,6 +22,7 @@ use utils;
 use strict;
 use warnings;
 use containers::common;
+use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_public_cloud);
 
@@ -30,83 +31,27 @@ sub run {
     $self->select_serial_terminal;
 
     my ($image_names, $stable_names) = get_suse_container_urls();
-    my ($plugin, $osversion, $version);
 
     install_docker_when_needed();
 
-    if (is_sle && !is_public_cloud) {
-        # Allow our internal 'insecure' registry
-        assert_script_run("mkdir -p /etc/docker");
-        assert_script_run('cat /etc/docker/daemon.json; true');
-        assert_script_run(
-            'echo "{ \"insecure-registries\" : [\"registry.suse.de\", \"registry.suse.de:443\", \"registry.suse.de:5000\"] }" > /etc/docker/daemon.json');
-        assert_script_run('cat /etc/docker/daemon.json');
-        systemctl('restart docker');
-
-        if (get_var('SCC_DOCKER_IMAGE')) {
-            my $regcode = get_var 'SCC_DOCKER_IMAGE';
-            assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{,.bak}";
-            assert_script_run "echo -ne \"$regcode\" > /etc/zypp/credentials.d/SCCcredentials";
-        }
+    if (is_sle()) {
+        ensure_ca_certificates_suse_installed();
+        allow_registry_suse_de_for_docker();
     }
 
-    if (check_var("ARCH", "x86_64") && !is_public_cloud) {
-        zypper_call("install container-diff");
-    }
+    scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
     for my $i (0 .. $#$image_names) {
-        # Load the image
-        assert_script_run("docker pull $image_names->[$i]", 1000);
-        # Running executables works
-        assert_script_run qq{docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c 'echo "I work" | grep "I work"'};
-        # It is the right version
-        if (is_sle) {
-            $osversion = get_required_var("VERSION") =~ s/-SP/ SP/r;    # 15 -> 15, 15-SP1 -> 15 SP1
-            validate_script_output("docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c 'cat /etc/os-release'", sub { /PRETTY_NAME="SUSE Linux Enterprise Server $osversion"/ });
-
-            if (is_sle('=12-SP3')) {
-                $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect';
-                assert_script_run "docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c '$plugin'";
-            } else {
-                $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
-                assert_script_run "docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c '$plugin -v'";
-                script_run "docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c '$plugin lp'", 420;
-                script_run "docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c '$plugin lm'", 420;
-            }
-        } elsif (is_opensuse) {
-            $version = get_required_var('VERSION');
-            validate_script_output qq{docker container run --rm $image_names->[$i] cat /etc/os-release}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
+        test_container_image($image_names->[$i], 'docker');
+        build_container_image($image_names->[$i], 'docker');
+        test_opensuse_based_image($image_names->[$i], 'docker');
+        if (check_var("ARCH", "x86_64")) {
+            perform_container_diff($image_names->[$i], $stable_names->[$i]);
         }
-        # zypper lr
-        script_retry("docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c 'zypper lr -s'", timeout => 600, delay => 5, retry => 5);
-        # zypper ref
-        script_retry("docker container run --name refreshed --entrypoint '/bin/bash' $image_names->[$i] -c 'zypper -v ref | grep \"All repositories have been refreshed\"'; if [[ \"\$?\" != \"0\" ]]; then docker rm --force refreshed; false; fi", timeout => 600, delay => 5, retry => 5);
-        # Commit the image
-        assert_script_run("docker commit refreshed refreshed-image", 300);
-        # Remove it
-        assert_script_run("docker rm --force refreshed", 120);
-        # Verify the image works
-        script_retry("docker container run --entrypoint '/bin/bash' --rm refreshed-image -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", timeout => 600, delay => 5, retry => 5);
-
-        if (check_var("ARCH", "x86_64") && !is_public_cloud) {
-            # container-diff
-            my $image_file = $image_names->[$i] =~ s/\/|:/-/gr;
-            if (script_run("docker pull $stable_names->[$i]", 600) == 0) {
-                assert_script_run("container-diff diff daemon://$image_names->[$i] daemon://$stable_names->[$i] --type=rpm --type=file --type=history > /tmp/container-diff-$image_file.txt", 300);
-                upload_logs("/tmp/container-diff-$image_file.txt");
-                assert_script_run("docker image rm --force $stable_names->[$i]");
-            }
-            else {
-                record_soft_failure("Could not compare $image_names->[$i] to $stable_names->[$i] as $stable_names->[$i] could not be downloaded");
-            }
-        }
-
-        # Remove the image again to save space
-        assert_script_run("docker image rm --force $image_names->[$i] refreshed-image");
     }
 
-    assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{.bak,}" if (is_sle() && get_var('SCC_DOCKER_IMAGE'));
-    clean_docker_host();
+    scc_restore_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
+    clean_container_host('docker');
 }
 
 1;

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -61,7 +61,7 @@ sub run {
     install_docker_when_needed;
 
     # remove leftover containers and images
-    clean_docker_host();
+    clean_container_host('docker');
 }
 
 1;

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -15,6 +15,8 @@ use testapi;
 use utils;
 use strict;
 use warnings;
+use containers::common;
+use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
@@ -24,53 +26,15 @@ sub run {
 
     my ($image_names, $stable_names) = get_suse_container_urls();
 
-    zypper_call "in podman";
-
-    # If there is no other CNI configured...
-    if (get_var("CNI", "podman") == "podman") {
-        # ... use the minimal podman CNI
-        zypper_call "in podman-cni-config";
-    }
-
-    if (is_leap("=15.1")) {
-        # bsc#1123387
-        zypper_call "in apparmor-parser";
-    }
-
-    if (is_sle() && script_run('rpm -qi ca-certificates-suse') == 1) {
-        my $distversion = get_required_var("VERSION") =~ s/-SP/_SP/r;    # 15 -> 15, 15-SP1 -> 15_SP1
-        zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_$distversion/SUSE:CA.repo");
-        zypper_call("in ca-certificates-suse");
-    }
+    ensure_ca_certificates_suse_installed() if (is_sle());
+    install_podman_when_needed();
 
     for my $i (0 .. $#$image_names) {
-        # Load the image
-        assert_script_run("podman pull $image_names->[$i]", 900);
-        # Running executables works
-        assert_script_run qq{podman run --rm $image_names->[$i] sh -c 'echo "I work" | grep "I work"'};
-        # It is the right version
-        if (is_sle) {
-            my $osversion = get_required_var("VERSION") =~ s/-SP/ SP/r;    # 15 -> 15, 15-SP1 -> 15 SP1
-            validate_script_output("podman run --rm $image_names->[$i] sh -c 'cat /etc/os-release'", sub { /PRETTY_NAME="SUSE Linux Enterprise Server $osversion"/ });
-        }
-        elsif (is_opensuse) {
-            my $version = get_required_var('VERSION');
-            validate_script_output qq{podman run --rm $image_names->[$i] cat /etc/os-release}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
-        }
-        # zypper lr
-        assert_script_run("podman run --rm $image_names->[$i] zypper lr -s", 120);
-        # zypper ref
-        assert_script_run("podman run --name refreshed $image_names->[$i] sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
-        # Commit the image
-        assert_script_run("podman commit refreshed refreshed-image", 120);
-        # Remove it
-        assert_script_run("podman rm --force refreshed", 120);
-        # Verify the image works
-        assert_script_run("podman run --rm refreshed-image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
-
-        # Remove the image again to save space
-        assert_script_run("podman image rm --force $image_names->[$i] refreshed-image");
+        test_container_image($image_names->[$i], 'podman');
+        build_container_image($image_names->[$i], 'podman');
+        test_opensuse_based_image($image_names->[$i], 'podman');
     }
+    clean_container_host('podman');
 }
 
 1;

--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -50,7 +50,7 @@ sub run {
     # apply all the updates to a new_image
     assert_script_run("zypper-docker update --auto-agree-with-licenses $testing_image new_image", timeout => 900);
 
-    clean_docker_host();
+    clean_container_host('docker');
 }
 
 1;


### PR DESCRIPTION
Hello,

the goal is to deduplicate `docker_image.pm` and `podman_image.pm` into a library.

- Related ticket: [poo#68182](https://progress.opensuse.org/issues/68182)
- Verification run:
   * SLE 15.2 [x86_64](https://openqa.suse.de/tests/4369044) [ppc64le](https://openqa.suse.de/tests/4369040)
   * SLE 15.2 image [x86_64](https://openqa.suse.de/tests/4369045) [ppc64le](https://openqa.suse.de/tests/4369041) [aarch64](https://openqa.suse.de/tests/4369039) [s390x](https://openqa.suse.de/tests/4369043)
   * Tumbleweed [x86_64](https://openqa.opensuse.org/tests/1307130) [ppc64le](https://openqa.opensuse.org/tests/1307132) [aarch64](https://openqa.opensuse.org/tests/1307179#)
   * Leap 15.2 [x86_64](https://openqa.opensuse.org/tests/1307142) [aarch64](https://openqa.opensuse.org/tests/1307138)
   * SLE [12.3](http://pdostal-server.suse.cz/tests/9034) [12.4](http://pdostal-server.suse.cz/tests/9035) [12.5](http://pdostal-server.suse.cz/tests/9036) [15](http://pdostal-server.suse.cz/tests/9037) [15.1](http://pdostal-server.suse.cz/tests/9038)
