### PR TITLE
Filesystem: add two modules to filesystem autoyast xml file

### DIFF
--- a/data/filesystem/autoyast_filesystem.xml
+++ b/data/filesystem/autoyast_filesystem.xml
@@ -23,6 +23,16 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-web-scripting</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
     </addons>
   </suse_register>
   <bootloader>

--- a/data/filesystem/autoyast_filesystem_ext4_btrfs.xml
+++ b/data/filesystem/autoyast_filesystem_ext4_btrfs.xml
@@ -23,6 +23,16 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-web-scripting</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
     </addons>
   </suse_register>
   <bootloader>

--- a/data/filesystem/autoyast_filesystem_withouthome.xml
+++ b/data/filesystem/autoyast_filesystem_withouthome.xml
@@ -23,6 +23,16 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-web-scripting</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
     </addons>
   </suse_register>
   <bootloader>


### PR DESCRIPTION
Add sle-module-server-applications and sle-module-web-scripting to fix
lack of package issue on create_hdd_xfstest

- Related ticket: https://progress.opensuse.org/issues/70993
- Needles: N/A
- Verification run: http://10.67.133.10/tests/151