### PR TITLE
Enlarge the wait time for nfs-config screen

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -178,7 +178,7 @@ sub check_nfs_ready {
 
 sub yast2_server_initial {
     do {
-        assert_screen([qw(nfs-server-not-installed nfs-firewall nfs-config)]);
+        assert_screen([qw(nfs-server-not-installed nfs-firewall nfs-config)], 120);
         # install missing packages as proposed
         if (match_has_tag('nfs-server-not-installed') or match_has_tag('nfs-firewall')) {
             send_key 'alt-i';


### PR DESCRIPTION
In the yast2_nfs service check on s390x, we need to enlarge the assert_screen time to wait the nfs_config screen to shown up.

- Related ticket: https://progress.opensuse.org/issues/68068
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/4376378
   https://openqa.nue.suse.com/tests/4376379
   https://openqa.nue.suse.com/tests/4376380