### PR TITLE
health_check: Fix post_fail_hook

### DIFF
--- a/tests/transactional/health_check.pm
+++ b/tests/transactional/health_check.pm
@@ -77,8 +77,8 @@ sub post_fail_hook {
     upload_logs "health-checker.log";
 
     # revert changes to rebootmgr.sh and reboot
-    if (script_run "test -e %{_libexecdir})/health-checker/fail.sh") {
-        trup_shell "rm $(rpm --eval %{_libexecdir})/health-checker/fail.sh";
+    if (script_run('test -e $(rpm --eval %{_libexecdir})/health-checker/fail.sh') == 0) {
+        trup_shell 'rm $(rpm --eval %{_libexecdir})/health-checker/fail.sh';
     }
 }
 


### PR DESCRIPTION
It was already broken previously (condition inverted), but the last change
introduced a copy paste error. Fix both.

No verification run, please raise your hand if you'd like one.