### PR TITLE
pam: ensure group(wheel) is present

### DIFF
--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -40,7 +40,7 @@ sub run {
     }
     zypper_call('install bats pam-test pam pam-config snapper perl');
     if (is_tumbleweed()) {
-        zypper_call('install pam-deprecated');
+        zypper_call('install pam-deprecated "group(wheel)"');
     }
 
     # create a snapshot for rollback


### PR DESCRIPTION
The pam.sh test script wants to add users to the group wheel. Since
this group is not supported by SUSE, we need to ensure that this
group is being added to the system before we can manipulate it

- Related ticket: https://bugzilla.opensuse.org/1171016
- Needles: N/A
- Verification runs:
  * https://openqa.opensuse.org/tests/1383083 (JeOS)
