### PR TITLE
[Log Enhancement]Shutdown newly installed guest on 11-SP4 host

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -59,7 +59,7 @@ sub run {
     # Add option to keep guest after successful installation
     # Only for x86_64 now
     if (check_var('ARCH', 'x86_64')) {
-        assert_script_run("sed -i 's/vm-install.sh/vm-install\.sh -g /' /usr/share/qa/qa_test_virtualization/installos");
+        assert_script_run("sed -i 's/vm-install.sh/vm-install\.sh -g -k /' /usr/share/qa/qa_test_virtualization/installos");
         assert_script_run("sed -i 's/virt-install.sh/virt-install\.sh -u /' /usr/share/qa/qa_test_virtualization/virt_installos");
         assert_script_run('cat /usr/share/qa/qa_test_virtualization/installos | grep vm-install');
         save_screenshot;


### PR DESCRIPTION
We need to shutdown newly installed guest on 11-SP4 host just as we do on other SLES releases. And what is more important is that we need to attach serial console to newly installed guest which is only feasible when guest is in shutdown state, because vm-install can not provide. Additionally putting them into shutdown state will make sure next time they are up and running with serial console.


- Related ticket: n/a
- Needles: n/a
- Verification run:
  - [15sp2 guest on 11sp4 host kvm](http://qadb2.suse.de/qadb/submission.php?submission_id=2680030)
  - [15sp2 guest on 11sp4 host xen](http://qadb2.suse.de/qadb/submission.php?submission_id=2680006)