### PR TITLE
Wait after key press which is closing firefox

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -694,6 +694,7 @@ sub firefox_open_url {
 sub exit_firefox_common {
     # Exit
     send_key 'ctrl-q';
+    wait_still_screen 1, 2;
     send_key_until_needlematch([qw(firefox-save-and-quit xterm-left-open xterm-without-focus)], "alt-f4", 3, 30);
     if (match_has_tag 'firefox-save-and-quit') {
         # confirm "save&quit"


### PR DESCRIPTION
There is short time period where xterm apears to be unselected and assert_screen finds match, because firefox was closed and xterm will be selected

- Fail: https://openqa.suse.de/tests/4520285#step/firefox_changesaving/26
- Verification run: https://openqa.suse.de/tests/4523021