### PR TITLE
Add iptables rules for mm tests

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -130,6 +130,8 @@ sub setup_networks {
 
     $setup_script .= "FIXED_NIC=`grep $net_conf->{fixed}->{mac} /sys/class/net/*/address |cut -d / -f 5`\n";
     $setup_script .= "iptables -F\n";
+    $setup_script .= "iptables -A INPUT -i \$FIXED_NIC -j ACCEPT\n";
+    $setup_script .= "iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n";
     $setup_script .= "iptables -t nat -A POSTROUTING -o \$FIXED_NIC -j MASQUERADE\n";
     for my $network (keys %$net_conf) {
         next if $network eq 'fixed';


### PR DESCRIPTION
Adding rules for tcp and upd seems to resolve the issue on x86_64 for both ssh and vnc.

- Related ticket: https://progress.opensuse.org/issues/68708
- Verification run: [ssh x86_64](http://aquarius.suse.cz/tests/3099) [vnc x86_64](http://aquarius.suse.cz/tests/3097)
