### PR TITLE
Remove sbd soft fail in HA test

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -112,7 +112,8 @@ sub run {
     # State of SBD if shared storage SBD is used
     if (!get_var('USE_DISKLESS_SBD')) {
         my $sbd_output = script_output("sbd -d \"$sbd_device\" list");
-        record_soft_failure 'bsc#1170037 - All nodes not shown by sbd list command'
+        # Check if all the nodes have sbd started and ready
+        die "Unexpected node count in sdb list command output"
           if (get_node_number != (my $clear_count = () = $sbd_output =~ /\sclear\s|\sclear$/g));
     }
 


### PR DESCRIPTION
We do not need this soft fail anymore, however, it can be changed into verification of the node count in the `sbd list `command.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
15-SP2: [node1](http://1a102.qa.suse.de/tests/5288), [node2](http://1a102.qa.suse.de/tests/5289), [supportserver](http://1a102.qa.suse.de/tests/5287)
