### PR TITLE
Revert "Use regcode variable instead of hardcoded version to determin…

### DIFF
--- a/data/autoyast_qam/12_installtest.xml.ep
+++ b/data/autoyast_qam/12_installtest.xml.ep
@@ -3,7 +3,7 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <add-on>
     <add_on_products config:type="list">
-      % if ($get_var->('SCC_REGCODE_LTSS')) {
+      % if ($get_var->('VERSION') =~ m/12-SP4|12-SP3|12-SP2|12-SP1/) {
       <listentry>
         <name>SLES-LTSS:<%= $get_var->('VERSION') %>::update</name>
         <alias>SLES-LTSS:<%= $get_var->('VERSION') %>::update</alias>
@@ -34,7 +34,7 @@
         <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-DESKTOP/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
       </listentry>
       % }
-      % unless ($get_var->('SCC_REGCODE_LTSS')) {
+      % unless ($get_var->('VERSION') =~ m/12-SP4|12-SP3|12-SP2|12-SP1/) {
       <listentry>
         <name>sle-sdk:<%= $get_var->('VERSION') %>::pool</name>
         <alias>sle-sdk:<%= $get_var->('VERSION') %>::pool</alias>


### PR DESCRIPTION
…e LTSS"

This reverts commit 25dadea6fbf1869ee15d7e04af65e18cc23736de.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
