### PR TITLE
Fix hana_install test module so it aborts if no suitable device for HANA is found in the system

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -43,15 +43,15 @@ sub get_hana_device_from_system {
     my $filter_devices;
     while ($devsize < $disk_requirement) {
         $out = script_output "echo DEV=\$($lsblk | egrep -vw '$filter_devices' | head -1)";
-        $out =~ /DEV=([\w\.]+)$/;
+        die "Could not find a suitable device for HANA installation." unless ($out =~ /DEV=([\w\.]+)$/);
         $device = $1;
         $filter_devices .= "|$device";
-        $filter_devices =~ s/^|//;
+        $filter_devices =~ s/^\|//;
         $device = $devpath . $device;
 
         # Need to verify there is enough space in the device for HANA
         $out = script_output "echo SIZE=\$(lsblk -o SIZE --nodeps --noheadings --bytes $device)";
-        $out =~ /SIZE=(\d+)$/;
+        die "Could not get size for [$device] block device." unless ($out =~ /SIZE=(\d+)$/);
         $devsize = $1;
         $devsize /= (1024 * 1024);    # Work in Mbytes since $RAM = $self->get_total_mem() is in Mbytes
     }


### PR DESCRIPTION
As calls to `lsblk` in the `sles4sap/hana_install` test module are wrapped into `echo` commands, these will not return a failing RETVAL to cause an early exit to the loop in `get_hana_device_from_system()` when no suitable devices for the HANA installation are available in the system, which can lead to the loop not finishing.

This PR fixes the issue by verifying that the regular expressions used to parse the `lsblk` output match.

- Related ticket: N/A
- Needles: N/A
- Verification run: [x86_64 on qemu](http://mango.suse.de/tests/2983), [ppc64le on hmc_pvm](http://mango.suse.de/tests/2982)
