### PR TITLE
WIP: systemd-testsuite: improve testsuite run time

### DIFF
--- a/lib/systemd_testsuite_test.pm
+++ b/lib/systemd_testsuite_test.pm
@@ -121,7 +121,6 @@ sub testsuiteprepare {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->SUPER::post_fail_hook();
     #upload logs from given testname
     $self->tar_and_upload_log('/var/opt/systemd-tests/logs',       '/tmp/systemd_testsuite-logs.tar.bz2');
     $self->tar_and_upload_log('/var/log/journal /run/log/journal', 'binary-journal-log.tar.bz2');

--- a/tests/systemd_testsuite/test_01_basic.pm
+++ b/tests/systemd_testsuite/test_01_basic.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-01-BASIC --run 2>&1 | tee /tmp/testsuite.log', 600;
+    assert_script_run './run-tests.sh TEST-01-BASIC --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-01-BASIC" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_02_cryptsetup.pm
+++ b/tests/systemd_testsuite/test_02_cryptsetup.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-02-CRYPTSETUP --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-02-CRYPTSETUP --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-02-CRYPTSETUP" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-02-CRYPTSETUP --clean';
 }

--- a/tests/systemd_testsuite/test_03_jobs.pm
+++ b/tests/systemd_testsuite/test_03_jobs.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-03-JOBS --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-03-JOBS --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-03-JOBS" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_04_journal.pm
+++ b/tests/systemd_testsuite/test_04_journal.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-04-JOURNAL --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-04-JOURNAL --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-04-JOURNAL" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_05_rlimits.pm
+++ b/tests/systemd_testsuite/test_05_rlimits.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-05-RLIMITS --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-05-RLIMITS --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-05-RLIMITS" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_07_issue_1981.pm
+++ b/tests/systemd_testsuite/test_07_issue_1981.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-07-ISSUE-1981 --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-07-ISSUE-1981 --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-07-ISSUE-1981" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_08_issue_2730.pm
+++ b/tests/systemd_testsuite/test_08_issue_2730.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-08-ISSUE-2730 --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-08-ISSUE-2730 --run 2>&1 | tee /tmp/testsuite.log', 600;
     assert_script_run 'grep "PASS: ...TEST-08-ISSUE-2730" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_09_issue_2691.pm
+++ b/tests/systemd_testsuite/test_09_issue_2691.pm
@@ -40,7 +40,7 @@ sub run {
     assert_screen "text-logged-in-root";
     assert_script_run 'cd /var/opt/systemd-tests';
     assert_script_run 'ls -l /shutdown-log.txt';
-    assert_script_run './run-tests.sh TEST-09-ISSUE-2691 --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-09-ISSUE-2691 --run 2>&1 | tee /tmp/testsuite.log', 300;
     assert_script_run 'grep "PASS: ...TEST-09-ISSUE-2691" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_10_issue_2467.pm
+++ b/tests/systemd_testsuite/test_10_issue_2467.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-10-ISSUE-2467 --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-10-ISSUE-2467 --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-10-ISSUE-2467" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_11_issue_3166.pm
+++ b/tests/systemd_testsuite/test_11_issue_3166.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-11-ISSUE-3166 --run 2>&1 | tee /tmp/testsuite.log', 600;
+    assert_script_run './run-tests.sh TEST-11-ISSUE-3166 --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-11-ISSUE-3166" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-11-ISSUE-3166 --clean';
 }

--- a/tests/systemd_testsuite/test_12_issue_3171.pm
+++ b/tests/systemd_testsuite/test_12_issue_3171.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-12-ISSUE-3171 --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-12-ISSUE-3171 --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-12-ISSUE-3171" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_13_nspawn_smoke.pm
+++ b/tests/systemd_testsuite/test_13_nspawn_smoke.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-13-NSPAWN-SMOKE --run 2>&1 | tee /tmp/testsuite.log', 120;
+    assert_script_run './run-tests.sh TEST-13-NSPAWN-SMOKE --run 2>&1 | tee /tmp/testsuite.log', 600;
     assert_script_run 'grep "PASS: ...TEST-13-NSPAWN-SMOKE" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_14_machine_id.pm
+++ b/tests/systemd_testsuite/test_14_machine_id.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-14-MACHINE-ID --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-14-MACHINE-ID --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-14-MACHINE-ID" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_15_dropin.pm
+++ b/tests/systemd_testsuite/test_15_dropin.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-15-DROPIN --run 2>&1 | tee /tmp/testsuite.log', 600;
+    assert_script_run './run-tests.sh TEST-15-DROPIN --run 2>&1 | tee /tmp/testsuite.log', 300;
     assert_script_run 'grep "PASS: ...TEST-15-DROPIN" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_16_extend_timeout.pm
+++ b/tests/systemd_testsuite/test_16_extend_timeout.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-16-EXTEND-TIMEOUT --run 2>&1 | tee /tmp/testsuite.log', 600;
+    assert_script_run './run-tests.sh TEST-16-EXTEND-TIMEOUT --run 2>&1 | tee /tmp/testsuite.log', 300;
     assert_script_run 'grep "PASS: ...TEST-16-EXTEND-TIMEOUT" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_17_udev_wants.pm
+++ b/tests/systemd_testsuite/test_17_udev_wants.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-17-UDEV-WANTS --run 2>&1 | tee /tmp/testsuite.log', 120;
+    assert_script_run './run-tests.sh TEST-17-UDEV-WANTS --run 2>&1 | tee /tmp/testsuite.log', 300;
     assert_script_run 'grep "PASS: ...TEST-17-UDEV-WANTS" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_19_delegate.pm
+++ b/tests/systemd_testsuite/test_19_delegate.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-19-DELEGATE --run 2>&1 | tee /tmp/testsuite.log', 120;
+    assert_script_run './run-tests.sh TEST-19-DELEGATE --run 2>&1 | tee /tmp/testsuite.log', 600;
     assert_script_run 'grep "PASS: ...TEST-19-DELEGATE" /tmp/testsuite.log';
     assert_script_run './run-tests.sh TEST-19-DELEGATE --clean', 120;
 }

--- a/tests/systemd_testsuite/test_22_tmpfiles.pm
+++ b/tests/systemd_testsuite/test_22_tmpfiles.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-22-TMPFILES --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-22-TMPFILES --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-22-TMPFILES" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_23_type_exec.pm
+++ b/tests/systemd_testsuite/test_23_type_exec.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-23-TYPE-EXEC --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-23-TYPE-EXEC --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-23-TYPE-EXEC" /tmp/testsuite.log';
 }
 

--- a/tests/systemd_testsuite/test_26_setenv.pm
+++ b/tests/systemd_testsuite/test_26_setenv.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-26-SETENV --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-26-SETENV --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-26-SETENV" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-26-SETENV --clean';
 }

--- a/tests/systemd_testsuite/test_27_stdoutfile.pm
+++ b/tests/systemd_testsuite/test_27_stdoutfile.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-27-STDOUTFILE --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-27-STDOUTFILE --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-27-STDOUTFILE" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-27-STDOUTFILE --clean';
 }

--- a/tests/systemd_testsuite/test_28_percentj_wantedby.pm
+++ b/tests/systemd_testsuite/test_28_percentj_wantedby.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-28-PERCENTJ-WANTEDBY --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-28-PERCENTJ-WANTEDBY --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-28-PERCENTJ-WANTEDBY" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-28-PERCENTJ-WANTEDBY --clean';
 }

--- a/tests/systemd_testsuite/test_29_udev_id_renaming.pm
+++ b/tests/systemd_testsuite/test_29_udev_id_renaming.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-29-UDEV-ID_RENAMING --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-29-UDEV-ID_RENAMING --run 2>&1 | tee /tmp/testsuite.log', 300;
     assert_script_run 'grep "PASS: ...TEST-29-UDEV-ID_RENAMING" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-29-UDEV-ID_RENAMING --clean';
 }

--- a/tests/systemd_testsuite/test_30_onclockchange.pm
+++ b/tests/systemd_testsuite/test_30_onclockchange.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-30-ONCLOCKCHANGE --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-30-ONCLOCKCHANGE --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-30-ONCLOCKCHANGE" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-30-ONCLOCKCHANGE --clean';
 }

--- a/tests/systemd_testsuite/test_31_device_enumeration.pm
+++ b/tests/systemd_testsuite/test_31_device_enumeration.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-31-DEVICE-ENUMERATION --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-31-DEVICE-ENUMERATION --run 2>&1 | tee /tmp/testsuite.log', 300;
     assert_script_run 'grep "PASS: ...TEST-31-DEVICE-ENUMERATION" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-31-DEVICE-ENUMERATION --clean';
 }

--- a/tests/systemd_testsuite/test_32_oompolicy.pm
+++ b/tests/systemd_testsuite/test_32_oompolicy.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-32-OOMPOLICY --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-32-OOMPOLICY --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-32-OOMPOLICY" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-32-OOMPOLICY --clean';
 }

--- a/tests/systemd_testsuite/test_33_clean_unit.pm
+++ b/tests/systemd_testsuite/test_33_clean_unit.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-33-CLEAN-UNIT --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-33-CLEAN-UNIT --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-33-CLEAN-UNIT" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-33-CLEAN-UNIT --clean';
 }

--- a/tests/systemd_testsuite/test_34_dynamicusermigrate.pm
+++ b/tests/systemd_testsuite/test_34_dynamicusermigrate.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-34-DYNAMICUSERMIGRATE --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-34-DYNAMICUSERMIGRATE --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-34-DYNAMICUSERMIGRATE" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-34-DYNAMICUSERMIGRATE --clean';
 }

--- a/tests/systemd_testsuite/test_37_runtimedirectorypreserve.pm
+++ b/tests/systemd_testsuite/test_37_runtimedirectorypreserve.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-37-RUNTIMEDIRECTORYPRESERVE --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-37-RUNTIMEDIRECTORYPRESERVE --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-37-RUNTIMEDIRECTORYPRESERVE" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-37-RUNTIMEDIRECTORYPRESERVE --clean';
 }

--- a/tests/systemd_testsuite/test_39_execreload.pm
+++ b/tests/systemd_testsuite/test_39_execreload.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-39-EXECRELOAD --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-39-EXECRELOAD --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-39-EXECRELOAD" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-39-EXECRELOAD --clean';
 }

--- a/tests/systemd_testsuite/test_40_exec_command_ex.pm
+++ b/tests/systemd_testsuite/test_40_exec_command_ex.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-40-EXEC-COMMAND-EX --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-40-EXEC-COMMAND-EX --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-40-EXEC-COMMAND-EX" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-40-EXEC-COMMAND-EX --clean';
 }

--- a/tests/systemd_testsuite/test_41_oneshot_restart.pm
+++ b/tests/systemd_testsuite/test_41_oneshot_restart.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-41-ONESHOT-RESTART --run 2>&1 | tee /tmp/testsuite.log', 600;
+    assert_script_run './run-tests.sh TEST-41-ONESHOT-RESTART --run 2>&1 | tee /tmp/testsuite.log', 300;
     assert_script_run 'grep "PASS: ...TEST-41-ONESHOT-RESTART" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-41-ONESHOT-RESTART --clean';
 }

--- a/tests/systemd_testsuite/test_42_execstoppost.pm
+++ b/tests/systemd_testsuite/test_42_execstoppost.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-42-EXECSTOPPOST --run 2>&1 | tee /tmp/testsuite.log', 600;
+    assert_script_run './run-tests.sh TEST-42-EXECSTOPPOST --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-42-EXECSTOPPOST" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-42-EXECSTOPPOST --clean';
 }

--- a/tests/systemd_testsuite/test_44_log_namespace.pm
+++ b/tests/systemd_testsuite/test_44_log_namespace.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-44-LOG-NAMESPACE --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-44-LOG-NAMESPACE --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-44-LOG-NAMESPACE" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-44-LOG-NAMESPACE --clean';
 }

--- a/tests/systemd_testsuite/test_47_issue_14566.pm
+++ b/tests/systemd_testsuite/test_47_issue_14566.pm
@@ -24,7 +24,7 @@ sub pre_run_hook {
 sub run {
     #run test
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh TEST-47-ISSUE-14566 --run 2>&1 | tee /tmp/testsuite.log', 60;
+    assert_script_run './run-tests.sh TEST-47-ISSUE-14566 --run 2>&1 | tee /tmp/testsuite.log', 120;
     assert_script_run 'grep "PASS: ...TEST-47-ISSUE-14566" /tmp/testsuite.log';
     script_run './run-tests.sh TEST-47-ISSUE-14566 --clean';
 }


### PR DESCRIPTION
This reverts commit d34a9b86e3c0a52977dbd350f5a1dc7d09552b7b.
As discussed with @tblume, reverting this commit will reduce the job time.

Also increase timeouts for all tests, since systemd v246 testsuite will run tests in QEMU, like upstream. 

Verification runs:
TW: http://emerson.suse.de/tests/2490
15-SP3: http://emerson.suse.de/tests/2493


