### PR TITLE
Introduce SERVICES_ENABLED for services_enabled.pm

### DIFF
--- a/lib/Utils/Systemd.pm
+++ b/lib/Utils/Systemd.pm
@@ -63,8 +63,8 @@ Please note that return code of this function is handle by 'script_run' or
 sub systemctl {
     my ($command, %args) = @_;
     croak "systemctl(): no command specified" if ($command =~ /^ *$/);
-    my $expect_false  = $args{expect_false} ? '!' : '';
-    my @script_params = ("$expect_false systemctl --no-pager $command", timeout => $args{timeout}, fail_message => $args{fail_message});
+    my $expect_false  = $args{expect_false} ? '! ' : '';
+    my @script_params = ("${expect_false}systemctl --no-pager $command", timeout => $args{timeout}, fail_message => $args{fail_message});
     if ($args{ignore_failure}) {
         script_run($script_params[0], $args{timeout});
     } else {


### PR DESCRIPTION
Introduce SERVICES_ENABLED for services_enabled.pm

Allows to modify the built in list either by adding resp removing
services to to replace the built in in setting entirely. The
intention is to allow overrides per product medium.

- Related ticket: https://progress.opensuse.org/issues/68170
- Needles: none required
- Verification run: http://tortuga.suse.de/tests/70#step/services_enabled/7