### PR TITLE
Add test boot_into_snapshot_after_upgrade

### DIFF
--- a/schedule/functional/boot_into_snapshot_after_upgrade.yaml
+++ b/schedule/functional/boot_into_snapshot_after_upgrade.yaml
@@ -1,0 +1,22 @@
+---
+name: boot_into_snapshot_after_upgrade
+description: >
+    Maintainer: zluo
+    add boot_into_snapshot_after_upgrade
+schedule:
+    - installation/isosize
+    - installation/bootloader
+    - installation/welcome
+    - installation/upgrade_select
+    - installation/online_repos
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/grub_test
+    - installation/first_boot
+    - installation/opensuse_welcome
+    - installation/boot_into_snapshot

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -23,10 +23,17 @@ use base "opensusebasetest";
 
 sub run {
     my ($self) = @_;
-    assert_screen 'linux-login', 200;
-    select_console 'root-console';
-    # 1)
-    assert_script_run('touch /etc/NOWRITE;test ! -f /etc/NOWRITE');
+    # for scenarios BOOT_INTO_SNAPSHOT_AFTER_UPGRADE we just need to make sure that root-console is there because
+    # the system is already up and running. For ROLL-BACK it shouldn't check that current snapshot is writeable or not.
+    if (get_var('BOOT_INTO_SNAPSHOT_AFTER_UPGRADE')) {
+        select_console 'root-console';
+    }
+    else {
+        assert_screen 'linux-login', 200;
+        select_console 'root-console';
+        # 1)
+        assert_script_run('touch /etc/NOWRITE;test ! -f /etc/NOWRITE');
+    }
     # 1b) just debugging infos
     assert_script_run("snapper --iso list");
     assert_script_run("cat /etc/os-release");


### PR DESCRIPTION
add boot_into_snapshot after upgrade from DVD installation
see https://progress.opensuse.org/issues/12964
verifications:
http://10.162.23.47/tests/8183 (BOOT_INTO_SNAPSHOT_AFTER_UPGRADE)
http://10.162.23.47/tests/8185 (SLES boot_into_snapshot)
http://10.162.23.47/tests/8184 (TW boot_into_snapshot)