### PR TITLE
check_os_release: remove the Jump prefix before matching os-release

### DIFF
--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -47,6 +47,10 @@ sub run {
         $checker{CPE_NAME} =~ s/\-SP/:sp/;
     }
     if (is_leap) {
+        if ($checker{VERSION} =~ /^Jump/) {
+            $checker{VERSION} =~ s/^Jump://;
+            $checker{VERSION_ID} = $checker{VERSION};
+        }
         $checker{NAME}        = "openSUSE Leap";
         $checker{ID}          = "opensuse";
         $checker{PRETTY_NAME} = $checker{NAME} . " " . $checker{VERSION};


### PR DESCRIPTION
on openQA. we're using `Jump:15.2` as Jump's medias version, therefore we need to do pre-processing before matching os-release.

Fix https://openqa.opensuse.org/tests/1377533#step/check_os_release/10

Verification run: https://openqa.opensuse.org/tests/1381248