### PR TITLE
Query php version is instaled before enabling apache module

### DIFF
--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,7 +10,7 @@
 # Summary: Ganglia Test - server
 #   Acts as server which gets data from the client and is running the webinterface
 #   to show the metrics for all connected hosts
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: soulofdestiny <mgriessmeier@suse.com>, Anton Pappas <apappas@suse.com>
 # Tags: https://fate.suse.com/323979
 
 use base 'hpcbase';
@@ -35,13 +35,27 @@ sub run {
     systemctl 'start gmond';
     barrier_wait('GANGLIA_GMOND_STARTED');
 
-    # wait for client
+    # Wait for client.
     barrier_wait('GANGLIA_INSTALLED');
     barrier_wait('GANGLIA_CLIENT_DONE');
 
-    #install web frontend and start apache
+    # Install web frontend and start apache2.
     zypper_call('in ganglia-web');
-    script_run('a2enmod php7');
+
+    # Check which version of php was installed during the previous step.
+    my $php_ver = '';
+    if (!zypper_call('se -i apache2-mod_php7', exitcode => [0, 104])) {
+        $php_ver = '7';
+    }
+    elsif (!zypper_call('se -i apache2-mod_php5', exitcode => [0, 104])) {
+        $php_ver = '5';
+    }
+    else {
+        record_info("Depedency issue", "Is apache-mod_php installed?");
+        die;
+    }
+    script_run("a2enmod php$php_ver");
+
     systemctl('start apache2');
     my $page_url = "http://ganglia-server/ganglia/?r=hour&cs=&ce=&c=unspecified&h=";
     $page_url .= "ganglia-server.openqa.test&tab=m&vn=&hide-hf=false";


### PR DESCRIPTION
Installing ganglia-web might install either php5 or php7 on 12SP3 so it's better
to query the installed version rather than picking php7 every time.

- Related ticket: https://progress.opensuse.org/issues/70273
- Verification run: [12SP2](http://10.163.42.106/tests/501) [12SP3](http://10.163.42.106/tests/504) [12SP4](http://10.163.42.106/tests/507) [12SP5](http://10.163.42.106/tests/528) [15](http://10.163.42.106/tests/498) [15SP1](http://10.163.42.106/tests/519) [15SP2](http://10.163.42.106/tests/525)
