### PR TITLE
Add test for local container registry

### DIFF
--- a/data/containers/registries.conf
+++ b/data/containers/registries.conf
@@ -1,0 +1,20 @@
+# For more information on this configuration file, see containers-registries.conf(5).
+#
+# Registries to search for images that are not fully-qualified.
+# i.e. foobar.com/my_image:latest vs my_image:latest
+[registries.search]
+registries = ["registry.opensuse.org", "docker.io"]
+
+# Registries that do not use TLS when pulling images or uses self-signed
+# certificates.
+[registries.insecure]
+registries = ["localhost:5000"]
+
+# Blocked Registries, blocks the `docker daemon` from pulling from the blocked registry.  If you specify
+# "*", then the docker daemon will only be allowed to pull from registries listed above in the search
+# registries.  Blocked Registries is deprecated because other container runtimes and tools will not use it.
+# It is recommended that you use the trust policy file /etc/containers/policy.json to control which
+# registries you want to allow users to pull and push from.  policy.json gives greater flexibility, and
+# supports all container runtimes and tools including the docker daemon, cri-o, buildah ...
+[registries.block]
+registries = []

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -178,4 +178,5 @@ sub test_built_img {
     assert_script_run('curl http://localhost:8888/ | grep "Networking test shall pass"');
     assert_script_run("rm -rf /root/templates");
 }
+
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1720,6 +1720,7 @@ sub load_extra_tests_docker {
         loadtest "containers/container_diff";
     }
     loadtest "containers/docker_compose" unless (is_sle('<15') || is_sle('>=15-sp2'));
+    loadtest 'containers/registry';
     loadtest "containers/zypper_docker";
 }
 

--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -30,5 +30,6 @@ schedule:
     - '{{docker_image}}'
     - '{{containers_3rd_party}}'
     - '{{docker_compose}}'
+    - containers/registry
     - containers/zypper_docker
     - console/coredump_collect

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -37,7 +37,6 @@ sub run {
 
     if (is_sle()) {
         ensure_ca_certificates_suse_installed();
-        allow_registry_suse_de_for_docker();
     }
 
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -1,0 +1,94 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: docker-distribution-registry
+# Summary: Test container registry package
+# - docker-distribution-registry package can be installed
+# - docker-distribution-registry daemon can be started
+# - images can be pushed
+# - images can be searched
+# - images can be pulled
+# - images can be deleted
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base "consoletest";
+use testapi;
+use strict;
+use warnings;
+use utils;
+use version_utils;
+use registration;
+use containers::common;
+use containers::utils;
+
+sub registry_push_pull {
+    my %args    = @_;
+    my $image   = $args{image};
+    my $runtime = $args{runtime};
+
+    die 'Argument $image not provided!'   unless $image;
+    die 'Argument $runtime not provided!' unless $runtime;
+
+    # Pull $image from default registry
+    assert_script_run "$runtime pull $image",            600;
+    assert_script_run "$runtime images | grep '$image'", 60;
+
+    # Tag $image for the local registry
+    assert_script_run "$runtime tag $image localhost:5000/$image",      90;
+    assert_script_run "$runtime images | grep 'localhost:5000/$image'", 60;
+
+    # Push $image to the local registry
+    assert_script_run "$runtime push localhost:5000/$image", 90;
+
+    # Remove $image as well as the local registry $image
+    # The localhost:5000/$image must be removed first
+    assert_script_run "$runtime image rm -f localhost:5000/$image",       90;
+    assert_script_run "$runtime image rm -f $image",                      90;
+    assert_script_run "! $runtime images | grep '$image'",                60;
+    assert_script_run "! $runtime images | grep 'localhost:5000/$image'", 60;
+
+    # Pull $image from the local registry
+    assert_script_run "$runtime pull localhost:5000/$image",            90;
+    assert_script_run "$runtime images | grep 'localhost:5000/$image'", 60;
+}
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    # Package Hub is not enabled on 15-SP3 yet.
+    return if is_sle '=15-SP3';
+
+    # Install and check that it's running
+    add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1) if is_sle(">=15");
+    zypper_call 'se -v docker-distribution-registry';
+    zypper_call 'in docker-distribution-registry';
+    systemctl '--now enable registry';
+    systemctl 'status registry';
+
+    script_retry 'curl http://127.0.0.1:5000/v2/_catalog', delay => 3, retry => 10;
+    assert_script_run 'curl -s http://127.0.0.1:5000/v2/_catalog | grep repositories';
+
+    # Run docker tests
+    install_docker_when_needed();
+    allow_selected_insecure_registries(runtime => 'docker');
+    registry_push_pull(image => 'opensuse/tumbleweed', runtime => 'docker');
+    clean_container_host(runtime => 'docker');
+
+    # Run podman tests
+    if (is_leap('15.1+') || is_tumbleweed || is_sle("15-sp1+")) {
+        install_podman_when_needed();
+        allow_selected_insecure_registries(runtime => 'podman');
+        registry_push_pull(image => 'opensuse/tumbleweed', runtime => 'podman');
+        clean_container_host(runtime => 'podman');
+    }
+}
+
+1;


### PR DESCRIPTION
Hello,

I'm introducing a new test module. This one is for `docker-distribution-registry` package.
This package is native on `SLE 12-SP3+` until `SLE 15+` where it's on PackageHub.

- Related ticket: [poo#67264](https://progress.opensuse.org/issues/67264)
- Verification run: [SLE12.3](http://pdostal-server.suse.cz/tests/9994) [SLE12.5](http://pdostal-server.suse.cz/tests/9993) [SLE15](http://pdostal-server.suse.cz/tests/9981) [SLE15.2](http://pdostal-server.suse.cz/tests/9991) [SLE15.3](http://pdostal-server.suse.cz/tests/9998) [Tumbleweed](http://pdostal-server.suse.cz/tests/9970)
