### PR TITLE
Enable validation modules for autoyast_reinstall

### DIFF
--- a/schedule/yast/autoyast_reinstall.yaml
+++ b/schedule/yast/autoyast_reinstall.yaml
@@ -18,6 +18,7 @@ schedule:
   - autoyast/wicked
   - autoyast/repos
   - autoyast/clone
+  - autoyast/verify_cloned_profile
   - autoyast/logs
   - autoyast/autoyast_reboot
   # Called on ARCH: s390x and on powerVM
@@ -25,6 +26,14 @@ schedule:
   # Called on BACKEND: qemu and on powerVM
   - '{{grub_test}}'
   - installation/first_boot
+  - console/validate_file_system
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - update/zypper_up
+  - console/zypper_in
+  - console/zypper_log
+  - console/orphaned_packages_check
 conditional_schedule:
   isosize:
     BACKEND:
@@ -51,10 +60,3 @@ conditional_schedule:
     DISTRI:
       sle:
         - autoyast/prepare_cloned_profile
-test_data:
-  paths:
-    - /var/lib/gdm/.bashrc
-    - /var/lib/empty/.bashrc
-    - /var/lib/polkit/.bashrc
-    - /var/lib/nobody/.bashrc
-    - /var/lib/pulseaudio/.bashrc

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_64bit.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_64bit.yaml
@@ -1,0 +1,71 @@
+paths:
+  - /var/lib/gdm/.bashrc
+  - /var/lib/empty/.bashrc
+  - /var/lib/polkit/.bashrc
+  - /var/lib/nobody/.bashrc
+  - /var/lib/pulseaudio/.bashrc
+device: vda
+table_type: gpt
+file_system:
+  /: btrfs
+swap: 1
+profile:
+  partitioning:
+    - drive:
+        unique_key: device
+        device: /dev/vda
+        disklabel: gpt
+        enable_snapshots: 'true'
+        partitions:
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 1
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 2
+              filesystem: btrfs
+              mount: /
+              subvolumes:
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: usr/local
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'false'
+                    path: var
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: srv
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: root
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: home
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: opt
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: boot/grub2/i386-pc
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: tmp
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: boot/grub2/x86_64-efi
+              subvolumes_prefix: '@'
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 3
+              filesystem: swap
+              mount: swap
+        type: CT_DISK

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_aarch64.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_aarch64.yaml
@@ -1,0 +1,69 @@
+paths:
+  - /var/lib/gdm/.bashrc
+  - /var/lib/empty/.bashrc
+  - /var/lib/polkit/.bashrc
+  - /var/lib/nobody/.bashrc
+  - /var/lib/pulseaudio/.bashrc
+device: vda
+table_type: gpt
+file_system:
+  /: btrfs
+swap: 1
+profile:
+  partitioning:
+    - drive:
+        unique_key: device
+        device: /dev/vda
+        disklabel: gpt
+        enable_snapshots: 'true'
+        partitions:
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 1
+              filesystem: vfat
+              mount: /boot/efi
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 2
+              filesystem: btrfs
+              mount: /
+              subvolumes:
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: usr/local
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'false'
+                    path: var
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: srv
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: root
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: home
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: opt
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: boot/grub2/arm64-efi
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: tmp
+              subvolumes_prefix: '@'
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 3
+              filesystem: swap
+              mount: swap
+        type: CT_DISK

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le-hmc.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le-hmc.yaml
@@ -1,0 +1,68 @@
+paths:
+  - /var/lib/gdm/.bashrc
+  - /var/lib/empty/.bashrc
+  - /var/lib/polkit/.bashrc
+  - /var/lib/nobody/.bashrc
+  - /var/lib/pulseaudio/.bashrc
+device: sda
+table_type: gpt
+file_system:
+  /: btrfs
+swap: 1
+profile:
+  partitioning:
+    - drive:
+        unique_key: device
+        device: /dev/sda
+        disklabel: gpt
+        enable_snapshots: 'true'
+        partitions:
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 1
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 2
+              filesystem: btrfs
+              mount: /
+              subvolumes:
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: usr/local
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'false'
+                    path: var
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: srv
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: root
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: opt
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: boot/grub2/powerpc-ieee1275
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: tmp
+              subvolumes_prefix: '@'
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 3
+              filesystem: xfs
+              mount: /home
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 4
+              filesystem: swap
+              mount: swap
+        type: CT_DISK

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le.yaml
@@ -1,0 +1,67 @@
+paths:
+  - /var/lib/gdm/.bashrc
+  - /var/lib/empty/.bashrc
+  - /var/lib/polkit/.bashrc
+  - /var/lib/nobody/.bashrc
+  - /var/lib/pulseaudio/.bashrc
+device: vda
+table_type: gpt
+file_system:
+  /: btrfs
+swap: 1
+profile:
+  partitioning:
+    - drive:
+        unique_key: device
+        device: /dev/vda
+        disklabel: gpt
+        enable_snapshots: 'true'
+        partitions:
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 1
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 2
+              filesystem: btrfs
+              mount: /
+              subvolumes:
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: usr/local
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'false'
+                    path: var
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: srv
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: root
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: home
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: opt
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: boot/grub2/powerpc-ieee1275
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: tmp
+              subvolumes_prefix: '@'
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 3
+              filesystem: swap
+              mount: swap
+        type: CT_DISK

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_s390x.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_s390x.yaml
@@ -1,0 +1,69 @@
+paths:
+  - /var/lib/gdm/.bashrc
+  - /var/lib/empty/.bashrc
+  - /var/lib/polkit/.bashrc
+  - /var/lib/nobody/.bashrc
+  - /var/lib/pulseaudio/.bashrc
+device: vda
+table_type: gpt
+file_system:
+  /: btrfs
+swap: 1
+profile:
+  partitioning:
+    - drive:
+        unique_key: device
+        device: /dev/disk/by-path/ccw-0.0.0000
+        disklabel: gpt
+        enable_snapshots: 'true'
+        partitions:
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 1
+              filesystem: ext2
+              mount: /boot/zipl
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 2
+              filesystem: btrfs
+              mount: /
+              subvolumes:
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: usr/local
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'false'
+                    path: var
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: srv
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: root
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: home
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: opt
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: boot/grub2/s390x-emu
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: tmp
+              subvolumes_prefix: '@'
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 3
+              filesystem: swap
+              mount: swap
+        type: CT_DISK


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/68803
- Verification run: 
   * 64bit: https://openqa.suse.de/tests/4479622
   * aarch64: https://openqa.suse.de/tests/4479620
   * s390x: https://openqa.suse.de/tests/4479627
   * ppc64le-2g : https://openqa.suse.de/tests/4479623
   * ppc64le-hmc : https://openqa.suse.de/tests/4479626
   * Tumbleweed :  (can't validate due to https://bugzilla.opensuse.org/show_bug.cgi?id=1174424) 
   * Leap: http://falafel.suse.cz/tests/871

When merged, the Jobgroups schedule needs to be changed for the different test_data files: 
https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/254/
