### PR TITLE
Improve suseconnect_scc UI check

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -41,6 +41,8 @@ sub run {
     assert_script_run $cmd;
     assert_script_run 'SUSEConnect --list-extensions';
     assert_screen 'activated-with-suseconnect';
+    assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'    \e\[1mServer Applications Module\')"';
+    assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'        \e\[1mWeb and Scripting Module\')"';
 
     # add modules
     if (is_sle '15+') {


### PR DESCRIPTION
needle match is only for Server Applications Module 15 SP2 and
Web and Scripting Module 15 SP2 without matching neither architecture,
nor the instructions to activate/deactivate
    
Verifications:
https://openqa.suse.de/tests/4384250#step/suseconnect_scc/15
https://openqa.suse.de/tests/4384249#step/suseconnect_scc/15
https://openqa.suse.de/tests/4384248#step/suseconnect_scc/15