### PR TITLE
install_klp_product: Don't install twice

### DIFF
--- a/tests/kernel/install_klp_product.pm
+++ b/tests/kernel/install_klp_product.pm
@@ -41,7 +41,7 @@ sub run {
         die "Failed to parse 'uname -r' output: '$output'";
     }
 
-    install_klp_product();
+    install_klp_product() unless get_var('KGRAFT');
     my $klp_pkg = find_installed_klp_pkg($kver, $kflavor);
     if (!$klp_pkg) {
         die "No installed kernel livepatch package for current kernel found";


### PR DESCRIPTION
In kgraft/livepatch incident tests, the livepatch product was already installed in the install_ltp job. Don't install it again in the KLP test job, otherwise the install_klp_product test module will fail.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - kernel-default: https://openqa.suse.de/tests/4600245
  - kernel-livepatch: https://openqa.suse.de/tests/4600246