### PR TITLE
Add tag for needles of sle15-sp3

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -83,6 +83,9 @@ sub cleanup_needles {
     $tounregister = is_sle('15-SP2+') ? '0' : '1';
     unregister_needle_tags("ENV-15SP2ORLATER-$tounregister");
 
+    $tounregister = is_sle('15-SP3+') ? '0' : '1';
+    unregister_needle_tags("ENV-15SP3ORLATER-$tounregister");
+
     if (!is_server) {
         unregister_needle_tags("ENV-FLAVOR-Server-DVD");
     }


### PR DESCRIPTION
This patch adds a tag to unregister particular needles when is not for sle15-sp3 version.

- Needles: _bootmenu-sles15-20200826_ I create this needle for testing. Check links below. in the first has been removed when it is used in sp3
- Verification run: 
[sp2](http://aquarius.suse.cz/tests/3227#step/bootloader_start/2) vs [sp3](http://aquarius.suse.cz/tests/3226#step/bootloader_start/2)