### PR TITLE
Check for updates requiring restart on plasma update applet.

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -16,6 +16,7 @@ use warnings;
 use utils;
 use testapi;
 use x11utils qw(ensure_unlocked_desktop turn_off_kde_screensaver);
+use power_action_utils qw( power_action);
 
 # Update with Plasma applet for software updates using PackageKit
 
@@ -30,6 +31,10 @@ sub run {
     my ($self) = @_;
     setup_system;
 
+    if (check_screen 'plasma-tray-update-error'){
+        record_info 'ERROR', 'Cannot reach repositories';
+        die;
+    }
     # There are two valid states.  Tray with updates or without.
     my @updates_state_tags = qw(plasma-tray-without-updates plasma-tray-with-updates );
     assert_screen \@updates_state_tags;
@@ -38,34 +43,43 @@ sub run {
     if (match_has_tag 'plasma-tray-with-updates') {
         # There can be a maximum of two updates cycles.
         my $update_count = 0;
-        do {
+        do {{
             # Install the updates.
             assert_and_click("plasma-tray-with-updates");
             assert_and_click_until_screen_change('plasma-updates-click-install');
-
             $update_count++;
-            # Wait until installation starts, intended to time out
-            wait_still_screen(stilltime => 4, timeout => 5);
-            # Wait until installation is done
-            assert_screen \@updates_state_tags, 3600;
 
-            # Make sure the applet has fetched the current status from the backend
-            # and has finished redrawing. In case the update status changed after
-            # the assert_screen, record a soft failure
-            wait_still_screen;
+            # Wait until installation starts and finishes.
+            while( check_screen 'plasma-tray-installing', 10){
+                last if(wait_still_screen(stilltime => 5, timeout => 10));
+            }
+            save_screenshot;
+
+            #Wait for the installation popup to expire.
+            while ( check_screen 'plasma-tray-updates-installed')  {
+               last if  wait_still_screen(stilltime => 3, timeout => 6);
+            } ;
 
             #Check if the applet reports that a restart is needed.
             if (check_screen 'plasma-updates_installed-restart') {
-                assert_and_click 'plasma-updates_installed-restart', 5;
+                select_console 'root-console';
+                power_action('reboot', textmode=>1);
                 $self->wait_boot;
                 setup_system;
                 next;
             }
+            save_screenshot;
+            
+            # Make sure the applet has fetched the current status from the backend
+            # and has finished redrawing. In case the update status changed after
+            # the assert_screen, record a soft failure
+            assert_screen \@updates_state_tags;
+            wait_still_screen;
             #Check if "Install new updates" pops up even though there are no updates. (boo#1041112)
             if (match_has_tag 'plasma-tray-with-updates' and check_screen 'plasma-tray-without-updates') {
                 record_soft_failure 'boo#1041112';
             }
-        }  while (  check_screen 'plasma-tray-with-updates' and  $update_count < 2);
+        }}  while (  check_screen 'plasma-tray-with-updates' and  $update_count < 2);
 
         if (match_has_tag 'plasma-tray-with-updates') {
             die "Updates should already have been installed";

--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -16,7 +16,6 @@ use warnings;
 use utils;
 use testapi;
 use x11utils qw(ensure_unlocked_desktop turn_off_kde_screensaver);
-use power_action_utils 'power_action';
 
 # Update with Plasma applet for software updates using PackageKit
 
@@ -31,62 +30,47 @@ sub run {
     my ($self) = @_;
     setup_system;
 
-    my @updates_installed_tags = qw(updates_none updates_available updates_available-tray );
-    assert_screen [qw(updates_available-tray tray-without-updates-available)];
-    if (match_has_tag 'updates_available-tray') {
-        assert_and_click("updates_available-tray");
+    # There are two valid states.  Tray with updates or without.
+    my @updates_state_tags = qw(plasma-tray-without-updates plasma-tray-with-updates );
+    assert_screen \@updates_state_tags;
 
-        # First update package manager, then packages, then bsc#992773 (2x)
-        while (1) {
-            assert_and_click_until_screen_change('updates_click-install');
+    # If there are no updates, the test passe.
+    if (match_has_tag 'plasma-tray-with-updates') {
+        # There can be a maximum of two updates cycles.
+        my $update_count = 0;
+        do {
+            # Install the updates.
+            assert_and_click("plasma-tray-with-updates");
+            assert_and_click_until_screen_change('plasma-updates-click-install');
 
+            $update_count++;
             # Wait until installation starts, intended to time out
             wait_still_screen(stilltime => 4, timeout => 5);
-
             # Wait until installation is done
-            assert_screen \@updates_installed_tags, 3600;
+            assert_screen \@updates_state_tags, 3600;
+
             # Make sure the applet has fetched the current status from the backend
             # and has finished redrawing. In case the update status changed after
             # the assert_screen, record a soft failure
             wait_still_screen;
 
             #Check if the applet reports that a restart is needed.
-            if (check_screen 'updates_installed-restart') {
-                assert_and_click 'updates_installed-restart', 5;
+            if (check_screen 'plasma-updates_installed-restart') {
+                assert_and_click 'plasma-updates_installed-restart', 5;
                 $self->wait_boot;
                 setup_system;
-                # Look again
-                assert_screen \@updates_installed_tags;
+                next;
             }
-            wait_still_screen;
-            if (match_has_tag('updates_none')) {
-                if (check_screen 'updates_none', 30) {
-                    last;
-                } else {
-                    record_soft_failure 'boo#992773';
-                }
-            } elsif (match_has_tag('updates_available')) {
-                # look again
-                if (check_screen 'updates_none', 0) {
-                    record_soft_failure 'boo#1041112';
-                    last;
-                }
+            #Check if "Install new updates" pops up even though there are no updates. (boo#1041112)
+            if (match_has_tag 'plasma-tray-with-updates' and check_screen 'plasma-tray-without-updates') {
+                record_soft_failure 'boo#1041112';
             }
-            # Check, if there are more updates available
-            elsif (match_has_tag('updates_available-tray')) {
-                # look again
-                if (check_screen 'updates_available-tray', 30) {
-                    assert_and_click("updates_available-tray");
-                } else {
-                    # Make sure, that there are no updates, otherwise fail
-                    assert_screen 'updates_none';
-                    record_soft_failure 'boo#1041112';
-                    last;
-                }
-            }
+        }  while (  check_screen 'plasma-tray-with-updates' and  $update_count < 2);
+
+        if (match_has_tag 'plasma-tray-with-updates') {
+            die "Updates should already have been installed";
         }
-        # Close tray updater
-        send_key("alt-f4");
+        assert_screen 'plasma-tray-without-updates';
     }
 }
 
@@ -97,7 +81,9 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 1};
+    return {milestone => 1
+                , fatal => 1};
 }
 
 1;
+


### PR DESCRIPTION
The test would previously restart only if the kernel was updated. However there are
other kinds of updates that require after they are applied. Now the test checks
if the applet reports a need for a restart and then restarts.


- Related ticket: https://progress.opensuse.org/issues/68578
- Verification run: ~~http://apappas-openqa.qam.suse.de/tests/299~~ 
http://apappas.openvpn.suse.de/tests/285#step/updates_packagekit_kde/18
