### PR TITLE
Use chained certificates instead of selfsigned in leap WSL testing

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -93,7 +93,7 @@ sub register_via_scc {
     wait_screen_change(sub { send_key 'alt-c' }, 10);
     wait_screen_change { type_string $reg_code, max_interval => 125, wait_screen_change => 2 };
     send_key 'alt-n';
-    assert_screen 'wsl-registration-repository-offer';
+    assert_screen 'wsl-registration-repository-offer', 90;
     send_key 'alt-y';
     assert_screen 'wsl-extension-module-selection';
     send_key 'alt-n';
@@ -101,7 +101,7 @@ sub register_via_scc {
 
 sub run {
     # WSL installation is in progress
-    assert_screen [qw(yast2-wsl-firstboot-welcome wsl-installing-prompt)], 240;
+    assert_screen [qw(yast2-wsl-firstboot-welcome wsl-installing-prompt)], 360;
 
     if (match_has_tag 'yast2-wsl-firstboot-welcome') {
         assert_and_click 'window-max';

--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -23,7 +23,7 @@ use base 'windowsbasetest';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle is_tumbleweed);
+use version_utils qw(is_sle is_opensuse);
 
 my $powershell_cmds = {
     enable_developer_mode =>
@@ -52,7 +52,7 @@ sub run {
     );
     $self->run_in_powershell(cmd => $powershell_cmds->{enable_developer_mode});
 
-    if (is_sle('>=15-sp2') || is_tumbleweed) {
+    if (is_sle('>=15-sp2') || is_opensuse) {
         $self->run_in_powershell(
             cmd => 'Invoke-WebRequest -Uri ' . data_url($certs->{get_required_var('DISTRI')}) . ' -O ' . $cert_file_path . ' -UseBasicParsing',
         );


### PR DESCRIPTION
- Related ticket: [[qac][WSL] leap15.2 certificate issue after pulling images from openSUSE:Leap:15.2:WSL](https://progress.opensuse.org/issues/68197)
- Verification runs: 
  * [opensuse-15.2-WSL-x86_64-Build1.19-wsl-main@uefi_win](http://kepler.suse.cz/tests/590)
  * [sle-15-SP2-WSL-x86_64-Build3.219-wsl-main+register@windows_bios_boot](http://kepler.suse.cz/tests/588)
  * [sle-15-SP2-WSL-x86_64-Build3.219-wsl-main+skip_reg@windows_uefi_boot](http://kepler.suse.cz/tests/589)
