### PR TITLE
Increase timeout in yast2_firstboot for slower archs

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -72,7 +72,7 @@ sub user_setup {
 }
 
 sub root_setup {
-    assert_screen 'root_user';
+    assert_screen 'root_user', 60;
     enter_rootinfo;
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
 }


### PR DESCRIPTION
Increase timeout in 'Root Password' step when using yast2 firstboot
due to previous step 'Users' takes more time in slower architectures.

- Related ticket: https://progress.opensuse.org/issues/68158
- Verification run: [30 of opensuse-15.2-DVD-aarch64-yast2_firstboot@aarch64](https://openqa.opensuse.org/tests/overview?build=203.2_jrivera_poo68158&distri=opensuse&version=15.2)
