### PR TITLE
[virt_autotest] fixup SSH Key issue on VM host

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -248,7 +248,7 @@ sub enable_libvirt_log {
 sub ssh_setup {
     my $default_ssh_key = "/root/.ssh/id_rsa";
     if (script_run("[[ -f $default_ssh_key ]]") != 0) {
-        script_run("ssh-keygen -t rsa -f $default_ssh_key -P ''", 0);
+        assert_script_run "ssh-keygen -t rsa -P '' -f $default_ssh_key";
     }
 }
 

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -68,6 +68,7 @@ sub run_test {
         $mac   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
+        check_guest_module($guest, module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_host_bridge --model $model --mac $mac --live $affecter", 60);
 
         my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_host_bridge';

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -68,7 +68,8 @@ sub run_test {
         $mac   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
-        check_guest_module($guest, module => "acpiphp");
+        #Check guest loaded kernel module before attach interface to guest system
+        check_guest_module("$guest", module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_host_bridge --model $model --mac $mac --live $affecter", 60);
 
         my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_host_bridge';

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -60,7 +60,8 @@ sub run_test {
         $mac   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
-        check_guest_module($guest, module => "acpiphp");
+        #Check guest loaded kernel module before attach interface to guest system
+        check_guest_module("$guest", module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_isolated --model $model --mac $mac --live $affecter", 60);
 
         my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_isolated';

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -62,6 +62,7 @@ sub run_test {
         $mac   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
+        check_guest_module($guest, module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_nated --model $model --mac $mac --live $affecter", 60);
 
         my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_nated';

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -62,7 +62,8 @@ sub run_test {
         $mac   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
-        check_guest_module($guest, module => "acpiphp");
+        #Check guest loaded kernel module before attach interface to guest system
+        check_guest_module("$guest", module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_nated --model $model --mac $mac --live $affecter", 60);
 
         my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_nated';

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -80,11 +80,13 @@ sub run_test {
         $mac1   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model1 = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
+        check_guest_module($guest, module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_routed --model $model1 --mac $mac1 --live $affecter", 60);
 
         $mac2   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model2 = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
+        check_guest_module($guest, module => "acpiphp");
         assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --model $model2 --mac $mac2 --live $affecter", 60);
 
         #Wait for guests attached interface from virtual routed network

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -80,13 +80,15 @@ sub run_test {
         $mac1   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model1 = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
-        check_guest_module($guest, module => "acpiphp");
+        #Check guest loaded kernel module before attach interface to guest system
+        check_guest_module("$guest", module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_routed --model $model1 --mac $mac1 --live $affecter", 60);
 
         $mac2   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model2 = (get_var('XEN') || check_var('SYSTEM_ROLE', 'xen') || check_var('HOST_HYPERVISOR', 'xen')) ? 'netfront' : 'virtio';
 
-        check_guest_module($guest, module => "acpiphp");
+        #Check guest loaded kernel module before attach interface to guest system
+        check_guest_module("$guest.clone", module => "acpiphp");
         assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --model $model2 --mac $mac2 --live $affecter", 60);
 
         #Wait for guests attached interface from virtual routed network

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -68,7 +68,8 @@ sub run_test {
         sleep 60;
         save_guest_ip($guest, name => "br123");
         my $mode = is_sle('=11-sp4') ? '' : '-f';
-        exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no $mode root\@$guest");
+        my $default_ssh_key = "/root/.ssh/id_rsa.pub";
+        exec_and_insert_password("ssh-copy-id -i $default_ssh_key -o StrictHostKeyChecking=no $mode root\@$guest");
         check_guest_module($guest, module => "acpiphp");
         #Prepare the new guest network interface files for libvirt virtual network
         assert_script_run("ssh root\@$guest 'cd /etc/sysconfig/network/; cp ifcfg-eth0 ifcfg-eth1; cp ifcfg-eth0 ifcfg-eth2; cp ifcfg-eth0 ifcfg-eth3; cp ifcfg-eth0 ifcfg-eth4; cp ifcfg-eth0 ifcfg-eth5; cp ifcfg-eth0 ifcfg-eth6'");

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -67,10 +67,9 @@ sub run_test {
         #Wait for forceful boot up guests
         sleep 60;
         save_guest_ip($guest, name => "br123");
-        my $mode = is_sle('=11-sp4') ? '' : '-f';
+        my $mode            = is_sle('=11-sp4') ? '' : '-f';
         my $default_ssh_key = "/root/.ssh/id_rsa.pub";
         exec_and_insert_password("ssh-copy-id -i $default_ssh_key -o StrictHostKeyChecking=no $mode root\@$guest");
-        check_guest_module($guest, module => "acpiphp");
         #Prepare the new guest network interface files for libvirt virtual network
         assert_script_run("ssh root\@$guest 'cd /etc/sysconfig/network/; cp ifcfg-eth0 ifcfg-eth1; cp ifcfg-eth0 ifcfg-eth2; cp ifcfg-eth0 ifcfg-eth3; cp ifcfg-eth0 ifcfg-eth4; cp ifcfg-eth0 ifcfg-eth5; cp ifcfg-eth0 ifcfg-eth6'");
         if ($guest =~ m/sles-?11/i) {


### PR DESCRIPTION
Refer to the new failure about OSD libvirt_virtual_network_init, 
https://149.44.176.58/tests/4403974

Should be used RAS as SSH KEY with -i [identity_file] option for ssh-copy-id shell script
ssh-copy-id -i /root/.ssh/id_rsa.pub -o StrictHostKeyChecking=no -f root@sles-11-sp4-64-fv-def-net
PUB_ID_FILE=/root/.ssh/id_rsa.pub -> overwrite the default SSH KEY as RSA
PRIV_ID_FILE=/root/.ssh/id_rsa

Full Verification Run:
gi-guest_sles11sp4-on-host-developing-kvm
http://10.67.19.82/tests/709
gi-guest_sles11sp4-on-host-developing-xen
http://10.67.19.82/tests/707
gi-guest_developing-on-host-developing-kvm 
http://10.67.19.82/tests/697
gi-guest_developing-on-host-developing-xen
http://10.67.19.82/tests/705