### PR TITLE
Fix bootloader_start for media check scenario on svirt

### DIFF
--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -63,6 +63,9 @@ sub run {
             record_info('bootloader_svirt');
             $self->bootloader_svirt::run();
         }
+        # In mediacheck we do selection from the bootmenu in installation/mediacheck
+        # As normally we also need `bootloader` for this scenario
+        return if get_var('MEDIACHECK');
     }
     # Load regular bootloader for all qemu backends and for x84_86 systems,
     # except Xen PV as id does not have VNC (bsc#961638).


### PR DESCRIPTION
In mediacheck we do selection from the bootmenu in
installation/mediacheck, no need to run `bootloader` for this scenario.

See [poo#70228](https://progress.opensuse.org/issues/70228).

[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23yast).

[Job group changes](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/271).