### PR TITLE
Skip sssd_samba test for Leap>=15.2 and TW

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1695,7 +1695,7 @@ sub load_extra_tests_console {
     loadtest 'console/libgcrypt' if ((is_sle(">=12-SP4") && (check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk'))) || is_opensuse);
     loadtest "console/gd";
     loadtest 'console/valgrind'       unless is_sle('<=12-SP3');
-    loadtest 'console/sssd_samba'     unless (is_sle("<15") || is_sle(">=15-sp2"));
+    loadtest 'console/sssd_samba'     unless (is_sle("<15") || is_sle(">=15-sp2") || is_leap('>=15.2') || is_tumbleweed);
     loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1') || is_jeos || is_public_cloud);
 }
 


### PR DESCRIPTION
The `sssd_samba` regression test should be skipped for Leap 15.2+ and Tumbleweed, as the package under test is obsoleted.

- Related ticket: https://progress.opensuse.org/issues/69679
- Needles: -
- Verification run: [Tumbleweed](https://openqa.opensuse.org/tests/1379843) | [Leap 15.2](https://openqa.opensuse.org/tests/1379844)- `sssd_samba` is not scheduled anymore
