### PR TITLE
Add validation to cryptlvm+cancel_existing scenario

### DIFF
--- a/lib/validate_encrypt_utils.pm
+++ b/lib/validate_encrypt_utils.pm
@@ -35,7 +35,7 @@ sub parse_devices_in_crypttab {
 
 sub parse_cryptsetup_status {
     my ($dev)  = @_;
-    my @lines  = split(/\n/, script_output("cryptsetup status $dev"));
+    my @lines  = split(/\n/, script_output("cryptsetup status $dev", proceed_on_failure => 1));
     my $status = {};
     foreach (@lines) {
         if (!exists $status->{message} && $_ =~ /is (in)?active/) {
@@ -65,7 +65,7 @@ sub verify_number_of_encrypted_devices {
 
 sub verify_cryptsetup_message {
     my ($expected_message, $actual_message) = @_;
-    record_info("active volumes", "Verify crypted volume is active");
+    record_info("Assert volumes status", "Verify crypted volume status based on test_data expectations");
     assert_matches(qr/$expected_message/, $actual_message,
         "Message of cryptsetup status does not match regex");
 }

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -14,6 +14,7 @@ schedule:
   - installation/accept_license
   - installation/scc_registration
   - installation/encrypted_volume_activation
+  - console/validate_encrypted_partition_not_activated
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -32,3 +33,5 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+test_data:
+  <<: !include test_data/yast/encryption/cryptlvm+cancel_existing.yaml

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -14,6 +14,7 @@ schedule:
   - installation/accept_license
   - installation/scc_registration
   - installation/encrypted_volume_activation
+  - console/validate_encrypted_partition_not_activated
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -33,3 +34,5 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+test_data:
+  <<: !include test_data/yast/encryption/cryptlvm+cancel_existing.yaml

--- a/test_data/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/test_data/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -1,0 +1,3 @@
+mapped_device: '/dev/mapper/cr-auto-2'
+device_status:
+  message: 'is inactive.'

--- a/tests/console/validate_encrypted_partition_not_activated.pm
+++ b/tests/console/validate_encrypted_partition_not_activated.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validation module to check that partition is inactive.
+# Covered scenarios:
+# - Validate that hard disk encryption(LUKS) is not activated on the configured partitioning
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "installbasetest";
+use scheduler 'get_test_suite_data';
+use testapi;
+use validate_encrypt_utils;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    select_console 'install-shell';
+    my $status = parse_cryptsetup_status($test_data->{mapped_device});
+    verify_cryptsetup_message($test_data->{device_status}->{message}, $status->{message});
+    select_console 'installation';
+}
+
+1;


### PR DESCRIPTION
The https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10744/files#diff-02e3850fe36faeb4fe731d27cdf08818
returns an error code 4 when the encryption is not activated. Passing the proceed_on_failure so we can run assertions even
if the script_output gets the error code.

- Related ticket: https://progress.opensuse.org/issues/69040
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP2&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2310801
