### PR TITLE
Pull container images only if necessary

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -141,8 +141,8 @@ sub test_container_image {
     my ($name, $tag) = split(/:/, $image);
     $tag //= 'latest';
 
-    # Pull the image
-    assert_script_run("$runtime pull $image", timeout => 300);
+    # Pull the image if necessary
+    assert_script_run("$runtime pull $image", timeout => 300) if script_run("$runtime image ls | grep \"$image\" | grep \"$tag\"") != 0;
     assert_script_run("$runtime image ls | grep '$name' | grep '$tag'");
 
     my $container = "${runtime}_${name}_${tag}_smoketest";


### PR DESCRIPTION
This commit check, if pull container images in `test_container_image` (`lib/containers/common.pm`) is required or if the image exists already locally. We require this for an upcoming test of custom build local images.

- Related ticket: https://progress.opensuse.org/issues/68440
- Needles: -
- Verification run: [SLE 15 SP1](https://openqa.suse.de/t4389536) | [SLE15](https://openqa.suse.de/t4389537) | [SLE12-SP5](https://openqa.suse.de/t4389538) | [SLE12-SP4](https://openqa.suse.de/t4389539) | [SLE12-SP3](https://openqa.suse.de/t4389540) | [Tumbleweed](https://openqa.opensuse.org/t1314871) | [Leap 15.2](https://openqa.opensuse.org/t1315199)