### PR TITLE
Enable cryptlvm+activate_existing+import_users on powerVM

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -130,7 +130,15 @@ sub prepare_pvm_installation {
     my $disks = script_output('lsblk -n -l -o NAME -d -e 7,11');
     for my $d (split('\n', $disks)) {
         script_run "wipefs -a /dev/$d";
-        create_encrypted_part(disk => $d) if get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_CANCEL_EXISTING');
+        if (get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_CANCEL_EXISTING'))
+        {
+            create_encrypted_part(disk => $d);
+            if (get_var('ETC_PASSWD') && get_var('ETC_SHADOW')) {
+                mimic_user_to_import(disk => $d,
+                    passwd => get_var('ETC_PASSWD'),
+                    shadow => get_var('ETC_SHADOW'));
+            }
+        }
     }
     # Switch to installation console (ssh or vnc)
     select_console('installation');

--- a/schedule/yast/encryption/cryptlvm+activate_existing+import_users_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing+import_users_pvm.yaml
@@ -1,0 +1,36 @@
+---
+description: >
+  Conduct installation activating encrypted partitions and importing users created
+  in that installation. Using pre-partitioned disk image to validate encrypted
+  partitions activation and that we can re-ecnrypt the disk.
+  Separate schedule is used because on powerVM we simulate existing users on the
+  encrypted partition by injecting /etc/passwd and /etc/shadow files.
+name: cryptlvm+activate_existing+import_users
+vars:
+  ENCRYPT_ACTIVATE_EXISTING: 1
+  ETC_PASSWD: "bernhard:x:1000:100:bernhard:/home/bernhard:/bin/bash"
+  ETC_SHADOW: "bernhard:$6$ZQ2QptdwejF6$QAEuGvFZJCsyA0oWlrFsWXcMSNcgkU4y3oVPGHhoOjuEHU7BhKAm8DN5L8FnwQlngmNheB.vZqyz1HripbwKL0:18435:0:99999:7:::"
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/encrypted_volume_activation
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm_reuse_existing
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_import
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot

--- a/variables.md
+++ b/variables.md
@@ -27,7 +27,7 @@ CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test mo
 CHECK_RELEASENOTES_ORIGIN | boolean | false | Loads `installation/releasenotes_origin` test module.
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
-CONTAINER_TOTEST | string | | The string can be "totest/" or "", depending on the URL of the image in the container image registry. 
+CONTAINER_TOTEST | string | | The string can be "totest/" or "", depending on the URL of the image in the container image registry.
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.
@@ -42,6 +42,10 @@ DUD_ADDONS | string | | Comma separated list of addons added using DUD.
 DVD |||
 ENCRYPT | boolean | false | Enables or indicates encryption of the disks. Can be combined with `FULL_LVM_ENCRYPT`, `ENCRYPT_CANCEL_EXISTING`, `ENCRYPT_ACTIVATE_EXISTING` and `UNENCRYPTED_BOOT`.
 ENCRYPT_CANCEL_EXISTING | boolean | false | Used to cancel activation of the encrypted partitions |
+ETC_PASSWD | string | | Sets content for /etc/passwd, can be used to mimic existing users. Is used to test import of existing users on backends which
+have no shapshoting support (powerVM, zVM). Should be used together with `ENCRYPT_ACTIVATE_EXISTING` and `ETC_SHADOW`.
+ETC_SHADOW | string | | Sets content for /etc/shadow, can be used to mimic existing users. Is used to test import of existing users on backends which
+have no shapshoting support (powerVM, zVM). Should be used together with `ENCRYPT_ACTIVATE_EXISTING` and `ETC_PASSWD`.
 EVERGREEN |||
 EXIT_AFTER_START_INSTALL | boolean | false | Indicates that test suite will be finished after `installation/start_install` test module. So that all the test modules after this one will not be scheduled and executed.
 EXPECTED_INSTALL_HOSTNAME | string | | Contains expected hostname YaST installer got from the environment (DHCP, 'hostname=', as a kernel cmd line argument)


### PR DESCRIPTION
As powerVM doesn't support snapshots as of now, we decided to stub user creation by creating needed files, so that installer should detect them and offer user import.

[Verification run](https://openqa.suse.de/tests/4377203#).

See [poo#67882](https://progress.opensuse.org/issues/67882).

[Job group settings merge request](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/214).