### PR TITLE
Add record_info message in HA qnetd test

### DIFF
--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -100,7 +100,7 @@ sub run {
 
     record_info('Split-brain info', 'Split brain test');
 
-    # Stop stonith to prevent fencing of node before our check
+    record_info('Stopping stonith', 'Stop stonith to prevent fencing of node before our check');
     assert_script_run "crm resource stop stonith-sbd" if is_node(1);
 
     # Add firewall rules to provoke a split brain situation and confirm that


### PR DESCRIPTION
This PR adds a record_info message to remember why we stop the stonith resource.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[ha_qnetd_server](http://1a102.qa.suse.de/tests/4597)
[ha_qdevice_node2](http://1a102.qa.suse.de/tests/4596)
[ha_qdevice_node1](http://1a102.qa.suse.de/tests/4595)
[ha_supportserver_qdevice](http://1a102.qa.suse.de/tests/4594)

New message visible [here](http://1a102.qa.suse.de/tests/4597#step/qnetd/6)


