### PR TITLE
Use more stable approach for ibus input source removal

### DIFF
--- a/tests/x11/ibus/ibus_clean.pm
+++ b/tests/x11/ibus/ibus_clean.pm
@@ -19,17 +19,14 @@ use utils;
 
 sub remove_cn {
     assert_and_click 'ibus-input-added-cn';
-    assert_and_click 'ibus-input-remove';
 }
 
 sub remove_jp {
     assert_and_click 'ibus-input-added-jp';
-    assert_and_click 'ibus-input-remove';
 }
 
 sub remove_kr {
     assert_and_click 'ibus-input-added-kr';
-    assert_and_click 'ibus-input-remove';
 }
 
 sub run {


### PR DESCRIPTION
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/681
Ticket: https://progress.opensuse.org/issues/66553
Verification: http://kazhua.qa.suse.de/tests/64#step/ibus_clean/4