### PR TITLE
Unify pvm schedules to use bootloader_start

### DIFF
--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -11,7 +11,7 @@ vars:
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
   DESKTOP: textmode
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -11,7 +11,7 @@ vars:
   MAX_JOB_TIME: '14400'
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration

--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -23,7 +23,7 @@ conditional_schedule:
         - installation/bootloader_zkvm
     BACKEND:
       spvm:
-        - installation/bootloader
+        - installation/bootloader_start
   # As per bsc#1161234 yast keyaboard won't be fixed on s390x
   yast_keyboard:
     BACKEND:

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
@@ -8,8 +8,7 @@ description:    >
 vars:
   INSTALLER_NO_SELF_UPDATE: 1
 schedule:
-  - installation/isosize
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration

--- a/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
@@ -8,8 +8,7 @@ description:    >
 vars:
   INSTALLER_SELF_UPDATE: 1
 schedule:
-  - installation/isosize
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration


### PR DESCRIPTION
Having same module in schedule will help us to label failures and also
make conclusions when other test failed in the same module.
`bootloader_start` just call the code from `bootloader` and provides
abstraction layer, so can be used on multiple backends to have same
schedule, so once we address other differences, those scehdules can be
united.

This change is cosmetic and doesn't change any functional part. Also
fixes schedules not to have `isosize` module executed on powerVM.
