### PR TITLE
Remove check for php version to reflect changed dependency

### DIFF
--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -41,9 +41,7 @@ sub run {
 
     #install web frontend and start apache
     zypper_call('in ganglia-web');
-    # SLE15 has installed by default php7, SLE12 has php5
-    my $php_mod = is_sle('15+') ? 'php7' : 'php5';
-    script_run('a2enmod ' . $php_mod);
+    script_run('a2enmod php7');
     systemctl('start apache2');
     my $page_url = "http://ganglia-server/ganglia/?r=hour&cs=&ce=&c=unspecified&h=";
     $page_url .= "ganglia-server.openqa.test&tab=m&vn=&hide-hf=false";


### PR DESCRIPTION
Installing ganglia-server now pulls php7 in SLE12 too, so there is no need for an OS version check.

- Related ticket:  https://progress.opensuse.org/issues/70273
- Verification run: [12SP2](http://localhost/tests/451) [12SP3](http://localhost/tests/454) [12SP4](http://localhost/tests/457) [12SP5](http://localhost/tests/443)
