### PR TITLE
Fix schedule for AY firstboot on openSUSE

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot.xml
@@ -28,9 +28,6 @@
         <pattern>base</pattern>
         <pattern>gnome</pattern>
       </patterns>
-      <products config:type="list">
-        <product>openSUSE</product>
-      </products>
     </software>
     <users config:type="list">
         <user>

--- a/schedule/yast/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/autoyast_y2_firstboot_opensuse.yaml
@@ -1,0 +1,15 @@
+name:           autoyast_y2_firstboot
+description:    >
+    Smoke test for YaST2 firstboot module
+vars:
+    AUTOYAST: autoyast_opensuse/autoyast_firstboot.xml
+    DESKTOP: gnome
+    YAST2_FIRSTBOOT_USERNAME: firstbootuser
+schedule:
+    - autoyast/prepare_profile
+    - installation/isosize
+    - installation/bootloader_start
+    - autoyast/installation
+    - installation/yast2_firstboot
+    - installation/first_boot
+    - console/validate_yast2_firstboot_configuration


### PR DESCRIPTION
See [poo#68383](https://progress.opensuse.org/issues/68383).

Issue was cause by test suites migration and wrong template was set in the yaml schedule.

## Verification runs
[TW](https://openqa.opensuse.org/tests/1314813#) (Fails on existing bug).
[Leap](https://openqa.opensuse.org/tests/1314816#).
