### PR TITLE
Fix apache2_changehat failure on deleting database

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -622,7 +622,7 @@ sub adminer_database_delete {
     assert_and_click("adminer-click-database-test");
     assert_and_click("adminer-click-drop-database-test");
     # Confirm drop
-    wait_screen_change { send_key 'spc' }
+    send_key_until_needlematch("adminer-database-dropped", 'ret', 10, 1);
     # Exit x11 and turn to console
     send_key "alt-f4";
     assert_screen("generic-desktop");


### PR DESCRIPTION
Fix apache2_changehat failure on deleting database.

This fail was introduced by the following code change (it works for TW but introduced new fails in SLES, also the code change is not  complete as test case will be passed without checking results):
https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/05bfdce44cacde76b8dc560fe84846aa51496325

- Related ticket: https://progress.opensuse.org/issues/70690
- Needles: N/A (pushed already)
- Verification run:
   SLES: http://openqa.suse.de/tests/4619883#
   TW: https://openqa.suse.de/tests/4585090#step/apache2_changehat/140