### PR TITLE
Revert "LTP: Schedule run_ltp from boot_ltp to avoid asset upload"

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -22,6 +22,7 @@ use testapi qw(check_var get_required_var get_var);
 use autotest;
 use Archive::Tar;
 use utils;
+use LTP::TestInfo 'testinfo';
 use File::Basename 'basename';
 use main_common qw(boot_hdd_image load_bootloader_s390x load_kernel_baremetal_tests);
 use 5.018;
@@ -30,9 +31,9 @@ use Utils::Backends 'is_pvm';
 # use warnings;
 
 our @EXPORT = qw(
+  get_ltp_tag
   load_kernel_tests
-  loadtest
-  shutdown_ltp
+  loadtest_from_runtest_file
 );
 
 sub loadtest {
@@ -43,6 +44,110 @@ sub loadtest {
 sub shutdown_ltp {
     loadtest('proc_sys_dump') if get_var('PROC_SYS_DUMP');
     loadtest('shutdown_ltp', @_);
+}
+
+sub parse_openposix_runfile {
+    my ($path, $name, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
+
+    open(my $rfile, $path) or die "Can not open runfile asset $path: $!";    ## no critic (InputOutput::ProhibitTwoArgOpen)
+    while (my $line = <$rfile>) {
+        chomp($line);
+        if ($line =~ m/$cmd_pattern/ && !($line =~ m/$cmd_exclude/)) {
+            my $test  = {name => basename($line, '.run-test'), command => $line};
+            my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
+            loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
+        }
+    }
+}
+
+sub parse_runtest_file {
+    my ($path, $name, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
+
+    open(my $rfile, $path) or die "Can not open runtest asset $path: $!";    ## no critic (InputOutput::ProhibitTwoArgOpen)
+    while (my $line = <$rfile>) {
+        next if ($line =~ /(^#)|(^$)/);
+
+        #Command format is "<name> <command> [<args>...] [#<comment>]"
+        if ($line =~ /^\s* ([\w-]+) \s+ (\S.+) #?/gx) {
+            next if (check_var('BACKEND', 'svirt') && ($1 eq 'dnsmasq' || $1 eq 'dhcpd'));    # poo#33850
+            my $test  = {name => $1, command => $2};
+            my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
+            if ($test->{name} =~ m/$cmd_pattern/ && !($test->{name} =~ m/$cmd_exclude/)) {
+                loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
+            }
+        }
+    }
+}
+
+sub get_ltp_tag {
+    my $tag = get_var('LTP_RUNTEST_TAG');
+
+    if (!defined $tag) {
+        if (defined get_var('HDD_1')) {
+            $tag = get_var('PUBLISH_HDD_1');
+            $tag = get_var('HDD_1') if (!defined $tag);
+            $tag = basename($tag);
+        } else {
+            $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
+        }
+    }
+    return $tag;
+}
+
+sub loadtest_from_runtest_file {
+    my $namelist           = get_var('LTP_COMMAND_FILE');
+    my $archive            = shift || get_var('ASSET_1');
+    my $unpack_path        = './runtest-files';
+    my $cmd_pattern        = get_var('LTP_COMMAND_PATTERN') || '.*';
+    my $cmd_exclude        = get_var('LTP_COMMAND_EXCLUDE') || '$^';
+    my $test_result_export = {
+        format      => 'result_array:v2',
+        environment => {},
+        results     => []};
+
+    if (!$archive) {
+        my $tag = get_ltp_tag();
+        $archive = get_var('ASSETDIR') . "/other/runtest-files-$tag.tar.gz";
+    }
+
+    loadtest('boot_ltp', run_args => testinfo($test_result_export));
+    if (get_var('LTP_COMMAND_FILE') =~ m/ltp-aiodio.part[134]/) {
+        loadtest 'create_junkfile_ltp';
+    }
+
+    if (get_var('LTP_COMMAND_FILE') =~ m/lvm\.local/) {
+        loadtest 'ltp_init_lvm';
+    }
+
+    mkdir($unpack_path, 0755);
+    my $tar = Archive::Tar->new();
+    $tar->read($archive) || die "tar read failed $? $!";
+    $tar->setcwd($unpack_path);
+    $tar->extract() || die "tar extract failed $? $!";
+
+    for my $name (split(/,/, $namelist)) {
+        if ($name eq 'openposix') {
+            parse_openposix_runfile("$unpack_path/openposix-test-list", $name, $cmd_pattern, $cmd_exclude, $test_result_export);
+        }
+        else {
+            parse_runtest_file("$unpack_path/$name", $name, $cmd_pattern, $cmd_exclude, $test_result_export);
+        }
+    }
+
+    shutdown_ltp(run_args => testinfo($test_result_export));
+}
+
+# Replace loadtest_from_runtest_file with this to stress test reverting to
+# snapshots
+sub stress_snapshots {
+    my $count = 100;
+
+    for (my $i = 0; $i < $count / 2; $i++) {
+        # This will always fail and revert to the previous milestone, which
+        # will either be boot_ltp or write_random#$i
+        loadtest('run_ltp');
+        loadtest('write_random');
+    }
 }
 
 sub load_kernel_tests {
@@ -67,6 +172,14 @@ sub load_kernel_tests {
             loadtest 'update_kernel';
         }
         loadtest 'install_ltp';
+        # If LTP_COMMAND_FILE is set, boot_ltp() and shutdown_ltp() will be added
+        # later by install_ltp task.
+        if (!get_var('LTP_COMMAND_FILE')) {
+            if (get_var('LTP_INSTALL_REBOOT')) {
+                loadtest 'boot_ltp';
+            }
+            shutdown_ltp();
+        }
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
         if (get_var('INSTALL_KOTD')) {
@@ -78,7 +191,7 @@ sub load_kernel_tests {
             loadtest 'change_kernel';
         }
 
-        loadtest 'boot_ltp';
+        loadtest_from_runtest_file();
     }
     elsif (get_var('QA_TEST_KLP_REPO')) {
         if (get_var('INSTALL_KOTD')) {

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -7,9 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: Waits for the guest to boot, sets some variables for LTP then
-#          dynamically loads the test modules based on the runtest file
-#          contents.
+# Summary: Waits for the guest to boot and sets some variables for LTP
 # Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
 
 use 5.018;
@@ -18,13 +16,11 @@ use base 'opensusebasetest';
 use testapi;
 use LTP::WhiteList 'download_whitelist';
 use LTP::utils;
-use LTP::TestInfo 'testinfo';
 use version_utils 'is_jeos';
-use main_ltp qw(loadtest shutdown_ltp);
 
 sub run {
-    my ($self) = @_;
-    my $cmd_file = get_var('LTP_COMMAND_FILE') || '';
+    my ($self, $tinfo) = @_;
+    my $cmd_file   = get_var('LTP_COMMAND_FILE') || '';
     my $is_network = $cmd_file =~ m/^\s*(net|net_stress)\./;
     my $is_ima     = $cmd_file =~ m/^ima$/i;
 
@@ -63,6 +59,32 @@ sub run {
     script_run("\$LTPROOT/ver_linux > $ver_linux_log 2>&1");
     upload_logs($ver_linux_log, failok => 1);
     my $ver_linux_out = script_output("cat $ver_linux_log");
+
+    if (defined $tinfo) {
+        my $environment = {
+            product     => get_var('DISTRI') . ':' . get_var('VERSION'),
+            revision    => get_var('BUILD'),
+            flavor      => get_var('FLAVOR'),
+            arch        => get_var('ARCH'),
+            backend     => get_var('BACKEND'),
+            kernel      => '',
+            libc        => '',
+            gcc         => '',
+            harness     => 'SUSE OpenQA',
+            ltp_version => ''
+        };
+        if ($ver_linux_out =~ qr'^Linux\s+(.*?)\s*$'m) {
+            $environment->{kernel} = $1;
+        }
+        if ($ver_linux_out =~ qr'^Linux C Library\s*>?\s*(.*?)\s*$'m) {
+            $environment->{libc} = $1;
+        }
+        if ($ver_linux_out =~ qr'^Gnu C\s*(.*?)\s*$'m) {
+            $environment->{gcc} = $1;
+        }
+        $environment->{ltp_version} = script_output('touch /opt/ltp_version; cat /opt/ltp_version');
+        $tinfo->test_result_export->{environment} = $environment;
+    }
 
     script_run('ps axf') if ($is_network || $is_ima);
 
@@ -131,93 +153,6 @@ EOF
     script_run 'grep -e Huge -e PageTables /proc/meminfo';
     script_run 'echo 1 > /proc/sys/vm/nr_hugepages';
     script_run 'grep -e Huge -e PageTables /proc/meminfo';
-
-    # If the command file (runtest file) is set then we dynamically schedule
-    # the test and shutdown modules.
-    return unless $cmd_file;
-
-    my $test_result_export = {
-        format      => 'result_array:v2',
-        environment => {},
-        results     => []};
-    my $cmd_pattern = get_var('LTP_COMMAND_PATTERN') || '.*';
-    my $cmd_exclude = get_var('LTP_COMMAND_EXCLUDE') || '$^';
-    my $environment = {
-        product     => get_var('DISTRI') . ':' . get_var('VERSION'),
-        revision    => get_var('BUILD'),
-        flavor      => get_var('FLAVOR'),
-        arch        => get_var('ARCH'),
-        backend     => get_var('BACKEND'),
-        kernel      => '',
-        libc        => '',
-        gcc         => '',
-        harness     => 'SUSE OpenQA',
-        ltp_version => ''
-    };
-    if ($ver_linux_out =~ qr'^Linux\s+(.*?)\s*$'m) {
-        $environment->{kernel} = $1;
-    }
-    if ($ver_linux_out =~ qr'^Linux C Library\s*>?\s*(.*?)\s*$'m) {
-        $environment->{libc} = $1;
-    }
-    if ($ver_linux_out =~ qr'^Gnu C\s*(.*?)\s*$'m) {
-        $environment->{gcc} = $1;
-    }
-    $environment->{ltp_version}        = script_output('touch /opt/ltp_version; cat /opt/ltp_version');
-    $test_result_export->{environment} = $environment;
-
-    if ($cmd_file =~ m/ltp-aiodio.part[134]/) {
-        loadtest 'create_junkfile_ltp';
-    }
-
-    if ($cmd_file =~ m/lvm\.local/) {
-        loadtest 'ltp_init_lvm';
-    }
-
-    for my $name (split(/,/, $cmd_file)) {
-        if ($name eq 'openposix') {
-            parse_openposix_runfile($name,
-                script_output("cat /opt/ltp/runtest/openposix-test-list"),
-                $cmd_pattern, $cmd_exclude, $test_result_export);
-        }
-        else {
-            parse_runtest_file($name, script_output("cat /opt/ltp/runtest/$name"),
-                $cmd_pattern, $cmd_exclude, $test_result_export);
-        }
-    }
-
-    shutdown_ltp(run_args => testinfo($test_result_export));
-}
-
-sub parse_openposix_runfile {
-    my ($name, $cmds, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
-
-    for my $line (split(/^/, $cmds)) {
-        chomp($line);
-        if ($line =~ m/$cmd_pattern/ && !($line =~ m/$cmd_exclude/)) {
-            my $test  = {name => basename($line, '.run-test'), command => $line};
-            my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
-            loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
-        }
-    }
-}
-
-sub parse_runtest_file {
-    my ($name, $cmds, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
-
-    for my $line (split(/^/, $cmds)) {
-        next if ($line =~ /(^#)|(^$)/);
-
-        #Command format is "<name> <command> [<args>...] [#<comment>]"
-        if ($line =~ /^\s* ([\w-]+) \s+ (\S.+) #?/gx) {
-            next if (check_var('BACKEND', 'svirt') && ($1 eq 'dnsmasq' || $1 eq 'dhcpd'));    # poo#33850
-            my $test  = {name => $1, command => $2};
-            my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
-            if ($test->{name} =~ m/$cmd_pattern/ && !($test->{name} =~ m/$cmd_exclude/)) {
-                loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
-            }
-        }
-    }
 }
 
 sub test_flags {

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: Executes a single LTP test case
+# Summary: Extracts test commands from an LTP runfile and executes them on the guest.
 # Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
 # More documentation is at the bottom
 
@@ -366,8 +366,9 @@ sub run_post_fail {
 
 =head1 Discussion
 
-This module executes a single LTP test case specified by LTP::TestInfo which
-is passed to run. This module is dynamically scheduled by boot_ltp at runtime.
+This module extracts an LTP runtest file from the VM[1], parses it and then
+executes the LTP test cases defined on each line of the runtest file. Logs are
+uploaded and interpreted after each LTP test case completes.
 
 LTP test cases are usually a binary executable or a shell script. Each line of
 the runtest file contains the name of the test case and a string which is
@@ -376,6 +377,10 @@ executed by the shell.
 The output of each test case is parsed for lines containing CONF and FAIL.
 If these terms are found in the output then a neutral or fail result will be
 reported, otherwise a pass.
+
+[1] Actually the parsing is now done by lib/main_ltp.pm which is called from
+    main.pm after install_ltp has uploaded the runtest files as
+    assets. run_ltp is scheduled once for each LTP test case/executable.
 
 [2] This overrides the default basetest class behaviour because the LTP tests
     are able to continue after most failures (without reverting to a
@@ -428,6 +433,12 @@ LTP test itself.
 
 Comma separated list of environment variables to be set for tests.
 E.g.: key=value,key2="value with spaces",key3='another value with spaces'
+
+=head2 LTP_RUNTEST_TAG
+
+The runtest asset files are appended with git or pkg depending on how LTP was
+installed. By default the runtest files from the git installation will be
+used, but setting this variable to pkg allows that behavior to be overridden.
 
 =cut
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#10609

This breaks every single test run with:

```
[0merror on tests/kernel/boot/boot_to_desktop.pm: Can't locate ../../../../pool/14/tests/kernel/boot/boot_to_desktop.pm at (eval 142) line 1.
Compilation failed in require at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 146.
```


```