### PR TITLE
Increase timeout to make sure command finished, pass or fail

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -337,7 +337,7 @@ sub toogle_package {
 
 sub use_wicked {
     script_run "cd /proc/sys/net/ipv4/conf";
-    script_run("for i in *[0-9]; do echo BOOTPROTO=dhcp > /etc/sysconfig/network/ifcfg-\$i; wicked --debug all ifup \$i; done", 300);
+    script_run("for i in *[0-9]; do echo BOOTPROTO=dhcp > /etc/sysconfig/network/ifcfg-\$i; wicked --debug all ifup \$i; done", 600);
     save_screenshot;
 }
 sub use_ifconfig {


### PR DESCRIPTION
This failure is repeating in MM setup despite the test would pass.

- Fail: https://openqa.suse.de/tests/4566265#step/logs_from_installation_system/17
- Verification run: not needed just timeout