### PR TITLE
Enable scenario select_disk for PowerVM

### DIFF
--- a/schedule/yast/select_disk.yaml
+++ b/schedule/yast/select_disk.yaml
@@ -1,0 +1,44 @@
+---
+description: >
+  Test the selection of "first" disk with the guided setup in partitioning.
+  This is also used as a prerequisite for real hardware tests to select
+  the right disk for installation and not a "random" one.
+name: select_disk
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_firstdisk
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - "{{edit_optional_kernel_cmd_parameters}}"
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - "{{reconnect_mgmt_console}}"
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_first_disk_selection
+conditional_schedule:
+  edit_optional_kernel_cmd_parameters:
+    BACKEND:
+      pvm_hmc:
+        - installation/edit_optional_kernel_cmd_parameters
+  reconnect_mgmt_console:
+    BACKEND:
+      pvm_hmc:
+        - boot/reconnect_mgmt_console
+test_data:
+  disks:
+    - vda
+    - vdb

--- a/test_data/yast/4disks_pvm.yaml
+++ b/test_data/yast/4disks_pvm.yaml
@@ -1,0 +1,5 @@
+disks:
+  - sda
+  - sdb
+  - sdc
+  - sdd

--- a/tests/console/validate_first_disk_selection.pm
+++ b/tests/console/validate_first_disk_selection.pm
@@ -1,0 +1,61 @@
+# SUSE's openQA tests
+#
+# Copyright � 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate that first disk was selected for installation
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'consoletest';
+
+use strict;
+use warnings;
+use testapi;
+
+use scheduler qw(get_test_suite_data);
+use utils qw(arrays_subset);
+
+sub compare_disks {
+    my %args     = @_;
+    my $expected = $args{expected};
+    my $got      = $args{got};
+
+    my @dif = arrays_subset($expected, $got);
+    if (scalar @dif > 0) {
+        die "Unexpected disks for this scenario:\n" .
+          "Expected: " . join(",", @{$expected}) . " Got: " . join(",", @{$got});
+    }
+}
+
+sub run {
+    select_console 'root-console';
+
+    my @errors;
+    my @expected_disks = @{get_test_suite_data()->{disks}};
+
+    # list info about block devices
+    my @lsblk_output = split(/\n/, script_output('lsblk -n'));
+    # get list of disk names
+    my @disks = map { (split ' ', $_)[0] } grep { /disk/ } @lsblk_output;
+    # compare disks found with expected
+    compare_disks(expected => \@expected_disks, got => \@disks);
+    # get first disk names
+    my $first_disk = shift @expected_disks;
+    # check existing partitioning in first disk
+    push @errors, "First disk $first_disk was not used for partitioning."
+      unless (grep { /$first_disk\d/ } @lsblk_output) > 0;
+    # Check for non-existing partitioning/mount points/swap in remaining disks
+    for my $disk (@expected_disks) {
+        push @errors, "Disk $disk was wrongly used during partitioning."
+          if (grep { /$disk.*(\/|[SWAP])/ } @lsblk_output) > 0;
+    }
+    # Show all found errors
+    die "Found errors:\n" . join("\n", @errors) if @errors;
+}
+
+1;


### PR DESCRIPTION
Add schedule for select_disk scenario and provide validation for it. Compare expected disks names with lsblk output regardless of the order used by this command to display them and check that first disk was used for partitioning and the rest of disks were not used, so they don't contain partitions or the disks itself do not have mount points or swap.

- Related ticket: https://progress.opensuse.org/issues/68254
- MR Job Group: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/230
- Verification run: 
  - [new select_disk scenario for PowerVM](https://openqa.suse.de/tests/4427345)
  - [existing select_disk scenarios](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23add_scenario_select_disk&version=15-SP2)
