### PR TITLE
Add test for iotop

### DIFF
--- a/schedule/qam/12-SP2/mau-extratests.yaml
+++ b/schedule/qam/12-SP2/mau-extratests.yaml
@@ -49,6 +49,7 @@ schedule:
 - console/timezone
 - console/ntp
 - console/procps
+- console/iotop
 - console/kmod
 - console/suse_module_tools
 - console/aaa_base

--- a/schedule/qam/12-SP3/mau-extratests.yaml
+++ b/schedule/qam/12-SP3/mau-extratests.yaml
@@ -52,6 +52,7 @@ schedule:
 - console/timezone
 - console/ntp
 - console/procps
+- console/iotop
 - console/kmod
 - console/suse_module_tools
 - console/aaa_base

--- a/schedule/qam/12-SP4/mau-extratests.yaml
+++ b/schedule/qam/12-SP4/mau-extratests.yaml
@@ -53,6 +53,7 @@ schedule:
 - console/timezone
 - console/ntp
 - console/procps
+- console/iotop
 - console/kmod
 - console/suse_module_tools
 - console/zziplib

--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -53,6 +53,7 @@ schedule:
 - console/timezone
 - console/ntp
 - console/procps
+- console/iotop
 - console/kmod
 - console/suse_module_tools
 - console/zziplib

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -53,6 +53,7 @@ schedule:
 - console/ntp_client
 - console/procps
 - '{{lshw}}'
+- console/iotop
 - console/kmod
 - console/suse_module_tools
 - console/zziplib

--- a/schedule/qam/15-SP2/mau-extratests.yaml
+++ b/schedule/qam/15-SP2/mau-extratests.yaml
@@ -53,6 +53,7 @@ schedule:
 - console/timezone
 - console/procps
 - '{{lshw}}'
+- console/iotop
 - console/kmod
 - console/suse_module_tools
 - console/zziplib

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -55,6 +55,7 @@ schedule:
 - console/ntp_client
 - console/procps
 - '{{lshw}}'
+- console/iotop
 - console/kmod
 - console/suse_module_tools
 - console/zziplib

--- a/tests/console/iotop.pm
+++ b/tests/console/iotop.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test iotop
+# - Check basic functionality of iotop
+# - Run iotop in background and create some load
+# - Make sure load is detected in the report
+# Maintainer: Michael Grifalconi <mgrifalconi@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    zypper_call 'in iotop';
+
+    # Test iotop with several options
+    assert_script_run("iotop -bakPtn 2");
+
+    # Test under load
+    type_string("iotop -baoqn 10 > iotop.log &");
+    assert_script_run("dd if=/dev/zero of=./file.img bs=1M count=1000 status=none");
+    assert_script_run("wait");
+    assert_script_run("grep 'dd if=/dev/zero of=./file.img' iotop.log");
+
+    # Cleanup
+    assert_script_run("rm file.img iotop.log");
+
+}
+
+1;


### PR DESCRIPTION
* Basic iotop functionality
* Run some load and detect it in the report

- Related ticket: https://progress.opensuse.org/issues/48968
- Needles: no needles
- Verification run: 
  - x86 15.2    https://openqa.suse.de/tests/4405928#
  - s390 15.1  https://openqa.suse.de/tests/4405927#
- Local verification:
  - 12.2           http://10.161.229.249/tests/57
  - 12.3           http://10.161.229.249/tests/56
  - 12.4           http://10.161.229.249/tests/55
  - 12.5           http://10.161.229.249/tests/54
  - 15              http://10.161.229.249/tests/53
  - 15.1           http://10.161.229.249/tests/52
  - 15.2           http://10.161.229.249/tests/51