### PR TITLE
Add YAML schedule for QAM HA HDD regular tests

### DIFF
--- a/schedule/qam/12-SP2/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/12-SP2/qam-create_hdd_ha_textmode.yaml
@@ -1,0 +1,48 @@
+name:           qam-create_hdd_ha_textmode
+description:    >
+  Create an updated SLES HDD with HA extension.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{add_update_test_repo}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/change_desktop
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{system_prepare}}'
+  - '{{patch_and_reboot}}'
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+conditional_schedule:
+  system_prepare:
+    QAM_INCI:
+      1:
+        - console/system_prepare
+  patch_and_reboot:
+    QAM_INCI:
+      1:
+        - qa_automation/patch_and_reboot
+  add_update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/12-SP3/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/12-SP3/qam-create_hdd_ha_textmode.yaml
@@ -1,0 +1,48 @@
+name:           qam-create_hdd_ha_textmode
+description:    >
+  Create an updated SLES HDD with HA extension.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{add_update_test_repo}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/change_desktop
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{system_prepare}}'
+  - '{{patch_and_reboot}}'
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+conditional_schedule:
+  system_prepare:
+    QAM_INCI:
+      1:
+        - console/system_prepare
+  patch_and_reboot:
+    QAM_INCI:
+      1:
+        - qa_automation/patch_and_reboot
+  add_update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/12-SP4/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/12-SP4/qam-create_hdd_ha_textmode.yaml
@@ -1,0 +1,48 @@
+name:           qam-create_hdd_ha_textmode
+description:    >
+  Create an updated SLES HDD with HA extension.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{add_update_test_repo}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/change_desktop
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{system_prepare}}'
+  - '{{patch_and_reboot}}'
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+conditional_schedule:
+  system_prepare:
+    QAM_INCI:
+      1:
+        - console/system_prepare
+  patch_and_reboot:
+    QAM_INCI:
+      1:
+        - qa_automation/patch_and_reboot
+  add_update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/12-SP5/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/12-SP5/qam-create_hdd_ha_textmode.yaml
@@ -1,0 +1,48 @@
+name:           qam-create_hdd_ha_textmode
+description:    >
+  Create an updated SLES HDD with HA extension.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{add_update_test_repo}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/change_desktop
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{system_prepare}}'
+  - '{{patch_and_reboot}}'
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+conditional_schedule:
+  system_prepare:
+    QAM_INCI:
+      1:
+        - console/system_prepare
+  patch_and_reboot:
+    QAM_INCI:
+      1:
+        - qa_automation/patch_and_reboot
+  add_update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/15-SP1/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/15-SP1/qam-create_hdd_ha_textmode.yaml
@@ -1,0 +1,47 @@
+name:           qam-create_hdd_ha_textmode
+description:    >
+  Create an updated SLES HDD with HA extension.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{add_update_test_repo}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{system_prepare}}'
+  - '{{patch_and_reboot}}'
+  - console/sle15_workarounds
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+conditional_schedule:
+  system_prepare:
+    QAM_INCI:
+      1:
+        - console/system_prepare
+  patch_and_reboot:
+    QAM_INCI:
+      1:
+        - qa_automation/patch_and_reboot
+  add_update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/15-SP2/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/15-SP2/qam-create_hdd_ha_textmode.yaml
@@ -1,0 +1,47 @@
+name:           qam-create_hdd_ha_textmode
+description:    >
+  Create an updated SLES HDD with HA extension.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{add_update_test_repo}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{system_prepare}}'
+  - '{{patch_and_reboot}}'
+  - console/sle15_workarounds
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+conditional_schedule:
+  system_prepare:
+    QAM_INCI:
+      1:
+        - console/system_prepare
+  patch_and_reboot:
+    QAM_INCI:
+      1:
+        - qa_automation/patch_and_reboot
+  add_update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo

--- a/schedule/qam/15/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/15/qam-create_hdd_ha_textmode.yaml
@@ -1,0 +1,47 @@
+name:           qam-create_hdd_ha_textmode
+description:    >
+  Create an updated SLES HDD with HA extension.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{add_update_test_repo}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{system_prepare}}'
+  - '{{patch_and_reboot}}'
+  - console/sle15_workarounds
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+conditional_schedule:
+  system_prepare:
+    QAM_INCI:
+      1:
+        - console/system_prepare
+  patch_and_reboot:
+    QAM_INCI:
+      1:
+        - qa_automation/patch_and_reboot
+  add_update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo


### PR DESCRIPTION
This PR adds a schedule for creating HDD images with SLES + HA that can be used for QAM HA tests. The schedule would also fix currently failing tests because it doesn't change by some variables automatically added.
The tests should be usable for Incidents as well by adding `QAM_INCI=1` as variable.


- Verification runs:
15-SP2: https://mishmash.suse.de/tests/overview?build=20200706&distri=sle&version=15-SP2&groupid=10
15-SP1: https://mishmash.suse.de/tests/overview?build=20200706&distri=sle&version=15-SP1&groupid=1 (Incidents HDD created as well as coarse grained test whether QAM_INCI works - haven't tested Incidents further with schedule because it's not the main scope)
15: https://mishmash.suse.de/tests/overview?build=20200706&distri=sle&version=15&groupid=2
12-SP5: https://mishmash.suse.de/tests/overview?build=20200706&distri=sle&version=12-SP5&groupid=6
12-SP4: https://mishmash.suse.de/tests/overview?build=20200706&distri=sle&version=12-SP4&groupid=5
12-SP3: https://mishmash.suse.de/tests/overview?build=20200706&distri=sle&version=12-SP3&groupid=4
12-SP2: https://mishmash.suse.de/tests/overview?build=20200706&distri=sle&version=12-SP2&groupid=3