### PR TITLE
Fix uefi_bootmenu_params after kiwi update in Leap 15.1

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -336,7 +336,7 @@ sub uefi_bootmenu_params {
       :         send_key 'e';
     # Kiwi in TW uses grub2-mkconfig instead of the custom kiwi config
     # Locate gfxpayload parameter and update it
-    if (is_jeos && (is_tumbleweed || is_sle('>=15-sp1') || is_leap('>=15.2'))) {
+    if (is_jeos && (is_tumbleweed || is_sle('>=15-sp1') || is_leap('>=15.1'))) {
         for (1 .. 3) { send_key "down"; }
         send_key "end";
         # delete "keep" word


### PR DESCRIPTION
The kiwi update was finally released, so adjust the version check.

Verification run: http://10.160.67.86/tests/776