### PR TITLE
Fix Tumbleweed vagrant tests

### DIFF
--- a/data/virtualization/Vagrantfile
+++ b/data/virtualization/Vagrantfile
@@ -3,13 +3,13 @@
 Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |virtbox|
-    virtbox.memory = 2048
-    virtbox.cpus = 2
+    virtbox.memory = 512
+    virtbox.cpus = 1
   end
 
   config.vm.provider :libvirt do |libvirt|
-    libvirt.cpus = 2
-    libvirt.memory = 2048
+    libvirt.cpus = 1
+    libvirt.memory = 512
   end
 
   config.vm.hostname = "vm-test"

--- a/data/virtualization/Vagrantfile
+++ b/data/virtualization/Vagrantfile
@@ -4,11 +4,11 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |virtbox|
     virtbox.memory = 2048
-    virtbox.cpus = 4
+    virtbox.cpus = 2
   end
 
   config.vm.provider :libvirt do |libvirt|
-    libvirt.cpus = 4
+    libvirt.cpus = 2
     libvirt.memory = 2048
   end
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/69292
- Needles: no needles
- Verification run: https://openqa.opensuse.org/tests/1372488#step/tumbleweed/61

The tumbleweed box test fails due to CPU soft lock and I think it is because of a too big VM created on the openqa worker. I would propose to try out a much smaller size.

In the verification run you can see that it is not failing with the usual error (https://openqa.opensuse.org/tests/1369026#step/tumbleweed/48). It is instead failing due to the current Virtualbox issue which is expected, see: https://forums.opensuse.org/showthread.php/542638-Virtualbox-Crash-with-kernel-5-8
