### PR TITLE
Add RMT automatic testing code for import and export

### DIFF
--- a/schedule/migration/rmt_export.yaml
+++ b/schedule/migration/rmt_export.yaml
@@ -3,4 +3,5 @@ description:    >
     This is for rmt export and mirror test
 schedule:
   - boot/boot_to_desktop
-  - console/consoletest_setup
+  - network/setup_multimachine
+  - x11/rmt/rmt_export

--- a/schedule/migration/rmt_import.yaml
+++ b/schedule/migration/rmt_import.yaml
@@ -4,4 +4,4 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - network/setup_multimachine
-  - x11/rmt
+  - x11/rmt/rmt_import

--- a/tests/x11/rmt/rmt_export.pm
+++ b/tests/x11/rmt/rmt_export.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: setup one RMT server, sync, enable, mirror and list
+# products. Then export RMT data to one folder. Wait another RMT
+# Server to import those data
+# Maintainer: Yutao Wang <yuwang@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use base 'x11test';
+use repo_tools;
+use utils;
+use x11utils 'turn_off_gnome_screensaver';
+use lockapi 'mutex_create';
+use mmapi 'wait_for_children';
+
+sub run {
+    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
+    # Avoid blank screen since smt sync needs time
+    turn_off_gnome_screensaver;
+    become_root;
+    rmt_wizard();
+    # sync, enable, mirror and list products
+    rmt_sync();
+    rmt_enable_pro();
+    rmt_mirror_repo();
+    rmt_list_pro();
+    # export data and repos
+    rmt_export_data();
+    mutex_create("FINISH_EXPORT_DATA");
+    wait_for_children;
+    type_string "killall xterm\n";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/x11/rmt/rmt_import.pm
+++ b/tests/x11/rmt/rmt_import.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Add rmt configuration test and basic configuration via
+#    rmt-wizard, import RMT data and repos from one folder which
+#    stored RMT export data, then verify the imported data can list
+# Maintainer: Yutao wang <yuwang@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use base 'x11test';
+use repo_tools;
+use utils;
+use x11utils 'turn_off_gnome_screensaver';
+use lockapi qw(mutex_create mutex_wait);
+
+sub run {
+    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
+    # Avoid blank screen since smt sync needs time
+    turn_off_gnome_screensaver;
+    become_root;
+    rmt_wizard();
+    # sync from SCC
+    rmt_sync;
+    # import data and repos from an existing RMT server
+    my $datapath = "/rmtdata/";
+    mutex_wait("FINISH_EXPORT_DATA");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no -r root\@10.0.2.101:$datapath /");
+    assert_script_run("chown -R _rmt:nginx $datapath");
+    rmt_import_data($datapath);
+    # check the imported products correct
+    rmt_enable_pro;
+    rmt_list_pro;
+    my $pro_ls = get_var('RMT_PRO') || 'sle-module-legacy/15/x86_64';
+    assert_script_run("rmt-cli product list | grep $pro_ls");
+    type_string "killall xterm\n";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Add RMT automatic testing code for import and export

- Related ticket:https://progress.opensuse.org/issues/60374
- Verification run: 
import: https://openqa.suse.de/tests/4474648#
export: https://openqa.suse.de/tests/4474647#
