### PR TITLE
Refine sshd backup/retore way to avoid test error in QAM/TW

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -72,8 +72,8 @@ sub run {
     assert_script_run("usermod -aG \$(stat -c %G /dev/$serialdev) $ssh_testman");
 
     # Backup/rename ~/.ssh , generated in consotest_setup, to ~/.ssh_bck
-    # poo#68200. Take FIPS_ENABLED into consideration, get rid of the problem from openssh_fips rm -r ~/.ssh/ directory in advance
-    assert_script_run 'mv ~/.ssh ~/.ssh_bck' unless ((get_var('INSTALLATION_VALIDATION') =~ /sshd/) || get_var('FIPS_ENABLED'));
+    # poo#68200. Confirm the ~/.ssh directory is exist in advance, in order to avoid the null backup
+    assert_script_run 'if [ -d ~/.ssh ]; then mv ~/.ssh ~/.ssh_bck; fi';
 
     # avoid harmless failures in virtio-console due to unexpected PS1
     assert_script_run("echo \"PS1='# '\" >> ~$ssh_testman/.bashrc") unless check_var('VIRTIO_CONSOLE', '0');
@@ -126,8 +126,9 @@ sub run {
     assert_script_run "scp -4v '$ssh_testman\@localhost:/etc/ssh/*.pub' /tmp";
 
     # Restore ~/.ssh generated in consotest_setup
-    # poo#68200. Take FIPS_ENABLED into consideration, get rid of the problem from openssh_fips rm -r ~/.ssh/ directory in advance
-    assert_script_run 'rm -rf ~/.ssh && mv ~/.ssh_bck ~/.ssh' unless ((get_var('INSTALLATION_VALIDATION') =~ /sshd/) || get_var('FIPS_ENABLED'));
+    # poo#68200. Confirm the ~/.ssh_bck directory is exist in advance and then restore, in order to avoid the null restore
+    assert_script_run 'rm -rf ~/.ssh';
+    assert_script_run 'if [ -d ~/.ssh_bck ]; then mv ~/.ssh_bck ~/.ssh; fi';
 
     assert_script_run "killall -u $ssh_testman || true";
     wait_still_screen 3;


### PR DESCRIPTION
**Description:**
The PR #10643 breaks the sshd test on SLE15 SP1 QAM test, and the PR #10668 breaks the sshxterm tests on openSUSE Tumbleweed. Patch needs to enhance and rewrite the approach to fulfill more different release products, and provide more VR is necessary here. Currently the chanages judge the directory exists only, and will not care about the variable anymore via unless condition. And in the restore part, we change to delete directory first and then move the backup directory back. This PR can fix the problem without the test sequence impact.

1. Refine sshd backup/retore way to avoid wrong action and testing fail in openSUSE TW
2. Replace unless usage to avoid testing break in SLE QAM

- Related ticket: https://progress.opensuse.org/issues/68200
- Needles: NA
- Verification run: 
**ALL the VR are passed.**
https://openqa.suse.de/tests/4449009 (SLES 15 SP2 QAM fips job group)
http://10.67.17.201/tests/1047 (SLES 15 SP1 QAM - sshd+sshfs)
http://10.67.17.201/tests/1049 (SLES 15 SP2 GM - sshd+sshfs)
https://openqa.opensuse.org/t1332365 (openSUSE TW Build293.2)
https://openqa.opensuse.org/tests/1333185 (openSUSE TW Snapshot20200714 - **sshd / sshfs / sshxterm** )