### PR TITLE
Upload all rng files if autoyast profile validation fails

### DIFF
--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -19,7 +19,7 @@ use version_utils qw(is_sle is_opensuse is_staging);
 use utils 'zypper_call';
 use repo_tools 'get_repo_var_name';
 
-my $xml_schema_path = "/usr/share/YaST2/schema/autoyast/rng/profile.rng";
+my $xml_schema_path = "/usr/share/YaST2/schema/autoyast/rng";
 
 sub run {
     my $self = shift;
@@ -52,7 +52,7 @@ sub run {
 
     zypper_call 'install jing';
     zypper_call "rr devel-repo" if (is_staging);
-    my $rc_jing = script_run "jing $xml_schema_path $ay_profile_path";
+    my $rc_jing = script_run "jing $xml_schema_path/profile.rng $ay_profile_path";
 
     if ($rc_jing) {
         if (is_sle('<15')) {
@@ -83,7 +83,7 @@ sub get_ftp_uri {
 sub post_fail_hook {
     my $self = shift;
     $self->SUPER::post_fail_hook;
-    upload_logs($xml_schema_path);
+    $self->tar_and_upload_log("$xml_schema_path/*.rng", '/tmp/autoyast_schema.tar.bz2');
 }
 
 1;


### PR DESCRIPTION
Schema file was split into multiple files, so to run check locally, we need to have all the files. With this change, all rng files will be uploaded as a tarball.

## Verification runs
* [TW with postfailhook](https://openqa.opensuse.org/tests/1339844#) See https://openqa.opensuse.org/tests/1339844/file/yast2_clone_system-autoyast_schema.tar.bz2
* [SLES](https://openqa.suse.de/t4478848)
