### PR TITLE
Check if apache is reloading correctly

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -46,6 +46,25 @@ sub run {
     systemctl 'start apache2';
     systemctl 'status apache2';
 
+    # Check if apache is working when php module is enabled
+    # Install apache2-mod_php72 php72-curl for versions smaller than SLE12-SP5, as dependencies for enabling php7 on SLE15+ are fulfilled
+    if (is_sle('<=12-SP5')) {
+        zypper_call('in apache2-mod_php72 php72-curl');
+    }
+
+    # Following the reproducer of bug#1174667, the regression was detected when php7 module enabled and when stopping or reloading apache service
+    assert_script_run('a2enmod php7');
+    systemctl 'stop apache2';
+    systemctl 'start apache2';
+    systemctl 'reload apache2';
+    systemctl 'status apache2';
+    assert_script_run 'a2dismod php7';
+
+    # In order to avoid future conflicts, apache2-mod_php72 php72-curl and their dependencies are removed
+    if (is_sle('<=12-SP5')) {
+        zypper_call('rm --clean-deps apache2-mod_php72 php72-curl');
+    }
+
     # Check if the server works and serves the right content
     assert_script_run 'curl -v http://localhost/ | grep "index"';
 


### PR DESCRIPTION
It checks if apache is reloading correctly when php modules is enabled.
This regression was spotted on SLE 12.sp3+

- Related ticket: https://progress.opensuse.org/issues/69538
- Needles: N/A
- Verification run: [SLE 12.sp5](http://10.161.229.247/tests/1019) [SLE 12sp4](https://openqa.suse.de/tests/4584919) https://openqa.suse.de/tests/4584020
[SLE 15sp2 ](http://10.161.229.247/tests/1021) [SLE 15sp1](http://10.161.229.247/tests/1023) [SLE 15](http://10.161.229.247/tests/1022)
