### PR TITLE
Enable yast_dns_server test in yast_cmd

### DIFF
--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -11,6 +11,7 @@ schedule:
   - yast2_cmd/yast_nfs_server
   - yast2_cmd/yast_nfs_client
   - yast2_cmd/yast_tftp_server
+  - '{{yast_dns_server}}'
   - '{{yast_lan}}'
   - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
@@ -33,3 +34,7 @@ conditional_schedule:
         - yast2_cmd/yast_lan
       svirt:
         - yast2_cmd/yast_lan
+  yast_dns_server:
+    BACKEND:
+      qemu:
+        - yast2_cmd/yast_dns_server


### PR DESCRIPTION
Add yast_dns_server from QAM to yast job group's yast_cmd test suite

- Related ticket: https://progress.opensuse.org/issues/69379
- Verification runs: 
64bit https://openqa.suse.de/tests/4506025#
s390x (excluded) https://openqa.suse.de/tests/4506026#
ppc64le https://openqa.suse.de/tests/4506027#
aarch64 https://openqa.suse.de/tests/4506028#
spvm (excluded) https://openqa.suse.de/tests/4506028#
