### PR TITLE
Remove samba_sssd from SLES15-SP2

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1690,7 +1690,7 @@ sub load_extra_tests_console {
     loadtest 'console/libgcrypt' if ((is_sle(">=12-SP4") && (check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk'))) || is_opensuse);
     loadtest "console/gd";
     loadtest 'console/valgrind'       unless is_sle('<=12-SP3');
-    loadtest 'console/sssd_samba'     unless is_sle("<15");
+    loadtest 'console/sssd_samba'     unless (is_sle("<15") || is_sle(">=15-sp2"));
     loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1') || is_jeos);
 }
 

--- a/schedule/qam/15-SP2/mau-extratests.yaml
+++ b/schedule/qam/15-SP2/mau-extratests.yaml
@@ -64,7 +64,6 @@ schedule:
 - console/libqca2
 - console/gd
 - console/valgrind
-- console/sssd_samba
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:


### PR DESCRIPTION
sssd-wbclient is not available anymore on SLES15-SP2, thus this test is not required anymore.

- Related ticket: https://progress.opensuse.org/issues/68989
- Needles: N/A
- Verification run: [SLE15-SP2](https://openqa.suse.de/tests/4461005) | [SLE15-SP1](https://openqa.suse.de/tests/4461006) | [SLE15](https://openqa.suse.de/tests/4461007) | [Leap](https://openqa.opensuse.org/tests/1335293) | [Tumbleweed](https://openqa.opensuse.org/tests/1335294)

I cancelled the runs, after checking that the suite starts to work and `sssd_samba` is not present on SLE15-SP2 anymore