### PR TITLE
Configures self_update repo and adjust welcome to import key

### DIFF
--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -6,7 +6,7 @@ description:    >
   Installation is validated by successful boot and that YaST does not report
   any issue.
 vars:
-  INSTALLER_SELF_UPDATE: 1
+  INSTALLER_SELF_UPDATE: http://openqa.suse.de/assets/repo/SLE-15-x86_64-self_update
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -32,6 +32,7 @@ use x11utils 'ensure_fullscreen';
 use version_utils qw(:VERSION :SCENARIO);
 use Utils::Backends 'is_remote_backend';
 use Utils::Architectures;
+use utils 'handle_untrusted_gpg_key';
 
 sub switch_keyboard_layout {
     record_info 'keyboard layout', 'Check keyboard layout switching to another language';
@@ -105,6 +106,7 @@ sub run {
     # Add tag to check for https://progress.opensuse.org/issues/30823 "test is
     # stuck in linuxrc asking if dhcp should be used"
     push @welcome_tags, 'linuxrc-dhcp-question';
+    push @welcome_tags, 'import-known-untrusted-gpg-key' if get_var('INSTALLER_SELF_UPDATE');
 
     # Process expected pop-up windows and exit when welcome/beta_war is shown or too many iterations
     while ($iterations++ < scalar(@welcome_tags)) {
@@ -115,6 +117,7 @@ sub run {
         if ((match_has_tag 'inst-betawarning') || (match_has_tag 'inst-welcome') || (match_has_tag 'inst-welcome-no-product-list')) {
             last;
         }
+        handle_untrusted_gpg_key;
         if (match_has_tag 'scc-invalid-url') {
             die 'SCC reg URL is invalid' if !get_var('SCC_URL_VALID');
             send_key 'alt-r';    # registration URL field


### PR DESCRIPTION
To simulate the test scenario of self_update, I set the test to use
a custom rpm repository. We can not verify that the package from the repo
is actually used (testing only manual at the moment). We need this because the
default value of self_update is 1 which because it does not find anything to download
it just returns to the main repo and it does not install any updated package.
In additional i modified the welcome to import the gpg key that i have signed the repo.


- Related ticket: https://progress.opensuse.org/issues/69583
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1418
- Verification run: 
[boot parameter](http://aquarius.suse.cz/tests/3167#step/bootloader_start/9)
[welcome import key](http://aquarius.suse.cz/tests/3167#step/welcome/1)