### PR TITLE
Skips the warning for NVIDIA driver on sle_sp3

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -479,6 +479,7 @@ sub process_scc_register_addons {
         # start addons/modules registration, it needs longer time if select multiple or all addons/modules
         my $counter = ADDONS_COUNT;
         my @needles = qw(import-untrusted-gpg-key nvidia-validation-failed yast_scc-pkgtoinstall yast-scc-emptypkg inst-addon contacting-registration-server refreshing-repository system-probing);
+        push @needles, 'bsc1175335' if is_sle('15-SP3+');
         if (is_sle('15-SP2+')) {
             # In SLE 15 SP2 multipath detection happens directly after registration, so using it to detect that all pop-up are processed
             push @needles, 'enable-multipath' if get_var('MULTIPATH');
@@ -491,6 +492,12 @@ sub process_scc_register_addons {
             assert_screen([@needles], 90);
             if (match_has_tag('import-untrusted-gpg-key')) {
                 handle_untrusted_gpg_key;
+                next;
+            }
+            elsif (match_has_tag('bsc1175335')) {
+                @needles = grep { $_ ne 'bsc1175335' } @needles;
+                send_key $cmd{ok};
+                send_key $cmd{next};
                 next;
             }
             elsif (match_has_tag('nvidia-validation-failed')) {

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2019 SUSE Linux GmbH
+# Copyright © 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -174,6 +174,7 @@ sub run {
 
     # Push needle 'inst-bootmenu' to ensure boot from hard disk on aarch64
     push(@needles, 'inst-bootmenu') if (check_var('ARCH', 'aarch64') && get_var('UPGRADE'));
+    push @needles, 'bsc1175335' if is_sle('15-SP3+');
     # Kill ssh proactively before reboot to avoid half-open issue on zVM, do not need this on zKVM
     prepare_system_shutdown if check_var('BACKEND', 's390x');
     my $postpartscript = 0;
@@ -201,6 +202,12 @@ sub run {
         elsif (match_has_tag('import-untrusted-gpg-key')) {
             handle_untrusted_gpg_key;
             @needles = grep { $_ ne 'import-untrusted-gpg-key' } @needles;
+            next;
+        }
+        elsif (match_has_tag('bsc1175335')) {
+            @needles = grep { $_ ne 'bsc1175335' } @needles;
+            send_key $cmd{ok};
+            send_key $cmd{next};
             next;
         }
         elsif (match_has_tag('prague-pxe-menu') || match_has_tag('qa-net-selection')) {

--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2019 SUSE LLC
+# Copyright © 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/70141
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1421
- [Verification run]( https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2310884&distri=sle&version=15-SP3) 
[autoyast_home_encrypted](http://aquarius.suse.cz/tests/3239#step/installation/4)
[we-module](http://aquarius.suse.cz/tests/3238#step/scc_registration/22)