### PR TITLE
Change offline migration and zypper migration to do migration on powerVM

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -17,6 +17,7 @@ use testapi;
 use utils;
 use power_action_utils 'power_action';
 use version_utils qw(is_desktop_installed is_sles4sap);
+use Utils::Backends 'is_pvm';
 
 sub run {
     my $self = shift;
@@ -106,6 +107,7 @@ sub run {
     # We can't use 'keepconsole' here, because sometimes a display-manager upgrade can lead to a screen change
     # during restart of the X/GDM stack
     power_action('reboot', textmode => 1);
+    reconnect_mgmt_console if is_pvm;
 
     # Do not attempt to log into the desktop of a system installed with SLES4SAP
     # being prepared for upgrade, as it does not have an unprivileged user to test

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -17,6 +17,7 @@ use version_utils qw(is_sle is_desktop_installed is_upgrade is_sles4sap);
 use migration;
 use registration;
 use qam;
+use Utils::Backends 'is_pvm';
 
 
 sub patching_sle {
@@ -68,6 +69,7 @@ sub patching_sle {
             script_run('sed -i s/#Enable=true/Enable=true/g /etc/gdm/custom.conf');
             # Remove '-f' for reboot for poo#65226
             type_string "reboot\n";
+            reconnect_mgmt_console if is_pvm;
             $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 300, nologin => $nologin);
             # Setup again after reboot
             $self->setup_sle();


### PR DESCRIPTION
Change offline migration and zypper migration to do migration on powerVM

- Related ticket: https://progress.opensuse.org/issues/64833
- Verification run: 
offline migration: https://openqa.nue.suse.com/tests/4399136
https://openqa.nue.suse.com/tests/4399137
zypper online migration: 
https://openqa.nue.suse.com/tests/4399134
https://openqa.nue.suse.com/tests/4399135#
