### PR TITLE
Improve virtualization runs

### DIFF
--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -23,7 +23,7 @@ sub run {
     my $self = shift;
 
     # Ensure additional package is installed
-    zypper_call '-t in libvirt-client';
+    zypper_call '-t in libvirt-client iputils nmap';
 
     assert_script_run "mkdir -p /var/lib/libvirt/images/xen/";
 

--- a/tests/virtualization/universal/virtmanager_offon.pm
+++ b/tests/virtualization/universal/virtmanager_offon.pm
@@ -42,7 +42,7 @@ sub run {
 
         detect_login_screen();
         powercycle();
-        detect_login_screen(120);
+        detect_login_screen(300);
         close_guest();
     }
 


### PR DESCRIPTION
Various small improvements to increase the robustness of the virtualization runs. In particular

* Increased timeouts for some needles
* Add ensure_online subroutine
* Whitelist more known spectre issues

- Related tickets: https://progress.opensuse.org/issues/69685 and https://progress.opensuse.org/issues/69778
- Needles: 
- Verification run: [SLE 15-SP1 kvm](http://phoenix-openqa.qam.suse.de/t2641) | [SLE 15-SP1 xen](http://phoenix-openqa.qam.suse.de/t2650)
