### PR TITLE
HPC: Upload logs for bsc#1173150

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -81,6 +81,10 @@ EOF
 
     barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
     barrier_wait("SLURM_MASTER_RUN_TESTS");
+
+    # always upload logs from slurmdbd as those are crucial and there is no simple
+    # way to get those logs if slurctld fails
+    upload_logs('/var/log/slurmdbd.log');
 }
 
 sub test_flags {


### PR DESCRIPTION
This should be considered a crude workaround to get slurmdbd logs for
one specific ARM bug. As of now however we might want to keep this as
otherwise it is difficult to get those logs in case of slurmctld failure