### PR TITLE
Add product to the ay firstboot profile for openSUSE

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot.xml
@@ -28,6 +28,9 @@
         <pattern>base</pattern>
         <pattern>gnome</pattern>
       </patterns>
+      <products config:type="list">
+        <product>openSUSE</product>
+      </products>
     </software>
     <users config:type="list">
         <user>


### PR DESCRIPTION
See [poo#68383](https://progress.opensuse.org/issues/68383).
