### PR TITLE
Accepts gpg keys of added repos

### DIFF
--- a/tests/support_server/configure.pm
+++ b/tests/support_server/configure.pm
@@ -47,7 +47,7 @@ sub _remove_installation_media_and_add_network_repos {
     if (get_var("SLENKINS_REPO")) {
         $script .= "zypper -n --no-gpg-checks ar --refresh '" . get_var("SLENKINS_REPO") . "' slenkins\n";
     }
-
+    $script .= "zypper --gpg-auto-import-keys ref -f\n";
     script_output($script);
 }
 


### PR DESCRIPTION
The gpg keys were missing for the added repos causing following calls on
zypper to return 106 - ZYPPER_EXIT_INF_REPOS_SKIPPED. Refresh the repos and
accept the gpg keys automatically solves the problem.

- Related ticket: https://progress.opensuse.org/issues/69862
- Verification run: http://aquarius.suse.cz/tests/3019#details