### PR TITLE
Implement BREAK_DEPS for zypper migration

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -77,8 +77,17 @@ sub run {
             send_key 'r';
             send_key 'ret';
         }
-        elsif ($out =~ $zypper_migration_conflict
-            || $out =~ $zypper_migration_fileconflict
+        elsif ($out =~ $zypper_migration_conflict)
+        {
+            if (check_var("BREAK_DEPS", '1')) {
+                send_key '1';
+                send_key 'ret';
+            } else {
+                save_screenshot;
+                die 'Zypper migration failed';
+            }
+        }
+        elsif ($out =~ $zypper_migration_fileconflict
             || $out =~ $zypper_migration_failed
             || $out =~ $zypper_migration_urlerror)
         {


### PR DESCRIPTION
We need to implement the BREAK_DEPS for migration, when sometime we hit the 
'zypper  migration ' conflicts  and the bug can't be fixed for the time being. By doing this
we can use this setting to workaround this and to make the migration goes on.

- Related ticket: https://progress.opensuse.org/issues/68203
- Needles: N/A
- Verification run: 
                             https://openqa.nue.suse.com/tests/4405918
                             https://openqa.nue.suse.com/tests/4405940
