### PR TITLE
Show zypper exceptions on zypper_call fail

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -539,6 +539,11 @@ sub zypper_call {
             script_run('tac /var/log/zypper.log | grep -F -m1 -B10000 "Hi, me zypper" | tac | grep \'\(SolverRequester.cc\|THROW\|CAUGHT\)\' > /tmp/z104.txt');
             $msg .= script_output('cat /tmp/z104.txt');
         }
+        else {
+            script_run('tac /var/log/zypper.log | grep -F -m1 -B10000 "Hi, me zypper" | tac | grep \'Exception.cc\' > /tmp/zlog.txt');
+            $msg .= "\n\nRelated zypper logs:\n";
+            $msg .= script_output('cat /tmp/zlog.txt');
+        }
         die $msg;
     }
     $IN_ZYPPER_CALL = 0;


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/70129
Verification: http://kazhua.qa.suse.de/tests/78#step/prepare_test_data/28

Verification was done by adding this code to `prepare_test_data.pm`:

```perl
zypper_call 'ar https://f3l.de/ f3l';
zypper_call 'ref';
zypper_call 'in blim123';
```