### PR TITLE
steamcmd: use the binary that users are also supposed to use

### DIFF
--- a/tests/console/steamcmd.pm
+++ b/tests/console/steamcmd.pm
@@ -24,9 +24,7 @@ sub run {
     zypper_call('in --auto-agree-with-licenses steamcmd');
     # see https://github.com/ValveSoftware/steam-for-linux/issues/4341
     my $allow_exit_codes = [qw(0 6 7 8)];
-    # /usr/bin/steamcmd currently does not forward arguments, see
-    # https://build.opensuse.org/request/show/592657
-    my $ret = script_run '/usr/lib/steamcmd/steamcmd.sh +login anonymous +app_update 90 validate +quit', 1200;
+    my $ret              = script_run '/usr/bin/steamcmd +login anonymous +app_update 90 validate +quit', 1200;
     die "'steamcmd' failed with exit code $ret" unless (grep { $_ == $ret } @$allow_exit_codes);
     assert_script_run 'test -f Steam/steamapps/common/Half-Life/hlds_run';
 }


### PR DESCRIPTION
Users are going to start steamcmd from the path (i.e usr/bin) and that
script then passes on to the real location. It can't be the users
responsibility to know where the script is installed (on TW 0825+ it
is in /usr/libexec/steamcmd)

The old reason for the test to use the non-wrapped script directly
was just to hide an actual bug in /usr/bin/steamcmd (fixed 2 years ago)

- Related ticket: https://progress.opensuse.org/issues/70609
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1374329
