### PR TITLE
Start yast2_i in ncurses explicitly

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -70,7 +70,7 @@ sub run {
             record_info("Required", "$1");
         }
     }
-    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'sw_single');
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'sw_single', yast2_opts => '--ncurses');
     assert_screen [qw(empty-yast2-sw_single yast2-preselected-driver)], 120;
 
     # we need to change filter to Search, in case yast2 reports available automatic update


### PR DESCRIPTION
On powerVM we connect to the machine over ssh with X forwarding enabled,
so module would start in qt by default, which breaks the test.

[Verification run](https://openqa.suse.de/tests/4446891#details).