### PR TITLE
Harden lib/apparmortest adminer_delete_database

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -619,11 +619,10 @@ sub adminer_database_delete {
     assert_screen("adminer-save-passwd");
     send_key "alt-s";
     assert_screen("adminer-select-database");
-    send_key_until_needlematch("adminer-select-database-test", 'tab', 30, 1);
-    assert_screen("adminer-select-database-test");
-    send_key "spc";
-    send_key_until_needlematch("adminer-database-dropped", 'ret', 10, 1);
-
+    assert_and_click("adminer-click-database-test");
+    assert_and_click("adminer-click-drop-database-test");
+    # Confirm drop
+    wait_screen_change { send_key 'spc' }
     # Exit x11 and turn to console
     send_key "alt-f4";
     assert_screen("generic-desktop");


### PR DESCRIPTION
Replacing the send_key_until_needlematch approach with an
assert_and_click to make the tests more robust

- Related ticket: https://progress.opensuse.org/issues/68818
- Needles: already created on O3
- Verification run: TBD
