### PR TITLE
Stabilize click on Upgrade icon on TW Live aarch64

### DIFF
--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -46,12 +46,19 @@ sub run {
     x11_start_program('systemctl stop packagekit.service', target_match => 'generic-desktop');
     turn_off_kde_screensaver;
     if (is_upgrade) {
-        assert_and_click 'live-upgrade';
+        if (is_aarch64) {
+            # On aarch64 there is sporadic issue when "Upgrade" icon is clicked too long,
+            # so that overlay appeared instead of opening the wizard.
+            x11_start_program('xdg-su -c "/usr/sbin/start-install.sh upgrade"', target_match => 'maximize');
+        }
+        else {
+            assert_and_click 'live-upgrade';
+        }
     }
     else {
         if (is_aarch64) {
             # On aarch64 there is sporadic issue when "Install" icon is clicked too long,
-            # so that context menu is called instead of opening the wizard.
+            # so that overlay appeared instead of opening the wizard.
             x11_start_program('xdg-su -c "/usr/sbin/start-install.sh"', target_match => 'maximize');
         }
         else {


### PR DESCRIPTION
The commit runs Upgrade wizard by calling x11_start_program with the appropriate path to the application.

On aarch64 there is a sporadic issue, when overlay appears instead of click on Upgrade icon.

The applied solution is the same as for installation scenario, when it was the same issue while clicking on "Install" icon. Since the solution was added, there were no sporadic fails.

- Related ticket: https://progress.opensuse.org/issues/64463
- Verification run: https://openqa.opensuse.org/tests/1327975

Ticket to remove the workaround as soon as the openQA worker is stable: https://progress.opensuse.org/issues/68797