### PR TITLE
Add MDS_TAA and MITIGATIONS testcases for CPU_BUGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PERL5LIB_:=../..:os-autoinst:lib:tests/installation:tests/x11:tests/qa_automation:tests/virt_autotest:$$PERL5LIB
+PERL5LIB_:=../..:os-autoinst:lib:tests/installation:tests/x11:tests/qa_automation:tests/virt_autotest:tests/cpu_bugs:$$PERL5LIB
 
 .PHONY: all
 all:

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2520,6 +2520,9 @@ sub load_mitigation_tests {
     if (get_var('TAA')) {
         loadtest "cpu_bugs/taa";
     }
+    if (get_var('MDS_TAA')) {
+        loadtest "cpu_bugs/mds_taa";
+    }
     if (get_var('ITLB')) {
         loadtest "cpu_bugs/itlb";
     }

--- a/tests/cpu_bugs/l1tf.pm
+++ b/tests/cpu_bugs/l1tf.pm
@@ -9,7 +9,7 @@
 
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: James Wang <jnwang@suse.com>
-
+package l1tf;
 use strict;
 use warnings;
 
@@ -22,11 +22,12 @@ use power_action_utils 'power_action';
 
 use Mitigation;
 
-my %mitigations_list =
+our %mitigations_list =
   (
-    name                   => "l1tf",
-    CPUID                  => hex '10000000',
-    IA32_ARCH_CAPABILITIES => 8,                #bit3 --SKIP_L1TF_VMENTRY
+    name => "l1tf",
+    #Refer to https://software.intel.com/security-software-guidance/insights/processors-affected-l1-terminal-fault
+    CPUID                  => hex 'ffffffff',    #Ignore CPUID checking
+    IA32_ARCH_CAPABILITIES => 1,                 #Use MSR bit#0 RDCL_NO check
     parameter              => 'l1tf',
     cpuflags               => ['flush_l1d'],
     sysfs_name             => "l1tf",

--- a/tests/cpu_bugs/mds_taa.pm
+++ b/tests/cpu_bugs/mds_taa.pm
@@ -1,0 +1,121 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: CPU BUGS on Linux kernel check
+# Maintainer: James Wang <jnwang@suse.com>
+
+use strict;
+use warnings;
+
+use base "consoletest";
+use bootloader_setup;
+use strict;
+use testapi;
+use utils;
+use power_action_utils 'power_action';
+
+use Mitigation;
+use mds;
+use taa;
+
+print "mds_taa.pm -> load\n";
+
+my %mds_taa_list =
+  (
+    name       => "mds_taa",
+    parameter  => ["mds", "tsx_async_abort"],
+    sysfs_name => ["mds", "tsx_async_abort"],
+    sysfs      => {
+        off => {
+            mds             => "Vulnerable; SMT vulnerable",
+            tsx_async_abort => "Vulnerable",
+        },
+        full => {
+            mds             => "Mitigation: Clear CPU buffers; SMT vulnerable",
+            tsx_async_abort => "Mitigation: Clear CPU buffers; SMT vulnerable",
+        },
+        default => {
+            mds             => "Mitigation: Clear CPU buffers; SMT vulnerable",
+            tsx_async_abort => "Mitigation: Clear CPU buffers; SMT vulnerable",
+        },
+        "full,nosmt" => {
+            mds             => "Mitigation: Clear CPU buffers; SMT disabled",
+            tsx_async_abort => "Mitigation: Clear CPU buffers; SMT disabled",
+        },
+    },
+    cmdline => [
+        "full",
+        "off",
+        "full,nosmt",
+    ],
+  );
+
+sub update_list_for_qemu {
+    my $self = shift;
+
+    $mds_taa_list{sysfs}->{full}->{mds}         =~ s/SMT vulnerable/SMT Host state unknown/ig;
+    $mds_taa_list{sysfs}->{"full,nosmt"}->{mds} =~ s/SMT disabled/SMT Host state unknown/ig;
+    $mds_taa_list{sysfs}->{default}->{mds}      =~ s/SMT vulnerable/SMT Host state unknown/ig;
+    $mds_taa_list{sysfs}->{off}->{mds} = "Vulnerable; SMT Host state unknown";
+
+    $mds_taa_list{sysfs}->{full}->{tsx_async_abort}         =~ s/SMT vulnerable/SMT Host state unknown/ig;
+    $mds_taa_list{sysfs}->{"full,nosmt"}->{tsx_async_abort} =~ s/SMT disabled/SMT Host state unknown/ig;
+    $mds_taa_list{sysfs}->{default}->{tsx_async_abort}      =~ s/SMT vulnerable/SMT Host state unknown/ig;
+
+    if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/) {
+        $mds_taa_list{sysfs}->{default}->{mds}                  = 'Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown';
+        $mds_taa_list{sysfs}->{default}->{tsx_async_abort}      = 'Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown';
+        $mds_taa_list{sysfs}->{off}->{mds}                      = $mds_taa_list{sysfs}->{default}->{mds};
+        $mds_taa_list{sysfs}->{off}->{tsx_async_abort}          = $mds_taa_list{sysfs}->{default}->{mds};
+        $mds_taa_list{sysfs}->{full}->{mds}                     = $mds_taa_list{sysfs}->{default}->{mds};
+        $mds_taa_list{sysfs}->{full}->{tsx_async_abort}         = $mds_taa_list{sysfs}->{default}->{tsx_async_abort};
+        $mds_taa_list{sysfs}->{'full,nosmt'}->{mds}             = $mds_taa_list{sysfs}->{default}->{mds};
+        $mds_taa_list{sysfs}->{'full,nosmt'}->{tsx_async_abort} = $mds_taa_list{sysfs}->{default}->{tsx_async_abort};
+    }
+}
+
+sub run {
+    my $self = shift;
+
+    my $taa_obj     = taa->new($taa::mitigations_list);
+    my $mds_obj     = Mitigation->new(\%mds::mitigations_list);
+    my $taa_vul_ret = $taa_obj->vulnerabilities();
+    my $mds_vul_ret = $mds_obj->vulnerabilities();
+    print "taa_vul_ret = $taa_vul_ret\n";
+    print "mds_vul_ret = $mds_vul_ret\n";
+
+    if ($taa_vul_ret and $mds_vul_ret) {
+        record_info("Both TAA and MDS", "Testing will continue.");
+        if (check_var('BACKEND', 'qemu')) {
+            update_list_for_qemu();
+        }
+        my $mds_taa_obj = Mitigation->new(\%mds_taa_list);
+        $mds_taa_obj->do_test();
+    } elsif ($taa_vul_ret and !$mds_vul_ret) {
+        record_info("TAA vulnerable only", "launch TAA testing");
+        autotest::loadtest("tests/cpu_bugs/taa.pm");
+    } elsif (!$taa_vul_ret and $mds_vul_ret) {
+        record_info("MDS vulnerable only", "launch MDS testing");
+        autotest::loadtest("tests/cpu_bugs/mds.pm");
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    select_console 'root-console';
+    assert_script_run(
+"md /tmp/upload_mitigations; cp " . $Mitigation::syspath . "* /tmp/upload_mitigations; cp /proc/cmdline /tmp/upload_mitigations; lscpu >/tmp/upload_mitigations/cpuinfo; tar -jcvf /tmp/upload_mitigations.tar.bz2 /tmp/upload_mitigations"
+    );
+    remove_grub_cmdline_settings('mds=[a-z,]*');
+    remove_grub_cmdline_settings('taa=[a-z,]*');
+    grub_mkconfig;
+    upload_logs '/tmp/upload_mitigations.tar.bz2';
+}
+
+1;

--- a/tests/cpu_bugs/meltdown.pm
+++ b/tests/cpu_bugs/meltdown.pm
@@ -20,7 +20,7 @@ use power_action_utils 'power_action';
 use testapi;
 use utils;
 
-my $mitigations_list =
+our $mitigations_list =
   {
     name                   => "meltdown",
     CPUID                  => hex '20000000',

--- a/tests/cpu_bugs/mitigations.pm
+++ b/tests/cpu_bugs/mitigations.pm
@@ -12,58 +12,196 @@
 
 use strict;
 use warnings;
-
 use base "consoletest";
 use bootloader_setup;
-use strict;
 use testapi;
 use utils;
 use power_action_utils 'power_action';
-
+use Data::Dumper;
 use Mitigation;
 
+my @mitigation_module = qw(l1tf mds meltdown spectre_v2 spectre_v4 taa);
+#MIssing itlb, spectre_v1
+foreach my $item (@mitigation_module) {
+    require "$item.pm";
+}
 my %mitigations_list =
   (
     name       => "mitigations",
     parameter  => 'mitigations',
-    sysfs_name => ["mds", "l1tf", "meltdown", "spec_store_bypass", "spectre_v2"],
+    sysfs_name => ["itlb_multihit", "l1tf", "mds", "meltdown", "spec_store_bypass", "spectre_v1", "spectre_v2", "tsx_async_abort"],
     sysfs      => {
-        off => {
-            mds               => "Mitigation: Clear CPU buffers; SMT vulnerable",
-            l1tf              => "Mitigation: PTE Inversion; VMX: vulnerable",
-            spectre_v2        => "Vulnerable,.*IBPB: disabled,.*STIBP: disabled",
-            meltdown          => "Vulnerable",
-            spec_store_bypass => "Vulnerable",
+        auto => {
+            itlb_multihit => "KVM: Mitigation: Split huge pages",
+            spectre_v1    => "Mitigation: usercopy/swapgs barriers and __user pointer sanitization",
         },
-        auto_nosmt => {
-            mds  => "Mitigation: Clear CPU buffers; SMT disabled",
-            l1tf => "Mitigation: PTE Inversion; VMX: conditional cache flushes, SMT disabled",
+        'auto,nosmt' => {
+            itlb_multihit => "KVM: Mitigation: Split huge pages",
+            spectre_v1    => "Mitigation: usercopy/swapgs barriers and __user pointer sanitization",
+        },
+        off => {
+            itlb_multihit => "KVM: Vulnerable",
+            spectre_v1    => "Vulnerable: __user pointer sanitization and usercopy barriers only; no swapgs barriers",
         },
     },
-    cmdline => [
-        "auto,nosmt",
-        "off",
-    ],
+    cmdline => ["auto,nosmt", "off", "auto"],
   );
 
-sub check_sysfs {
-    my ($self, $value) = @_;
-    record_info('mitigations', "this check_sysfs is overwrited!");
-    foreach my $sysfs (@{$self->Sysfs()}) {
-        assert_script_run('cat ' . $Mitigation::syspath . $sysfs);
-        if (@_ == 2) {
-            assert_script_run(
-                'cat ' . $Mitigation::syspath . $sysfs . '| grep ' . '"' . $self->sysfs($value)->{$sysfs} . '"');
+sub run {
+    my $self = shift;
+    select_console 'root-console';
+
+    # When set VUL_SYSFS_DEBUG=1,
+    # the test ONLY collects 'sysfs: /sys/devices/system/cpu/vulnerabilities/*'
+    # and convert it to hash, then report softfail.
+    if (get_var("VUL_SYSFS_DEBUG")) {
+        record_info('SYSFS2HASH', "VUL_SYSFS_DEBUG is set");
+        dump_sysfs_to_hash();
+        record_info("DEBUG", "Only for vulnerabilities sysfs to hash");
+        return;
+    }
+
+    foreach my $item (@mitigation_module) {
+        my $obj;
+        my $current_list;
+
+        #UPDATE list for QEMU first
+        if (check_var('BACKEND', 'qemu')) {
+            mds::smt_status_qemu();
+            taa::update_list_for_qemu();
+        }
+
+        #Unable to use dynamic hash name because limitations:
+        #Can't use string "taa::mitigations_list" as a HASH ref while "strict refs" in use.
+        if ($item eq 'taa' && $taa::mitigations_list) {
+            $current_list = $taa::mitigations_list;
+            $obj          = taa->new($current_list);
+            $item         = "tsx_async_abort";
+        } elsif ($item eq 'meltdown' && $meltdown::mitigations_list) {
+            $current_list = $meltdown::mitigations_list;
+            $obj          = meltdown->new($current_list);
+        } elsif ($item eq 'mds' && %mds::mitigations_list) {
+            $current_list = \%mds::mitigations_list;
+            $obj          = Mitigation->new($current_list);
+        } elsif ($item eq 'l1tf' && %l1tf::mitigations_list) {
+            $current_list = \%l1tf::mitigations_list;
+            $obj          = Mitigation->new($current_list);
+        } elsif ($item eq 'spectre_v2' && %spectre_v2::mitigations_list) {
+            $current_list = \%spectre_v2::mitigations_list;
+            $obj          = Mitigation->new($current_list);
+        } elsif ($item eq 'spectre_v4' && %spectre_v4::mitigations_list) {
+            $current_list = \%spectre_v4::mitigations_list;
+            $obj          = Mitigation->new($current_list);
+            $item         = "spec_store_bypass";
+        } else {
+            record_info("undefine vulnerabilities items: $item");
+        }
+        die "Unable to get vulnerabilities instance, exit!" unless $obj;
+        my $ret = $obj->vulnerabilities();
+        if ($ret eq 1) {
+            #off
+            $mitigations_list{sysfs}->{off}->{$item} = $current_list->{sysfs}->{off};
+            #auto
+            if (exists $current_list->{sysfs}->{auto}) {
+                $mitigations_list{sysfs}->{auto}->{$item} = $current_list->{sysfs}->{auto};
+            } elsif (exists $current_list->{sysfs}->{flush}) {
+                $mitigations_list{sysfs}->{auto}->{$item} = $current_list->{sysfs}->{flush};
+            } elsif (exists $current_list->{sysfs}->{full}) {
+                $mitigations_list{sysfs}->{auto}->{$item} = $current_list->{sysfs}->{full};
+            }
+            #default
+            if (exists $current_list->{sysfs}->{default}) {
+                $mitigations_list{sysfs}->{default}->{$item} = $current_list->{sysfs}->{default};
+            } else {
+                $mitigations_list{sysfs}->{default}->{$item} = $mitigations_list{sysfs}->{auto}->{$item};
+            }
+            #nosmt
+            if (exists $current_list->{sysfs}->{'full,nosmt'}) {
+                $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = $current_list->{sysfs}->{'full,nosmt'};
+            } elsif (exists $current_list->{sysfs}->{'flush_nosmt'}) {
+                $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = $current_list->{sysfs}->{'flush_nosmt'};
+            } elsif (exists $current_list->{sysfs}->{full_nosmt}) {
+                $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = $current_list->{sysfs}->{full_nosmt};
+            } else {
+                print "$item is vulnerabilities, but unable to get sysfs define on nosmt, try auto";
+                $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = $mitigations_list{sysfs}->{auto}->{$item};
+                if ($item eq 'spectre_v2') {
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Full generic retpoline,.*IBPB: conditional, IBRS_FW*";
+                }
+            }
+            if (check_var('BACKEND', 'qemu')) {
+                #spectre_v2
+                if ($item eq 'spectre_v2') {
+                    $mitigations_list{sysfs}->{auto}->{'spectre_v2'}         =~ s/STIBP: conditional/STIBP: disabled/g;
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{'spectre_v2'} =~ s/STIBP: conditional/STIBP: disabled/g;
+                }
+                #NO-IBRS
+                if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/ && $item eq 'mds') {
+                    $mitigations_list{sysfs}->{auto}->{mds}         = 'Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown';
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{mds} = $mitigations_list{sysfs}->{auto}->{mds};
+                    $mitigations_list{sysfs}->{off}->{mds}          = 'Vulnerable; SMT Host state unknown';
+                }
+                if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/ && $item eq 'spec_store_bypass') {
+                    $mitigations_list{sysfs}->{auto}->{spec_store_bypass}         = 'Vulnerable';
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{spec_store_bypass} = $mitigations_list{sysfs}->{auto}->{spec_store_bypass};
+                    $mitigations_list{sysfs}->{default}->{spec_store_bypass}      = $mitigations_list{sysfs}->{auto}->{spec_store_bypass};
+                }
+                if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/ && $item eq 'spectre_v2') {
+                    $mitigations_list{sysfs}->{auto}->{spectre_v2}         = 'Mitigation: Full generic retpoline, STIBP: disabled, RSB filling';
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{spectre_v2} = $mitigations_list{sysfs}->{auto}->{spectre_v2};
+                    $mitigations_list{sysfs}->{off}->{spectre_v2}          = 'Vulnerable, STIBP: disabled';
+                }
+                if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/ && $item eq 'tsx_async_abort') {
+                    $mitigations_list{sysfs}->{off}->{tsx_async_abort}  = 'Vulnerable';
+                    $mitigations_list{sysfs}->{auto}->{tsx_async_abort} = 'Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown';
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{tsx_async_abort} = $mitigations_list{sysfs}->{auto}->{tsx_async_abort};
+                    $mitigations_list{sysfs}->{default}->{tsx_async_abort}      = $mitigations_list{sysfs}->{auto}->{tsx_async_abort};
+                }
+                if (get_var('MACHINE', '') =~ /passthrough/ && $item eq 'l1tf') {
+                    $mitigations_list{sysfs}->{auto}->{l1tf}         = 'Mitigation: PTE Inversion; VMX: flush not necessary, SMT disabled';
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{l1tf} = $mitigations_list{sysfs}->{auto}->{l1tf};
+                    $mitigations_list{sysfs}->{off}->{l1tf}          = $mitigations_list{sysfs}->{auto}->{l1tf};
+                    $mitigations_list{sysfs}->{default}->{l1tf}      = $mitigations_list{sysfs}->{auto}->{l1tf};
+                } elsif ($item eq 'l1tf') {
+                    $mitigations_list{sysfs}->{auto}->{l1tf}         = "Mitigation: PTE Inversion";
+                    $mitigations_list{sysfs}->{off}->{l1tf}          = $mitigations_list{sysfs}->{auto}->{l1tf};
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{l1tf} = $mitigations_list{sysfs}->{auto}->{l1tf};
+                    $mitigations_list{sysfs}->{default}->{l1tf}      = $mitigations_list{sysfs}->{auto}->{l1tf};
+                }
+            }
+        } elsif ($ret eq 0) {
+            record_info("Not affected", "$item");
+            $mitigations_list{sysfs}->{auto}->{$item}         = "Not affected";
+            $mitigations_list{sysfs}->{off}->{$item}          = "Not affected";
+            $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Not affected";
+            if ($item eq 'spectre_v2') {
+                record_info("EIBRS", "This machine support EIBRS on spectre_v2");
+                $mitigations_list{sysfs}->{auto}->{$item}         = "Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling";
+                $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling";
+                $mitigations_list{sysfs}->{off}->{$item}          = $current_list->{sysfs}->{off};
+            }
+        } else {
+            die("$item vulnerabilities is unkown");
         }
     }
-}
 
-sub run {
+    #Handle itlb_multihit
     if (check_var('BACKEND', 'qemu')) {
+        if (get_var('MACHINE', '') =~ /passthrough/) {
+            record_info("itlb_multihit Not affected", "itlb_multihit is not affected on qemu passthrough");
+            $mitigations_list{sysfs}->{auto}->{'itlb_multihit'}         = "Not affected";
+            $mitigations_list{sysfs}->{off}->{'itlb_multihit'}          = "Not affected";
+            $mitigations_list{sysfs}->{'auto,nosmt'}->{'itlb_multihit'} = "Not affected";
+        } else {
+            $mitigations_list{sysfs}->{off}->{'itlb_multihit'}          = "KVM: Vulnerable";
+            $mitigations_list{sysfs}->{auto}->{'itlb_multihit'}         = "KVM: Vulnerable";
+            $mitigations_list{sysfs}->{'auto,nosmt'}->{'itlb_multihit'} = "KVM: Vulnerable";
+        }
     }
-    my $obj = Mitigation->new(\%mitigations_list);
-    #run base function testing
-    $obj->do_test();
+
+    print Dumper \%mitigations_list;
+    my $test_obj = Mitigation->new(\%mitigations_list);
+    $test_obj->do_test();
 }
 
 
@@ -71,11 +209,52 @@ sub post_fail_hook {
     my ($self) = @_;
     select_console 'root-console';
     assert_script_run(
-"md /tmp/upload_mitigations; cp " . $Mitigation::syspath . "* /tmp/upload_mitigations; cp /proc/cmdline /tmp/upload_mitigations; lscpu >/tmp/upload_mitigations/cpuinfo; tar -jcvf /tmp/upload_mitigations.tar.bz2 /tmp/upload_mitigations"
+"md /tmp/upload_mitigations; cp " . $Mitigation::syspath . "* /tmp/upload_mitigations; cp /proc/cmdline /tmp/upload_mitigations; head /sys/devices/system/cpu/vulnerabilities/* > /tmp/upload_mitigations/vulnerabilities; lscpu >/tmp/upload_mitigations/cpuinfo; tar -jcvf /tmp/upload_mitigations.tar.bz2 /tmp/upload_mitigations"
     );
     remove_grub_cmdline_settings('mitigations=[a-z,]*');
     grub_mkconfig;
     upload_logs '/tmp/upload_mitigations.tar.bz2';
 }
+
+sub dump_sysfs_to_hash {
+    my ($self) = @_;
+    my %ret_data;
+
+    assert_script_run('cat /proc/cmdline');
+    my $ret = script_run('grep "' . "mitigations" . '=[a-z]*" /proc/cmdline');
+    if ($ret eq 0) {
+        remove_grub_cmdline_settings("mitigations=[a-z,]*");
+    }
+    grub_mkconfig();
+    Mitigation::reboot_and_wait($self, 150);
+    assert_script_run('cat /proc/cmdline');
+    script_run("head /sys/devices/system/cpu/vulnerabilities/* > /tmp/vulnerabilities.manual.txt");
+    upload_logs "/tmp/vulnerabilities.manual.txt";
+
+    my @kernel_parameter = ("off", "auto", "auto,nosmt");
+    foreach my $cmd (@kernel_parameter) {
+        record_info("$cmd");
+        add_grub_cmdline_settings("mitigations=" . $cmd);
+        grub_mkconfig();
+        clear_console;
+        Mitigation::reboot_and_wait($self, 150);
+        assert_script_run('cat /proc/cmdline');
+        my $script_output = script_output("grep -H . /sys/devices/system/cpu/vulnerabilities/*");
+        my %tmp_hash;
+        foreach my $line (split(/\n/, $script_output)) {
+            my @tmp = split(/([^\/]+?):(.+)/, $line);
+            $tmp_hash{$tmp[1]} = $tmp[2];
+        }
+        $ret_data{$cmd} = \%tmp_hash;
+
+        $cmd =~ s/,/_/ig;
+        my $logfile = "vulnerabilities.$cmd.txt";
+        script_run("head /sys/devices/system/cpu/vulnerabilities/* > /tmp/$logfile");
+        upload_logs "/tmp/$logfile";
+        remove_grub_cmdline_settings("mitigations=[a-z,]*");
+    }
+    print Dumper \%ret_data;
+}
+
 
 1;

--- a/tests/cpu_bugs/spectre_v2.pm
+++ b/tests/cpu_bugs/spectre_v2.pm
@@ -9,7 +9,7 @@
 
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: James Wang <jnwang@suse.com>
-
+package spectre_v2;
 use strict;
 use warnings;
 
@@ -26,7 +26,7 @@ my $eibrs_string_on      = "Mitigation: Enhanced IBRS, IBPB: always-on, RSB fill
 my $eibrs_string_default = "Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling";
 my $retpoline_string     = "Mitigation: Full generic retpoline,";
 
-my %mitigations_list =
+our %mitigations_list =
   (
     name                   => "spectre_v2",
     CPUID                  => hex '4000000',

--- a/tests/cpu_bugs/spectre_v2_user.pm
+++ b/tests/cpu_bugs/spectre_v2_user.pm
@@ -9,7 +9,7 @@
 
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: James Wang <jnwang@suse.com>
-
+package spectre_v2_user;
 use strict;
 use warnings;
 
@@ -22,7 +22,7 @@ use power_action_utils 'power_action';
 
 use Mitigation;
 
-my %mitigations_list =
+our %mitigations_list =
   (
     name                   => "spectre_v2_user",
     CPUID                  => hex 'C000000',
@@ -61,7 +61,7 @@ sub run {
         $mitigations_list{sysfs}->{auto}         =~ s/STIBP: conditional/STIBP: disabled/g;
     }
     my $obj = Mitigation->new(\%mitigations_list);
-    if (($obj->read_cpuid() & $obj->CPUID()) eq 0) {
+    if (($obj->read_cpuid_edx() & $obj->CPUID()) eq 0) {
         $mitigations_list{sysfs}->{off} = ".*STIBP: disabled";
     }
     #run base function testing

--- a/tests/cpu_bugs/spectre_v4.pm
+++ b/tests/cpu_bugs/spectre_v4.pm
@@ -9,7 +9,7 @@
 
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: James Wang <jnwang@suse.com>
-
+package spectre_v4;
 use strict;
 use warnings;
 
@@ -22,7 +22,7 @@ use utils;
 
 use Mitigation;
 
-my %mitigations_list =
+our %mitigations_list =
   (
     name                   => "spectre_v4",
     CPUID                  => hex '80000000',


### PR DESCRIPTION
These changes will address the followed requirements:
1. The mitigation switch for MDS and TAA are linkage, test individual
or combination mitigation according to vulnerable detection status.
2. Tests kernel boot options "mitigations=auto/off/auto,nosmt" by
verifying sysfs changes according to vulnerable detection status.

Major changes to implement above requirements:
1. Add/improve TAA and  L1TF vulnerable detection.
2. Add/improve read_cpuid_*
3. Mitigation.pm: Handle ARRAY or non-ARRAY on check_default_status(),
check_sysfs(), add_parameter() and remove_parameter()
4. Workflow for MDS_TAA and MITIGATIONS:
new Mitigation obj with hash -> check vulnerable -> update hash -> do_test
5. Fill checking pairs between mitigation switch and sysfs output.
6. Share mitigations_list from each tests.

Verification URL: http://10.67.19.72/