### PR TITLE
LTP baremetal: Don't run perf and oprofile

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -3180,8 +3180,6 @@ sub load_kernel_baremetal_tests {
     }
     # make sure we always have the toolchain installed
     loadtest "toolchain/install";
-    loadtest "console/perf";
-    loadtest "console/oprofile";
     # some tests want to build and run a custom kernel
     loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
 }


### PR DESCRIPTION
The purpose of install_ltp_baremetal* isn't to test installation, but
prepare SLES for kernel tests as quick as possible. Thus removing these
to speedup LTP bare metal testing (about 4 min).

console/oprofile is not now used anywhere, it should be either put
somewhere else or removed.

Fixes: 37ffec088 ("Schedule perf test on all versions")
Fixes: af2454ba0 ("Add bare metal test for oprofile")

- Verification run: https://openqa.suse.de/tests/4590714
