### PR TITLE
Verify writing conflict of 70-yast.conf with other confs

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -40,6 +40,8 @@ our @EXPORT = qw(
   handle_dhcp_popup
   open_yast2_lan
   close_yast2_lan
+  open_yast2_routing
+  change_ipforward
   wait_for_xterm_to_be_visible
   clear_journal_log
   close_xterm
@@ -351,6 +353,39 @@ sub handle_dhcp_popup {
     if (match_has_tag('dhcp-popup')) {
         wait_screen_change { send_key 'alt-o' };
     }
+}
+
+=head2 open_yast2_routing
+
+ open_yast2_routing();
+
+Open yast2 routing
+
+=cut
+sub open_yast2_routing {
+    $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'routing');
+    assert_screen "yast2_routing", 120;
+}
+
+=head2 change_ipforward
+
+ change_ipforward([$state], [$should_conflict]);
+
+C<$state> enabled/disabled will used to set the expected needle to match
+C<$should_conflict> 1 means conflict is expected or 0 otherwise
+
+Open routing module and enable or disable ip_forwarding
+
+=cut
+sub change_ipforward {
+    my %options = @_;
+    open_yast2_routing();
+    send_key 'spc';
+    assert_screen "ipv4_forwarding_$options{state}";
+    send_key 'alt-n', wait_screen_change => 1;
+    assert_screen "sysctl_ip_forward_conflict" if ($options{should_conflict});
+    send_key 'alt-o';
+    wait_serial("yast2-routing-status-0", 180) || die "'yast2-routing' didn't finish";
 }
 
 =head2 open_yast2_lan

--- a/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml
@@ -33,6 +33,7 @@ conditional_schedule:
         - console/yast2_apparmor
         - console/yast2_lan
         - console/yast2_lan_hostname
+        - console/yast2_settings
         - console/yast2_dns_server
         - console/yast2_nfs_client
         - console/yast2_snapper_ncurses

--- a/tests/console/yast2_settings.pm
+++ b/tests/console/yast2_settings.pm
@@ -1,0 +1,75 @@
+# SUSE's openQA tests
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: YaST writes config to 70-yast.conf and detects conflicts
+# - Install yast2-network
+# - verify writing config to the correct file
+# - ensure conflict detected when custom config with higher priority exists
+# - validate that YaST applies changes to the system. bsc#1167234
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base "y2_module_consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use y2lan_restart_common;
+
+my $yastconf              = '/etc/sysctl.d/70-yast.conf';
+my $customconf_in_etc     = '/etc/sysctl.d/90-custom.conf';
+my $customconf_in_usr_lib = '/usr/lib/sysctl.d/90-custom.conf';
+my $ipv4_forward          = 'net.ipv4.ip_forward';
+
+sub verify_write_config {
+    change_ipforward(state => 'enabled', should_conflict => 0);
+}
+
+sub ensure_conflict_detected {
+    _create_conflicts();
+    change_ipforward(state => 'disabled', should_conflict => 1);
+    # Log trace for conflict
+    validate_script_output "grep 'have conflicts with' /var/log/YaST2/y2log", sub { m%$customconf_in_etc% };
+    # No conflict if config is under /usr/lib/
+    validate_script_output "grep 'have conflicts with' /var/log/YaST2/y2log", sub { !m%$customconf_in_usr_lib% };
+}
+
+sub validate_changes_applied_to_system {
+    assert_script_run("grep '$ipv4_forward = 1' $yastconf");
+    assert_script_run("sysctl $ipv4_forward | grep 1");
+    assert_script_run("cat /proc/sys/net/ipv4/ip_forward | grep 1", fail_message => "ip_forward not applied to system bsc#1167234");
+}
+
+sub _create_conflicts {
+    # Files with higher priority that 70-yast.conf.
+    # But /etc has precedence over /usr/lib, thus second one should not
+    # cause conflict
+    foreach my $conf ($customconf_in_etc, $customconf_in_usr_lib) {
+        assert_script_run("touch $conf");
+        my $create_other_conf = "echo $ipv4_forward=1 > $conf && (exit $?)";
+        assert_script_run("$create_other_conf", fail_message => "Creating $conf failed.");
+        script_run("cat $conf", output => "show output for $conf");
+    }
+}
+
+sub run {
+    my $self = shift;
+
+    select_console 'root-console';
+    zypper_call "in yast2-network";    # make sure yast2 routing module installed
+
+    assert_script_run("sysctl net.ipv4.ip_forward | grep 0");
+    verify_write_config;
+    validate_changes_applied_to_system;
+    ensure_conflict_detected;
+    # make sure that nothing has changed
+    validate_changes_applied_to_system;
+    script_run("rm -rf $customconf_in_etc $customconf_in_usr_lib", output => "cleanup test files");
+    clear_console;
+}
+
+1;


### PR DESCRIPTION
Create manual config files and test that the yast reports                                                                                                                                                                                    
conflict when writes changes. To practice this we use                                                                                                                                                                                        
ip_forwarding. Due to precendence when we modify this value                                                                                                                                                                                  
we should have conflict with /etc/sysctl.d/* but not in /usr/lib.                                                                                                                                                                            
Also check that the change is taking place bsc#1167234

Progress: https://progress.opensuse.org/issues/65088
Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1394
VR: http://aquarius.suse.cz/tests/2810#