### PR TITLE
Add record_soft_failure for firefox not responding

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -27,17 +27,22 @@ sub run() {
     $self->start_firefox;
     wait_still_screen;
     send_key_until_needlematch('firefox-help-menu', 'alt-h', 5, 6);
-    send_key_until_needlematch('test-firefox-3',    'a',     5, 6);
+    send_key_until_needlematch('test-firefox-3',    'a',     9, 6);
 
     # close About
     send_key "alt-f4";
     assert_screen 'firefox-html-test';
 
     send_key "alt-f4";
-    assert_screen [qw(firefox-save-and-quit generic-desktop)];
-    if (match_has_tag 'firefox-save-and-quit') {
+    assert_screen [qw(firefox-save-and-quit generic-desktop not-responding), timeout => 90];
+    if (match_has_tag 'not-responding') {
+        record_soft_failure "firefox is not responding, see boo#1174857";
         # confirm "save&quit"
-        send_key_until_needlematch('generic-desktop', 'ret', 5, 6);
+        send_key_until_needlematch('generic-desktop', 'ret', 9, 6);
+    }
+    elsif (match_has_tag 'firefox-save-and-quit') {
+        # confirm "save&quit"
+        send_key_until_needlematch('generic-desktop', 'ret', 9, 6);
     }
 }
 


### PR DESCRIPTION
for KDE live we have issue boo#1174857 and other send_key issue because of
poor performance.

see https://progress.opensuse.org/issues/63892
needle PR:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/677
verifications:
http://10.162.23.47/tests/7935#step/firefox
http://10.162.23.47/tests/7936#step/firefox
