### PR TITLE
Fix fail in firefox regression tests

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -675,6 +675,8 @@ sub firefox_open_url {
         wait_screen_change { assert_and_click 'firefox_titlebar' };
         send_key 'alt-d';
         send_key 'delete';
+        send_key 'alt-d';
+        send_key 'delete';
         last if check_screen('firefox-empty-bar', 3);
         if ($counter++ > 5) {
             assert_screen('firefox-empty-bar', 0);

--- a/tests/x11/firefox/firefox_passwd.pm
+++ b/tests/x11/firefox/firefox_passwd.pm
@@ -34,7 +34,7 @@ use strict;
 use warnings;
 use base "x11test";
 use testapi;
-use version_utils 'is_sle';
+use version_utils;
 
 sub run {
     my ($self) = @_;
@@ -51,6 +51,7 @@ sub run {
     assert_and_click('firefox-passwd-security');
 
     send_key "alt-shift-u";
+    send_key "alt-shift-u" unless (is_sle('=15') || is_leap('=15'));
     wait_still_screen 3;
     send_key 'spc' unless check_screen('firefox-passwd-master_setting');
 
@@ -89,14 +90,21 @@ sub run {
     assert_screen('firefox-passwd-saved');
 
     send_key "alt-shift-a";    #"Remove"
-    wait_still_screen 3;
+    assert_and_click('firefox-saved-logins-remove') unless (is_sle('=15') || is_leap('=15'));
+    wait_still_screen 3                             unless (is_sle('=15') || is_leap('=15'));
+    send_key "spc"                                  unless (is_sle('=15') || is_leap('=15'));
+    wait_still_screen 3                             unless (is_sle('=15') || is_leap('=15'));
     send_key "alt-y";
     wait_still_screen 3;
     send_key "alt-shift-c";
     wait_still_screen 3;
     send_key "ctrl-w";
     wait_still_screen 3;
+    send_key "ctrl-w"   unless (is_sle('=15') || is_leap('=15'));
+    wait_still_screen 3 unless (is_sle('=15') || is_leap('=15'));
     send_key "f5";
+    wait_still_screen 3;
+    send_key "f5" unless (is_sle('=15') || is_leap('=15'));
     assert_screen('firefox-passwd-removed', 60);
 
     # Exit

--- a/tests/x11/firefox/firefox_pdf.pm
+++ b/tests/x11/firefox/firefox_pdf.pm
@@ -39,7 +39,6 @@ sub run {
     send_key "tab";
     for my $i (1 .. 4) { assert_and_click 'firefox-pdf-zoom_in_button'; }
     assert_screen('firefox-pdf-zoom_in');
-
     assert_and_click 'firefox-pdf-zoom_menu';
     sleep 1;
     assert_and_click 'firefox-pdf-zoom_menu_actual_size';    #"Actual Size"

--- a/tests/x11/firefox/firefox_ssl.pm
+++ b/tests/x11/firefox/firefox_ssl.pm
@@ -39,8 +39,8 @@ sub run {
     send_key "tab";
     send_key 'spc';
     send_key_until_needlematch 'firefox-ssl-risk-accept-and-continue-button-selected', 'tab', 7, 1;
-    send_key 'spc';
-    if (check_screen 'firefox-ssl-addexception', 5) {
+    assert_and_click('firefox-ssl-risk-accept-and-continue-button-selected');
+    if (check_screen 'firefox-ssl-addexception', 10) {
         send_key 'alt-c';
     }
 


### PR DESCRIPTION
Small fixes in fails of firefox regression tests

- Related ticket: https://progress.opensuse.org/issues/68929
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1407
- Verification run: [SLES 15sp2](http://10.161.229.247/tests/912) [15sp1](https://openqa.suse.de/tests/4466538) [15](https://openqa.suse.de/tests/4466737) [12sp5](https://openqa.suse.de/tests/4467029) [12sp4](https://openqa.suse.de/tests/4467030) [12sp3](https://openqa.suse.de/tests/4467540)
[SLED 15sp2](https://openqa.suse.de/tests/4469012) 

Info : No runs performed on TW and Leap, as these tests are not yet scheduled on ooo. A progress issue will be opened for this scheduling.