### PR TITLE
Add validation for zfcp disk

### DIFF
--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -31,53 +31,6 @@ schedule:
   - installation/first_boot
   - console/validate_multipath
 test_data:
-  WWID: 0QEMU_QEMU_HARDDISK_hd0
-  device_map:
-    0QEMU_QEMU_HARDDISK_hd0: dm-0
-    0QEMU_QEMU_HARDDISK_hd0-part1: dm-1
-    0QEMU_QEMU_HARDDISK_hd0-part2: dm-2
-    0QEMU_QEMU_HARDDISK_hd0-part3: dm-3
-    0QEMU_QEMU_HARDDISK_hd0-part4: dm-4
-  paths_list:
-    sda:
-      vendor_product_revision: QEMU,QEMU HARDDISK
-    sdb:
-      vendor_product_revision: QEMU,QEMU HARDDISK
-  attributes:
-    # Specifies whether to use world-wide IDs (WWIDs) or to use the /var/lib/multipath/bindings file
-    # to assign a persistent and unique alias to the multipath devices in the form of /dev/mapper/mpathN.
-    user_friendly_names: "\"no\""
-    # Specifies whether to monitor the failed path recovery, and indicates the timing for group failback
-    # after failed paths return to service.
-    failback: "\"manual\""
-    # Determines the state of the path.
-    #   tur: Issues an SCSI test unit ready command to the device.
-    path_checker: "\"tur\""
-    # Specifies the path grouping policy for a multipath device hosted by a given controller.
-    #   failover: One path is assigned per priority group so that only one path at a time is used.
-    path_grouping_policy: "\"failover\""
-    # Specifies the path-selector algorithm to use for load balancing
-    #   service-time 0: A service-time oriented load balancer that balances I/O on paths according
-    #                   to the latency.
-    path_selector: "\"service-time 0\""
-    # Specifies the time in seconds between the end of one path checking cycle and the beginning
-    # of the next path checking cycle.
-    polling_interval: 5
-    # Specifies the number of I/O requests to route to a path before switching to the next path
-    # in the current path group.
-    rr_min_io_rq: 1
-    # Specifies the weighting method to use for paths.
-    #   uniform: All paths have the same round-robin weights.
-    rr_weight: "\"uniform\""
-    # A udev attribute that provides a unique path identifier
-    uid_attribute: "\"ID_SERIAL\""
-  topology:
-    sda:
-      prio: 0
-      status: active
-    sdb:
-      prio: 0
-      status: enabled
   software:
     packages:
       # Device Mapper Tools
@@ -89,3 +42,48 @@ test_data:
       # Manages partition tables on device-mapper devices
       kpartx:
         installed: 1
+  multipath:
+    attributes:
+      # Specifies whether to use world-wide IDs (WWIDs) or to use the /var/lib/multipath/bindings file
+      # to assign a persistent and unique alias to the multipath devices in the form of /dev/mapper/mpathN.
+      user_friendly_names: 'no'
+      # Specifies whether to monitor the failed path recovery, and indicates the timing for group failback
+      # after failed paths return to service.
+      failback: manual
+      # Determines the state of the path.
+      #   tur: Issues an SCSI test unit ready command to the device.
+      path_checker: tur
+      # Specifies the path grouping policy for a multipath device hosted by a given controller.
+      #   failover: One path is assigned per priority group so that only one path at a time is used.
+      path_grouping_policy: failover
+      # Specifies the path-selector algorithm to use for load balancing
+      #   service-time 0: A service-time oriented load balancer that balances I/O on paths according
+      #                   to the latency.
+      path_selector: 'service-time 0'
+      # Specifies the time in seconds between the end of one path checking cycle and the beginning
+      # of the next path checking cycle.
+      polling_interval: 5
+      # Specifies the number of I/O requests to route to a path before switching to the next path
+      # in the current path group.
+      rr_min_io_rq: 1
+      # Specifies the weighting method to use for paths.
+      #   uniform: All paths have the same round-robin weights.
+      rr_weight: uniform
+      # A udev attribute that provides a unique path identifier
+      uid_attribute: ID_SERIAL
+    topology:
+      vendor_product_revision: 'QEMU,QEMU HARDDISK'
+      features: 0
+      hwhandler: 0
+      wp: rw
+      priority_groups:
+        - prio: 1
+          status: active
+          paths:
+            - name: sda
+              status: 'active ready running'
+        - prio: 1
+          status: enabled
+          paths:
+            - name: sdb
+              status: 'active ready running'

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -28,3 +28,63 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/validate_zfcp
+  - console/validate_multipath
+test_data:
+  software:
+    packages:
+      # Device Mapper Tools
+      device-mapper:
+        installed: 1
+      # Tools to Manage Multipathed Devices with the device-mapper
+      multipath-tools:
+        installed: 1
+      # Manages partition tables on device-mapper devices
+      kpartx:
+        installed: 1
+  zfcp:
+    fcp_devices:
+      - fcp_channel: '0.0.fa00'
+        attributes:
+          online: 1
+          port_type: 'NPIV VPORT'
+        fcp_luns:
+          - wwpn: '0x500507630718d3b3'
+            names: 'sda sg0'
+            scsi:
+              peripheral_type: disk
+              vendor_model_revision: 'IBM'
+              device_node_name: '/dev/sda'
+          - wwpn: '0x500507630713d3b3'
+            names: 'sdb sg1'
+            scsi:
+              peripheral_type: disk
+              vendor_model_revision: 'IBM'
+              device_node_name: '/dev/sdb'
+      - fcp_channel: '0.0.fc00'
+        attributes:
+          online: 0
+  multipath:
+    attributes:
+      user_friendly_names: 'no'
+      failback: manual
+      path_checker: tur
+      path_grouping_policy: failover
+      path_selector: 'service-time 0'
+      polling_interval: 5
+      rr_min_io_rq: 1
+      rr_weight: uniform
+      uid_attribute: ID_SERIAL
+    topology:
+      vendor_product_revision: IBM
+      features: '1 queue_if_no_path'
+      hwhandler: '1 alua'
+      wp: rw
+      priority_groups:
+        - prio: 50
+          status: active
+          paths:
+            - name: sda
+              status: 'active ready running'
+            - name: sdb
+              status: 'active ready running'

--- a/tests/console/validate_multipath.pm
+++ b/tests/console/validate_multipath.pm
@@ -22,6 +22,13 @@ use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 use repo_tools 'verify_software';
 
+# A multipath device can be identified by its WWID, by a user-friendly name, or by an alias
+# (Default) Use the WWIDs shown in the /dev/disk/by-id/ location.
+sub get_wwid {
+    my $wwid = script_output('awk -F"[/]" \'NF>1 {print $2}\' /etc/multipath/wwids');
+    defined $wwid ? return $wwid : die "WWWID not found in /etc/multipath/wwids";
+}
+
 sub verify_packages_installed {
     my ($software) = shift;
     record_info('packages', 'Verify required packages installed');
@@ -47,29 +54,6 @@ sub verify_services_running {
     validate_script_output("systemctl show -p SubState --value $_", qr/running/) for (@{$srv_ref});
 }
 
-sub verify_worldwide_id_used {
-    my ($wwid) = shift;
-    record_info('WWID', 'Verify Worldwide ID is used');
-    assert_script_run("grep \"$wwid\" /etc/multipath/wwids",
-        fail_message => "WWID '$wwid' not listed in '/etc/multipath/wwids'");
-}
-
-sub verify_devices_mapped {
-    my ($test_data) = shift;
-
-    record_info('dev map', 'Verify device mapping');
-    # Devices with WWID are listed in directories /dev/mapper and /dev/disk/by-id/ with symbolic
-    # links pointing to their respective multipath device which are created under /dev
-    # in the form of /dev/dm-N (non-administrative devices)
-    while (my ($admin_dev, $internal_dev) = each(%{$test_data->{device_map}})) {
-        for my $path (qw(/dev/mapper /dev/disk/by-id)) {
-            assert_script_run("ls -l $path | grep ^l.*$admin_dev.*-\>.*$internal_dev",
-                fail_message => "Expected multipath device listed in '$path' with name " .
-                  "'$admin_dev' with symbolic link pointing to '/dev/$internal_dev'");
-        }
-    }
-}
-
 sub verify_multipath_conf_file_not_exist {
     record_info('/etc/multipath.conf', 'Verify /etc/multipath.conf does not exist');
     assert_script_run('! test -e /etc/multipath.conf',
@@ -82,46 +66,57 @@ sub verify_multipath_configuration {
     record_info('configuration', 'Verify multipath configuration with multipath tool');
     my $conf_output = script_output("multipath -t");
     while (my ($k, $v) = each(%{$test_data->{attributes}})) {
-        assert_matches(qr/$k\s$v/, $conf_output, "Multipath attribute '$k $v' not found");
+        assert_matches(qr/$k\s"?$v"?/, $conf_output, "Multipath attribute '$k $v' not found");
     }
 }
 
 sub verify_multipath_topology {
-    my ($test_data) = shift;
+    my (%args) = @_;
 
-    my $wwid = $test_data->{WWID};
-    my $dm_N = $test_data->{device_map}->{hd0};
+    my $wwid      = $args{wwid};
+    my $test_data = $args{test_data};
 
     record_info('topology', 'Verify multipath topology');
-    my $topology_output = script_output("multipath -l");
+    my $topology_output = script_output("multipath -ll");
 
-    # Check infomation header
-    assert_matches(qr/$wwid $dm_N/, $topology_output,
-        "Topology information does not show header info with WWID dm-N");
-    # Check paths
-    while (my ($dev, $values) = each(%{$test_data->{topology}})) {
-        # Check policy
-        assert_matches(qr/prio=$values->{prio} status=$values->{status}/, $topology_output,
-            "Policy unexpected for multipath path to $dev");
-        # Check device
-        assert_matches(qr/$dev.*active.*running/, $topology_output,
-            "Device '$dev' should be active and running");
-    }
-}
+    # Check general topology info
+    my $topology    = $test_data->{topology};
+    my $ven_pro_rev = $topology->{vendor_product_revision};
+    assert_matches(qr/$wwid dm-0 $ven_pro_rev/, $topology_output,
+        'General topology info are not displayed properly');
 
-sub verify_paths_list {
-    my ($test_data) = shift;
-    my $wwid = $test_data->{WWID};
+    # Check specific topology info
+    my $features  = $topology->{features};
+    my $hwhandler = $topology->{hwhandler};
+    my $wp        = $topology->{wp};
+    assert_matches(qr/size=.* features='$features' hwhandler='$hwhandler' wp=$wp/,
+        $topology_output, 'Specific topology info are not displayed properly');
 
-    record_info('paths', 'Verify multipath paths');
-    while (my ($dev, $values) = each(%{$test_data->{paths_list}})) {
-        validate_script_output("multipath -d -v3 | grep ^$wwid",
-            qr/$wwid.*$dev.*$values->{vendor_product_revision}/);
+    # Check priority groups
+    my $policy = $test_data->{attributes}->{path_selector};
+    for my $priority_group (@{$topology->{priority_groups}}) {
+        my $prio   = $priority_group->{prio};
+        my $status = $priority_group->{status};
+        assert_matches(qr/policy='$policy' prio=$prio status=$status/,
+            $topology_output, "Policy/Priority/Status unexpected for priority group");
+
+        for my $path (@{$priority_group->{paths}}) {
+            my $name   = $path->{name};
+            my $status = $path->{status};
+            assert_matches(qr/\d:\d:\d:\d+ $name \d+:\d+\s+$status/, $topology_output,
+                "Path to '$name' should be '$status'");
+
+            validate_script_output("multipath -d -v3 | grep ^$wwid",
+                qr/$wwid.*$name/);
+        }
     }
 }
 
 sub verify_basic_multipath_configuration {
-    my ($test_data) = shift;
+    my (%args) = @_;
+
+    my $wwid      = $args{wwid};
+    my $test_data = $args{test_data};
 
     verify_packages_installed($test_data->{software});
 
@@ -135,39 +130,37 @@ sub verify_basic_multipath_configuration {
     #   * multipathd.service: Device-Mapper Multipath Device Controller
     verify_services_running(['multipathd']);
 
-    # A multipath device can be identified by its WWID, by a user-friendly name, or by an alias
-    # (Default) Use the WWIDs shown in the /dev/disk/by-id/ location.
-    verify_worldwide_id_used($test_data->{WWID});
-
-    # Verify internal device mapping
-    verify_devices_mapped($test_data);
-
     # (Default) The multipath.conf file does not exist until you create and configure it.
     verify_multipath_conf_file_not_exist();
 }
 
 sub verify_multipath {
-    my ($test_data) = shift;
+    my (%args) = @_;
+
+    my $wwid      = $args{wwid};
+    my $test_data = $args{test_data};
 
     # Verify the currently used multipathd configuration
     verify_multipath_configuration($test_data);
 
     # Verify the current multipath topology from information fetched in sysfs and the device mapper
-    verify_multipath_topology($test_data);
-
-    # Verify paths list
-    verify_paths_list($test_data);
+    verify_multipath_topology(wwid => $wwid, test_data => $test_data);
 }
 
 sub run {
     select_console 'root-console';
-    my $test_data = get_test_suite_data();
+
+    my $test_data_multipath = get_test_suite_data()->{multipath};
+
+    # Obtain dynamic WWID
+    my $wwid = get_wwid();
 
     # Basic verification: checking packages, services, paths and content of files
-    verify_basic_multipath_configuration($test_data);
+    verify_basic_multipath_configuration(wwid => $wwid,
+        test_data => $test_data_multipath);
 
     # Verification using multipath tool
-    verify_multipath($test_data);
+    verify_multipath(wwid => $wwid, test_data => $test_data_multipath);
 }
 
 1;

--- a/tests/console/validate_zfcp.pm
+++ b/tests/console/validate_zfcp.pm
@@ -1,0 +1,202 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate zfcp in the installed system:
+#          - Verification of FCP devices online
+#          - Verificaiton of FCP devices
+#          - Verification of LUNs visible as SCSI devices
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_suite_data';
+use utils qw(arrays_subset);
+
+# Get devices online.
+# For each physical adapter in the mainframe there is a corresponding FCP channel providing physical
+# connection to the SAN Fabric (multiple FCP channels are configured to increase the I/O bandwidth
+# and improve data availability).
+# HBAs are shown in the system as FCP devices
+sub get_fcp_devices_online {
+    record_info('FCP devices', 'Get expected devices online');
+
+    # get test data
+    my $test_data = get_test_suite_data();
+
+    # FCP devices (online and offline)
+    my $fcp_devices = $test_data->{zfcp}->{fcp_devices};
+    # filtering online devices
+    return [grep { $_->{attributes}->{online} } @{$fcp_devices}];
+}
+
+# Compare fcp devices
+sub compare_fcp_devices {
+    my (%args) = @_;
+
+    my $devs_expected = [map { $_->{fcp_channel} } @{$args{devs_expected}}];
+    my $devs_current  = $args{devs_current};
+    my $only_warning  = $args{only_warning};
+
+    if (scalar arrays_subset($devs_expected, $devs_current) > 0) {
+        my $message = "Unexpected FCP devices online found in the installed system. " .
+          "Please, check if it was an error or is intended and new adaptor became renamed " .
+          "or (not) available:\n" .
+          "Expected: " . join(",", @{$devs_expected}) . " " .
+          "Got: " . join(",", @{$devs_current});
+        $only_warning ? record_info('WARNING', $message) : die $message;
+    }
+}
+
+# Checks if the installed system use all devices available online or throw a warning
+sub check_fcp_devices_against_installed_system {
+    my ($fcp_devices) = shift;
+
+    my $fcp_devices_system = [split(/\n/,
+            script_output("lszdev --no-headings --columns ID zfcp-host --online"))];
+    compare_fcp_devices(devs_expected => $fcp_devices, devs_current => $fcp_devices_system,
+        only_warning => 1);
+}
+
+# Checks if devices introduced during installation (for instance set via MACHINE level)
+# match the ones for verification (specified in test data)
+sub verify_fcp_devices_against_infrastructure {
+    my ($fcp_devices) = shift;
+
+    my $fcp_devices_infra = [split(/,/, get_required_var('ZFCP_ADAPTERS'))];
+    compare_fcp_devices(devs_expected => $fcp_devices, devs_current => $fcp_devices_infra);
+}
+
+# Verify FCP attributes, for instance:
+#   port_type: FCP setups running in NPIV mode detect the LUNs automatically and
+#              after setting the device online no further configuration is necessary.
+#   online:    Channel is online or offline
+sub verify_fcp_attributes {
+    my ($fcp_devices) = shift;
+
+    for my $fcp_device (@{$fcp_devices}) {
+        my $fcp_channel = $fcp_device->{fcp_channel};
+        while (my ($attribute, $value) = each(%{$fcp_device->{attributes}})) {
+            validate_script_output("lszfcp -b $fcp_channel -a | grep $attribute", qr/\"$value\"/);
+        }
+    }
+}
+# Set FCP devices offline and set back online
+sub verify_fcp_devices_can_be_set_online_offline {
+    my ($fcp_devices) = shift;
+
+    for my $fcp_device (@{$fcp_devices}) {
+        my $fcp_channel = $fcp_device->{fcp_channel};
+        assert_script_run("chccwdev -d $fcp_channel",
+            fail_message => "FCP device with bus $fcp_channel could not be set offline");
+        assert_script_run("chccwdev -e $fcp_channel",
+            fail_message => "FCP device with bus $fcp_channel could not be set back online");
+    }
+}
+
+# Verify SCSI devices using following commands:
+#   lsscsi: list SCSI devices (or hosts) and their attributes.
+#   lszfcp: list information about zfcp adapters, ports, and units
+#   lszdev: Display configuration of z Systems specific devices
+sub verify_scsi_devices {
+    my ($fcp_devices) = shift;
+
+    record_info('LUNs SCSI', 'Verification of LUNs visible as SCSI devices');
+    for my $fcp_device (@{$fcp_devices}) {
+        for my $lun (@{$fcp_device->{fcp_luns}}) {
+            # Validate scsi devices with specific scsi command
+            my $peripheral_type       = $lun->{scsi}->{peripheral_type};
+            my $vendor_model_revision = $lun->{scsi}->{vendor_model_revision};
+            my $device_node_name      = $lun->{scsi}->{device_node_name};
+            my $iscsi_output          = script_output("lsscsi | grep '$device_node_name'");
+            unless ($iscsi_output =~ /^\[(?<hctl>.*)\]\s*$peripheral_type\s+$vendor_model_revision/)
+            {
+                die "SCSI device $device_node_name was not found with peripheral type '$peripheral_type' and " .
+                  "vendor/model/revision '$vendor_model_revision'";
+            }
+
+            # Save H:C:T:L
+            my $hctl = $+{hctl};
+
+            # Validate scsi devices with specific command for zfcp: lszfcp
+            my $fcp_channel = $fcp_device->{fcp_channel};
+            my $wwpn        = $lun->{wwpn};
+            my $bus_wwpn    = "$fcp_channel/$wwpn";
+            validate_script_output("lszfcp -D -b $fcp_channel | grep '$bus_wwpn'", qr/$hctl/);
+
+            # Validate scsi devices with specific command for zfcp: lszdev
+            my $names = $lun->{names};
+            $bus_wwpn = "$fcp_channel:$wwpn";
+            validate_script_output("lszdev --no-headings zfcp-lun | grep '$names'",
+                qr/$bus_wwpn/);
+
+            # Set SCSI devices offline and set back online (other states are also possible)
+            my $state_file = "\"/sys/bus/scsi/devices/$hctl/state\"";
+            validate_script_output("cat $state_file", qr/running/);
+            assert_script_run("echo offline > $state_file",
+                fail_message => "state offline could not be set for SCSI device $hctl");
+            validate_script_output("cat $state_file", qr/offline/);
+            assert_script_run("echo running > $state_file",
+                fail_message => "state online could not be set for SCSI device $hctl");
+            validate_script_output("cat $state_file", qr/running/);
+        }
+    }
+}
+
+# Verify FCP devices
+sub verify_fcp_devices {
+    my ($fcp_devices) = shift;
+
+    record_info('FCP devices', 'Verification of FCP devices');
+    check_fcp_devices_against_installed_system($fcp_devices);
+    verify_fcp_devices_against_infrastructure($fcp_devices);
+    verify_fcp_attributes($fcp_devices);
+    verify_fcp_devices_can_be_set_online_offline($fcp_devices);
+}
+
+# The zfcp_ping and zfcp_show commands can probe ports and retrieve information about ports
+# in the attached storage servers and in interconnect elements such as switches, bridges, and hubs.
+# Because the commands are processed by the SAN management server, information can be obtained
+# about ports and interconnect elements that are not connected to your FCP channel.
+# Thus, zfcp_ping and zfcp_show can help to identify configuration problems in a SAN.
+# The zfcp_show command retrieves information about the SAN topology and details about the SAN components.
+sub investigate_san_fabric {
+    my ($fcp_devices) = shift;
+
+    zypper_call("in libzfcphbaapi0");
+    for my $fcp_device (@{$fcp_devices}) {
+        for my $lun (@{$fcp_devices->{fcp_luns}}) {
+            my $wwpn = $lun->{wwpn};
+            script_run("zfcp_ping -t97 $wwpn >> /tmp/zfcp_ping_wwpns.log");
+        }
+    }
+    upload_logs('/tmp/zfcp_ping_wwpns.log');
+    script_run('zfcp_show -v > /tmp/zfcp_show.log');
+    upload_logs('/tmp/zfcp_show.log');
+}
+
+sub run {
+    select_console 'root-console';
+
+    my $fcp_devices = get_fcp_devices_online();
+    verify_fcp_devices($fcp_devices);
+    verify_scsi_devices($fcp_devices);
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+
+    my $fcp_devices_online = get_fcp_devices_online();
+    investigate_san_fabric($fcp_devices_online);
+    $self->SUPER::post_fail_hook();
+}
+
+1;


### PR DESCRIPTION
Description:
- Add validation for zfcp disk in s390x.
- Adapt multipath validation to work with zfcp disk.

See [poo#69229](https://progress.opensuse.org/issues/69229)

Verification run: [zfcp & multipath test suites](https://openqa.suse.de/tests/overview?version=15-SP3&build=jknphy%2Fos-autoinst-distri-opensuse%23add_validation_zfcp&distri=sle)