### PR TITLE
Add yaml schedule for test suites from YaST Job Group

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -1,0 +1,51 @@
+---
+name: btrfs+warnings
+description: >
+  Test suite verifies variety of warning which are expected to be shown when
+  something is missing during manual partitioning using Expert Partitioner.
+  Following warning are verified:
+    - Missing root partition;
+    - Invalid boot partitioning (bios boot,/boot/zipl/,EFI, prep-boot),
+      only storage NG;
+    - Minimal size for the root with btrfs and snapshots and non-btrfs
+      (only storage-ng);
+    - No swap partition.
+vars:
+  FILESYSTEM: btrfs
+  PARTITIONING_WARNINGS: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_warnings
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  # Called on BACKEND: svirt
+  - '{{reconnect_mgmt_console}}'
+  # Called on BACKEND: qemu
+  - '{{grub_test}}'
+  - installation/first_boot
+conditional_schedule:
+  reconnect_mgmt_console:
+    BACKEND:
+      svirt:
+        - boot/reconnect_mgmt_console
+  grub_test:
+    BACKEND:
+      qemu:
+        - installation/grub_test

--- a/schedule/yast/clone_system.yaml
+++ b/schedule/yast/clone_system.yaml
@@ -1,0 +1,26 @@
+---
+name: clone_system
+description: >
+  Test suite triggers `yast clone_system` command and checks that profile is
+  generated and no error reported by YaST. No validation of the profile is done.
+vars:
+  DESKTOP: gnome
+schedule:
+  # Called on ARCH: s390x
+  - '{{bootloader_zkvm}}'
+  # Called on ARCH: aarch64
+  - '{{uefi_bootmenu}}'
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/yast2_clone_system
+  - console/consoletest_finish
+conditional_schedule:
+  bootloader_zkvm:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
+  uefi_bootmenu:
+    ARCH:
+      aarch64:
+        - boot/uefi_bootmenu

--- a/schedule/yast/mediacheck.yaml
+++ b/schedule/yast/mediacheck.yaml
@@ -13,4 +13,3 @@ conditional_schedule:
     VIRSH_VMM_TYPE:
       hvm:
         - installation/bootloader_start
-

--- a/schedule/yast/mediacheck.yaml
+++ b/schedule/yast/mediacheck.yaml
@@ -1,0 +1,16 @@
+---
+name: mediacheck
+description: >
+  Test suite triggers installation medium check and verifies that check passes
+  in linuxrc.
+vars:
+  MEDIACHECK: '1'
+schedule:
+  - '{{bootloader}}'
+  - installation/mediacheck
+conditional_schedule:
+  bootloader:
+    VIRSH_VMM_TYPE:
+      hvm:
+        - installation/bootloader_start
+

--- a/schedule/yast/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered.yaml
@@ -1,0 +1,25 @@
+---
+name: releasenotes_origin+unregistered
+description: >
+  Test fate#323273 - Check the origin (rpm or url) of the showed release notes.
+vars:
+  CHECK_RELEASENOTES_ORIGIN: '1'
+  EXIT_AFTER_START_INSTALL: '1'
+  SCC_REGISTER: 'none'
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/releasenotes_origin
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install

--- a/schedule/yast/usb_install.yaml
+++ b/schedule/yast/usb_install.yaml
@@ -1,0 +1,37 @@
+---
+name: USBinstall
+description: >
+  Basic installation test with USB boot. Verification that usb repo is enabled
+  after first boot. Test covers both Online and Full medium installations.
+vars:
+  DESKTOP: textmode
+  USBBOOT: 1
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/sle15_workarounds
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/enable_usb_repo
+  - console/zypper_lr


### PR DESCRIPTION
The pull request adds yaml schedule for the following test suites:
   - USBinstall
   - mediacheck
   - releasenotes_origin+unregistered
   - btrfs+warnings
   - clone_system

Verification runs: https://openqa.suse.de/tests/overview?groupid=96&distri=sle&version=15-SP2&build=Build209.2_yaml

Could you please also merge the MR with Job Group Settings: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/224