### PR TITLE
Add module to validate addon repos

### DIFF
--- a/schedule/yast/addon-module-ftp.yaml
+++ b/schedule/yast/addon-module-ftp.yaml
@@ -25,6 +25,10 @@ schedule:
   - installation/reboot_after_installation
   - '{{grub}}'
   - installation/first_boot
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/zypper_ref
+  - console/validate_addon_repos
 conditional_schedule:
   hostname_inst:
     BACKEND:

--- a/schedule/yast/addon-module-http.yaml
+++ b/schedule/yast/addon-module-http.yaml
@@ -25,6 +25,12 @@ schedule:
   - installation/reboot_after_installation
   - '{{grub}}'
   - installation/first_boot
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/zypper_ref
+  - console/validate_addon_repos
 conditional_schedule:
   hostname_inst:
     BACKEND:

--- a/tests/console/validate_addon_repos.pm
+++ b/tests/console/validate_addon_repos.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate that addon repos activated during the installation are
+# properly added and enabled.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'consoletest';
+
+use strict;
+use warnings;
+
+use testapi;
+use repo_tools 'validate_repo_enablement';
+
+sub run {
+    select_console 'root-console';
+
+    for my $addon (split(/,/, get_required_var('ADDONURL'))) {
+        my $uc_addon = uc($addon);
+        my $uri      = get_required_var("ADDONURL_$uc_addon");
+        my $alias    = get_required_var("REPO_SLE_PRODUCT_$uc_addon");
+        my $name     = get_required_var("DISTRI") . "-$addon";
+        validate_repo_enablement(alias => $alias, name => $name, uri => $uri);
+    }
+}
+
+1;

--- a/tests/console/validate_mirror_repos.pm
+++ b/tests/console/validate_mirror_repos.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use Test::Assert ':all';
+use repo_tools 'validate_repo_enablement';
 
 sub run {
     select_console 'root-console';
@@ -23,20 +23,10 @@ sub run {
     my $method     = uc get_required_var('INSTALL_SOURCE');
     my $mirror_src = get_required_var("MIRROR_$method");
     $mirror_src .= '?ssl_verify=no' if ($method eq 'HTTPS');
-
-    my $output   = script_output('zypper lr --uri');
     my $sle_prod = uc get_var('SLE_PRODUCT') . get_var('VERSION');
-    $output =~ /
-        \d\s+\|                 # #
-        \s+$sle_prod.*\s+\|     # Alias
-        \s+$sle_prod.*\s+\|     # Name
-        \s+Yes\s+\|             # Enabled
-        \s+\(r\s+\)\s+Yes\s+\|  # GPG Check
-        \s+Yes\s+\|             # Refresh
-        \s+(?<uri>.*)           # URI
-    /x;
-    assert_equals($mirror_src, $+{uri},
-        "Repository on the installed system does not match mirror for installation");
+
+    record_info("Check mirror", "Validate if mirror used for installation is added in the installed system");
+    validate_repo_enablement(alias => $sle_prod, name => $sle_prod, uri => $mirror_src);
 }
 
 1;


### PR DESCRIPTION
See [poo#67579](https://progress.opensuse.org/issues/67579).

## Verification runs
* [addon-http](https://openqa.suse.de/tests/4365665)
* [addon-ftp](https://openqa.suse.de/tests/4365666)
* [addon-ftp-powerVM](https://openqa.suse.de/tests/4369625)
* [gnome_smb](https://openqa.suse.de/tests/4365469)

We need to get #10531 merged first, so I could adjust the schedule and add VR for powerVM.