### PR TITLE
[Log Enhancement] Traditional projects post_fail_hook transformation

### DIFF
--- a/data/virt_autotest/fetch_logs_from_guest.sh
+++ b/data/virt_autotest/fetch_logs_from_guest.sh
@@ -73,7 +73,7 @@ function fetch_logs_from_guest_via_ssh() {
             echo -e "Failed to fetch ${logs_folder} from guest ${guest_domain} via ssh."
         fi
 
-        return ${ret_result}
+	return ${ret_result}
 }
 
 #Fetch logs from virtual machine to local host by using libguestfs tools
@@ -195,13 +195,17 @@ function compress_virt_logs_folder() {
 	local logs_root=${logs_folder/\//}
 	logs_root=${logs_root/\/*/}
 
-	echo -e "tar -czvf /${logs_root}/virt_logs_all.tar.gz ${logs_folder}"
-	tar -czvf /${logs_root}/virt_logs_all.tar.gz ${logs_folder}
+	pushd ${logs_folder}
+	local mycmd="tar -czvf /${logs_root}/virt_logs_all.tar.gz *"
+	echo -e "$mycmd"
+	$mycmd
 	if [[ $? -eq 0 ]];then
 	   echo -e "Successfully compressed ${logs_folder} to /${logs_root}/virt_logs_all.tar.gz"
+	   popd
 	   return 0
 	else
 	   echo -e "Failed to ${logs_folder} to /${logs_root}/virt_logs_all.tar.gz"
+	   popd
 	   return 1
 	fi
 }

--- a/data/virt_autotest/virt_logs_collector.sh
+++ b/data/virt_autotest/virt_logs_collector.sh
@@ -331,7 +331,7 @@ help_usage(){
 [-h help]"
 }
 
-virt_logs_collecor_log="/var/log/virt_logs_collecor.log"
+virt_logs_collecor_log="/var/log/virt_logs_collector.log"
 virt_logs_folder=""
 virt_extra_logs_host=""
 virt_extra_logs_guest=""

--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -53,6 +53,16 @@ sub analyzeResult {
     return $result;
 }
 
+sub post_execute_script_assertion {
+    my $self   = shift;
+    my $output = $self->{script_output};
+
+    $output =~ s/"|'|`//g;
+    my $guest_installation_assert_pattern = "Test[[:space:]]in[[:space:]]progress.*(fail|timeout).*Test[[:space:]]run[[:space:]]complete";
+    script_output("shopt -s nocasematch;[[ ! \"$output\" =~ $guest_installation_assert_pattern ]]", type_command => 0, proceed_on_failure => 0);
+    save_screenshot;
+}
+
 sub run {
     my $self = shift;
 

--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -56,11 +56,16 @@ sub run {
 
     #upload logs
     script_run("xl dmesg > /tmp/xl-dmesg.log");
-    my $logs = "/var/log/libvirt /var/log/messages /var/lib/xen/dump /tmp/xl-dmesg.log";
+    my $xen_logs = "";
+    if ($hypervisor =~ /XEN/im) {
+        $xen_logs = "/var/lib/xen/dump /tmp/xl-dmesg.log";
+        script_run("xl dmesg > /tmp/xl-dmesg.log");
+        #separate the xen logs from other virt logs because it needs to be remained or xen service will fail to start
+        script_run "tar -czf var_log_xen.tar.gz /var/log/xen";
+        upload_logs "var_log_xen.tar.gz";
+    }
+    my $logs = "/var/log/libvirt /var/log/messages $xen_logs";
     virt_autotest_base::upload_virt_logs($logs, "guest-migration-dst-logs");
-    #separate the xen logs from other virt logs because it needs to be remained or xen service will fail to start
-    script_run "tar -czf var_log_xen.tar.gz /var/log/xen";
-    upload_logs "var_log_xen.tar.gz";
     virt_utils::upload_supportconfig_log;
     save_screenshot;
 

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -83,6 +83,37 @@ sub analyzeResult {
     return $result;
 }
 
+#Mutex lock/unlock functionality
+sub set_mutex_lock {
+    my ($self, $lock_signal) = @_;
+
+    mutex_lock($lock_signal);
+    mutex_unlock($lock_signal);
+}
+
+sub post_execute_script_configuration {
+    my $self = shift;
+
+    #let dst host upload logs
+    set_var('SRC_TEST_DONE', 1);
+    bmwqemu::save_vars();
+    $self->set_mutex_lock('DST_UPLOAD_LOG_DONE');
+}
+
+sub post_execute_script_assertion {
+    my $self = shift;
+
+    #display test result
+    $self->{script_output} = script_output("cd /tmp; zcat $self->{compressed_log_name}.tar.gz | sed -n '/Executing check validation/,/[0-9]* fail [0-9]* succeed/p'");
+    save_screenshot;
+
+    my $output = $self->{script_output};
+
+    my $guest_migration_src_assert_pattern = "[1-9]{1,}[[:space:]]fail|[1-9]{1,}[[:space:]]internal_error";
+    script_output("shopt -s nocasematch;[[ ! \"$output\" =~ $guest_migration_src_assert_pattern ]]", type_command => 0, proceed_on_failure => 0);
+    save_screenshot;
+}
+
 sub run {
     my ($self) = @_;
 
@@ -94,40 +125,20 @@ sub run {
     bmwqemu::save_vars();
 
     #wait for destination to be ready
-    mutex_lock('DST_READY_TO_START');
-    mutex_unlock('DST_READY_TO_START');
+    $self->set_mutex_lock('DST_READY_TO_START');
 
     #real test start
     my $timeout         = get_var("MAX_MIGRATE_TIME", "10800") - 30;
     my $log_dirs        = "/var/log/qa";
     my $upload_log_name = "guest-migration-src-logs";
+    $self->{"package_name"} = "Guest Migration Test";
 
     # clean up logs from prevous tests
     $self->execute_script_run('[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/',     30) if !get_var('SKIP_GUEST_INSTALL');
     $self->execute_script_run('[ -d /var/log/qa/ctcs2/ ] && rm -r /var/log/qa/ctcs2/*',                     30);
     $self->execute_script_run('[ -d /tmp/prj3_migrate_admin_log/ ] && rm -rf /tmp/prj3_migrate_admin_log/', 30);
 
-    $self->run_test($timeout, "", "no", "yes", "$log_dirs", "$upload_log_name");
-
-    #display test result
-    my $cmd                       = "cd /tmp; zcat $upload_log_name.tar.gz | sed -n '/Executing check validation/,/[0-9]* fail [0-9]* succeed/p'";
-    my $guest_migrate_log_content = script_output("$cmd");
-    save_screenshot;
-
-    #upload junit log
-    $self->{"package_name"} = "Guest Migration Test";
-    $self->add_junit_log("$guest_migrate_log_content");
-
-    #let dst host upload logs
-    set_var('SRC_TEST_DONE', 1);
-    bmwqemu::save_vars();
-    mutex_lock('DST_UPLOAD_LOG_DONE');
-    mutex_unlock('DST_UPLOAD_LOG_DONE');
-
-    #mark test result
-    if ($guest_migrate_log_content =~ /0 succeed/m) {
-        die "Guest migration failed! It had unsuccessful migration cases!";
-    }
+    $self->run_test($timeout, "", "yes", "yes", "$log_dirs", "$upload_log_name");
 }
 
 1;

--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -28,25 +28,20 @@ sub get_script_run {
     return "rm /var/log/qa/old* /var/log/qa/ctcs2/* -r;" . "$pre_test_cmd";
 }
 
-sub run {
+sub post_execute_script_configuration {
     my $self = shift;
-    $self->run_test(12600, "Host upgrade to .* is done. Need to reboot system|Executing host upgrade to .* offline",
-        "no", "yes", "/var/log/qa/", "host-upgrade-prepAndUpgrade");
-
-    #replace module url with openqa daily build modules link
-    my $installed_product   = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
-    my ($installed_release) = $installed_product =~ /^(\d+)/;
-    my $upgrade_product     = get_required_var('UPGRADE_PRODUCT');
-    my ($upgrade_release)   = lc($upgrade_product) =~ /sles-([0-9]+)-sp/;
-    if (($upgrade_release >= 15) && ($installed_release ne $upgrade_release)) {
-        upload_logs('/root/autoupg.xml');
-    }
 
     #online upgrade actually
     if (is_remote_backend && check_var('ARCH', 'aarch64') && is_installed_equal_upgrade_major_release) {
         set_serial_console_on_vh('', '', 'kvm');
         set_pxe_efiboot('');
     }
+}
+
+sub run {
+    my $self = shift;
+    $self->run_test(12600, "Host upgrade to .* is done. Need to reboot system|Executing host upgrade to .* offline",
+        "no", "yes", "/var/log/qa/", "host-upgrade-prepAndUpgrade");
 }
 
 1;

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -85,29 +85,95 @@ sub generateXML {
     generateXML_from_data($data, \%xmldata);
 }
 
+sub save_test_configuration {
+    my ($self, $assert_pattern, $add_junit_log_flag, $upload_virt_log_flag, $log_dir, $compressed_log_name, $upload_guest_assets_flag) = @_;
+
+    $self->{assert_pattern}           = $assert_pattern;
+    $self->{add_junit_log_flag}       = $add_junit_log_flag;
+    $self->{upload_virt_log_flag}     = $upload_virt_log_flag;
+    $self->{log_dir}                  = $log_dir;
+    $self->{compressed_log_name}      = $compressed_log_name;
+    $self->{upload_guest_assets_flag} = $upload_guest_assets_flag;
+}
+
+#This is the subroutine called inside post_execute_script_run. It aims to do configurations have to be done after script
+#execution but before test assertion, for example, modifying boot options, communicating to peer with lock/unlcok and many other
+#things as long as they should be done and need to be done right after test execution or the following test steps may malfunction
+#without them. post_execute_script_configuration should be overriden in individual test modules.
+sub post_execute_script_configuration {
+    diag("You need to override this function post_execute_script_config in your test module");
+}
+
+#This is the subroutine called inside post_execute_script_run. This is introduced to faciliate tests that do not have or not convenient
+#to use assert pattern,  can not use directly returned output from execute_script_run or needs more customized way to manipuluate results.
+#So individual test modules can also have more control over how their test results should be extracted out, intead of just relying on a
+#singel assert pattern. post_execute_script_assertion needs to be overriden in individual test modules.
+sub post_execute_script_assertion {
+    diag("You need to override this function post_execute_script_assertion in your test module");
+}
+
+#This subroutine incorporates operations needs to be done after finishing executing script. It is further dividied into three parts,
+#including post_execute_script_configuration, upload_virt_logs and do test assertion. Test assertion can be done in two ways by using
+#assert pattern or newly introduced post_execute_script_assertion subroutine, the latter is only used when $assert_pattern is not provided
+#by individual test module to run_test
+sub post_execute_script_run {
+    my $self = shift;
+
+    $self->post_execute_script_configuration;
+
+    if ($self->{upload_virt_log_flag} eq "yes") {
+        upload_virt_logs($self->{log_dir}, $self->{compressed_log_name});
+    }
+    save_screenshot;
+
+    my $output = $self->{script_output};
+    if ($self->{assert_pattern}) {
+        diag("Going to do assertion after test. Use assert pattern: $self->{assert_pattern} provided by test module.");
+        unless ($output =~ /$self->{assert_pattern}/m) {
+            assert_script_run("grep -E \"$self->{assert_pattern}\" $self->{log_dir} -r || zcat /tmp/$self->{compressed_log_name}.tar.gz | grep -aE \"$self->{assert_pattern}\"");
+        }
+    }
+    else {
+        diag("Going to do assertion after test. Call post_execute_script_assertion because assert pattern is not available.");
+        $self->post_execute_script_assertion;
+    }
+    save_screenshot;
+}
+
+#Adding junit log and uploading guest assets are wrapped up here in newly introduced subroutine post_run_test.
+#This is called after post_execute_script_run in run_test if test passes or in post_fail_hook if test fails.
+sub post_run_test {
+    my $self = shift;
+
+    if ($self->{add_junit_log_flag} eq "yes") {
+        $self->add_junit_log($self->{script_output});
+    }
+
+    if ($self->{upload_guest_assets_flag} eq "yes") {
+        record_info('Check UPLOAD_GUEST_ASSETS flag', 'This test should upload guest assets!');
+        $self->upload_guest_assets;
+    }
+}
+
 sub execute_script_run {
     my ($self, $cmd, $timeout) = @_;
     my $pattern = "CMD_FINISHED-" . int(rand(999999));
-
     if (!$timeout) {
         $timeout = 10;
     }
 
     type_string "(" . $cmd . "; echo $pattern) 2>&1 | tee -a /dev/$serialdev\n";
-    my $ret = wait_serial($pattern, $timeout);
-
+    $self->{script_output} = wait_serial($pattern, $timeout);
     save_screenshot;
 
-    if ($ret) {
-        save_screenshot;
-        $ret =~ s/[\r\n]+$pattern[\r\n]+//g;
-        return $ret;
-    }
-    else {
+    if (!$self->{script_output} or !defined $self->{script_output}) {
         save_screenshot;
         die "Timeout due to cmd run :[" . $cmd . "]\n";
     }
-
+    else {
+        save_screenshot;
+        $self->{script_output} =~ s/[\r\n]+$pattern[\r\n]+//g;
+    }
 }
 
 sub push_junit_log {
@@ -131,29 +197,11 @@ sub run_test {
         return;
     }
 
-    my $script_output = $self->execute_script_run($test_cmd, $timeout);
-
-    if ($add_junit_log_flag eq "yes") {
-        $self->add_junit_log($script_output);
-    }
-
-    if ($upload_virt_log_flag eq "yes") {
-        upload_virt_logs($log_dir, $compressed_log_name);
-        virt_utils::upload_supportconfig_log;
-        $self->upload_coredumps;
-    }
-
-    if ($upload_guest_assets_flag eq "yes") {
-        record_info('Check UPLOAD_GUEST_ASSETS flag', 'This test should upload guest assets!');
-        $self->upload_guest_assets;
-    }
-
-    if ($assert_pattern) {
-        unless ($script_output =~ /$assert_pattern/m) {
-            assert_script_run("grep -E \"$assert_pattern\" $log_dir -r || zcat /tmp/$compressed_log_name.tar.gz | grep -aE \"$assert_pattern\"");
-        }
-    }
-
+    $self->save_test_configuration($assert_pattern, $add_junit_log_flag, $upload_virt_log_flag, $log_dir, $compressed_log_name, $upload_guest_assets_flag);
+    $self->execute_script_run($test_cmd, $timeout);
+    $self->post_execute_script_run;
+    $self->post_run_test;
+    save_screenshot;
 }
 
 sub add_junit_log {
@@ -203,5 +251,22 @@ sub upload_guest_assets {
     }
 }
 
+sub post_fail_hook {
+    my ($self) = shift;
+
+    $self->post_run_test;
+    save_screenshot;
+
+    if (get_var('VIRT_PRJ2_HOST_UPGRADE')) {
+        virt_utils::collect_host_and_guest_logs('', '/root/autoupg.xml', '');
+    }
+    else {
+        virt_utils::collect_host_and_guest_logs;
+    }
+    save_screenshot;
+
+    $self->upload_coredumps;
+    save_screenshot;
+}
 1;
 

--- a/tests/virt_autotest/virt_v2v_src.pm
+++ b/tests/virt_autotest/virt_v2v_src.pm
@@ -17,6 +17,7 @@ use warnings;
 use testapi;
 use lockapi;
 use mmapi;
+use virt_utils;
 
 sub run {
     my ($self) = @_;
@@ -34,7 +35,7 @@ sub run {
     wait_for_children;
 
     script_run("xl dmesg > /tmp/xl-dmesg.log");
-    virt_autotest_base::upload_virt_logs("/var/log/libvirt /var/log/messages /var/log/xen /var/lib/xen/dump /tmp/xl-dmesg.log", "virt-v2v-xen-src-logs");
+    virt_utils::upload_virt_logs("/var/log/libvirt /var/log/messages /var/log/xen /var/lib/xen/dump /tmp/xl-dmesg.log", "virt-v2v-xen-src-logs");
 }
 
 1;


### PR DESCRIPTION
* **Inroduce** some new functions in virt_autotest_base.pm to facilitate post_fail_hook transformation and traditional test projects improvement:
  * **save_test_configuration** - This function saves all parameters passed in from run_test in individual test modules. So they can be universal and used later depends on test result. They are:
    * $self->{assert_pattern} = $assert_pattern;
    * $self->{add_junit_log_flag} = $add_junit_log_flag;
    * $self->{upload_virt_log_flag} = $upload_virt_log_flag;
    * $self->{log_dir} = $log_dir;
    * $self->{compressed_log_name} = $compressed_log_name;
    * $self->{upload_guest_assets_flag} = $upload_guest_assets_flag;
  * **post_execute_script_run** - This function follows immediately after execute_script_run to perform customized post script run operations, which is fulfilled by another function post_execute_script_configuration called inside, upload compressed legacy virtualization logs and assert test result if assert pattern is available or call post_execute_script_assertion to do customized test result assertion
  * **post_execute_script_configuration** - Content of this function depends on requirement of individual test project, so it should be overridden. Any customized operation should be performed immediately after executing script can be put in this function, for example, set_pxe_efiboot and set_serial_console_on_vh in host_upgrade_step2_run
  * **post_execute_script_assertion** - This function should be used to assert test result based on situations of individual test project if assert pattern is not available or $self->{script_output} returned directly can not be used for assertion and junit log generation or you need more customized, accurate and detailed information to do assertion and generate junit log. It should be overridden in individual test project because they do use different methods to produce test and junit log results
  * **post_run_test** - This is the function should be called in run_test or in post_fail_hook depends on passed or failed test result. It help add junit log and upload guest asset if needed
  * **Add** another universal $self->{script_output} to replace $ret to record directly returned result of execute_script_run which can be used to assert test result and produce junit log. It can also be further manipulated in post_execute_script_assertion if directly returned one is not enough for specific test to assert test result and generate junit log
  * **Any** future modifications to test projects can use the above newly introduced functions to have cleaner development. Generally speaking, post_execute_script_run is enough if handy assert pattern is available and $self->{script_output} returned directly can be used for junit log generation, otherwise post_execute_script_assertion allows you to do your own customization. Anyway any configurations or operations must be done after test execution should be put into post_execute_script_configuration
  * **Preserve** most of current test logic in individual test projects and make no change to some test modules, because they behave in more unique way, for example, virt_v2v and guest_migration_dst

* **Some** changes to traditional test projects:
  * **Guest installation** - Add post_execute_script_assertion to determine its test result and perform operations in post_fail_hook if failed
  * **Guest upgrade** -  Add post_execute_script_assertion to determine its test result and perform operations in post_fail_hook if failed
  * **Guest migration** - Add both post_execute_script_configuration and post_execute_script_assertion and eliminate xen log uploading on kvm host. Wrap up all locks operations in set_mutex_lock. Also eliminate xen logs uploading on kvm host issue.
  * **Host upgrade** - Add post_execute_script_configuration to perform console and boot setup on aarch64 after executing script. Eliminate necessity to upload autoupg.xml in test module directly which will be collected in post_fail_hook if failed
  * **virt-v2v** - Change virt_autotest_base::upload_virt_logs to virt_utils::upload_virt_logs
* **Add** new function collect_host_and_guest_logs in virt_utils.pm which wraps up virt_logs_collector.sh and fetch_logs_from_guest.sh and provides the same set of arguments $guest_wanted, $host_extra_logs and $guest_extra_logs
* **Add** new post_fail_hook in virt_autotest_base.pm which calls post_run_test, virt_utils::collect_host_and_guest_logs and upload_coredumps
* **Correct** a spelling error in virt_logs_collector.sh
* **Work flow** in virt_autotest_base.pm:
  * run_test in individual test modules -> 
  * run_test in base module ->
  * **save_test_configuration** ->
  * execute_script_run in base module -> 
  * Begin **post_execute_script_run** in base module, this calls -> 
     * **post_execute_script_configurations** in individual test modules -> 
     * then upload_virt_logs function -> 
     * at last do assertion by using assert_pattern provided by individual test modules or call **post_execute_script_assertion** in individual test modules -> 
  * After finishing **post_execute_script_run** in base module ->
  * **post_run test** in run_test in base module if pass or **post_run_test** in **post_fail_hook** in base module if fail -> 
  * finish in run_test or **collect_host_and_guest_logs** in **post_fail_hook** -> 
  * finish in **post_fail_hook**



* **Verification runs**:
  * [Guest installation Passed](http://10.67.133.40/tests/398)
  * [Guest installation Failed](http://10.67.133.40/tests/401)
  * [Host upgrade Passed](http://10.67.133.40/tests/391)
  * [Host upgrade Failed](http://10.67.133.40/tests/392)
  * [Guest upgrade Passed](http://10.67.133.40/tests/394)
  * [Guest upgrade Failed](http://10.67.133.40/tests/395)
  * [virt-v2v src Passed](http://10.67.133.40/tests/376)
  * [virt-v2v src Failed](http://10.67.133.40/tests/384)
  * [virt-v2v dst passed](http://10.67.133.40/tests/388)
  * [virt-v2v dst failed](http://10.67.133.40/tests/389)
  * [pvusb passed](http://10.67.133.40/tests/437)
  * [pvusb failed](http://10.67.133.40/tests/439)
  * [Guest migration src Passed](http://10.67.133.40/tests/368)
  * [Guest migration src Failed](http://10.67.133.40/tests/371)
  * [Guest migration dst Passed](http://10.67.133.40/tests/374)
  * [Guest migration dst Failed](http://10.67.133.40/tests/385)