### PR TITLE
Transfer YaST test suite vars in schedules

### DIFF
--- a/schedule/yast/autoyast/autoyast_ext4.yaml
+++ b/schedule/yast/autoyast/autoyast_ext4.yaml
@@ -5,7 +5,9 @@ description: >
   with product defined in the profile.
 vars:
   AUTOYAST: autoyast_sle15/autoyast_ext4.xml
+  AUTOYAST_PREPARE_PROFILE: '1'
   DESKTOP: gnome
+  FILESYSTEM: ext4
 schedule:
   - autoyast/prepare_profile
   - installation/isosize

--- a/schedule/yast/autoyast/autoyast_gnome.yaml
+++ b/schedule/yast/autoyast/autoyast_gnome.yaml
@@ -5,6 +5,7 @@ description: >
   validated by execution set of smoke userspace tests.
 vars:
   AUTOYAST: autoyast_sle15/autoyast_gnome.xml
+  AUTOYAST_PREPARE_PROFILE: '1'
   DESKTOP: gnome
 schedule:
   - autoyast/prepare_profile

--- a/schedule/yast/autoyast/autoyast_installonly.yaml
+++ b/schedule/yast/autoyast/autoyast_installonly.yaml
@@ -6,6 +6,7 @@ description: >
   variables. The variables are specified in Job Group or in Test Suite settings.
 vars:
   AUTOYAST_PREPARE_PROFILE: '1'
+  DESKTOP: textmode
 schedule:
   - autoyast/prepare_profile
   - installation/isosize

--- a/schedule/yast/autoyast/autoyast_keyboard_layout.yaml
+++ b/schedule/yast/autoyast/autoyast_keyboard_layout.yaml
@@ -5,6 +5,7 @@ description: >
   different than us.
 vars:
   AUTOYAST: autoyast_sle15/autoyast_keyboard_layout.xml
+  AUTOYAST_PREPARE_PROFILE: '1'
   DESKTOP: textmode
   INSTALL_KEYBOARD_LAYOUT: cz
 schedule:

--- a/schedule/yast/autoyast/autoyast_mini.yaml
+++ b/schedule/yast/autoyast/autoyast_mini.yaml
@@ -6,6 +6,8 @@ description: >
   variables. The variables are specified in Job Group or in Test Suite settings.
 vars:
   AUTOYAST_PREPARE_PROFILE: '1'
+  AUTOYAST_CONFIRM: '1'
+  DESKTOP: textmode
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start

--- a/schedule/yast/autoyast/autoyast_mini_spvm.yaml
+++ b/schedule/yast/autoyast/autoyast_mini_spvm.yaml
@@ -6,6 +6,7 @@ description: >
 vars:
   AUTOYAST: autoyast_sle15/mini_remote.xml
   AUTOYAST_CONFIRM: 1
+  DESKTOP: textmode
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start

--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -3,7 +3,10 @@ name: autoyast_multi_btrfs
 description: >
   Test autoyast installation, while using multi-device Btrfs filesystem
 vars:
+  AUTOYAST: autoyast_sle15/autoyast_multi_btrfs.xml
+  DESKTOP: gnome
   ENCRYPT: 1
+  NUMDISKS: '4'
 schedule:
   - autoyast/prepare_profile
   - installation/isosize

--- a/schedule/yast/autoyast_non_secure_boot.yaml
+++ b/schedule/yast/autoyast_non_secure_boot.yaml
@@ -4,6 +4,7 @@ description:   >
 vars:
   AUTOYAST: autoyast_sle15/autoyast_non_secure_boot.xml
   AUTOYAST_PREPARE_PROFILE: 1
+  DESKTOP: textmode
   EXTRABOOTPARAMS: startshell=1
 schedule:
   - autoyast/prepare_profile

--- a/schedule/yast/autoyast_salt_formulas.yaml
+++ b/schedule/yast/autoyast_salt_formulas.yaml
@@ -2,6 +2,12 @@
 name: autoyast_salt_formulas
 description: |
   Test installation using AutoYaST plus salt formulas.
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_salt.xml
+  AUTOYAST_CONFIRM: '1'
+  AUTOYAST_PREPARE_PROFILE: '1'
+  DESKTOP: textmode
+  SALT_FORMULAS_PATH: yast2/salt.tar.gz
 schedule:
   - autoyast/prepare_profile
   - installation/isosize

--- a/schedule/yast/autoyast_y2_firstboot.yaml
+++ b/schedule/yast/autoyast_y2_firstboot.yaml
@@ -1,16 +1,21 @@
+---
 name:           autoyast_y2_firstboot
 description:    >
-    Smoke test for YaST2 firstboot module
+  Smoke test for YaST2 Firstboot module, basically same as yast2_firstboot test suite.
+  Test pre-defined autoyast profile, which enables YaST2 Firstboot during system deployment.
+  SUT should boot to YaST2 Firstboot wizard after reboot. Test goes through all Firstboot tabs,
+  configure root and user accounts. SUT should end up in GDM screen after exiting YaST2
+  Firstboot.
 vars:
-    AUTOYAST: autoyast_sle15/autoyast_firstboot.xml
-    DESKTOP: gnome
-    NOAUTOLOGIN: 1
-    YAST2_FIRSTBOOT_USERNAME: firstbootuser
+  AUTOYAST: autoyast_sle15/autoyast_firstboot.xml
+  DESKTOP: gnome
+  NOAUTOLOGIN: 1
+  YAST2_FIRSTBOOT_USERNAME: firstbootuser
 schedule:
-    - autoyast/prepare_profile
-    - installation/isosize
-    - installation/bootloader_start
-    - autoyast/installation
-    - installation/yast2_firstboot
-    - installation/first_boot
-    - console/validate_yast2_firstboot_configuration
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - installation/yast2_firstboot
+  - installation/first_boot
+  - console/validate_yast2_firstboot_configuration

--- a/schedule/yast/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/autoyast_y2_firstboot_opensuse.yaml
@@ -1,15 +1,20 @@
+---
 name:           autoyast_y2_firstboot
 description:    >
-    Smoke test for YaST2 firstboot module
+  Smoke test for YaST2 Firstboot module, basically same as yast2_firstboot test suite.
+  Test pre-defined autoyast profile, which enables YaST2 Firstboot during system deployment.
+  SUT should boot to YaST2 Firstboot wizard after reboot. Test goes through all Firstboot tabs,
+  configure root and user accounts. SUT should end up in GDM screen after exiting YaST2
+  Firstboot.
 vars:
-    AUTOYAST: autoyast_opensuse/autoyast_firstboot.xml
-    DESKTOP: gnome
-    YAST2_FIRSTBOOT_USERNAME: firstbootuser
+  AUTOYAST: autoyast_opensuse/autoyast_firstboot.xml
+  DESKTOP: gnome
+  YAST2_FIRSTBOOT_USERNAME: firstbootuser
 schedule:
-    - autoyast/prepare_profile
-    - installation/isosize
-    - installation/bootloader_start
-    - autoyast/installation
-    - installation/yast2_firstboot
-    - installation/first_boot
-    - console/validate_yast2_firstboot_configuration
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - installation/yast2_firstboot
+  - installation/first_boot
+  - console/validate_yast2_firstboot_configuration

--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -9,7 +9,6 @@ description: >
 vars:
   DESKTOP: gnome
   ENCRYPT: 1
-  INSTALLONLY: 1
   LVM: 0
   MAX_JOB_TIME: 14400
 schedule:

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -11,7 +11,6 @@ description: >
 vars:
   DESKTOP: textmode
   ENCRYPT: 1
-  INSTALLONLY: 1
   LVM: 0
   MAX_JOB_TIME: 14400
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -6,6 +6,7 @@ description: >
 vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1
+  MAX_JOB_TIME: '14400'
 conditional_schedule:
   boot_encrypt_reconnect_mgmt_console:
     ARCH:

--- a/schedule/yast/encryption/lvm_full_encrypt_opensuse.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_opensuse.yaml
@@ -6,6 +6,7 @@ description: >
 vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1
+  MAX_JOB_TIME: '14400'
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -10,6 +10,7 @@ vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  MAX_JOB_TIME: '14400'
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -5,8 +5,10 @@ description: >
   wizard screen.
 name: cryptlvm
 vars:
-  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
   DESKTOP: textmode
+  LVM: '1'
+  MAX_JOB_TIME: '14400'
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -7,8 +7,9 @@ description: >
   SLE 12 we register the installation and have system roles wizard screen.
 name: lvm
 vars:
-  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
   DESKTOP: textmode
+  MAX_JOB_TIME: '14400'
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
 schedule:
   - installation/bootloader
   - installation/welcome

--- a/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
@@ -5,6 +5,7 @@ description: >
   Test validates if installation can successfully start in case of usage of
   these parameters.
 vars:
+  EXIT_AFTER_START_INSTALL: '1'
   EXPECTED_INSTALL_HOSTNAME: dhcphostname
   EXTRABOOTPARAMS: ifcfg=*=dhcp
   NICTYPE_USER_OPTIONS: hostname=dhcphostname

--- a/schedule/yast/yast_hostname/yast_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname.yaml
@@ -3,6 +3,8 @@ name: yast_hostname
 description: >
   Test suite uses default option to set hostname. Test validates if installation
   can successfully start in case of usage of these parameters.
+vars:
+  EXIT_AFTER_START_INSTALL: '1'
 schedule:
   - installation/bootloader_start
   - installation/welcome


### PR DESCRIPTION
In order to delete Test suite settings from osd test data base but maintain the same settings, some of the settings' vars need to be transferred in the test suite schedule files.

- Related PR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/256
- Related ticket: https://progress.opensuse.org/issues/66987