### PR TITLE
microos/image_checks: Add check for combustion

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -31,6 +31,9 @@ sub run {
     # Verify that the filesystem mounted at /var grew beyond the default 5GiB
     my $varsize = script_output "findmnt -rnboSIZE -T/var";
     die "/var did not grow, got $varsize B" unless $varsize > (5 * 1024 * 1024 * 1024);
+
+    # Verify that combustion ran (not on 15.2 yet)
+    validate_script_output('cat /usr/share/combustion-welcome', qr/Combustion was here/) unless check_var('VERSION', '15.2');
 }
 
 1;


### PR DESCRIPTION
The image is configured with a drive containing combustion/script:
```
#!/bin/sh
systemctl enable sshd
echo Combustion was here > /usr/share/combustion-welcome
```

This adds a check to validate that combustion was run and the image was
booted into a snapshot with the expected changes.

For o3, the needed file is added in `/home/fvogt/ignition.qcow2`, which has to be copied to `/var/lib/openqa/factory/hdd/fixed/ignition.qcow2` before.

Verification runs:
Tumbleweed: http://10.160.67.86/tests/769
Leap 15.2: http://10.160.67.86/tests/770 (combustion not in there yet)