### PR TITLE
Remove warning for missing glibc-locale in jeos-firstboot

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -79,14 +79,16 @@ sub run {
     # For 'en_US' pick 'UTC', for 'de_DE' select 'Europe/Berlin'
     my %tz_key = ('en_US' => 'u', 'de_DE' => 'e');
 
-    # Select locale
-    assert_screen 'jeos-locale', 300;
-    # Without this 'ret' sometimes won't get to the dialog
-    wait_still_screen;
-    send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 50;
-    send_key 'ret';
+    assert_screen [qw(jeos-locale jeos-keylayout)], 300;
 
-    # Select language
+    if (match_has_tag 'jeos-locale') {
+        # Without this 'ret' sometimes won't get to the dialog
+        wait_still_screen;
+        send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 50;
+        send_key 'ret';
+    }
+
+    # Select keyboard layout
     send_key_until_needlematch "jeos-keylayout-$lang", $keylayout_key{$lang}, 30;
     send_key 'ret';
 


### PR DESCRIPTION
- Related tickets: 
  * [Drop the info dialog about glibc-locale (jsc#SLE-15348)](https://build.suse.de/request/show/225299)
  * [Factory](https://build.opensuse.org/request/show/829940)
- Needles: 
  * [sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1424)
  * [oS](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/685)
- Verification runs: 
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build20.1-jeos-base+phub@uefi-virtio-vga](http://kepler.suse.cz/tests/1380#step/firstrun/1)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build20.1-jeos-container-engines_and_tools@svirt-xen-pv](http://kepler.suse.cz/tests/1382#step/firstrun/1)
  * [sle-15-SP3-JeOS-for-MS-HyperV-x86_64-Build20.1-jeos-base+phub_hyperv@svirt-hyperv-uefi](http://kepler.suse.cz/tests/1376#step/firstrun/1)
  * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build31.155-jeos@64bit_virtio-2G](http://kepler.suse.cz/tests/1378#step/firstrun/1)
  * [ opensuse-Tumbleweed-JeOS-for-AArch64](https://openqa.opensuse.org/tests/1378617#step/firstrun/1)
