### PR TITLE
Reuse parse_repo_data to validate repos

### DIFF
--- a/tests/console/validate_addon_repos.pm
+++ b/tests/console/validate_addon_repos.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 
 use testapi;
-use repo_tools 'validate_repo_enablement';
+use repo_tools 'validate_repo_properties';
 
 sub run {
     select_console 'root-console';
@@ -28,7 +28,13 @@ sub run {
         my $uri      = get_required_var("ADDONURL_$uc_addon");
         my $alias    = get_required_var("REPO_SLE_PRODUCT_$uc_addon");
         my $name     = get_required_var("DISTRI") . "-$addon";
-        validate_repo_enablement(alias => $alias, name => $name, uri => $uri);
+        validate_repo_properties({
+                Alias       => $alias,
+                Name        => $name,
+                URI         => $uri,
+                Enabled     => 'Yes',
+                Autorefresh => 'On'
+        });
     }
 }
 

--- a/tests/console/validate_dud_addon_repos.pm
+++ b/tests/console/validate_dud_addon_repos.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 
 use testapi;
-use repo_tools 'parse_repo_data';
+use repo_tools 'validate_repo_properties';
 use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 
@@ -26,11 +26,7 @@ sub run {
     my $test_data = get_test_suite_data();
     select_console 'root-console';
     foreach my $expected_dud_repo (@{$test_data->{dud_repos}}) {
-        my $actual_dud_repo = parse_repo_data($expected_dud_repo->{URI});
-        assert_equals($expected_dud_repo->{Enabled}, $actual_dud_repo->{Enabled},
-            "Fail! It is expected that the 'Enabled' field is set to $expected_dud_repo->{Enabled}, but it is $actual_dud_repo->{Enabled}");
-        assert_equals($expected_dud_repo->{Autorefresh}, $actual_dud_repo->{Autorefresh},
-            "Fail! It is expected that the 'Autorefresh' field is set to $expected_dud_repo->{Autorefresh}, but it is $actual_dud_repo->{Autorefresh}");
+        validate_repo_properties($expected_dud_repo);
     }
     assert_script_run('zypper -v ref | grep "All repositories have been refreshed"', 120);
 }

--- a/tests/console/validate_mirror_repos.pm
+++ b/tests/console/validate_mirror_repos.pm
@@ -15,7 +15,8 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use repo_tools 'validate_repo_enablement';
+use repo_tools 'validate_repo_properties';
+use registration 'scc_version';
 
 sub run {
     select_console 'root-console';
@@ -24,9 +25,17 @@ sub run {
     my $mirror_src = get_required_var("MIRROR_$method");
     $mirror_src .= '?ssl_verify=no' if ($method eq 'HTTPS');
     my $sle_prod = uc get_var('SLE_PRODUCT') . get_var('VERSION');
+    my $name     = $sle_prod . '-' . scc_version() . '-0';
 
     record_info("Mirror Validation", "Validate $mirror_src used for installation is added in the installed system");
-    validate_repo_enablement(alias => $sle_prod, name => $sle_prod, uri => $mirror_src);
+    validate_repo_properties({
+            Filter      => $name,
+            Alias       => $sle_prod,
+            Name        => $sle_prod,
+            URI         => $mirror_src,
+            Enabled     => 'Yes',
+            Autorefresh => 'On'
+    });
 }
 
 1;


### PR DESCRIPTION
We have nice method to get all the repo properties which we then can use
to validate repositories. Reusing this method allows to validate repo
properties granularly.

See [poo#69598](https://progress.opensuse.org/issues/69586).

[Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23repo_validation&distri=sle).