### PR TITLE
Schedule perf test on all versions

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1640,7 +1640,7 @@ sub load_extra_tests_console {
     loadtest "console/sqlite3";
     loadtest "console/ant" if is_sle('<15-sp1');
     loadtest "console/gdb";
-    loadtest "console/perf" if is_sle('<15-sp1');
+    loadtest "console/perf" unless is_sle;
     loadtest "console/sysctl";
     loadtest "console/sysstat";
     loadtest "console/curl_ipv6" unless get_var('PUBLIC_CLOUD');
@@ -3207,6 +3207,7 @@ sub load_kernel_baremetal_tests {
     }
     # make sure we always have the toolchain installed
     loadtest "toolchain/install";
+    loadtest "console/perf";
     # some tests want to build and run a custom kernel
     loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
 }

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -26,6 +26,7 @@ schedule:
 - console/java
 - console/sqlite3
 - console/gdb
+- console/perf
 - console/sysctl
 - console/sysstat
 - console/krb5

--- a/schedule/qam/15-SP2/mau-extratests.yaml
+++ b/schedule/qam/15-SP2/mau-extratests.yaml
@@ -27,6 +27,7 @@ schedule:
 - console/java
 - console/sqlite3
 - console/gdb
+- console/perf
 - console/sysctl
 - console/sysstat
 - console/krb5


### PR DESCRIPTION
Remove condition to run perf test only on sle<15-sp1

- Related ticket: https://progress.opensuse.org/issues/48983
- Needles: no needles
- Verification run:
  - 15.1 https://openqa.suse.de/tests/4452665
  - 15.2 https://openqa.suse.de/tests/4452677
  - 15.2 (s390) https://openqa.suse.de/tests/4452678
  - Bare Metal 15.1 http://10.161.229.249/tests/135#step/perf/41
  - TW https://openqa.opensuse.org/tests/1334332
 