### PR TITLE
Fix cryptlvm_iscsi test_data adding backup missing variable

### DIFF
--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -44,4 +44,6 @@ schedule:
 test_data:
   crypttab:
     num_devices_encrypted: 1
+  cr_scsi-1IET_00010001-part2:
+    backup_path: '/root/bkp_luks_header_cr_scsi-1IET_00010001-part2'
   <<: !include test_data/yast/encryption/default_enc.yaml

--- a/t/schema/Schedule-1.yaml
+++ b/t/schema/Schedule-1.yaml
@@ -41,7 +41,7 @@ properties:
     additionalProperties: false
     type: object
     patternProperties:
-      "^([a-zA-Z0-9_]+)$":
+      "^([a-zA-Z0-9_-]+)$":
         oneOf:
         - type: string
         - type: number


### PR DESCRIPTION
Missing configuration for 
https://openqa.suse.de/tests/4622945 

- Related ticket: https://progress.opensuse.org/issues/69751
