### PR TITLE
Remove workaround for second console selection on powerVM

### DIFF
--- a/tests/console/validate_encrypt.pm
+++ b/tests/console/validate_encrypt.pm
@@ -99,7 +99,7 @@ sub verify_cryptsetup_luks {
 }
 
 sub run {
-    select_console 'root-console' unless is_pvm;
+    select_console 'root-console';
     my $test_data = get_test_suite_data();
     my $crypttab  = parse_crypttab();
     verify_crypttab(num_devices => $test_data->{crypttab}->{num_devices_encrypted},


### PR DESCRIPTION
After testing this, I have found out that consecutive console
selections work fine and the only missing piece is to remove this
workaround.

See [poo#68546](https://progress.opensuse.org/issues/68546).
[Verification run](https://openqa.suse.de/tests/4411164).
