### PR TITLE
systemd: separate testsuite preparation from binary tests

### DIFF
--- a/schedule/systemd/suse_patches-systemd_testsuite.yaml
+++ b/schedule/systemd/suse_patches-systemd_testsuite.yaml
@@ -48,6 +48,7 @@ conditional_schedule:
                 - systemd_testsuite/test_47_issue_14566
 schedule:
     - boot/boot_to_desktop
+    - systemd_testsuite/prepare_systemd_and_testsuite
     - systemd_testsuite/binary_tests
     - systemd_testsuite/test_01_basic
     - systemd_testsuite/test_02_cryptsetup

--- a/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
+++ b/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Run binary tests from upstream after openSUSE/SUSE patches.
+# Summary: Prepare systemd and testsuite.
 # Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
 
 use base 'systemd_testsuite_test';
@@ -16,15 +16,12 @@ use strict;
 use testapi;
 
 sub run {
-    # run binary tests
-    assert_script_run('cd /var/opt/systemd-tests');
-    validate_script_output('./run-tests.sh | tee /tmp/testsuite.log', sub { m/# FAIL:\s*0/ }, timeout => 600);
-    save_screenshot;
-    script_run 'clear';
+    my ($self) = @_;
+    $self->testsuiteinstall;
 }
 
 sub test_flags {
-    return {milestone => 1};
+    return {fatal => 1};
 }
 
 1;


### PR DESCRIPTION
- Verification run: 
   - http://emerson.suse.de/tests/2284
   - http://emerson.suse.de/tests/2288 with `SYSTEMD_FROM_TESTREPO=1`