### PR TITLE
LTP: Schedule run_ltp from boot_ltp to avoid asset upload 

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -22,7 +22,6 @@ use testapi qw(check_var get_required_var get_var);
 use autotest;
 use Archive::Tar;
 use utils;
-use LTP::TestInfo 'testinfo';
 use File::Basename 'basename';
 use main_common qw(boot_hdd_image load_bootloader_s390x load_kernel_baremetal_tests);
 use 5.018;
@@ -31,9 +30,9 @@ use Utils::Backends 'is_pvm';
 # use warnings;
 
 our @EXPORT = qw(
-  get_ltp_tag
   load_kernel_tests
-  loadtest_from_runtest_file
+  loadtest
+  shutdown_ltp
 );
 
 sub loadtest {
@@ -44,110 +43,6 @@ sub loadtest {
 sub shutdown_ltp {
     loadtest('proc_sys_dump') if get_var('PROC_SYS_DUMP');
     loadtest('shutdown_ltp', @_);
-}
-
-sub parse_openposix_runfile {
-    my ($path, $name, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
-
-    open(my $rfile, $path) or die "Can not open runfile asset $path: $!";    ## no critic (InputOutput::ProhibitTwoArgOpen)
-    while (my $line = <$rfile>) {
-        chomp($line);
-        if ($line =~ m/$cmd_pattern/ && !($line =~ m/$cmd_exclude/)) {
-            my $test  = {name => basename($line, '.run-test'), command => $line};
-            my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
-            loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
-        }
-    }
-}
-
-sub parse_runtest_file {
-    my ($path, $name, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
-
-    open(my $rfile, $path) or die "Can not open runtest asset $path: $!";    ## no critic (InputOutput::ProhibitTwoArgOpen)
-    while (my $line = <$rfile>) {
-        next if ($line =~ /(^#)|(^$)/);
-
-        #Command format is "<name> <command> [<args>...] [#<comment>]"
-        if ($line =~ /^\s* ([\w-]+) \s+ (\S.+) #?/gx) {
-            next if (check_var('BACKEND', 'svirt') && ($1 eq 'dnsmasq' || $1 eq 'dhcpd'));    # poo#33850
-            my $test  = {name => $1, command => $2};
-            my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
-            if ($test->{name} =~ m/$cmd_pattern/ && !($test->{name} =~ m/$cmd_exclude/)) {
-                loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
-            }
-        }
-    }
-}
-
-sub get_ltp_tag {
-    my $tag = get_var('LTP_RUNTEST_TAG');
-
-    if (!defined $tag) {
-        if (defined get_var('HDD_1')) {
-            $tag = get_var('PUBLISH_HDD_1');
-            $tag = get_var('HDD_1') if (!defined $tag);
-            $tag = basename($tag);
-        } else {
-            $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
-        }
-    }
-    return $tag;
-}
-
-sub loadtest_from_runtest_file {
-    my $namelist           = get_var('LTP_COMMAND_FILE');
-    my $archive            = shift || get_var('ASSET_1');
-    my $unpack_path        = './runtest-files';
-    my $cmd_pattern        = get_var('LTP_COMMAND_PATTERN') || '.*';
-    my $cmd_exclude        = get_var('LTP_COMMAND_EXCLUDE') || '$^';
-    my $test_result_export = {
-        format      => 'result_array:v2',
-        environment => {},
-        results     => []};
-
-    if (!$archive) {
-        my $tag = get_ltp_tag();
-        $archive = get_var('ASSETDIR') . "/other/runtest-files-$tag.tar.gz";
-    }
-
-    loadtest('boot_ltp', run_args => testinfo($test_result_export));
-    if (get_var('LTP_COMMAND_FILE') =~ m/ltp-aiodio.part[134]/) {
-        loadtest 'create_junkfile_ltp';
-    }
-
-    if (get_var('LTP_COMMAND_FILE') =~ m/lvm\.local/) {
-        loadtest 'ltp_init_lvm';
-    }
-
-    mkdir($unpack_path, 0755);
-    my $tar = Archive::Tar->new();
-    $tar->read($archive) || die "tar read failed $? $!";
-    $tar->setcwd($unpack_path);
-    $tar->extract() || die "tar extract failed $? $!";
-
-    for my $name (split(/,/, $namelist)) {
-        if ($name eq 'openposix') {
-            parse_openposix_runfile("$unpack_path/openposix-test-list", $name, $cmd_pattern, $cmd_exclude, $test_result_export);
-        }
-        else {
-            parse_runtest_file("$unpack_path/$name", $name, $cmd_pattern, $cmd_exclude, $test_result_export);
-        }
-    }
-
-    shutdown_ltp(run_args => testinfo($test_result_export));
-}
-
-# Replace loadtest_from_runtest_file with this to stress test reverting to
-# snapshots
-sub stress_snapshots {
-    my $count = 100;
-
-    for (my $i = 0; $i < $count / 2; $i++) {
-        # This will always fail and revert to the previous milestone, which
-        # will either be boot_ltp or write_random#$i
-        loadtest('run_ltp');
-        loadtest('write_random');
-    }
 }
 
 sub load_kernel_tests {
@@ -172,14 +67,6 @@ sub load_kernel_tests {
             loadtest 'update_kernel';
         }
         loadtest 'install_ltp';
-        # If LTP_COMMAND_FILE is set, boot_ltp() and shutdown_ltp() will be added
-        # later by install_ltp task.
-        if (!get_var('LTP_COMMAND_FILE')) {
-            if (get_var('LTP_INSTALL_REBOOT')) {
-                loadtest 'boot_ltp';
-            }
-            shutdown_ltp();
-        }
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
         if (get_var('INSTALL_KOTD')) {
@@ -191,7 +78,7 @@ sub load_kernel_tests {
             loadtest 'change_kernel';
         }
 
-        loadtest_from_runtest_file();
+        loadtest 'boot_ltp';
     }
     elsif (get_var('QA_TEST_KLP_REPO')) {
         if (get_var('INSTALL_KOTD')) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -20,7 +20,7 @@ use testapi;
 use registration;
 use utils;
 use bootloader_setup qw(add_custom_grub_entries add_grub_cmdline_settings);
-use main_ltp qw(get_ltp_tag loadtest_from_runtest_file);
+use main_ltp qw(loadtest shutdown_ltp);
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
 use serial_terminal 'prepare_serial_console';
@@ -174,25 +174,6 @@ sub install_build_dependencies {
     }
 }
 
-sub upload_runtest_files {
-    my ($dir, $tag) = @_;
-    my $aiurl = autoinst_url();
-
-    my $up_script = qq%
-ldir='/tmp/runtest-files-$tag'
-archive="\$ldir.tar.gz"
-mkdir -p \$ldir
-cd \$ldir
-cp -v $dir/* ~/openposix-test-list \$ldir
-tar czvf \$archive *
-ls -la \$archive
-file \$archive
-echo "curl --form upload=\@\$archive --form target=assets_public $aiurl/upload_asset/\$(basename \$archive)"
-curl --form upload=\@\$archive --form target=assets_public $aiurl/upload_asset/\$(basename \$archive)
-%;
-    script_output($up_script, 300);
-}
-
 sub install_from_git {
     my $url         = get_var('LTP_GIT_URL', 'https://github.com/linux-test-project/ltp');
     my $rel         = get_var('LTP_RELEASE');
@@ -301,7 +282,6 @@ sub setup_network {
 sub run {
     my $self       = shift;
     my $inst_ltp   = get_var 'INSTALL_LTP';
-    my $tag        = get_ltp_tag();
     my $grub_param = 'ignore_loglevel';
 
     if ($inst_ltp !~ /(repo|git)/i) {
@@ -359,17 +339,16 @@ sub run {
         assert_script_run('generate_lvm_runfile.sh');
     }
 
-    upload_runtest_files('/opt/ltp/runtest', $tag);
-
-    if (get_var('LTP_COMMAND_FILE')) {
-        # This assumes that current working directory is the worker's pool dir
-        loadtest_from_runtest_file("assets_public/runtest-files-$tag.tar.gz");
-    }
-
     is_jeos && zypper_call 'in system-user-bin system-user-daemon';
 
-    power_action('reboot', textmode => 1) if (get_var('LTP_INSTALL_REBOOT') ||
-        get_var('LTP_COMMAND_FILE')) && !is_jeos;
+    # boot_ltp will schedule the tests and shutdown_ltp if there is a command
+    # file
+    if (get_var('LTP_COMMAND_FILE') || get_var('LTP_INSTALL_REBOOT')) {
+        power_action('reboot', textmode => 1) unless is_jeos;
+        loadtest 'boot_ltp';
+    }
+
+    shutdown_ltp() unless get_var('LTP_COMMAND_FILE');
 }
 
 sub post_fail_hook {

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: Extracts test commands from an LTP runfile and executes them on the guest.
+# Summary: Executes a single LTP test case
 # Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
 # More documentation is at the bottom
 
@@ -366,9 +366,8 @@ sub run_post_fail {
 
 =head1 Discussion
 
-This module extracts an LTP runtest file from the VM[1], parses it and then
-executes the LTP test cases defined on each line of the runtest file. Logs are
-uploaded and interpreted after each LTP test case completes.
+This module executes a single LTP test case specified by LTP::TestInfo which
+is passed to run. This module is dynamically scheduled by boot_ltp at runtime.
 
 LTP test cases are usually a binary executable or a shell script. Each line of
 the runtest file contains the name of the test case and a string which is
@@ -377,10 +376,6 @@ executed by the shell.
 The output of each test case is parsed for lines containing CONF and FAIL.
 If these terms are found in the output then a neutral or fail result will be
 reported, otherwise a pass.
-
-[1] Actually the parsing is now done by lib/main_ltp.pm which is called from
-    main.pm after install_ltp has uploaded the runtest files as
-    assets. run_ltp is scheduled once for each LTP test case/executable.
 
 [2] This overrides the default basetest class behaviour because the LTP tests
     are able to continue after most failures (without reverting to a
@@ -433,12 +428,6 @@ LTP test itself.
 
 Comma separated list of environment variables to be set for tests.
 E.g.: key=value,key2="value with spaces",key3='another value with spaces'
-
-=head2 LTP_RUNTEST_TAG
-
-The runtest asset files are appended with git or pkg depending on how LTP was
-installed. By default the runtest files from the git installation will be
-used, but setting this variable to pkg allows that behavior to be overridden.
 
 =cut
 


### PR DESCRIPTION
Revert back to having a single run_ltp test module instead of dynamically
generating modules for each LTP test case. This means runtest files no longer
must be uploaded as assets during install_ltp. It also reduces the load on the
OpenQA DB.

The result for individual LTP test cases should still be available under the
'external' results tab. We didn't have this tab when the dynamic module
generation was introduced.

https://progress.opensuse.org/issues/65675
