### PR TITLE
Remove no-quorum-policy for two nodes cluster

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -52,6 +52,12 @@ sub cluster_init {
     }
 }
 
+sub cluster_stop_start {
+    my ($action, $partner_node) = @_;
+    assert_script_run "crm cluster $action";
+    assert_script_run "ssh -o StrictHostKeyChecking=no root\@$partner_node 'crm cluster $action'";
+}
+
 sub run {
     # Validate cluster creation with ha-cluster-init tool
     my $cluster_name  = get_cluster_name;
@@ -95,10 +101,6 @@ sub run {
     diag 'Waiting for other nodes to join...';
     barrier_wait("NODE_JOINED_$cluster_name");
 
-    # We need to configure the quorum policy according to the number of nodes
-    $quorum_policy = 'ignore' if (get_node_number == 2) && !get_var('QDEVICE');
-    assert_script_run "crm configure property no-quorum-policy=$quorum_policy";
-
     # Execute csync2 to synchronise the configuration files
     exec_csync;
 
@@ -111,6 +113,27 @@ sub run {
 
     # Check if the multicast port is correct (should be 5405 or 5407 by default)
     assert_script_run "grep -Eq '^[[:blank:]]*mcastport:[[:blank:]]*(5405|5407)[[:blank:]]*' $corosync_conf";
+
+    # Set wait_for_all option to 0 if we are in a two nodes cluster situation
+    # We need to set it for reproducing the same behaviour we had with no-quorum-policy=ignore
+    # This step can only be done after second node has joined the cluster, because 'get_node_number' is
+    # the unique way to know the number of nodes.
+    if (get_node_number == 2) {
+        my $partner = choose_node(2);
+
+        # Stop the cluster in both nodes
+        cluster_stop_start('stop', $partner);
+
+        # Set and check the 'wait_for_all' option
+        assert_script_run "crm corosync set quorum.wait_for_all 0";
+        assert_script_run "grep -q 'wait_for_all: 0' $corosync_conf";
+
+        # Synchronize the corosync.conf file
+        exec_csync;
+
+        # Start the cluster
+        cluster_stop_start('start', $partner);
+    }
 
     # Do a check of the cluster with a screenshot
     save_state;


### PR DESCRIPTION
HA developers told us to not use `no-quorum-policy=ignore` for two nodes cluster in SLE12/SLE15.
Two nodes cluster is managed by the `two_nodes` option in corosync.conf.
However, for reproducing the same behaviour as `no-quorum-policy=ignore`, we have to add the `wait_for_all: 0` to corosync.conf. For setting it, we have to stop the cluster in both nodes.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
15-SP2 2 nodes cluster: [node1](http://1a102.qa.suse.de/tests/5114), [node2](http://1a102.qa.suse.de/tests/5115), [suportserver](http://1a102.qa.suse.de/tests/5113)
15-SP2 3 nodes cluster: [node1](http://1a102.qa.suse.de/tests/5157), [node2](http://1a102.qa.suse.de/tests/5158), [node3](http://1a102.qa.suse.de/tests/5159), [supportserver](http://1a102.qa.suse.de/tests/5156)
12-SP2 2 nodes cluster: [node1](http://1a102.qa.suse.de/tests/5183), [node2](http://1a102.qa.suse.de/tests/5184), [supportserver](http://1a102.qa.suse.de/tests/5182)