### PR TITLE
Add HA rolling_upgrade tests to SLE12 QAM

### DIFF
--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
@@ -1,0 +1,52 @@
+name:           qam_ha_rolling_upgrade_migration
+description:    >
+  Test a rolling upgrade in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - migration/online_migration/register_without_ltss
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_init
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/await_upgrade_or_update
+  - migration/version_switch_upgrade_target
+  - '{{cluster_boot_mgmt}}'
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_migration
+  - migration/online_migration/post_migration
+  - '{{cluster_boot_mgmt}}'
+  - '{{console_reboot}}'
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  cluster_boot_mgmt:
+    QAM_INCI:
+      1:
+        - ha/cluster_boot_mgmt
+  console_reboot:
+    QAM_INCI:
+      1:
+        - console/console_reboot

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
@@ -1,0 +1,52 @@
+name:           qam_ha_rolling_upgrade_migration
+description:    >
+  Test a rolling upgrade in a two nodes cluster
+  Further info about the test suite
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - update/zypper_up
+  - console/console_reboot
+  - migration/online_migration/register_without_ltss
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - ha/ha_cluster_join
+  - ha/check_hawk
+  - ha/dlm
+  - ha/clvmd_lvmlockd
+  - ha/cluster_md
+  - ha/vg
+  - ha/filesystem
+  - ha/drbd_passive
+  - ha/filesystem
+  - ha/ctdb
+  - ha/haproxy
+  - ha/await_upgrade_or_update
+  - migration/version_switch_upgrade_target
+  - '{{cluster_boot_mgmt}}'
+  - ha/cluster_state_mgmt
+  - migration/online_migration/zypper_migration
+  - migration/online_migration/post_migration
+  - '{{cluster_boot_mgmt}}'
+  - '{{console_reboot}}'
+  - ha/check_cluster_integrity
+  - ha/check_hawk
+  - ha/wait_others_upgraded_or_updated
+  - ha/check_logs
+conditional_schedule:
+  cluster_boot_mgmt:
+    QAM_INCI:
+      1:
+        - ha/cluster_boot_mgmt
+  console_reboot:
+    QAM_INCI:
+      1:
+        - console/console_reboot

--- a/tests/migration/online_migration/register_without_ltss.pm
+++ b/tests/migration/online_migration/register_without_ltss.pm
@@ -28,6 +28,15 @@ sub run {
     set_var('SCC_ADDONS', join(',', @scc_addons));
 
     register_system_in_textmode;
+
+    # Sometimes in HA scenario, we need to test rolling upgrade migration from
+    # a LTSS version to another one LTSS version.
+    # In this case, we need to add ltss again to SCC_ADDONS and set HDDVERSION to
+    # the targeted OS version for getting the good LTSS regcode.
+    if (get_var('LTSS_TO_LTSS')) {
+        set_var('SCC_ADDONS', join(',', @scc_addons, 'ltss'));
+        set_var('HDDVERSION', get_var('UPGRADE_TARGET_VERSION', get_var('VERSION')));
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
This PR adds new rolling upgrade tests to SLE12 QAM.
_12-SP4 LTSS to 12-SP5
12-SP3 LTSS to 12-SP4 LTSS
12-SP2 LTSS to 12-SP3 LTSS_

- Related ticket: N/A
- Needles: N/A
- JIRA ticket: https://jira.suse.com/browse/TEAM-2101
- Verification run: 
12-SP4 LTSS to 12-SP5: [node1](http://1a102.qa.suse.de/tests/5850) - [node2](http://1a102.qa.suse.de/tests/5851)
12-SP3 LTSS to 12-SP4: [node1](http://1a102.qa.suse.de/tests/5847) - [node2](http://1a102.qa.suse.de/tests/5848)
12-SP2 LTSS to 12-SP3 LTSS: [node1](http://1a102.qa.suse.de/tests/5856) - [node2](http://1a102.qa.suse.de/tests/5857)
