### PR TITLE
Disable install_klp_product module in kernel-azure test

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -88,7 +88,9 @@ sub load_kernel_tests {
         }
         loadtest_kernel 'boot_ltp';
         loadtest_kernel 'qa_test_klp';
-        unless (get_var('KOTD_REPO') || get_var('INSTALL_KOTD')) {
+        unless (get_var('KOTD_REPO') ||
+            get_var('INSTALL_KOTD') ||
+            get_var('AZURE')) {
             loadtest_kernel 'install_klp_product';
         }
     }


### PR DESCRIPTION
There are no livepatch packages for kernel-azure so the test will fail.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - kernel-azure: https://openqa.suse.de/tests/4638738
  - kernel-default: https://openqa.suse.de/tests/4638739
  - kernel-livepatch: https://openqa.suse.de/tests/4638740