### PR TITLE
Rewrite sshd backup/retore method to replace unless condition

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -72,8 +72,8 @@ sub run {
     assert_script_run("usermod -aG \$(stat -c %G /dev/$serialdev) $ssh_testman");
 
     # Backup/rename ~/.ssh , generated in consotest_setup, to ~/.ssh_bck
-    # poo#68200. Take FIPS_ENABLED into consideration, get rid of the problem from openssh_fips rm -r ~/.ssh/ directory in advance
-    assert_script_run 'mv ~/.ssh ~/.ssh_bck' unless ((get_var('INSTALLATION_VALIDATION') =~ /sshd/) || get_var('FIPS_ENABLED'));
+    # poo#68200. Confirm the ~/.ssh directory is exist in advance, in order to avoid the null backup
+    assert_script_run 'if [ -d ~/.ssh ]; then mv ~/.ssh ~/.ssh_bck; fi';
 
     # avoid harmless failures in virtio-console due to unexpected PS1
     assert_script_run("echo \"PS1='# '\" >> ~$ssh_testman/.bashrc") unless check_var('VIRTIO_CONSOLE', '0');
@@ -126,8 +126,8 @@ sub run {
     assert_script_run "scp -4v '$ssh_testman\@localhost:/etc/ssh/*.pub' /tmp";
 
     # Restore ~/.ssh generated in consotest_setup
-    # poo#68200. Take FIPS_ENABLED into consideration, get rid of the problem from openssh_fips rm -r ~/.ssh/ directory in advance
-    assert_script_run 'rm -rf ~/.ssh && mv ~/.ssh_bck ~/.ssh' unless ((get_var('INSTALLATION_VALIDATION') =~ /sshd/) || get_var('FIPS_ENABLED'));
+    # poo#68200. Confirm the ~/.ssh_bck directory is exist in advance, in order to avoid the null restore
+    assert_script_run 'if [ -d ~/.ssh_bck ]; then mv ~/.ssh_bck ~/.ssh; else rm -rf ~/.ssh; fi';
 
     assert_script_run "killall -u $ssh_testman || true";
     wait_still_screen 3;


### PR DESCRIPTION
**Description**:
The PR #10643 break the sshd test on SLE15 SP1 QAM test, it needs to enhance and rewrite the approach to judge the directory exists only, and will not care about the variable anymore via unless condition. This PR can fix the problem without the test sequence impact.

1. Rewrite the condition as checking ~/.ssh/ directory exists only and then do the next step, it can get rid of the null backup/restore if the directory is deleted from the previous case
2. Replace the unless condition usage to avoid a testing break in QAM 

- Related ticket: https://progress.opensuse.org/issues/68200
- Needles: NA
- Verification run: 
https://openqa.suse.de/t4431718 (SLE15 SP2 b209.2 on x86_64)
https://openqa.suse.de/t4431719 (SLE15 SP2 b209.2 on s390x)
http://10.67.17.201/tests/1044# (QAM test run on 15 SP1)

