### PR TITLE
Remove useless double screen check of mate shutdown dialog to fix missing it

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -197,7 +197,6 @@ sub poweroff_x11 {
     if (check_var("DESKTOP", "mate")) {
         x11_start_program("mate-session-save --shutdown-dialog", valid => 0);
         send_key "ctrl-alt-delete";    # shutdown
-        assert_screen 'mate_logoutdialog', 15;
         assert_and_click 'mate_shutdown_btn';
     }
 


### PR DESCRIPTION
```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10599 https://openqa.opensuse.org/tests/1316240
```

https://openqa.opensuse.org/t1317439

Related progress issue: https://progress.opensuse.org/issues/68485