### PR TITLE
Add ha addon for sles4sap sle12 qam

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -328,9 +328,9 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
     # set SCC_ADDONS before push to slenkins
     set_var('SCC_ADDONS', join(',', @addons));
 
-    # SLES4SAP does not have addon on SLE12
-    # We need to push sles4sap for using _TEST_ISSUES and _TEST_TEMPLATE below
-    push(@addons, 'sles4sap') if (is_sle('<15') && !get_var('PLAIN_SLE') && check_var('FLAVOR', 'SAP-DVD-Updates')) || check_var('FLAVOR', 'Server-DVD-SAP-Incidents');
+    # SLES4SAP and HA do not have addon on SLE12
+    # We need to push sles4sap and ha for using _TEST_ISSUES and _TEST_TEMPLATE below
+    push(@addons, 'sles4sap', 'ha') if (is_sle('<15') && !get_var('PLAIN_SLE') && check_var('FLAVOR', 'SAP-DVD-Updates')) || check_var('FLAVOR', 'Server-DVD-SAP-Incidents');
 
     # push sdk addon to slenkins tests
     if (get_var('TEST', '') =~ /^slenkins/) {


### PR DESCRIPTION
We need to push ha addon if we are doing a QAM on SAP < 15, because ha is already included in sles4sap. Moreover, we need ha defined in addons variable for using _TEST_ISSUES and _TEST_TEMPLATE.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[SAP test on SLES4SAP](http://1a102.qa.suse.de/tests/4573)
[SAP test on plain SLE](http://1a102.qa.suse.de/tests/4574)
[SAP QAM SLE 15 with flavor Server-DVD-SAP-Incidents](http://1a102.qa.suse.de/tests/4575)
[SAP QAM SLE 12-SP5 with flavor Server-DVD-SAP-Incidents](http://1a102.qa.suse.de/tests/4576)