### PR TITLE
sles4sap: Temporary fix for Maintenance tests while sapconf v5 is tested & released

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -152,6 +152,9 @@ sub prepare_profile {
     # for netweaver and the recommended one for hana
     my $has_saptune = $self->is_saptune_installed();
 
+    # NOTE: Remove when sapconf v5 is released
+    return unless ($has_saptune);
+
     if ($has_saptune) {
         assert_script_run "tuned-adm profile saptune";
         assert_script_run "saptune solution apply $profile";

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -46,7 +46,8 @@ sub run {
           unless (check_var('SYSTEM_ROLE', 'textmode') or is_upgrade() or is_updates_tests() or check_var('SLE_PRODUCT', 'sles'));
         record_info('install sap_server', 'Installing sap_server pattern and starting tuned');
         zypper_call('in -y -t pattern sap_server');
-        systemctl 'start tuned';
+        # NOTE: Remove when sapconf v5 is released on SLES 12
+        systemctl 'start tuned' unless is_sle('15+');
     }
 
     # This test is also used for testing SAP products installation on plain SLE

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -127,6 +127,9 @@ sub run {
 
     assert_script_run("rpm -q sapconf");
 
+    # NOTE: Remove when sapconf v5 is released
+    return;
+
     my $output = script_output "tuned-adm active";
     $output =~ /Current active profile: ([a-z\-]+)/;
     my $default_profile = $1;


### PR DESCRIPTION
Temporarily disable sapconf checks while sapconf v5 is in the queue
