### PR TITLE
Add HA rolling update tests in SLE12

### DIFF
--- a/schedule/ha/qam/12-SP2/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/12-SP2/ha_rolling_update_node01.yaml
@@ -1,0 +1,40 @@
+name:           qam-ha_rolling_update_migration
+description:    >
+  Test a rolling update in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - '{{qam_incident}}'
+  - ha/await_upgrade_or_update
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_patch
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/12-SP2/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/12-SP2/ha_rolling_update_node02.yaml
@@ -1,0 +1,40 @@
+name:           qam-ha_rolling_update_migration
+description:    >
+  Test a rolling update in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - '{{qam_incident}}'
+  - ha/await_upgrade_or_update
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_patch
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/12-SP3/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/12-SP3/ha_rolling_update_node01.yaml
@@ -1,0 +1,40 @@
+name:           qam-ha_rolling_update_migration
+description:    >
+  Test a rolling update in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - '{{qam_incident}}'
+  - ha/await_upgrade_or_update
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_patch
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/12-SP3/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/12-SP3/ha_rolling_update_node02.yaml
@@ -1,0 +1,40 @@
+name:           qam-ha_rolling_update_migration
+description:    >
+  Test a rolling update in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - '{{qam_incident}}'
+  - ha/await_upgrade_or_update
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_patch
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/12-SP4/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/12-SP4/ha_rolling_update_node01.yaml
@@ -1,0 +1,40 @@
+name:           qam-ha_rolling_update_migration
+description:    >
+  Test a rolling update in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - '{{qam_incident}}'
+  - ha/await_upgrade_or_update
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_patch
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/12-SP4/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/12-SP4/ha_rolling_update_node02.yaml
@@ -1,0 +1,40 @@
+name:           qam-ha_rolling_update_migration
+description:    >
+  Test a rolling update in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - '{{qam_incident}}'
+  - ha/await_upgrade_or_update
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_patch
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/12-SP5/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/12-SP5/ha_rolling_update_node01.yaml
@@ -1,0 +1,40 @@
+name:           qam-ha_rolling_update_migration
+description:    >
+  Test a rolling update in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - '{{qam_incident}}'
+  - ha/await_upgrade_or_update
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_patch
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy

--- a/schedule/ha/qam/12-SP5/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/12-SP5/ha_rolling_update_node02.yaml
@@ -1,0 +1,40 @@
+name:           qam-ha_rolling_update_migration
+description:    >
+  Test a rolling update in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - '{{qam_incident}}'
+  - ha/await_upgrade_or_update
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_patch
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  qam_incident:
+    QAM_INCI:
+      1:
+        - ha/ctdb
+        - ha/haproxy


### PR DESCRIPTION
This PR adds a rolling update scenario for QAM HA in SLE12 (SLE15 tests are already on production).

Short description of what the test is doing:
- Use a qcow2 stored in openQA(hdd/fixed)
- Update the qcow2 + reboot
- Configure a basic 2 nodes cluster
- Update node one by one with QAM packages + reboot
- Check cluster state

It will be used in QAM incident and QAM Test Repo.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
12-SP5: [node1](http://1a102.qa.suse.de/tests/5295) [node2](http://1a102.qa.suse.de/tests/5296) [supportserver](http://1a102.qa.suse.de/tests/5294)
12-SP4: [node1](http://1a102.qa.suse.de/tests/5302) [node2](http://1a102.qa.suse.de/tests/5303) [supportserver](http://1a102.qa.suse.de/tests/5301)
12-SP3: [node1](http://1a102.qa.suse.de/tests/5315) [node2](http://1a102.qa.suse.de/tests/5316) [supportserver](http://1a102.qa.suse.de/tests/5314)
12-SP2: [node1](http://1a102.qa.suse.de/tests/5330) [node2](http://1a102.qa.suse.de/tests/5331) [supportserver](http://1a102.qa.suse.de/tests/5329)
