### PR TITLE
Fix ssh issue in ha qdevice test

### DIFF
--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -17,7 +17,7 @@ use warnings;
 use testapi;
 use lockapi;
 use hacluster;
-use utils qw(zypper_call);
+use utils qw(zypper_call exec_and_insert_password);
 
 sub qdevice_status {
     my ($expected_status) = @_;
@@ -27,6 +27,9 @@ sub qdevice_status {
     my $output;
 
     $num_nodes-- if ($expected_status eq 'stopped');
+
+    # We have to enable ssh passwordless between qnetd server and node2
+    exec_and_insert_password($qnetd_status_cmd) if is_node(2);
 
     # Check qdevice status
     $output = script_output "$qnetd_status_cmd" if ($expected_status ne 'stopped');


### PR DESCRIPTION
We need to adapt our test due to bsc#1174385.
SSH password needs to be typed for enabling ssh passwordless between qnetd server and node2.

- Related ticket: N/A
- Needles: 
- Verification run: 
  Node2: http://1a102.qa.suse.de/tests/4624#step/qnetd/14
  We can see the password prompted for enabling ssh passwordless.
  The test is failing but this is another bug I've opened (a corosync one)
