### PR TITLE
Remove ghostscript workaround poo#41393/bsc#1109788

### DIFF
--- a/tests/x11/ghostscript.pm
+++ b/tests/x11/ghostscript.pm
@@ -41,14 +41,6 @@ sub run {
     # special case for gv which is not installed on all flavors
     my $gv_missing = zypper_call("in gv", exitcode => [0, 104]);
 
-    # Remove known failing test file poo#41393/bsc#1109788
-    my $excluded_file = "/usr/share/ghostscript/9.25/examples/transparency_example.ps";
-    my $file_status   = script_run("ls $excluded_file");
-    unless ($file_status) {
-        record_soft_failure("bsc#1109788");
-        assert_script_run("rm $excluded_file");
-    }
-
     # exit root shell
     type_string "exit\n";
 
@@ -59,7 +51,6 @@ sub run {
 
     # download ghostscript converter script and test if download succeeded
     assert_script_run "wget " . data_url("ghostscript/$gs_script");
-    assert_script_run "test -f $gs_script";
     assert_script_run "test -s $gs_script";
 
     # convert example *.ps files to *.pdf


### PR DESCRIPTION
Remove one test of downloaded file, one is more than enough

- Related ticket: https://progress.opensuse.org/issues/60764
- Verification run:
http://10.100.12.155/tests/16284