### PR TITLE
Add softfail on validate_addons_repos due to bsc#1175374

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -469,8 +469,14 @@ sub validate_repo_properties {
     }
 
     if ($args->{Name}) {
-        assert_true($actual_repo_data->{Name} =~ /$args->{Name}/,
-            "Repository '$args->{Name}' has wrong name: '$actual_repo_data->{Name}'");
+        # TODO remove workaround poo#70546
+        if ($actual_repo_data->{Name} =~ /$args->{Alias}\/?/) {
+            record_soft_failure "repo name is not set correctly - bsc#1175374 - found actual repo name $actual_repo_data->{Name}";
+        }
+        else {
+            assert_true($actual_repo_data->{Name} =~ /$args->{Name}/,
+                "Repository '$args->{Name}' has wrong name: '$actual_repo_data->{Name}'");
+        }
     }
 
     if ($args->{URI}) {


### PR DESCRIPTION
The problem verified is the bug reported on bsc#1175374. The value of the name                                                                                                                                                                                                                                               
is filled by the alias plus a /. I use a regex similar to the assert validation                                                                                                                                                                                                                                              
to catch the cases where the addon has the format "number | alias | alias/ |" and                                                                                                                                                                                                                                            
return. 

- Related ticket: https://progress.opensuse.org/issues/70174
- Verification run: 
[addon-module-ftp](http://aquarius.suse.cz/tests/3190)
