### PR TITLE
Remove DESKTOP from autoyast_installonly.yaml

### DIFF
--- a/schedule/yast/autoyast/autoyast_installonly.yaml
+++ b/schedule/yast/autoyast/autoyast_installonly.yaml
@@ -6,7 +6,6 @@ description: >
   variables. The variables are specified in Job Group or in Test Suite settings.
 vars:
   AUTOYAST_PREPARE_PROFILE: '1'
-  DESKTOP: textmode
 schedule:
   - autoyast/prepare_profile
   - installation/isosize


### PR DESCRIPTION
The particular job schedule is used by multiple test which DESKTOP value should differ.