### PR TITLE
Fix valgrind test in publiccloud

### DIFF
--- a/tests/console/valgrind.pm
+++ b/tests/console/valgrind.pm
@@ -38,6 +38,7 @@ sub run {
     if (is_sle && !main_common::is_updates_tests()) {
         cleanup_registration;
         register_product;
+        add_suseconnect_product(get_addon_fullname('desktop'));
         add_suseconnect_product(get_addon_fullname('sdk'));
     }
     # install requirements


### PR DESCRIPTION
Valgrind addon product misses 'desktop', which is required for adding 'sdk'.

- Related ticket: https://progress.opensuse.org/issues/69565
- Needles: 
- Verification run: [SLES15-SP2 x86_64](https://openqa.suse.de/t4523235) | [SLES15-SP1 x86_64](https://openqa.suse.de/t4523236) | [SLES15 x86_64](https://openqa.suse.de/t4523237) | [SLES15-SP2 s390x](https://openqa.suse.de/t4523238) | [SLES15-SP1 s390x](https://openqa.suse.de/t4523239) | [SLES15 s390x](https://openqa.suse.de/t4523240) | 
