### PR TITLE
Temporary fix for yast2_samba

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -183,11 +183,15 @@ sub setup_samba_startup {
         assert_screen 'yast2_samba-server_start-during-boot';
     }
     else {
-        change_service_configuration(
-            after_writing => {start         => 'alt-e'},
-            after_reboot  => {start_on_boot => 'alt-a'}
-        );
+        send_key 'alt-e';
+        send_key 'end';
+        send_key_until_needlematch 'yast2_ncurses_service_start_after_writing_conf', 'up', 5, 1;
+        send_key 'ret';
+        send_key 'alt-a';
+        send_key_until_needlematch 'yast2_ncurses_service_start_on_boot_after_reboot', 'up', 5, 1;
+        send_key 'ret';
     }
+
     send_key $actions{firewall}->{shortcut};
     assert_screen 'yast2_samba_open_port_firewall';
 }


### PR DESCRIPTION
This workaround will work until we fix the real problem, see ticket. 

- Related ticket: https://progress.opensuse.org/issues/67123
- Verification run: 
http://waaa-amazing.suse.cz/tests/12389#
VR is a failed one. However, this change fixes this : https://openqa.opensuse.org/tests/1318824#step/yast2_samba/46 (as explained in thicket). Fixing the next failure is not the scope of this change.
