### PR TITLE
Enable allmodules+allpatterns validation on powerVM

### DIFF
--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -12,10 +12,8 @@ sub yast2_console_exec {
     die "Yast2 module has not been found among function arguments!\n" unless (defined($args{yast2_module}));
     my $y2_start    = y2_module_basetest::with_yast_env_variables() . ' yast2 ';
     my $module_name = 'yast2-' . $args{yast2_module} . '-status';
-    $y2_start .= (defined($args{yast2_opts})) ?
-      $args{yast2_opts} . ' ' . $args{yast2_module} . ';' :
-      $args{yast2_module} . ';';
-
+    $y2_start .= (defined($args{yast2_opts})) ? $args{yast2_opts} . ' ' : '';
+    $y2_start .= $args{yast2_module} . ' --ncurses;';
     # poo#40715: Hyper-V 2012 R2 serial console is unstable (a Hyper-V product bug)
     # and is in many cases loosing the 15th character, so e.g. instead of the expected
     # 'yast2-scc-status-0' we get 'yast2-scc-statu-0' (sic, see the missing 's').

--- a/schedule/yast/allmodules+allpatterns/allmodules+allpatterns_pvm.yaml
+++ b/schedule/yast/allmodules+allpatterns/allmodules+allpatterns_pvm.yaml
@@ -32,3 +32,6 @@ schedule:
   - boot/reconnect_mgmt_console
   - installation/grub_test
   - installation/first_boot
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/yast2_i


### PR DESCRIPTION
During the migration of the scenario we seem to forget about validation modules in the schedule, so adding those to be consistent.

As we use ssh with x forwarding, we got module started in qt instead of ncurses which requires second commit to start yast modules in `ncurses` explicitly. See https://openqa.suse.de/tests/4428206#step/yast2_i/18

### Verification runs
* [SLE 15 SP2 PVM](https://openqa.suse.de/tests/4431950)
* [TW](https://openqa.opensuse.org/tests/1328439)
* [SLЁ 12](https://openqa.suse.de/tests/4432323#)