### PR TITLE
Fix assertion of repo URI in validate_repo_properties

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -480,7 +480,7 @@ sub validate_repo_properties {
     }
 
     if ($args->{URI}) {
-        assert_true($actual_repo_data->{URI} =~ /$args->{Alias}/,
+        assert_true($actual_repo_data->{URI} =~ /$args->{URI}/,
             "Repository $args->{Name} has wrong URI, expected: '$args->{URI}', got: '$actual_repo_data->{URI}'");
     }
 


### PR DESCRIPTION
There was copy paste mistake and I've put Alias instead of URI.

See [poo#70693](https://progress.opensuse.org/issues/70693).
