### PR TITLE
Fix assert_screen call in x11/firefox.pm

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -34,7 +34,7 @@ sub run() {
     assert_screen 'firefox-html-test';
 
     send_key "alt-f4";
-    assert_screen [qw(firefox-save-and-quit generic-desktop not-responding), timeout => 90];
+    assert_screen([qw(firefox-save-and-quit generic-desktop not-responding)], timeout => 90);
     if (match_has_tag 'not-responding') {
         record_soft_failure "firefox is not responding, see boo#1174857";
         # confirm "save&quit"


### PR DESCRIPTION
Currently it uses "90" as tag, not as timeout.

Verification run: http://10.160.67.86/tests/784