### PR TITLE
Change test order so as for sshd to work

### DIFF
--- a/schedule/qam/common/qam-security-fips.yml
+++ b/schedule/qam/common/qam-security-fips.yml
@@ -10,10 +10,10 @@ schedule:
 - fips/fips_setup
 - fips/openssl/openssl_pubkey_rsa
 - fips/openssl/openssl_pubkey_dsa
-- fips/openssh/openssh_fips
 - console/sshd
 - console/ssh_pubkey
 - console/ssh_cleanup
+- fips/openssh/openssh_fips
 - console/curl_https
 - console/apache_ssl
 - console/cryptsetup


### PR DESCRIPTION
Change to test order in the schedule yaml file so as for sshd to work

- Related ticket: https://progress.opensuse.org/issues/68149
- Needles: 
- Verification run: 
http://10.67.17.201/tests/1012
