### PR TITLE
Fix wpa_supplicant schedule for s390x

### DIFF
--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -66,7 +66,7 @@ schedule:
 - console/gd
 - console/valgrind
 - console/sssd_samba
-- console/wpa_supplicant
+- '{{wpa_supplicant}}'
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:
@@ -82,4 +82,8 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/lshw
+  wpa_supplicant:
+    ARCH:
+      x86_64:
+        - console/wpa_supplicant
 ...

--- a/schedule/qam/15-SP2/mau-extratests.yaml
+++ b/schedule/qam/15-SP2/mau-extratests.yaml
@@ -65,7 +65,7 @@ schedule:
 - console/libqca2
 - console/gd
 - console/valgrind
-- console/wpa_supplicant
+- '{{wpa_supplicant}}'
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:
@@ -85,4 +85,8 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/lshw
+  wpa_supplicant:
+    ARCH:
+      x86_64:
+        - console/wpa_supplicant
 ...

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -67,7 +67,7 @@ schedule:
 - console/gd
 - console/valgrind
 - console/sssd_samba
-- console/wpa_supplicant
+- '{{wpa_supplicant}}'
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:
@@ -83,4 +83,8 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/lshw
+  wpa_supplicant:
+    ARCH:
+      x86_64:
+        - console/wpa_supplicant
 ...


### PR DESCRIPTION
Add conditional (x86_64 only) for `wpa_supplicant` in the yaml schedule

- Related ticket: https://progress.opensuse.org/issues/69429
- Needles: -
- Verification runs: [SLES15-SP2 s390x](https://openqa.suse.de/tests/4501514) | [SLES15-SP2 x86_64](https://openqa.suse.de/tests/4501515) - checked the schedule. In s390x `wpa_supplicant` not appearing, in x86_64 it is