### PR TITLE
btrfs-progs: Move "CD" command to run.pm for more stable on S390x

### DIFF
--- a/tests/btrfs-progs/install.pm
+++ b/tests/btrfs-progs/install.pm
@@ -50,7 +50,7 @@ sub run {
         zypper_call '--gpg-auto-import-keys ref';
         zypper_call 'in -r filesystems btrfs-progs';
         zypper_call 'rr filesystems';
-        assert_script_run 'cd /opt/btrfs-progs-tests';
+        set_var('WORK_DIR', '/opt/btrfs-progs-tests');
     }
     else {
         # Build test suite of btrfs-progs from git
@@ -60,7 +60,7 @@ sub run {
         assert_script_run 'wget ' . autoinst_url('/data/btrfs-progs/install.sh');
         assert_script_run 'chmod a+x install.sh';
         assert_script_run './install.sh ' . GIT_URL . " " . INST_DIR, timeout => 1200;
-        assert_script_run 'cd ' . INST_DIR;
+        set_var('WORK_DIR', INST_DIR);
     }
 
     # Create log file

--- a/tests/btrfs-progs/run.pm
+++ b/tests/btrfs-progs/run.pm
@@ -97,6 +97,7 @@ sub run {
     my $self = shift;
     select_console('root-console');
 
+    assert_script_run('cd ' . get_var('WORK_DIR'));
     for my $category (@category) {
         assert_script_run('mkdir -p ' . LOG_DIR . $category);
 


### PR DESCRIPTION
select_console('root-console') on S390x will cause terminal reset, and then current work directory back to home. Therefore move "CD" command from install.pm to run.pm for more stable on S390x

- Related ticket: https://progress.opensuse.org/issues/61795
- Verification run: 
http://10.67.133.10/tests/109 (install from git)
https://openqa.nue.suse.com/tests/4481211  (install from IBS and running on s390x)
