### PR TITLE
Fix yaml_generator script

### DIFF
--- a/script/yaml_generator/create_scheduler.py
+++ b/script/yaml_generator/create_scheduler.py
@@ -28,7 +28,7 @@ def _get_conf(jobid, srv):
     client = OpenQA_Client(server='http://%s' % srv)
     conf = client.openqa_request('GET', 'jobs/%s' % jobid)
 
-    testname = conf['job']['test']
+    testname = conf['job']['settings']['TEST_SUITE_NAME']
     jobvars = {}
     jobvars['name'] = testname
     suitevars = client.openqa_request('GET', 'test_suites')
@@ -36,11 +36,9 @@ def _get_conf(jobid, srv):
     vars_generator = (settings for settings in suitevars['TestSuites'])
 
     for v in vars_generator:
-        # there are test jobs that the name is modified in job group and is run with
-        # another name than the name in 'TestSuites' ex installer_extended_textmode
-        # Because ususally the name just appends the name we just check if it startswith
-        if testname.startswith(v['name']):
+        if testname == v.get('name'):
             jobvars.update(v)
+            break
     return jobvars
 
 


### PR DESCRIPTION
This commit adds a fix for this error:
```
Traceback (most recent call last):
  File "../../script/yaml_generator/create_scheduler.py", line 78, in <module>
    conf = _get_conf(jobid, openqa_server)
  File "../../script/yaml_generator/create_scheduler.py", line 42, in _get_conf
    if testname.startswith(v['name']):
KeyError: 'name'
```

It was due to a testsuite with an empty name (sounds like an error, but can happen).

This PR also change a little bit the way how the test suite is searched and also stop the test suite search when the good one is found. This avoid parsing the whole test suite database.

- Related ticket: N/A
- Needles: N/A
- Failing run: `python3 create_scheduler.py 4635393 tmp/` fails with the mentioned error
- Verification run: `python3 create_scheduler.py 4635393 tmp/` now works