### PR TITLE
Add validation to self_update and no_self_update scenarios

### DIFF
--- a/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
@@ -8,9 +8,9 @@ description:    >
 vars:
   INSTALLER_NO_SELF_UPDATE: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/welcome
+  - installation/validate_no_self_update
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle

--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -6,11 +6,11 @@ description:    >
   Installation is validated by successful boot and that YaST does not report
   any issue.
 vars:
-  INSTALLER_SELF_UPDATE: 1
+  INSTALLER_SELF_UPDATE: 'http://openqa.suse.de/assets/repo/%REPO_SLE_PRODUCT_SLES%'
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/welcome
+  - installation/validate_self_update
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle

--- a/tests/installation/validate_no_self_update.pm
+++ b/tests/installation/validate_no_self_update.pm
@@ -1,0 +1,34 @@
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Validate installer self update is not attempted when explicitly disabled
+# Maintainer: QA SLE YaST <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my $self = shift;
+    select_console('install-shell');
+    assert_script_run('test -z "$(ls -A /download)"',
+        fail_message => '/download directory is NOT empty, expected to be empty as no updates should be downloaded');
+    assert_script_run('! grep /var/log/YaST2/y2log -e "Trying installer update"',
+        fail_message => 'YaST logs contain entry that self update was attempted, but is explicitly disabled');
+    select_console('installation');
+}
+
+1;

--- a/tests/installation/validate_self_update.pm
+++ b/tests/installation/validate_self_update.pm
@@ -1,0 +1,38 @@
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Validate installer self update feature downloads updates and applies
+#          them to the system
+# Maintainer: QA SLE YaST <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my $self = shift;
+    select_console('install-shell');
+    my $self_update_repo = get_required_var('INSTALLER_SELF_UPDATE');
+    assert_script_run("grep /var/log/YaST2/y2log -e '$self_update_repo'",
+        fail_message => 'Expected to have log entries that self update repo was contacted');
+    assert_script_run('test -n "$(ls -A /download)"',
+        fail_message => '/download directory is empty, expected to contain downloaded updates');
+    assert_script_run('mount | grep -P "/download/yast_\d+"',
+        fail_message => 'updates are not mounted, expected /download/yast_* to be mounted as /mount/yast_*');
+    select_console('installation');
+}
+
+1;


### PR DESCRIPTION
In order to test self update, we decided to use SLES product repo, as contains just couple of packages and has trusted certificate, so no need to process additional pop-up.

For validation we use internal knowledge about how updates are applied, namely downloaded in `/download` directory and then each update is mounted as `/mount/yast_*'.

In negative scenario we check log entries and that directory is empty. As for distribution there are no updates available, directory would still remain empty. We will request QAM team to enable this scenario for the released updates to make sure no updates are downloaded even if are available.

As next iteration we are going to publish updates in the stub repo and validate that installer runs never version of the package.

See [poo#69238](https://progress.opensuse.org/issues/69238).

[Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23yast&version=15-SP3&distri=sle).

[Test suite description update in the test plan](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/273).