### PR TITLE
WIP: Add wait_screen_change when GRUB appears twice

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -47,7 +47,7 @@ sub process_reboot {
         } else {
             # Replace by wait_boot if possible
             assert_screen 'grub2', 100;
-            send_key 'ret';
+            wait_screen_change { send_key 'ret' };
             # After automated rollback is still needed to pass by grub a second time
             if ($args{automated_rollback}) {
                 process_reboot();


### PR DESCRIPTION
This is the only difference that could be related with problem here: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10550#issuecomment-648712262

- Related ticket: https://progress.opensuse.org/issues/67687
- Verification run: https://openqa.opensuse.org/t1313681