### PR TITLE
Revert "ensure_installed: pkcon newly returns 7 if the package is already installed"

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -343,9 +343,6 @@ sub ensure_installed {
         $self->_ensure_installed_zypper_fallback($pkglist);
         record_soft_failure 'boo#1100134 - pkcon randomly fails to download packages';
     }
-    elsif ($ret =~ /pkcon-status-7/) {
-        record_info 'pkcon succeeded: no package needed be installed. Requested package already up-to-date';
-    }
     elsif ($ret !~ /pkcon-status-0/) {
         die "pkcon install did not succeed, return code: $ret";
     }


### PR DESCRIPTION
If pkcon returns 7 it failed the transaction.
This reverts commit fa51bf59d416f02c5c268491bb35e03747d9be37.

Ticket: https://progress.opensuse.org/issues/64439