### PR TITLE
firefox: Don't press pgdwn on flashplayer webpage

### DIFF
--- a/tests/x11/firefox/firefox_flashplayer.pm
+++ b/tests/x11/firefox/firefox_flashplayer.pm
@@ -29,7 +29,6 @@ sub run {
     $self->firefox_open_url('http://www.adobe.com/software/flash/about/', 'do_not_check_loaded_url');
     assert_screen('firefox-flashplayer-verify_loaded', 90);
 
-    send_key "pgdn";
     # flashplayer dropped since sled12 sp2
     while (assert_screen([qw(firefox-flashplayer-dropped firefox-flashplayer-verify)])) {
         last if (match_has_tag('firefox-flashplayer-dropped'));


### PR DESCRIPTION
Flash plugin is not visible when webpage is at the bottom

- Fail: https://openqa.suse.de/tests/4569941#step/firefox_flashplayer/11
- Verification run: http://10.100.12.155/tests/16351#step/firefox_flashplayer/9
