### PR TITLE
Mitigations: add perl-JSON package for ipmi_to_qemu

### DIFF
--- a/tests/cpu_bugs/ipmi_to_qemu.pm
+++ b/tests/cpu_bugs/ipmi_to_qemu.pm
@@ -50,7 +50,7 @@ sub run {
     zypper_call("ar http://download.opensuse.org/repositories/devel:/openQA:/SLE-$sles_running_version/$current_dist/devel:openQA:SLE-$sles_running_version.repo");
     zypper_call('--gpg-auto-import-keys ref');
     zypper_call('dup --auto-agree-with-licenses');
-    zypper_call('in openQA-worker perl-DBIx-Class-DeploymentHandler perl-YAML-Tiny perl-Test-Assert');
+    zypper_call('in openQA-worker perl-DBIx-Class-DeploymentHandler perl-YAML-Tiny perl-Test-Assert perl-JSON');
     zypper_call('in --replacefiles perl-DBD-SQLite');
 
     #NFS mount


### PR DESCRIPTION
create_hdd_textmode for mitigation test failed due to lack perl-JSON package as below, add this package to resolve qemu worker issue.
http://10.67.129.4/tests/15626/file/autoinst-log.txt

- Verification run: http://10.67.129.4/tests/15635
