### PR TITLE
Implement  migration from Leap+textmode to SLES

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key);
-use version_utils qw(is_sle is_sles4sap is_caasp is_upgrade);
+use version_utils qw(is_sle is_sles4sap is_caasp is_upgrade is_leap_migration);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
 
@@ -659,7 +659,7 @@ sub fill_in_registration_data {
         verify_preselected_modules($modules_needle) if get_var('CHECK_PRESELECTED_MODULES');
         # Add desktop module for SLES if desktop is gnome
         # Need desktop application for minimalx to make change_desktop work
-        if (check_var('SLE_PRODUCT', 'sles')
+        if ((check_var('SLE_PRODUCT', 'sles') && !is_leap_migration)
             && (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'minimalx'))
             && (my $addons = get_var('SCC_ADDONS')) !~ /(?:desktop|we)/)
         {
@@ -720,7 +720,14 @@ sub registration_bootloader_params {
 }
 
 sub yast_scc_registration {
-    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'scc');
+    # for leap to sle migration, we need to install yast2-registration
+    # before running yast2 registration module.
+    my $client_module = 'scc';
+    if (is_leap_migration) {
+        zypper_call('in yast2-registration');
+        $client_module = 'registration';
+    }
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module);
     assert_screen_with_soft_timeout(
         'scc-registration',
         timeout      => 90,

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -49,6 +49,7 @@ use constant {
           is_using_system_role
           is_using_system_role_first_flow
           is_public_cloud
+          is_leap_migration
           requires_role_selection
           check_version
           get_sles_release
@@ -585,3 +586,12 @@ Returns true if PUBLIC_CLOUD is set to 1
 sub is_public_cloud {
     return get_var('PUBLIC_CLOUD');
 }
+
+=head2 is_leap_migration
+
+Returns true if called in a leap to sle migration scenario
+=cut
+sub is_leap_migration {
+    return is_upgrade && get_var('ORIGIN_SYSTEM_VERSION') =~ /leap/;
+}
+

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -16,7 +16,7 @@ use warnings;
 use testapi;
 use utils;
 use power_action_utils 'power_action';
-use version_utils qw(is_desktop_installed is_sles4sap);
+use version_utils qw(is_desktop_installed is_sles4sap is_leap_migration);
 use Utils::Backends 'is_pvm';
 
 sub run {
@@ -37,6 +37,7 @@ sub run {
     my $zypper_migration_urlerror     = qr/URI::InvalidURIError/m;
     my $zypper_migration_reterror     = qr/^No migration available|Can't get available migrations/m;
 
+    my $zypper_migration_signing_key = qr/^Do you want to reject the key, trust temporarily, or trust always?[\s\S,]* \[r/m;
     # start migration
     script_run("(zypper migration;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
     # migration process take long time
@@ -44,7 +45,7 @@ sub run {
     my $migration_checks = [
         $zypper_migration_target, $zypper_disable_repos,      $zypper_continue,               $zypper_migration_done,
         $zypper_migration_error,  $zypper_migration_conflict, $zypper_migration_fileconflict, $zypper_migration_notification,
-        $zypper_migration_failed, $zypper_migration_license,  $zypper_migration_reterror
+        $zypper_migration_failed, $zypper_migration_license,  $zypper_migration_reterror,     $zypper_migration_signing_key
     ];
     my $zypper_migration_error_cnt = 0;
     my $out                        = wait_serial($migration_checks, $timeout);
@@ -87,6 +88,11 @@ sub run {
                 die 'Zypper migration failed';
             }
         }
+        elsif ($out =~ $zypper_migration_signing_key)
+        {
+            send_key 'a';
+            send_key 'ret';
+        }
         elsif ($out =~ $zypper_migration_fileconflict
             || $out =~ $zypper_migration_failed
             || $out =~ $zypper_migration_urlerror)
@@ -113,6 +119,10 @@ sub run {
         }
         $out = wait_serial($migration_checks, $timeout);
     }
+    # check if the migration success or not by checking the /etc/os-release file with the VERSION
+    my $target_version = get_var("VERSION");
+    assert_script_run("grep VERSION= /etc/os-release | grep $target_version");
+
     # We can't use 'keepconsole' here, because sometimes a display-manager upgrade can lead to a screen change
     # during restart of the X/GDM stack
     power_action('reboot', textmode => 1);
@@ -123,7 +133,7 @@ sub run {
     # with other than the SAP Administrator
     #
     # sometimes reboot takes longer time after online migration, give more time
-    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => is_sles4sap);
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => (is_sles4sap || is_leap_migration));
 }
 
 1;


### PR DESCRIPTION
Now we support leap15.2 textmode to SLE15SP2 migration through 'zypper migration' and with 
yast UI. We added the following 2 methods of migration. And migration should be leap 15.2 to sles15SP2 or leap15.3 to sles15SP3.

1. Add migration from Leap 15.2 textmode to SLES15SP2 with yast UI.
2. Add migration from Leap 15.2 textmode to SLES15SP2 with 'zypper migration'.

During the test, we added a needle bootmenu-LEAP-15-2-20200708 with tag grub2.

- Related ticket: 
         https://progress.opensuse.org/issues/52460
         https://progress.opensuse.org/issues/68609

- Needles: N/A
  
- Verification run: 
         http://openqa.nue.suse.com/tests/4459604 yast
         http://openqa.nue.suse.com/tests/4459605 zypper