### PR TITLE
systemd: remove conditional schedule for 15.2 and 15 SP2

### DIFF
--- a/schedule/systemd/suse_patches-systemd_testsuite.yaml
+++ b/schedule/systemd/suse_patches-systemd_testsuite.yaml
@@ -5,22 +5,6 @@ description:    >
 conditional_schedule:
     systemd_testsuite_if_VERSION:
         VERSION:
-            '15.2':
-                - systemd_testsuite/test_16_extend_timeout
-                - systemd_testsuite/test_17_udev_wants
-                - systemd_testsuite/test_18_failureaction
-                - systemd_testsuite/test_19_delegate
-                - systemd_testsuite/test_20_mainpidgames
-                - systemd_testsuite/test_21_sysusers
-                - systemd_testsuite/test_23_type_exec
-            '15-SP2':
-                - systemd_testsuite/test_16_extend_timeout
-                - systemd_testsuite/test_17_udev_wants
-                - systemd_testsuite/test_18_failureaction
-                - systemd_testsuite/test_19_delegate
-                - systemd_testsuite/test_20_mainpidgames
-                - systemd_testsuite/test_21_sysusers
-                - systemd_testsuite/test_23_type_exec
             'Tumbleweed':
                 - systemd_testsuite/test_16_extend_timeout
                 - systemd_testsuite/test_17_udev_wants


### PR DESCRIPTION
These tests did not exist in systemd v234, they were added later. 

I also found this surprising when I tried to create patches for them, because I saw them here in this schedule and thought that the patches are just missing from the testsuite package here: 
- https://build.suse.de/package/show/QA:Head/systemd-v234-testsuite
and here:
- https://build.opensuse.org/package/show/devel:openSUSE:QA:Leap:15/systemd-v234-testsuite.

That was not the case, so the schedule needs to be adjusted.