### PR TITLE
Fix no_self_update scenario on s390x

### DIFF
--- a/tests/installation/validate_no_self_update.pm
+++ b/tests/installation/validate_no_self_update.pm
@@ -24,8 +24,8 @@ use testapi;
 sub run {
     my $self = shift;
     select_console('install-shell');
-    assert_script_run('test -z "$(ls -A /download)"',
-        fail_message => '/download directory is NOT empty, expected to be empty as no updates should be downloaded');
+    assert_script_run('test -z "$(ls -A /download | grep yast_)"',
+        fail_message => '/download directory contains updates, expected not to contain any yast_* files');
     assert_script_run('! grep /var/log/YaST2/y2log -e "Trying installer update"',
         fail_message => 'YaST logs contain entry that self update was attempted, but is explicitly disabled');
     select_console('installation');

--- a/tests/installation/validate_self_update.pm
+++ b/tests/installation/validate_self_update.pm
@@ -28,8 +28,8 @@ sub run {
     my $self_update_repo = get_required_var('INSTALLER_SELF_UPDATE');
     assert_script_run("grep /var/log/YaST2/y2log -e '$self_update_repo'",
         fail_message => 'Expected to have log entries that self update repo was contacted');
-    assert_script_run('test -n "$(ls -A /download)"',
-        fail_message => '/download directory is empty, expected to contain downloaded updates');
+    assert_script_run('test -n "$(ls -A /download | grep yast_)"',
+        fail_message => '/download is expected to contain downloaded updates, no yast_* files found');
     assert_script_run('mount | grep -P "/download/yast_\d+"',
         fail_message => 'updates are not mounted, expected /download/yast_* to be mounted as /mount/yast_*');
     select_console('installation');


### PR DESCRIPTION
Release notes and update packages are downloaded to the `/download`
directory in case of remote installation. So adjusting tests, to check
for update files, which have names matching `yast_xxx` mask.

See [poo#69238](https://progress.opensuse.org/issues/69238).

### Verification runs
[s390x no self update](https://openqa.suse.de/tests/4637829#)
[self update](https://openqa.suse.de/tests/4637848)