### PR TITLE
zypper_extend: Don't use a Tumbleweed repo everywhere unconditionally

### DIFF
--- a/tests/console/zypper_extend.pm
+++ b/tests/console/zypper_extend.pm
@@ -90,7 +90,7 @@ sub run {
     zypper_call "rm --clean-deps cmake";
 
     #Add a repository
-    zypper_call 'ar -p 90 -f --no-gpgcheck http://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Tumbleweed/ packman';
+    zypper_call 'ar -p 90 -f --no-gpgcheck http://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_15.1/ packman';
     assert_script_run("zypper lr | grep packman");
 
     #Install package from a disabled repository


### PR DESCRIPTION
The approach used by the test is invalid - only repos targeted for the
distribution can be used. However, to provide a quick and simple workaround
for the time being just use the Leap repo everywhere as it's more compatible
(e.g. no zstd).

Verification run: https://openqa.opensuse.org/tests/1378110