### PR TITLE
Add HANA cluster test for pvm_hmc

### DIFF
--- a/schedule/sles4sap/pvm_hana_cluster_node.yaml
+++ b/schedule/sles4sap/pvm_hana_cluster_node.yaml
@@ -1,0 +1,108 @@
+---
+name: pvm_hana_cluster_node
+description: >
+  HanaSR Cluster Test for pvm_hmc. Schedule for all nodes.
+
+  Some settings are required in the job group for this schedule to work.
+  HA_CLUSTER_SETUP must be defined for all jobs. In one of the jobs (the parent),
+  it must be defined to 'init', while in the rest to 'join'. This will only
+  control the conditional scheduling of ha_cluster_init or ha_cluster_join.
+
+  The other settings required in the job group are.
+
+  CLUSTER_INFOS must be defined in the parent job to the name of the cluster, number
+  of nodes and number of LUNs. Example 'hana:2:3'
+  CLUSTER_NAME must be defined for all jobs as a string.
+  HA_CLUSTER_INIT must be defined to a non false value in the parent job
+  HA_CLUSTER_JOIN must be defined for the rest of the jobs, and it must contain the
+  hostname of the parent job (the job where HA_CLUSTER_SETUP is defined to init)
+  HANA must be defined pointing to the location of the HANA installation masters
+  HOSTNAME must be defined to different hostnames for each node.
+  ISCSI_LUN_INDEX must be defined in the parent job pointing to an available LUN
+  index in the iSCSI server
+  ISCSI_SERVER must be defined in all jobs pointing to an iSCSI server
+  MAX_JOB_TIME is recommended to be defined as well to a high value (ex. 20000)
+  NFS_SUPPORT_SHARE must be defined in all jobs pointing to a NFS share used by
+  the cluster nodes to share configuration files
+  All jobs with the exception of the parent job must include a PARALLEL_WITH setting
+  referencing the parent job.
+  SLE_PRODUCT must be defined and set to sles4sap.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  AUTOMATED_REGISTER: 'false'
+  DESKTOP: 'textmode'
+  DM_NEEDS_USERNAME: '1'
+  HA_CLUSTER: '1'
+  INSTANCE_ID: '00'
+  INSTANCE_IP_CIDR: '10.0.2.200/24'
+  INSTANCE_SID: HA1
+  INSTANCE_TYPE: HDB
+  MULTIPATH_CONFIRM: 'yes'
+schedule:
+  - '{{barrier_init}}'
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{multipath}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/sles4sap_product_installation_mode
+  - installation/partitioning
+  - installation/partitioning_firstdisk
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/setup_hosts_and_luns
+  - ha/watchdog
+  - sles4sap/patterns
+  - sles4sap/hana_install
+  - '{{cluster_setup}}'
+  - sles4sap/hana_cluster
+  - '{{sap_suse_cluster_connector}}'
+  - ha/fencing
+  - '{{boot_to_desktop}}'
+  - ha/check_after_reboot
+  - ha/check_logs
+conditional_schedule:
+  multipath:
+    MULTIPATH:
+      1:
+        - installation/multipath
+  barrier_init:
+    HA_CLUSTER_INIT:
+      1:
+        - ha/barrier_init
+  cluster_setup:
+    HA_CLUSTER_SETUP:
+      init:
+        - ha/ha_cluster_init
+      join:
+        - ha/ha_cluster_join
+  sap_suse_cluster_connector:
+    HA_CLUSTER_INIT:
+      1:
+        - sles4sap/sap_suse_cluster_connector
+  boot_to_desktop:
+    HA_CLUSTER_INIT:
+      1:
+        - boot/reconnect_mgmt_console
+        - installation/grub_test
+        - installation/first_boot

--- a/tests/ha/setup_hosts_and_luns.pm
+++ b/tests/ha/setup_hosts_and_luns.pm
@@ -33,7 +33,8 @@ sub run {
     my $nfs_share    = get_required_var('NFS_SUPPORT_SHARE');
     my $mountpt      = '/support_fs';
     my $cluster_name = get_cluster_name;
-    my $dir_id       = join('_', $cluster_name, get_required_var('VERSION'), get_required_var('ARCH'));
+    my $build        = join('_', get_required_var('BUILD') =~ m/(\w+)/g);
+    my $dir_id       = join('_', $cluster_name, get_required_var('VERSION'), get_required_var('ARCH'), $build);
     my $testname     = get_required_var('TEST');
     my $time_to_wait;
 


### PR DESCRIPTION
HANA cluster test for the pvm_hmc backend relies on a YAML schedule file for both nodes, and existing HA & SLES for SAP Applications test modules.

Included in this PR are:

1. YAML schedule file for both nodes of the HANA cluster test.
2. Changes to `tests/ha/iscsi_client.pm` so it works on remote backends that set DISPLAY on textmode test scenarios.
3. Changes to `tests/ha/iscsi_client.pm` so it is able to handle iSCSI LUNs when multipath is enabled in SUT.

See the description on the YAML schedule file for information on how to configure the tests in the job group. The following is an example on how this can be done:

```
  ppc64le:
    sle-15-SP2-Online-ppc64le:
    - sles4sap_hana_node01:
        testsuite: '-'
        settings:
          CLUSTER_INFOS: 'hana:2:3'
          CLUSTER_NAME: hana
          HA_CLUSTER_INIT: '1'
          HA_CLUSTER_SETUP: 'init'
          HANA: 'nfs://some.nfs.host/path/to/hana/installation/master/%ARCH%'
          HOSTNAME: '%CLUSTER_NAME%-node01'
          ISCSI_LUN_INDEX: '5'
          ISCSI_SERVER: '192.168.1.10'
          MAX_JOB_TIME: '20000'
          NFS_SUPPORT_SHARE: 'some.nfs.host:/Public/support_nfs'
          SLE_PRODUCT: sles4sap
          YAML_SCHEDULE: schedule/sles4sap/pvm_hana_cluster_node.yaml
    - sles4sap_hana_node02:
        testsuite: '-'
        settings:
          CLUSTER_NAME: hana
          HA_CLUSTER_JOIN: '%CLUSTER_NAME%-node01'
          HA_CLUSTER_SETUP: 'join'
          HANA: 'nfs://some.nfs.host/path/to/hana/installation/master/%ARCH%'
          HOSTNAME: '%CLUSTER_NAME%-node02'
          ISCSI_SERVER: '192.168.1.10'
          MAX_JOB_TIME: '20000'
          NFS_SUPPORT_SHARE: 'some.nfs.host:/Public/support_nfs'
          PARALLEL_WITH: sles4sap_hana_node01
          SLE_PRODUCT: sles4sap
          YAML_SCHEDULE: schedule/sles4sap/pvm_hana_cluster_node.yaml  
```

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1422
- Verification runs: [node 1](http://mango.suse.de/tests/3042) & [node 2](http://mango.suse.de/tests/3043); [node 1 with multipath](http://mango.suse.de/tests/3044) & [node 2 with multipath](http://mango.suse.de/tests/3045); [node 1](http://mango.suse.de/tests/3085) & [node 2 with multipath](http://mango.suse.de/tests/3086); [node 1 - new support dir name](http://mango.suse.de/tests/3087#step/setup_hosts_and_luns/7) & [node 2 - new support dir name](http://mango.suse.de/tests/3088)
- Regression test. HA alpha node in x86_64 over qemu: [node 1](http://mango.suse.de/tests/3077), [node 2](http://mango.suse.de/tests/3078) & [support server](http://mango.suse.de/tests/3076)
