### PR TITLE
systemd testsuite: extend timeout for test 11 and call clean function, call post_fail_hook of parent class in systemd lib

### DIFF
--- a/lib/systemd_testsuite_test.pm
+++ b/lib/systemd_testsuite_test.pm
@@ -121,6 +121,7 @@ sub testsuiteprepare {
 
 sub post_fail_hook {
     my ($self) = @_;
+    $self->SUPER::post_fail_hook();
     #upload logs from given testname
     $self->tar_and_upload_log('/var/opt/systemd-tests/logs', '/tmp/systemd_testsuite-logs.tar.bz2');
     $self->save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.log');

--- a/tests/systemd_testsuite/test_11_issue_3166.pm
+++ b/tests/systemd_testsuite/test_11_issue_3166.pm
@@ -24,8 +24,9 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-11-ISSUE-3166 --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-11-ISSUE-3166 --run 2>&1 | tee /tmp/testsuite.log', 600;
     assert_script_run 'grep "PASS: ...TEST-11-ISSUE-3166" /tmp/testsuite.log';
+    script_run './run-tests.sh TEST-11-ISSUE-3166 --clean';
 }
 
 sub test_flags {


### PR DESCRIPTION
- Failed run: http://emerson.suse.de/tests/2271#step/test_11_issue_3166/21
- Verification run: http://emerson.suse.de/tests/2277#step/test_11_issue_3166/21