### PR TITLE
Wait between type_strings to avoid early typing

### DIFF
--- a/tests/hpc/conman.pm
+++ b/tests/hpc/conman.pm
@@ -54,6 +54,7 @@ sub run {
 
     # test from netcat side
     type_string("fg 1\n");
+    wait_still_screen(1, 2);
     type_string("Hello from nc...\n");
     send_key('ctrl-z');
     type_string("fg 2\n");


### PR DESCRIPTION
resulting into needle not matching due to missing e.g. first letter H

- Fail: https://openqa.suse.de/tests/4625175#step/conman/15
- Verification run: https://openqa.suse.de/tests/4625176