### PR TITLE
Fix textmode SAP product selection in Installer

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -70,7 +70,7 @@ sub get_product_shortcuts {
             : 'i',
             sled => 'x',
             sles4sap => is_ppc64le() ? 'i'
-            : (is_sle('=15-SP2') && is_x86_64()) ? 't'
+            : (is_sle('15-SP2+') && is_x86_64()) ? 't'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',
             rt  => is_x86_64() ? 't' : undef


### PR DESCRIPTION
As Real Time Product is also not part of 15-SP3, the change done in commit 20c5960ed should be done for SP2+.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/4636330#step/welcome/6
- Verification run: http://1b210.qa.suse.de/tests/6776