### PR TITLE
Wait after type_string to make it finish properly

### DIFF
--- a/tests/console/iotop.pm
+++ b/tests/console/iotop.pm
@@ -29,6 +29,7 @@ sub run {
 
     # Test under load
     type_string("iotop -baoqn 10 > iotop.log &");
+    wait_still_screen(1, 2);
     assert_script_run("dd if=/dev/zero of=./file.img bs=1M count=1000 status=none");
     assert_script_run("wait");
     assert_script_run("grep 'dd if=/dev/zero of=./file.img' iotop.log");


### PR DESCRIPTION
following command can type to soon and fail due to missing first characters, in this case new line

- Fail: https://openqa.suse.de/tests/4655422/file/serial_terminal.txt
- Verification run: https://openqa.suse.de/tests/4656778
