### PR TITLE
Install sharutils also in publiccloud

### DIFF
--- a/tests/console/shar.pm
+++ b/tests/console/shar.pm
@@ -20,7 +20,7 @@ use version_utils;
 sub run {
     my $self = shift;
 
-    if (is_jeos()) {
+    if (is_jeos() || is_public_cloud()) {
         select_console 'root-console';
         zypper_call('in sharutils');
     }


### PR DESCRIPTION
This is a fix for `tests/console/shar.pm` where `sharutils` needs to be installed on Public Cloud as well.

- Related ticket: [poo#69307](https://progress.opensuse.org/issues/69307)
- Verification run: [SLES12-SP5](http://pdostal-server.suse.cz/tests/9367#step/shar/1)
