### PR TITLE
Add support for testing VMware and Hyper-V guests

### DIFF
--- a/lib/xen.pm
+++ b/lib/xen.pm
@@ -23,6 +23,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils 'is_sle';
+use virt_autotest::utils;
 
 # Supported guest configuration
 #   * location of the installation tree
@@ -130,7 +131,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         },
         sles12sp5HVM => {
             autoyast     => 'autoyast_xen/sles12sp5HVM_PRG.xml',
-            extra_params => '--connect xen:/// --virt-type xen --hvm --os-variant sles12sp5',
+            extra_params => '--connect xen:/// --virt-type xen --hvm --os-variant sles12sp4',            # old system compatibility
             macaddress   => '52:54:00:78:73:ad',
             ip           => '192.168.122.113',
             distro       => 'SLE_12_SP5',
@@ -138,7 +139,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         },
         sles12sp5PV => {
             autoyast     => 'autoyast_xen/sles12sp5PV_PRG.xml',
-            extra_params => '--connect xen:/// --virt-type xen --paravirt --os-variant sles12sp5',
+            extra_params => '--connect xen:/// --virt-type xen --paravirt --os-variant sles12sp4',       # old system compatibility
             macaddress   => '52:54:00:78:73:ae',
             ip           => '192.168.122.114',
             distro       => 'SLE_12_SP5',
@@ -181,7 +182,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         },
         sles15sp1 => {
             autoyast     => 'autoyast_kvm/sles15sp1_PRG.xml',
-            extra_params => '--os-variant sle15sp1',
+            extra_params => '--os-variant sles12',                                                          # problems after kernel upgrade
             macaddress   => '52:54:00:78:73:ab',
             ip           => '192.168.122.111',
             distro       => 'SLE_15',
@@ -189,13 +190,93 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         },
         sles12sp5 => {
             autoyast     => 'autoyast_kvm/sles12sp5_PRG.xml',
-            extra_params => '--os-variant sles12sp5',
+            extra_params => '--os-variant sles12sp4',                                                       # old system compatibility
             macaddress   => '52:54:00:78:73:ad',
             ip           => '192.168.122.113',
             distro       => 'SLE_12_SP5',
             location     => 'http://mirror.suse.cz/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/',
         },
     );
+} elsif (is_vmware_virtualization) {
+    %guests = (
+        sles11sp4x64 => {
+            ip => 'd125.qam.suse.de',
+        },
+        sles11sp4x32 => {
+            ip => 'd11.qam.suse.de',
+        },
+        sles12sp2 => {
+            ip => 'vm-sle12-sp2-a60.qam.suse.de',
+        },
+        sles12sp3 => {
+            ip => 'd153.qam.suse.de',
+        },
+        sles12sp4 => {
+            ip => 'd370.qam.suse.de',
+        },
+        sles12sp5 => {
+            ip => 'd388.qam.suse.de',
+        },
+        sles15 => {
+            ip => 'd294.qam.suse.de',
+        },
+        sles15sp1 => {
+            ip => 'd208.qam.suse.de',
+        },
+        sles15sp2 => {
+            ip => 'd192.qam.suse.de',
+        },
+    );
+
+    delete($guests{sles11sp4x32}) if (!is_sle('=11-SP4'));
+    delete($guests{sles11sp4x64}) if (!is_sle('=11-SP4'));
+    delete($guests{sles12sp2})    if (!is_sle('=12-SP2'));
+    delete($guests{sles12sp3})    if (!is_sle('=12-SP3'));
+    delete($guests{sles12sp4})    if (!is_sle('=12-SP4'));
+    delete($guests{sles12sp5})    if (!is_sle('=12-SP5'));
+    delete($guests{sles15})       if (!is_sle('=15'));
+    delete($guests{sles15sp1})    if (!is_sle('=15-SP1'));
+    delete($guests{sles15sp2})    if (!is_sle('=15-SP2'));
+} elsif (is_hyperv_virtualization) {
+    %guests = (
+        sles11sp4x32 => {
+            ip => 'borg-11.qam.suse.de',
+        },
+        sles11sp4x64 => {
+            ip => 'borg-10.qam.suse.de',
+        },
+        sles12sp3 => {
+            ip => 'borg-14.qam.suse.de',
+        },
+        sles12sp2 => {
+            ip => 'borg-13.qam.suse.de',
+        },
+        sles12sp4 => {
+            ip => 'd112.qam.suse.de',
+        },
+        sles12sp5 => {
+            ip => 'd387.qam.suse.de',
+        },
+        sles15 => {
+            ip => 'd67.qam.suse.de',
+        },
+        sles15sp1 => {
+            ip => 'd402.qam.suse.de',
+        },
+        sles15sp2 => {
+            ip => 'd196.qam.suse.de',
+        },
+    );
+
+    delete($guests{sles11sp4x32}) if (!is_sle('=11-SP4'));
+    delete($guests{sles11sp4x64}) if (!is_sle('=11-SP4'));
+    delete($guests{sles12sp2})    if (!is_sle('=12-SP2'));
+    delete($guests{sles12sp3})    if (!is_sle('=12-SP3'));
+    delete($guests{sles12sp4})    if (!is_sle('=12-SP4'));
+    delete($guests{sles12sp5})    if (!is_sle('=12-SP5'));
+    delete($guests{sles15})       if (!is_sle('=15'));
+    delete($guests{sles15sp1})    if (!is_sle('=15-SP1'));
+    delete($guests{sles15sp2})    if (!is_sle('=15-SP2'));
 } else {
     %guests = ();
 }

--- a/schedule/virtualization/vmware_hyperv.yaml
+++ b/schedule/virtualization/vmware_hyperv.yaml
@@ -1,0 +1,11 @@
+name:           vmware_hyperv
+description:    >
+    Maintainer: pdostal@suse.cz
+    Testing Kernel on VMware / Hyper-V SLE hosts
+schedule:
+    - boot/boot_to_desktop
+    - virtualization/external/prepare
+    - virtualization/xen/ssh_hypervisor_init
+    - virtualization/xen/ssh_guests_init
+    - virtualization/xen/upgrade_guests
+    - virtualization/xen/patch_guests

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -25,6 +25,7 @@
 # Maintainer: Leon Guo <xguo@suse.com>
 
 use virt_autotest::virtual_network_utils;
+use virt_autotest::utils;
 use base "virt_feature_test_base";
 use virt_utils;
 use set_config_as_glue;
@@ -45,7 +46,7 @@ sub run_test {
     virt_autotest::virtual_network_utils::enable_libvirt_log();
 
     #VM HOST SSH SETUP
-    virt_autotest::virtual_network_utils::ssh_setup();
+    virt_autotest::utils::ssh_setup();
 
     #Backup file /etc/hosts before virtual network testing
     virt_autotest::virtual_network_utils::hosts_backup();
@@ -64,7 +65,7 @@ sub run_test {
         #Check that all guests are still running before virtual network tests
         script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 180);
         save_guest_ip($guest, name => "br123");
-        virt_autotest::virtual_network_utils::ssh_copy_id($guest);
+        virt_autotest::utils::ssh_copy_id($guest);
         #Prepare the new guest network interface files for libvirt virtual network
         assert_script_run("ssh root\@$guest 'cd /etc/sysconfig/network/; cp ifcfg-eth0 ifcfg-eth1; cp ifcfg-eth0 ifcfg-eth2; cp ifcfg-eth0 ifcfg-eth3; cp ifcfg-eth0 ifcfg-eth4; cp ifcfg-eth0 ifcfg-eth5; cp ifcfg-eth0 ifcfg-eth6'");
         if ($guest =~ m/sles-?11/i) {

--- a/tests/virtualization/xen/kernel.pm
+++ b/tests/virtualization/xen/kernel.pm
@@ -19,13 +19,14 @@ use utils;
 use qam;
 
 sub run {
-    my $self = shift;
+    my $self       = shift;
+    my $kernel_log = shift // '/tmp/virt_kernel.txt';
 
-    script_run "zypper lr -d";
     script_run "rpm -qa > /tmp/rpm-qa.txt";
     upload_logs("/tmp/rpm-qa.txt");
 
-    check_virt_kernel();
+    check_virt_kernel(log_file => $kernel_log);
+    upload_logs($kernel_log);
 }
 
 sub post_run_hook {

--- a/tests/virtualization/xen/patch_and_reboot.pm
+++ b/tests/virtualization/xen/patch_and_reboot.pm
@@ -21,14 +21,16 @@ use utils;
 use qam;
 
 sub run {
-    my $self = shift;
+    my $self       = shift;
+    my $kernel_log = shift // '/tmp/virt_kernel.txt';
 
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));
 
-    check_virt_kernel();
-    script_run "zypper lr -d";
     script_run "rpm -qa > /tmp/rpm-qa.txt";
     upload_logs("/tmp/rpm-qa.txt");
+
+    check_virt_kernel(log_file => $kernel_log);
+    upload_logs($kernel_log);
 
     add_test_repositories;
     fully_patch_system;

--- a/tests/virtualization/xen/upgrade_guests.pm
+++ b/tests/virtualization/xen/upgrade_guests.pm
@@ -21,6 +21,10 @@ use xen;
 sub run {
     my ($self) = @_;
 
+    assert_script_run "ssh root\@$_ rm /etc/zypp/repos.d/SUSE_Maintenance* || true" foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$_ rm /etc/zypp/repos.d/TEST* || true"             foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$_ rm /tmp/dup* || true"                           foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$_ zypper ref"                                     foreach (keys %xen::guests);
     record_info "DUP", "Upgrading the system to it's latest version";
     script_run "( ssh root\@$_ '( zypper -n dup > /tmp/dup.log; echo \$? > /tmp/dup )' & )" foreach (keys %xen::guests);
     record_info "WAIT", "Waiting for all systems to be upgraded";


### PR DESCRIPTION
In QAM we have bunch of guests for VMware and Hyper-V Kernel testing.
We wanna use those guests but automate the test scenario.
A lot of XEN / KVM guest tests are also reused here.

- Related ticket: [poo#51812](https://progress.opensuse.org/issues/51812)
- Verification run: [VMware](http://pdostal-server.suse.cz/tests/9630) [Hyper-V](http://pdostal-server.suse.cz/tests/9629)
