### PR TITLE
Add bare-metal test for oprofile

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -3210,6 +3210,7 @@ sub load_kernel_baremetal_tests {
     # make sure we always have the toolchain installed
     loadtest "toolchain/install";
     loadtest "console/perf";
+    loadtest "console/oprofile";
     # some tests want to build and run a custom kernel
     loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
 }

--- a/tests/console/oprofile.pm
+++ b/tests/console/oprofile.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Simple tests for oprofile.
+# - profile example application (fio to create some load)
+# - check report
+# Maintainer: Michael Grifalconi <mgrifalconi@suse.com>
+
+use strict;
+use warnings;
+use base 'consoletest';
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Install fio as load generator and oprofile
+    zypper_call "in fio oprofile";
+
+    # Start a system wide profiling
+    script_run "(operf --system-wide &)";
+
+    # Start load and stop profiler when finished
+    assert_script_run "fio --name=randwrite --filename=/tmp/randwrite --bs=4k --size=1G; killall -s SIGINT operf";
+
+    # Make sure the report is generated correctly and also check for an entry for the fio load
+    assert_script_run "opreport > /tmp/opreport.log";
+    upload_logs "/tmp/opreport.log";
+    assert_script_run "opreport | grep 'fio'";
+}
+
+sub post_run_hook {
+    script_run "rm -rf /tmp/randwrite /tmp/opreport.log oprofile_data";
+}
+
+1;


### PR DESCRIPTION
Add test for oprofile: start profiling, run some load, check report

- Related ticket: https://progress.opensuse.org/issues/48986
- Needles: no needles
- Verification run: 
  - 15.1 bare-metal http://10.161.229.249/tests/124#
  - Failed runs on nested VM (this is why we run on BM)
    - 15.1 https://openqa.suse.de/tests/4425032#
    - 12.5 https://openqa.suse.de/tests/4425033#
    - TW  https://openqa.opensuse.org/tests/1326566
