### PR TITLE
systemd_testsuite: run testsuite preparation script

### DIFF
--- a/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
+++ b/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
@@ -18,6 +18,8 @@ use testapi;
 sub run {
     my ($self) = @_;
     $self->testsuiteinstall;
+    assert_script_run('cd /var/opt/systemd-tests');
+    assert_script_run('./run-tests.sh --prepare', 600);
 }
 
 sub test_flags {

--- a/tests/systemd_testsuite/test_19_delegate.pm
+++ b/tests/systemd_testsuite/test_19_delegate.pm
@@ -26,7 +26,7 @@ sub run {
     assert_script_run 'cd /var/opt/systemd-tests';
     assert_script_run './run-tests.sh TEST-19-DELEGATE --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-19-DELEGATE" /tmp/testsuite.log';
-    assert_script_run './run-tests.sh TEST-19-DELEGATE --cleanup', 120;
+    assert_script_run './run-tests.sh TEST-19-DELEGATE --clean', 120;
 }
 
 sub test_flags {


### PR DESCRIPTION
Once I add [the new run-tests.sh script](https://github.com/eliroca/run-systemd-tests/pull/1) to the testsuite packages, we'll need this merged

- Verification run: http://emerson.suse.de/tests/2461
