### PR TITLE
Fix warnings about "Use of uninitialized value in split"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -719,6 +719,7 @@ sub map_incidents_to_repo {
     my ($incidents, $templates) = @_;
     my @maint_repos;
     for my $i (keys %$incidents) {
+        next unless $incidents->{$i};
         for my $j (split(/,/, $incidents->{$i})) {
             if ($j) {
                 push @maint_repos, join($j, split('@INCIDENTNR@', $templates->{$i}));

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -702,11 +702,12 @@ sub select_addons_in_textmode {
 sub registration_bootloader_cmdline {
     # https://www.suse.com/documentation/smt11/book_yep/data/smt_client_parameters.html
     # SCC_URL=https://smt.example.com
+    my $cmdline = '';
     if (my $url = get_var('SMT_URL') || get_var('SCC_URL')) {
-        my $cmdline = " regurl=$url";
+        $cmdline .= " regurl=$url";
         $cmdline .= " regcert=$url" if get_var('SCC_CERT');
-        return $cmdline;
     }
+    return $cmdline;
 }
 
 sub registration_bootloader_params {


### PR DESCRIPTION
Verification runs:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10764 https://openqa.opensuse.org/tests/1348002,https://openqa.suse.de/tests/4512233
```

* opensuse-Tumbleweed-DVD-x86_64-Build20200730-gnome@64bit -> https://openqa.opensuse.org/t1348734
* sle-15-SP2-Server-DVD-HPC-Incidents-x86_64-Build:15887:netcdf-hpc_conman@64bit -> https://openqa.suse.de/t4512488

Related progress issue: https://progress.opensuse.org/issues/10704