### PR TITLE
Increase bootloader timeout to avoid occasional failures

### DIFF
--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -88,7 +88,8 @@ sub run {
         }
         prepare_system_shutdown;
         type_string "reboot\n";
-        $self->wait_boot;
+        my $timeout = check_var('ARCH', 'aarch64') ? '300' : '200';
+        $self->wait_boot(bootloader_time => $timeout);
     }
 }
 


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4466823#step/install_update/65
- Verification run: https://openqa.suse.de/tests/4475080
