### PR TITLE
xfstests: Reorganize xfstests and fix a known issue

### DIFF
--- a/data/xfstests/wrapper.sh
+++ b/data/xfstests/wrapper.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+XFSTESTS_DIR='/opt/xfstests'
+PROG="$XFSTESTS_DIR/check"
+SCRIPT_DIR=$(realpath $(dirname "$0"))
+FSTYPE=${2:-'xfs'}
+
+function usage()
+{
+    echo "Usage: $0 TEST [FILESYSTEM TYPE]"
+}
+
+function unset_vars()
+{
+    unset TEST_DEV
+    unset TEST_DIR
+    unset SCRATCH_MNT
+    unset SCRATCH_DEV_POOL
+    unset SCRATCH_DEV
+}
+
+# Parse the output of "check"
+# 1 - Test item
+# 2 - Output to be parsed
+function parse_result()
+{
+    # Is it skipped?
+    echo "$2" | grep -i "Not run: $1" &> /dev/null
+    if [[ $? -eq 0 ]]; then
+        return 22
+    fi
+    # Is it failed?
+    echo "$2" | grep -i "Failures: $1" &> /dev/null
+    if [[ $? -eq 0 ]]; then
+        return 1
+    fi
+    # Is it passed?
+    echo "$2" | grep -i "Passed all 1 tests" &> /dev/null
+    if [[ $? -eq 0 ]]; then
+        return 0
+    fi
+    # Internal error
+    return 11
+}
+
+# Check for cmdline arguments
+if [ "$#" -lt 1 -o "$#" -gt 2 ]; then
+    usage
+    exit 255
+fi
+# Exit if xfstests not installed
+if [[ ! -x "$PROG" ]]; then
+    echo "[FAIL] xfstests not installed to /opt"
+    exit 255
+fi
+
+# Fix hostname problem
+grep -P "127\.0\.0\.1.*?$(hostname)" /etc/hosts &> /dev/null
+if [[ $? -ne 0 ]]; then
+    sed -i -e "s/127\\.0\\.0\\.1.*/& $(hostname)/g" /etc/hosts
+fi
+grep -P "::1.*?$(hostname)" /etc/hosts &> /dev/null
+if [[ $? -ne 0 ]]; then
+    sed -i -e "s/::1.*/& $(hostname)/g" /etc/hosts
+fi
+
+# Load xfstests settings from ~/.xfstests
+if [[ -f "$HOME/.xfstests" ]]; then
+    unset_vars
+    source "$HOME/.xfstests"
+fi
+
+pushd "$XFSTESTS_DIR" &> /dev/null
+
+# Umount /mnt/test and /mnt/scratch
+umount $TEST_DEV &> /dev/null
+if [[ -n "$SCRATCH_DEV_POOL" ]]; then
+    for device in $SCRATCH_DEV_POOL; do
+        umount $device &> /dev/null
+    done
+else
+    umount $SCRATCH_DEV
+fi
+
+# Run test
+log_file="/tmp/xfstests-$(echo "$1" | tr '/' '_').tmp"
+./$(basename "$PROG") -d "$1" | tee "$log_file"
+output=$(cat "$log_file")
+rm -f $log_file
+
+parse_result "$1" "$output"
+ret=$?
+
+popd &> /dev/null
+if [[ -f "$HOME/.xfstests" ]]; then
+    unset_vars
+fi
+exit $ret

--- a/lib/filesystem_utils.pm
+++ b/lib/filesystem_utils.pm
@@ -1,0 +1,234 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Base module for xfstests
+# - Including some operation(create/remove/format) to partitions
+# - Get free space infomation from storage
+# Maintainer: Yong Sun <yosun@suse.com>
+package filesystem_utils;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use utils;
+use testapi;
+
+our @EXPORT = qw(str_to_mb parted_print partition_num_by_start_end
+  partition_num_by_type free_space mountpoint_to_partition
+  partition_table create_partition remove_partition format_partition);
+
+=head2 str_to_mb
+
+Format number and unit from KB, MB, GB, TB to MB
+
+=cut
+sub str_to_mb {
+    my $str = shift;
+    if ($str =~ /(\d+(\.\d+)?)K/) {
+        return $1 / 1024;
+    }
+    elsif ($str =~ /(\d+(\.\d+)?)M/) {
+        return $1;
+    }
+    elsif ($str =~ /(\d+(\.\d+)?)G/) {
+        return $1 * 1024;
+    }
+    elsif ($str =~ /(\d+(\.\d+)?)T/) {
+        return $1 * 1024 * 1024;
+    }
+    else {
+        return;
+    }
+}
+
+=head2 parted_print
+
+Print dev partition info by MB
+
+=cut
+sub parted_print {
+    my $dev = shift;
+    my $cmd = "parted -s $dev unit MB print free";
+    script_output($cmd);
+}
+
+=head2 partition_num_by_start_end
+
+Get partition number by given device partition start and end
+
+=cut
+sub partition_num_by_start_end {
+    my ($dev, $start, $end) = @_;
+    my $output = parted_print($dev);
+    my $match;
+    if ($output =~ /(\d+)\s+($start)MB\s+($end)MB\s+(\d+\.?\d*)MB/i) {
+        $match = $1;
+    }
+    return $match;
+}
+
+=head2 partition_num_by_type
+
+Get the first parition number by given device and partition/FS type. e.g. extended, xfs
+Return -1 when not find
+
+=cut
+sub partition_num_by_type {
+    my ($dev, $type) = @_;
+    my $output = parted_print($dev);
+    if ($output =~ /(\d+)\s+([\d.]+)MB\s+([\d.]+)MB\s+([\d.]+)MB.*?$type/i) {
+        return $1;
+    }
+    else {
+        return -1;
+    }
+}
+
+=head2 free_space
+
+Get all information (start, end, size) about the bigest free space
+Return a hash contain start, end and size
+
+=cut
+sub free_space {
+    my $dev = shift;
+    my %space;
+    my $output = parted_print($dev);
+    my ($start, $end, $size);
+    foreach my $line (split(/\n/, $output)) {
+        if ($line =~ /\s*([\d.]+)MB\s+([\d.]+)MB\s+([\d.]+)MB\s*Free Space/) {
+            $start = $1;
+            $end   = $2;
+            $size  = $3;
+            if (!exists($space{size}) || $size > $space{size}) {
+                $space{start} = $start;
+                $space{end}   = $end;
+                $space{size}  = $size;
+            }
+        }
+    }
+    return %space;
+}
+
+=head2 mountpoint_to_partition
+
+Get partition by mountpoint, e.g. give /home get /dev/sda3
+
+=cut
+sub mountpoint_to_partition {
+    my $mountpoint = shift;
+    my $output     = script_output('mount');
+    my $match;
+    if ($output =~ /(\S+) on $mountpoint type/i) {
+        $match = $1;
+    }
+    else {
+        print 'Warning: mountpoint did not match.';
+        return $match;
+    }
+}
+
+=head2 partition_table
+
+Get partition table information by giving device
+
+=cut
+sub partition_table {
+    my $dev    = shift;
+    my $output = parted_print($dev);
+    my $match;
+    if ($output =~ /Partition Table:\s*(\w+)/i) {
+        $match = $1;
+    }
+    return $match;
+}
+
+=head2 create_partition
+
+Create a new partition by giving device, partition type and partition size
+part_type (extended|logical|primary)
+
+=cut
+sub create_partition {
+    my ($dev, $part_type, $size) = @_;
+    my ($part_start, $part_end);
+    my $part_table       = partition_table($dev);
+    my %msdos_part_types = ('extended', 1, 'logical', 1);
+    if ($part_table != 'msdos' && exists($msdos_part_types{$part_type})) {
+        die 'extended/logical partitions can only be created with msdos partition table!';
+    }
+    my %space      = free_space($dev);
+    my $space_size = int($space{size});
+    if ($space_size == 0) {
+        die 'No space left in device!';
+    }
+    if ($size =~ /max/ || $part_type =~ /extended/) {
+        $part_start = $space{start};
+        $part_end   = $space{end};
+    }
+    else {
+        $part_start = $space{start};
+        $part_end   = int($space{start}) + $size;
+    }
+    my $cmd = "parted -s -a min $dev mkpart $part_type $part_start" . "MB $part_end" . "MB";
+    assert_script_run($cmd);
+    sleep 1;
+    script_run("partprobe $dev");
+    my $seq = partition_num_by_start_end($dev, $part_start, $part_end);
+    # For NVMe
+    if ($dev =~ /\d$/) {
+        return $dev . 'p' . $seq;
+    }
+    else {
+        return $dev . $seq;
+    }
+}
+
+=head2 remove_partition
+
+Remove a partition by given partition name, e.g /dev/sdb5
+
+=cut
+sub remove_partition {
+    my $part = shift;
+    my ($dev, $num);
+    if ($part =~ /(.*?)(\d+)/) {
+        $dev = $1;
+        $num = $2;
+    }
+    else {
+        die "Invalid partition: $part\n";
+    }
+    assert_script_run("umount -f $part");
+    sleep 1;
+    assert_script_run("parted -s $dev rm $num");
+    sleep 1;
+    script_run("partprobe $dev");
+}
+
+=head2 format_partition
+
+Format partition to target filesystem
+
+=cut
+sub format_partition {
+    my ($part, $filesystem) = @_;
+    script_run("umount -f $part");
+    sleep 1;
+    if ($filesystem =~ /ext4/) {
+        script_run("mkfs.$filesystem -F $part");
+    }
+    else {
+        script_run("mkfs.$filesystem -f $part");
+    }
+}
+
+1;

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -26,7 +26,6 @@ use repo_tools 'add_qa_head_repo';
 
 my $STATUS_LOG  = '/opt/status.log';
 my $VERSION_LOG = '/opt/version.log';
-my $LOCAL_DIR   = '/tmp/xfstests-dev';
 
 sub install_xfstests_from_ibs {
     add_qa_head_repo(priority => 100);
@@ -44,7 +43,7 @@ sub log_create {
 
 sub collect_version {
     my $file = shift;
-    my $cmd  = "(cd /tmp/xfstests-dev; git rev-parse HEAD; cd - > /dev/null; rpm -qa xfsprogs xfsdump btrfsprogs; uname -r) | tee $file";
+    my $cmd  = "(rpm -qa xfsprogs xfsdump btrfsprogs kernel-default xfstests; uname -r) | tee $file";
     script_run($cmd);
 }
 
@@ -56,6 +55,7 @@ sub run {
     pkcon_quit;
 
     install_xfstests_from_ibs;
+    script_run 'ln -s /var/lib/xfstests/ /opt/xfstests';
 
     # Create log file
     log_create($STATUS_LOG);

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,25 +20,11 @@ use warnings;
 use base 'opensusebasetest';
 use utils;
 use testapi;
+use filesystem_utils qw(str_to_mb parted_print partition_num_by_type mountpoint_to_partition
+  partition_table create_partition remove_partition format_partition);
 
-sub str_to_mb {
-    my $str = shift;
-    if ($str =~ /(\d+(\.\d+)?)K/) {
-        return $1 / 1024;
-    }
-    elsif ($str =~ /(\d+(\.\d+)?)M/) {
-        return $1;
-    }
-    elsif ($str =~ /(\d+(\.\d+)?)G/) {
-        return $1 * 1024;
-    }
-    else {
-        return;
-    }
-}
-
-# Number of SCRATCH disk in SCRATCH_DEV_POOL, other than btrfs has only 1 SCRATCH_DEV
-sub partition_size_num {
+# Number of SCRATCH disk in SCRATCH_DEV_POOL, other than btrfs has only 1 SCRATCH_DEV, xfstests specific
+sub partition_amount_by_homesize {
     my $home_size = shift;
     $home_size = str_to_mb($home_size);
     my %ret;
@@ -61,29 +47,115 @@ sub partition_size_num {
         $ret{size} = int($home_size / 2);
         return %ret;
     }
+    else {
+        print "Info: Current HDD file don't have a /home partition.";
+    }
     return %ret;
+}
+
+# Do partition by giving inputs
+# Inputs explain
+# $filesystem: filesystem type
+# $amount: Amount of partitions to be created for SCRATCH_DEV. Available for btrfs, at most 5.
+# $size: Size of each partition size for TEST_DEV and SCRATCH_DEV. Default: 5120
+# $dev: Optional. Device to be partitioned. Default: same device as root partition
+# $delhome: Delete home partition to get free space for test partition.
+sub do_partition_for_xfstests {
+    my $ref  = shift;
+    my %para = %{$ref};
+    my ($part_table, $part_type, $test_dev);
+    unless ($para{size}) {
+        $para{size} = 5120;
+    }
+    unless ($para{amount}) {
+        $para{amount} = 1;
+    }
+    if ($para{fstype} =~ /btrfs/ && $para{amount} > 5) {
+        $para{amount} = 5;
+    }
+    else {
+        # Mandatory xfs and ext4 has only 1 SCRATCH_DEV
+        $para{amount} = 1;
+    }
+    unless (exists($para{dev})) {
+        my $part = mountpoint_to_partition('/');
+        if ($part =~ /(.*?)(\d+)/) {
+            $para{dev} = $1;
+        }
+    }
+    if (exists($para{delhome}) && $para{delhome} != 0) {
+        my $part = mountpoint_to_partition('/home');
+        remove_partition($part);
+        script_run("sed -i -e '/ \/home /d' /etc/fstab");
+        script_run('mkdir /home/fsgqa; mkdir /home/fsgqa-123456');
+    }
+    parted_print($para{dev});
+    # Prepare suitable partition type, if don't have extended then create one
+    $part_table = partition_table($para{dev});
+    if ($part_table =~ 'msdos') {
+        $part_type = 'logical';
+    }
+    else {
+        $part_type = 'primary';
+    }
+    if ($part_table =~ 'msdos' && partition_num_by_type($para{dev}, 'extended') == -1) {
+        create_partition($para{dev}, 'extended', 'max');
+        parted_print($para{dev});
+    }
+    # Create TEST_DEV
+    $test_dev = create_partition($para{dev}, $part_type, $para{size});
+    parted_print($para{dev});
+    format_partition($test_dev, $para{fstype});
+    # Create SCRATCH_DEV or SCRATCH_DEV_POOL
+    my @scratch_dev;
+    my $num = $para{amount};
+    while ($num != 0) {
+        $num -= 1;
+        my $part = create_partition($para{dev}, $part_type, $para{size});
+        format_partition($part, $para{fstype});
+        push @scratch_dev, $part;
+    }
+    parted_print($para{dev});
+    # Create mount points
+    script_run('mkdir /mnt/test /mnt/scratch');
+    # Generate ~/.xfstests
+    script_run("export TEST_DEV=$test_dev");
+    script_run('export TEST_DIR=/mnt/test');
+    script_run('export SCRATCH_MNT=/mnt/scratch');
+    if ($para{amount} == 1) {
+        script_run("export SCRATCH_DEV=$scratch_dev[0]");
+    }
+    else {
+        script_run("export SCRATCH_DEV_POOL='" . join(' ', @scratch_dev) . "'");
+    }
+    # Sync
+    script_run('sync');
 }
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    # Create partitions
+    # DO NOT set XFSTESTS_DEVICE if you don't know what's this mean
+    # by default we use /home partition spaces for test, and don't need this setting
+    my $device = get_var('XFSTESTS_DEVICE');
+
     my $filesystem = get_required_var('XFSTESTS');
-    my $device     = get_var('XFSTESTS_DEVICE');
-    my $home_size  = script_output("df -h | grep home | awk -F \" \" \'{print \$2}\'");
-    my %size_num   = partition_size_num($home_size);
+    my %para;
     if ($device) {
         assert_script_run("parted $device --script -- mklabel gpt");
-        assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --device $device $filesystem && sync", 600);
+        $para{fstype} = $filesystem;
+        $para{dev}    = $device;
+        do_partition_for_xfstests(\%para);
     }
     else {
-        if (%size_num) {
-            assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem -t $size_num{size} -s $size_num{size} -n $size_num{num} && sync", 600);
-        }
-        else {
-            assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem && sync", 600);
-        }
+        my $home_size = script_output("df -h | grep home | awk -F \" \" \'{print \$2}\'");
+        my %size_num  = partition_amount_by_homesize($home_size);
+        $para{fstype}  = $filesystem;
+        $para{amount}  = $size_num{num};
+        $para{size}    = $size_num{size};
+        $para{delhome} = 1;
+        do_partition_for_xfstests(\%para);
     }
 }
 

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -23,6 +23,9 @@ use testapi;
 use filesystem_utils qw(str_to_mb parted_print partition_num_by_type mountpoint_to_partition
   partition_table create_partition remove_partition format_partition);
 
+my $INST_DIR    = '/opt/xfstests';
+my $CONFIG_FILE = "$INST_DIR/local.config";
+
 # Number of SCRATCH disk in SCRATCH_DEV_POOL, other than btrfs has only 1 SCRATCH_DEV, xfstests specific
 sub partition_amount_by_homesize {
     my $home_size = shift;
@@ -118,15 +121,16 @@ sub do_partition_for_xfstests {
     parted_print($para{dev});
     # Create mount points
     script_run('mkdir /mnt/test /mnt/scratch');
-    # Generate ~/.xfstests
-    script_run("export TEST_DEV=$test_dev");
-    script_run('export TEST_DIR=/mnt/test');
-    script_run('export SCRATCH_MNT=/mnt/scratch');
+    # Setup configure file xfstests/local.config
+    script_run("echo 'export TEST_DEV=$test_dev' >> $CONFIG_FILE");
+    script_run("echo 'export TEST_DIR=/mnt/test' >> $CONFIG_FILE");
+    script_run("echo 'export SCRATCH_MNT=/mnt/scratch' >> $CONFIG_FILE");
     if ($para{amount} == 1) {
-        script_run("export SCRATCH_DEV=$scratch_dev[0]");
+        script_run("echo 'export SCRATCH_DEV=$scratch_dev[0]' >> $CONFIG_FILE");
     }
     else {
-        script_run("export SCRATCH_DEV_POOL='" . join(' ', @scratch_dev) . "'");
+        my $SCRATCH_DEV_POOL = join(' ', @scratch_dev);
+        script_run("echo 'export SCRATCH_DEV_POOL=\"$SCRATCH_DEV_POOL\"' >> $CONFIG_FILE");
     }
     # Sync
     script_run('sync');

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018-2019 SUSE LLC
+# Copyright © 2018-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -46,7 +46,7 @@ my $HB_SCRIPT    = '/opt/heartbeat.sh';
 # - XFSTESTS_SUBTEST_MAXTIME: Debug use. To set the max time to wait for sub test to finish. Meet this time frame will trigger reboot, and continue next tests.
 # - XFSTESTS: TEST_DEV type, and test in this folder and generic/ folder will be triggered. XFSTESTS=(xfs|btrfs|ext4)
 my $TEST_RANGES  = get_required_var('XFSTESTS_RANGES');
-my $TEST_WRAPPER = '/usr/share/qa/qa_test_xfstests/wrapper.sh';
+my $TEST_WRAPPER = '/opt/wrapper.sh';
 my %BLACKLIST    = map { $_ => 1 } split(/,/, get_var('XFSTESTS_BLACKLIST'));
 my @GROUPLIST    = split(/,/, get_var('XFSTESTS_GROUPLIST'));
 my $STATUS_LOG   = '/opt/status.log';
@@ -380,6 +380,10 @@ END_CMD
 sub run {
     my $self = shift;
     select_console('root-console');
+
+    # Get wrapper
+    assert_script_run('wget --quiet ' . data_url('xfstests/wrapper.sh') . " -O $TEST_WRAPPER");
+    assert_script_run("chmod a+x $TEST_WRAPPER");
 
     # Get test list
     my @tests = tests_from_ranges($TEST_RANGES, $INST_DIR);


### PR DESCRIPTION
As conclusion in discussion[1]. I revert PR#10101 and PR#10222. To reduce the risk during GMC, I revert those two PR before GMC. As we have GM now, let's re-revert it, and develop with this reorganized xfstests. It's looks the same as PR#10101 and PR#10222.

[1] https://confluence.suse.com/pages/viewpage.action?spaceKey=qasle&title=Filesystem+Test+Discussion

Besides those two commit, I add one more commit to fix known issue in previous 2 commits. In previous code, global parameter use export command to set, but if an unexpected reboot happens those global parameter will lose meaning. This commit will fix this by using local.config file to control all global parameters in xfstests.

- Related ticket: https://progress.opensuse.org/issues/66850
- Verify run:
[SLE-filesystem]
Installation: http://openqa.suse.de/tests/4405947
btrfs: http://openqa.suse.de/tests/4406079
xfs: http://openqa.suse.de/tests/4406080
s390x: http://openqa.suse.de/tests/4409915
ppc64le: http://openqa.suse.de/tests/4409916

[QAM xfstests]
Installation: http://openqa.suse.de/tests/4412863
qam-xfstests_xfs-generic+sle12-001-100: http://openqa.suse.de/tests/4412949
