### PR TITLE
Also remove https repos in zypper_clear_repos

### DIFF
--- a/tests/update/zypper_clear_repos.pm
+++ b/tests/update/zypper_clear_repos.pm
@@ -26,7 +26,7 @@ sub run {
     my $repos_folder = '/etc/zypp/repos.d';
     zypper_call 'lr -d', exitcode => [0, 6];
     assert_script_run(
-"find $repos_folder/*.repo -type f -exec grep -q 'baseurl=http://download.opensuse.org/' {} \\; -delete && echo 'unneed_repos_removed' > /dev/$serialdev",
+"find $repos_folder/*.repo -type f -exec grep -Eq 'baseurl=(http|https)://download.opensuse.org/' {} \\; -delete && echo 'unneed_repos_removed' > /dev/$serialdev",
         15
     );
     zypper_call 'lr -d', exitcode => [0, 6];


### PR DESCRIPTION
This time with a regex in the original find expression

- Related ticket: https://progress.opensuse.org/issues/66259

Followup to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10578
Verification needed
