### PR TITLE
Fix reboot timed out issue for SELinux on SPVM

### DIFF
--- a/tests/security/selinux/enforcing_mode_setup.pm
+++ b/tests/security/selinux/enforcing_mode_setup.pm
@@ -24,6 +24,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -45,7 +46,8 @@ sub run {
     assert_script_run("echo 'SELINUX=enforcing' >> /etc/selinux/config");
 
     power_action("reboot", textmode => 1);
-    $self->wait_boot;
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
     select_console "root-console";
 
     validate_script_output(

--- a/tests/security/selinux/semanage_boolean.pm
+++ b/tests/security/selinux/semanage_boolean.pm
@@ -24,6 +24,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -50,7 +51,8 @@ sub run {
 
     # reboot and check again
     power_action("reboot", textmode => 1);
-    $self->wait_boot;
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
     select_console "root-console";
 
     validate_script_output("semanage boolean -l | grep $test_boolean", sub { m/${test_boolean}.*(on.*,.*on).*Allow.*to.*/ });

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -24,6 +24,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -41,7 +42,8 @@ sub run {
 
     # reboot the vm and reconnect the console
     power_action("reboot", textmode => 1);
-    $self->wait_boot;
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
     select_console "root-console";
 
     validate_script_output(

--- a/tests/security/selinux/setsebool.pm
+++ b/tests/security/selinux/setsebool.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -50,7 +51,8 @@ sub run {
 
     # reboot and check again
     power_action("reboot", textmode => 1);
-    $self->wait_boot;
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
     select_console "root-console";
 
     validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ on/ });
@@ -61,7 +63,8 @@ sub run {
 
     # reboot and check again
     power_action("reboot", textmode => 1);
-    $self->wait_boot;
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
     select_console "root-console";
 
     validate_script_output("getsebool $test_boolean", sub { m/${test_boolean}\ -->\ on/ });


### PR DESCRIPTION
Fix SELinux 4 test modules, for SELinux test on powervm environment, 
change the console connection logic after rebooting the node.

ALL passed.

- Related ticket: https://progress.opensuse.org/issues/69070
- Needles: NA
- Verification run: 
  create_hdd_textmode_spvm@ppc64le-spvm -> http://openqa.suse.de/t4465552
  selinux_spvm@ppc64le-spvm -> http://openqa.suse.de/t4465553
