### PR TITLE
Adapt module services_enabled for Tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1605,6 +1605,7 @@ sub load_extra_tests_geo_desktop {
 
 sub load_extra_tests_console {
     loadtest "console/check_os_release";
+    loadtest 'console/services_enabled';
     loadtest "console/orphaned_packages_check";
     # JeOS kernel is missing 'openvswitch' kernel module
     loadtest "console/openvswitch" unless is_jeos;

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -45,7 +45,7 @@ sub load_feature_tests {
     loadtest 'microos/libzypp_config';
     loadtest 'microos/image_checks' if is_image_flavor;
     loadtest 'microos/one_line_checks';
-    loadtest 'microos/services_enabled';
+    loadtest 'console/services_enabled';
     load_transactional_role_tests;
     loadtest 'microos/journal_check';
     if (check_var 'SYSTEM_ROLE', 'kubeadm') {

--- a/tests/console/services_enabled.pm
+++ b/tests/console/services_enabled.pm
@@ -19,8 +19,9 @@ use testapi;
 use version_utils 'is_caasp';
 
 my %services_for = (
-    default => [qw(sshd issue-generator issue-add-ssh-keys)],
-    microos => [qw(transactional-update.timer)],
+    # default is Tumbleweed
+    default => [qw(sshd issue-generator !issue-add-ssh-keys)],
+    microos => [qw(!sshd transactional-update.timer)],
     cloud   => [qw(cloud-init-local cloud-init cloud-config cloud-final)],
     cluster => [qw(chronyd)],
     admin   => [qw(docker kubelet etcd)],

--- a/tests/console/services_enabled.pm
+++ b/tests/console/services_enabled.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,8 @@ use testapi;
 use version_utils 'is_caasp';
 
 my %services_for = (
-    default => [qw(sshd issue-generator issue-add-ssh-keys transactional-update.timer)],
+    default => [qw(sshd issue-generator issue-add-ssh-keys)],
+    microos => [qw(transactional-update.timer)],
     cloud   => [qw(cloud-init-local cloud-init cloud-config cloud-final)],
     cluster => [qw(chronyd)],
     admin   => [qw(docker kubelet etcd)],


### PR DESCRIPTION
The module was created initially for microOS and cloud.

- Related ticket: https://progress.opensuse.org/issues/68170
- Verification runs
  - Tumbleweed
    - Schedule: http://openqa.slindomansilla-vm.qa.suse.de/tests/2568
    - Behavior: http://openqa.slindomansilla-vm.qa.suse.de/tests/2576
  - Leap 15.2
    - Schedule: http://openqa.slindomansilla-vm.qa.suse.de/tests/2578
    - Behavior: (coming soon)
  - MicroOS
    - Schedule: (coming soon)
    - Behavior: (coming soon)