### PR TITLE
Schedule perf and oprofile tests on BM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2716,6 +2716,8 @@ sub load_hypervisor_tests {
         loadtest 'virtualization/universal/virtmanager_final';    # Check that every guest shows the login screen
         loadtest "virtualization/universal/smoketest";            # Virtualization smoke test for hypervisor
         loadtest "virtualization/universal/stresstest";           # Perform stress tests on the guests
+        loadtest "console/perf";                                  # Run QAM perf test
+        loadtest "console/oprofile";                              # Run QAM oprofile test
     }
 }
 

--- a/tests/console/oprofile.pm
+++ b/tests/console/oprofile.pm
@@ -17,10 +17,20 @@ use warnings;
 use base 'consoletest';
 use testapi;
 use utils;
+use version_utils qw(is_sle);
+use registration qw(add_suseconnect_product);
+
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
+
+    # Add required product
+    if (is_sle '>=15') {
+        add_suseconnect_product('sle-module-development-tools');
+    } else {
+        add_suseconnect_product('sle-sdk');
+    }
 
     # Install fio as load generator and oprofile
     zypper_call "in fio oprofile psmisc";


### PR DESCRIPTION
Test were scheduled with ltp but were removed by #10885 
This PR is to schedule them in a better place.

- Related ticket: https://progress.opensuse.org/issues/48986
          - https://progress.opensuse.org/issues/48983
- Needles: no needles
- Verification run: 
  - http://openqa.qam.suse.cz/tests/12243 (oprofiled failed here, will be fixed on following run)
  - http://openqa.qam.suse.cz/tests/12246 (fixed oprofile issue)
