### PR TITLE
Boot from DVD when use machine UEFI

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -626,6 +626,12 @@ sub wait_grub {
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";
         send_key "ret";
+        if (get_var('ONLINE_MIGRATION') && check_var('BOOTFROM', 'd')) {
+            assert_screen 'inst-bootmenu';
+            # Select boot from HDD
+            send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
+            send_key 'ret';
+        }
         assert_screen "grub2", 15;
     }
     elsif (get_var("LIVETEST")) {

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -83,7 +83,7 @@ sub run {
     if (get_var("QEMUVGA") && get_var("QEMUVGA") ne "cirrus") {
         sleep 5;
     }
-    if (get_var("ZDUP") && !is_jeos) {
+    if ((get_var("ZDUP") && !is_jeos) || (get_var('ONLINE_MIGRATION') && check_var('BOOTFROM', 'd'))) {
         # 'eject_cd' is broken ATM (at least on aarch64), so select HDD from menu - poo#47303
         # Check we are booting the ISO
         assert_screen 'inst-bootmenu';


### PR DESCRIPTION
Online migration with UEFI machine, need boot from DVD. Choose 'Start from hard disk' menu.

- Related ticket: https://progress.opensuse.org/issues/70705
- Verification run: https://openqa.suse.de/tests/4642293#
