### PR TITLE
[virt_autotest] move virtual network tests under setup_dns_service

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -772,6 +772,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/guest_installation_run";
         if (!(get_var("GUEST_PATTERN") =~ /win/img) && is_x86_64) {
             loadtest "virt_autotest/set_config_as_glue";
+            loadtest "virt_autotest/setup_dns_service";
             if (get_var("ENABLE_VIR_NET")) {
                 loadtest "virt_autotest/libvirt_virtual_network_init";
                 loadtest "virt_autotest/libvirt_host_bridge_virtual_network";
@@ -779,7 +780,6 @@ elsif (get_var("VIRT_AUTOTEST")) {
                 loadtest "virt_autotest/libvirt_routed_virtual_network";
                 loadtest "virt_autotest/libvirt_isolated_virtual_network";
             }
-            loadtest "virt_autotest/setup_dns_service";
             loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH");
             loadtest "virtualization/xen/hotplugging"                   if get_var("ENABLE_HOTPLUGGING");
             loadtest "virtualization/xen/storage"                       if get_var("ENABLE_STORAGE");

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -64,6 +64,8 @@ sub run_test {
         check_guest_module("$guest", module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_isolated --model $model --mac $mac --live $affecter", 60);
 
+        #Wait for guests attached interface from virtual isolated network
+        sleep 30;
         my $net = is_sle('=11-sp4') ? 'br123' : 'vnet_isolated';
         test_network_interface($guest, mac => $mac, gate => $gate, isolated => 1, net => $net);
 
@@ -73,9 +75,6 @@ sub run_test {
     #Destroy ISOLATED NETWORK
     assert_script_run("virsh net-destroy vnet_isolated");
     save_screenshot;
-
-    #Restore Guest systems
-    virt_autotest::virtual_network_utils::restore_guests();
 
     #After finished all virtual network test, need to restore file /etc/hosts from backup
     virt_autotest::virtual_network_utils::hosts_restore();


### PR DESCRIPTION
**Background:**
So far, we have added **virtual network,** **sriov network**, **hotplugging,** **storage** and **virsh snapshot** as new feature functional tests to virt_autotest.
Will keep these added tests as the same _**level**_ under virt_autotest, so, need to move virtual network under setup_dns_service.

Thus, after moved **virtual network** under setup_dns_service, added **virtual network,** **sriov network**, **hotplugging,** **storage** and **virsh snapshot** as new feature functional tests to virt_autotest, keep the same level easy to trigger **[START_DIRECTLY_AFTER_TEST](https://confluence.suse.com/pages/viewpage.action?spaceKey=qasleapac2&title=Reconstruct+virtualization+test+suites+in+openQA+based+on+START_DIRECTLY_AFTER_TEST)** in openQA. 

What is the setup_dns_service?
Let vm host access guest system by **guest name** directly without **password** via **ssh** command. 

- Verification run:
gi-guest_developing-on-host_developing-kvm
http://10.67.131.5/tests/122
gi-guest_developing-on-host_developing-xen
http://10.67.131.5/tests/109
gi-guest_sles11sp4-on-host_developing-kvm
http://10.67.131.5/tests/42
gi-guest_sles11sp4-on-host_developing-xen
http://10.67.131.5/tests/43
gi-guest_developing-on-host_sles12sp5-kvm
http://10.67.131.5/tests/124
gi-guest_developing-on-host_sles12sp5-xen
http://10.67.131.5/tests/125
gi-guest_developing-on-host_sles15sp1-xen
http://10.67.131.5/tests/130
gi-guest_developing-on-host_sles12sp4-xen
http://10.67.131.5/tests/111
gi-guest_developing-on-host_sles12sp4-kvm
http://10.67.131.5/tests/134
gi-guest_developing-on-host_sles15-xen
http://10.67.131.5/tests/129