### PR TITLE
HPC: Replace getting slurmdbd with basic logs

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -545,7 +545,7 @@ sub post_fail_hook {
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');
     $self->upload_service_log('slurmctld');
-    $self->upload_service_log('slurmdbd');
+    $self->export_logs_basic;
     upload_logs('/var/log/slurmctld.log');
 }
 


### PR DESCRIPTION
In fact there is no no specific slurmdbd tests where this daemon would
be running on the master node, so there is no specific logs to collect.
It make sense however to get some more logs form the system in case
more elaborate tests fail
