### PR TITLE
Add test for zypper-docker

### DIFF
--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -46,6 +46,7 @@ sub run {
         test_container_image(image => $image_names->[$i], runtime => 'docker');
         build_container_image(image => $image_names->[$i], runtime => 'docker');
         test_opensuse_based_image(image => $image_names->[$i], runtime => 'docker');
+        build_with_zypper_docker(image => $image_names->[$i], runtime => 'docker');
     }
 
     scc_restore_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));


### PR DESCRIPTION
Small regression test for zypper-docker

- Related ticket: https://progress.opensuse.org/issues/66367
- Needles: No Needles
- Verification runs: 
* [SLE 15 SP2 x86_64](http://10.161.229.232/tests/1129)
* [SLE 15 SP1 x86_64](http://10.161.229.232/tests/1128)
* [SLE 15 x86_64](http://10.161.229.232/tests/1127)
* [SLE 12 SP5 x86_64](http://10.161.229.232/tests/1133)
* [SLE 12 SP4 x86_64](http://10.161.229.232/tests/1132)
* [SLE 12 SP3 x86_64](http://10.161.229.232/tests/1130)
* [tumbleweed x86_64](http://10.161.229.232/tests/1131)


