### PR TITLE
Create multimachine samba against AD test poo#63277

### DIFF
--- a/data/supportserver/samba/krb5.conf
+++ b/data/supportserver/samba/krb5.conf
@@ -1,0 +1,32 @@
+[libdefaults]
+        dns_canonicalize_hostname = false
+        rdns = false
+        default_realm = GEEKO.COM
+        default_ccache_name = FILE:/tmp/krb5cc_%{uid}
+        clockskew = 300
+
+[domain_realm]
+        .geeko.com = GEEKO.COM
+        geeko.com = GEEKO.COM
+
+[logging]
+        kdc = FILE:/var/log/krb5/krb5kdc.log
+        admin_server = FILE:/var/log/krb5/kadmind.log
+        default = SYSLOG:NOTICE:DAEMON
+
+[realms]
+GEEKO.COM = {
+        kdc = win-r70413psjm4.geeko.com
+        admin_server = win-r70413psjm4.geeko.com
+        default_domain = geeko.com
+        auth_to_local = RULE:[1:$1@$0]
+}
+[appdefaults]
+        pam = {
+                ticket_lifetime = 1d
+                renew_lifetime = 1d
+                forwardable = true
+                proxiable = false
+                minimum_uid = 1
+        }
+

--- a/data/supportserver/samba/nsswitch.conf
+++ b/data/supportserver/samba/nsswitch.conf
@@ -1,0 +1,17 @@
+passwd: compat winbind
+group:  compat winbind
+
+hosts:  files dns
+networks:       files dns
+
+services:       files
+protocols:      files
+rpc:    files
+ethers: files
+netmasks:       files
+netgroup:       files winbind
+publickey:      files
+
+bootparams:     files
+automount:      files
+aliases:        files

--- a/data/supportserver/samba/smb.conf
+++ b/data/supportserver/samba/smb.conf
@@ -1,0 +1,29 @@
+[global]
+        security = ADS
+        workgroup = geeko
+        log file = /var/log/samba/%m.log
+        kerberos method = secrets and keytab
+        client signing = yes
+        client use spnego = yes
+        add machine script = /usr/sbin/useradd  -c Machine -d /var/lib/nobody -s /bin/false %m$
+        domain logons = No
+        domain master = Auto
+        local master = Yes
+        netbios name = SLES-VM
+        os level = 65
+        passdb backend = smbpasswd
+        preferred master = Yes
+        usershare allow guests = No
+        usershare max shares = 100
+        wins support = No
+        idmap gid = 10000-20000
+        idmap uid = 10000-20000
+        realm = GEEKO.COM
+        template homedir = /home/%D/%U
+        winbind refresh tickets = yes
+        template shell = /bin/bash
+
+[netlogon]
+        comment = Network Logon Service
+        path = /var/lib/samba/netlogon
+        write list = root

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1056,6 +1056,25 @@ else {
             loadtest 'network/curl_client';
         }
     }
+    elsif (get_var('QAM_WIN2019_INSTALL')) {
+        set_var('INSTALLONLY', 1);
+        boot_hdd_image;
+        if (check_var('HOSTNAME', 'win2k19')) {
+            loadtest 'support_server/windows/win2019_install';
+            loadtest 'support_server/windows/win2019_config';
+            loadtest 'support_server/windows/win2019_config_AD';
+        }
+    }
+    elsif (get_var('QAM_SAMBA_AD')) {
+        boot_hdd_image;
+        if (check_var('HOSTNAME', 'client')) {
+            loadtest 'network/setup_multimachine';
+            loadtest 'network/samba/samba_adcli';
+        }
+        elsif (check_var('HOSTNAME', 'win2k19')) {
+            loadtest 'support_server/windows/win2019_boot';
+        }
+    }
     elsif (get_var('QAM_SMT')) {
         set_var('INSTALLONLY', 1);
         if (check_var('HOSTNAME', 'server')) {

--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: samba test conecting with Active Directory using adcli
+# package: samba adcli samba-winbind krb5-client
+#
+# Maintainer: Marcelo Martins <mmartins@suse.com>
+
+use strict;
+use warnings;
+use base "consoletest";
+use repo_tools qw(add_qa_head_repo add_qa_web_repo);
+use testapi;
+use utils;
+
+sub samba_sssd_install {
+    zypper_call('in  samba adcli samba-winbind krb5-client');
+    #Copy config files enviroment.
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/smb.conf  >/etc/samba/smb.conf";
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/krb5.conf  >/etc/krb5.conf";
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/nsswitch.conf  >/etc/nsswitch.conf";
+    assert_script_run("echo '10.0.2.102 susetest.geeko.com susetest' > /etc/hosts");
+    assert_script_run("echo '10.0.2.101 win-r70413psjm4.geeko.com win-r70413psjmn4' >> /etc/hosts");
+    assert_script_run("echo 'nameserver 10.0.2.101' > /etc/resolv.conf");
+    assert_script_run("echo 'search geeko.com' >> /etc/resolv.conf");
+}
+
+sub run {
+    my $self = shift;
+    #select_console 'root-console';
+    $self->select_serial_terminal;
+    samba_sssd_install;
+
+    #Join the Active Directory
+    assert_script_run 'cat /etc/hosts';
+    script_run 'kinit Administrator', quiet => 1;
+    wait_serial 'Password for Administrator@GEEKO.COM:';
+    type_string "N0tS3cr3t@\n";
+    assert_script_run 'adcli join -v -W --domain geeko.com -U Administrator -C';
+    #Verify if machine already added
+    assert_script_run 'adcli info -D geeko.com  -S 10.0.2.101 -v';
+
+    #test samba with AD
+    assert_script_run "klist";
+    script_run "net ads join -U Administrator", quiet => 1;
+    wait_serial "Set Administrator's password:";
+    type_string "N0tS3cr3t@\n";
+    systemctl('restart smb nmb winbind');
+    #systemctl('restart nmb');
+    #systemctl('restart winbind');
+    #Enable pam authentication
+    assert_script_run "pam-config -a --winbind";
+    #Verify users and groups  from AD
+    assert_script_run "wbinfo -u";
+    assert_script_run "wbinfo -g";
+    assert_script_run "wbinfo -D geeko.com";
+    assert_script_run "wbinfo -i geekouser\@geeko.com";
+    assert_script_run "wbinfo -i Administrator\@geeko.com";
+}
+
+1;

--- a/tests/support_server/windows/win2019_boot.pm
+++ b/tests/support_server/windows/win2019_boot.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Boot Windows server 2019 and wait samba_ad job child tests
+# Maintainer: mmartins <mmartins@suse.com>
+
+use strict;
+use warnings;
+use base 'windowsbasetest';
+use testapi;
+use mmapi;
+
+sub run {
+    my $self = shift;
+    assert_screen "windows-installed-ok", timeout => 400;
+    $self->windows_server_login_Administrator;
+
+    #wait child job.
+    wait_for_children;
+    record_info 'SAMBA Done', 'SAMBA  test done.';
+    #shutdonw
+    $self->reboot_or_shutdown();
+    check_shutdown;
+}
+
+1;

--- a/tests/support_server/windows/win2019_config.pm
+++ b/tests/support_server/windows/win2019_config.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Install VDMP tools to enable network drivers correctly.
+#
+# Maintainer: mmartins <mmartins@suse.com>
+
+use base 'windowsbasetest';
+use strict;
+use warnings;
+use testapi;
+use mmapi;
+
+sub run {
+    my $self = shift;
+
+    assert_screen "windows-installed-ok", timeout => 90;
+    $self->windows_server_login_Administrator;
+
+    #install VMDP drivers and reboot
+    $self->open_powershell_as_admin;
+    $self->run_in_powershell(cmd => 'e:\VMDP-WIN-2.5.2\setup.exe', tags => 'win-ad-powershell');
+    wait_screen_change { assert_and_click 'VMDP-focus'; };
+    send_key 'alt-n';
+    wait_screen_change { assert_and_click 'VMDP-reboot'; };
+
+    #login
+    assert_screen "windows-installed-ok", timeout => 90;    #waiting boot
+    $self->windows_server_login_Administrator;
+
+    #simple check ip address
+    $self->open_powershell_as_admin;
+    $self->run_in_powershell(cmd => 'ipconfig', tags => 'win-ad-powershell');
+
+}
+
+1;

--- a/tests/support_server/windows/win2019_config_AD.pm
+++ b/tests/support_server/windows/win2019_config_AD.pm
@@ -1,0 +1,116 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Boot and configure one Active Directory on Windows server 2019
+#    Used this how-to:
+#           https://docs.microsoft.com/pt-br/powershell/module/addsdeployment/install-addsforest?view=win10-ps
+#           https://social.technet.microsoft.com/wiki/contents/articles/52765.windows-server-2019-step-by-step-setup-active-directory-environment-using-powershell.aspx
+#
+# Maintainer: mmartins <mmartins@suse.com>
+
+use base 'windowsbasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    #Configure Ip adress to Multimachine setup
+    $self->run_in_powershell(cmd => 'ipconfig',         tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Get-NetIPAddress', tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'New-NetIPAddress -InterfaceAlias Ethernet -IPAddress 10.0.2.101 -PrefixLength 24 -DefaultGateway 10.0.2.101', tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Set-DnsClientServerAddress -InterfaceAlias Ethernet -ServerAddresses ("10.0.2.101","127.0.0.1")', tags => 'win-ad-powershell');
+
+    $self->run_in_powershell(cmd => 'Get-NetIPAddress', tags => 'win-ad-powershell');
+
+    #Install and configure Active Directory Services
+    $self->run_in_powershell(cmd => 'Install-WindowsFeature -Name AD-Domain-Services -IncludeManagementTools', tags => 'win-ad-powershell');
+    assert_screen("AD_2019_installed", timeout => 90);
+    $self->run_in_powershell(cmd => "Install-ADDSForest -DomainName 'geeko.com' -CreateDnsDelegation:\$false -DatabasePath 'C:\\Windows\\NTDS' -DomainMode '7' -DomainNetbiosName 'geeko' -ForestMode '7' -InstallDns:\$true -LogPath 'C:\\Windows\\NTDS' -NoRebootOnCompletion:\$True -SysvolPath 'C:\\Windows\\SYSVOL' -Force:\$true", tags => 'win-ad-powershell');
+
+    assert_screen("InstallAD-pwd");
+    type_string_slow "N0tS3cr3t@";
+    send_key "ret";
+    assert_screen "InstallAD-pwd-confirm";
+    type_string_slow "N0tS3cr3t@";
+    send_key "ret";
+    assert_screen("windows_ad_installed", timeout => 300);
+    #It is a windows, need restart baby.
+    $self->reboot_or_shutdown('reboot');
+
+    assert_screen "windows-installed-ok", timeout => 400;
+    send_key "ctrl-alt-delete";
+    assert_screen "windows_server_login", timeout => 60;
+    type_string "N0tS3cr3t@";
+    send_key "ret";
+    #some times server_manager windows slow to open, fix waiting few seconds more...
+    assert_screen "wint_manage_server", timeout => 45;
+    $self->open_powershell_as_admin;
+
+    #Check if AD is running, and create one user test with Unix attributes:
+    $self->run_in_powershell(cmd => 'ipconfig',                        tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Start-Service adws,kdc,Netlogon', tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Get-Service adws,kdc,Netlogon',   tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Get-ADDomain geeko.com',          tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Get-ADForest geeko.com',          tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'New-ADUser -Name "geekouser" -GivenName GeekoUser -Surname Test -SamAccountName geekouser -UserPrincipalName geekouser@geeko.com', tags => 'win-ad-powershell');
+
+    $self->run_in_powershell(cmd => 'Get-ADUser geekouser', tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Set-ADAccountPassword "CN=geekouser,CN=users,DC=geeko,DC=com" -Reset -NewPassword (ConvertTo-SecureString -AsPlainText "Test@123" -Force)', tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Enable-ADAccount -Identity geekouser',         tags => 'win-ad-powershell');
+    $self->run_in_powershell(cmd => 'Add-AdGroupMember "Domain Admins" geekouser ', tags => 'win-ad-powershell');
+
+    #Open Users and Groups
+    $self->run_in_powershell(cmd => 'dsa.msc', tags => 'win-ad-powershell');
+    #Enable Advanced View
+    assert_and_click("mmc-geeko-domain", button => 'left', dclick => 1);
+    hold_key 'alt';
+    send_key 'v';
+    send_key 'v';
+    release_key 'alt';
+    #Select usertest on Users
+    assert_and_click("mmc-geeko-users",    button => 'left', dclick => 1);
+    assert_and_click("mmc-geekouser-open", button => 'left', dclick => 1);
+    #select Atribute Editor tab, and got to Unix attribts:
+    assert_and_click("mmc-geeko-select-attribute");
+    send_key 'shift-end';
+    send_key 'pgup';
+    send_key 'pgup';
+    send_key 'up';
+    send_key 'up';
+    send_key 'up';
+    send_key 'up';
+    send_key 'up';
+    assert_and_click("mmc-geeko-unix-userid", button => 'left', dclick => 1);
+    wait_screen_change { type_string "1001"; };
+    send_key 'ret';
+    assert_and_click("mmc-geeko-unix-gid-ok");
+    wait_screen_change { send_key 'g'; };
+    send_key 'g';
+    send_key 'down';
+    send_key 'down';
+    assert_and_click("mmc-geeko-unix-gid", button => 'left', dclick => 1);
+    type_string "1001";
+    send_key 'ret';
+    send_key 'h';
+    assert_and_click("mmc-geeko-unix-home", button => 'left', dclick => 1);
+    type_string "/home/usertest";
+    send_key 'ret';
+    save_screenshot;
+    wait_screen_change { send_key 'ret'; };
+
+    #Configuration done. shutdown machine.
+    $self->reboot_or_shutdown();
+    check_shutdown;
+
+}
+
+1;

--- a/tests/support_server/windows/win2019_install.pm
+++ b/tests/support_server/windows/win2019_install.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Boot and install Windows server 2019
+# Maintainer: mmartins <mmartins@suse.com>
+
+use base 'windowsbasetest';
+use strict;
+use warnings;
+use testapi;
+use mmapi;
+
+sub run {
+    #sometimes windows spend more time to boot, added "start waiting"
+    assert_and_click "start", timeout => 120;
+
+    assert_and_click "install_now";
+    assert_and_click "skip_registration";
+    assert_and_click "windows_server_stand-desktop";
+    assert_and_click "windows_server_stand";
+    assert_and_click "windows_license_terms_accept";
+    assert_and_click "windows_license_terms_next";
+    assert_and_click "windows_install";
+
+    assert_screen 'windows-disk-partitioning';
+    send_key 'alt-l';    # load disk driver from VMDP-2.5.2 ISO
+    assert_screen 'windows-load-driver';
+    send_key 'alt-b';    # browse button
+    send_key 'c';
+    save_screenshot;
+    send_key 'c';        # go to second CD drive with drivers
+    send_key 'right';    # choose win2019 INF files
+    sleep 0.5;
+    send_key 'down';
+    send_key 'right';    # ok
+    sleep 0.5;
+    send_key 'down';
+    send_key 'down';
+    sleep 0.5;
+    send_key 'ret';
+    wait_still_screen stilltime => 3, timeout => 10;
+    send_key 'shift-down';    # select all drivers
+    send_key 'alt-n';
+    assert_and_click "windows_format_new";
+    assert_and_click "windows-size";
+    assert_and_click "windows-additional-partitions";
+    assert_and_click "windows-next-install";
+    assert_and_click "windows-admin-login2", timeout => 600;
+    type_string "N0tS3cr3t@";
+    send_key "tab";
+    wait_screen_change { type_string "N0tS3cr3t@" };
+    send_key "ret";
+    assert_and_click "windows-admin-finish";
+    assert_screen "windows-installed-ok";
+}
+
+1;


### PR DESCRIPTION
Create windows server machine with Active directory configured
Run multimachine test with SLE testing samba and adcli authenticating in AD.

- Related ticket: https://progress.opensuse.org/issues/63277
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/689
- Verification run:
  qam-win209 
    Windows 2019 Server install ->  http://10.161.228.111/tests/3286
    Windows 2019 Test AD -> http://10.161.228.111/tests/3114 
  qam-samba-ad
    SLES 15-SP2: http://10.161.228.111/tests/3131#
    SLES 15-SP1: http://10.161.228.111/tests/3290#
    SLES 15 GA : http://10.161.228.111/tests/3125#
    SLES 12-SP5: http://10.161.228.111/tests/3129#
    SLES 12-SP4: http://10.161.228.111/tests/3143#
    SLES 12-SP3: http://10.161.228.111/tests/3145#
    SLES 12-SP2 don't have adcli package.

**-To this tests need:**

_2 new ISOS on windows machine job:_
  http://download.suse.de/install/windows/2k19/en_windows_server_2019_x64_dvd_4cb967d8.iso
  http://dist.suse.de/ibs/SUSE/Products/SLE-VMDP/2.5/x86_64/iso/VMDP-WIN-2.5_virtio.iso

_Testsuites:_
[qam-samba-ad-Testsuites.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5174103/qam-samba-ad-Testsuites.txt)

_Job Group yaml_
[job-group.-aml.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5174111/job-group.-aml.txt)


Schedule qam-win2019-install test suite to run 1 once per month, to create qcow2 image to samba test.

Schedule MultiMachine test to run qam-samba-ad and qam-win2019-ad