### PR TITLE
s390x: Dynamically add available zfcp adapters

### DIFF
--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -45,8 +45,9 @@ sub run {
     if (check_var('S390_DISK', 'ZFCP')) {
         assert_screen 'disk-activation-zfcp';
         wait_screen_change { send_key 'alt-z' };
-        add_zfcp_disk('0.0.fa00');
-        add_zfcp_disk('0.0.fc00');
+        foreach my $zfcp (split(/,/, get_required_var('ZFCP_ADAPTERS'))) {
+            add_zfcp_disk($zfcp);
+        }
         assert_screen 'zfcp-activated';
         send_key $cmd{next};
         wait_still_screen 5;

--- a/variables.md
+++ b/variables.md
@@ -153,5 +153,6 @@ YAML_TEST_DATA | string | | Defines yaml file containing test data.
 YAST2_FIRSTBOOT_USERNAME | string | | Defines username for the user to be created with YaST Firstboot
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Comma separated list of repositories to be added/used for zypper dup call, defaults to SUSEMIRROR or attached media, e.g. ISO.
+ZFCP_ADAPTERS | string | | Comma separated list of available ZFCP adapters in the machine (usually 0.0.fa00 and/or 0.0.fc00)
 LINUXRC_BOOT | boolean | true | To be used only in scenarios where we are booting an installed system from the installer medium (for example, a DVD) with the menu option "Boot Linux System" (not "boot From Hard Disk"). This option uses linuxrc.
 ZYPPER_WHITELISTED_ORPHANS | string | empty | Whitelist expected orphaned packages, do not fail if any are found. Upgrade scenarios are expecting orphans by default. Used by console/orphaned_packages_check.pm


### PR DESCRIPTION
VR with only fa00: https://openqa.suse.de/tests/4447700


