### PR TITLE
Skip test for role selection screen SLE12SP3 through SLE12SP5 on ARM

### DIFF
--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -73,11 +73,15 @@ sub assert_system_role {
 }
 
 sub run {
-    return record_info(
-        "Skip screen",
-        "System Role screen is displayed only for x86_64 in SLE-12-SP5 due to it has more than one role available"
-    ) if (is_sle('=12-SP5') && !check_var('ARCH', 'x86_64'));
-    assert_system_role;
+    if (is_sle('=12-SP5') && !check_var('ARCH', 'x86_64')) {
+        record_info("Skip screen", "System Role screen is displayed only for x86_64 in SLE-12-SP5 due to it has more than one role available");
+    }
+    elsif (check_var('ARCH', 'aarch64') && is_sle('>=12-SP3') && is_sle('<15')) {
+        record_info("Skip screen", "System Role screen is  not displayed on aarch64 between 12SP3 and 12SP5");
+    }
+    else {
+        assert_system_role;
+    }
 }
 
 1;


### PR DESCRIPTION
The installer doesn't present a system role selection menu for SLE12SP3 to 

- Related ticket: https://progress.opensuse.org/issues/71074
- Verification runs:
[sle-12-SP2](https://openqa.suse.de/t4660029)
[sle-12-SP3](https://openqa.suse.de/t4660028)
[sle-12-SP4](https://openqa.suse.de/t4660032)
[sle-12-SP5](https://openqa.suse.de/t4660033)
[sle-12-SP5](https://openqa.suse.de/t4660031)
[sle-15](https://openqa.suse.de/t4660027)
[sle-15-SP1](https://openqa.suse.de/t4660030)