### PR TITLE
Replace the backup file name to use for luks Backup and Restore

### DIFF
--- a/lib/validate_encrypt_utils.pm
+++ b/lib/validate_encrypt_utils.pm
@@ -1,3 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: A set of tools to verify encryption.
+#
+# Maintainer: QA SLE YaST <qa-sle-yast@suse.de>
+
 package validate_encrypt_utils;
 use strict;
 use warnings;
@@ -17,7 +38,13 @@ our @EXPORT = qw(
   verify_restoring_luks_backups
 );
 
-# Check https://www.freedesktop.org/software/systemd/man/crypttab.html for more info about parsing
+=head2 parse_devices_in_crypttab
+
+  parse_devices_in_crypttab();
+
+This sub reads the output of F</etc/crypttab> and returns C<%crypttab> reference with its data.
+Check https://www.freedesktop.org/software/systemd/man/crypttab.html for more info about parsing 
+=cut
 sub parse_devices_in_crypttab {
     my @lines    = split(/\n/, script_output("cat /etc/crypttab"));
     my $crypttab = {};
@@ -33,6 +60,19 @@ sub parse_devices_in_crypttab {
     return $crypttab;
 }
 
+=head2 parse_cryptsetup_status
+
+  parse_cryptsetup_status($dev);
+
+=over
+
+=item C<$dev>
+  The encrypted device name
+
+=back
+
+returns the C<$status> of the encrypted device. If no encrypted device found it returns a reference to an empty anonymous hash.
+=cut
 sub parse_cryptsetup_status {
     my ($dev)  = @_;
     my @lines  = split(/\n/, script_output("cryptsetup status $dev", proceed_on_failure => 1));
@@ -50,11 +90,32 @@ sub parse_cryptsetup_status {
     return $status;
 }
 
+=head2 verify_crypttab_file_existence
+
+  verify_crypttab_file_existence();
+
+Verify the existence of F</etc/crypttab> file.
+=cut
 sub verify_crypttab_file_existence {
     record_info("crypttab file", "Verify the existence of /etc/crypttab file");
     assert_script_run("test -f /etc/crypttab", fail_message => "No /etc/crypttab found");
 }
 
+=head2 verify_number_of_encrypted_devices
+
+  verify_number_of_encrypted_devices($expected_number, $actual_number);
+
+=over
+
+=item C<$expected_number>
+  the int number of the expected encrypted devices
+
+=item C<$actual_number>
+  the int number of the actual encrypted devices
+
+=back
+
+=cut
 sub verify_number_of_encrypted_devices {
     my ($expected_number, $actual_number) = @_;
     record_info("devices number", "Verify number of encrypted devices");
@@ -63,6 +124,21 @@ sub verify_number_of_encrypted_devices {
           Dumper($actual_number));
 }
 
+=head2 verify_cryptsetup_message
+
+  verify_cryptsetup_message($expected_message, $actual_message);
+
+=over
+
+=item C<$expected_message>
+  A string with the expected status message of a device
+
+=item C<$actual_message>
+  A string with the actual status message of a device
+
+=back
+
+=cut
 sub verify_cryptsetup_message {
     my ($expected_message, $actual_message) = @_;
     record_info("Assert volumes status", "Verify crypted volume status based on test_data expectations");
@@ -70,6 +146,20 @@ sub verify_cryptsetup_message {
         "Message of cryptsetup status does not match regex");
 }
 
+=head2 verify_cryptsetup_properties
+
+  verify_cryptsetup_properties($expected_properties, $actual_properties);
+
+=over
+
+=item C<$expected_properties>
+  A hash reference with the expected LUKS properties
+
+=item C<$actual_properties>
+  A hash reference with the actual LUKS properties
+
+=back
+=cut
 sub verify_cryptsetup_properties {
     my ($expected_properties, $actual_properties) = @_;
     record_info("params", "Verify parameters, that are set for crypted volumes");
@@ -80,19 +170,40 @@ sub verify_cryptsetup_properties {
     }
 }
 
+=head2 verify_restoring_luks_backups
+
+  verify_restoring_luks_backups(%args);
+
+Where C<%args> expects the following parameters:
+
+=over
+
+=item C<$mapped_device>
+  path of encrypted device
+
+=item C<$backup_file_info>
+  unique string to match with the info of the backup file
+
+=item C<$backup_path_path>
+  path to a binary file used for backup of the keys
+
+=back
+
+Validates that the device is an encrypted one and tests the backup of the keyslot info.
+=cut
 sub verify_restoring_luks_backups {
     my (%args)           = @_;
-    my $mapped_dev       = $args{encrypted_device};
+    my $mapped_dev_path  = $args{encrypted_device_path};
     my $backup_file_info = $args{backup_file_info};
-    my $backup_path      = "/root/$mapped_dev";
+    my $backup_path      = $args{backup_base_path};
     record_info("LUKS", "Verify storing and restoring for binary backups of LUKS header and keyslot areas.");
-    assert_script_run("cryptsetup -v isLuks $mapped_dev");
-    assert_script_run("cryptsetup -v luksUUID $mapped_dev");
-    assert_script_run("cryptsetup -v luksDump $mapped_dev");
-    assert_script_run("cryptsetup -v luksHeaderBackup $mapped_dev" .
+    assert_script_run("cryptsetup -v isLuks $mapped_dev_path");
+    assert_script_run("cryptsetup -v luksUUID $mapped_dev_path");
+    assert_script_run("cryptsetup -v luksDump $mapped_dev_path");
+    assert_script_run("cryptsetup -v luksHeaderBackup $mapped_dev_path" .
           " --header-backup-file $backup_path");
     validate_script_output("file $backup_path", sub { m/$backup_file_info/ });
-    assert_script_run("cryptsetup -v --batch-mode luksHeaderRestore $mapped_dev" .
+    assert_script_run("cryptsetup -v --batch-mode luksHeaderRestore $mapped_dev_path" .
           " --header-backup-file $backup_path");
 }
 

--- a/test_data/yast/encryption/default_enc.yaml
+++ b/test_data/yast/encryption/default_enc.yaml
@@ -8,3 +8,4 @@ cryptsetup:
       key_location: dm-crypt
       mode: read/write
 backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
+backup_base_path: '/root/bkp_luks_header'

--- a/tests/console/validate_encrypt.pm
+++ b/tests/console/validate_encrypt.pm
@@ -2,11 +2,19 @@
 #
 # Copyright © 2020 SUSE LLC
 #
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved. This file is offered as-is,
-# without any warranty.
-
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
 # Summary: Validation module to check encrypted volumes.
 # Scenarios covered:
 # - Verify existence and content of '/etc/crypttab';
@@ -37,8 +45,10 @@ sub run {
         verify_cryptsetup_properties($test_data->{cryptsetup}->{device_status}->{properties}, $status->{properties});
     }
     foreach my $dev (sort keys %{$devices}) {
-        verify_restoring_luks_backups(encrypted_device => $devices->{$dev}->{encrypted_device},
-            backup_file_info => $test_data->{backup_file_info}
+        verify_restoring_luks_backups(
+            encrypted_device_path => $devices->{$dev}->{encrypted_device},
+            backup_file_info      => $test_data->{backup_file_info},
+            backup_base_path      => $test_data->{backup_base_path}
         );
     }
 }


### PR DESCRIPTION
The code used the encrypted-device path from the crypttab output. The path could be                                                                                                                                                                                                                                          
either the underlying block device or file, or a specification of a block device with a UUID.                                                                                                                                                                                                                                
So the `luksHeaderBackup` and `luksHeaderRestore` used to use for the binary backup file a                                                                                                                                                                                                                                   
structure like /roor/UUID=<device_uuid>. In the case of s390x the structure was root/<path>.                                                                                                                                                                                                                                 
I think the reason of the failure is that the `--header-backup-file` expects a new file in an                                                                                                                                                                                                                                
existing path.                                                                                                                                                                                                                                                                                                               
Because for both cases this looks wrong to me i copy the backup_path that it was being used before                                                                                                                                                                                                                           
the refactoring. The current approach pass /root/bkp_luks_header_<device_name>                                                                                                                                                                                                                                               
in `--header-backup-file` of `luksHeaderBackup` and `luksHeaderRestore` for all the test_suites

- Related ticket: https://progress.opensuse.org/issues/69751
- [Verification run](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2369751_validate_encrypt_s390)
