### PR TITLE
[qam][maint]Fix failed tests of ssh_pubkey, apache_ssl and firefox_nss

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -75,7 +75,8 @@ sub setup_apache2 {
     }
     if ($mode =~ m/SSL|NSS/) {
         assert_script_run "sed -i '/^APACHE_SERVER_FLAGS=/s/^/#/' /etc/sysconfig/apache2";
-        assert_script_run 'echo APACHE_SERVER_FLAGS="SSL" >> /etc/sysconfig/apache2';
+        assert_script_run 'echo APACHE_SERVER_FLAGS=\"SSL\" >> /etc/sysconfig/apache2';
+        assert_script_run "sed -i '/SSLCARevocationFile/a SSLFIPS on' /etc/apache2/ssl-global.conf" if get_var("FIPS_ENABLED");
     }
     # Create x509 certificate for this apache server
     if ($mode eq "SSL") {

--- a/schedule/qam/common/qam-security-fips.yml
+++ b/schedule/qam/common/qam-security-fips.yml
@@ -11,7 +11,6 @@ schedule:
 - fips/openssl/openssl_pubkey_rsa
 - fips/openssl/openssl_pubkey_dsa
 - console/sshd
-- console/ssh_pubkey
 - console/ssh_cleanup
 - fips/openssh/openssh_fips
 - console/curl_https

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -6,13 +6,12 @@
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-#
+
 # Case #1560076 - FIPS: Firefox Mozilla NSS
-#
+
 # Summary: FIPS mozilla-nss test for firefox : firefox_nss
-#
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tag: tc#1744155, poo#47018, poo#58079, poo#65375, poo#67054, poo#67132
+# Tag: poo#47018, poo#58079
 
 use base "x11test";
 use strict;
@@ -46,14 +45,11 @@ sub run {
     assert_screen('firefox-preferences');
 
     # Search "Passwords" section
-    type_string "Passwords";
-    send_key "tab";    # Hide blinking cursor in the search box
+    type_string "Use a";    # Search "Passwords" section
     wait_still_screen 2;
-
-    # Use a master password
-    send_key_until_needlematch("firefox-use-a-master-password", "tab", 20, 1);
-    send_key "spc";
+    send_key "alt-shift-u";    # Use a master password
     assert_screen('firefox-passwd-master_setting');
+
     type_string $fips_password;
     send_key "tab";
     type_string $fips_password;
@@ -61,42 +57,27 @@ sub run {
     assert_screen "firefox-password-change-succeeded";
     send_key "ret";
     wait_still_screen 3;
+
     send_key "ctrl-f";
     send_key "ctrl-a";
-
-    # Search "Certificates" section
-    type_string "certificates";
+    type_string "certificates";    # Search "Certificates" section
     send_key "tab";
     wait_still_screen 2;
 
-    # Device Manager
-    send_key_until_needlematch("firefox-security-devices", "tab", 20, 1);
-    send_key "spc";
+    send_key "alt-shift-d";        # Device Manager
     assert_screen "firefox-device-manager";
 
-    # Enable the FIPS Mode in ENV Mode
-    # FIPS Enabled in Kernel Mode is set by default in Firefox preference
-    if (get_var("FIPS_ENV_MODE")) {
-        send_key_until_needlematch("firefox-enable-fips", "tab", 20, 1);
-        send_key "spc";
-        assert_screen "firefox-confirm-fips_enabled";
-    }
-    else {
-        assert_screen "firefox-device-manager_fips-kernel-mode";
-    }
+    send_key "alt-shift-f";        # Enable FIPS mode
+    assert_screen "firefox-confirm-fips_enabled";
+    send_key "esc";                # Quit device manager
 
-    # Quit device manager
-    send_key "esc";
-
-    # Quit Firefox and back to desktop
     quit_firefox;
     assert_screen "generic-desktop";
 
     # "start_firefox" will be not used, since the master password is
     # required when firefox launching in FIPS mode
-    x11_start_program('firefox --setDefaultBrowser https://html5test.opensuse.org', target_match => 'firefox-fips-password-inputfiled', match_timeout => 360);
+    x11_start_program('firefox --setDefaultBrowser https://html5test.opensuse.org', target_match => 'firefox-fips-password-inputfiled');
     type_string $fips_password;
-    wait_still_screen 2;
     send_key "ret";
     assert_screen "firefox-url-loaded";
 
@@ -106,31 +87,15 @@ sub run {
     send_key "n";
     assert_screen('firefox-preferences');
 
-    # Search "Certificates" section
-    type_string "certificates";
+    type_string "certificates";    # Search "Certificates" section
     send_key "tab";
     wait_still_screen 2;
-
-    # Device Manager
-    send_key_until_needlematch("firefox-security-devices", "tab", 20, 1);
-    send_key "spc";
+    send_key "alt-shift-d";        # Device Manager
     assert_screen "firefox-device-manager";
+    assert_screen "firefox-confirm-fips_enabled";
 
-    # Confirm FIPS Mode is enabled in ENV Mode
-    if (get_var("FIPS_ENV_MODE")) {
-        assert_screen "firefox-confirm-fips_enabled";
-    }
-    else {
-        assert_screen "firefox-device-manager_fips-kernel-mode";
-    }
-
-    # Quit Firefox and back to desktop
     quit_firefox;
     assert_screen "generic-desktop";
-}
-
-sub test_flags {
-    return {fatal => 0};
 }
 
 1;


### PR DESCRIPTION
1. removed ssh_pubkey from schedule as its test is covered by sshd
2. improve apachetest so that apache can start in ssl fips mode
3. Reduce  firefox_nss the number of needle matching action

- Related ticket: https://progress.opensuse.org/issues/68212
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1389
- Verification run: 
sles15sp1: http://10.67.17.201/tests/1016
sles12sp5: http://10.67.17.201/tests/1017
