### PR TITLE
Omit FSS checks on SLE for journalctl

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -37,6 +37,11 @@ sub check_journal {
     return script_run("if [ -s $filename ]; then true; else false; fi");
 }
 
+sub skip_fss_check {
+    # FSS check is not supported by SLE. Disable this check for SLES
+    return is_sle;
+}
+
 sub check_syslog {
     # rsyslog is not installed on tumbleweed anymore
     return !is_tumbleweed && !is_jeos;
@@ -60,12 +65,11 @@ sub run {
     }
     # Enable persistent journal
     assert_script_run("sed -i 's/.*Storage=.*/Storage=persistent/' /etc/systemd/journald.conf");
-    assert_script_run("sed -i 's/.*Seal=.*/Seal=yes/' /etc/systemd/journald.conf");
+    assert_script_run("sed -i 's/.*Seal=.*/Seal=yes/' /etc/systemd/journald.conf") unless skip_fss_check;
     assert_script_run("systemctl restart systemd-journald");
     assert_script_run("journalctl -e | grep -i 'Flush Journal to Persistent Storage'");
     # Setup FSS keys before reboot
-    assert_script_run('journalctl --interval=10s --setup-keys | tee /var/tmp/journalctl-setup-keys.txt');
-    assert_script_run('journalctl --rotate');
+    assert_script_run('journalctl --interval=10s --setup-keys | tee /var/tmp/journalctl-setup-keys.txt && journalctl --rotate') unless skip_fss_check;
     assert_script_run("date '+%F %T' | tee /var/tmp/reboottime");
     assert_script_run("echo 'The batman is going to sleep' | systemd-cat -p info -t batman");
     # Reboot system - public cloud does not handle reboot well atm
@@ -76,7 +80,7 @@ sub run {
         record_info("publiccloud", "Public cloud omits rebooting (temporary workaround)");
     }
     # Check journal state after reboot to trigger bsc#1171858
-    record_soft_failure "bsc#1171858" if (script_run('journalctl --verify --verify-key=`cat /var/tmp/journalctl-setup-keys.txt`') != 0);
+    record_soft_failure "bsc#1171858" if (!skip_fss_check && script_run('journalctl --verify --verify-key=`cat /var/tmp/journalctl-setup-keys.txt`') != 0);
     # Basic journalctl tests: Export journalctl with various arguments and ensure they are not empty
     script_run('echo -e "Reboot time:  `cat /var/tmp/reboottime`\nCurrent time: `date -u \'+%F %T\'`"');
     die "journalctl empty" if check_journal('', "journalctl.txt");
@@ -133,9 +137,15 @@ sub run {
     assert_script_run('journalctl --vacuum-size=100M');
     assert_script_run('journalctl --vacuum-time=1years');
     # Rotate once more and verify the journal afterwards
-    record_soft_failure "bsc#1171858" if (script_run('journalctl --verify --verify-key=`cat /var/tmp/journalctl-setup-keys.txt`') != 0);
-    assert_script_run('journalctl --rotate');
-    record_soft_failure "bsc#1171858" if (script_run('journalctl --verify --verify-key=`cat /var/tmp/journalctl-setup-keys.txt`') != 0);
+    if (skip_fss_check) {
+        assert_script_run('journalctl --verify');
+        assert_script_run('journalctl --rotate');
+        assert_script_run('journalctl --verify');
+    } else {
+        record_soft_failure "bsc#1171858" if (script_run('journalctl --verify --verify-key=`cat /var/tmp/journalctl-setup-keys.txt`') != 0);
+        assert_script_run('journalctl --rotate');
+        record_soft_failure "bsc#1171858" if (script_run('journalctl --verify --verify-key=`cat /var/tmp/journalctl-setup-keys.txt`') != 0);
+    }
 }
 
 sub cleanup {


### PR DESCRIPTION
FSS (Forward Secure Sealing) is not supported on SLE, thus this commit disables checking for it on SLE and Leap. It remains enabled in Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/69481
- Verification runs: [SLE-15-SP2 s390x](https://openqa.suse.de/tests/4531485) | [SLE-15-SP2 x86_64](https://openqa.suse.de/tests/4531486) | [SLE-15-SP1 s390x](https://openqa.suse.de/tests/4531487) | [SLE-15-SP1 x86_64](https://openqa.suse.de/tests/4531488) | [SLE-15 s390x](https://openqa.suse.de/tests/4531489) | [SLE-15 x86_64](https://openqa.suse.de/tests/4531490) | [SLE-12-SP5 s390x](https://openqa.suse.de/tests/4531491) | [SLE-12-SP5 x86_64](https://openqa.suse.de/tests/4531492) | [SLE-12-SP4 s390x](https://openqa.suse.de/tests/4531493) | [SLE-12-SP4 x86_64](https://openqa.suse.de/tests/4531494) | [SLE-12-SP3 x86_64](https://openqa.suse.de/tests/4531495) | [SLE-12-SP2 x86_64](https://openqa.suse.de/tests/4531496) | [Leap](https://openqa.opensuse.org/tests/1355183) | [Tumbleweed](https://openqa.opensuse.org/tests/1355150)
