### PR TITLE
Add SAP QAM tests for SLES12SP5

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -329,7 +329,7 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
     set_var('SCC_ADDONS', join(',', @addons));
 
     # SLES4SAP does not have addon on SLE12SP3
-    push(@addons, 'sles4sap') if is_sle('<15') && check_var('FLAVOR', 'Server-DVD-SLES4SAP-Updates');
+    push(@addons, 'sles4sap') if is_sle('<15') && check_var('FLAVOR', 'Server-DVD-SLES4SAP-Updates') || check_var('FLAVOR', 'Server-DVD-SAP-Incidents');
 
     # push sdk addon to slenkins tests
     if (get_var('TEST', '') =~ /^slenkins/) {

--- a/schedule/qam/12-SP5/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/12-SP5/qam-create_hdd_sles4sap_gnome.yml
@@ -8,6 +8,7 @@ schedule:
   - installation/accept_license
   - installation/scc_registration
   - installation/sles4sap_product_installation_mode
+  - '{{update_test_repo}}'
   - installation/addon_products_sle
   - installation/partitioning
   - installation/partitioning_finish
@@ -28,3 +29,8 @@ schedule:
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo


### PR DESCRIPTION
This PR adds SAP tests for 12SP5 QAM

- Related ticket: N/A
- Needles: N/A
- Verification run: http://1a102.qa.suse.de/tests/4431
- Regression test (without QAM_INCI set): http://1a102.qa.suse.de/tests/4435
