### PR TITLE
Add new yast language test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1445,6 +1445,7 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_nfs_server';
     loadtest 'yast2_cmd/yast_nfs_client';
     loadtest 'yast2_cmd/yast_dns_server';
+    loadtest 'yast2_cmd/yast_lang';
 
     #temporary runs for QAM while tests under y2uitest_ncurses are being ported
     loadtest "console/yast2_apparmor";

--- a/tests/yast2_cmd/yast_lang.pm
+++ b/tests/yast2_cmd/yast_lang.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: yast language test
+# List languages, set default and secondary languages
+# Maintainer: Michael Grifalconi <mgrifalconi@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    zypper_call "in yast2-country";
+    validate_script_output 'yast language list', sub { m/(.*)de_DE(.*)it_IT(.*)/s };
+    assert_script_run 'yast language set lang=de_DE languages=it_IT';
+    validate_script_output 'yast language summary', sub { m/(.*)de_DE(.*)it_IT(.*)/s };
+    assert_script_run 'yast language set lang=en_US';
+}
+
+1;


### PR DESCRIPTION
- List languages
- Set system and secondary languages

- Related ticket: https://progress.opensuse.org/issues/49286
- Needles: no needles
- Verification run: 
  - 15    https://openqa.suse.de/tests/4439246
  - 15.1 https://openqa.suse.de/tests/4436333
  - 15.2 https://openqa.suse.de/tests/4439245
  - 12.3 https://openqa.suse.de/tests/4437879
  - 12.4 https://openqa.suse.de/tests/4437880
  - 12.5 https://openqa.suse.de/tests/4437881
 
