### PR TITLE
Import and test Windows 2019 on XEN and KVM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2732,8 +2732,14 @@ sub load_hypervisor_tests {
         loadtest 'virtualization/universal/virtmanager_final';    # Check that every guest shows the login screen
         loadtest "virtualization/universal/smoketest";            # Virtualization smoke test for hypervisor
         loadtest "virtualization/universal/stresstest";           # Perform stress tests on the guests
-        loadtest "console/perf";                                  # Run QAM perf test
-        loadtest "console/oprofile";                              # Run QAM oprofile test
+        loadtest "console/perf";
+        loadtest "console/oprofile" unless (get_var("REGRESSION", '') =~ /xen/);
+    }
+
+    if (check_var('VIRT_PART', 'windows')) {
+        loadtest "virt_autotest/login_console";
+        loadtest "virtualization/universal/download_image";       # Download Windows disk image(s)
+        loadtest "virtualization/universal/windows";              # Import and test Windows
     }
 }
 

--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -138,7 +138,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles15sp2HVM => {
             name         => 'sles15sp2HVM',
             autoyast     => 'autoyast_xen/sles15sp2HVM_PRG.xml',
-            extra_params => '--connect xen:/// --virt-type xen --hvm --os-variant sle15sp2',
+            extra_params => '--connect xen:/// --virt-type xen --hvm --os-variant sle15sp1',           # sle15sp2 is unknown on 12.3
             macaddress   => '52:54:00:78:73:b0',
             ip           => '192.168.122.116',
             distro       => 'SLE_15',
@@ -147,7 +147,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles15sp2PV => {
             name         => 'sles15sp2PV',
             autoyast     => 'autoyast_xen/sles15sp2PV_PRG.xml',
-            extra_params => '--connect xen:/// --virt-type xen --paravirt --os-variant sle15sp2',
+            extra_params => '--connect xen:/// --virt-type xen --paravirt --os-variant sle15sp1',      # sle15sp2 is unknown on 12.3
             macaddress   => '52:54:00:78:73:af',
             ip           => '192.168.122.115',
             distro       => 'SLE_15',
@@ -337,6 +337,35 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     delete($guests{sles15sp2})    if (!is_sle('=15-SP2'));
 } else {
     %guests = ();
+}
+
+our %imports = ();    # imports are virtual machines that we don't install but just import. We test those separately.
+if (get_var("REGRESSION", '') =~ /xen/) {
+    %imports = (
+        win2k19 => {
+            name         => 'win2k19',
+            extra_params => '--connect xen:/// --hvm --os-type windows --os-variant win2k19',
+            disk         => '/var/lib/libvirt/images/win2k19.raw',
+            source       => '/mnt/virt_images/xen/win2k19.raw',
+            macaddress   => '52:54:00:78:73:66',
+            ip           => '192.168.122.66',
+            version      => 'Microsoft Windows Server 2019',
+        },
+    );
+} elsif (get_var("REGRESSION", '') =~ /kvm|qemu/) {
+    %imports = (
+        win2k19 => {
+            name         => 'win2k19',
+            extra_params => '--os-type windows --os-variant win2k19',
+            disk         => '/var/lib/libvirt/images/win2k19.raw',
+            source       => '/mnt/virt_images/kvm/win2k19.raw',
+            macaddress   => '52:54:00:78:73:66',
+            ip           => '192.168.122.66',
+            version      => 'Microsoft Windows Server 2019',
+        },
+    );
+} else {
+    %imports = ();
 }
 
 1;

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -30,10 +30,13 @@ use version_utils;
 use testapi;
 use DateTime;
 use Utils::Architectures 'is_s390x';
-use virt_utils;
 
 our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest is_xen_host is_kvm_host check_host check_guest print_cmd_output_to_file
-  ssh_setup ssh_copy_id create_guest install_default_packages upload_y2logs ensure_online);
+  ssh_setup ssh_copy_id create_guest import_guest install_default_packages upload_y2logs ensure_default_net_is_active ensure_online add_guest_to_hosts restart_libvirtd);
+
+sub restart_libvirtd {
+    is_sle '12+' ? systemctl "restart libvirtd", timeout => 180 : assert_script_run "service libvirtd restart", 180;
+}
 
 #return 1 if it is a VMware test judging by REGRESSION variable
 sub is_vmware_virtualization {
@@ -108,13 +111,32 @@ sub ssh_setup {
 }
 
 sub ssh_copy_id {
-    my $guest           = shift;
+    my ($guest, %args) = @_;
+
+    my $username        = $args{username}        // 'root';
+    my $authorized_keys = $args{authorized_keys} // '.ssh/authorized_keys';
+    my $scp             = $args{scp}             // 0;
     my $mode            = is_sle('=11-sp4')             ? ''                      : '-f';
     my $default_ssh_key = (!(get_var('VIRT_AUTOTEST'))) ? "/root/.ssh/id_rsa.pub" : "/var/testvirt.net/.ssh/id_rsa.pub";
     script_retry "nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12;
     assert_script_run "ssh-keyscan $guest >> ~/.ssh/known_hosts";
-    if (script_run("ssh -o PreferredAuthentications=publickey root\@$guest hostname -f") != 0) {
-        exec_and_insert_password("ssh-copy-id -i $default_ssh_key -o StrictHostKeyChecking=no $mode root\@$guest");
+    if (script_run("ssh -o PreferredAuthentications=publickey -o ControlMaster=no $username\@$guest hostname") != 0) {
+        # Our client key is not authorized, we have to type password with evry command
+        my $options = "-o PreferredAuthentications=password,keyboard-interactive -o ControlMaster=no";
+        unless ($scp == 1) {
+            exec_and_insert_password("ssh-copy-id $options $mode -i $default_ssh_key $username\@$guest");
+        } else {
+            exec_and_insert_password("ssh $options $username\@$guest 'mkdir .ssh' || true");
+            exec_and_insert_password("scp $options $default_ssh_key $username\@$guest:'$authorized_keys'");
+            if (script_run("nmap $guest -PN -p ssh -sV | grep Windows") == 0) {
+                exec_and_insert_password("ssh $options $username\@$guest 'icacls $authorized_keys /remove \"NT AUTHORITY\\Authenticated Users\"'");
+                exec_and_insert_password("ssh $options $username\@$guest 'icacls $authorized_keys /inheritance:r'");
+            } else {
+                exec_and_insert_password("ssh $options $username\@$guest 'chmod 0700 ~/.ssh/'");
+                exec_and_insert_password("ssh $options $username\@$guest 'chmod 0644 ~/.ssh/authorized_keys'");
+            }
+        }
+        assert_script_run "ssh -o PreferredAuthentications=publickey -o ControlMaster=no $username\@$guest hostname";
     }
 }
 
@@ -137,6 +159,25 @@ sub create_guest {
     }
 }
 
+sub import_guest {
+    my ($guest, $method) = @_;
+
+    my $name         = $guest->{name};
+    my $disk         = $guest->{disk};
+    my $macaddress   = $guest->{macaddress};
+    my $extra_params = $guest->{extra_params} // "";
+
+    if ($method eq 'virt-install') {
+        record_info "$name", "Going to import $name guest";
+        send_key 'ret';    # Make some visual separator
+
+        # Run unattended installation for selected guest
+        my $virtinstall = "virt-install $extra_params --name $name --vcpus=4,maxvcpus=4 --memory=4096,maxmemory=4096 --cpu host";
+        $virtinstall .= " --graphics vnc --disk $disk --network network=default,mac=$macaddress --noautoconsole  --autostart --import";
+        assert_script_run $virtinstall;
+    }
+}
+
 sub install_default_packages {
     # Install nmap, ip, dig
     if (is_s390x()) {
@@ -151,6 +192,9 @@ sub ensure_online {
 
     my $hypervisor = $args{HYPERVISOR}    // "192.168.122.1";
     my $dns_host   = $args{DNS_TEST_HOST} // "suse.de";
+    my $skip_ssh   = $args{skip_ssh}      // 0;
+    my $ping_delay = $args{ping_delay}    // 15;
+    my $ping_retry = $args{ping_retry}    // 60;
     # Ensure guest is running
     # Only xen/kvm support to reboot guest at the moment
     if (is_xen_host || is_kvm_host) {
@@ -158,15 +202,22 @@ sub ensure_online {
             assert_script_run("virsh start '$guest'");
         }
     }
-    die "$guest does not respond to ICMP" if (script_retry("ping -c 1 '$guest'", delay => 5, retry => 60) != 0);
+    die "$guest does not respond to ICMP" if (script_retry("ping -c 1 '$guest'", delay => $ping_delay, retry => $ping_retry) != 0);
     # Wait for ssh to come up
     die "$guest does not start ssh" if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12) != 0);
-    die "$guest not ssh-reachable"  if (script_run("ssh $guest uname") != 0);
-    # Ensure default route is set
-    script_run("ssh $guest ip route add default via $hypervisor");
-    die "Pinging hypervisor failed for $guest" if (script_retry("ssh $guest ping -c 1 $hypervisor", delay => 1, retry => 10) != 0);
-    # Check also if name resolution works
-    die "name resolution failed for $guest" if (script_retry("ssh $guest ping -c 1 -w 120 $dns_host", delay => 1, retry => 10) != 0);
+    unless ($skip_ssh == 1) {
+        die "$guest not ssh-reachable" if (script_run("ssh $guest uname") != 0);
+        # Ensure default route is set
+        if (script_run("ssh $guest ip r s | grep default") != 0) {
+            assert_script_run("ssh $guest ip r a default via $hypervisor");
+        }
+        die "Pinging hypervisor failed for $guest" if (script_retry("ssh $guest ping -c 1 $hypervisor", delay => 1, retry => 10) != 0);
+        # Check also if name resolution works - restart libvirtd if not
+        if (script_run("ssh $guest ping -c 1 -w 120 $dns_host") != 0) {
+            restart_libvirtd;
+            die "name resolution failed for $guest" if (script_retry("ssh $guest ping -c 1 -w 120 $dns_host", delay => 1, retry => 10) != 0);
+        }
+    }
 }
 
 sub upload_y2logs {
@@ -174,6 +225,21 @@ sub upload_y2logs {
     assert_script_run "save_y2logs /tmp/y2logs.tar.bz2", 180;
     upload_logs("/tmp/y2logs.tar.bz2");
     save_screenshot;
+}
+
+sub ensure_default_net_is_active {
+    if (script_run("virsh net-list --all | grep default | grep ' active'", 90) != 0) {
+        restart_libvirtd;
+        if (script_run("virsh net-list --all | grep default | grep ' active'", 90) != 0) {
+            assert_script_run "virsh net-start default";
+        }
+    }
+}
+
+sub add_guest_to_hosts {
+    my ($hostname, $address) = @_;
+    assert_script_run "sed -i '/ $hostname /d' /etc/hosts";
+    assert_script_run "echo '$address $hostname # virtualization' >> /etc/hosts";
 }
 
 1;

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -94,7 +94,7 @@ sub post_fail_hook {
     virt_autotest::virtual_network_utils::upload_debug_log();
 
     #Restart libvirtd service
-    virt_autotest::virtual_network_utils::restart_libvirtd();
+    virt_autotest::utils::restart_libvirtd();
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -92,7 +92,7 @@ sub post_fail_hook {
     virt_autotest::virtual_network_utils::upload_debug_log();
 
     #Restart libvirtd service
-    virt_autotest::virtual_network_utils::restart_libvirtd();
+    virt_autotest::utils::restart_libvirtd();
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -85,7 +85,7 @@ sub post_fail_hook {
     virt_autotest::virtual_network_utils::upload_debug_log();
 
     #Restart libvirtd service
-    virt_autotest::virtual_network_utils::restart_libvirtd();
+    virt_autotest::utils::restart_libvirtd();
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -119,7 +119,7 @@ sub post_fail_hook {
     virt_autotest::virtual_network_utils::upload_debug_log();
 
     #Restart libvirtd service
-    virt_autotest::virtual_network_utils::restart_libvirtd();
+    virt_autotest::utils::restart_libvirtd();
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -84,7 +84,7 @@ sub post_fail_hook {
     my ($self) = @_;
 
     #Restart libvirtd service
-    virt_autotest::virtual_network_utils::restart_libvirtd();
+    virt_autotest::utils::restart_libvirtd();
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -25,7 +25,7 @@ use IO::File;
 use List::Util 'first';
 use proxymode;
 use version_utils 'is_sle';
-use virt_autotest::utils qw(is_xen_host);
+use virt_autotest::utils;
 
 our @EXPORT
   = qw(enable_debug_logging update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk upload_supportconfig_log download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console);

--- a/tests/virtualization/universal/dom_install.pm
+++ b/tests/virtualization/universal/dom_install.pm
@@ -27,7 +27,7 @@ sub run {
     select_console 'root-console';
     opensusebasetest::select_serial_terminal();
 
-    zypper_call '-t in vhostmd';
+    zypper_call '-t in vhostmd', exitcode => [0, 4, 102, 103, 106];
 
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "Install vm-dump-metrics on xl-$guest";

--- a/tests/virtualization/universal/download_image.pm
+++ b/tests/virtualization/universal/download_image.pm
@@ -1,0 +1,34 @@
+#Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Download disk image
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base "consoletest";
+use virt_autotest::common;
+use virt_autotest::utils;
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    ensure_default_net_is_active();
+
+    script_run "if [ -d \"/mnt/virt_images\" ]; then umount /mnt/virt_images; else mkdir /mnt/virt_images; fi";
+    assert_script_run "mount " . get_var('VIRT_IMAGE_PATH') . " /mnt/virt_images";
+
+    # Pull images from server if necessary
+    zypper_call("install rsync") if (script_run("which rsync") != 0);
+    assert_script_run "if [ ! -f \"$virt_autotest::common::imports{$_}->{disk}\" ]; then rsync -v --progress $virt_autotest::common::imports{$_}->{source} $virt_autotest::common::imports{$_}->{disk}; fi", 600 foreach (keys %virt_autotest::common::imports);
+
+    assert_script_run "umount /mnt/virt_images";
+}
+
+1;

--- a/tests/virtualization/universal/guest_management.pm
+++ b/tests/virtualization/universal/guest_management.pm
@@ -12,6 +12,7 @@
 
 use base "consoletest";
 use virt_autotest::common;
+use virt_autotest::utils;
 use strict;
 use warnings;
 use testapi;
@@ -52,7 +53,10 @@ sub run {
 
     record_info "START", "Start all guests";
     foreach my $guest (keys %virt_autotest::common::guests) {
-        script_retry "virsh start $guest",                 delay => 30, retry => 12;
+        if (script_retry("virsh start $guest", delay => 30, retry => 6) != 0) {
+            restart_libvirtd;
+            script_retry "virsh start $guest", delay => 30, retry => 6;
+        }
         script_retry "nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12;
     }
 

--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -46,6 +46,7 @@ sub run_test {
                 }
             }
             script_retry "ssh root\@$guest ip l | grep " . $virt_autotest::common::guests{$guest}->{macaddress}, delay => 60, retry => 3, timeout => 60;
+            assert_script_run "virsh domiflist $guest", 90;
             assert_script_run "virsh attach-interface --domain $guest --type bridge ${interface_model_option} --source br0 --mac " . $mac{$guest} . " --live " . ${persistent_config_option};
             assert_script_run "virsh domiflist $guest | grep br0";
             assert_script_run "ssh root\@$guest cat /proc/uptime | cut -d. -f1", 60;

--- a/tests/virtualization/universal/list_guests.pm
+++ b/tests/virtualization/universal/list_guests.pm
@@ -19,24 +19,9 @@ use utils;
 sub run {
     my $self = shift;
 
-    if (script_run("virsh net-list --all | grep default | grep ' active'", 90) != 0) {
-        systemctl "restart libvirtd";
-        if (script_run("virsh net-list --all | grep default | grep ' active'", 90) != 0) {
-            assert_script_run "virsh net-start default";
-        }
-    }
+    ensure_default_net_is_active();
 
     assert_script_run "virsh list --all", 90;
-
-    # Check for powered off guests
-    if (script_run("virsh list --all | grep \"shut off\"", 90) == 0) {
-        foreach my $guest (keys %virt_autotest::common::guests) {
-            if (script_run("virsh list --all | grep \"$guest\" | grep \"shut off\"", 90) == 0) {
-                record_soft_failure "$guest should be on but is not";
-                assert_script_run "virsh start $guest";
-            }
-        }
-    }
 
     # Ensure all guests are online and have network connectivity
     foreach my $guest (keys %virt_autotest::common::guests) {
@@ -46,7 +31,7 @@ sub run {
         } or do {
             my $err = $@;
             record_info("$guest failure: $err");
-        }
+        };
     }
 }
 

--- a/tests/virtualization/universal/smoketest.pm
+++ b/tests/virtualization/universal/smoketest.pm
@@ -55,7 +55,13 @@ sub run {
     # Run smoketests on guests
     smoketest('localhost');
     foreach my $guest (keys %virt_autotest::common::guests) {
-        ensure_online($guest);
+        # This should fix some common issues on the guests. If the procedure fails we still want to go on
+        eval {
+            ensure_online($guest);
+        } or do {
+            my $err = $@;
+            record_info("$guest failure: $err");
+        };
         smoketest($guest);
     }
 }

--- a/tests/virtualization/universal/virsh_start.pm
+++ b/tests/virtualization/universal/virsh_start.pm
@@ -33,7 +33,7 @@ sub run {
     }
 
     record_info "LIBVIRTD", "Restart libvirtd and expect all guests to boot up";
-    systemctl 'restart libvirtd';
+    restart_libvirtd;
 
 
     # Ensure all guests have network connectivity

--- a/tests/virtualization/universal/virsh_stop.pm
+++ b/tests/virtualization/universal/virsh_stop.pm
@@ -18,6 +18,7 @@
 
 use base "consoletest";
 use virt_autotest::common;
+use virt_autotest::utils;
 use strict;
 use warnings;
 use testapi;
@@ -32,7 +33,7 @@ sub run {
     assert_script_run "virsh autostart --disable $_" foreach (keys %virt_autotest::common::guests);
 
     record_info "LIBVIRTD", "Restart libvirtd and expect all guests to stay down";
-    systemctl 'restart libvirtd';
+    restart_libvirtd;
 }
 
 sub test_flags {

--- a/tests/virtualization/universal/windows.pm
+++ b/tests/virtualization/universal/windows.pm
@@ -1,0 +1,50 @@
+#Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Import and test Windows guest
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base "consoletest";
+use virt_autotest::common;
+use virt_autotest::utils;
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub remove_guest {
+    my $guest = shift;
+
+    if (script_run("virsh list --all | grep '$guest'", 90) == 0) {
+        assert_script_run "virsh destroy $guest";
+        assert_script_run "virsh undefine $guest";
+    }
+}
+
+sub run {
+    my $self     = shift;
+    my $username = 'Administrator';
+
+    remove_guest $_ foreach (keys %virt_autotest::common::imports);
+
+    import_guest $_,       'virt-install'                            foreach (values %virt_autotest::common::imports);
+    add_guest_to_hosts $_, $virt_autotest::common::imports{$_}->{ip} foreach (keys %virt_autotest::common::imports);
+
+    # Check if SSH is open because of that means that the guest is installed
+    ensure_online $_, skip_ssh => 1 foreach (keys %virt_autotest::common::imports);
+
+    ssh_copy_id $_, username => $username, authorized_keys => 'C:\ProgramData\ssh\administrators_authorized_keys', scp => 1 foreach (keys %virt_autotest::common::imports);
+
+    # Print system info, upload it and check the OS version
+    assert_script_run "ssh $username\@$_ 'systeminfo' | tee /tmp/$_-systeminfo.txt"                            foreach (keys %virt_autotest::common::imports);
+    upload_logs "/tmp/$_-systeminfo.txt"                                                                       foreach (keys %virt_autotest::common::imports);
+    assert_script_run "ssh $username\@$_ 'systeminfo' | grep '$virt_autotest::common::imports{$_}->{version}'" foreach (keys %virt_autotest::common::imports);
+
+    remove_guest $_ foreach (keys %virt_autotest::common::imports);
+}
+
+1;


### PR DESCRIPTION
Hello,

this test implements two modules:
 1) `download_image.pm` mounts `pandora.suse.cz` and downloads `.raw` disk images from it.
 2) `windows.pm` imports those guests using the existing disk images and tests that the machine responds to ICMP and SSH.

To avoid code duplication I created several new functions out of our old code and reused those.

There are also some small virtualization fixes such as timeout increasings, or exit code exceptions.

- Related ticket: [poo#69919](https://progress.opensuse.org/issues/69919)
- Verification run: [XEN](http://pdostal-server.suse.cz/tests/10217) [KVM](http://pdostal-server.suse.cz/tests/10191)
