### PR TITLE
Parse Salt logs

### DIFF
--- a/tests/network/salt_master.pm
+++ b/tests/network/salt_master.pm
@@ -38,7 +38,7 @@ use utils qw(script_retry zypper_call);
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
+    $self->select_serial_terminal;
 
     # Install, configure and start the salt master
     $self->master_prepare();
@@ -95,9 +95,7 @@ sub run {
     assert_script_run("salt --state-output=terse -t 300 '*' state.highstate", 300);
     mutex_create 'SALT_STATES_SYSCTL';
 
-    # Stop both master and minion at the end
     barrier_wait 'SALT_FINISHED';
-    $self->stop();
 }
 
 1;

--- a/tests/network/salt_minion.pm
+++ b/tests/network/salt_minion.pm
@@ -31,7 +31,7 @@ use mm_network 'setup_static_mm_network';
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
+    $self->select_serial_terminal;
 
     # Install, configure and start the salt minion
     $self->minion_prepare();
@@ -63,9 +63,7 @@ sub run {
     assert_script_run("sysctl -a | grep 'net.ipv4.ip_forward = 1'");
     assert_script_run("cat /proc/sys/net/ipv4/ip_forward");
 
-    # Stop the minion at the end
     barrier_wait 'SALT_FINISHED';
-    $self->stop();
 }
 
 1;


### PR DESCRIPTION
As I saw in [bsc#1174165](https://bugzilla.suse.com/show_bug.cgi?id=1174165) the syslog may contain keywords like "WARNING", "ERROR", or "Traceback" which I now check for.
I also filed a bug [bsc#1174379](https://bugzilla.suse.com/show_bug.cgi?id=1174379) which happens when exiting the minion on SLE12-SP4.

- Related ticket: [poo#69091](https://progress.opensuse.org/issues/69091)
- Verification run: [SLE12-SP4](http://pdostal-server.suse.cz/tests/9334) [SLE15-SP2](http://pdostal-server.suse.cz/tests/9328)
