### PR TITLE
Use persistent block devices paths in HA tests

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -345,6 +345,7 @@ sub check_cluster_state {
 }
 
 # Wait for resources to be started
+# If changing this, remember to also change wait_until_resources_started in tests/publiccloud/sles4sap.pm
 sub wait_until_resources_started {
     my %args    = @_;
     my @cmds    = ('crm cluster wait_for_startup');
@@ -427,7 +428,7 @@ sub get_lun {
     mutex_unlock 'iscsi';
 
     # Return the real path of the block device
-    return block_device_real_path "$lun";
+    return $lun;
 }
 
 # This method checks for the presence of a device in the system for up to a defined timeout (defaults to 20seconds)

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -45,7 +45,7 @@ sub run {
     if (is_node(1)) {
         # Create cluster-md device
         assert_script_run
-"mdadm --create $clustermd_device $clustermd_name_opt --bitmap=clustered --metadata=1.2 --raid-devices=2 --level=mirror $clustermd_lun_01 $clustermd_lun_02", $default_timeout;
+"mdadm --create $clustermd_device $clustermd_name_opt --bitmap=clustered --metadata=1.2 --raid-devices=2 --level=mirror \"$clustermd_lun_01\" \"$clustermd_lun_02\"", $default_timeout;
 
         # We need to create the configuration file on all nodes
         assert_script_run "echo DEVICE $clustermd_lun_01 $clustermd_lun_02 > $mdadm_conf", $default_timeout;
@@ -63,7 +63,7 @@ sub run {
 
     # We need to start the cluster-md device on all nodes but node01, as it still has the device started
     if (!is_node(1)) {
-        assert_script_run "mdadm -A $clustermd_device $clustermd_lun_01 $clustermd_lun_02", $default_timeout;
+        assert_script_run "mdadm -A $clustermd_device \"$clustermd_lun_01\" \"$clustermd_lun_02\"", $default_timeout;
     }
 
     # Wait until cluster-md device is started

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -74,8 +74,8 @@ sub run {
         assert_script_run "sed -i 's/%ADDR_NODE_02%/$node_02_ip/g' $drbd_rsc_file";
 
         # Note: we use ';' instead of '/' as the sed separator because of UNIX file names
-        assert_script_run "sed -i 's;%DRBD_LUN_01%;$drbd_lun_01;g' $drbd_rsc_file";
-        assert_script_run "sed -i 's;%DRBD_LUN_02%;$drbd_lun_02;g' $drbd_rsc_file";
+        assert_script_run "sed -i 's;%DRBD_LUN_01%;\"$drbd_lun_01\";g' $drbd_rsc_file";
+        assert_script_run "sed -i 's;%DRBD_LUN_02%;\"$drbd_lun_02\";g' $drbd_rsc_file";
 
         # Show the result
         type_string "cat $drbd_rsc_file\n";

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -77,7 +77,7 @@ sub run {
 
     # Format the Filesystem device
     if (is_node(1)) {
-        assert_script_run "mkfs -t $fs_type $fs_opts $fs_lun", $default_timeout;
+        assert_script_run "mkfs -t $fs_type $fs_opts \"$fs_lun\"", $default_timeout;
     }
     else {
         diag 'Wait until Filesystem device is formatted...';

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -61,7 +61,7 @@ sub run {
     my $sbd_cfg       = '/etc/sysconfig/sbd';
     my $unicast_opt   = get_var("HA_UNICAST") ? '-u' : '';
     my $quorum_policy = 'stop';
-    my $fencing_opt   = "-s $sbd_device";
+    my $fencing_opt   = "-s \"$sbd_device\"";
     my $qdevice_opt;
 
     # Qdevice configuration
@@ -104,7 +104,7 @@ sub run {
 
     # State of SBD if shared storage SBD is used
     if (!get_var('USE_DISKLESS_SBD')) {
-        my $sbd_output = script_output("sbd -d $sbd_device list");
+        my $sbd_output = script_output("sbd -d \"$sbd_device\" list");
         record_soft_failure 'bsc#1170037 - All nodes not shown by sbd list command'
           if (get_node_number != (my $clear_count = () = $sbd_output =~ /\sclear\s|\sclear$/g));
     }

--- a/tests/ha/sbd.pm
+++ b/tests/ha/sbd.pm
@@ -25,7 +25,7 @@ sub run {
     if (is_node(1)) {
         # Create sbd device
         my $sbd_lun = get_lun;
-        assert_script_run "sbd -d $sbd_lun create";
+        assert_script_run "sbd -d \"$sbd_lun\" create";
 
         # Add sbd device in /etc/sysconfig/sbd
         assert_script_run "curl -f -v " . autoinst_url . "/data/ha/sbd.template -o $sbd_cfg";

--- a/tests/ha/sbd.pm
+++ b/tests/ha/sbd.pm
@@ -15,7 +15,8 @@ use strict;
 use warnings;
 use testapi;
 use lockapi;
-use utils 'systemctl';
+use utils qw(systemctl);
+use version_utils qw(is_sle);
 use hacluster;
 
 sub run {
@@ -51,7 +52,13 @@ sub run {
     # We need to restart the cluster to start SBD
     # A mutex is used to restart one node at a time
     mutex_lock 'cluster_restart';
-    assert_script_run "crm cluster restart";
+    if (is_sle('12-SP4+')) {
+        assert_script_run "crm cluster restart";
+    }
+    else {
+        assert_script_run "crm cluster stop";
+        assert_script_run "crm cluster start";
+    }
     mutex_unlock 'cluster_restart';
 
     # Print SBD information

--- a/tests/ha/vg.pm
+++ b/tests/ha/vg.pm
@@ -47,7 +47,7 @@ sub run {
         $vg_luns  = "/dev/$resource" if is_node(1);
     }
     else {
-        $vg_luns = get_lun . ' ' . get_lun if is_node(1);
+        $vg_luns = '"' . get_lun . '" "' . get_lun . '"' if is_node(1);
     }
     my $vg_name = "vg_$resource";
 

--- a/tests/sles4sap/netweaver_filesystems.pm
+++ b/tests/sles4sap/netweaver_filesystems.pm
@@ -33,9 +33,9 @@ sub run {
     $self->select_serial_terminal;
 
     # Create/format/mount local filesystems
-    assert_script_run "mkfs -t xfs -f $lun";
+    assert_script_run "mkfs -t xfs -f \"$lun\"";
     assert_script_run "mkdir -p $sap_dir/${type}${instance_id}";
-    assert_script_run "mount $lun $sap_dir/${type}${instance_id}";
+    assert_script_run "mount \"$lun\" $sap_dir/${type}${instance_id}";
 
     # Mount NFS filesystem
     assert_script_run "echo '$path/$arch/nfs_share/sapmnt /sapmnt $proto defaults,bg 0 0' >> /etc/fstab";


### PR DESCRIPTION
Currently HA tests rely on block devices provided by an iSCSI server to perform some of the required filesystem cluster tests (sbd, cluster_md, drbd, etc). These block devices are taken as LUNs from a list provided by the iSCSI server, and then passed to `realpath(1)`, which returns the resolved paths (`/dev/sd?`). Problem with these resolved paths, is that they are not necessarily persistent between different boots of the system, which can lead to HA resources failing to start if the resolved path changes after a fence; it can also lead to failures in the HA bootstrap process if the resolved paths of a given LUN are different between nodes. This commit introduces changes so the HA tests use the persistent paths/LUNs from `/dev/disk/by-path/...` supplied by the support server.

- Related ticket: N/A
- Needles: N/A
- Verification runs:

1. Cluster with HA bootstrap script: [node 1](http://mango.suse.de/tests/2744), [node 2](http://mango.suse.de/tests/2745) & [support server](http://mango.suse.de/tests/2743)
2. Cluster with `yast2 cluster` module: [node 1](http://mango.suse.de/tests/2783), [node 2](http://mango.suse.de/tests/2784) & [support server](http://mango.suse.de/tests/2782)
3. SAP NetWeaver cluster: [node 1](http://mango.suse.de/tests/2786), [node 2](http://mango.suse.de/tests/2787) & [support server](http://mango.suse.de/tests/2785)
