### PR TITLE
Install prove in pam test explicitly

### DIFF
--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -38,7 +38,7 @@ sub run {
         my $qa_head_repo = "http://download.suse.de/ibs/QA:/Head/" . 'SLE-' . $version;
         zypper_ar("$qa_head_repo", name => 'qa-head-repo');
     }
-    zypper_call('install bats pam-test pam pam-config snapper');
+    zypper_call('install bats pam-test pam pam-config snapper perl');
 
     # create a snapshot for rollback
     assert_script_run("snapbf=\$(snapper create -p -d 'before pam test')");


### PR DESCRIPTION
It's directly called later on.

https://openqa.opensuse.org/tests/1333086#step/pam/12

Verification run: http://10.160.67.86/tests/705