### PR TITLE
Generate support_server image for SLES on aarch64

### DIFF
--- a/data/supportserver/autoyast_supportserver_aarch64_sle15.xml
+++ b/data/supportserver/autoyast_supportserver_aarch64_sle15.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns"
+         xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+  </suse_register>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_halt config:type="boolean">false</final_halt>
+      <final_reboot config:type="boolean">false</final_reboot>
+      <halt config:type="boolean">false</halt>
+      <second_stage config:type="boolean">true</second_stage>
+    </mode>
+    <proposals config:type="list"/>
+    <!-- The PackageHub repos feature an unknown gpg key. We want to both trust it and import it. -->
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">false</accept_file_without_checksum>
+      <!-- autoyast docu says: ... accept known keys you have not yet trusted . Not enough here. -->
+      <accept_non_trusted_gpg_key config:type="boolean">false</accept_non_trusted_gpg_key>
+      <!-- autoyast docu says: ... new GPG keys of the installation sources... Supposedly needed. -->
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <!-- autoyast docu says: ... accept and import new GPG keys ... in its database. Supposedly also needed. -->
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/aarch64/product/</media_url>
+        <product>sle-module-basesystem</product>
+        <alias>sle-module-basesystem:15.2::pool</alias>
+        <name>sle-module-basesystem:15.2::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <!-- SLE15SP1 AutoYaST docu sec. 4.9.3 Installing Additional/Customized Packages or Products example 4.24
+             "true" <==> Users are asked whether to add such a product. If so, then
+             selected: defines the default state of pre-selected state of packages -->
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/aarch64/update/</media_url>
+        <alias>sle-module-basesystem:15.2::update</alias>
+        <name>sle-module-basesystem:15.2::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP2/aarch64/product/</media_url>
+        <product>sle-module-development-tools</product>
+        <alias>sle-module-development-tools:15.2::pool</alias>
+        <name>sle-module-development-tools:15.2::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <alias>sle-module-development-tools:15.2::update</alias>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP2/aarch64/update/</media_url>
+        <name>sle-module-development-tools:15.2::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/aarch64/product/</media_url>
+        <product>sle-module-server-applications</product>
+        <alias>sle-module-server-applications:15.2::pool</alias>
+        <name>sle-module-server-applications:15.2::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <alias>sle-module-server-applications:15.2::update</alias>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/aarch64/update/</media_url>
+        <name>sle-module-server-applications:15.2::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <alias>sle-module-development-tools:15.2::update</alias>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP2/aarch64/update/</media_url>
+        <name>sle-module-desktop-applications:15.2::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP2/aarch64/product/</media_url>
+        <product>sle-module-desktop-applications</product>
+        <alias>sle-module-desktop-applications:15.2::pool</alias>
+        <name>sle-module-desktop-applications:15.2::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/aarch64/product/</media_url>
+        <product>SLES</product>
+        <alias>SLES:15.2::pool</alias>
+        <name>SLES:15.2::pool</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <!-- SLE15SP1 AutoYaST docu sec. 4.9.2 Package Selection with Patterns and Packages Sections
+             "true" here triggers a "confirm license" dialog rather than auto-accepting the license. Unwanted. -->
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <alias>SLES:15.2::update</alias>
+        <media_url>http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/aarch64/update/</media_url>
+        <name>SLES:15.2::update</name>
+        <priority config:type="integer">99</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Backports/SLE-15-SP2_aarch64/product/</media_url>
+        <alias>PackageHub:15.2::product</alias>
+        <name>PackageHub:15.2::product</name>
+        <priority config:type="integer">20</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE/Backports/SLE-15-SP2_aarch64/standard</media_url>
+        <!-- NFS: /mounts/mirror/SuSE/build.suse.de/SUSE/Backports/SLE-15-SP2_aarch64/standard
+             NOTE: *four* RPM subdirs: noarch{,_GA}, aarch64{,_GA}. Looks like both GA pool and updates.  -->
+        <alias>PackageHub:15.2::pool</alias>
+        <name>PackageHub:15.2::pool</name>
+        <priority config:type="integer">20</priority>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <confirm_license config:type="boolean">false</confirm_license>
+        <ask_user config:type="boolean">false</ask_user>
+        <selected config:type="boolean">true</selected>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+      <append>splash=verbose</append>
+    </global>
+  </bootloader>
+  <networking>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>onboot</startmode>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">false</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+  <software>
+    <image/>
+    <instsource/>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+    <packages config:type="list">
+      <package>vim</package>
+      <package>apache2</package>
+      <package>dhcp-server</package>
+      <package>mc</package>
+      
+      <package>openssh</package>
+      <package>less</package>
+      <package>nfs-client</package>
+      <package>autofs</package>
+      <package>bind</package>
+      <package>tftp</package>
+      <package>yast2-iscsi-lio-server</package>
+      <package>tgt</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>documentation</pattern>
+      <pattern>enhanced_base</pattern>
+      <pattern>gnome_basic</pattern>
+      <pattern>gnome_basis</pattern>
+      <pattern>minimal_base</pattern>
+      <pattern>x11</pattern>
+      <pattern>x11_enhanced</pattern>
+    </patterns>
+  </software>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <username>root</username>
+      <user_password>nots3cr3t</user_password>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <username>bernhard</username>
+      <user_password>nots3cr3t</user_password>
+    </user>
+  </users>
+  <services-manager>
+  <!-- SLE15SP1 AutoYaST docu sec. 4.11: Services and Targets-->
+    <default_target>multi-user</default_target>
+    <!-- We don't want much by default. For testing of this autoyast let's tmp. enable sshd
+         FIXME: don't forget to comment this part out later. The real supportserver won't need it. -->
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+    <!-- END  enabling sshd service -->
+  </services-manager>
+</profile>

--- a/data/supportserver/autoyast_supportserver_generator_sle15.sh
+++ b/data/supportserver/autoyast_supportserver_generator_sle15.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+#  Created_by: QA SLE YaST team <qa-sle-yast@suse.de>
+#  Last Update: 2020
+#
+#  This script generates a supportserver disk image based on textmode.
+#  Target arch are aarch64 and x86_64. Despite the build number the GMC is used.
+#  
+#  When the job is done you should find qcow2 image in https://openqa.suse.de/assets/hdd/
+#  
+
+echo "Usage: $0 [<BUILD>] [<ARCH>] [<Flavor>]" >&2 
+build_number=${1:-209.2}
+arch=${2:-aarch64}
+flavor=${3:-Online}
+if [ -z ${build_number+x} ]; then echo "Build is not given"; else echo "build is set to $build_number"; fi
+if [ -z ${arch+x} ]; then echo "Arch is not given"; else echo "arch is set to $arch"; fi
+if [ -z ${flavor+x} ]; then echo "Flavor is not given"; else echo "flavor is set to $flavor"; fi
+
+case $arch in
+    'aarch64')
+	machine=aarch64
+	;;
+    'x86_64')
+	machine=64bit
+	;;
+esac
+
+if [ -z ${machine+x} ]; then echo "Machine is unset"; else echo "machine is set to $machine"; fi
+
+/usr/share/openqa/script/openqa-cli api --osd -X POST jobs \
+				    ARCH=$arch \
+				    FLAVOR=$flavor \
+				    DISTRI=sle \
+				    MACHINE=$machine \
+				    VERSION=15-SP2 \
+				    BUILD=$build_number \
+				    BUILD_SLE=$build_number \
+				    ISO=SLE-15-SP2-$flavor-$arch-GMC-Media1.iso \
+				    INSTALLONLY=1 \
+				    DESKTOP=textmode \
+				    AUTOYAST_PREPARE_PROFILE=1 \
+				    TEST=supportserver_generator \
+				    SUPPORT_SERVER_GENERATOR=1 \
+				    AUTOYAST=supportserver/autoyast_supportserver_${arch}_sle15.xml \
+				    PUBLISH_HDD_1=openqa_support_server_sles15sp2_${arch}_textmode_$(date +"%Y%m").qcow2 

--- a/how_to_create_a_support_server.md
+++ b/how_to_create_a_support_server.md
@@ -1,0 +1,62 @@
+# Supportserver generator guide
+- [How to generate a supportserver](#How-to-generate-a-supportserver)
+- [Using autoyast](#Using-autoyast)
+- [Using create_hdd](#Using-create_hdd)
+- [Supportserver_generator_from_hdd](#Supportserver_generator_from_hdd)
+
+## How to generate a supportserver
+
+There are two ways to create a supportserver. The first one is using a job called
+*supportserver_generator* and the second leveraging the *create_hdd*
+
+We are also obliged to generate two images based on the desktop that the test is used on. Thus we need separate qcow image to support test with gnome and another for textmode.
+
+## Using autoyast
+
+In this case you need to find and provide an autoyast xml file with the configuration that you need. Some of the existing ones can be found in `os-autoinst-distri-opensuse/data/supportserver/`.
+
+In general you have to make an API request to jobs with the required parameters (alike the isos post, it requires ARCH, FLAVOR, DISTRI, MACHINE, ISO etc), plus AUTOYAST with the xml file of your choice. In addition the PUBLISH_HDD_1 is needed to set the name of the generated cqow image. 
+
+We provide a script to make this easier for textmode images. The script can be used as it is shown in the following example
+
+```bash
+./data/supportserver/autoyast_supportserver_generator_sle15.sh 209.2 aarch64 Online
+```
+
+where:
+- 209.2 is the build number
+- aarch64 represents the architecture
+- Online is the Flavor (Online,Full)
+
+The above values are the default, thus `./data/supportserver/autoyast_supportserver_generator_sle15.sh` will procude the same image as the command in the example with the parameters.
+
+The producing image will have the name based on the arch. i include the creation date to be able to track when it was last updated. for instance
+```
+openqa_support_server_sles15sp2_aarch64_textmode_202007.qcow2
+```
+
+## Using create_hdd
+
+The disadvantage with the Autoyast is that you need to get a working xml for your needs. The xml might change from build to build. Also the autoyast_supportserver_generator works for the textmode but there is provided xml for gnome. In the other side we have `create_hdd_gnome` and `create_hdd_textmode` which can be used as normal jobs with some extra tweaking, to add particular configuration. For this we can use the `support_server/configure.pm` which is scheduled in `schedule/supportserver_generator.yaml` yaml scheduler. The simpliest way to trigger the generation, per se, is cloning the job with the scheduler yaml or with an isos POST request
+
+for gnome
+```bash
+openqa-cli api --osd -X POST isos TEST=create_hdd_gnome YAML_SCHEDULE=schedule/supportserver_generator.yaml PUBLISH_HDD_1=openqa_support_server_sles15sp2_%ARCH%_%BUILD%@%MACHINE%_%DESKTOP%.qcow2 {...}
+```
+
+for textmode
+```bash
+openqa-cli api --osd -X POST isos TEST=create_hdd_textmode YAML_SCHEDULE=schedule/supportserver_generator.yaml PUBLISH_HDD_1=openqa_support_server_sles15sp2_%ARCH%_%BUILD%@%MACHINE%_%DESKTOP%.qcow2 {...}
+```
+
+where {...} are all the specific variables for the arch, build, etc
+
+## supportserver_generator_from_hdd
+
+To accelerate the creation we can chain the jobs between create_hdd_gnome/create_hdd_textmode and a job that is scheduled with the `schedule/supportserver_generator_from_hdd.yaml`. The chained job has to be in accordance with the DESKTOP variable that it is used in the create_hdd(ex: DESKTOP=gnome if publish image is coming from create_hdd_gnome). The chained job has to have enabled the BOOT_HDD_IMAGE, HDD_1 and BOOTFROM. At the end we need to define the PUBLISH_HDD_1 with the new name of the supportserver.
+
+```bash
+openqa-cli api --osd -X POST isos TEST=supportserver_generator_from_hdd YAML_SCHEDULE=schedule/supportserver_generator_from_hdd.yaml PUBLISH_HDD_1=openqa_support_server_sles15sp2_%ARCH%_%BUILD%@%MACHINE%_%DESKTOP%.qcow2 DESKTOP=textmode START_AFTER_TEST=create_hdd_gnome:aarch64 BOOTFROM=c _SKIP_CHAINED_DEPS=1 CONSOLE_JUST_ACTIVATED=0 HDD_1=SLES-15-SP2-%ARCH%-Build%{BUILD}%@%ARCH%-%DESKTOP%.qcow2 {...}
+```
+
+where {...} are all the specific variables for the arch, build, etc

--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -32,6 +32,7 @@ our @EXPORT = qw(is_network_manager_default
   accept_warning_network_manager_default
   workaround_suppress_lvm_warnings
   with_yast_env_variables
+  use_wicked_network_manager
 );
 
 =head2 with_yast_env_variables
@@ -104,6 +105,21 @@ sub workaround_suppress_lvm_warnings {
         record_soft_failure('bsc#1124481 - LVM is polluting stdout with leaked invocation warnings');
         assert_script_run('export LVM_SUPPRESS_FD_WARNINGS=1');
     }
+}
+
+=head2 use_wicked_network_manager
+
+ use_wicked_network_manager();
+
+switch network manager to wicked.
+
+=cut
+sub use_wicked_network_manager {
+    return unless is_network_manager_default;
+    assert_script_run "systemctl disable NetworkManager --now";
+    assert_script_run "systemctl enable --force wicked --now";
+    assert_script_run "systemctl start wickedd.service";
+    assert_script_run "systemctl start wicked.service";
 }
 
 sub post_fail_hook {

--- a/schedule/supportserver_generator.yaml
+++ b/schedule/supportserver_generator.yaml
@@ -1,0 +1,36 @@
+---
+name: supportserver_generator
+description: |
+  image creation job used as parent for other jobs testing based on existing installation.
+  use of create_hdd_gnome and create_hdd_textmode to configure supportserver image for MM tests.
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/no_separate_home
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/sle15_workarounds
+  - console/hostname
+  - console/force_scheduled_tasks
+  - support_server/configure
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/supportserver_generator_from_hdd.yaml
+++ b/schedule/supportserver_generator_from_hdd.yaml
@@ -1,0 +1,15 @@
+---
+name: supportserver_generator_from_hdd
+description: |
+  supportserver image creation job used as parent for other jobs testing based on existing installation.
+  use of create_hdd_gnome to configure supportserver image for MM tests.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - console/consoletest_setup
+  - support_server/configure
+  - console/consoletest_finish
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/yast/remote_ssh/remote_ssh_target_ftp_sle15.yaml
+++ b/schedule/yast/remote_ssh/remote_ssh_target_ftp_sle15.yaml
@@ -7,8 +7,7 @@ description: >
   any issue. Boots with ssh=1 parameter and waits for parallel job
   (remote_ssh_controller) to install the system.
 schedule:
-  - installation/isosize
-  - installation/bootloader
+  - installation/bootloader_start
   - remote/remote_target
   - console/system_prepare
   - console/check_network

--- a/schedule/yast/remote_vnc/remote_vnc_target_nfs.yaml
+++ b/schedule/yast/remote_vnc/remote_vnc_target_nfs.yaml
@@ -6,6 +6,5 @@ description: >
 vars:
   DESKTOP: gnome
 schedule:
-  - installation/isosize
-  - installation/bootloader
+  - installation/bootloader_start
   - remote/remote_target

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -111,6 +111,7 @@ sub run {
 
     uefi_bootmenu_params;
     bootmenu_default_params;
+    bootmenu_remote_target;
     specific_bootmenu_params unless is_caasp || is_jeos;
 
     # JeOS and CaaSP are never deployed with Linuxrc involved,

--- a/tests/support_server/configure.pm
+++ b/tests/support_server/configure.pm
@@ -56,7 +56,7 @@ sub _install_packages {
     zypper_call("in " . join(" ", @packages));
 }
 
-sub turnoff_gnome_screensaver_and_suspend {
+sub _turnoff_gnome_screensaver_and_suspend {
     assert_script_run "gsettings set org.gnome.desktop.session idle-delay 0";
     assert_script_run "gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type 'nothing'";
 }
@@ -67,7 +67,7 @@ sub run {
     if (!check_var('SUPPORT_SERVER_GENERATOR', 1)) {
         _install_packages;
         use_wicked_network_manager;
-        turnoff_gnome_screensaver_and_suspend if check_var('DESKTOP', 'gnome');
+        _turnoff_gnome_screensaver_and_suspend if check_var('DESKTOP', 'gnome');
     }
 }
 

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -129,6 +129,7 @@ sub setup_networks {
     $setup_script .= "systemctl restart network\n";
 
     $setup_script .= "FIXED_NIC=`grep $net_conf->{fixed}->{mac} /sys/class/net/*/address |cut -d / -f 5`\n";
+    $setup_script .= "iptables -F\n";
     $setup_script .= "iptables -t nat -A POSTROUTING -o \$FIXED_NIC -j MASQUERADE\n";
     for my $network (keys %$net_conf) {
         next if $network eq 'fixed';


### PR DESCRIPTION
I create a new xml for aarch64 that it is used by the supportserver_generator job to create a support server.
I also add a script for future reference and usage. 

I run it against ssh and despite the test fails i think it is for different reason.  [controller](https://openqa.suse.de/tests/4462210) [target](https://openqa.suse.de/tests/4462211) which is out of scope for this task

- Related ticket: https://progress.opensuse.org/issues/68708
- Verification run: 
[create_hdd_textmode](https://openqa.suse.de/tests/4506016)
[create_hdd_gnome](https://openqa.suse.de/tests/4505505#)