### PR TITLE
systemd: remove obsolete configuration

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -95,7 +95,6 @@ our @EXPORT = qw(
   load_ssh_key_import_tests
   load_svirt_boot_tests
   load_svirt_vm_setup_tests
-  load_systemd_patches_tests
   load_system_update_tests
   loadtest
   load_testdir
@@ -2552,43 +2551,6 @@ sub load_security_tests {
             diag "unknown scenario for SECURITY_TEST value $test_name";
         }
     }
-}
-
-sub load_systemd_patches_tests {
-    if (get_var('BOOT_HDD_IMAGE')) {
-        if (check_var('ARCH', 'aarch64')) {
-            loadtest 'installation/bootloader_uefi';
-        }
-        else {
-            boot_hdd_image;
-        }
-    }
-    loadtest 'systemd_testsuite/binary_tests';
-    loadtest 'systemd_testsuite/test_01_basic';
-    loadtest 'systemd_testsuite/test_02_cryptsetup';
-    loadtest 'systemd_testsuite/test_03_jobs';
-    loadtest 'systemd_testsuite/test_04_journal';
-    loadtest 'systemd_testsuite/test_05_rlimits';
-    #loadtest 'systemd_testsuite/test_06_selinux';
-    loadtest 'systemd_testsuite/test_07_issue_1981';
-    loadtest 'systemd_testsuite/test_08_issue_2730';
-    loadtest 'systemd_testsuite/test_09_issue_2691';
-    loadtest 'systemd_testsuite/test_10_issue_2467';
-    loadtest 'systemd_testsuite/test_11_issue_3166';
-    loadtest 'systemd_testsuite/test_12_issue_3171';
-    loadtest 'systemd_testsuite/test_13_nspawn_smoke';
-    loadtest 'systemd_testsuite/test_14_machine_id';
-    loadtest 'systemd_testsuite/test_15_dropin';
-    loadtest 'systemd_testsuite/test_16_extend_timeout';
-    loadtest 'systemd_testsuite/test_17_udev_wants';
-    loadtest 'systemd_testsuite/test_18_failureaction';
-    loadtest 'systemd_testsuite/test_19_delegate';
-    loadtest 'systemd_testsuite/test_20_mainpidgames';
-    loadtest 'systemd_testsuite/test_21_sysusers';
-    loadtest 'systemd_testsuite/test_22_tmpfiles';
-    loadtest 'systemd_testsuite/test_23_type_exec';
-
-    load_shutdown_tests;
 }
 
 sub load_system_prepare_tests {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -341,14 +341,6 @@ elsif (get_var('SECURITY_TEST')) {
     prepare_target();
     load_security_tests;
 }
-elsif (get_var('SYSTEMD_TESTSUITE')) {
-    if (!get_var('BOOT_HDD_IMAGE')) {
-        load_boot_tests();
-        load_inst_tests();
-        load_reboot_tests();
-    }
-    load_systemd_patches_tests;
-}
 elsif (get_var('AUTOFS')) {
     load_mm_autofs_tests;
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -923,14 +923,6 @@ elsif (get_var('HPC')) {
         loadtest 'hpc/post_migration';
     }
 }
-elsif (get_var('SYSTEMD_TESTSUITE')) {
-    if (!get_var('BOOT_HDD_IMAGE')) {
-        load_boot_tests();
-        load_inst_tests();
-        load_reboot_tests();
-    }
-    load_systemd_patches_tests;
-}
 elsif (get_var('VALIDATE_PCM_PATTERN')) {
     load_public_cloud_patterns_validation_tests;
 }


### PR DESCRIPTION
`SYSTEMD_TESTSUITE` has no use anymore and also needs to be removed from [Test Suite Settings on openQA](https://openqa.opensuse.org/admin/test_suites)

The rest is not needed since we have a yaml schedule.