### PR TITLE
Enable aggregate testing for ha qam test repo

### DIFF
--- a/schedule/qam/12-SP2/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/12-SP2/qam-create_hdd_ha_textmode.yaml
@@ -27,7 +27,8 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - '{{system_prepare}}'
-  - '{{patch_and_reboot}}'
+  - '{{patch_and_reboot_inci}}'
+  - '{{patch_and_reboot_test_repo}}'
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
@@ -38,9 +39,13 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/system_prepare
-  patch_and_reboot:
+  patch_and_reboot_inci:
     QAM_INCI:
       1:
+        - qa_automation/patch_and_reboot
+  patch_and_reboot_test_repo:
+    FLAVOR:
+      Server-DVD-HA-Updates:
         - qa_automation/patch_and_reboot
   add_update_test_repo:
     QAM_INCI:

--- a/schedule/qam/12-SP3/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/12-SP3/qam-create_hdd_ha_textmode.yaml
@@ -27,7 +27,8 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - '{{system_prepare}}'
-  - '{{patch_and_reboot}}'
+  - '{{patch_and_reboot_inci}}'
+  - '{{patch_and_reboot_test_repo}}'
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
@@ -38,9 +39,13 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/system_prepare
-  patch_and_reboot:
+  patch_and_reboot_inci:
     QAM_INCI:
       1:
+        - qa_automation/patch_and_reboot
+  patch_and_reboot_test_repo:
+    FLAVOR:
+      Server-DVD-HA-Updates:
         - qa_automation/patch_and_reboot
   add_update_test_repo:
     QAM_INCI:

--- a/schedule/qam/12-SP4/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/12-SP4/qam-create_hdd_ha_textmode.yaml
@@ -27,7 +27,8 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - '{{system_prepare}}'
-  - '{{patch_and_reboot}}'
+  - '{{patch_and_reboot_inci}}'
+  - '{{patch_and_reboot_test_repo}}'
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
@@ -38,9 +39,13 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/system_prepare
-  patch_and_reboot:
+  patch_and_reboot_inci:
     QAM_INCI:
       1:
+        - qa_automation/patch_and_reboot
+  patch_and_reboot_test_repo:
+    FLAVOR:
+      Server-DVD-HA-Updates:
         - qa_automation/patch_and_reboot
   add_update_test_repo:
     QAM_INCI:

--- a/schedule/qam/12-SP5/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/12-SP5/qam-create_hdd_ha_textmode.yaml
@@ -27,7 +27,8 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - '{{system_prepare}}'
-  - '{{patch_and_reboot}}'
+  - '{{patch_and_reboot_inci}}'
+  - '{{patch_and_reboot_test_repo}}'
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
@@ -38,9 +39,13 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/system_prepare
-  patch_and_reboot:
+  patch_and_reboot_inci:
     QAM_INCI:
       1:
+        - qa_automation/patch_and_reboot
+  patch_and_reboot_test_repo:
+    FLAVOR:
+      Server-DVD-HA-Updates:
         - qa_automation/patch_and_reboot
   add_update_test_repo:
     QAM_INCI:

--- a/schedule/qam/15-SP1/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/15-SP1/qam-create_hdd_ha_textmode.yaml
@@ -25,7 +25,8 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - '{{system_prepare}}'
-  - '{{patch_and_reboot}}'
+  - '{{patch_and_reboot_inci}}'
+  - '{{patch_and_reboot_test_repo}}'
   - console/sle15_workarounds
   - console/hostname
   - console/force_scheduled_tasks
@@ -37,9 +38,13 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/system_prepare
-  patch_and_reboot:
+  patch_and_reboot_inci:
     QAM_INCI:
       1:
+        - qa_automation/patch_and_reboot
+  patch_and_reboot_test_repo:
+    FLAVOR:
+      Server-DVD-HA-Updates:
         - qa_automation/patch_and_reboot
   add_update_test_repo:
     QAM_INCI:

--- a/schedule/qam/15-SP2/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/15-SP2/qam-create_hdd_ha_textmode.yaml
@@ -25,7 +25,8 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - '{{system_prepare}}'
-  - '{{patch_and_reboot}}'
+  - '{{patch_and_reboot_inci}}'
+  - '{{patch_and_reboot_test_repo}}'
   - console/sle15_workarounds
   - console/hostname
   - console/force_scheduled_tasks
@@ -37,9 +38,13 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/system_prepare
-  patch_and_reboot:
+  patch_and_reboot_inci:
     QAM_INCI:
       1:
+        - qa_automation/patch_and_reboot
+  patch_and_reboot_test_repo:
+    FLAVOR:
+      Server-DVD-HA-Updates:
         - qa_automation/patch_and_reboot
   add_update_test_repo:
     QAM_INCI:

--- a/schedule/qam/15/qam-create_hdd_ha_textmode.yaml
+++ b/schedule/qam/15/qam-create_hdd_ha_textmode.yaml
@@ -25,7 +25,8 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - '{{system_prepare}}'
-  - '{{patch_and_reboot}}'
+  - '{{patch_and_reboot_inci}}'
+  - '{{patch_and_reboot_test_repo}}'
   - console/sle15_workarounds
   - console/hostname
   - console/force_scheduled_tasks
@@ -37,9 +38,13 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/system_prepare
-  patch_and_reboot:
+  patch_and_reboot_inci:
     QAM_INCI:
       1:
+        - qa_automation/patch_and_reboot
+  patch_and_reboot_test_repo:
+    FLAVOR:
+      Server-DVD-HA-Updates:
         - qa_automation/patch_and_reboot
   add_update_test_repo:
     QAM_INCI:


### PR DESCRIPTION
This PR adds the module `patch_and_reboot` if flavor `Server-DVD-HA-Updates` is used.
With that, aggregate testing will work for HA in `Maintenance Test repo`.

- Related ticket: N/A
- Needles: N/A
- Verification run: [15-SP2](http://1a102.qa.suse.de/tests/5037)
