### PR TITLE
Add scenario cryptlvm_iscsi - 2nd try

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/GuidedSetupController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/GuidedSetupController.pm
@@ -67,14 +67,17 @@ sub get_select_hard_disks_page {
 
 sub edit_proposal {
     my ($self, %args) = @_;
+    my $multiple_disks = $args{multiple_disks};
+
     $self->get_suggested_partitioning_page()->press_guided_setup_button();
+    $self->get_select_hard_disks_page()->skip_hard_disk_selection() if $multiple_disks;
     $self->_set_partitioning(%args);
 }
 
 sub edit_proposal_for_existing_partition {
     my ($self, %args) = @_;
     $self->get_suggested_partitioning_page()->press_guided_setup_button();
-    $self->get_select_hard_disks_page()->press_next();
+    $self->get_select_hard_disks_page()->skip_handling_partitions();
     $self->_set_partitioning(%args);
 }
 

--- a/lib/Installation/Partitioner/LibstorageNG/SelectHardDisksPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/SelectHardDisksPage.pm
@@ -19,12 +19,18 @@ use testapi;
 use parent 'Installation::WizardPage';
 
 use constant {
-    SELECT_HARD_DISKS_PAGE => 'inst-select-disk-to-use-as-root'
+    SELECT_HARD_DISKS_PAGE     => 'select-hard-disks-one-selected',
+    SELECT_HANDLING_PARTITIONS => 'inst-select-disk-to-use-as-root'
 };
 
-sub press_next {
+sub skip_hard_disk_selection {
     my ($self) = @_;
     $self->SUPER::press_next(SELECT_HARD_DISKS_PAGE);
+}
+
+sub skip_handling_partitions {
+    my ($self) = @_;
+    $self->SUPER::press_next(SELECT_HANDLING_PARTITIONS);
 }
 
 1;

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -1,0 +1,47 @@
+---
+name: cryptlvm_iscsi
+description: >
+  Conducts installation on iSCSI device relying on iBFT with encrypted LVM.
+vars:
+  DESKTOP: gnome
+  ENCRYPT: 1
+  IBFT: 1
+  LVM: 1
+  NBF: iqn.2016-02.openqa.de:for.openqa
+  NICTYPE: user
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/iscsi_configuration
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/system_prepare
+  - console/sle15_workarounds
+  - console/hostname
+  - console/force_scheduled_tasks
+  - installation/validation/ibft
+  - console/validate_lvm
+  - console/validate_encrypt
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  <<: !include test_data/yast/encryption/default_enc.yaml

--- a/tests/installation/iscsi_configuration.pm
+++ b/tests/installation/iscsi_configuration.pm
@@ -17,6 +17,16 @@ use strict;
 use warnings;
 use testapi;
 
+# In order to have clear expectations about state of the disk we need to erase it.
+# As it could be encrypted or non-encrypted (with or without partitions) making UI to
+# react in different ways. It assumes only one iscsi disk already mounted.
+sub wipe_iscsi_disk {
+    select_console 'install-shell';
+    my $disk = script_output("lsscsi | grep 'disk' | awk 'NF>1{print \$NF}'");
+    assert_script_run("wipefs -a $disk");
+    select_console 'installation';
+}
+
 sub run {
     assert_screen 'disk-activation-iscsi';
     send_key 'alt-i';    # configure iscsi disk
@@ -25,6 +35,7 @@ sub run {
     assert_screen 'iscsi-ibft';
     send_key 'alt-o';    # OK
     assert_screen 'disk-activation-iscsi';
+    wipe_iscsi_disk;     # At this point should be mounted and can proceed to erase it
     send_key $cmd{next};
 }
 

--- a/tests/installation/partitioning/encrypt_lvm.pm
+++ b/tests/installation/partitioning/encrypt_lvm.pm
@@ -16,9 +16,14 @@ use strict;
 use warnings FATAL => 'all';
 use testapi;
 
+sub has_multiple_disks {
+    return 1 if (get_var('NUMDISKS') > 1 || get_var('IBFT'));
+    return 0;
+}
+
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();
-    $partitioner->edit_proposal(is_lvm => 1, is_encrypted => 1);
+    $partitioner->edit_proposal(multiple_disks => has_multiple_disks, is_lvm => 1, is_encrypted => 1);
     $partitioner->get_suggested_partitioning_page()->assert_encrypted_partition_with_lvm_shown_in_the_list();
 }
 


### PR DESCRIPTION
Conducts installation on iSCSI device relying on iBFT with encrypted LVM.

This could be a destructive scenario for any other job picking the resulting iscsi disk in the same worker. There are 3 cases at least that I can count about the status of the iscsi disk in the worker for each run which in turns influence the UI:

 - encrypted (pop-up appears)
 - non-encrypted with partitions (intermediate screen appears asking for actions with existing partitions).
 - non-encrypted without partitions.

In order to set clear expectation we can just implement the 3rd case erasing always the disks in previous step.

- Related ticket: https://progress.opensuse.org/issues/66052
- Verification run:
  - [opensuse-Tumbleweed-DVD-x86_64-Build20200630-cryptlvm@64bit](https://openqa.opensuse.org/t1322680)
  - [sle-15-SP2-Online-x86_64-Build209.2-cryptlvm_iscsi@64bit](https://openqa.suse.de/t4408765)