### PR TITLE
Fix oprofile (install psmisc dependency)

### DIFF
--- a/tests/console/oprofile.pm
+++ b/tests/console/oprofile.pm
@@ -23,7 +23,7 @@ sub run {
     $self->select_serial_terminal;
 
     # Install fio as load generator and oprofile
-    zypper_call "in fio oprofile";
+    zypper_call "in fio oprofile psmisc";
 
     # Start a system wide profiling
     script_run "(operf --system-wide &)";


### PR DESCRIPTION
to add missing killall dependency.
    
Fixes SLES 15sp3 bare metal tests:
https://openqa.suse.de/tests/4579026#step/oprofile/7
    
Fixes: af2454ba0 ("Add bare metal test for oprofile")