### PR TITLE
Unschedule kdump_and_crash for extra_tests_textmode

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -89,5 +89,4 @@ schedule:
     - console/aaa_base
     - console/osinfo_db
     - console/zypper_ref
-    - console/kdump_and_crash
     - console/coredump_collect


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/67780


`kdump_and_crash` is still scheduled in the [toolchain_zypper](https://openqa.suse.de/tests/4308746) testsuite.