### PR TITLE
Add verification modules for autoyast_lvm

### DIFF
--- a/schedule/yast/autoyast/autoyast_lvm.yaml
+++ b/schedule/yast/autoyast/autoyast_lvm.yaml
@@ -13,6 +13,8 @@ schedule:
   - autoyast/installation
   - autoyast/console
   - autoyast/login
+  - console/validate_lvm
+  - autoyast/verify_lvm_partitions
   - autoyast/wicked
   - autoyast/autoyast_verify
   - autoyast/repos
@@ -21,3 +23,43 @@ schedule:
   - autoyast/autoyast_reboot
   - installation/grub_test
   - installation/first_boot
+  - autoyast/verify_cloned_profile
+test_data:
+  profile:
+    partitioning:
+      - drive:
+          unique_key: device
+          device: /dev/system
+          partitions:
+            - partition:
+                unique_key: lv_name
+                lv_name: root_lv
+                mount: /
+            - partition:
+                unique_key: lv_name
+                lv_name: opt_lv
+                mount: /opt
+            - partition:
+                unique_key: lv_name
+                lv_name: swap_lv
+                mount: swap
+      - drive:
+          unique_key: device
+          device: /dev/sda
+          partitions:
+            - partition:
+                unique_key: partition_nr
+                partition_nr: 1
+                lvm_group: system
+            - partition:
+                unique_key: partition_nr
+                partition_nr: 2
+            - partition:
+                unique_key: partition_nr
+                partition_nr: 3
+  lvm:
+    vg: system
+    lvs:
+      - root_lv
+      - opt_lv
+      - swap_lv

--- a/tests/autoyast/verify_lvm_partitions.pm
+++ b/tests/autoyast/verify_lvm_partitions.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# Summary: Verify lvm partitions after autoyast installation
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use parent 'installbasetest';
+use testapi;
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my $test_data = get_test_suite_data();
+    my $vg        = $test_data->{lvm}->{vg};
+    assert_script_run("vgdisplay $vg");
+    foreach my $lv (@{$test_data->{lvm}->{lvs}}) {
+        assert_script_run("lvdisplay /dev/$vg/$lv");
+    }
+}
+
+1;


### PR DESCRIPTION
Add 3 modules in autoyast_lvm to validate autoyast profile, and look if the lvm objects are actually present and looking good after install.
Includes also a modification of vaidate_lvm to work in different scenarios.

- Related ticket: https://progress.opensuse.org/issues/68398
- Verification run: 
autoyast_lvm: http://waaa-amazing.suse.cz/tests/12728
cryptlvm: http://waaa-amazing.suse.cz/tests/12731