### PR TITLE
Rename container_base_images

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1708,7 +1708,7 @@ sub load_extra_tests_docker {
 
     loadtest "containers/docker";
     loadtest "containers/docker_runc";
-    loadtest "containers/container_base_images";
+    loadtest "containers/containers_3rd_party";
     loadtest "containers/docker_image" if (!is_public_cloud && (is_sle(">=12-sp3") || is_opensuse));
     loadtest "containers/docker_compose" unless is_sle('<15');
     loadtest "containers/zypper_docker";

--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -22,10 +22,10 @@ conditional_schedule:
         DISTRI:
             'opensuse':
                 - containers/docker_image
-    container_base_images:
+    containers_3rd_party:
         DISTRI:
             'opensuse':
-                - containers/container_base_images
+                - containers/containers_3rd_party
     docker_compose:
         DISTRI:
             'opensuse':
@@ -38,7 +38,7 @@ schedule:
     - containers/docker
     - containers/docker_runc
     - '{{docker_image}}'
-    - '{{container_base_images}}'
+    - '{{containers_3rd_party}}'
     - '{{docker_compose}}'
     - containers/zypper_docker
     - console/coredump_collect

--- a/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
+++ b/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
@@ -35,6 +35,6 @@ schedule:
     - containers/docker
     - containers/docker_runc
     - containers/docker_image
-    - containers/container_base_images
+    - containers/containers_3rd_party
     - containers/zypper_docker
     - containers/docker_compose

--- a/tests/containers/containers_3rd_party.pm
+++ b/tests/containers/containers_3rd_party.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Pull and test several base images (alpine, openSUSE, debian, ubuntu, fedora, centos) for their base functionality
-#          Log the test results in container_base_images.txt
+#          Log the test results in containers_3rd_party.txt
 #          Docker or Podman tests can be skipped by setting SKIP_DOCKER_IMAGE_TESTS=1 or SKIP_PODMAN_IMAGE_TESTS=1 in the job
 # Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
 
@@ -34,17 +34,17 @@ sub run_image_tests {
     my @images = @_;
     foreach my $image (@images) {
         test_container_image($image, $engine);
-        script_run("echo 'OK: $engine - $image:latest' >> /var/tmp/container_base_images_log.txt");
+        script_run("echo 'OK: $engine - $image:latest' >> /var/tmp/containers_3rd_party_log.txt");
     }
 }
 
 sub upload_image_logs {
     # Rename for better visibility in Uploaded Logs
-    if (script_run('mv /var/tmp/container_base_images_log.txt /tmp/container_base_images.txt') != 0) {
+    if (script_run('mv /var/tmp/containers_3rd_party_log.txt /tmp/containers_3rd_party.txt') != 0) {
         record_info("No logs", "No logs found");
     } else {
-        upload_logs("/tmp/container_base_images.txt");
-        script_run("rm /tmp/container_base_images.txt");
+        upload_logs("/tmp/containers_3rd_party.txt");
+        script_run("rm /tmp/containers_3rd_party.txt");
     }
 }
 
@@ -55,11 +55,11 @@ sub run {
     my @docker_images = ('alpine', 'opensuse/leap', 'opensuse/tumbleweed', 'debian', 'ubuntu', 'centos', 'fedora');
     my @podman_images = ('alpine', 'opensuse/leap', 'opensuse/tumbleweed', 'debian', 'ubuntu', 'centos', 'fedora');
 
-    script_run('echo "Container base image tests:" > /var/tmp/container_base_images_log.txt');
+    script_run('echo "Container base image tests:" > /var/tmp/containers_3rd_party_log.txt');
     # Run docker tests
     if (skip_docker) {
         record_info("Skip Docker", "Docker image tests skipped");
-        script_run("echo 'INFO: Docker image tests skipped' >> /var/tmp/container_base_images_log.txt");
+        script_run("echo 'INFO: Docker image tests skipped' >> /var/tmp/containers_3rd_party_log.txt");
     } else {
         install_docker_when_needed();
         run_image_tests('docker', @docker_images);
@@ -68,7 +68,7 @@ sub run {
     # Run podman tests
     if (skip_podman) {
         record_info("Skip Podman", "Podman image tests skipped");
-        script_run("echo 'INFO: Podman image tests skipped' >> /var/tmp/container_base_images_log.txt");
+        script_run("echo 'INFO: Podman image tests skipped' >> /var/tmp/containers_3rd_party_log.txt");
     } else {
         # In SLE we need to add the Containers module
         install_podman_when_needed();


### PR DESCRIPTION
Renames `container_base_images` to `container_3rd_party`

- Related ticket: None (Followup to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10438)
- Needles: None
- Verification run: [SLE15-SP1](http://phoenix-openqa.qam.suse.de/t1674) | [SLE15](http://phoenix-openqa.qam.suse.de/t1675) | [SLE12-SP5](http://phoenix-openqa.qam.suse.de/t1676) | [SLE12-SP4](http://phoenix-openqa.qam.suse.de/t1677) | [SLE12-SP3](http://phoenix-openqa.qam.suse.de/t1678) | [Tumbleweed](http://phoenix-openqa.qam.suse.de/tests/1680) | [Leap 15.2](http://phoenix-openqa.qam.suse.de/tests/1679)