### PR TITLE
[WIP] Disable kernel watchdog as bypass poo#68218

### DIFF
--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -37,6 +37,8 @@ use constant {
           is_aarch64
           is_arm
           is_ppc64le
+          is_ppc64
+          is_powerpc
           )
     ]
 };
@@ -124,6 +126,28 @@ Returns C<check_var('ppc64le')>.
 =cut
 sub is_ppc64le {
     return check_var('ARCH', 'ppc64le');
+}
+
+=head2 is_ppc64
+
+ is_ppc64();
+
+Returns C<check_var('ppc64')>.
+
+=cut
+sub is_ppc64 {
+    return check_var('ARCH', 'ppc64');
+}
+
+=head2 is_powerpc
+
+ is_powerpc();
+
+Returns C<check_var('ppc64le') || check_var('ppc64')>.
+
+=cut
+sub is_powerpc {
+    return (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'ppc64'));
 }
 
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -444,7 +444,9 @@ sub load_reboot_tests {
         # exclude this scenario for autoyast test with switched keyboard layaout
         loadtest "installation/first_boot" unless get_var('INSTALL_KEYBOARD_LAYOUT');
         loadtest "installation/opensuse_welcome" if opensuse_welcome_applicable();
-        if (is_aarch64 && !get_var('INSTALLONLY') && !get_var('LIVE_INSTALLATION') && !get_var('LIVE_UPGRADE')) {
+        if ((is_aarch64 && !get_var('INSTALLONLY') &&
+                !get_var('LIVE_INSTALLATION') &&
+                !get_var('LIVE_UPGRADE')) || is_powerpc) {
             loadtest "installation/system_workarounds";
         }
     }

--- a/tests/installation/system_workarounds.pm
+++ b/tests/installation/system_workarounds.pm
@@ -14,13 +14,16 @@ use strict;
 use warnings;
 use testapi;
 use base 'opensusebasetest';
+use Utils::Architectures qw(is_aarch64 is_powerpc);
+
 
 sub run {
     select_console('root-console');
 
-    # boo#1105302 - Disable kernel watchdog on aarch64 (for running system and for next boot)
-    if (check_var('ARCH', 'aarch64')) {
-        record_info('boo#1105302', "Disable kernel watchdog to avoid test failures due to 'watchdog: BUG: soft lockup - CPU#0 stuck for XXs!'");
+    # boo#1105302 - Disable kernel watchdog on aarch64 and PowerPC
+    # (for running system and for next boot)
+    if (is_aarch64 || is_powerpc) {
+        record_info('boo#1105302', "boo#1105302: Disable kernel watchdog to avoid test failures due to 'watchdog: BUG: soft lockup - CPU#0 stuck for XXs!'");
         assert_script_run('echo 0 > /proc/sys/kernel/watchdog_thresh');
         assert_script_run('echo "kernel.watchdog_thresh = 0" > /etc/sysctl.d/watchdog.conf');
     }


### PR DESCRIPTION
this is same disable as done for aarch64 for boo#1105302

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>

- Related ticket: https://progress.opensuse.org/issues/68218
                         https://bugzilla.opensuse.org/show_bug.cgi?id=1105302
- Needles: none
- Verification run: pending https://openqa.opensuse.org/tests/overview?build=michelmno%2Fos-autoinst-distri-opensuse%2310591&version=Tumbleweed&distri=opensuse
