### PR TITLE
[WIP]Support directly chained tests for virtualization functional QA tests (not ready)

### DIFF
--- a/tests/virt_autotest/cleanup_service.pm
+++ b/tests/virt_autotest/cleanup_service.pm
@@ -1,0 +1,31 @@
+# Summary: revert or cleanup the configuration files and restart services
+# Maintainer: Julie CAO <jcao@suse.com>
+package cleanup_service;
+
+use strict;
+use warnings;
+use base "virt_autotest_base";
+use testapi;
+use virt_utils qw(remove_vm);
+
+sub run {
+    #revert dns setting
+    if (script_run('ls /etc/resolv.conf.orig') == 0) {
+        script_run("mv /etc/resolv.conf.orig /etc/resolv.conf; mv /etc/named.conf.orig /etc/named.conf; mv /etc/ssh/ssh_config.orig /etc/ssh/ssh_config; mv /etc/dhcpd.conf.orig /etc/dhcpd.conf");
+        script_run("sed -irn '/^nameserver 192\\.168\\.123\\.1/d' /etc/resolv.conf");
+        script_run("rm /var/lib/named/testvirt.net.zone; rm /var/lib/named/123.168.192.zone");
+    }
+
+    #remove existing guests
+    my $listed_guests = script_output("virsh list --all | sed -n '/^-/,\$p' | sed '1d;/Domain-0/d' | awk '{print \$2;}'", 30);
+    remove_vm($_) foreach (split "\n", $listed_guests);
+
+    #remove br123 and restart services
+    assert_script_run "source /usr/share/qa/qa_test_virtualization/cleanup";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/virt_autotest/download_guest_assets.pm
+++ b/tests/virt_autotest/download_guest_assets.pm
@@ -21,12 +21,7 @@ use virt_utils;
 sub run {
     # download vm image and xml file from NFS location to skip installing guest
     my $vm_xml_dir = "/tmp/download_vm_xml";
-    set_var("GUEST_LIST", get_var("GUEST")) if get_var("GUEST");
-    handle_sp_in_settings_with_fcs("GUEST_LIST");
-    my $guest_list = get_required_var("GUEST_LIST");
-    if (download_guest_assets($guest_list, $vm_xml_dir)) {
-        die "Fatal Error: The guest assets for $guest_list were not downloaded successfully!";
-    }
+    die "Fail to download guest assets!" if download_guest_assets($vm_xml_dir) == 0;
 }
 
 sub test_flags {

--- a/tests/virt_autotest/prepare_guest.pm
+++ b/tests/virt_autotest/prepare_guest.pm
@@ -1,0 +1,29 @@
+# Summary: make the guests(specified by test suite settings) ready(virsh define).
+# Maintainer: Julie CAO <jcao@suse.com>
+package prepare_guest;
+
+use strict;
+use warnings;
+use base "virt_autotest_base";
+use testapi;
+use version_utils 'is_sle';
+use virt_utils qw(get_guest_list remove_vm);
+
+sub run {
+    # figure out the guest list to be prepared
+    my $tested_guests = get_guest_list();
+
+    #clean up other guests and define needed guests, or the step is done by restore_guests? no, some step not restore guests.
+    my $listed_guests = script_output("virsh list --all | sed -n '/^-/,\$p' | sed '1d;/Domain-0/d' | awk '{print \$2;}'", 30);
+    foreach (split "\n", $listed_guests) {
+        $_ =~ /^((\w+-){1,6}\w+)/;
+        my $domain = $&;
+        remove_vm($_) unless (grep /$domain/, $tested_guests);
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/virt_autotest/restore_guests.pm
+++ b/tests/virt_autotest/restore_guests.pm
@@ -1,0 +1,30 @@
+# Summary: make the guests(specified by test suite settings) ready(virsh define).
+# Maintainer: Julie CAO <jcao@suse.com>
+package restore_guests;
+
+use strict;
+use warnings;
+use testapi;
+use base "virt_autotest_base";
+use virt_utils qw(get_guest_list remove_vm restore_downloaded_guests);
+
+sub run {
+    my $guest_list         = get_guest_list();
+    my $downloaded_xml_dir = "/tmp/download_vm_xml";
+
+    #clean up env
+    my $listed_guests = script_output "virsh list --all | sed -n '/^-/,\$p' | sed '1d;/Domain-0/d' | awk '{print \$2;}'";
+    foreach my $guest (split "\n", $listed_guests) {
+        remove_vm($guest);
+    }
+
+    foreach my $guest (split "\n", $guest_list) {
+        restore_downloaded_guests($guest, $downloaded_xml_dir);
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -23,11 +23,12 @@ use Data::Dumper;
 use XML::Writer;
 use IO::File;
 use List::Util 'first';
+use LWP::Simple 'head';
 use proxymode;
 use version_utils 'is_sle';
 
 our @EXPORT
-  = qw(enable_debug_logging update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk upload_supportconfig_log download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console);
+  = qw(enable_debug_logging update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk upload_supportconfig_log get_guest_list remove_vm download_guest_assets restore_downloaded_guests is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console);
 
 sub enable_debug_logging {
 
@@ -309,8 +310,6 @@ sub generate_guest_asset_name {
       . lc(get_required_var('SYSTEM_ROLE')) . '_'
       . get_required_var('ARCH');
 
-    record_info('Guest asset info', "Guest asset name is : $composed_name");
-
     return $composed_name;
 }
 
@@ -323,7 +322,6 @@ sub get_guest_disk_name_from_guest_xml {
     $disk_from_xml =~ /file='(.*)'/;
     $disk_from_xml = $1;
     die 'There is no guest disk file parsed out from guest xml configuration!' unless $disk_from_xml;
-    record_info('Guest disk name', "Guest $guest disk_from_xml is: $disk_from_xml.");
 
     return $disk_from_xml;
 }
@@ -349,58 +347,99 @@ sub upload_supportconfig_log {
     save_screenshot;
 }
 
+# get the guest list from the test suite settings
+sub get_guest_list {
+
+    #get the guest pattern from test suite settings
+    if (get_var('GUEST_PATTERN')) {
+        set_var('GUEST_LIST', get_var('GUEST_PATTERN'));
+    }
+    elsif (get_var('GUEST')) {
+        set_var('GUEST_LIST', get_var('GUEST'));
+    }
+    handle_sp_in_settings_with_fcs("GUEST_LIST");
+    my $guest_pattern = get_required_var("GUEST_LIST");
+
+    #parse the guest list from the pattern
+    return $guest_pattern if ($guest_pattern =~ /win/i);
+    my $qa_guest_config_file = "/usr/share/qa/virtautolib/data/vm_guest_config_in_vh_update";
+    my $hypervisor_type      = get_var('SYSTEM_ROLE', '');
+    my $guest_list = script_output "source /usr/share/qa/virtautolib/lib/virtlib; get_vms_from_config_file $qa_guest_config_file $guest_pattern $hypervisor_type";
+    record_soft_failure("Not found guest pattern $guest_pattern in $qa_guest_config_file") if ($guest_list eq '');
+    return $guest_list;
+}
+
+# remove a vm listed via 'virsh list'
+sub remove_vm {
+    my $vm               = shift;
+    my $is_persistent_vm = script_output "virsh dominfo $vm | sed -n '/Persistent:/p' | awk '{print \$2}'";
+    my $vm_state         = script_output "virsh domstate $vm";
+    if ($vm_state ne "shut off") {
+        assert_script_run("virsh destroy $vm", 30);
+    }
+    if ($is_persistent_vm eq "yes") {
+        assert_script_run("virsh undefine $vm", 30);
+    }
+}
+
 # Download guest image and xml from a NFS location to local
 # the image and xml is coming from a guest installation testsuite
 # need set SKIP_GUEST_INSTALL=1 in the test suite settings
+# return the account of the guests downloaded
 # only available on x86_64
 sub download_guest_assets {
 
     # guest_pattern is a string, like sles-11-sp4-64, may or may not with pv or fv given.
-    my ($guest_pattern, $vm_xml_dir) = @_;
+    my $vm_xml_dir = shift;
 
     # list the guests matched the pattern
-    my $qa_guest_config_file = "/usr/share/qa/virtautolib/data/vm_guest_config_in_vh_update";
-    my $hypervisor_type      = get_var('SYSTEM_ROLE', '');
-    my $install_guest_list = script_output "source /usr/share/qa/virtautolib/lib/virtlib; get_vms_from_config_file $qa_guest_config_file $guest_pattern $hypervisor_type";
-    save_screenshot;
-    if ($install_guest_list eq '') {
-        record_soft_failure("Not found guest pattern $guest_pattern in $qa_guest_config_file");
-        return 1;
-    }
+    my $expected_guests = get_guest_list();
 
     # mount the remote NFS location of guest assets
     # OPENQA_URL="localhost" in local openQA instead of the IP, so the line below need to be turned on and set to the webUI IP when you are using local openQA
     # Tips: Using local openQA, you need "rcnfs-server start & vi /etc/exports; exportfs -r")
     # set_var('OPENQA_URL', "your_ip");
     my $openqa_server = get_required_var('OPENQA_URL');
-    $openqa_server =~ s/^http:\/\///;
-    my $remote_export_dir = "/var/lib/openqa/factory/other/";
-    my $mount_point       = "/tmp/remote_guest";
+
+    # check if vm xml files have been uploaded
+    my @available_guests = ();
+    foreach my $guest (split "\n", $expected_guests) {
+        my $guest_asset = generate_guest_asset_name("$guest");
+        my $vm_disk_url = $openqa_server . "/assets/other/" . $guest_asset . '.disk';
+        $vm_disk_url =~ s#^(?!http://)(.*)$#http://$1#;    #add 'http://' at beginning if needed.
+        if (head($vm_disk_url)) {
+            push @available_guests, $guest;
+        }
+        else {
+            record_soft_failure("$vm_disk_url not found!");
+        }
+    }
+    return 0 unless @available_guests;
 
     # clean up vm stuff
+    my $mount_point = "/tmp/remote_guest";
     script_run "[ -d $mount_point ] && { if findmnt $mount_point; then umount $mount_point; rm -rf $mount_point; fi }";
     script_run "mkdir -p $mount_point";
     script_run "[ -d $vm_xml_dir ] && rm -rf $vm_xml_dir; mkdir -p $vm_xml_dir";
     my $disk_image_dir = script_output "source /usr/share/qa/virtautolib/lib/virtlib; get_vm_disk_dir";
-    script_run "umount $disk_image_dir; rm -rf $disk_image_dir";
+    script_run "umount $disk_image_dir; rm -rf $disk_image_dir/*";
     script_run "[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/" if get_var('VIRT_NEW_GUEST_MIGRATION_SOURCE');
-    save_screenshot;
 
     # tip: nfs4 is not supported on sles12sp4, so use '-t nfs' instead of 'nfs4' here.
+    $openqa_server =~ s/^http:\/\///;
+    my $remote_export_dir = "/var/lib/openqa/factory/other/";
     assert_script_run("mount -t nfs $openqa_server:$remote_export_dir $mount_point", 120);
-    save_screenshot;
 
     # copy guest images and xml files to local
     # test aborts if failing in copying all the guests
-    my $remote_guest_count = 0;
-    foreach my $guest (split "\n", $install_guest_list) {
+    my $guest_count = 0;
+    foreach my $guest (@available_guests) {
         my $guest_asset           = generate_guest_asset_name("$guest");
         my $remote_guest_xml_file = $guest_asset . '.xml';
         my $remote_guest_disk     = $guest_asset . '.disk';
 
         # download vm xml file
         my $rc = script_run("cp $mount_point/$remote_guest_xml_file $vm_xml_dir/$guest.xml", 60);
-        save_screenshot;
         if ($rc) {
             record_soft_failure("Failed copying: $mount_point/$remote_guest_xml_file");
             next;
@@ -424,19 +463,26 @@ sub download_guest_assets {
         script_run "[ -d `dirname $local_guest_image` ] || mkdir -p `dirname $local_guest_image`";
         $rc = script_run("cp $mount_point/$remote_guest_disk $local_guest_image", 300);    #it took 75 seconds copy from vh016 to vh001
         script_run "ls -l $local_guest_image";
-        save_screenshot;
         if ($rc) {
             record_soft_failure("Failed to download: $remote_guest_disk");
             next;
         }
-        $remote_guest_count++;
+        $guest_count++;
     }
 
     # umount
     script_run("umount $mount_point");
-    save_screenshot;
 
-    return 1 if ($remote_guest_count == 0);
+    return $guest_count;
+}
+
+#Start the guest from the downloaded vm xml and vm disk file
+sub restore_downloaded_guests {
+    my ($guest, $vm_xml_dir) = @_;
+    record_info("Guest", "$guest");
+    assert_script_run("source /usr/share/qa/qa_test_virtualization/shared/standalone", 180);
+    my $vm_xml = "$vm_xml_dir/$guest.xml";
+    assert_script_run("virsh define $vm_xml", 30);
 }
 
 sub is_installed_equal_upgrade_major_release {


### PR DESCRIPTION
About the background and the design, please refer to https://confluence.suse.com/display/qasleapac2/Reconstruct+virtualization+test+suites+in+openQA+based+on+START_DIRECTLY_AFTER_TEST

Here is the code reconstruction part.
- two job groups under development folder are created to run trial tests in OSD.

https://openqa.nue.suse.com/tests/overview?distri=sle&version=15-SP2&build=207.1&groupid=115
https://openqa.nue.suse.com/tests/overview?distri=sle&version=15-SP2&build=207.1&groupid=213

- Standalone tests are still be supported after the test reconstruction. Standalone tests here mean original tests which are not chained, such as prj2 and part of prj3. Also, you can still run legacy tests without chain, such as prj1/prj2/prj3/prj4/prj5, but no extended test following prj1.

- skip external snapshot tests for now to avoid staining host. It will be evaluated after the first run.

@alice-suse @xguo @waynechen55

Verification run: 
Two runs or three runs are expected. 

- The first run just began, which intend to verify the test chains and code support:

prepare host test: https://openqa.nue.suse.com/tests/4565592
guest installation test: https://openqa.nue.suse.com/tests/4565746
virtual network test: not started yet.
other extended test: not started yet.
host upgrade test: https://openqa.nue.suse.com/tests/4565596(fail but not related to this pr)
guest migration test: https://openqa.nue.suse.com/tests/4565660 & https://openqa.nue.suse.com/tests/4565659
guest upgrade test: not started yet.
pvusb test: not started yet.

- The second run is planed to verify the test order and balance the time.
