### PR TITLE
Schedule podman.pm,podman_image.pm in SLE15-SP1

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1701,7 +1701,7 @@ sub load_extra_tests_docker {
     my ($image_names, $stable_names) = get_suse_container_urls();
     return unless @$image_names;
 
-    if (is_leap('15.1+') || is_tumbleweed) {
+    if (is_leap('15.1+') || is_tumbleweed || is_sle("15-sp1+")) {
         loadtest 'containers/podman';
         loadtest "containers/podman_image" unless is_public_cloud;
     }


### PR DESCRIPTION
Schedule podman.pm and podman_image.pm to run for SLE15-SP1

- Related ticket: https://progress.opensuse.org/issues/68278
- Needles: N/A
- Verification run: [SLE15sp1](http://10.161.229.247/tests/463) [SLE 15](http://10.161.229.247/tests/464)
