### PR TITLE
selinux_setup: do not flag busybox-selinux-tools for installation

### DIFF
--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -33,7 +33,7 @@ sub run {
         assert_script_run('zypper -n in policycoreutils-python');
     }
 
-    my $pkgs = script_output("echo `zypper se selinux | grep -i selinux | grep -v -e srcpackage -e debuginfo -e debugsource | cut -d '|' -f 2`");
+    my $pkgs = script_output("echo `zypper se selinux | grep -i selinux | grep -v -e srcpackage -e debuginfo -e debugsource -e busybox | cut -d '|' -f 2`");
     zypper_call("in $pkgs", timeout => 3000);
 
     # for opensuse, e.g, Tumbleweed install selinux_policy pkgs as needed


### PR DESCRIPTION
The generic attempt to just install *selinux* is flawed in various ways,
but in a quick way to get things going again, let's at least filter out
busybox-selinux-tools, which conflicts (intentionally) with selinux-tools.

Selecting both for installation onto the same system can't be intended

https://progress.opensuse.org/issues/70090
 (workarund - the test needs more generic restructuring)

- Related ticket: https://progress.opensuse.org/issues/70090
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1367236
