### PR TITLE
Build SLE base container images

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Functionality concerning the testing of container images
+# Maintainer: George Gkioulis <ggkioulis@suse.de>
+
+package containers::container_images;
+
+use base Exporter;
+use Exporter;
+
+use base "consoletest";
+use testapi;
+use utils;
+use strict;
+use warnings;
+use version_utils;
+
+our @EXPORT = qw(build_container_image build_with_zypper_docker build_with_sle2docker);
+
+# Build any container image using a basic Dockerfile
+sub build_container_image {
+    my $image   = shift;
+    my $runtime = shift // "docker";
+
+    my $dir = "/root/sle_base_image/docker_build";
+
+    record_info("Building $image", "Building $image using $runtime");
+
+    assert_script_run("mkdir -p $dir");
+    assert_script_run("cd $dir");
+
+    # Create basic Dockerfile
+    assert_script_run("echo -e 'FROM $image\nENV WORLD_VAR Arda' > Dockerfile");
+
+    # Build the image
+    assert_script_run("$runtime build -t dockerfile_derived .");
+
+    assert_script_run("$runtime run --entrypoint 'printenv' dockerfile_derived WORLD_VAR | grep Arda");
+    assert_script_run("$runtime images");
+}
+
+# Build a sle container image using zypper_docker
+sub build_with_zypper_docker {
+}
+
+# Build a sle image using sle2docker
+sub build_with_sle2docker {
+}
+
+1;


### PR DESCRIPTION
Build derived SLE container image using:
* Dockerfile
* zypper-docker
* sle2docker

Also verify functionality of derived containers.

- Related ticket: https://progress.opensuse.org/issues/66367
- Needles: no needles
- Verification run: [SLE 15 SP1 x86_64](http://angmar.suse.de/tests/2343)
