### PR TITLE
Enable desktop applications module in dud test

### DIFF
--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -2,11 +2,15 @@
 name: dud_development_tools
 description: >
   Same as dud_sdk, but due to bsc#1080292 we cannot use ISO.  FTP url is used
-  instead. Limitation is that we use x86_64 url,  as cannot create DUD in the
+  instead. Limitation is that we use x86_64 url, as cannot create DUD in the
   runtime, so test cannot be executed on other architectures.
+  Also development tools module requires desktop applications module as a
+  dependency, so DESKTOP is set to gnome.
 vars:
   DUD: dev_tools.dud
   DUD_ADDONS: sdk
+  DESKTOP: gnome
+  SCC_ADDONS: base,serverapp,desktop
 schedule:
   - installation/isosize
   - installation/bootloader_start


### PR DESCRIPTION
We have tricky setup for this test, and after fixing symlink to point to
SLE-15-SP3 repo, we got correct error about missing Desktop Application
module. So to fix the test, setting `DESKTOP` variable to `gnome` in
order to enable the module and resolve dependency issue.

[Verification run](https://openqa.suse.de/tests/4622954#).