### PR TITLE
Validate ftp mirror repo in remote_ssh_target_ftp scenario

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -542,7 +542,7 @@ sub select_installation_source {
     my ($m_server, $m_share, $m_directory);
 
     # Parse SUSEMIRROR into variables
-    if ($m_mirror =~ m{^[a-z]+://([a-zA-Z0-9.-]*)(/.*)$}) {
+    if ($m_mirror =~ m{^[a-z]+://([a-zA-Z0-9.-]*)/(.*)$}) {
         ($m_server, $m_directory) = ($1, $2);
         if ($m_protocol eq "smb") {
             ($m_share, $m_directory) = $m_directory =~ /\/(.+?)(\/.*)/;

--- a/schedule/yast/remote_ssh/remote_ssh_target_ftp_sle15.yaml
+++ b/schedule/yast/remote_ssh/remote_ssh_target_ftp_sle15.yaml
@@ -19,6 +19,7 @@ schedule:
   - console/force_scheduled_tasks
   - console/textinfo
   - console/hostname
+  - console/validate_mirror_repos
   - console/installation_snapshots
   - console/zypper_lr
   - console/zypper_ref

--- a/tests/console/validate_mirror_repos.pm
+++ b/tests/console/validate_mirror_repos.pm
@@ -25,7 +25,7 @@ sub run {
     $mirror_src .= '?ssl_verify=no' if ($method eq 'HTTPS');
     my $sle_prod = uc get_var('SLE_PRODUCT') . get_var('VERSION');
 
-    record_info("Check mirror", "Validate if mirror used for installation is added in the installed system");
+    record_info("Mirror Validation", "Validate $mirror_src used for installation is added in the installed system");
     validate_repo_enablement(alias => $sle_prod, name => $sle_prod, uri => $mirror_src);
 }
 


### PR DESCRIPTION
Schedule validate_mirror_repos in remote_ssh_target_ftp

- Related ticket: https://progress.opensuse.org/issues/69220
- Verification run: http://aquarius.suse.cz/tests/2959#step/validate_mirror_repos/6