### PR TITLE
Modify scheduling code for install_klp_product

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -88,6 +88,9 @@ sub load_kernel_tests {
         }
         loadtest_kernel 'boot_ltp';
         loadtest_kernel 'qa_test_klp';
+        unless (get_var('KOTD_REPO') || get_var('INSTALL_KOTD')) {
+            loadtest_kernel 'install_klp_product';
+        }
     }
     elsif (get_var('INSTALL_KLP_PRODUCT')) {
         loadtest_kernel 'boot_ltp';

--- a/tests/kernel/install_klp_product.pm
+++ b/tests/kernel/install_klp_product.pm
@@ -25,6 +25,13 @@ sub run {
     my $kver;
     my $kflavor;
 
+    # Running in the same job as qa_test_klp, reboot to fix kernel state
+    if (get_var('QA_TEST_KLP_REPO')) {
+        power_action('reboot', textmode => 1);
+        $self->wait_boot;
+        $self->select_serial_terminal;
+    }
+
     my $output = script_output('uname -r');
     if ($output =~ /^([0-9]+([-.][0-9a-z]+)*)-([a-z][a-z0-9]*)/i) {
         $kver    = $1;


### PR DESCRIPTION
The install_klp_product test will not work with KOTD builds so creating a separate job for it would waste worker resources. Append it to the existing livepatch job with exception for KOTD builds.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-12SP2: https://openqa.suse.de/tests/4567159
  - SLE-15SP2@x86_64: https://openqa.suse.de/tests/4567160
  - SLE-15SP2@PPC64LE: https://openqa.suse.de/tests/4567161
  - SLE-15SP1 (KOTD, module skipped): https://openqa.suse.de/tests/4567162
