### PR TITLE
lib: consider Jump is Leap testbase

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -345,6 +345,7 @@ sub default_desktop {
     return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
     return         if get_var('VERSION', '') lt '12';
     return 'gnome' if get_var('VERSION', '') lt '15';
+    return 'gnome' if get_var('VERSION', '') =~ /^Jump/;
     # with SLE 15 LeanOS only the default is textmode
     return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
     return 'gnome' if is_desktop_module_selected;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -251,13 +251,14 @@ sub is_leap {
 
     # Leap and its stagings
     return 0 unless check_var('DISTRI', 'opensuse');
-    return 0 unless $version =~ /^\d{2,}\.\d/;
+    return 0 unless $version =~ /^\d{2,}\.\d/ || $version =~ /^Jump/;
     return 1 unless $query;
 
     # Hacks for staging and HG2G :)
     $query   =~ s/^([<>=]*)42/${1}14/;
     $version =~ s/^42/14/;
     $version =~ s/:(Core|S)[:\w]*//i;
+    $version =~ s/^Jump://i;
 
     return check_version($query, $version, qr/\d{2,}\.\d/);
 }


### PR DESCRIPTION
Consider Jump is Leap testbase.

- Reference: https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Jump%3A15.2&build=21.5&groupid=75
- Verification run:
    * DVD: http://10.156.41.177/tests/93
    * Netinstall: http://10.156.41.177/tests/95