### PR TITLE
Enable yast2_lan_device_settings for svirt backend

### DIFF
--- a/schedule/yast/yast2_ncurses/yast2_ncurses_textmode.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_textmode.yaml
@@ -10,19 +10,9 @@ schedule:
   - console/yast2_lan
   - console/yast2_i
   - console/yast2_bootloader
-  - "{{yast2_lan_device_settings}}"
+  - console/yast2_lan_device_settings
 conditional_schedule:
   bootloader_start:
     BACKEND:
       svirt:
         - installation/bootloader_start
-  # The test module is temporary excluded on s390x due to the failures.
-  # https://progress.opensuse.org/issues/67603
-  yast2_lan_device_settings:
-    ARCH:
-      aarch64:
-        - console/yast2_lan_device_settings
-      ppc64le:
-        - console/yast2_lan_device_settings
-      x86_64:
-        - console/yast2_lan_device_settings

--- a/schedule/yast/yast2_ncurses/yast2_ncurses_textmode@svirt-xen-hvm.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_textmode@svirt-xen-hvm.yaml
@@ -11,4 +11,5 @@ schedule:
   - console/consoletest_setup
   - console/yast2_i
   - console/yast2_bootloader
+  - console/yast2_lan_device_settings
   - console/coredump_collect


### PR DESCRIPTION
Slight modifications in yast2_lan_device_setting, in order for it to run on svirt backend. 
Modification of YAML schedules.

- Related ticket: https://progress.opensuse.org/issues/67603
- Needles: already in production:
yast2_lan_device_settings-device-setup-pop-up-20200715
yast2_lan-add-vlan-selected-20200715
yast2_lan-vlan-added--20200715
yast2_lan-vlan-selected-20200715
yast2_lan-static-ip-address-set-20200716
yast2_lan_duplicate_ip-20200717
- Verification runs: 
    * xen-hvm: https://openqa.suse.de/tests/4461295
    * s390x    : https://openqa.suse.de/tests/4461296
    * 64bit      : https://openqa.suse.de/tests/4461293

