### PR TITLE
Fix AutoYaST cloned profile validator

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -268,7 +268,8 @@ sub generate_expressions {
         for my $k (keys %{$node}) {
             next if $k =~ /unique_key|unique_value/;
             if (!ref $node->{$k}) {
-                push @{$expressions}, "$exp" . "/ns:$k" . "[text() = '$node->{$k}']";
+                push @{$expressions}, "$exp" . "/ns:$k" . "[text() = '$node->{$k}'" .
+                  (($node->{$k} eq '') ? ' or not(text())]' : ']');    # node might not have text node descendant
             }
             else {
                 generate_expressions(node => $node->{$k}, exp => "$exp/ns:$k",


### PR DESCRIPTION
Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1172944

Improve validation by allowing to specify in yaml empty nodes and
validate them regardless if contains a text node descendant or not.
For example, in yaml we have:
```yaml
subvolumes_prefix: ''
```
In xml the following would be validated:
```xml
<subvolumes_prefix/>
<subvolumes_prefix></subvolumes_prefix>
```
- Verification run: (on-going)
  - [sle-15-SP2-Online-x86_64-Build209.2-autoyast_multi_btrfs@64bit](https://openqa.suse.de/t4366585)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20200617-autoyast_multi_btrfs@64bit](https://openqa.opensuse.org/t1306060)

