### PR TITLE
Fix package metadata in container tests

### DIFF
--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# package podman
+# package: podman
 # Summary: Test installation and running of the docker image from the registry for this snapshot
 # Maintainer: Fabian Vogt <fvogt@suse.com>
 


### PR DESCRIPTION
Typo fix on the metadata.
The container tests should include package metadata in order to try out the automated generation of test coverage.

*  Related ticket: No progress issue, this is tied to https://confluence.suse.com/display/~vpelcak/Test+Coverage+Generated+from+the+openQA+Testcases
 *   Needles: No needles
  *  Verification run: No verification run
