### PR TITLE
Improve cluster shutdown when generating qcow2 img

### DIFF
--- a/tests/ha/prepare_shutdown.pm
+++ b/tests/ha/prepare_shutdown.pm
@@ -13,11 +13,10 @@
 use base 'opensusebasetest';
 use strict;
 use warnings;
-use utils 'systemctl';
 
 sub run {
-    # We need to stop pacemaker to avoid fencing during shutdown
-    systemctl 'stop pacemaker.service';
+    # We need to stop the cluster stack to avoid fencing during shutdown
+    assert_script_run("crm cluster stop");
 }
 
 1;


### PR DESCRIPTION
This PR changes the way that we use for stopping the cluster.
It is more appropriate to use `crm cluster stop`.

- Related ticket: N/A
- Needles: N/A
- Verification run: [node1](http://1a102.qa.suse.de/tests/5382) [node2](http://1a102.qa.suse.de/tests/5383) [supportserver](http://1a102.qa.suse.de/tests/5381)
