### PR TITLE
[virt_autotest] Fix guest sles11sp4 failure from virtual network test

### DIFF
--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -60,6 +60,7 @@ sub run_test {
         $mac   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
+        check_guest_module($guest, module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_isolated --model $model --mac $mac --live $affecter", 60);
 
         my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_isolated';

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -69,9 +69,14 @@ sub run_test {
         save_guest_ip($guest, name => "br123");
         my $mode = is_sle('=11-sp4') ? '' : '-f';
         exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no $mode root\@$guest");
+        check_guest_module($guest, module => "acpiphp");
         #Prepare the new guest network interface files for libvirt virtual network
         assert_script_run("ssh root\@$guest 'cd /etc/sysconfig/network/; cp ifcfg-eth0 ifcfg-eth1; cp ifcfg-eth0 ifcfg-eth2; cp ifcfg-eth0 ifcfg-eth3; cp ifcfg-eth0 ifcfg-eth4; cp ifcfg-eth0 ifcfg-eth5; cp ifcfg-eth0 ifcfg-eth6'");
-        assert_script_run("ssh root\@$guest 'rcnetwork restart'", 60);
+        if ($guest =~ m/sles-?11/i) {
+            assert_script_run("ssh root\@$guest service network restart", 90);
+        } else {
+            assert_script_run("time ssh -v root\@$guest systemctl restart network", 120);
+        }
     }
 
     #Skip restart network service due to bsc#1166570


### PR DESCRIPTION
Used with 'sles-11' for sles11sp4 guest system as VIRT_AUTOTEST' required

Due to bsc#1167828, there was not load acpiphp kernel module as defaults for sles11sp4 guest system, 
so, block hotplug device test (e.g attach interface from host bridge network)

Have to manually load acpiphp kernel module to sles11sp4 guest system before virtual network test. 

- Verification run: 
gi-guest_sles11sp4-on-host-developing-kvm
http://10.67.19.82/tests/645
gi-guest_sles11sp4-on-host-developing-xen
http://10.67.19.82/tests/636
