### PR TITLE
Remove exp-sgcheck from valgrind tests

### DIFF
--- a/data/valgrind/valgrind-test.sh
+++ b/data/valgrind/valgrind-test.sh
@@ -80,14 +80,6 @@ GREP 'Conditional jump or move depends on uninitialised value' "output_7.txt"
 GREP 'Uninitialised value was created by a heap allocation' "output_7.txt"
 GREP 'All heap blocks were freed -- no leaks are possible' "output_7.txt"
 
-# sgcheck is only available on x86_64
-if [[ $x86_64 == 1 ]]; then
-	valgrind --tool=exp-sgcheck --log-file="output_8.txt" ./valgrind-test --oob-stack 65
-	GREP 'Invalid read of size ' "output_8.txt"
-else
-	echo "    INFO: Skipping sg-check (not supported on this platform)"
-fi
-
 echo "Testing callgrind ... "
 valgrind --tool=callgrind --callgrind-out-file="callgrind.out" ./valgrind-test 2>/dev/null
 GREP '# callgrind format' callgrind.out


### PR DESCRIPTION
`exp-sgcheck` has been removed in the current valgrind release.
As this was always marked as experimental we remove this part of the test.

- Related ticket: https://progress.opensuse.org/issues/68522
- Needles: -
- Verification run: 
- - SLES 15 SP2 [s390x](https://openqa.suse.de/tests/4435453) | [x86_64](https://openqa.suse.de/tests/4435447)
- - SLES 15 SP1 [s390x](https://openqa.suse.de/tests/4435458) | [x86_64](https://openqa.suse.de/tests/4435448)
- - SLES 15 [s390x](https://openqa.suse.de/tests/4435454) | [x86_64](https://openqa.suse.de/tests/4435449)
- - SLES 12 SP5 [s390x](https://openqa.suse.de/tests/4435455) | [x86_64](https://openqa.suse.de/tests/4435450)
- - SLES 12 SP4 [s390x](https://openqa.suse.de/tests/4435456) | [x86_64](https://openqa.suse.de/tests/4435451)
- - Tumbleweed [x86_64](https://openqa.opensuse.org/t1328513)
- - Leap [x86_64](https://openqa.opensuse.org/t1328514)
