### PR TITLE
[WIP] Enable s390-tools tests

### DIFF
--- a/schedule/qam/12-SP4/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP4/qam-minimal-base.yaml
@@ -58,6 +58,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- '{{s390tools}}'
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
@@ -82,4 +83,8 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/glibc_sanity
+  s390tools:
+    ARCH:
+      s390x:
+        - qam-minimal/s390tools
 ...

--- a/schedule/qam/12-SP5/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-base.yaml
@@ -58,6 +58,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- '{{s390tools}}'
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
@@ -78,4 +79,8 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/glibc_sanity
+  s390tools:
+    ARCH:
+      s390x:
+        - qam-minimal/s390tools
 ...

--- a/schedule/qam/15-SP1/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP1/qam-minimal-base.yaml
@@ -59,6 +59,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- '{{s390tools}}'
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
@@ -83,4 +84,8 @@ conditional_schedule:
     BACKEND:
       qemu:
         - console/yast2_nfs_server
+  s390tools:
+    ARCH:
+      s390x:
+        - qam-minimal/s390tools
 ...

--- a/schedule/qam/15-SP2/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP2/qam-minimal-base.yaml
@@ -59,6 +59,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- '{{s390tools}}'
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
@@ -83,4 +84,8 @@ conditional_schedule:
     BACKEND:
       qemu:
         - console/yast2_nfs_server
+  s390tools:
+    ARCH:
+      s390x:
+        - qam-minimal/s390tools
 ...

--- a/schedule/qam/15/qam-minimal-base.yaml
+++ b/schedule/qam/15/qam-minimal-base.yaml
@@ -59,6 +59,7 @@ schedule:
 - console/apache_ssl
 - console/apache_nss
 - console/postgresql_server
+- '{{s390tools}}'
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
@@ -83,4 +84,8 @@ conditional_schedule:
     BACKEND:
       qemu:
         - console/yast2_nfs_server
+  s390tools:
+    ARCH:
+      s390x:
+        - qam-minimal/s390tools
 ...


### PR DESCRIPTION
Enable s390tools run on qam-minimal-base

- Related ticket: https://progress.opensuse.org/issues/53012
- Needles: no needles
- Verification run:
  - s390 15.2: https://openqa.suse.de/tests/4475244
  - s390 15.1 https://openqa.suse.de/tests/4475249
  - s390 15    https://openqa.suse.de/tests/4475397
  - s390 12.5 https://openqa.suse.de/tests/4475449
  - s390 12.4 https://openqa.suse.de/tests/4476103
  - x86 15.2  https://openqa.suse.de/tests/4476122