### PR TITLE
[WIP] Schedule rmt test on SLE 15 updates

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1490,7 +1490,7 @@ sub load_extra_tests_desktop {
         # TODO: check why this is not called on opensuse
         # poo#35574 - Excluded for Xen PV as it was never passed due to the fail while interacting with grub.
         loadtest 'x11/user_defined_snapshot' unless is_s390x || (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'));
-	loadtest 'x11/rmt_feature' unless is_sle("<15");
+        loadtest 'x11/rmt/rmt_feature'       unless is_sle("<15");
     }
     elsif (check_var('DISTRI', 'opensuse')) {
         if (gnomestep_is_applicable()) {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1490,6 +1490,7 @@ sub load_extra_tests_desktop {
         # TODO: check why this is not called on opensuse
         # poo#35574 - Excluded for Xen PV as it was never passed due to the fail while interacting with grub.
         loadtest 'x11/user_defined_snapshot' unless is_s390x || (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'));
+	loadtest 'x11/rmt_feature' unless is_sle("<15");
     }
     elsif (check_var('DISTRI', 'opensuse')) {
         if (gnomestep_is_applicable()) {

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -274,7 +274,7 @@ Function to sync rmt server
 
 =cut
 sub rmt_sync {
-    assert_script_run 'rmt-cli sync', 1800;
+    script_retry 'rmt-cli sync', delay => 30, retry => 6, timeout => 1800;
 }
 
 =head2 rmt_enable_pro

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -179,10 +179,26 @@ sub handle_login {
     my ($myuser, $user_selected) = @_;
     $myuser        //= $username;
     $user_selected //= 0;
-
     save_screenshot();
     # wait for DM, avoid screensaver and try to login
-    send_key_until_needlematch('displaymanager', 'esc', 30, 3);
+    
+    my $counter = 0;
+    while (!check_screen('displaymanager') &&  $counter < 5) {
+        send_key 'esc';
+        wait_still_screen 3;
+	$counter++;
+    }
+
+    if ($counter >= 5) {
+        if (check_screen 'screenlock') {
+            mouse_set(50,50); # move mouse to workaround #bsc1058521
+	    mouse_click('left');
+	    record_soft_failure('bsc#1058521');
+        }
+    }
+
+    send_key_until_needlematch('displaymanager', 'esc', 5, 3);
+
     if (get_var('ROOTONLY')) {
         if (check_screen 'displaymanager-username-notlisted', 10) {
             record_soft_failure 'bgo#731320/boo#1047262 "not listed" Login screen for root user is not intuitive';


### PR DESCRIPTION
Schedule existing rmt test on SLE 15.x updates

NOTE: It does require these additional test suite vars:
```
PRODUCT_ALLM
PRODUCT_ALLMA
SMT_DATA_FILE
SMT_DATA_URL
SMT_ORG_NAME
SMT_ORG_PASSWORD
```

- Related ticket: https://progress.opensuse.org/issues/55784
- Needles: no needles
- Verification run:
  - Single perl module:
    - 15.1 https://openqa.suse.de/tests/4587879
    - 15.2 https://openqa.suse.de/tests/4584969
  - Full mau-extratests-desktop :
    - 15.2 https://openqa.suse.de/tests/4619287#
    - 15.1 https://openqa.suse.de/tests/4608009#
