### PR TITLE
Fix path parsing for the smb mirror

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -542,10 +542,10 @@ sub select_installation_source {
     my ($m_server, $m_share, $m_directory);
 
     # Parse SUSEMIRROR into variables
-    if ($m_mirror =~ m{^[a-z]+://([a-zA-Z0-9.-]*)/(.*)$}) {
-        ($m_server, $m_directory) = ($1, $2);
+    if ($m_mirror =~ m{^[a-z]+://(?<server>[a-zA-Z0-9.-]*)/(?<dir>.*)$}) {
+        ($m_server, $m_directory) = ($+{server}, $+{dir});
         if ($m_protocol eq "smb") {
-            ($m_share, $m_directory) = $m_directory =~ /\/(.+?)(\/.*)/;
+            ($m_share, $m_directory) = split(/\//, $m_directory, 2);
         }
     }
 


### PR DESCRIPTION
We have fixed regexp not to put extra '/', but it broke parsing of the
share and subdirectory.

Fixes https://openqa.suse.de/tests/4564529

[Verification run](https://openqa.suse.de/tests/4566061#).
