### PR TITLE
Fix wpa_supplicant for SLES and public cloud

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1694,7 +1694,7 @@ sub load_extra_tests_console {
     loadtest "console/gd";
     loadtest 'console/valgrind'       unless is_sle('<=12-SP3');
     loadtest 'console/sssd_samba'     unless (is_sle("<15") || is_sle(">=15-sp2"));
-    loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1') || is_jeos);
+    loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1') || is_jeos || is_public_cloud);
 }
 
 sub load_extra_tests_sdk {

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -66,6 +66,7 @@ schedule:
 - console/gd
 - console/valgrind
 - console/sssd_samba
+- console/wpa_supplicant
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/schedule/qam/15-SP2/mau-extratests.yaml
+++ b/schedule/qam/15-SP2/mau-extratests.yaml
@@ -65,6 +65,7 @@ schedule:
 - console/libqca2
 - console/gd
 - console/valgrind
+- console/wpa_supplicant
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -67,6 +67,7 @@ schedule:
 - console/gd
 - console/valgrind
 - console/sssd_samba
+- console/wpa_supplicant
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:


### PR DESCRIPTION
Skips the `wpa_supplicant` tests on public cloud test runs and schedules `wpa_supplicant` on SLES 15+

- Related ticket: https://progress.opensuse.org/issues/69403
- Needles: -
- Verification run: [SLE 15-SP2](https://openqa.suse.de/tests/4495029) | [SLE 15-SP1](https://openqa.suse.de/tests/4495030) | [SLE 15](https://openqa.suse.de/tests/4495031) | [SLE 15-SP1 Azure](https://openqa.suse.de/t4495710) - still running, schedule is OK