### PR TITLE
Fix HA DC issue with two nodes cluster

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -52,12 +52,6 @@ sub cluster_init {
     }
 }
 
-sub cluster_stop_start {
-    my ($action, $partner_node) = @_;
-    assert_script_run "crm cluster $action";
-    assert_script_run "ssh -o StrictHostKeyChecking=no root\@$partner_node 'crm cluster $action'";
-}
-
 sub run {
     # Validate cluster creation with ha-cluster-init tool
     my $cluster_name  = get_cluster_name;
@@ -94,6 +88,17 @@ sub run {
     # If we failed to initialize the cluster with 'ha-cluster-init', trying again with crm in debug mode
     cluster_init('crm-debug-mode', $fencing_opt, $unicast_opt, $qdevice_opt) if (!wait_serial("ha-cluster-init-finished-0", $join_timeout));
 
+    # Set wait_for_all option to 0 if we are in a two nodes cluster situation
+    # We need to set it for reproducing the same behaviour we had with no-quorum-policy=ignore
+    if (!check_var('TWO_NODES', 'no')) {
+        record_info("Cluster info", "Two nodes cluster detected");
+        assert_script_run "crm corosync set quorum.wait_for_all 0";
+        assert_script_run "grep -q 'wait_for_all: 0' $corosync_conf";
+        assert_script_run "crm cluster stop";
+        assert_script_run "crm cluster start";
+        wait_until_resources_started;
+    }
+
     # Signal that the cluster stack is initialized
     barrier_wait("CLUSTER_INITIALIZED_$cluster_name");
 
@@ -113,27 +118,6 @@ sub run {
 
     # Check if the multicast port is correct (should be 5405 or 5407 by default)
     assert_script_run "grep -Eq '^[[:blank:]]*mcastport:[[:blank:]]*(5405|5407)[[:blank:]]*' $corosync_conf";
-
-    # Set wait_for_all option to 0 if we are in a two nodes cluster situation
-    # We need to set it for reproducing the same behaviour we had with no-quorum-policy=ignore
-    # This step can only be done after second node has joined the cluster, because 'get_node_number' is
-    # the unique way to know the number of nodes.
-    if (get_node_number == 2) {
-        my $partner = choose_node(2);
-
-        # Stop the cluster in both nodes
-        cluster_stop_start('stop', $partner);
-
-        # Set and check the 'wait_for_all' option
-        assert_script_run "crm corosync set quorum.wait_for_all 0";
-        assert_script_run "grep -q 'wait_for_all: 0' $corosync_conf";
-
-        # Synchronize the corosync.conf file
-        exec_csync;
-
-        # Start the cluster
-        cluster_stop_start('start', $partner);
-    }
 
     # Do a check of the cluster with a screenshot
     save_state;


### PR DESCRIPTION
This PR fixes a bug introduced by #10911.
After restarting the cluster, the DC could be another node than node1 and we don't want that. 
DC must be node1 in order to successfully pass the DRBD tests.
For avoiding the restart of each node, we set the `wait_for_all `option just after the cluster initialization (when the cluster is only composed of the first node), 
Of course, only if we are in a two nodes cluster scenario.
A new variable has to be set in our 3 nodes cluster: `TWO_NODES=no`
With it, the wait_for_all option will not be configured.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
15-SP2 2 nodes cluster: [node1](http://1a102.qa.suse.de/tests/5285), [node2](http://1a102.qa.suse.de/tests/5286), [suportserver](http://1a102.qa.suse.de/tests/5284)
15-SP2 3 nodes cluster: [node1](http://1a102.qa.suse.de/tests/5281), [node2](http://1a102.qa.suse.de/tests/5282), [node3](http://1a102.qa.suse.de/tests/5283), [supportserver](http://1a102.qa.suse.de/tests/5280)
12-SP2 2 nodes cluster: [node1](http://1a102.qa.suse.de/tests/5272), [node2](http://1a102.qa.suse.de/tests/5273), [supportserver](http://1a102.qa.suse.de/tests/5271)
