### PR TITLE
[WIP] Add leap to SLE migration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key);
-use version_utils qw(is_sle is_sles4sap is_caasp is_upgrade);
+use version_utils qw(is_sle is_sles4sap is_caasp is_upgrade is_leap_migration);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
 
@@ -659,7 +659,7 @@ sub fill_in_registration_data {
         verify_preselected_modules($modules_needle) if get_var('CHECK_PRESELECTED_MODULES');
         # Add desktop module for SLES if desktop is gnome
         # Need desktop application for minimalx to make change_desktop work
-        if (check_var('SLE_PRODUCT', 'sles')
+        if ((check_var('SLE_PRODUCT', 'sles') && !is_leap_migration)
             && (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'minimalx'))
             && (my $addons = get_var('SCC_ADDONS')) !~ /(?:desktop|we)/)
         {
@@ -720,7 +720,14 @@ sub registration_bootloader_params {
 }
 
 sub yast_scc_registration {
-    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'scc');
+    # for leap to sle migration, we need to install yast2-registration
+    # before running yast2 registration module.
+    my $client_module = 'scc';
+    if (is_leap_migration) {
+        zypper_call('in yast2-registration');
+        $client_module = 'registration';
+    }
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module);
     assert_screen_with_soft_timeout(
         'scc-registration',
         timeout      => 90,

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -49,6 +49,7 @@ use constant {
           is_using_system_role
           is_using_system_role_first_flow
           is_public_cloud
+          is_leap_migration
           requires_role_selection
           check_version
           get_sles_release
@@ -585,3 +586,12 @@ Returns true if PUBLIC_CLOUD is set to 1
 sub is_public_cloud {
     return get_var('PUBLIC_CLOUD');
 }
+
+=head2 is_leap_migration
+
+Returns true if called in a leap to sle migration scenario
+=cut
+sub is_leap_migration {
+    return is_upgrade && get_var('ORIGIN_SYSTEM_VERSION') =~ /leap/;
+}
+

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -16,7 +16,7 @@ use warnings;
 use testapi;
 use utils;
 use power_action_utils 'power_action';
-use version_utils qw(is_desktop_installed is_sle);
+use version_utils qw(is_desktop_installed is_sle is_leap_migration);
 use x11utils qw(ensure_unlocked_desktop turn_off_gnome_screensaver);
 use Utils::Backends 'is_pvm';
 
@@ -106,7 +106,7 @@ sub run {
     }
     else {
         select_console 'x11', await_console => 0;
-        ensure_unlocked_desktop;
+        ensure_unlocked_desktop unless is_leap_migration;
         mouse_hide(1);
         assert_screen 'generic-desktop';
 


### PR DESCRIPTION
Now we support leap15.2 to SLE15SP2 migration, we need to make it an automatic test.

- Related ticket: https://progress.opensuse.org/issues/52460
- Needles: N/A
- Verification run: 
                    https://openqa.nue.suse.com/tests/4439351 yast textmode
                    https://openqa.nue.suse.com/tests/4440303 zypper textmode
