### PR TITLE
xfstests: Fix a typo in partition part and leave some free space for /root

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -151,7 +151,7 @@ sub create_loop_device_by_rootsize {
     }
     $size  = int($para{size} / ($amount + 1));
     $bsize = 4096;
-    $count = int($size * 1028 * 1028 / $bsize);
+    $count = int($size * 1024 * 1024 / $bsize);
     my $num = 0;
     my $filename;
     while ($amount >= $num) {
@@ -204,7 +204,7 @@ sub run {
         if ($loopdev) {
             $para{fstype} = $filesystem;
             $para{size}   = script_output("df -h | grep /\$ | awk -F \" \" \'{print \$4}\'");
-            $para{siza}   = str_to_mb($para{siza});
+            $para{size}   = str_to_mb($para{size});
             create_loop_device_by_rootsize(\%para);
         }
         else {

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -149,7 +149,8 @@ sub create_loop_device_by_rootsize {
     if ($para{fstype} =~ /btrfs/) {
         $amount = 5;
     }
-    $size  = int($para{size} / ($amount + 1));
+    # Use 90% of free space, not use all space in /root
+    $size  = int($para{size} * 0.9 / ($amount + 1));
     $bsize = 4096;
     $count = int($size * 1024 * 1024 / $bsize);
     my $num = 0;


### PR DESCRIPTION
Fix a typo in partition.pm. Because size not set into MB, it will cause partition size very small.
And avoid to use all free space in /root, it will cause read/write error, here change to leave 10% free space in /root.

- Verification run: http://10.67.133.10/tests/146