### PR TITLE
Enable yast2_cmd/yast_lang in yast2_cmd test suite

### DIFF
--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -15,6 +15,7 @@ schedule:
   - '{{yast_lan}}'
   - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
+  - '{{yast_lang}}'
 conditional_schedule:
   bootloader:
     ARCH:
@@ -38,3 +39,7 @@ conditional_schedule:
     BACKEND:
       qemu:
         - yast2_cmd/yast_dns_server
+  yast_lang:
+    BACKEND:
+      qemu:
+        - yast2_cmd/yast_lang


### PR DESCRIPTION
See [poo#69877](https://progress.opensuse.org/issues/69877).

[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=rwx788%2Fos-autoinst-distri-opensuse%23yast)
