### PR TITLE
Remove testcase for LTSS module tests

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -47,8 +47,9 @@ sub run {
     systemctl 'status apache2';
 
     # Check if apache is working when php module is enabled
+    # LTSS module test does not have apache2-mod_php72 php72-curl
     # Install apache2-mod_php72 php72-curl for versions smaller than SLE12-SP5, as dependencies for enabling php7 on SLE15+ are fulfilled
-    if (is_sle('<=12-SP5')) {
+    if (get_var('SCC_ADDONS') != 'ltss' && is_sle('<=12-SP5')) {
         zypper_call('in apache2-mod_php72 php72-curl');
     }
 
@@ -61,7 +62,7 @@ sub run {
     assert_script_run 'a2dismod php7';
 
     # In order to avoid future conflicts, apache2-mod_php72 php72-curl and their dependencies are removed
-    if (is_sle('<=12-SP5')) {
+    if (get_var('SCC_ADDONS') != 'ltss' && is_sle('<=12-SP5')) {
         zypper_call('rm --clean-deps apache2-mod_php72 php72-curl');
     }
 


### PR DESCRIPTION
The testcase of apache when php module enabled, is now removed for ltss runs. The ltss module tests do not include the addons needed for this testcase.

- Related ticket: https://progress.opensuse.org/issues/70642
- Needles: N/A
- Verification run: [SLES 12-SP3](https://openqa.suse.de/tests/4619880) [SLES 12-SP4](https://openqa.suse.de/tests/4619879) [SLES 12-SP5](http://10.161.229.247/tests/1029) [SLES 15](https://openqa.suse.de/tests/4619878) [SLES 15-SP1](https://openqa.suse.de/tests/4619877) [SLES 15-SP2](https://openqa.suse.de/tests/4619876)
