### PR TITLE
Adapt sap QAM SLE12 files for aggregate testing

### DIFF
--- a/schedule/qam/12-SP2/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/12-SP2/qam-create_hdd_sle_sap_gnome.yml
@@ -24,9 +24,15 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/12-SP2/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/12-SP2/qam-create_hdd_sles4sap_gnome.yml
@@ -25,6 +25,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
@@ -44,3 +45,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - installation/user_settings
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/12-SP3/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/12-SP3/qam-create_hdd_sle_sap_gnome.yml
@@ -24,9 +24,15 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/12-SP3/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/12-SP3/qam-create_hdd_sles4sap_gnome.yml
@@ -25,6 +25,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
@@ -44,3 +45,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - installation/user_settings
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/12-SP4/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/12-SP4/qam-create_hdd_sle_sap_gnome.yml
@@ -24,9 +24,15 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/12-SP4/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/12-SP4/qam-create_hdd_sles4sap_gnome.yml
@@ -25,6 +25,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
@@ -44,3 +45,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - installation/user_settings
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/12-SP5/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/12-SP5/qam-create_hdd_sle_sap_gnome.yml
@@ -24,9 +24,15 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot

--- a/schedule/qam/12-SP5/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/12-SP5/qam-create_hdd_sles4sap_gnome.yml
@@ -23,6 +23,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - '{{patch_and_reboot}}'
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
@@ -34,3 +35,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - installation/add_update_test_repo
+  patch_and_reboot:
+    FLAVOR:
+      SAP-DVD-Updates:
+        - qa_automation/patch_and_reboot


### PR DESCRIPTION
This PR adds the possibility to trigger the patch_and_reboot module for testing aggregate builds on SLE12 versions.

That means we can test sap installation on top of a qcow2 which contains maintenance incidents being tested and not already released.
For example BASE_TEST_ISSUES=10959,13642,14171,14396,14495,15020,15037,15177,15206 will create a qcow2 with all these maintenance incident.

Same PR as #10647 (SLE15)

- Related ticket: N/A
- Needles: N/A
- Verification run:
[sles4sap 12-SP5](http://1a102.qa.suse.de/tests/4547)
[plain sle 12-SP5](http://1a102.qa.suse.de/tests/4538)
[sles4sap 12-SP4](http://1a102.qa.suse.de/tests/4543)
[plain sle 12-SP4](http://1a102.qa.suse.de/tests/4542)
[sles4sap 12-SP3](http://1a102.qa.suse.de/tests/4549)
[plain sle 12-SP3](http://1a102.qa.suse.de/tests/4534)
[sles4sap 12-SP2](http://1a102.qa.suse.de/tests/4544)
[plain sle 12-SP2](http://1a102.qa.suse.de/tests/4545)