### PR TITLE
Mitigations: Update XEN_GRUB_SETUP test for XEN boot args

### DIFF
--- a/tests/cpu_bugs/xen_grub_setup.pm
+++ b/tests/cpu_bugs/xen_grub_setup.pm
@@ -7,8 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Update grub to show grub in com2 for XEN test
+# Summary: Update grub for XEN test
 # - Replace <unit0> with <unit1> in line of initial with <GRUB_SERIAL_COMMAND=> in /etc/default/grub, using sed.
+# - Add <parameter> into /etc/default/grub, using sed.
 # - regenerate /boot/grub2/grub.cfg with grub2-mkconfig
 # - upload configuration
 # Maintainer: An Long <lan@suse.com>
@@ -18,12 +19,17 @@ use strict;
 use base "opensusebasetest";
 use testapi;
 use utils;
-use bootloader_setup 'replace_grub_cmdline_settings';
+use bootloader_setup qw(replace_grub_cmdline_settings add_grub_cmdline_settings);
 
 sub run {
     my $self = shift;
 
-    replace_grub_cmdline_settings('unit=0', 'unit=1', update_grub => 1, search => '^GRUB_SERIAL_COMMAND=');
+    my $xen_boot_args = get_var('XEN_BOOT_ARGS', 'ucode=scan dom0_max_vcpus=8 dom0_mem=8G,max:8G');
+
+    unless (get_var('KEEP_XEN_SERIAL')) {
+        replace_grub_cmdline_settings('unit=0', 'unit=1', search => '^GRUB_SERIAL_COMMAND=');
+    }
+    add_grub_cmdline_settings($xen_boot_args, update_grub => 1, search => '^GRUB_CMDLINE_XEN_DEFAULT=');
 }
 
 1;


### PR DESCRIPTION
Add boot args in line of GRUB_CMDLINE_XEN_DEFAULT

- Related ticket: N/A
- Needles: N/A
- Verification run: http://10.67.134.217/tests/11374
