### PR TITLE
Update initial jeos-firstboot screen handling

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -8,14 +8,14 @@
 # without any warranty.
 
 # Summary: Configure JeOS
-# Maintainer: Ciprian Cret <mnowak@suse.com>
+# Maintainer: qa-c team <qa-c@suse.de>
 
 use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle is_tumbleweed is_leap);
-use Utils::Architectures 'is_aarch64';
+use version_utils qw(is_sle is_tumbleweed is_leap is_opensuse);
+use Utils::Architectures qw(is_aarch64 is_x86_64);
 use Utils::Backends 'is_hyperv';
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);
 
@@ -67,11 +67,7 @@ sub verify_mounts {
 
 sub run {
     my ($self) = @_;
-
-    mouse_hide;    # JeOS on generalhw
-
     my $lang = is_sle('15+') ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
-
     # For 'en_US' pick 'en_US', for 'de_DE' select 'de_DE'
     my %locale_key = ('en_US' => 'e', 'de_DE' => 'd');
     # For 'en_US' pick 'us', for 'de_DE' select 'de'
@@ -79,16 +75,23 @@ sub run {
     # For 'en_US' pick 'UTC', for 'de_DE' select 'Europe/Berlin'
     my %tz_key = ('en_US' => 'u', 'de_DE' => 'e');
 
-    assert_screen [qw(jeos-locale jeos-keylayout)], 300;
-
-    if (match_has_tag 'jeos-locale') {
+    # JeOS on generalhw
+    mouse_hide;
+    # kiwi-templates-JeOS images (sle, opensuse x86_64 only) are build w/o translations
+    # jeos-firstboot >= 0.0+git20200827.e920a15 locale warning dialog has been removed
+    if (is_sle('<15-sp3') || (is_leap('<15.3') && is_x86_64)) {
+        assert_screen 'jeos-lang-notice', 300;
         # Without this 'ret' sometimes won't get to the dialog
         wait_still_screen;
+        send_key 'ret';
+    } elsif (is_opensuse && !is_x86_64) {
+        assert_screen 'jeos-locale', 300;
         send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 50;
         send_key 'ret';
     }
 
     # Select keyboard layout
+    assert_screen 'jeos-keylayout';
     send_key_until_needlematch "jeos-keylayout-$lang", $keylayout_key{$lang}, 30;
     send_key 'ret';
 


### PR DESCRIPTION
**jeos-locale** needle had been used to match 2 different scenarios (missing translations dialogue and list of available translations) in jeos-firstboot. Images based on kiwi-templates-JeOS do not contain pre-installed translations, therefore jeos-firstboot skips displaying list of available translations or older versions display educative/warning dialogue about missing glibc-locale.
As other images build according to other templates than kiwi-templates-JeOS contain translations, thus jeos-firstboot shows list of available translations which should be represented by **jeos-locale** needle only and **jeos-lang-warning** should be restricted to glibc-locale pop up only.

- Needles: 
  * [oS](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/686)
  * [sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1425)
- Verification runs: 
  * sle
     * [sle-15-SP1-JeOS](http://kepler.suse.cz/tests/1517#step/firstrun/1)
     * [sle-15-SP2-JeOS](http://kepler.suse.cz/tests/1527#step/firstrun/1)
     * [sle-15-SP3-JeOS](http://kepler.suse.cz/tests/1520#step/firstrun/1)
     * [sle-15-SP3-JeOS@svirt-xen-pv](http://kepler.suse.cz/tests/1521#step/firstrun/1)
     * [sle-15-SP3-JeOS@svirt-hyperv-uefi](http://kepler.suse.cz/tests/1522#step/firstrun/1)
  * oS
     * [opensuse-Tumbleweed-JeOS](http://kepler.suse.cz/tests/1523#step/firstrun/1)
     * [opensuse-15.1-JeOS](http://kepler.suse.cz/tests/1524#step/firstrun/1)
     * [opensuse-15.2-JeOS](http://kepler.suse.cz/tests/1525#step/firstrun/1)
     * [opensuse-15.1-JeOS-for-AArch64](https://openqa.opensuse.org/tests/1384377)
     * [opensuse-Tumbleweed-JeOS-for-AArch64](https://openqa.opensuse.org/tests/1384378)
     * [opensuse-15.2-JeOS-for-AArch64](https://openqa.opensuse.org/tests/1384379)