### PR TITLE
Increase timeout for prepartitioning in autoyast tests

### DIFF
--- a/tests/autoyast/pre_partitioning.pm
+++ b/tests/autoyast/pre_partitioning.pm
@@ -19,10 +19,9 @@ use bootloader_setup 'create_encrypted_part';
 
 sub run {
     my $test_data = get_test_suite_data();
-    assert_screen 'linuxrc-start-shell-before-installation', 60;
+    assert_screen 'linuxrc-start-shell-before-installation', 120;
     create_encrypted_part(disk => $test_data->{device}, luks_type => 'luks2');
     type_string "exit\n";
 }
 
 1;
-


### PR DESCRIPTION
Booting installation sometimes takes longer than 60 seconds.

Fixes https://openqa.suse.de/tests/4553314
