### PR TITLE
Add a basic cluster in qam HA

### DIFF
--- a/schedule/ha/qam/common/qam_alpha_cluster_01.yaml
+++ b/schedule/ha/qam/common/qam_alpha_cluster_01.yaml
@@ -1,0 +1,39 @@
+name:           qam-alpha_cluster
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: 'textmode'
+  HA_CLUSTER: '1'
+  HA_CLUSTER_INIT: '1'
+  HDDMODEL: 'scsi-hd'
+  HOSTNAME: '%CLUSTER_NAME%-node01'
+  NICTYPE: 'tap'
+  QEMU_DISABLE_SNAPSHOTS: '1'
+  USE_SUPPORT_SERVER: '1'
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/fencing
+  - boot/boot_to_desktop
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs

--- a/schedule/ha/qam/common/qam_alpha_cluster_02.yaml
+++ b/schedule/ha/qam/common/qam_alpha_cluster_02.yaml
@@ -1,0 +1,38 @@
+name:           qam-alpha_cluster
+description:    >
+  Create a 2 nodes cluster
+  Further info about the test suite
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: 'textmode'
+  HA_CLUSTER: '1'
+  HA_CLUSTER_JOIN: '%CLUSTER_NAME%-node01'
+  HDDMODEL: 'scsi-hd'
+  HOSTNAME: '%CLUSTER_NAME%-node02'
+  NICTYPE: 'tap'
+  QEMU_DISABLE_SNAPSHOTS: '1'
+  USE_SUPPORT_SERVER: '1'
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/fencing
+  - ha/check_after_reboot
+  - ha/remove_node
+  - ha/check_logs

--- a/schedule/ha/qam/common/qam_alpha_supportserver.yaml
+++ b/schedule/ha/qam/common/qam_alpha_supportserver.yaml
@@ -1,0 +1,23 @@
+name:           qam-alpha_supportserver
+description:    >
+  Create a supportserver for the alpha two nodes cluster
+  Further info about the test suite
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: 'textmode'
+  HA_CLUSTER: '1'
+  HDDMODEL: 'scsi-hd'
+  HDDSIZEGB_2: '6'
+  NICTYPE: 'tap'
+  NUMDISKS: '2'
+  NUMLUNS: '5'
+  QEMU_DISABLE_SNAPSHOTS: '1'
+  SUPPORT_SERVER: '1'
+  SUPPORT_SERVER_ROLES: 'dhcp,dns,ntp,ssh,iscsi'
+  VIDEOMODE: 'text'
+  VIRTIO_CONSOLE: '0'
+schedule:
+  - support_server/login
+  - support_server/setup
+  - ha/barrier_init
+  - support_server/wait_children


### PR DESCRIPTION
This PR adds a basic cluster test in QAM.
It only uses YAML and jobgroup definition, no testsuite used anymore.

- Related ticket: N/A
- Needles: N/A
- Verification run: [node1](http://1a102.qa.suse.de/tests/5084), [node2](http://1a102.qa.suse.de/tests/5085), [supportserver](http://1a102.qa.suse.de/tests/5083)
