### PR TITLE
Adjust seahorse test flow and record_soft_failure boo#1175513

### DIFF
--- a/tests/x11/seahorse.pm
+++ b/tests/x11/seahorse.pm
@@ -45,9 +45,22 @@ sub run {
     send_key "ret";                                   # Next field (confirm PW)
     type_password;                                    # Re-type user password
     send_key "ret";                                   # Confirm password
-    assert_and_click('seahorse-default_keyring', button  => 'right');    # right click the new keyring
-    assert_and_click('seahorse-set_as_default',  timeout => 60);         # Set the new keyring as default
-    send_key "alt-f4";                                                   # Close seahorse
+    wait_still_screen 1;
+    if (check_screen "seahorse-keyring-locked") {
+        assert_and_click "unlock";
+        type_password;
+        send_key "ret";
+    }
+    assert_screen [qw(seahorse-collecton-is-empty seahorse-default_keyring)];
+    if (match_has_tag "seahorse-collecton-is-empty") {
+        record_soft_failure 'Missing entries of Passwords, Keys, Certificates, see boo#1175513';
+        send_key_until_needlematch("generic-desktop", "alt-f4", 5, 5);
+    }
+    elsif (match_has_tag "seahorse-default_keyring") {
+        assert_and_click('seahorse-default_keyring', button  => 'right');    # right click the new keyring
+        assert_and_click('seahorse-set_as_default',  timeout => 60);         # Set the new keyring as default
+        send_key "alt-f4";                                                   # Close seahorse
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
We have problem with keyring which is locked as user logged in.
This is different that it on SLED.
Because of issue boo#1175513 we need to add record_soft_failure for now.

see https://progress.opensuse.org/issues/66149
verification:
http://10.162.23.47/tests/8003#step/seahorse/13 (TW)
http://10.162.23.47/tests/7997#step/seahorse/12 (SLED)
Needle PR:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/684
