### PR TITLE
Add yaml schedule for minimal+base for PowerVM

### DIFF
--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - '{{reconnect_mgmt_console}}'
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare
@@ -39,3 +40,8 @@ schedule:
   - console/orphaned_packages_check
   - console/validate_selected_patterns
   - console/consoletest_finish
+conditional_schedule:
+  reconnect_mgmt_console:
+    BACKEND:
+      pvm_hmc:
+        - boot/reconnect_mgmt_console


### PR DESCRIPTION
The PR adds the yaml schedule for minimal+base for PowerVM.

- Related ticket: https://progress.opensuse.org/issues/68733
- Verification run: https://openqa.suse.de/tests/4449157
- **Job Group Settings:** https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/246