### PR TITLE
Add schedule for minimal+minimal_role for PowerVM

### DIFF
--- a/schedule/yast/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
+  # Called on BACKEND: qemu, svirt
+  - '{{hostname_inst}}'
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
@@ -28,17 +29,27 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on BACKEND: svirt
+  # Called on BACKEND: svirt, pvm_hmc
   - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
+  # Called on BACKEND: qemu, pvm_hmc
   - '{{grub_test}}'
   - installation/first_boot
 conditional_schedule:
+  hostname_inst:
+    BACKEND:
+      qemu:
+        - installation/hostname_inst
+      svirt:
+        - installation/hostname_inst
   reconnect_mgmt_console:
     BACKEND:
       svirt:
         - boot/reconnect_mgmt_console
+      pvm_hmc:
+        - boot/reconnect_mgmt_console
   grub_test:
     BACKEND:
       qemu:
+        - installation/grub_test
+      pvm_hmc:
         - installation/grub_test


### PR DESCRIPTION
The PR adds new yaml schedule for minimal+minimal_role on PowerVM.

- Related ticket: https://progress.opensuse.org/issues/68736
- Verification run: https://openqa.suse.de/tests/4441263
- **Job Group Settings:** https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/238
