### PR TITLE
Adapt online textmode expertpartitioner shutcut key during install

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -159,6 +159,10 @@ sub init_cmd {
         $testapi::cmd{sync_interval}       = "alt-i";
         $testapi::cmd{sync_without_daemon} = "alt-s";
     }
+    if (check_var('VIDEOMODE', 'text') && check_var('SCC_REGISTER', 'installation')) {
+        $testapi::cmd{expertpartitioner} = "alt-x";
+    }
+
     ## keyboard cmd vars end
 }
 


### PR DESCRIPTION
[Adapt online-textmode expertpartitioner shotcut key during installation]

shortcut is different depends on previously setup choice

old PR is revert due some issues . this PR is follow 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9899

- Related ticket: N/A
- Needles: N/A
- Verification run: http://openqa.qa2.suse.asia/tests/15545
