### PR TITLE
HPC: Getting logs from specified machine

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -45,6 +45,11 @@ sub post_fail_hook {
     upload_service_log('wickedd-dhcp4.service');
 }
 
+sub get_remote_logs {
+    my ($self, $machine, $logs) = @_;
+    script_run("scp -o StrictHostKeyChecking=no root\@$machine:/var/log/$logs /tmp/$machine\@$logs");
+}
+
 sub switch_user {
     my ($self, $username) = @_;
     type_string("su - $username\n");

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -546,6 +546,8 @@ sub post_fail_hook {
     $self->upload_service_log('munge');
     $self->upload_service_log('slurmctld');
     $self->export_logs_basic;
+    #just tmp change
+    $self->get_remote_logs('slave-node02', 'slurmdbd.log');
     upload_logs('/var/log/slurmctld.log');
 }
 


### PR DESCRIPTION
For specific ARM problem (bsc#1173150) some logs from remote VM are
needed to better understand the problem. This patch is first and simple
approach to get some of logs collected in the master node