### PR TITLE
Rename SAP QAM flavor

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -328,8 +328,9 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
     # set SCC_ADDONS before push to slenkins
     set_var('SCC_ADDONS', join(',', @addons));
 
-    # SLES4SAP does not have addon on SLE12SP3
-    push(@addons, 'sles4sap') if is_sle('<15') && check_var('FLAVOR', 'Server-DVD-SLES4SAP-Updates') || check_var('FLAVOR', 'Server-DVD-SAP-Incidents');
+    # SLES4SAP does not have addon on SLE12
+    # We need to push sles4sap for using _TEST_ISSUES and _TEST_TEMPLATE below
+    push(@addons, 'sles4sap') if is_sle('<15') && check_var('FLAVOR', 'SAP-DVD-Updates') || check_var('FLAVOR', 'Server-DVD-SAP-Incidents');
 
     # push sdk addon to slenkins tests
     if (get_var('TEST', '') =~ /^slenkins/) {


### PR DESCRIPTION
Flavor `Server-DVD-SLES4SAP-Updates` is no longer used.
This PR renames it to `SAP-DVD-Updates`.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
Flavor `Server-DVD-SLES4SAP-Updates` does not exist anymore in openQA medium definition.
http://1a102.qa.suse.de/tests/4528
