### PR TITLE
Enable validation for cryptlvm on pvm

### DIFF
--- a/schedule/yast/encryption/cryptlvm+activate_existing_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+activate_existing_spvm.yaml
@@ -15,6 +15,7 @@ schedule:
   - installation/accept_license
   - installation/scc_registration
   - installation/encrypted_volume_activation
+  - console/validate_activation_encrypted_partition
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -35,3 +36,12 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+test_data:
+  mapped_device: '/dev/mapper/cr-auto-1'
+  device_status:
+    message: 'is active.'
+    properties:
+      type: 'LUKS1'
+      cipher: 'aes-xts-plain64'
+      key_location: 'dm-crypt'
+      mode: 'read/write'


### PR DESCRIPTION
Enable validation module in to cryptlvm+activate_existing for powervm

We just need to use use_ssh_serial_console, then switching works back and forth: https://openqa.suse.de/tests/4529101#step/validate_activation_encrypted_partition/2. Unfortunately the test fails as the device shows as "active" instead of "active and in use" : https://openqa.suse.de/tests/4529102#step/validate_activation_encrypted_partition/6. Trying to figure out what is wrong.

- Related ticket: https://progress.opensuse.org/issues/69406
- Verification run: https://openqa.suse.de/tests/4961403