### PR TITLE
Fix yast2 gui tests for SLE15-SP2

### DIFF
--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -56,7 +56,8 @@ sub test_nfs_instserver {
     assert_screen('yast2-instserver-nfs');
     # use default nfs config
     send_key_and_wait("alt-n", 2);
-    assert_screen('yast2-instserver-ui');
+    assert_screen('yast2-instserver-ui', 200);
+    send_key_and_wait("alt-n", 3) if is_sle("=15-SP2");
     # finish wizard
     send_key_and_wait("alt-f", 3);
     # check that the nfs instserver is working
@@ -124,7 +125,7 @@ sub test_http_instserver {
     send_key_until_needlematch("yast2-instserver_sr0dev", "down", 3);
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
-    assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 200);
+    assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 300);
     # skip "insert next cd" on SLE 12.x
     send_key_and_wait("alt-s", 2) if is_sle("<=12-SP5") && match_has_tag('yast2-instserver-change-media');
     assert_screen('yast2-instserver-ui');

--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -35,10 +35,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils "is_sle";
 
 sub run {
     my $self = shift;
     select_console("x11");
+    my $accept_keybind = is_sle("<=15-SP1") ? "alt-o" : "alt-a";
 
     # 1. start yast2 keyboard
     $self->launch_yast2_module_x11("keyboard", match_timeout => 120);
@@ -48,7 +50,7 @@ sub run {
 
     # 2. Switch keymap from us to german
     send_key_until_needlematch("yast2_keyboard-layout-german", "down");
-    wait_screen_change { send_key "alt-o" };
+    wait_screen_change { send_key $accept_keybind };
     assert_screen "generic-desktop", timeout => 90;
 
     # 3. Use gedit to enter german characters to verify keyboard layout
@@ -71,8 +73,9 @@ sub run {
     send_key "alt-k";
     wait_still_screen 2;
     send_key "e";
+    send_key "n" if is_sle("=15-SP2");
     send_key_until_needlematch("yast2_keyboard-layout-us", "down");
-    send_key "alt-o";
+    send_key $accept_keybind;
     assert_screen "generic-desktop", timeout => 90;
 
     # 5. Reproduce bug 1142559

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -115,6 +115,8 @@ sub run {
     assert_screen "yast2_storage_ng-partition-created";
     send_key "alt-n";
     wait_still_screen 2;
+    send_key "alt-n";
+    wait_still_screen 2;
     send_key "alt-f";
     wait_still_screen 2;
 
@@ -154,6 +156,8 @@ sub run {
     assert_screen "yast2_storage_ng-partition-resized";
     wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;
+    wait_screen_change { send_key "alt-n" };
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
 
     # check that the partion is ~170MiB (output is: /dev/vdb1     2048 355477  353430 172.6M 83 Linux)
@@ -172,6 +176,8 @@ sub run {
     wait_still_screen 1;
     wait_screen_change { send_key "alt-y" };
     assert_screen "yast2_storage_ng-unpartitioned";
+    wait_screen_change { send_key "alt-n" };
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
@@ -222,6 +228,8 @@ sub run {
     wait_screen_change { send_key $fs_page_shortcut };
 
     # summary and finish
+    wait_still_screen 1;
+    wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;
     wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;


### PR DESCRIPTION
Fix fail in yast2_storage_ng, yast2_keyboard, yast2_instserver

- Related ticket: https://progress.opensuse.org/issues/68660
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1400
- Verification run: [SLE15-SP2](https://openqa.suse.de/tests/4436334) [SLE15-SP1](http://10.161.229.247/tests/607) [SLE15](http://10.161.229.247/tests/608) [SLE12-SP5](http://10.161.229.247/tests/609) [SLE12-SP4](http://10.161.229.247/tests/610)
