### PR TITLE
Enable firstboot_hostname in first boot test

### DIFF
--- a/data/yast2/firstboot/firstboot_custom-opensuse.xml
+++ b/data/yast2/firstboot/firstboot_custom-opensuse.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0"?>
+<productDefines  xmlns="http://www.suse.com/1.0/yast2ns"
+    xmlns:config="http://www.suse.com/1.0/configns">
+
+    <!--
+	 Custom file from TW build 20200819
+    -->
+
+    <!--
+    $Id$
+    Work around for the text domain
+    textdomain="firstboot"
+    -->
+
+    <textdomain>firstboot</textdomain>
+
+	<!---
+	See https://github.com/yast/yast-installation/blob/master/doc/control-file.md for more
+	explanation about the control file settings.
+	-->
+
+    <globals>
+
+	<!--
+	If a variable root_password_as_first_user is present in globals section,
+	inst_user step will have the check box
+	    "Use this password for system administrator"
+	so you don't need to include root password step (fate#306297).
+	If the variable is missing (commented), the check box won't appear.
+
+	The value of the variable (true/false) will set the default value for the check box.
+	<root_password_as_first_user config:type="boolean">true</root_password_as_first_user>
+	 -->
+
+	<!-- The default value of "Automatic Login" checkbox -->
+	<enable_autologin config:type="boolean">false</enable_autologin>
+
+	<!-- This option is deprecated in favor of installation-layout -->
+	<!-- <installation_ui>sidebar</installation_ui> -->
+
+	<!-- Configuration of the installation/firstboot layout -->
+	<installation_layout>
+		<mode>steps</mode>
+		<banner config:type="boolean">false</banner>
+	</installation_layout>
+
+	<!--
+	For more variables that can be in this section, look into the control file
+	(/etc/YaST2/control.xml or root directory of installation media).
+	-->
+    </globals>
+    <proposals config:type="list">
+        <proposal>
+            <name>firstboot_hardware</name>
+            <mode>installation</mode>
+            <stage>firstboot</stage>
+            <label>Hardware Configuration</label>
+            <proposal_modules config:type="list">
+                <proposal_module>printer</proposal_module>
+            </proposal_modules>
+        </proposal>
+    </proposals>
+    <workflows  config:type="list">
+        <workflow>
+            <defaults>
+                <enable_back>yes</enable_back>
+                <enable_next>yes</enable_next>
+                <archs>all</archs>
+            </defaults>
+            <stage>firstboot</stage>
+            <label>Configuration</label>
+            <mode>installation</mode>
+            <modules  config:type="list">
+                <module>
+                    <label>Network Autosetup</label>
+                    <name>firstboot_setup_dhcp</name>
+                </module>
+                <module>
+                    <label>Language and Keyboard</label>
+                    <enabled config:type="boolean">true</enabled>
+		    <!-- step for configuration of both language and keyboard layout (fate#306296) -->
+                    <name>firstboot_language_keyboard</name>
+                </module>
+                <module>
+                    <label>Language</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_language</name>
+                </module>
+                <module>
+                    <label>Keyboard Layout</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_keyboard</name>
+                </module>
+                <module>
+                    <label>Welcome</label>
+                    <name>firstboot_welcome</name>
+                </module>
+                <module>
+                    <label>License Agreement</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_licenses</name>
+                </module>
+                <module>
+                    <label>Host Name</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_hostname</name>
+                </module>
+                <module>
+                    <label>Network</label>
+		    <!-- this step only restarts service 'network' -->
+                    <name>firstboot_network_write</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_ssh</name>
+                </module>
+                <module>
+                    <label>Network</label>
+                    <name>inst_lan</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                 <module>
+                    <label>Automatic Configuration</label>
+                    <name>inst_automatic_configuration</name>
+                    <enabled config:type="boolean">false</enabled>
+                 </module>
+                <module>
+                    <label>Time and Date</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_timezone</name>
+                </module>
+                <module>
+                    <label>NTP Client</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_ntp</name>
+                </module>
+                <module>
+                    <label>Desktop</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_desktop</name>
+                </module>
+                <module>
+                    <label>Network</label>
+                    <name>inst_lan</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
+                    <label>Users</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_user</name>
+                </module>
+                <module>
+                    <label>Root Password</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_root</name>
+                </module>
+                <module>
+                    <label>Customer Center</label>
+                    <name>registration</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
+                    <label>Hardware</label>
+                    <name>inst_proposal</name>
+                    <enabled config:type="boolean">false</enabled>
+                    <proposal>firstboot_hardware</proposal>
+                </module>
+                <module>
+                    <label>Finish Setup</label>
+                    <name>firstboot_write</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>no</enable_next>
+                </module>
+                <module>
+                    <label>Finish Setup</label>
+                    <name>inst_congratulate</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+
+            </modules>
+        </workflow>
+    </workflows>
+    <texts>
+	<!--
+	Labels used during Automatic Configuration: use "text_id" from "ac_step"
+	-->
+	<ac_label_1><label>Configuring network...</label></ac_label_1>
+	<ac_label_2><label>Configuring hardware...</label></ac_label_2>
+    </texts>
+</productDefines>

--- a/data/yast2/firstboot/firstboot_custom-sle.xml
+++ b/data/yast2/firstboot/firstboot_custom-sle.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0"?>
+<productDefines  xmlns="http://www.suse.com/1.0/yast2ns"
+    xmlns:config="http://www.suse.com/1.0/configns">
+
+    <!--
+	 Custom file takem from Leap 15.2
+    -->
+
+    <!--
+    $Id$
+    Work around for the text domain
+    textdomain="firstboot"
+    -->
+
+    <textdomain>firstboot</textdomain>
+
+    <globals>
+
+	<!--
+	If a variable root_password_as_first_user is present in globals section,
+	inst_user step will have the check box
+	    "Use this password for system administrator"
+	so you don't need to include root password step (fate#306297).
+	If the variable is missing (commented), the check box won't appear.
+
+	The value of the variable (true/false) will set the default value for the check box.
+	<root_password_as_first_user config:type="boolean">true</root_password_as_first_user>
+	 -->
+
+	<!-- The default value of "Automatic Login" checkbox -->
+	<enable_autologin config:type="boolean">false</enable_autologin>
+
+	<!--
+	For more variables that can be in this section, look into the control file
+	(/etc/YaST2/control.xml or root directory of installation media)
+	-->
+    </globals>
+    <proposals config:type="list">
+        <proposal>
+            <name>firstboot_hardware</name>
+            <mode>installation</mode>
+            <stage>firstboot</stage>
+            <label>Hardware Configuration</label>
+            <proposal_modules config:type="list">
+                <proposal_module>printer</proposal_module>
+            </proposal_modules>
+        </proposal>
+    </proposals>
+    <workflows  config:type="list">
+        <workflow>
+            <defaults>
+                <enable_back>yes</enable_back>
+                <enable_next>yes</enable_next>
+                <archs>all</archs>
+            </defaults>
+            <stage>firstboot</stage>
+            <label>Configuration</label>
+            <mode>installation</mode>
+            <modules  config:type="list">
+                <module>
+                    <label>Network Autosetup</label>
+                    <name>firstboot_setup_dhcp</name>
+                </module>
+                <module>
+                    <label>Language and Keyboard</label>
+                    <enabled config:type="boolean">true</enabled>
+		    <!-- step for configuration of both language and keyboard layout (fate#306296) -->
+                    <name>firstboot_language_keyboard</name>
+                </module>
+                <module>
+                    <label>Language</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_language</name>
+                </module>
+                <module>
+                    <label>Keyboard Layout</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_keyboard</name>
+                </module>
+                <module>
+                    <label>Welcome</label>
+                    <name>firstboot_welcome</name>
+                </module>
+                <module>
+                    <label>License Agreement</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_licenses</name>
+                </module>
+                <module>
+                    <label>Host Name</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_hostname</name>
+                </module>
+                <module>
+                    <label>Network</label>
+		    <!-- this step only restarts service 'network' -->
+                    <name>firstboot_network_write</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_ssh</name>
+                </module>
+                <module>
+                    <label>Network</label>
+                    <name>inst_lan</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                 <module>
+                    <label>Automatic Configuration</label>
+                    <name>inst_automatic_configuration</name>
+                    <enabled config:type="boolean">false</enabled>
+                 </module>
+                <module>
+                    <label>Time and Date</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_timezone</name>
+                </module>
+                <module>
+                    <label>NTP Client</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_ntp</name>
+                </module>
+                <module>
+                    <label>Desktop</label>
+                    <enabled config:type="boolean">false</enabled>
+                    <name>firstboot_desktop</name>
+                </module>
+                <module>
+                    <label>Network</label>
+                    <name>inst_lan</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
+                    <label>Users</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_user</name>
+                </module>
+                <module>
+                    <label>Root Password</label>
+                    <enabled config:type="boolean">true</enabled>
+                    <name>firstboot_root</name>
+                </module>
+                <module>
+                    <label>Customer Center</label>
+                    <name>registration</name>
+                    <enabled config:type="boolean">false</enabled>
+                </module>
+                <module>
+                    <label>Hardware</label>
+                    <name>inst_proposal</name>
+                    <enabled config:type="boolean">false</enabled>
+                    <proposal>firstboot_hardware</proposal>
+                </module>
+                <module>
+                    <label>Finish Setup</label>
+                    <name>firstboot_write</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>no</enable_next>
+                </module>
+                <module>
+                    <label>Finish Setup</label>
+                    <name>inst_congratulate</name>
+                    <enable_back>no</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+
+            </modules>
+        </workflow>
+    </workflows>
+    <texts>
+	<!--
+	Labels used during Automatic Configuration: use "text_id" from "ac_step"
+	-->
+	<ac_label_1><label>Configuring network...</label></ac_label_1>
+	<ac_label_2><label>Configuring hardware...</label></ac_label_2>
+    </texts>
+</productDefines>

--- a/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
@@ -7,8 +7,9 @@ description:    >
   configure root and user accounts. SUT should end up in GDM screen after exiting YaST2
   Firstboot.
 vars:
-  AUTOYAST: autoyast_opensuse/autoyast_firstboot.xml
+  AUTOYAST: autoyast_sle15/autoyast_firstboot.xml
   DESKTOP: gnome
+  NOAUTOLOGIN: 1
   YAST2_FIRSTBOOT_USERNAME: firstbootuser
 schedule:
   - autoyast/prepare_profile
@@ -18,3 +19,5 @@ schedule:
   - installation/yast2_firstboot
   - installation/first_boot
   - console/validate_yast2_firstboot_configuration
+test_data:
+  <<: !include test_data/yast/firstboot/yast2_firstboot.yaml

--- a/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
@@ -7,9 +7,8 @@ description:    >
   configure root and user accounts. SUT should end up in GDM screen after exiting YaST2
   Firstboot.
 vars:
-  AUTOYAST: autoyast_sle15/autoyast_firstboot.xml
+  AUTOYAST: autoyast_opensuse/autoyast_firstboot.xml
   DESKTOP: gnome
-  NOAUTOLOGIN: 1
   YAST2_FIRSTBOOT_USERNAME: firstbootuser
 schedule:
   - autoyast/prepare_profile
@@ -19,3 +18,5 @@ schedule:
   - installation/yast2_firstboot
   - installation/first_boot
   - console/validate_yast2_firstboot_configuration
+test_data:
+  <<: !include test_data/yast/firstboot/yast2_firstboot.yaml

--- a/schedule/yast/firstboot/yast2_firstboot.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot.yaml
@@ -15,3 +15,5 @@ schedule:
     - installation/yast2_firstboot
     - installation/first_boot
     - console/validate_yast2_firstboot_configuration
+test_data:
+  <<: !include test_data/yast/firstboot/yast2_firstboot.yaml

--- a/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
@@ -1,0 +1,28 @@
+---
+name:           yast2_fistboot_custom
+description:    >
+    Variant of YaST2 Firstboot module using custom control file. Allows us to test different scenarios,
+    and to see if the yast2-firstboot package remains stable whith an old, potentially deprecated control file.
+vars:
+    YAST2_FIRSTBOOT_USERNAME: firstbootuser
+schedule:
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/hostname
+    - installation/enable_y2_firstboot
+    - autoyast/autoyast_reboot
+    - installation/grub_test
+    - installation/yast2_firstboot
+    - installation/first_boot
+    - console/validate_yast2_firstboot_configuration
+test_data:
+    clients:
+        - firstboot_language_keyboard
+        - firstboot_welcome
+        - firstboot_licenses
+        - firstboot_hostname
+        - firstboot_timezone
+        - firstboot_user
+        - firstboot_root
+    custom_control_file: "yast2/firstboot/firstboot_custom-opensuse.xml"

--- a/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
@@ -1,0 +1,28 @@
+---
+name:           yast2_fistboot_custom
+description:    >
+    Variant of YaST2 Firstboot module using custom control file. Allows us to test different scenarios,
+    and to see if the yast2-firstboot package remains stable whith an old, potentially deprecated control file.
+vars:
+    YAST2_FIRSTBOOT_USERNAME: firstbootuser
+schedule:
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/hostname
+    - installation/enable_y2_firstboot
+    - autoyast/autoyast_reboot
+    - installation/grub_test
+    - installation/yast2_firstboot
+    - installation/first_boot
+    - console/validate_yast2_firstboot_configuration
+test_data:
+    clients:
+        - firstboot_language_keyboard
+        - firstboot_welcome
+        - firstboot_licenses
+        - firstboot_hostname
+        - firstboot_timezone
+        - firstboot_user
+        - firstboot_root
+    custom_control_file: "yast2/firstboot/firstboot_custom-sle.xml"

--- a/test_data/yast/firstboot/yast2_firstboot.yaml
+++ b/test_data/yast/firstboot/yast2_firstboot.yaml
@@ -1,0 +1,7 @@
+clients:
+  - firstboot_language_keyboard
+  - firstboot_welcome
+  - firstboot_licenses
+  - firstboot_timezone
+  - firstboot_user
+  - firstboot_root

--- a/tests/installation/enable_y2_firstboot.pm
+++ b/tests/installation/enable_y2_firstboot.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,18 +9,24 @@
 
 # Summary: Enable YaST2 Firstboot module - Desktop workstation configuration utility
 # Doc: https://en.opensuse.org/YaST_Firstboot
-# Maintainer: Martin Loviska <mloviska@suse.com>
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
 use utils qw(zypper_call clear_console);
+use scheduler 'get_test_suite_data';
 
 sub run {
+    my $test_data = get_test_suite_data();
     select_console 'root-console';
     zypper_call "in yast2-firstboot";
     assert_script_run 'touch /var/lib/YaST2/reconfig_system';
+    # Use default file from package if no custom file was specified
+    if ($test_data->{custom_control_file}) {
+        assert_script_run 'wget ' . data_url($test_data->{custom_control_file}) . ' -O /etc/YaST2/firstboot.xml';
+    }
     clear_console;
 }
 


### PR DESCRIPTION
This change also aims to allow testing other firstboot clients, see
motivation here https://progress.opensuse.org/issues/69130

- Related ticket https://progress.opensuse.org/issues/69175
- Needles: will push later
- Verification run:
SP3, standard file http://waaa-amazing.suse.cz/tests/12831
SP3, custom http://waaa-amazing.suse.cz/tests/12842

Passed 50 test runs
