### PR TITLE
Add new cluster rolling upgrade test

### DIFF
--- a/schedule/ha/bv/ha_rolling_upgrade_migration_node01.yaml
+++ b/schedule/ha/bv/ha_rolling_upgrade_migration_node01.yaml
@@ -1,0 +1,51 @@
+name:           qam-ha_rolling_upgrade_migration
+description:    >
+  Test a rolling upgrade in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - console/suseconnect_scc
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/await_upgrade
+  - migration/version_switch_upgrade_target
+  - '{{cluster_boot_mgmt}}'
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_migration
+  - migration/online_migration/post_migration
+  - '{{cluster_boot_mgmt}}'
+  - '{{console_reboot}}'
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded
+  - ha/check_logs
+conditional_schedule:
+  cluster_boot_mgmt:
+    QAM_INCI:
+      1:
+        - ha/cluster_boot_mgmt
+  console_reboot:
+    QAM_INCI:
+      1:
+        - console/console_reboot

--- a/schedule/ha/bv/ha_rolling_upgrade_migration_node02.yaml
+++ b/schedule/ha/bv/ha_rolling_upgrade_migration_node02.yaml
@@ -1,0 +1,51 @@
+name:           qam-ha_rolling_upgrade_migration
+description:    >
+  Test a rolling upgrade in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - console/suseconnect_scc
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/await_upgrade
+  - migration/version_switch_upgrade_target
+  - '{{cluster_boot_mgmt}}'
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_migration
+  - migration/online_migration/post_migration
+  - '{{cluster_boot_mgmt}}'
+  - '{{console_reboot}}'
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded
+  - ha/check_logs
+conditional_schedule:
+  cluster_boot_mgmt:
+    QAM_INCI:
+      1:
+        - ha/cluster_boot_mgmt
+  console_reboot:
+    QAM_INCI:
+      1:
+        - console/console_reboot

--- a/tests/ha/await_upgrade.pm
+++ b/tests/ha/await_upgrade.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Wait for all nodes which are allowed to upgrade before.
+# Maintainer: Christian Lanig <clanig@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use hacluster;
+use lockapi;
+
+sub run {
+    my $cluster_name = get_cluster_name;
+    record_info("Upgrade node 1", "upgrade has started for node 1") if is_node(1);
+
+    if (is_node(2)) {
+        record_info("Waiting node 1", "Node 1 is upgrading");
+        barrier_wait("NODE_UPGRADED_${cluster_name}_NODE1");
+        record_info("Upgrade node 2", "upgrade has started for node 2");
+    }
+}
+
+1;

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -122,6 +122,11 @@ sub run {
         barrier_create("SPLIT_BRAIN_TEST_READY_$cluster_name", $num_nodes + 1);
         barrier_create("SPLIT_BRAIN_TEST_DONE_$cluster_name",  $num_nodes + 1);
 
+        # ROLLING UPGRADE barriers
+        for (1 .. $num_nodes) {
+            barrier_create("NODE_UPGRADED_${cluster_name}_NODE$_", $num_nodes);
+        }
+
         # Create barriers for multiple tests
         foreach my $fs_tag ('LUN', 'CLUSTER_MD', 'DRBD_PASSIVE', 'DRBD_ACTIVE') {
             barrier_create("VG_INIT_${fs_tag}_$cluster_name",             $num_nodes);

--- a/tests/ha/check_cluster_integrity.pm
+++ b/tests/ha/check_cluster_integrity.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Check cluster integrity
+# Maintainer: Christian Lanig <clanig@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use hacluster;
+use utils 'systemctl';
+
+sub run {
+    select_console 'root-console';
+    # Check for the state of the whole cluster
+    check_cluster_state;
+}
+
+1;

--- a/tests/ha/cluster_boot_mgmt.pm
+++ b/tests/ha/cluster_boot_mgmt.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Manage cluster at boot time
+#          Disable pacemaker at boot if pacemaker is active, otherwise enable it.
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils 'systemctl';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    if (systemctl('-q is-active pacemaker', ignore_failure => 1)) {
+        record_info("Enable cluster", "Cluster is enabled at boot");
+        systemctl("enable pacemaker");
+    }
+    else {
+        record_info("Disable cluster", "Cluster is disabled at boot");
+        systemctl("disable pacemaker");
+    }
+}
+
+1;

--- a/tests/ha/cluster_state_mgmt.pm
+++ b/tests/ha/cluster_state_mgmt.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Manage cluster stack
+#          Stop the cluster if pacemaker is active, otherwise start it.
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils 'systemctl';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    if (systemctl('-q is-active pacemaker', ignore_failure => 1)) {
+        record_info("Start cluster", "Cluster is starting");
+        script_run "crm cluster start";
+    }
+    else {
+        record_info("Stop cluster", "Cluster is stopping");
+        script_run "crm cluster stop";
+    }
+}
+
+1;

--- a/tests/ha/wait_others_upgraded.pm
+++ b/tests/ha/wait_others_upgraded.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Wait for all nodes which are allowed to upgrade after.
+# Maintainer: Christian Lanig <clanig@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use hacluster;
+use lockapi;
+
+sub run {
+    my $cluster_name = get_cluster_name;
+    if (is_node(1)) {
+        record_info("Upgrade done", "Node 1 successfully upgraded");
+        barrier_wait("NODE_UPGRADED_${cluster_name}_NODE1");
+        record_info("Waiting node 2", "Node 2 is upgrading");
+    }
+    for (1 .. get_node_number) {
+        barrier_wait("NODE_UPGRADED_${cluster_name}_NODE$_");
+    }
+}
+
+1;


### PR DESCRIPTION
This PR adds a new test for HA, a cluster rolling upgrade:
_In a cluster rolling upgrade one cluster node at a time is upgraded while the rest of the cluster is still running. You take the first node offline, upgrade it and bring it back online to join the cluster. Then you continue one by one until all cluster nodes are upgraded to a major version._

Only tested in 15+ for the moment.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
15-SP2 QAM: [node1](http://1a102.qa.suse.de/tests/4781) / [node2](http://1a102.qa.suse.de/tests/4782) / [supportserver](http://1a102.qa.suse.de/tests/4780)
15-SP1 QAM: [node1](http://1a102.qa.suse.de/tests/4766) / [node2](http://1a102.qa.suse.de/tests/4767) / [supportserver](http://1a102.qa.suse.de/tests/4760)
15-SP2 BV: [node1](http://1a102.qa.suse.de/tests/4796) / [node2](http://1a102.qa.suse.de/tests/4797) / [supportserver](http://1a102.qa.suse.de/tests/4795)

**Scenario details:**
The tests use an unregistered qcow2 stored in hdd/fixed (`sle-15-SP1-x86_64-ha-rolling_upgrade.qcow2` if it is a 15-SP2 test)
1- Loads this qcow2 in the rolling upgrade test
2- Register and update to the OS to the latest version
3- Configure a cluster on top of 15-SP1 OS
4- Disable cluster at boot (loaded only when QAM)
4- Stop the cluster in node1
5- Upgrade to 15-SP2 with zypper migration
6- Add [the QAM repo](http://1a102.qa.suse.de/tests/4722#step/post_migration/16) in post migration step
7- Apply the [QAM update](http://1a102.qa.suse.de/tests/4722#step/post_migration/18)
8- Enable cluster at boot (loaded only when QAM)
9- Reboot (loaded only when QAM)
10- Check the cluster status
11- Send a [GO](http://1a102.qa.suse.de/tests/4722#step/wait_others_upgraded/1) for [upgrading node2](http://1a102.qa.suse.de/tests/4723#step/await_upgrade/3) in the same way 

