### PR TITLE
Adjust enlightenment test for changes in Tumbleweed

### DIFF
--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -42,11 +42,8 @@ sub run {
         assert_screen 'enlightenment_compositing';
     }
     assert_and_click "enlightenment_assistant_next";
-    assert_screen [qw(enlightenment_generic_desktop enlightenment_acpid_missing)];
-    if (match_has_tag 'enlightenment_acpid_missing') {
-        assert_and_click 'enlightenment_acpid_missing';
-        assert_screen 'enlightenment_generic_desktop';
-    }
+    assert_and_click 'enlightenment_acpid_missing';
+    assert_screen 'enlightenment_generic_desktop';
 }
 
 sub test_flags {

--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -32,9 +32,11 @@ sub run {
     assert_and_click "enlightenment_assistant_next";
     assert_screen "enlightenment_windowfocus";
     assert_and_click "enlightenment_assistant_next";
-    assert_screen "enlightenment_keybindings";
-    assert_and_click "enlightenment_assistant_next";
-    assert_screen [qw(enlightenment_compositing enlightenment_bluez_not_found)];
+    assert_screen [qw(enlightenment_keybindings enlightenment_bluez_not_found)];
+    if (match_has_tag 'enlightenment_keybindings') {
+        assert_and_click "enlightenment_assistant_next";
+        assert_screen [qw(enlightenment_compositing enlightenment_bluez_not_found)];
+    }
     if (match_has_tag 'enlightenment_bluez_not_found') {
         assert_and_click 'enlightenment_assistant_next';
         assert_screen 'enlightenment_compositing';

--- a/tests/x11/terminology.pm
+++ b/tests/x11/terminology.pm
@@ -17,7 +17,14 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    $self->test_terminal('terminology');
+    x11_start_program('teminology', target_match => [qw(terminology terminology-config-scale)]);
+    # Somehow the window loses focus after click_lastmatch hides the mouse, avoid that
+    mouse_set(25, 25);
+    click_lastmatch if match_has_tag('terminology-config-scale');
+    $self->enter_test_text('terminology', cmd => 1);
+    mouse_hide(1);
+    assert_screen('test-terminology-1');
+    send_key('alt-f4');
 }
 
 1;


### PR DESCRIPTION
The first start wizard apparently dropped the keybindings step, but
terminology has a setup now.

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/675
- Verification runs:
Tumbleweed: http://10.160.67.86/tests/761
Leap 15.2: http://10.160.67.86/tests/762