### PR TITLE
Add yast2_lang for all the architectures

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
@@ -19,6 +19,7 @@ schedule:
     - yast2_gui/yast2_users
     - yast2_gui/yast2_datetime
     - yast2_gui/yast2_security
+    - yast2_gui/yast2_lang
     - yast2_gui/yast2_bootloader
     - x11/yast2_snapper
     - yast2_gui/yast2_hostnames

--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -39,6 +39,7 @@ conditional_schedule:
                 - yast2_gui/yast2_software_management
                 - yast2_gui/yast2_security
                 - x11/yast2_snapper
+                - yast2_gui/yast2_lang
                 - yast2_gui/yast2_users
                 - yast2_gui/yast2_datetime
                 - yast2_gui/yast2_hostnames
@@ -50,6 +51,7 @@ conditional_schedule:
                 - yast2_gui/yast2_software_management
                 - yast2_gui/yast2_security
                 - x11/yast2_snapper
+                - yast2_gui/yast2_lang
                 - yast2_gui/yast2_users
                 - yast2_gui/yast2_datetime
                 - yast2_gui/yast2_hostnames
@@ -61,6 +63,7 @@ conditional_schedule:
                 - yast2_gui/yast2_software_management
                 - yast2_gui/yast2_security
                 - x11/yast2_snapper
+                - yast2_gui/yast2_lang
                 - yast2_gui/yast2_users
                 - yast2_gui/yast2_datetime
                 - yast2_gui/yast2_hostnames


### PR DESCRIPTION
The PR enables yast2_lang test module for other than x64 architectures.

The changes required needles updating. The required needles updated directly on osd.

- Related ticket: https://progress.opensuse.org/issues/67732
- Verification Runs:
   - aarch64: https://openqa.suse.de/tests/4428217
   - ppc64le: https://openqa.suse.de/tests/4428215
   - s390x: https://openqa.suse.de/tests/4428216
   - x64: https://openqa.suse.de/tests/4428245