### PR TITLE
Ctdb and haproxy must be conditionnal in HA QAM

### DIFF
--- a/schedule/ha/qam/15-SP1/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/15-SP1/ha_rolling_update_node01.yaml
@@ -26,8 +26,7 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
-  - ha/haproxy
+  - '{{qam_incident}}'
   - ha/await_upgrade_or_update
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_patch
@@ -35,3 +34,9 @@ schedule:
   - ha/check_hawk
   - ha/wait_others_upgraded_or_updated
   - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/15-SP1/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/15-SP1/ha_rolling_update_node02.yaml
@@ -26,8 +26,7 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
-  - ha/haproxy
+  - '{{qam_incident}}'
   - ha/await_upgrade_or_update
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_patch
@@ -35,3 +34,9 @@ schedule:
   - ha/check_hawk
   - ha/wait_others_upgraded_or_updated
   - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/15-SP2/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/15-SP2/ha_rolling_update_node01.yaml
@@ -26,8 +26,7 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
-  - ha/haproxy
+  - '{{qam_incident}}'
   - ha/await_upgrade_or_update
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_patch
@@ -35,3 +34,9 @@ schedule:
   - ha/check_hawk
   - ha/wait_others_upgraded_or_updated
   - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/15-SP2/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/15-SP2/ha_rolling_update_node02.yaml
@@ -26,8 +26,7 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
-  - ha/haproxy
+  - '{{qam_incident}}'
   - ha/await_upgrade_or_update
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_patch
@@ -35,3 +34,9 @@ schedule:
   - ha/check_hawk
   - ha/wait_others_upgraded_or_updated
   - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/15/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/15/ha_rolling_update_node01.yaml
@@ -26,8 +26,7 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
-  - ha/haproxy
+  - '{{qam_incident}}'
   - ha/await_upgrade_or_update
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_patch
@@ -35,3 +34,9 @@ schedule:
   - ha/check_hawk
   - ha/wait_others_upgraded_or_updated
   - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/15/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/15/ha_rolling_update_node02.yaml
@@ -26,8 +26,7 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
-  - ha/haproxy
+  - '{{qam_incident}}'
   - ha/await_upgrade_or_update
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_patch
@@ -35,3 +34,9 @@ schedule:
   - ha/check_hawk
   - ha/wait_others_upgraded_or_updated
   - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy


### PR DESCRIPTION
This PR adds conditional scheduling for loading `ctdb` and `haproxy` tests in HA QAM.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
