### PR TITLE
[ARM64 ThunderX for openQA] Make sol console work with ThunderX machines

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -21,7 +21,7 @@ use version_utils qw(is_storage_ng is_sle);
 use utils;
 use power_action_utils 'prepare_system_shutdown';
 
-our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot boot_local_disk_arm_huawei);
+our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot boot_local_disk_arm_huawei ipmitool);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
@@ -386,6 +386,22 @@ sub boot_local_disk_arm_huawei {
     save_screenshot;
     send_key 'ret';
     save_screenshot;
+}
+
+#ipmitool to perform server management
+sub ipmitool {
+    my ($cmd) = @_;
+
+    my @cmd = ('ipmitool', '-I', 'lanplus', '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
+    push(@cmd, split(/ /, $cmd));
+
+    my ($stdin, $stdout, $stderr, $ret);
+    $ret = IPC::Run::run(\@cmd, \$stdin, \$stdout, \$stderr);
+    chomp $stdout;
+    chomp $stderr;
+
+    bmwqemu::diag("IPMI: $stdout");
+    return $stdout;
 }
 
 1;

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -33,10 +33,19 @@ sub run {
         mutex_unlock('pxe');
         resume_vm();
     }
+
     if (check_var('BACKEND', 'ipmi')) {
-        select_console 'sol', await_console => 0;
+        if (is_remote_backend && check_var('ARCH', 'aarch64') && get_var('IPMI_HW') eq 'thunderx') {
+            select_console 'sol', await_console => 1;
+            send_key 'ret';
+            ipmi_backend_utils::ipmitool 'chassis power reset';
+        }
+        else {
+            select_console 'sol', await_console => 0;
+        }
     }
-    assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 300);
+    assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600);
+
     # boot bare-metal/IPMI machine
     if (check_var('BACKEND', 'ipmi') && get_var('BOOT_IPMI_SYSTEM')) {
         send_key 'ret';


### PR DESCRIPTION
* **Current** already implemented sequence of operations, including mc reset, power off and power on, followed by select_console(sol) does not really activate the sol console and show serial redirection output from ARM64 ThunderX machine.
* **The** simplest way that really addresses the above issue should be setting IPMI_BACKEND_MC_RESET=0 and IPMI_DO_NOT_RESTART_HOST=1, selecting sol console with await_console=1, then perform power reset by using ipmitool
* **Subroutine** ipmitool which wraps ipmitool command line is moved to and exported by lib/ipmi_backend_utils.pm. Then this subroutine can also be called not only by login_console but also many other modules
* **You** can still set IPMI_BACKEND_MC_RESET and IPMI_DO_NOT_RESTART_HOST to other values if desired under certain circumstances or just want to clean the system up. Under normal circumstances,  IPMI_BACKEND_MC_RESET=0 and IPMI_DO_NOT_RESTART_HOST=1 is enough.
* **Additionally** extend assert_screen(pxemenu) timeout to 600s to suit slow ARM machine boot.
* **Related ticket:** n/a
* **Needles:**
  * [boot_from_pxe-sol-20200828 Tags:sol](http://10.67.133.40/tests/475#step/boot_from_pxe/1)
  * [boot_from_pxe-qa-net-selection-20200828 Tags:qa-net-selection](http://10.67.133.40/tests/475#step/boot_from_pxe/2)
* **Verification run:** 
  * [boot_from_pxe](http://10.67.133.40/tests/475)
  * [login_console](http://10.67.133.40/tests/476)
  * Test runs with other arches and other kind of aarch64 machines will not be affected
