### PR TITLE
Separate container-diff and refactor in lib/containers/

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -138,6 +138,7 @@ sub basic_container_tests {
 # Setup environment
 sub set_up {
     my $dir = shift;
+    die "You must define the directory!" unless $dir;
 
     assert_script_run("mkdir -p $dir/BuildTest");
     assert_script_run "curl -f -v " . data_url('containers/app.py') . " > $dir/BuildTest/app.py";
@@ -147,7 +148,8 @@ sub set_up {
 
 # Build the image
 sub build_img {
-    my $dir     = shift;
+    my $dir = shift;
+    die "You must define the directory!" unless $dir;
     my $runtime = shift;
     die "You must define the runtime!" unless $runtime;
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1709,8 +1709,11 @@ sub load_extra_tests_docker {
     loadtest "containers/docker";
     loadtest "containers/docker_runc";
     loadtest "containers/containers_3rd_party";
-    loadtest "containers/docker_image" if (!is_public_cloud && (is_sle(">=12-sp3") || is_opensuse));
-    loadtest "containers/docker_compose" unless is_sle('<15');
+    if ((!is_public_cloud() && is_sle(">=12-sp3")) || is_opensuse()) {
+        loadtest "containers/docker_image";
+        loadtest "containers/container_diff";
+    }
+    loadtest "containers/docker_compose" unless (is_sle('<15') || is_sle('>=15-sp2'));
     loadtest "containers/zypper_docker";
 }
 

--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -22,6 +22,7 @@ conditional_schedule:
         DISTRI:
             'opensuse':
                 - containers/docker_image
+                - containers/container_diff
     containers_3rd_party:
         DISTRI:
             'opensuse':

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -19,3 +19,4 @@ schedule:
     - boot/boot_to_desktop
     - containers/podman_image
     - containers/docker_image
+    - containers/container_diff

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Print and save diffs between two cotaniners using container-diff tool
+# Maintainer: Pavel Dostál <pdostal@suse.cz>
+
+use base 'consoletest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+use containers::container_images;
+use suse_container_urls 'get_suse_container_urls';
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    zypper_call("install container-diff") if (script_run("which container-diff") != 0);
+
+    my ($image_names, $stable_names) = get_suse_container_urls();
+
+    # container-diff
+    for my $i (0 .. $#$image_names) {
+        my $image_file = $image_names->[$i] =~ s/\/|:/-/gr;
+        assert_script_run("container-diff diff $image_names->[$i] $stable_names->[$i] --type=rpm --type=file --type=size > /tmp/container-diff-$image_file.txt", 300);
+        upload_logs("/tmp/container-diff-$image_file.txt");
+    }
+}
+
+1;

--- a/tests/containers/containers_3rd_party.pm
+++ b/tests/containers/containers_3rd_party.pm
@@ -33,7 +33,7 @@ sub run_image_tests {
     my $engine = shift;
     my @images = @_;
     foreach my $image (@images) {
-        test_container_image($image, $engine);
+        test_container_image(image => $image, runtime => $engine);
         script_run("echo 'OK: $engine - $image:latest' >> /var/tmp/containers_3rd_party_log.txt");
     }
 }
@@ -63,7 +63,7 @@ sub run {
     } else {
         install_docker_when_needed();
         run_image_tests('docker', @docker_images);
-        clean_container_host('docker');
+        clean_container_host(runtime => 'docker');
     }
     # Run podman tests
     if (skip_podman) {
@@ -73,7 +73,7 @@ sub run {
         # In SLE we need to add the Containers module
         install_podman_when_needed();
         run_image_tests('podman', @podman_images);
-        clean_container_host('podman');
+        clean_container_host(runtime => 'podman');
     }
 }
 

--- a/tests/containers/docker.pm
+++ b/tests/containers/docker.pm
@@ -58,7 +58,7 @@ sub run {
     test_built_img("docker");
 
     # Clean container
-    clean_container_host("docker");
+    clean_container_host(runtime => "docker");
 }
 
 1;

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -69,7 +69,7 @@ sub run {
     assert_script_run 'cd';
 
     remove_suseconnect_product(get_addon_fullname('phub')) if is_sle();
-    clean_container_host('docker');
+    clean_container_host(runtime => 'docker');
 }
 
 sub post_fail_hook {

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -42,16 +42,13 @@ sub run {
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
     for my $i (0 .. $#$image_names) {
-        test_container_image($image_names->[$i], 'docker');
-        build_container_image($image_names->[$i], 'docker');
-        test_opensuse_based_image($image_names->[$i], 'docker');
-        if (check_var("ARCH", "x86_64")) {
-            perform_container_diff($image_names->[$i], $stable_names->[$i]);
-        }
+        test_container_image(image => $image_names->[$i], runtime => 'docker');
+        build_container_image(image => $image_names->[$i], runtime => 'docker');
+        test_opensuse_based_image(image => $image_names->[$i], runtime => 'docker');
     }
 
     scc_restore_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
-    clean_container_host('docker');
+    clean_container_host(runtime => 'docker');
 }
 
 1;

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -61,7 +61,7 @@ sub run {
     install_docker_when_needed;
 
     # remove leftover containers and images
-    clean_container_host('docker');
+    clean_container_host(runtime => 'docker');
 }
 
 1;

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -53,7 +53,7 @@ sub run {
     test_built_img("podman");
 
     # Clean container
-    clean_container_host("podman");
+    clean_container_host(runtime => "podman");
 }
 
 sub post_fail_hook {

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -30,11 +30,11 @@ sub run {
     install_podman_when_needed();
 
     for my $i (0 .. $#$image_names) {
-        test_container_image($image_names->[$i], 'podman');
-        build_container_image($image_names->[$i], 'podman');
-        test_opensuse_based_image($image_names->[$i], 'podman');
+        test_container_image(image => $image_names->[$i], runtime => 'podman');
+        build_container_image(image => $image_names->[$i], runtime => 'podman');
+        test_opensuse_based_image(image => $image_names->[$i], runtime => 'podman');
     }
-    clean_container_host('podman');
+    clean_container_host(runtime => 'podman');
 }
 
 1;

--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -50,7 +50,7 @@ sub run {
     # apply all the updates to a new_image
     assert_script_run("zypper-docker update --auto-agree-with-licenses $testing_image new_image", timeout => 900);
 
-    clean_container_host('docker');
+    clean_container_host(runtime => 'docker');
 }
 
 1;


### PR DESCRIPTION
Hello,

 * Function `perform_container_diff()` moved from `docker_image.pm` to `container_diff.pm`
 * Various functions in `lib/containers/` are now validating presence of required parameters
 * this is a follow up to #10532 and I'd like to solve all the remaining issues here

- Verification run:
   * Released: [SLE12-SP3](http://pdostal-server.suse.cz/tests/9141) [SLE15-SP1](http://pdostal-server.suse.cz/tests/9148) [SLE15-SP2](http://pdostal-server.suse.cz/tests/9092) [Tumbleweed](http://pdostal-server.suse.cz/tests/9146)
   * SLE15-SP2 images: [s390x](https://openqa.suse.de/tests/4389547) [ppc64le](https://openqa.suse.de/tests/4389546) [aarch64](https://openqa.suse.de/tests/4389545#) [x86_64](https://openqa.suse.de/tests/4389548)
