### PR TITLE
HPC: Add slurm to the db node

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -30,7 +30,7 @@ sub run {
     $self->prepare_user_and_group();
 
     # Install slurm
-    zypper_call("in slurm-munge slurm-slurmdbd");
+    zypper_call("in slurm slurm-munge slurm-slurmdbd");
     # install slurm-node if sle15, not available yet for sle12
     zypper_call('in slurm-node') if is_sle '15+';
 


### PR DESCRIPTION
The sacctmgr is delivered in the slurm rpm only and should be then
installed
