### PR TITLE
[ARM64 ThunderX for openQA] Keep ssh connection alive to record long-time run test result

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -47,6 +47,7 @@ use constant {
           set_sshserial_dev
           unset_sshserial_dev
           use_ssh_serial_console
+          set_ssh_console_timeout
           )
     ]
 };
@@ -159,6 +160,15 @@ Returns true if the current instance is running as PowerVM backend 'spvm' or 'hm
 
 sub is_pvm {
     return check_var('BACKEND', 'spvm') || check_var('BACKEND', 'pvm_hmc');
+}
+
+#This subroutine takes absolute file path of sshd config file and desired ssh connection timeout as arguments
+#The ssh connection timeout is counted as seconds
+sub set_ssh_console_timeout {
+    my ($sshd_config_file, $sshd_timeout) = @_;
+    my $client_count_max = $sshd_timeout / 60;
+    script_run("sed -irnE 's/^.*TCPKeepAlive.*\$/TCPKeepAlive yes/g; s/^.*ClientAliveInterval.*\$/ClientAliveInterval 60/g; s/^.*ClientAliveCountMax.*\$/ClientAliveCountMax $client_count_max/g' $sshd_config_file");
+    script_run("service sshd restart") if (script_run("systemctl restart sshd") ne '0');
 }
 
 1;


### PR DESCRIPTION
* **Ssh** serial teminal log may fail to record result returned from long-time run test in ssh console, because server may deem ssh connection is lost to client after a short period of time. This can be addressed by specifying larger product value of ClientAliveInterval x ClientAliveCountMax in server /etc/ssh/sshd_config, then restart sshd service. 
* **And** settingTCPKeepAlive to yes ensures machines are well noticed if network goes down, route is lost or remote end dies
* **New** subroutine set_ssh_console_timeout is put in lib/Utils/Backend.pm, which performs modifying sshd_config and restarting sshd service on SUT server
* **New** subroutine set_ssh_console_timeout_before_use is put in login_console.pm, which calls set_ssh_console_timeout and takes care all related operations
* **Currently** this issue only affects ARM64 ThunderX machine
* **Related ticket:** n/a
* **Needles:** n/a
* **Verification run:**
  [Test run failed due to serial terminal log does not record test output](http://10.67.133.40/tests/441)
  [Test run passed with this pull request applied](http://10.67.133.40/tests/479)