### PR TITLE
Add validation for disk encryption activation

### DIFF
--- a/lib/validate_encrypt_utils.pm
+++ b/lib/validate_encrypt_utils.pm
@@ -1,0 +1,99 @@
+package validate_encrypt_utils;
+use strict;
+use warnings;
+use testapi;
+use Test::Assert ':all';
+use Data::Dumper;
+use base "Exporter";
+use Exporter;
+
+our @EXPORT = qw(
+  parse_devices_in_crypttab
+  parse_cryptsetup_status
+  verify_crypttab_file_existence
+  verify_number_of_encrypted_devices
+  verify_cryptsetup_message
+  verify_cryptsetup_properties
+  verify_restoring_luks_backups
+);
+
+# Check https://www.freedesktop.org/software/systemd/man/crypttab.html for more info about parsing
+sub parse_devices_in_crypttab {
+    my @lines    = split(/\n/, script_output("cat /etc/crypttab"));
+    my $crypttab = {};
+    foreach (@lines) {
+        next if /^\s*#.*$/;
+        if ($_ =~ /(?<name>.+?)\s+(?<encrypted_device>.+?)($|\s+(?<password>.*?)($|\s+(?<options>.*)))/) {
+            $crypttab->{$+{name}} = {
+                encrypted_device => $+{encrypted_device},
+                password         => $+{password},
+                options          => $+{options}};
+        }
+    }
+    return $crypttab;
+}
+
+sub parse_cryptsetup_status {
+    my ($dev)  = @_;
+    my @lines  = split(/\n/, script_output("cryptsetup status $dev"));
+    my $status = {};
+    foreach (@lines) {
+        if (!exists $status->{message} && $_ =~ /is (in)?active/) {
+            $status->{message} = $_;
+        }
+        elsif ($_ =~ /\s+(?<param>.*):\s+(?<value>.*)$/) {
+            my ($param, $value) = ($+{param}, $+{value});
+            $param =~ s/ /_/g;
+            $status->{properties}->{$param} = $value;
+        }
+    }
+    return $status;
+}
+
+sub verify_crypttab_file_existence {
+    record_info("crypttab file", "Verify the existence of /etc/crypttab file");
+    assert_script_run("test -f /etc/crypttab", fail_message => "No /etc/crypttab found");
+}
+
+sub verify_number_of_encrypted_devices {
+    my ($expected_number, $actual_number) = @_;
+    record_info("devices number", "Verify number of encrypted devices");
+    assert_equals($expected_number, $actual_number,
+        "/etc/crypttab contains different number of encrypted devices than expected:\n" .
+          Dumper($actual_number));
+}
+
+sub verify_cryptsetup_message {
+    my ($expected_message, $actual_message) = @_;
+    record_info("active volumes", "Verify crypted volume is active");
+    assert_matches(qr/$expected_message/, $actual_message,
+        "Message of cryptsetup status does not match regex");
+}
+
+sub verify_cryptsetup_properties {
+    my ($expected_properties, $actual_properties) = @_;
+    record_info("params", "Verify parameters, that are set for crypted volumes");
+    foreach my $property (sort keys %{$expected_properties}) {
+        diag("Verifying that expected property $expected_properties->{properties}{$property} corresponds to the actual $actual_properties->{properties}->{$property}");
+        assert_equals($expected_properties->{$property}, $actual_properties->{$property},
+            "Property of cryptsetup status does not match");
+    }
+}
+
+sub verify_restoring_luks_backups {
+    my (%args)           = @_;
+    my $mapped_dev       = $args{encrypted_device};
+    my $backup_file_info = $args{backup_file_info};
+    my $backup_path      = "/root/$mapped_dev";
+    record_info("LUKS", "Verify storing and restoring for binary backups of LUKS header and keyslot areas.");
+    assert_script_run("cryptsetup -v isLuks $mapped_dev");
+    assert_script_run("cryptsetup -v luksUUID $mapped_dev");
+    assert_script_run("cryptsetup -v luksDump $mapped_dev");
+    assert_script_run("cryptsetup -v luksHeaderBackup $mapped_dev" .
+          " --header-backup-file $backup_path");
+    validate_script_output("file $backup_path", sub { m/$backup_file_info/ });
+    assert_script_run("cryptsetup -v --batch-mode luksHeaderRestore $mapped_dev" .
+          " --header-backup-file $backup_path");
+}
+
+1;

--- a/schedule/yast/encryption/cryptlvm+activate_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing.yaml
@@ -11,6 +11,7 @@ schedule:
   - installation/accept_license
   - installation/scc_registration
   - installation/encrypted_volume_activation
+  - console/validate_activation_encrypted_partition
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -29,3 +30,5 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+test_data:
+  <<: !include test_data/yast/encryption/cryptlvm+activate_existing.yaml

--- a/schedule/yast/encryption/cryptlvm+activate_existing_dasd.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing_dasd.yaml
@@ -15,6 +15,7 @@ schedule:
   - installation/disk_activation
   - installation/scc_registration
   - installation/encrypted_volume_activation
+  - console/validate_activation_encrypted_partition
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -32,3 +33,5 @@ schedule:
   - installation/boot_encrypt
   - boot/reconnect_mgmt_console
   - installation/first_boot
+test_data:
+  <<: !include test_data/yast/encryption/cryptlvm+activate_existing.yaml

--- a/test_data/yast/encryption/cryptlvm+activate_existing.yaml
+++ b/test_data/yast/encryption/cryptlvm+activate_existing.yaml
@@ -1,0 +1,8 @@
+mapped_device: '/dev/mapper/cr-auto-2'
+device_status:
+  message: 'is active and is in use.'
+  properties:
+    type: 'LUKS1'
+    cipher: 'aes-xts-plain64'
+    key_location: 'dm-crypt'
+    mode: 'read/write'

--- a/test_data/yast/encryption/default_enc.yaml
+++ b/test_data/yast/encryption/default_enc.yaml
@@ -7,6 +7,4 @@ cryptsetup:
       cipher: aes-xts-plain64
       key_location: dm-crypt
       mode: read/write
-luks:
-  backup_base_path: /root/bkp_luks_header
-  backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
+backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'

--- a/test_data/yast/encryption/encrypt_home.yaml
+++ b/test_data/yast/encryption/encrypt_home.yaml
@@ -8,6 +8,4 @@ cryptsetup:
       device: /dev/sda4
       key_location: dm-crypt
       mode: read/write
-luks:
-  backup_base_path: /root/bkp_luks_header
-  backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
+backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'

--- a/tests/console/validate_activation_encrypted_partition.pm
+++ b/tests/console/validate_activation_encrypted_partition.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validation module to check that previously encrypted partition is active.
+# Covered scenarios:
+# - Verify that activated during installation the existing encrypted partition is actually active;
+# - Verify that all properties of the activated partition are correct (using 'cryptsetup status')
+# encrypted volumes that encrypted volume is successfully activated during
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "installbasetest";
+use scheduler 'get_test_suite_data';
+use testapi;
+use validate_encrypt_utils;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    select_console 'install-shell';
+    my $status = parse_cryptsetup_status($test_data->{mapped_device});
+    verify_cryptsetup_message($test_data->{device_status}->{message}, $status->{message});
+    verify_cryptsetup_properties($test_data->{device_status}->{properties}, $status->{properties});
+    select_console 'installation';
+}
+
+1;

--- a/tests/console/validate_encrypt.pm
+++ b/tests/console/validate_encrypt.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,103 +10,37 @@
 # Summary: Validation module to check encrypted volumes.
 # Scenarios covered:
 # - Verify existence and content of '/etc/crypttab';
-# - Verify crypted volumes are active;
-# - Verify storing and restoring for binary backups of LUKS header and keyslot areas.
-#
-# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+# - Verify number of encrypted devices is correct;
+# - Verify the following for each encrypted device:
+#    - It is active;
+#    - Its properties are correct.
+#    - Storing and restoring for binary backups of LUKS header and keyslot areas.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
+package validate_encrypt;
 use strict;
 use warnings;
 use base "opensusebasetest";
-use testapi;
-use Test::Assert ':all';
 use scheduler 'get_test_suite_data';
-use Data::Dumper;
-use Utils::Backends 'is_pvm';
-
-# Check https://www.freedesktop.org/software/systemd/man/crypttab.html for more info about parsing
-sub parse_crypttab {
-    my @lines    = split(/\n/, script_output("cat /etc/crypttab"));
-    my $crypttab = {};
-    foreach (@lines) {
-        next if /^\s*#.*$/;
-        if ($_ =~ /(?<name>.+?)\s+(?<encrypted_device>.+?)($|\s+(?<password>.*?)($|\s+(?<options>.*)))/) {
-            $crypttab->{$+{name}} = {
-                encrypted_device => $+{encrypted_device},
-                password         => $+{password},
-                options          => $+{options}};
-        }
-    }
-    return $crypttab;
-}
-
-sub parse_cryptsetup_status {
-    my $dev    = shift;
-    my @lines  = split(/\n/, script_output("cryptsetup status $dev"));
-    my $status = {};
-    foreach (@lines) {
-        if (!exists $status->{message} && $_ =~ /is (in)?active/) {
-            $status->{message} = $_;
-        }
-        elsif ($_ =~ /\s+(?<param>.*):\s+(?<value>.*)$/) {
-            my ($param, $value) = ($+{param}, $+{value});
-            $param =~ s/ /_/g;
-            $status->{properties}->{$param} = $value;
-        }
-    }
-    return $status;
-}
-
-sub verify_crypttab {
-    my (%args) = @_;
-    record_info("crypttab", "Verify file existence and number of devices encrypted");
-    assert_script_run("test -f /etc/crypttab", fail_message => "No /etc/crypttab found");
-    assert_equals($args{num_devices}, scalar keys %{$args{crypttab}},
-        "/etc/crypttab contains different number of encrypted devices than expected:\n" .
-          Dumper($args{crypttab}));
-}
-
-sub verify_cryptsetup_status {
-    my (%args) = @_;
-    record_info("active volumes", "Verify crypted volumes are active");
-    foreach my $dev (sort keys %{$args{crypttab}}) {
-        my $status = parse_cryptsetup_status($dev);
-        assert_matches(qr/$args{status}->{message}/, $status->{message},
-            "Message of cryptsetup status does not match regex for device $dev");
-        foreach my $property (sort keys %{$args{status}->{properties}}) {
-            assert_equals($args{status}->{properties}->{$property},
-                $status->{properties}->{$property},
-                "Property of cryptsetup status does not match for device $dev");
-        }
-    }
-}
-
-sub verify_cryptsetup_luks {
-    my (%args) = @_;
-    record_info("LUKS", "Verify LUKS");
-    foreach my $dev (sort keys %{$args{crypttab}}) {
-        my $mapped_dev  = $args{crypttab}->{$dev}->{encrypted_device};
-        my $backup_path = $args{luks}->{backup_base_path} . '_' . $dev;
-        assert_script_run("cryptsetup -v isLuks $mapped_dev");
-        assert_script_run("cryptsetup -v luksUUID $mapped_dev");
-        assert_script_run("cryptsetup -v luksDump $mapped_dev");
-        assert_script_run("cryptsetup -v luksHeaderBackup $mapped_dev" .
-              " --header-backup-file $backup_path");
-        validate_script_output("file $backup_path", sub { m/$args{luks}->{backup_file_info}/ });
-        assert_script_run("cryptsetup -v --batch-mode luksHeaderRestore $mapped_dev" .
-              " --header-backup-file $backup_path");
-    }
-}
+use validate_encrypt_utils;
+use testapi;
 
 sub run {
     select_console 'root-console';
     my $test_data = get_test_suite_data();
-    my $crypttab  = parse_crypttab();
-    verify_crypttab(num_devices => $test_data->{crypttab}->{num_devices_encrypted},
-        crypttab => $crypttab);
-    verify_cryptsetup_status(status => $test_data->{cryptsetup}->{device_status},
-        crypttab => $crypttab);
-    verify_cryptsetup_luks(luks => $test_data->{luks}, crypttab => $crypttab);
+    my $devices   = parse_devices_in_crypttab();
+    verify_crypttab_file_existence();
+    verify_number_of_encrypted_devices($test_data->{crypttab}->{num_devices_encrypted}, scalar keys %{$devices});
+    foreach my $dev (sort keys %{$devices}) {
+        my $status = parse_cryptsetup_status($dev);
+        verify_cryptsetup_message($test_data->{cryptsetup}->{device_status}->{message}, $status->{message});
+        verify_cryptsetup_properties($test_data->{cryptsetup}->{device_status}->{properties}, $status->{properties});
+    }
+    foreach my $dev (sort keys %{$devices}) {
+        verify_restoring_luks_backups(encrypted_device => $devices->{$dev}->{encrypted_device},
+            backup_file_info => $test_data->{backup_file_info}
+        );
+    }
 }
 
 1;


### PR DESCRIPTION
The test module verifies that encrypted partition is activated in cryptlvm+activate_existing test suite.

PowerVM test suite does not include this change due to issues with console switching. An appropriate follow-up ticket will be created.

- Related ticket: https://progress.opensuse.org/issues/68962
- Verification runs:
aarch64: https://openqa.suse.de/tests/4482076
ppc64le: https://openqa.suse.de/tests/4482077
64bit: https://openqa.suse.de/tests/4482078 

lvm_full_encrypt (to check that existing tests are not broken by the change): https://openqa.suse.de/tests/4482677