### PR TITLE
Remove workaround in yast2_vnc

### DIFF
--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Configure remote administration with yast2 vnc
-# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use strict;
 use warnings;
@@ -46,13 +46,8 @@ sub configure_remote_admin {
 
 sub check_service_listening {
     my $cmd_check_port = $is_older_product ? 'netstat' : 'ss -tln | grep -E LISTEN.*:5901';
-    if (script_run($cmd_check_port)) {
-        record_soft_failure 'boo#1088646 - service vncmanager is not started automatically';
-        systemctl('status vncmanager', expect_false => 1);
-        systemctl('restart vncmanager');
-        systemctl('status vncmanager');
-        assert_script_run $cmd_check_port;
-    }
+    script_retry("$cmd_check_port", retry => 5, delay => 1);
+    systemctl('status vncmanager');
 }
 
 sub test_setup {


### PR DESCRIPTION
Remove a workaround for fixed [bug](https://bugzilla.opensuse.org/show_bug.cgi?id=1088646) and try to avoid [sporadic failure](https://openqa.opensuse.org/tests/1326878#step/yast2_vnc/21) where it seems like port is not yet opened.

- Related ticket: https://progress.opensuse.org/issues/68755
- Verification run: http://waaa-amazing.suse.cz/tests/12760
