### PR TITLE
Added snapper_rollback to powerVM migration testing

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -20,6 +20,7 @@ use testapi;
 use utils;
 use version_utils qw(is_caasp is_jeos is_leap is_sle is_tumbleweed);
 use mm_network;
+use Utils::Backends 'is_pvm';
 
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_CONSOLE_DEFAULT_DEVICE SERIAL_CONSOLE_DEFAULT_PORT);
 
@@ -261,7 +262,7 @@ sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
     # assert needle to avoid send down key early in grub_test_snapshot.
-    assert_screen('snap-default', 120) if get_var('OFW');
+    assert_screen('snap-default', 120) if (get_var('OFW') || is_pvm);
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);

--- a/schedule/migration/offline_spvm_Upgrade.yaml
+++ b/schedule/migration/offline_spvm_Upgrade.yaml
@@ -21,3 +21,5 @@ schedule:
   - console/system_prepare
   - console/consoletest_setup
   - console/zypper_lr
+  - boot/grub_test_snapshot
+  - boot/snapper_rollback

--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -16,8 +16,9 @@ use warnings;
 use base 'opensusebasetest';
 use testapi;
 use power_action_utils 'power_action';
-use utils 'workaround_type_encrypted_passphrase';
+use utils qw(workaround_type_encrypted_passphrase reconnect_mgmt_console);
 use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
+use Utils::Backends 'is_pvm';
 
 sub run {
     my $self = shift;
@@ -25,6 +26,7 @@ sub run {
     select_console 'root-console';
     power_action('reboot', keepconsole => 1, textmode => 1);
     reset_consoles;
+    reconnect_mgmt_console if is_pvm;
     $self->wait_grub(bootloader_time => 200);
     # To keep the screen at grub page
     # Refer https://progress.opensuse.org/issues/49040

--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -17,6 +17,7 @@ use strict;
 use warnings;
 use migration qw(check_rollback_system boot_into_ro_snapshot);
 use power_action_utils 'power_action';
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -32,6 +33,7 @@ sub run {
     script_run("snapper rollback -d rollback-before-migration");
     assert_script_run("snapper list | tail -n 2 | grep rollback", 180);
     power_action('reboot', textmode => 1, keepconsole => 1);
+    reconnect_mgmt_console if is_pvm;
     $self->wait_boot(ready_time => 300, bootloader_time => 300);
     select_console 'root-console';
     check_rollback_system;


### PR DESCRIPTION
Added snapper_rollback to powerVM migration testing

- Related ticket:https://progress.opensuse.org/issues/68690
- Verification run: 
Online migration:
step 1: http://openqa.suse.de/t4424432
step 2: http://openqa.suse.de/t4424433