### PR TITLE
[Log Enhancement] enable y2log for offline host upgrade

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -31,7 +31,7 @@ use testapi;
 use DateTime;
 
 our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest is_xen_host is_kvm_host check_host check_guest print_cmd_output_to_file
-  ssh_setup ssh_copy_id create_guest install_default_packages);
+  ssh_setup ssh_copy_id create_guest install_default_packages upload_y2logs);
 
 #return 1 if it is a VMware test judging by REGRESSION variable
 sub is_vmware_virtualization {
@@ -138,6 +138,13 @@ sub create_guest {
 sub install_default_packages {
     # Install nmap, ip, dig
     zypper_call '-t in nmap iputils bind-utils', exitcode => [0, 4, 102, 103, 106];
+}
+
+sub upload_y2logs {
+    # Create and Upload y2log for analysis
+    assert_script_run "save_y2logs /tmp/y2logs.tar.bz2", 180;
+    upload_logs("/tmp/y2logs.tar.bz2");
+    save_screenshot;
 }
 
 1;

--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -16,6 +16,7 @@ use File::Basename;
 use testapi;
 use virt_utils 'clean_up_red_disks';
 use base 'reboot_and_wait_up';
+use virt_autotest::utils;
 
 sub run {
     my $self = shift;
@@ -46,6 +47,14 @@ sub run {
     }
 
     $self->reboot_and_wait_up($timeout);
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    reset_consoles;
+    select_console('root-console');
+    $self->upload_y2logs if (check_var('offline_upgrade', 'yes'));
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
- Background:

Current Offline host upgrade does not provide log collection(y2log) after failing to reach 'reboot' step.

This PR will deal with this problem, the offline host upgrade test was not complete successfully (ssh service still keep active on vm host) after failing to reach 'reboot' step.

So, added `post_fail_hook` under reboot_and_wait_up_upgrade.pm to call `enable_y2log_analysis` func to provide log collection(y2log) on vm host, and then used upload_logs to upload this created y2log

- Verification run:

[prj2_host_upgrade:fail call post_fail_hook](http://10.67.131.5/tests/227)
[prj2_host_upgrade:fail at assert_screen('rebootnow', 2700) ](http://10.67.131.5/tests/254)
[prj2_host_upgrade:pass](http://10.67.131.5/tests/244)