### PR TITLE
Add service check for SLES11SP4

### DIFF
--- a/lib/services/apache.pm
+++ b/lib/services/apache.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -50,14 +50,13 @@ sub check_function {
 # check apache service before and after migration
 # stage is 'before' or 'after' system migration.
 sub full_apache_check {
-    my ($stage) = @_;
+    my ($stage, $type) = @_;
     $stage //= '';
     if ($stage eq 'before') {
         install_service();
-        enable_service();
-        start_service();
+        common_service_start('apache2', $type);
     }
-    check_service();
+    common_service_status('apache2', $type);
     check_function();
 }
 


### PR DESCRIPTION
We need to add sle11sp4 service check to our tests, but  cause they use SystemV init system, 
for our service framework we need handle this kind of difference.

- Related ticket: https://progress.opensuse.org/issues/54380
- Needles: N/A
- Verification run:  

we use cups and apache as a example here:
https://openqa.nue.suse.com/tests/4579059
https://openqa.nue.suse.com/tests/4584864
https://openqa.nue.suse.com/tests/4584965
https://openqa.nue.suse.com/tests/4584967

sles12sp5 regression test
https://openqa.nue.suse.com/tests/4599707

sles15sp2 regression test
https://openqa.nue.suse.com/tests/4599965
sles15sp1 online passed
https://openqa.nue.suse.com/tests/4682022
https://openqa.nue.suse.com/tests/4682016

sles15sp3 
https://openqa.nue.suse.com/tests/4682052