### PR TITLE
Reuse verify_software in validate_multipath

### DIFF
--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -78,3 +78,14 @@ test_data:
     sdb:
       prio: 0
       status: enabled
+  software:
+    packages:
+      # Device Mapper Tools
+      device-mapper:
+        installed: 1
+      # Tools to Manage Multipathed Devices with the device-mapper
+      multipath-tools:
+        installed: 1
+      # Manages partition tables on device-mapper devices
+      kpartx:
+        installed: 1


### PR DESCRIPTION
Simply adjust verify_packages_installed sub to loop throught a list
of software coming via test_data->`software` and execute verify_software.
Basically i tried to copycat the approach from the @rwx788's usage and change as less as possible the existing design. 

- Related ticket: https://progress.opensuse.org/issues/70552
- [Verification run](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2370552_verify_software&distri=sle&version=15-SP3)
[failing](https://openqa.suse.de/tests/4600182#step/validate_multipath/16)