### PR TITLE
Fix devel:tools repository

### DIFF
--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -4,7 +4,7 @@ description:    >
 vars:
     AUTOYAST: autoyast_mlx_con5.xml
     AUTOYAST_PREPARE_PROFILE: 1
-    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/home:/MMoese:/branches:/devel:/tools/SLE_12_SP4/home:MMoese:branches:devel:tools.repo
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
     GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1


### PR DESCRIPTION
In the past we used a branched package without all bindings,
because twopence failed to build. In the meantime, this package
seems to be fixed, so we should switch to using this one.