### PR TITLE
Remove deregistration in HA rolling update test

### DIFF
--- a/schedule/ha/qam/15-SP1/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/15-SP1/ha_rolling_update_node01.yaml
@@ -6,7 +6,6 @@ schedule:
   - boot/boot_to_desktop
   - console/suseconnect_scc
   - update/zypper_up
-  - console/scc_deregistration
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare

--- a/schedule/ha/qam/15-SP1/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/15-SP1/ha_rolling_update_node02.yaml
@@ -6,7 +6,6 @@ schedule:
   - boot/boot_to_desktop
   - console/suseconnect_scc
   - update/zypper_up
-  - console/scc_deregistration
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare

--- a/schedule/ha/qam/15-SP2/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/15-SP2/ha_rolling_update_node01.yaml
@@ -6,7 +6,6 @@ schedule:
   - boot/boot_to_desktop
   - console/suseconnect_scc
   - update/zypper_up
-  - console/scc_deregistration
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare

--- a/schedule/ha/qam/15-SP2/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/15-SP2/ha_rolling_update_node02.yaml
@@ -6,7 +6,6 @@ schedule:
   - boot/boot_to_desktop
   - console/suseconnect_scc
   - update/zypper_up
-  - console/scc_deregistration
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare

--- a/schedule/ha/qam/15/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/15/ha_rolling_update_node01.yaml
@@ -6,7 +6,6 @@ schedule:
   - boot/boot_to_desktop
   - console/suseconnect_scc
   - update/zypper_up
-  - console/scc_deregistration
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare

--- a/schedule/ha/qam/15/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/15/ha_rolling_update_node02.yaml
@@ -6,7 +6,6 @@ schedule:
   - boot/boot_to_desktop
   - console/suseconnect_scc
   - update/zypper_up
-  - console/scc_deregistration
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare


### PR DESCRIPTION
This PR removes the module `scc_deregistration` in the ha rolling update scenario. It is not needed anymore.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
