### PR TITLE
Enable yast2_storage_ng in SLE15-SP3

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -35,6 +35,7 @@ conditional_schedule:
                 - yast2_gui/yast2_lan_restart_bridge
                 - yast2_gui/yast2_lan_restart_vlan
                 - yast2_gui/yast2_lan_restart_bond
+                - yast2_gui/yast2_storage_ng
             aarch64:
                 - yast2_gui/yast2_software_management
                 - yast2_gui/yast2_security
@@ -59,6 +60,7 @@ conditional_schedule:
                 - yast2_gui/yast2_lan_restart_bridge
                 - yast2_gui/yast2_lan_restart_vlan
                 - yast2_gui/yast2_lan_restart_bond
+                - yast2_gui/yast2_storage_ng
             s390x:
                 - yast2_gui/yast2_software_management
                 - yast2_gui/yast2_security


### PR DESCRIPTION
Enable yast2_storage_ng in SLE15-SP3

- Related ticket: https://progress.opensuse.org/issues/70201
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23enable_yast2_storage_ng&version=15-SP3

Note: for aarch is /dev/vda instead of /dev/vdb the name of the attached disk after booting the image when during installation is always /dev/vda https://openqa.suse.de/tests/4588084#step/yast2_storage_ng/17
I got confirmation that we should not rely on names lie /dev/vda or /dev/vdb being chosen, so I'm not adding it in the schedule due to the code is is thought to have this order and the scope of the ticket was anyway only x86_64. Ticket related with this issue: https://progress.opensuse.org/issues/34675
