### PR TITLE
Fix container-diff for non x86_64 archs

### DIFF
--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -15,6 +15,7 @@ use testapi;
 use utils;
 use strict;
 use warnings;
+use containers::common;
 use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
 
@@ -22,6 +23,7 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
+    install_docker_when_needed();
     zypper_call("install container-diff") if (script_run("which container-diff") != 0);
 
     my ($image_names, $stable_names) = get_suse_container_urls();
@@ -29,9 +31,14 @@ sub run {
     # container-diff
     for my $i (0 .. $#$image_names) {
         my $image_file = $image_names->[$i] =~ s/\/|:/-/gr;
-        assert_script_run("container-diff diff $image_names->[$i] $stable_names->[$i] --type=rpm --type=file --type=size > /tmp/container-diff-$image_file.txt", 300);
+        assert_script_run("docker pull $image_names->[$i]",  360);
+        assert_script_run("docker pull $stable_names->[$i]", 360);
+        assert_script_run("container-diff diff daemon://$image_names->[$i] daemon://$stable_names->[$i] --type=rpm --type=file --type=size > /tmp/container-diff-$image_file.txt", 300);
         upload_logs("/tmp/container-diff-$image_file.txt");
     }
+
+    # Clean container
+    clean_container_host(runtime => "docker");
 }
 
 1;


### PR DESCRIPTION
As found by @ggardet in #10588 the `container-diff` is broken on non x86_64 archs.
As @Vogtinator pointed out, we need to `docker pull` the image and then use `daemon://` image path.

- Related ticket: [poo#68521](https://progress.opensuse.org/issues/68521)
- Verification run: [aarch64](https://openqa.opensuse.org/tests/1324104#)