### PR TITLE
Fixes to tests/sles4sap/hana_install: size conversion to Mbytes, device filtering without full paths

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -50,7 +50,7 @@ sub get_hana_device_from_system {
         $out = script_output "echo SIZE=\$(lsblk -o SIZE --nodeps --noheadings --bytes $device)";
         $out =~ /SIZE=(\d+)$/;
         $devsize = $1;
-        $devsize /= 1024;    # Work in Mbytes since $RAM = $self->get_total_mem() is in Mbytes
+        $devsize /= (1024 * 1024);    # Work in Mbytes since $RAM = $self->get_total_mem() is in Mbytes
 
         $filter_devices .= "|$device";
         $filter_devices =~ s/^|//;

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -44,16 +44,16 @@ sub get_hana_device_from_system {
     while ($devsize < $disk_requirement) {
         $out = script_output "echo DEV=\$($lsblk | egrep -vw '$filter_devices' | head -1)";
         $out =~ /DEV=([\w\.]+)$/;
-        $device = $devpath . $1;
+        $device = $1;
+        $filter_devices .= "|$device";
+        $filter_devices =~ s/^|//;
+        $device = $devpath . $device;
 
         # Need to verify there is enough space in the device for HANA
         $out = script_output "echo SIZE=\$(lsblk -o SIZE --nodeps --noheadings --bytes $device)";
         $out =~ /SIZE=(\d+)$/;
         $devsize = $1;
         $devsize /= (1024 * 1024);    # Work in Mbytes since $RAM = $self->get_total_mem() is in Mbytes
-
-        $filter_devices .= "|$device";
-        $filter_devices =~ s/^|//;
     }
 
     return $device;


### PR DESCRIPTION
This PR addresses 2 issues introduced by #10637 :

1. Fixes disk size conversion to Mbytes in `tests/sles4sap/hana_install`. Bytes to Mbytes is with 1024^2.
2. Filter list should not contain full paths to devices as output of `lsblk` does not.

- Related ticket: #10637 
- Needles: N/A
- Verification run: [x86_64 on qemu](http://mango.suse.de/tests/2969), [pp64le LPAR on pvm_hmc](http://mango.suse.de/tests/2970), [QAM job, x86_64 on qemu](https://openqa.suse.de/t4424597)
