### PR TITLE
Add package metadata in container tests

### DIFF
--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -7,6 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package: container-diff
 # Summary: Print and save diffs between two cotaniners using container-diff tool
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 

--- a/tests/containers/containers_3rd_party.pm
+++ b/tests/containers/containers_3rd_party.pm
@@ -7,6 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package: docker podman
 # Summary: Pull and test several base images (alpine, openSUSE, debian, ubuntu, fedora, centos) for their base functionality
 #          Log the test results in containers_3rd_party.txt
 #          Docker or Podman tests can be skipped by setting SKIP_DOCKER_IMAGE_TESTS=1 or SKIP_PODMAN_IMAGE_TESTS=1 in the job

--- a/tests/containers/docker.pm
+++ b/tests/containers/docker.pm
@@ -8,6 +8,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package: docker
 # Summary: Test docker installation and extended usage
 # - docker package can be installed
 # - docker daemon can be started

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -7,6 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package: docker-compose
 # Summary: Test docker-compose installation
 #    Cover the following aspects of docker-compose:
 #      * package can be installed

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -7,6 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package: docker
 # Summary: Test installation and running of the docker image from the registry for this snapshot
 # - if on SLE, enable internal registry
 # - load image

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -7,6 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package: runc docker-runc
 # Summary: Test docker-runc and runc installation, and extended usage
 #    Cover the following aspects of docker-runc and runc respectively:
 #      * package can be installed

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -8,6 +8,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package: podman
 # Summary: Test podman installation and extended usage in a Kubic system
 #    Cover the following aspects of podman:
 #      * podman daemon can be started

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -7,6 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package podman
 # Summary: Test installation and running of the docker image from the registry for this snapshot
 # Maintainer: Fabian Vogt <fvogt@suse.com>
 

--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -7,6 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# package: zypper-docker
 # Summary: Test zypper-docker installation and its usage
 #    Cover the following aspects of zypper-docker:
 #      * zypper-docker package can be installed


### PR DESCRIPTION
The container tests should include package metadata in order to try out the automated generation of test coverage.

- Related ticket: No progress issue, this is tied to https://confluence.suse.com/display/~vpelcak/Test+Coverage+Generated+from+the+openQA+Testcases
- Needles: No needles
- Verification run: No verification run
