### PR TITLE
Mitigations: Add MITIGATION_ENV_SETUP test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2487,6 +2487,9 @@ sub load_mitigation_tests {
     if (get_var('XEN_GRUB_SETUP')) {
         loadtest "cpu_bugs/xen_grub_setup";
     }
+    if (get_var('MITIGATION_ENV_SETUP')) {
+        loadtest "cpu_bugs/mitigation_env_setup";
+    }
     if (get_var('MELTDOWN')) {
         loadtest "cpu_bugs/meltdown";
     }

--- a/tests/cpu_bugs/mitigation_env_setup.pm
+++ b/tests/cpu_bugs/mitigation_env_setup.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Setup test environment for mitigation test
+# Maintainer: An Long <lan@suse.com>
+
+use warnings;
+use strict;
+use base "opensusebasetest";
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    my $newlabel = get_required_var('DISTRI') . '-' . get_required_var('VERSION') . '-';
+
+    # for mitigation test, disk label with build tag, while with Build number
+    if (lc(get_var('MYBUILD')) =~ /alpha|beta|rc|gm/) {
+        $newlabel .= get_var('MYBUILD');
+    }
+    else {
+        $newlabel .= 'BUILD' . get_required_var('BUILD');
+    }
+
+    assert_script_run("btrfs filesystem label / $newlabel");
+
+}
+
+1;


### PR DESCRIPTION
Add build information in disk label. So that got performance test data
and OS in which partition easily.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
http://openqa.qa2.suse.asia/tests/17052 (with MYBUILD)
http://openqa.qa2.suse.asia/tests/17053 (without MYBUILD)
