### PR TITLE
Fix schedule for autoyast_lvm and autoyast_tftp

### DIFF
--- a/schedule/yast/autoyast/autoyast_lvm.yaml
+++ b/schedule/yast/autoyast/autoyast_lvm.yaml
@@ -1,11 +1,12 @@
 ---
-name: autoyast_tftp
+name: autoyast_lvm
 description: >
-  AutoYaST installation with tftp configuration. tftp service configuration is validated in the end of the installation.
-  Profile additionally contains following features being tested:
-     - Post installation script execution
-     - Adding host entries to the /etc/hosts
-     - ntp/chrony configuration
+  AutoYaST installation using LVM for partitioning, having GPT with /, /opt and swap Logical Volumes in a single Volume
+  Group. Following is validated in the SUT:
+     - LVM configuration
+     - Firewall configuration
+     - Subvolumes configuration
+     - Passwords are set for the users in the profile
 schedule:
   - installation/isosize
   - boot/boot_from_pxe


### PR DESCRIPTION
The PR adds the common schedule for autoyast_lvm and autoyast_tftp. All the variables are specified in Job Group Settings.

Job Group Settings: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/237

VR: 
  -  autoyast_lvm:https://openqa.suse.de/tests/4441242
  -  autoyast_tftp: https://openqa.suse.de/tests/4447027