### PR TITLE
Revert "Configures self_update repo and adjust welcome to import key"

### DIFF
--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -6,7 +6,7 @@ description:    >
   Installation is validated by successful boot and that YaST does not report
   any issue.
 vars:
-  INSTALLER_SELF_UPDATE: http://openqa.suse.de/assets/repo/SLE-15-x86_64-self_update
+  INSTALLER_SELF_UPDATE: 1
 schedule:
   - installation/isosize
   - installation/bootloader_start

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -32,7 +32,6 @@ use x11utils 'ensure_fullscreen';
 use version_utils qw(:VERSION :SCENARIO);
 use Utils::Backends 'is_remote_backend';
 use Utils::Architectures;
-use utils 'handle_untrusted_gpg_key';
 
 sub switch_keyboard_layout {
     record_info 'keyboard layout', 'Check keyboard layout switching to another language';
@@ -106,7 +105,6 @@ sub run {
     # Add tag to check for https://progress.opensuse.org/issues/30823 "test is
     # stuck in linuxrc asking if dhcp should be used"
     push @welcome_tags, 'linuxrc-dhcp-question';
-    push @welcome_tags, 'import-known-untrusted-gpg-key' if get_var('INSTALLER_SELF_UPDATE');
 
     # Process expected pop-up windows and exit when welcome/beta_war is shown or too many iterations
     while ($iterations++ < scalar(@welcome_tags)) {
@@ -117,7 +115,6 @@ sub run {
         if ((match_has_tag 'inst-betawarning') || (match_has_tag 'inst-welcome') || (match_has_tag 'inst-welcome-no-product-list')) {
             last;
         }
-        handle_untrusted_gpg_key;
         if (match_has_tag 'scc-invalid-url') {
             die 'SCC reg URL is invalid' if !get_var('SCC_URL_VALID');
             send_key 'alt-r';    # registration URL field


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#10864

As per [poo#69238](https://progress.opensuse.org/issues/69238), we will start using SLES Product repo, e.g. `ftp://openqa.suse.de/SLE-15-SP2-Product-SLES-POOL-x86_64-Build209.2-Media1` which has trusted certificate and still allows to test that update packages were downloaded, which doesn't happen in case of installer repo.