### PR TITLE
Test rmt feature includes enable/disable, sync, mirror and import

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -219,6 +219,13 @@ Install Repository Mirroring Tool and mariadb database
 
 =cut
 sub rmt_wizard {
+    # add develop version of rmt repo
+    if (get_var("DEV_PATH")) {
+        my $url = get_var("DEV_PATH");
+        zypper_call("ar -f http://download.suse.de/ibs/Devel:/SCC:/RMT/$url/ scc_rmt");
+        zypper_call '--gpg-auto-import-keys ref';
+    }
+
     # install RMT and mariadb
     zypper_call 'in rmt-server';
     zypper_call 'in mariadb';
@@ -246,10 +253,9 @@ sub rmt_wizard {
     send_key 'alt-n';
     assert_screen 'yast2_rmt_ssl_CA_password';
     type_password_twice;
+    assert_screen ['yast2_rmt_firewall', 'yast2_rmt_firewall_disable'], 50;
     if (check_screen 'yast2_rmt_firewall') {
         send_key 'alt-o';
-    } else {
-        assert_screen 'yast2_rmt_firewall_disable';
     }
     wait_still_screen;
     send_key 'alt-n';

--- a/schedule/migration/rmt_feature.yaml
+++ b/schedule/migration/rmt_feature.yaml
@@ -1,0 +1,6 @@
+name:    rmt_feature
+description:    >
+    This is for rmt feature test
+schedule:
+  - boot/boot_to_desktop
+  - x11/rmt/rmt_feature

--- a/tests/x11/rmt/rmt_feature.pm
+++ b/tests/x11/rmt/rmt_feature.pm
@@ -1,0 +1,97 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Add rmt configuration test and basic configuration via
+#    rmt-wizard, test enable/disable products/repo, test rmt sync
+#    rmt mirror, test import SMT data to RMT
+# Maintainer: Yutao wang <yuwang@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use base 'x11test';
+use repo_tools;
+use utils;
+use x11utils 'turn_off_gnome_screensaver';
+
+sub run {
+    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
+    # Avoid blank screen since smt sync needs time
+    turn_off_gnome_screensaver;
+    become_root;
+    rmt_wizard();
+    # sync from SCC
+    rmt_sync;
+    # enable all modules of products at one arch
+    my $pro = get_var("PRODUCT_ALLM");
+    assert_script_run("rmt-cli p e $pro --all-modules");
+    assert_script_run("rmt-cli product list | grep $pro");
+    # enable all modules of products at four arch
+    my $pro1 = get_var("PRODUCT_ALLMA");
+    assert_script_run("rmt-cli products enable --all-modules $pro1");
+    assert_script_run("rmt-cli product list | grep " . $pro1 . "/aarch64");
+    assert_script_run("rmt-cli product list | grep " . $pro1 . "/ppc64le");
+    assert_script_run("rmt-cli product list | grep " . $pro1 . "/s390x");
+    assert_script_run("rmt-cli product list | grep " . $pro1 . "/x86_64");
+    my @proid = split(/\n/, script_output("rmt-cli products list | awk -F '|' '{print \$2}'"));
+    foreach my $i (@proid) {
+        assert_script_run("rmt-cli products disable $i") if ($i =~ /\d{4}/);
+    }
+
+    # enable product with product ID 1798-Web and Scripting Module/15.1/x86_64
+    # 1973-Web and Scripting Module/15.2/aarch64 1974-Web and Scripting Module/15.2/ppc64le
+    assert_script_run("rmt-cli product enable 1798 1973 1974");
+    assert_script_run("rmt-cli product list | grep 1798");
+    assert_script_run("rmt-cli product list | grep 1973");
+    assert_script_run("rmt-cli product list | grep 1974");
+
+    # disable product with product ID
+    assert_script_run("rmt-cli product disable 1798 1973 1974");
+
+    # enable repo with repo ID 3393-SLE-Module-Web-Scripting15-SP1-Pool for sle-15-x86_64
+    # 3391-SLE-Module-Web-Scripting15-SP1-Updates for sle-15-x86_64
+    assert_script_run("rmt-cli repo enable 3393 3391");
+    assert_script_run("rmt-cli repo list | grep 3393");
+    assert_script_run("rmt-cli repo list | grep 3391");
+
+    # disable repo with repo ID
+    assert_script_run("rmt-cli repo disable 3393 3391");
+
+    # mirror packages
+    rmt_enable_pro;
+    rmt_mirror_repo();
+    assert_script_run("rmt-cli product list | grep sle-module-legacy/15/x86_64");
+
+    # import smt data
+    my $datapath = "/rmtdata/";
+    my $datafile = get_var("SMT_DATA_FILE");
+    my $dataurl  = get_var("SMT_DATA_URL");
+    assert_script_run("mkdir -p $datapath");
+    assert_script_run("cd $datapath");
+    assert_script_run("wget -q " . $dataurl . $datafile);
+    assert_script_run("tar -xzvf $datafile -C $datapath");
+    assert_script_run("chown -R _rmt:nginx $datapath");
+    assert_script_run("sudo rmt-data-import -d /rmtdata/smt-data-export/");
+
+    # check imported data 4205-SLE-Module-Live-Patching15-SP2-Source-Pool for sle-15-x86_64
+    # 4203-SLE-Module-Live-Patching15-SP2-Pool for sle-15-x86_64
+    assert_script_run("rmt-cli repo enable 4205 4203");
+    assert_script_run("rmt-cli repo list");
+    assert_script_run("rmt-cli repo list | grep 4205");
+    assert_script_run("rmt-cli repo list | grep 4203");
+
+
+    type_string "killall xterm\n";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
To test rmt feature includes enable/disable, sync, mirror and
import SMT data to RMT

- Related ticket:
   https://progress.opensuse.org/issues/69166
   https://progress.opensuse.org/issues/69265
   https://progress.opensuse.org/issues/69271
   https://progress.opensuse.org/issues/69277
- Verification run: https://openqa.suse.de/tests/4546827#
