### PR TITLE
Don't run khelpcenter on live media

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1299,10 +1299,10 @@ sub load_x11tests {
         }
     }
     if (kdestep_is_applicable()) {
-        if ((is_tumbleweed || is_leap("15.1+")) && !get_var('LIVECD')) {
+        if (!get_var('LIVECD')) {
             loadtest "x11/plasma_browser_integration";
+            loadtest "x11/khelpcenter";
         }
-        loadtest "x11/khelpcenter";
         if (get_var("PLASMA5")) {
             loadtest "x11/systemsettings5";
         }


### PR DESCRIPTION
For saving space, documentation isn't included anyway and in Tumbleweed
khelpcenter isn't on there at all anymore.

Fixes https://progress.opensuse.org/issues/70231

Leap < 15.1 isn't tested anymore, so drop that condition while at it.

- Verification run: https://openqa.opensuse.org/tests/1378082
