### PR TITLE
New test for SUSE MicroOS 5.0 DVD installation

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -36,8 +36,10 @@ our @EXPORT = qw(
 
 # Download files needed for transactional update tests
 sub get_utt_packages {
-    # SLE needs an additional repo for testing
-    assert_script_run 'curl -O ' . data_url("microos/utt.repo") if is_sle;
+    # SLE and SUSE MicroOS need an additional repo for testing
+    unless (is_opensuse) {
+        assert_script_run 'curl -O ' . data_url("microos/utt.repo");
+    }
 
     # Different testfiles for SUSE MicroOS and openSUSE MicroOS
     my $tarball = 'utt-';

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -3,6 +3,7 @@ use warnings;
 use testapi qw(check_var get_var get_required_var);
 use needle;
 use File::Basename;
+use scheduler 'load_yaml_schedule';
 BEGIN {
     unshift @INC, dirname(__FILE__) . '/../../lib';
 }
@@ -90,6 +91,8 @@ sub load_installation_tests {
 #######################
 # Testing starts here #
 #######################
+return 1 if load_yaml_schedule;
+
 if (get_var 'STACK_ROLE') {
     load_boot_from_disk_tests;
     load_tdup_tests      if (get_var 'TDUP');

--- a/schedule/microos/suse_microos.yaml
+++ b/schedule/microos/suse_microos.yaml
@@ -1,0 +1,31 @@
+name:           suse_microos
+description:    >
+    Maintainer: jalausuch@suse.com, qa-c@suse.de.
+    SUSE MicroOS tests
+schedule:
+    - installation/bootloader
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/ntp_config_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/reboot_after_installation
+    - microos/disk_boot
+    - microos/networking
+    - microos/libzypp_config
+    - microos/one_line_checks
+    - microos/services_enabled
+    - update/zypper_clear_repos
+    - console/zypper_ar
+    - console/zypper_ref
+    - transactional/filesystem_ro
+    - transactional/transactional_update
+    - transactional/rebootmgr
+    - transactional/health_check
+    - microos/journal_check
+    - shutdown/shutdown

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -148,7 +148,12 @@ sub run {
 
     ensure_fullscreen;
 
-    assert_screen((is_sle('15+') && get_var('UPGRADE')) ? 'inst-welcome-no-product-list' : 'inst-welcome');
+    if (is_microos('suse') || (is_sle('15+') && get_var('UPGRADE'))) {
+        assert_screen('inst-welcome-no-product-list');
+    }
+    else {
+        assert_screen('inst-welcome');
+    }
     mouse_hide;
     wait_still_screen(3);
 


### PR DESCRIPTION
SUSE MicroOS is a new enterprise product, which require
adaptations and needling in the installation process.

The way to differentiate it with openSUSE MicroOS will be
with the VERSION variable, set to 5.0 for this product.

- Related ticket: https://progress.opensuse.org/issues/68140
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1430
- Verification run: http://fromm.arch.suse.de/tests/67#
