### PR TITLE
IB: Remove mpitests-openmpi3 workaround

### DIFF
--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -119,11 +119,6 @@ sub run {
     exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$slave");
     script_run("/usr/bin/clear");
 
-    if ((is_sle && is_sle('>15-sp2')) && (script_run('zypper se mpitests-openmpi3') != 0)) {
-        record_info('mpistests-openmpi3', 'add GA Repo (mpitests-openmpi3 missing)', result => 'softfail');
-        zypper_ar("http://download.suse.de/ibs/SUSE:/SLE-$version:/GA/standard/SUSE:SLE-$version:GA.repo");
-    }
-
     barrier_wait('IBTEST_SETUP');
 
     if ($role eq 'IBTEST_MASTER') {


### PR DESCRIPTION
Since mpitests-openmpi3 there is no need to keep the workaround
introduced in SLE15 SP2