### PR TITLE
Upload y2log when failure happened

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -18,6 +18,7 @@ use migration;
 use registration;
 use qam;
 use Utils::Backends 'is_pvm';
+use y2_installbase;
 
 
 sub patching_sle {
@@ -312,4 +313,8 @@ sub test_flags {
     return {milestone => 1, fatal => 1};
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    y2_installbase::save_upload_y2logs;
+}
 1;


### PR DESCRIPTION
Sometimes we need to manually reproduce failed cases to provide y2log when reporting bugs. To reduce manually saving logs, we need to add "save_y2log" on some failed modules and upload it to the case's "Logs & Assets".

- Related ticket: https://progress.opensuse.org/issues/69151
- Needles: N/A
- Verification run: 
                           - patch-sle : https://openqa.nue.suse.com/tests/4519707#downloads
