### PR TITLE
Handle GRUB twice in zkvm - 2nd try

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1290,12 +1290,15 @@ sub _handle_login_not_found {
 
  reconnect_mgmt_console([timeout => $timeout]);
 
-After each reboot we have to reconnect to the management console on remote backends
+After each reboot we have to reconnect to the management console on remote backends.
+C<$timeout> can be set to some specific time and if during reboot GRUB is shown twice C<grub_expected_twice>
+can be set to 1.
 
 =cut
 sub reconnect_mgmt_console {
     my (%args) = @_;
-    $args{timeout} //= 300;
+    $args{timeout}             //= 300;
+    $args{grub_expected_twice} //= 0;
 
     if (check_var('ARCH', 's390x')) {
         my $login_ready = qr/Welcome to /;
@@ -1324,9 +1327,15 @@ sub reconnect_mgmt_console {
                 wait_serial($login_ready) || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
             }
             else {
-                wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
                 select_console('svirt');
                 save_svirt_pty;
+                if ($args{grub_expected_twice}) {
+                    wait_serial('Press enter to boot the selected OS') ||
+                      diag 'Could not find boot selection, continuing nevertheless, trying to boot';
+                    type_line_svirt '';
+                }
+                wait_serial('GNU GRUB') ||
+                  diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
                 type_line_svirt '', expect => $login_ready, timeout => $args{timeout}, fail_message => 'Could not find login prompt';
             }
         }

--- a/tests/transactional/health_check.pm
+++ b/tests/transactional/health_check.pm
@@ -62,10 +62,7 @@ sub run {
     die "The current snapshot is not ahead of the logged one" unless $current_id > $logged_id;
 
     # Automated rollback shows grub menu twice (timeout disabled)
-    type_string "reboot\n";
-    assert_screen 'grub2', 100;
-    wait_screen_change { send_key 'ret' };
-    process_reboot;
+    process_reboot(automated_rollback => 1);
 
     my $final_id = get_btrfsid;
     die "health-checker does not rollback to the correct snapshot" unless $initial_id == $final_id;

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -69,7 +69,7 @@ sub run {
     if (is_opensuse && get_var('BETA')) {
         record_info 'Remove pkgs', 'Remove preinstalled packages on Leap BETA';
         trup_call "pkg remove update-test-[^t]*";
-        process_reboot 1;
+        process_reboot(trigger => 1);
     }
 
     get_utt_packages;


### PR DESCRIPTION
Similar to #10550 which was reverted but this time I didn't forget the path of code for microos!

- Related ticket: https://progress.opensuse.org/issues/67687
- Verification run:
  - [transactional_server_helper_apps in microos](https://openqa.opensuse.org/tests/1313853)
  - [transactional_server_helper_apps in SLE](https://openqa.suse.de/tests/overview?version=15-SP2&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23handle_grub_twice_zkvm)