### PR TITLE
Rename ibus test to right country

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2165,7 +2165,7 @@ sub load_common_x11 {
     elsif (check_var("REGRESSION", "ibus")) {
         loadtest "boot/boot_to_desktop";
         loadtest "x11/ibus/ibus_installation";
-        loadtest "x11/ibus/ibus_test_ch";
+        loadtest "x11/ibus/ibus_test_cn";
         loadtest "x11/ibus/ibus_test_jp";
         loadtest "x11/ibus/ibus_test_kr";
         loadtest "x11/ibus/ibus_clean";

--- a/tests/x11/ibus/ibus_clean.pm
+++ b/tests/x11/ibus/ibus_clean.pm
@@ -17,8 +17,8 @@ use warnings;
 use testapi;
 use utils;
 
-sub remove_ch {
-    assert_and_click 'ibus-input-added-ch';
+sub remove_cn {
+    assert_and_click 'ibus-input-added-cn';
     assert_and_click 'ibus-input-remove';
 }
 
@@ -46,7 +46,7 @@ sub run {
     send_key 'ret';
 
     assert_screen 'ibus-region-language';
-    remove_ch;
+    remove_cn;
     remove_jp;
     remove_kr;
 

--- a/tests/x11/ibus/ibus_test_cn.pm
+++ b/tests/x11/ibus/ibus_test_cn.pm
@@ -17,7 +17,7 @@ use warnings;
 use testapi;
 use utils;
 
-sub ibus_enable_source_ch {
+sub ibus_enable_source_cn {
     send_key 'super';
     wait_still_screen;
     type_string_slow ' region & language';
@@ -31,21 +31,21 @@ sub ibus_enable_source_ch {
 
     assert_and_click 'ibus-input-chinese';
     assert_and_dclick 'ibus-input-chinese-pinyin';
-    assert_screen 'ibus-input-added-ch';
+    assert_screen 'ibus-input-added-cn';
     send_key 'alt-f4';
     assert_screen 'generic-desktop';
 }
 
-sub test_ch {
+sub test_cn {
     x11_start_program('gedit');
     hold_key 'super';
-    send_key_until_needlematch 'ibus_switch_ch', 'spc', 6;
+    send_key_until_needlematch 'ibus_switch_cn', 'spc', 6;
     release_key 'super';
 
     wait_still_screen(3);
     type_string_slow 'nihao';
     type_string_slow '1';
-    assert_screen 'ibus_ch_nihao';
+    assert_screen 'ibus_cn_nihao';
 
     hold_key 'super';
     send_key_until_needlematch 'ibus_switch_en', 'spc', 6;
@@ -62,10 +62,10 @@ sub run {
 
     assert_screen "generic-desktop";
     # enable Chinese input sources
-    ibus_enable_source_ch;
+    ibus_enable_source_cn;
 
     # open gedit and test chinese
-    test_ch;
+    test_cn;
 }
 
 1;


### PR DESCRIPTION
CH: Switzerland
CN: China

Ticket: https://progress.opensuse.org/issues/66553
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/679

`openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10837 https://openqa.opensuse.org/tests/1357390 NEEDLES_DIR=https://github.com/asdil12/os-autoinst-needles-opensuse.git#ibus`
Created job #1365359: opensuse-Tumbleweed-DVD-aarch64-Build20200807-gnome-x11-ibus@aarch64 -> https://openqa.opensuse.org/t1365359