### PR TITLE
Install sharutils if not installed poo#70522

### DIFF
--- a/tests/console/shar.pm
+++ b/tests/console/shar.pm
@@ -20,10 +20,9 @@ use version_utils;
 sub run {
     my $self = shift;
 
-    if (is_jeos() || is_public_cloud() || is_sle()) {
-        select_console 'root-console';
-        zypper_call('in sharutils');
-    }
+    select_console 'root-console';
+    zypper_call('in sharutils');
+
     if (check_var('MACHINE', 'RPi3') || check_var('MACHINE', 'RPi4')) {
         select_console 'root-console';
         zypper_call('in diffutils');


### PR DESCRIPTION
to avoid openQA test failure on Jump15.2
https://openqa.opensuse.org/tests/1372831#step/shar/6


- Related ticket: https://progress.opensuse.org/issues/70522
- Needles: none
- Verification run: 
   https://openqa.opensuse.org/tests/1374379#step/shar/2   for Jump ppc64le shar  now passed with zypper install sharutils
   https://openqa.opensuse.org/tests/1374390#step/shar/2  for TW ppc64le shar with package already installed.