### PR TITLE
Fix variable assignment in encrypt utils logs

### DIFF
--- a/lib/validate_encrypt_utils.pm
+++ b/lib/validate_encrypt_utils.pm
@@ -74,7 +74,7 @@ sub verify_cryptsetup_properties {
     my ($expected_properties, $actual_properties) = @_;
     record_info("params", "Verify parameters, that are set for crypted volumes");
     foreach my $property (sort keys %{$expected_properties}) {
-        diag("Verifying that expected property $expected_properties->{properties}{$property} corresponds to the actual $actual_properties->{properties}->{$property}");
+        diag("Verifying that expected property $expected_properties->{$property} corresponds to the actual $actual_properties->{$property}");
         assert_equals($expected_properties->{$property}, $actual_properties->{$property},
             "Property of cryptsetup status does not match");
     }


### PR DESCRIPTION
Blank items in the logs ere shown, because the `$expected_properties->{properties}` is wrong, it should be `$expected_properties->{$property} `. The PR fixes the issue.