### PR TITLE
Enhance the check logic for IMA enforce mode

### DIFF
--- a/tests/security/ima/ima_verify.pm
+++ b/tests/security/ima/ima_verify.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@ sub run {
     my $cert_der = "/root/certs/ima_cert.der";
 
     # Make sure IMA is in the enforce mode
-    validate_script_output "grep 'ima_appraise=fix' /etc/default/grub || echo 'IMA enforced'", sub { m/IMA enforced/ };
+    validate_script_output "grep -E 'ima_appraise=(fix|log|off)' /etc/default/grub || echo 'IMA enforced'", sub { m/IMA enforced/ };
     assert_script_run("test -e /etc/sysconfig/ima-policy", fail_message => 'ima-policy file is missing');
 
     assert_script_run "evmctl ima_sign -a sha256 -k $mok_priv $sample_app";


### PR DESCRIPTION
We have 4 available modes for IMA, these are "enforce/fix/off/log", to make sure IMA is working at enforce mode, we should make sure the other 3 modes are not listed in grub.

However, during our tests, we have several issues in the chain test process, this change will not affect other cases and other failures will not impact this function as well. 

- Related ticket: https://progress.opensuse.org/issues/69742
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/4568841#step/ima_verify/9
