### PR TITLE
Add minimal+proxy_SCC-postreg_SUSEconnect.yaml

### DIFF
--- a/schedule/functional/minimal+proxy_SCC-postreg_SUSEconnect.yaml
+++ b/schedule/functional/minimal+proxy_SCC-postreg_SUSEconnect.yaml
@@ -1,0 +1,7 @@
+name:           minimal+proxy_SCC-postreg_SUSEconnect
+description:    >
+    Maintainer: riafarov
+    Register modules after a system is installed using SUSEconnect.
+schedule:
+    - boot/boot_to_desktop
+    - console/suseconnect_scc


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/68527
- Verification runs:
  - Expected test modules: `boot/boot_to_desktop` and `console/suseconnect_scc`
  - aarch64: http://openqa.slindomansilla-vm.qa.suse.de/tests/2542 (`_EXIT_AFTER_SCHEDULE`)
  - ppc64le: https://openqa.suse.de/tests/4402644 (`_EXIT_AFTER_SCHEDULE`)
  - s390x: N/A
  - x86_64: http://openqa.slindomansilla-vm.qa.suse.de/tests/2544 (`_EXIT_AFTER_SCHEDULE`)
