### PR TITLE
Remove isosize from the HPC SLE15SP2 schedule

### DIFF
--- a/schedule/hpc/create_hdd_hpc_textmode.yaml
+++ b/schedule/hpc/create_hdd_hpc_textmode.yaml
@@ -17,12 +17,7 @@ conditional_schedule:
         - installation/bootloader_uefi
       x86_64:
         - installation/bootloader
-  isosize:
-    VERSION:
-      15-SP2:
-        - installation/isosize
 schedule:
-  - '{{isosize}}'
   - '{{bootloader}}'
   - installation/welcome
   - installation/accept_license


### PR DESCRIPTION
As the iso is already released it makes no sense to keep checking it's size.

- Verification run: http://apappas.openvpn.suse.de/tests/254