### PR TITLE
Package regex match only non-whitespace characters

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -31,7 +31,7 @@ use testapi;
 
 sub install_packages {
     my $patch_info = shift;
-    my $pattern    = qr/\s+(.+)(?!\.(src|nosrc))\..*\s<\s.*/;
+    my $pattern    = qr/\s+(\S+)(?!\.(src|nosrc))\.\S*\s<\s.*/;
 
     # loop over packages in patchinfo and try installation
     foreach my $line (split(/\n/, $patch_info)) {


### PR DESCRIPTION
To avoid false match e.g. BuildRequires:  ( go >= 1.14 with go < 1.15 )

- Fail: https://openqa.suse.de/tests/4451378#step/update_install/26
- Verification run: 
https://openqa.suse.de/tests/4467432
https://openqa.suse.de/tests/4467433
