### PR TITLE
Remove PackageHub Activating code for w3m_https

### DIFF
--- a/tests/console/w3m_https.pm
+++ b/tests/console/w3m_https.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests - FIPS tests
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,7 +23,7 @@ use web_browser qw(setup_web_browser_env run_web_browser_text_based);
 
 sub run {
     select_console("root-console");
-    setup_web_browser_env();
+    zypper_call("--no-refresh --no-gpg-checks search -it pattern fips") if get_var('FIPS_ENABLED');
     zypper_call("--no-refresh --no-gpg-checks in w3m");
     run_web_browser_text_based("w3m", undef);
 }


### PR DESCRIPTION
Remove PackageHub Activating code for fips test case "w3m_https".

Pkg "w3m" is not in "Packagehub" now (at lease on sle12sp5， sle15sp2) so delete the invoking of "setup_web_browser_env()" which activates "Packagehub",
"Packagehub" activation usually fails as it is not ready at the early developing stage (bug#1175578).
https://bugzilla.suse.com/show_bug.cgi?id=1175578

After the fix test case "w3m_https" is PASS now.

- Related ticket: https://progress.opensuse.org/issues/70492
- Needles: NA
- Verification run: http://openqa.suse.de/tests/4662978#
