### PR TITLE
Add workaround for bsc#1172356

### DIFF
--- a/tests/virtualization/xen/virtmanager_add_devices.pm
+++ b/tests/virtualization/xen/virtmanager_add_devices.pm
@@ -32,6 +32,9 @@ sub run {
 
     establish_connection();
 
+    # guests where we need to apply workaround for bsc#1172356
+    my @bsc1172356_guests;
+
     foreach my $guest (keys %xen::guests) {
         unless ($guest =~ m/hvm/i) {
             record_info "$guest", "VM $guest will get some new devices";
@@ -60,10 +63,16 @@ sub run {
             send_key 'tab';
             type_string '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
             assert_and_click 'virt-manager_add-hardware-finish';
-
-            assert_and_click 'virt-manager_disk2';
-            assert_screen 'virt-manager_disk2_name';
-            assert_and_click 'virt-manager_nic2';
+            # Workaround for bsc#1172356
+            if (check_screen('virt-manager_add_network_bsc1172356', timeout => 20)) {
+                record_soft_failure('bsc#1172356', 'Virt-manager cannot add NIC');
+                assert_and_click 'virt-manager_add_network_bsc1172356';
+                push(@bsc1172356_guests, "$guest");
+            } else {
+                assert_and_click 'virt-manager_disk2';
+                assert_screen 'virt-manager_disk2_name';
+                assert_and_click 'virt-manager_nic2';
+            }
 
             assert_and_click 'virt-manager_graphical-console';
 
@@ -73,6 +82,16 @@ sub run {
     }
 
     wait_screen_change { send_key 'ctrl-q'; };
+
+    # Note: hotplugging in virsh is tested in hotplugging.pm
+    # We still add the NIC here, so virtmanager_rm_devices finds it
+    if (@bsc1172356_guests) {
+        foreach my $guest (@bsc1172356_guests) {
+            my $mac = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
+            script_run("virsh attach-interface --domain $guest --type bridge --source br0 --live --mac $mac");
+        }
+        save_screenshot;
+    }
 }
 
 1;


### PR DESCRIPTION
This commit adds a workaround for virt-manager attaching network interfaces not working on SLE12SP5.

- Related ticket: https://progress.opensuse.org/issues/67864
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1390
- Verification run: http://phoenix-openqa.qam.suse.de/tests/1672
