### PR TITLE
Remove AUTOYAST from autoyast_multi_btrfs schedule

### DIFF
--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -3,7 +3,6 @@ name: autoyast_multi_btrfs
 description: >
   Test autoyast installation, while using multi-device Btrfs filesystem
 vars:
-  AUTOYAST: autoyast_sle15/autoyast_multi_btrfs.xml
   DESKTOP: gnome
   ENCRYPT: 1
   NUMDISKS: '4'


### PR DESCRIPTION
Removing AUTOYAST var from the schedule of the test suite autoyast_multi_btrfs, as it overrides the same variable in o3 jobgroups for the corrsponding test suite, leading to failure: https://openqa.opensuse.org/tests/1352380

I have included the AUTOYAST var for sle in Jobgroups pull request: 
JobGroups/SLE_15/x86_64.yaml line 194
https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/256/diffs#14b5739fca83e73d73bda6c083b58b96f0fd3bdc_187_194