### PR TITLE
Add yast2-storage test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1446,6 +1446,7 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_nfs_client';
     loadtest 'yast2_cmd/yast_dns_server';
     loadtest 'yast2_cmd/yast_lang';
+    loadtest 'yast2_cmd/yast_storage' if is_sle('<15');
 
     #temporary runs for QAM while tests under y2uitest_ncurses are being ported
     loadtest "console/yast2_apparmor";

--- a/tests/yast2_cmd/yast_storage.pm
+++ b/tests/yast2_cmd/yast_storage.pm
@@ -1,0 +1,77 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: yast storage test
+# List disks and list partitions
+# Maintainer: Michael Grifalconi <mgrifalconi@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    zypper_call "in yast2-storage";
+    #    assert_script_run 'yast disk list disks';
+    #    assert_script_run 'yast disk list partitions';
+    #
+    my $lsblk_output      = script_output("lsblk");
+    my $list_disks_output = script_output("yast disk list disks");
+    my $list_part_output  = script_output("yast disk list partitions");
+
+    # Checks that all disks listed by 'lsblk' are part of 'yast disk list disks'
+    my $current_test_device;
+    my $found;
+    my @tested_devices;
+    for my $lsblk_line (split /^/, $lsblk_output) {
+        if ($lsblk_line =~ /^([a-z]d[a-z])(.*)disk/) {
+            $current_test_device = $1;
+            $found               = 0;
+            for my $list_disks_line (split /^/, $list_disks_output) {
+                if ($list_disks_line =~ /^(.*)$current_test_device/) {
+                    $found++;
+                    push @tested_devices, $current_test_device;
+                }
+            }
+            die "Could not find disk match between lsblk and yast disk list disks" unless ($found);
+        }
+    }
+    die "Could not find a valid block device to test" unless (@tested_devices);
+
+    # Checks that all partitions listed by 'lsblk' are part of 'yast disk list partitions'
+    my @part_not_matched;
+    @tested_devices = ();
+
+    for my $lsblk_line (split /^/, $lsblk_output) {
+        if ($lsblk_line =~ /([a-z]d[a-z][1-9]+)(.*)part/) {
+            $current_test_device = $1;
+            $found               = 0;
+            for my $list_part_line (split /^/, $list_part_output) {
+                if ($list_part_line =~ /^(.*)$current_test_device/) {
+                    $found++;
+                    push @tested_devices, $current_test_device;
+                }
+            }
+            unless ($found) {
+                push @part_not_matched, $current_test_device;
+            }
+        }
+    }
+    die "Could not find a valid partition to test" unless (@tested_devices);
+
+    # Some partitions may not be listed in 'yast disk list partitions' due to a known issue.
+    if (@part_not_matched) {
+        record_soft_failure 'bsc#1150450';
+    }
+}
+
+1;


### PR DESCRIPTION
list disks and list partitions


- Related ticket: https://progress.opensuse.org/issues/49265
- Needles: no needles
- Verification run:
  - 12.5 https://openqa.suse.de/tests/4449151
  - 12.4 https://openqa.suse.de/tests/4449162
  - 12.3 https://openqa.suse.de/tests/4449163
  - 12.2 https://openqa.suse.de/tests/4449177

No runs on 15 or TW because yast2-storage was replaced with yast2-storage-ng and there is a module for it already