### PR TITLE
[ARM64 ThunderX for openQA] IPMI backend host installation shall work with openQA ARM64

### DIFF
--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -37,6 +37,8 @@ use constant {
           is_aarch64
           is_arm
           is_ppc64le
+          is_orthos_machine
+          is_supported_suse_domain
           )
     ]
 };
@@ -124,6 +126,32 @@ Returns C<check_var('ppc64le')>.
 =cut
 sub is_ppc64le {
     return check_var('ARCH', 'ppc64le');
+}
+
+=head2 is_orthos_machine
+
+ is_orthos_machine();
+
+Returns C<true if machine FQDN has arch.suse.de suffix>.
+
+=cut
+sub is_orthos_machine {
+    my $sut_fqdn = get_var('SUT_IP', 'nosutip');
+    return 1 if $sut_fqdn =~ /(arch\.suse\.de)/im;
+    return 0;
+}
+
+=head2 is_supported_suse_domain
+
+ is_supported_suse_domain();
+
+Returns C<true if machine FQDN has qa.suse.de, qa2.suse.asia or arch.suse.de suffix>.
+
+=cut
+sub is_supported_suse_domain {
+    my $sut_fqdn = get_var('SUT_IP', 'nosutip');
+    return 1 if $sut_fqdn =~ /(arch\.suse\.de|qa2\.suse\.asia|qa\.suse\.de)/im;
+    return 0;
 }
 
 1;


### PR DESCRIPTION
* **Reuse** the host installation method developed for Orthos arm64 machines with new needle tags added, including qa-net-grub-boot, qa-net-grub-boot-linux and qa-net-grub-boot-initrd, and different media mount point used for openQA qa network arm64 machines
* **Move** previous judgement functionality used to differentiate valid aarch64 machines to new subroutine is_covered_machine in lib/Utils/Architecture.pm. Currently only ARM64 machines from orthos, qa-apac2 and openQA use ipmi backend and boot from pxe. So this subroutine can be used to filter out only those machines covered
* **Introduce** new subroutine is_orthos_machine in lib/Utils/Architecture.pm to differentiate different media mount point used in openQA(/mnt/openqa/repo) from what is used in orthos network(auto/openqa/repo)
* **Related ticket:** n/a
* **Needles:**
  [boot_from_pxe-qa-net-grub-boot-20200902 Tag:qa-net-grub-boot](http://10.67.133.40/tests/487#step/boot_from_pxe/4)
  [boot_from_pxe-orthos-grub-boot-linux-20190708 Tag:qa-net-grub-boot-linux](http://10.67.133.40/tests/487#step/boot_from_pxe/7)
  [boot_from_pxe-orthos-grub-boot-initrd-20190705 Tag:qa-net-grub-boot-initrd](http://10.67.133.40/tests/487#step/boot_from_pxe/9)
* **Verification run:**
  [boot_from_pxe with 15-SP2 build](http://10.67.133.40/tests/487)
  [boot_from_pxe with 15-SP3 build](http://10.67.133.40/tests/489)
