### PR TITLE
firefox: Add wait time and define timeout due to blinking cursor

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -598,8 +598,9 @@ sub start_firefox_with_profile {
     type_string "killall -9 firefox;rm -rf .mozilla .config/iced* .cache/iced* .local/share/gnome-shell/extensions/*;cp -rp .mozilla_first_run .mozilla\n";
     # Start Firefox
     type_string "firefox $url >firefox.log 2>&1 &\n";
-    wait_still_screen 3;
+    wait_still_screen 2,                4;
     assert_screen 'firefox-url-loaded', 300;
+    wait_still_screen 2,                4;
 }
 
 sub start_firefox {
@@ -672,7 +673,8 @@ sub firefox_open_url {
     my $counter = 1;
     while (1) {
         # make sure firefox window is focused
-        wait_screen_change { assert_and_click 'firefox_titlebar' };
+        assert_and_click 'firefox_titlebar';
+        wait_still_screen 1, 2;
         send_key 'alt-d';
         send_key 'delete';
         send_key 'alt-d';

--- a/tests/x11/firefox/firefox_downloading.pm
+++ b/tests/x11/firefox/firefox_downloading.pm
@@ -41,9 +41,8 @@ my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.0/iso/
 
 sub dl_location_switch {
     my ($tg) = @_;
-    wait_screen_change {
-        send_key "alt-e";
-    };
+    send_key "alt-e";
+    wait_still_screen 2, 4;
     send_key "n";
     assert_screen('firefox-preferences');
 

--- a/tests/x11/firefox/firefox_extensions.pm
+++ b/tests/x11/firefox/firefox_extensions.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -39,6 +39,7 @@ sub run {
     assert_and_click "firefox-extensions";
     assert_and_click 'firefox-searchall-addon';
     type_string "flagfox\n";
+    wait_still_screen 2, 4;
     assert_and_click 'firefox-extensions-flagfox';
     wait_still_screen 3;
     assert_and_click 'firefox-extensions-add-to-firefox';

--- a/tests/x11/firefox/firefox_passwd.pm
+++ b/tests/x11/firefox/firefox_passwd.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -46,7 +46,7 @@ sub run {
     $self->start_firefox_with_profile;
 
     send_key "alt-e";
-    wait_still_screen 3;
+    wait_still_screen 2, 4;
     send_key "n";
     assert_and_click('firefox-passwd-security');
 


### PR DESCRIPTION
- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10800
- Verification run:
https://openqa.suse.de/tests/4541957 
https://openqa.suse.de/tests/4541958
https://openqa.suse.de/tests/4541959
https://openqa.suse.de/tests/4541985
https://openqa.suse.de/tests/4541979
https://openqa.suse.de/tests/4541984
https://openqa.suse.de/tests/4541981
https://openqa.suse.de/tests/4541983
https://openqa.suse.de/tests/4541963
https://openqa.suse.de/tests/4541964
https://openqa.suse.de/tests/4541965
https://openqa.suse.de/tests/4542888
https://openqa.suse.de/tests/4542889