### PR TITLE
Prevent undefined timeout value in 'console_selected'

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -888,6 +888,7 @@ sub console_selected {
     $args{await_console} //= 1;
     $args{tags}          //= $console;
     $args{ignore}        //= qr{sut|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary};
+    $args{timeout}       //= 30;
 
     if ($args{tags} =~ $args{ignore} || !$args{await_console} || (get_var('FLAVOR') eq 'WSL')) {
         set_var('CONSOLE_JUST_ACTIVATED', 0);


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10748#issuecomment-665563097

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10757 https://openqa.opensuse.org/tests/1346160 
```

opensuse-Tumbleweed-DVD-x86_64-Build20200728-cryptlvm@64bit -> https://openqa.opensuse.org/t1346509
