### PR TITLE
Revert "multipath after registration for 15-SP2+"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -835,8 +835,7 @@ sub load_inst_tests {
     if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
         loadtest "installation/encrypted_volume_activation";
     }
-    # SLE-15 SP2 pushes the multipath activation dialog after the scc_registration dialog, see below
-    if ((get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) and not is_sle('15-SP2+')) {
+    if (get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
         loadtest "installation/multipath";
     }
     if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {
@@ -857,11 +856,6 @@ sub load_inst_tests {
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
         loadtest "installation/scc_registration";
-    }
-    if (is_sle('15-SP2+') and (get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM'))) {
-        loadtest "installation/multipath";
-    }
-    if (is_sle) {
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#9725

Looks like the different mulitpath behaviour was temporary.
https://openqa.suse.de/tests/4375834#step/scc_registration/5

VR: https://openqa.suse.de/tests/4377204