### PR TITLE
LTP: Ignore failure on disabling firewalld

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -275,7 +275,7 @@ sub setup_network {
         script_run('/etc/init.d/SuSEfirewall2_setup stop');
     }
     else {
-        disable_and_stop_service(opensusebasetest::firewall);
+        disable_and_stop_service(opensusebasetest::firewall, ignore_failure => 1);
     }
 }
 


### PR DESCRIPTION
autoyast_64bit-intel-ltp.xml does not install firewalld, thus
disable_and_stop_service(opensusebasetest::firewall) fails:

Test died: command 'systemctl --no-pager disable firewalld' failed at
/var/lib/openqa/pool/30/os-autoinst-distri-opensuse/lib/Utils/Systemd.pm
line 71.

We could limit it only for LTP_BAREMETAL, but it's better for all test
(including QEMU) not failing just because this failed.

Fixes: a92cecc79 ("Add autoyast profiles for WORKER_CLASS 64bit-intel-ltp")

- Verification run: https://openqa.suse.de/tests/4588914