### PR TITLE
Install pam-deprecated to test pam_tally2

### DIFF
--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -38,7 +38,7 @@ sub run {
         my $qa_head_repo = "http://download.suse.de/ibs/QA:/Head/" . 'SLE-' . $version;
         zypper_ar("$qa_head_repo", name => 'qa-head-repo');
     }
-    zypper_call('install bats pam-test pam pam-config snapper perl');
+    zypper_call('install bats pam-test pam pam-config pam-deprecated snapper perl');
 
     # create a snapshot for rollback
     assert_script_run("snapbf=\$(snapper create -p -d 'before pam test')");


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/68116
Verification: https://openqa.opensuse.org/t1334356