### PR TITLE
prepare_tools: apply workaround for the bug in ec2uploadimg

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -75,7 +75,8 @@ sub run {
     # Install ec2imgutils
     install_in_venv('ec2imgutils', 'ec2uploadimg');
     assert_script_run("curl " . data_url('publiccloud/ec2utils.conf') . " -o /root/.ec2utils.conf");
-    record_info('ec2imgutils', 'ec2uploadimg:' . script_output('ec2uploadimg --version'));
+    # TODO: revert to 'ec2uploadimg --version' when it will be fixed
+    record_info('ec2imgutils', 'ec2uploadimg:' . script_output('ec2uploadimg -h'));
 
     # Install Azure cli
     install_in_venv('azure-cli', 'az');


### PR DESCRIPTION
apply workaround for the bug in ec2uploadimg

currently `ec2uploadimg --version` producing error : 

```
ec2uploadimg --version
> EOT_1GlGs
1GlGs-0-
# echo 1GlGs; bash -oe pipefail /tmp/script1GlGs.sh ; echo SCRIPT_FINISHED1GlGs-$?-
1GlGs
usage: ec2uploadimg [-h] [-a ACCOUNT_NAME] [--access-id AWS_ACCESS_KEY]
                    [-B EC2_BACKING_STORE] [--billing-codes BILLING_CODES]
                    [--boot-kernel AWS_AKI_ID] -d IMAGE_DESCRIPTION
                    [-e AWS_AMI_ID] [--ena-support] [-f CONFIG_FILE] [--grub2]
                    [-i AWS_INSTANCE_ID] -m ARCH -n IMAGE_NAME
                    [-p PRIVATE_KEY] -r EC2_REGIONS
                    [--root-volume-size ROOT_VOLUME_SIZE]
                    [--ssh-key-pair AWS_KEY_PAIR_NAME] [-s AWS_SECRET_KEY]
                    [--security-group-ids AWS_SECURITY_GROUP_IDS]
                    [--session-token AWS_SESSION_TOKEN] [--snaponly]
                    [--sriov-support] [--ssh-timeout SSH_TIME_OUT]
                    [-t AWS_UPLOAD_INST_TYPE] [-u AWS_INSTANCE_USER]
                    [--use-private-ip] [--use-root-swap] [-V AWS_VIRT_TYPE]
                    [--verbose] [--version] [--vpc-subnet-id VPC_SUBNET_ID]
                    [--wait-count AWS_WAIT_COUNT]
                    source
ec2uploadimg: error: the following arguments are required: -d/--description, -m/--machine, -n/--name, -r/--regions, source
```
so we basically can not use `--version` flag 

VR: https://openqa.suse.de/tests/4405923