### PR TITLE
Work around issue with send_key for firefox

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -37,7 +37,7 @@ sub run() {
     assert_screen [qw(firefox-save-and-quit generic-desktop)];
     if (match_has_tag 'firefox-save-and-quit') {
         # confirm "save&quit"
-        send_key "ret";
+        send_key_until_needlematch('generic-desktop', 'ret', 5, 6);
     }
 }
 


### PR DESCRIPTION
especially on LIVECD installation we have sometimes issue with send_key alt-f4.
see https://progress.opensuse.org/issues/63892
verifications:
http://10.162.23.47/tests/7883#step/firefox (Gnome LIVECD)
http://10.162.23.47/tests/7876#step/firefox (KDE LIVECD)
http://10.162.23.47/tests/7888#step/firefox (TW NET Gnome)
http://10.162.23.47/tests/7885#step/firefox (sles 15 aarch64)
