### PR TITLE
Add yaml schedule for the ssh-X test scenario

### DIFF
--- a/schedule/yast/ssh-x.yaml
+++ b/schedule/yast/ssh-x.yaml
@@ -1,0 +1,42 @@
+name:           ssh-X
+description:    >
+  Conduct an installation using ssh with X-Forwarding.
+  Might only be effective for zVM and powerVM
+vars:
+  DESKTOP: textmode
+  PATTERNS: minimal,base
+  VIDEOMODE: ssh-x
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  # Required on zVM
+  - '{{disk_activation}}'
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/select_patterns
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  # Called on powerVM BACKEND
+  - '{{grub_test}}'
+  - installation/first_boot
+conditional_schedule:
+  disk_activation:
+    BACKEND:
+      s390x:
+        - installation/disk_activation
+  grub_test:
+    BACKEND:
+      pvm_hmc:
+        - installation/grub_test


### PR DESCRIPTION
Related job group changes: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/263

### Verification runs
* [zVM](https://openqa.suse.de/tests/4553801)
* [powerVM](https://openqa.suse.de/tests/4553856) Fails due to servers being off, but schedule is same as https://openqa.suse.de/tests/4341862

See [poo#69571](https://progress.opensuse.org/issues/69571).
