### PR TITLE
Revert "Skips the warning for NVIDIA driver on sle_sp3"

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -479,7 +479,6 @@ sub process_scc_register_addons {
         # start addons/modules registration, it needs longer time if select multiple or all addons/modules
         my $counter = ADDONS_COUNT;
         my @needles = qw(import-untrusted-gpg-key nvidia-validation-failed yast_scc-pkgtoinstall yast-scc-emptypkg inst-addon contacting-registration-server refreshing-repository system-probing);
-        push @needles, 'bsc1175335' if is_sle('15-SP3+');
         if (is_sle('15-SP2+')) {
             # In SLE 15 SP2 multipath detection happens directly after registration, so using it to detect that all pop-up are processed
             push @needles, 'enable-multipath' if get_var('MULTIPATH');
@@ -492,12 +491,6 @@ sub process_scc_register_addons {
             assert_screen([@needles], 90);
             if (match_has_tag('import-untrusted-gpg-key')) {
                 handle_untrusted_gpg_key;
-                next;
-            }
-            elsif (match_has_tag('bsc1175335')) {
-                @needles = grep { $_ ne 'bsc1175335' } @needles;
-                send_key $cmd{ok};
-                send_key $cmd{next};
                 next;
             }
             elsif (match_has_tag('nvidia-validation-failed')) {

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -174,7 +174,6 @@ sub run {
 
     # Push needle 'inst-bootmenu' to ensure boot from hard disk on aarch64
     push(@needles, 'inst-bootmenu') if (check_var('ARCH', 'aarch64') && get_var('UPGRADE'));
-    push @needles, 'bsc1175335' if is_sle('15-SP3+');
     # Kill ssh proactively before reboot to avoid half-open issue on zVM, do not need this on zKVM
     prepare_system_shutdown if check_var('BACKEND', 's390x');
     my $postpartscript = 0;
@@ -202,12 +201,6 @@ sub run {
         elsif (match_has_tag('import-untrusted-gpg-key')) {
             handle_untrusted_gpg_key;
             @needles = grep { $_ ne 'import-untrusted-gpg-key' } @needles;
-            next;
-        }
-        elsif (match_has_tag('bsc1175335')) {
-            @needles = grep { $_ ne 'bsc1175335' } @needles;
-            send_key $cmd{ok};
-            send_key $cmd{next};
             next;
         }
         elsif (match_has_tag('prague-pxe-menu') || match_has_tag('qa-net-selection')) {


### PR DESCRIPTION
This reverts commit 22d64d5e0d131aa1397d44e682ec620c1755de94.

[bsc#1175335](https://bugzilla.suse.com/show_bug.cgi?id=1175335) is
fixed, so we can revert this workaround.

[Verification run](https://openqa.suse.de/t4619846).