### PR TITLE
Adapt sles4sap QAM files for agregate testing

### DIFF
--- a/schedule/qam/15-SP1/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/15-SP1/qam-create_hdd_sle_sap_gnome.yml
@@ -24,6 +24,8 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
+  - qa_automation/patch_and_reboot
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
@@ -31,3 +33,8 @@ schedule:
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/15-SP1/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/15-SP1/qam-create_hdd_sles4sap_gnome.yml
@@ -24,6 +24,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
@@ -36,3 +37,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - installation/add_update_test_repo
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/15-SP2/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/15-SP2/qam-create_hdd_sle_sap_gnome.yml
@@ -24,6 +24,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
@@ -31,3 +32,8 @@ schedule:
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/15-SP2/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/15-SP2/qam-create_hdd_sles4sap_gnome.yml
@@ -24,6 +24,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
@@ -36,3 +37,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - installation/add_update_test_repo
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/15/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/15/qam-create_hdd_sle_sap_gnome.yml
@@ -24,6 +24,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
@@ -31,3 +32,8 @@ schedule:
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/15/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/15/qam-create_hdd_sles4sap_gnome.yml
@@ -24,6 +24,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
@@ -36,3 +37,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - installation/add_update_test_repo
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot


### PR DESCRIPTION
This PR adds the possibility to trigger the patch_and_reboot module for testing aggregate builds.

That means we can test sap installation on top of a qcow2 which contains maintenance incidents being tested and not already released.
For example `BASE_TEST_ISSUES=10959,13642,14171,14396,14495,15020,15037,15177,15206` will create a qcow2 with all these maintenance incident.

**For the moment It targets only SLE15**

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[sles4sap 15-SP2](http://1a102.qa.suse.de/tests/4493)
[plain sle 15-SP2](http://1a102.qa.suse.de/tests/4491)
[sles4sap 15-SP1](http://1a102.qa.suse.de/tests/4476)
[plain sle 15-SP1](http://1a102.qa.suse.de/tests/4478)
[sles4sap 15](http://1a102.qa.suse.de/tests/4484)
[plain sle 15](http://1a102.qa.suse.de/tests/4489)