### PR TITLE
Fix encrypt_lvm when NUMDISKS undefined

### DIFF
--- a/tests/installation/partitioning/encrypt_lvm.pm
+++ b/tests/installation/partitioning/encrypt_lvm.pm
@@ -17,7 +17,7 @@ use warnings FATAL => 'all';
 use testapi;
 
 sub has_multiple_disks {
-    return 1 if (get_var('NUMDISKS') > 1 || get_var('IBFT'));
+    return 1 if (get_var('NUMDISKS', 0) > 1 || get_var('IBFT'));
     return 0;
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/68386
- Verification run: [sle-15-SP2-Online-x86_64-Build209.2-cryptlvm@64bit](https://openqa.suse.de/t4411165)