### PR TITLE
Mitigations: Add XEN_GRUB_SETUP test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2483,6 +2483,9 @@ sub load_mitigation_tests {
     if (get_var('IPMI_TO_QEMU')) {
         loadtest "cpu_bugs/ipmi_to_qemu";
     }
+    if (get_var('XEN_GRUB_SETUP')) {
+        loadtest "cpu_bugs/xen_grub_setup";
+    }
     if (get_var('MELTDOWN')) {
         loadtest "cpu_bugs/meltdown";
     }

--- a/tests/cpu_bugs/xen_grub_setup.pm
+++ b/tests/cpu_bugs/xen_grub_setup.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Update grub to show grub in com2 for XEN test
+# - Replace <unit0> with <unit1> in line of initial with <GRUB_SERIAL_COMMAND=> in /etc/default/grub, using sed.
+# - regenerate /boot/grub2/grub.cfg with grub2-mkconfig
+# - upload configuration
+# Maintainer: An Long <lan@suse.com>
+
+use warnings;
+use strict;
+use base "opensusebasetest";
+use testapi;
+use utils;
+use bootloader_setup 'replace_grub_cmdline_settings';
+
+sub run {
+    my $self = shift;
+
+    replace_grub_cmdline_settings('unit=0', 'unit=1', update_grub => 1, search => '^GRUB_SERIAL_COMMAND=');
+}
+
+1;


### PR DESCRIPTION
XEN tests need show grub on com2 in some environment. This test do the
grub update for it.

- Related ticket: N/A
- Verification run: 10.67.134.217/tests/11364
