### PR TITLE
Handle GRUB twice for zkvm

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -34,18 +34,25 @@ our @EXPORT = qw(
 );
 
 sub process_reboot {
-    my $trigger = shift // 0;
+    my (%args) = @_;
+    $args{trigger}            //= 0;
+    $args{automated_rollback} //= 0;
 
     if (is_caasp) {
-        microos_reboot $trigger;
+        microos_reboot $args{trigger};
     } else {
-        power_action('reboot', observe => !$trigger, keepconsole => 1);
+        power_action('reboot', observe => !$args{trigger}, keepconsole => 1);
         if (check_var('ARCH', 's390x')) {
-            reconnect_mgmt_console(timeout => 500);
+            reconnect_mgmt_console(timeout => 500, grub_expected_twice => $args{automated_rollback});
         } else {
             # Replace by wait_boot if possible
             assert_screen 'grub2', 100;
             send_key 'ret';
+            # After automated rollback is still needed to pass by grub a second time
+            if ($args{automated_rollback}) {
+                process_reboot();
+                return;
+            }
         }
         assert_screen 'linux-login', 200;
 
@@ -68,11 +75,11 @@ sub check_reboot_changes {
     my $change_happened = script_run "diff $mounted $default";
 
     # If changes are expected check that default subvolume changed
-    die "Error during diff"                                            if $change_happened > 1;
-    die "Change expected: $change_expected, happeed: $change_happened" if $change_expected != $change_happened;
+    die "Error during diff"                                             if $change_happened > 1;
+    die "Change expected: $change_expected, happened: $change_happened" if $change_expected != $change_happened;
 
     # Reboot into new snapshot
-    process_reboot 1 if $change_happened;
+    process_reboot(trigger => 1) if $change_happened;
 }
 
 # Return names and version of packages for transactional-update tests
@@ -142,7 +149,7 @@ sub trup_install {
     }
     if ($necessary) {
         trup_call("pkg install $necessary");
-        process_reboot(1);
+        process_reboot(trigger => 1);
     }
 
     # By the end, all pkgs should be installed
@@ -161,7 +168,7 @@ sub trup_shell {
     type_string("exit\n");
     wait_serial('trup_shell-status-0') || die "'transactional-update shell' didn't finish";
 
-    process_reboot 1 if $args{reboot};
+    process_reboot(trigger => 1) if $args{reboot};
 }
 
 # When transactional-update is triggered manually is required to wait for rollback.service

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1290,12 +1290,15 @@ sub _handle_login_not_found {
 
  reconnect_mgmt_console([timeout => $timeout]);
 
-After each reboot we have to reconnect to the management console on remote backends
+After each reboot we have to reconnect to the management console on remote backends.
+C<$timeout> can be set to some specific time and if during reboot GRUB is shown twice C<grub_expected_twice>
+can be set to 1.
 
 =cut
 sub reconnect_mgmt_console {
     my (%args) = @_;
-    $args{timeout} //= 300;
+    $args{timeout}             //= 300;
+    $args{grub_expected_twice} //= 0;
 
     if (check_var('ARCH', 's390x')) {
         my $login_ready = qr/Welcome to /;
@@ -1324,9 +1327,15 @@ sub reconnect_mgmt_console {
                 wait_serial($login_ready) || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
             }
             else {
-                wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
                 select_console('svirt');
                 save_svirt_pty;
+                if ($args{grub_expected_twice}) {
+                    wait_serial('Press enter to boot the selected OS') ||
+                      diag 'Could not find boot selection, continuing nevertheless, trying to boot';
+                    type_line_svirt '';
+                }
+                wait_serial('GNU GRUB') ||
+                  diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
                 type_line_svirt '', expect => $login_ready, timeout => $args{timeout}, fail_message => 'Could not find login prompt';
             }
         }

--- a/tests/transactional/health_check.pm
+++ b/tests/transactional/health_check.pm
@@ -62,10 +62,7 @@ sub run {
     die "The current snapshot is not ahead of the logged one" unless $current_id > $logged_id;
 
     # Automated rollback shows grub menu twice (timeout disabled)
-    type_string "reboot\n";
-    assert_screen 'grub2', 100;
-    wait_screen_change { send_key 'ret' };
-    process_reboot;
+    process_reboot(trigger => 1, automated_rollback => 1);
 
     my $final_id = get_btrfsid;
     die "health-checker does not rollback to the correct snapshot" unless $initial_id == $final_id;

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -82,7 +82,7 @@ sub run {
     if (is_opensuse && get_var('BETA')) {
         record_info 'Remove pkgs', 'Remove preinstalled packages on Leap BETA';
         trup_call "pkg remove update-test-[^t]*";
-        process_reboot 1;
+        process_reboot(trigger => 1);
     }
 
     get_utt_packages;


### PR DESCRIPTION
When GRUB is presented twice (for instance in transactional updates
when automated rollback) with this fix we can reconnect in zkvm
to the management console and handle both GRUB screens.

- Related ticket: https://progress.opensuse.org/issues/67687
- MR Job Group: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/213
- Verification run: [health_check_zkvm_and_x86_64](https://openqa.suse.de/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%23fix_health_check_zkvm&version=15-SP2&distri=sle)