### PR TITLE
Add yast_self_update and yast_no_self_update for pvm

### DIFF
--- a/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
@@ -1,12 +1,12 @@
 ---
-name:           yast_self_update
+name:           yast_no_self_update
 description:    >
-  Test suite conducts installation with self-update explicitly enabled. No hard
-  checks are done that the self-updating is really disabled.
+  Test suite conducts installation with self-update explicitly disabled. No
+  hard checks are done that the self-updating is really disabled.
   Installation is validated by successful boot and that YaST does not report
   any issue.
 vars:
-  INSTALLER_SELF_UPDATE: 1
+  INSTALLER_SELF_UPDATE: 0
 schedule:
   - installation/isosize
   - installation/bootloader

--- a/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
@@ -1,0 +1,33 @@
+---
+name:           yast_self_update
+description:    >
+  Test suite conducts installation with self-update explicitly enabled. No hard
+  checks are done that the self-updating is really disabled.
+  Installation is validated by successful boot and that YaST does not report
+  any issue.
+vars:
+  INSTALLER_SELF_UPDATE: 1
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot


### PR DESCRIPTION
The PR adds schedule for yast_self_update and yast_self_no_update for pvm.

**Please, merge also Job Group settings MR:** https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/217

- Related tickets: https://progress.opensuse.org/issues/68392, https://progress.opensuse.org/issues/68389 
- Verification runs: 
   - yast_self_update: https://openqa.suse.de/tests/4389533
   - yast_no_self_update: https://openqa.suse.de/tests/4389534
