### PR TITLE
Update list of missing packages for yast control center

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -324,8 +324,7 @@ sub run {
         # kdump is disabled by default in the installer, so ensure that it's installed
         ensure_installed 'yast2-kdump';
         # see bsc#1062331, sound is not added to the yast2 pattern
-        # also add missing yast2-ca-management and yast2-auth-server
-        ensure_installed 'yast2-boot-server yast2-sound yast2-ca-management yast2-auth-server';
+        ensure_installed 'yast2-boot-server yast2-sound';
     }
     $self->launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
 


### PR DESCRIPTION
[bsc#1062331](https://bugzilla.suse.com/show_bug.cgi?id=1062331) is
fixed. And now we also have test failing because we try to install
yast2-ca-management package which was dropped for SLE 15 completely.

Test module is not executed for other versions of SLES.

[Verification run](https://openqa.suse.de/tests/4566185).