### PR TITLE
Update zdup migration code for powerVM cases on spvm backend

### DIFF
--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -17,6 +17,7 @@ use warnings;
 use testapi;
 use utils;
 use power_action_utils 'power_action';
+use Utils::Backends 'is_pvm';
 
 sub run {
     clear_console;
@@ -30,6 +31,7 @@ sub run {
     # switch to root-console (in case we are in X)
     select_console 'root-console';
     power_action('reboot', keepconsole => 1, textmode => 1);
+    reconnect_mgmt_console if is_pvm;
 }
 
 1;

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -16,12 +16,13 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_jeos';
+use version_utils qw(is_jeos is_desktop_installed);
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
 
-    $self->wait_boot(ready_time => 600) unless is_jeos;
+    $self->wait_boot(textmode => !is_desktop_installed(), bootloader_time => 300, ready_time => 600) unless is_jeos;
     if (get_var('ZDUP_IN_X')) {
         x11_start_program('xterm');
         become_root;
@@ -53,6 +54,7 @@ sub run {
             type_string("/sbin/reboot\n");
 
             reset_consoles;
+            reconnect_mgmt_console if is_pvm;
             $self->wait_boot(textmode => 1, bootloader_time => 200);
 
             select_console('root-console');

--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -18,6 +18,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -34,8 +35,9 @@ sub run {
     }
     assert_script_run "sync", 300;
     type_string "reboot\n";
+
     # After remove -f for reboot, we need wait more time for boot menu and avoid exception during reboot caused delay to boot up.
-    assert_screen('inst-bootmenu', 300) unless check_var('ARCH', 's390x');
+    assert_screen('inst-bootmenu', 300) unless (check_var('ARCH', 's390x') || is_pvm);
 }
 
 1;

--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -19,6 +19,8 @@ use warnings;
 use testapi;
 use migration;
 use version_utils 'is_sle';
+use Utils::Backends 'is_pvm';
+use utils;
 
 sub run {
     # After being patched, original system is ready for upgrade
@@ -49,7 +51,11 @@ sub run {
     set_var('DM_NEEDS_USERNAME', '1') if (check_var('DESKTOP', 'KDE') && is_sle('15+') && (get_var('ADDONURL', '') !~ /phub/));
 
     record_info('Version', 'VERSION=' . get_var('VERSION'));
-    reset_consoles_tty;
+    if (is_pvm) {
+        reconnect_mgmt_console;
+    } else {
+        reset_consoles_tty;
+    }
 }
 
 1;


### PR DESCRIPTION
Update zdup migration code for powerVM cases on spvm backend
As zdup migration cannot support powerVM migration. So we need change code to support powerVM zdup migration. It will apply at SLES.

- Related ticket: https://progress.opensuse.org/issues/68791
- Verification run:
Step1: https://openqa.nue.suse.com/tests/4439344#
Step2:https://openqa.nue.suse.com/tests/4439345#