### PR TITLE
LTP: Ensure shutdown_ltp is scheduled before svirt asset upload

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -66,6 +66,9 @@ sub load_kernel_tests {
             loadtest_kernel 'update_kernel';
         }
         loadtest_kernel 'install_ltp';
+        # If there is a command file then install_ltp schedules boot_ltp which
+        # will schedule shutdown
+        shutdown_ltp() unless get_var('LTP_COMMAND_FILE');
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
         if (get_var('INSTALL_KOTD')) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -20,7 +20,7 @@ use testapi;
 use registration;
 use utils;
 use bootloader_setup qw(add_custom_grub_entries add_grub_cmdline_settings);
-use main_ltp qw(loadtest_kernel shutdown_ltp);
+use main_ltp 'loadtest_kernel';
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
 use serial_terminal 'prepare_serial_console';
@@ -347,8 +347,6 @@ sub run {
         power_action('reboot', textmode => 1) unless is_jeos;
         loadtest_kernel 'boot_ltp';
     }
-
-    shutdown_ltp() unless get_var('LTP_COMMAND_FILE');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Move shutdown_ltp back to main_ltp so that it is scheduled before the svirt
upload which must come after it.

Note, svirt upload still won't work if tests are scheduled during install_ltp, but
then you don't need to run the tests in the same job as install if you are
publishing the HD image.