### PR TITLE
Add migration and saptune YAML files for SLES4SAP

### DIFF
--- a/schedule/sles4sap/migration_offline_sles4sap.yaml
+++ b/schedule/sles4sap/migration_offline_sles4sap.yaml
@@ -1,0 +1,47 @@
+---
+name: migration_offline_dvd_sles4sap
+description: >
+  Offline migration from installed SLES4SAP.
+
+  This test does an offline migration using the *DVD* media, with or without SCC registration.
+vars:
+  BOOT_HDD_IMAGE: '1'
+  HDDSIZEGB: '60'
+  HDD_1: sle-%HDDVERSION%-%ARCH%-sap-nw-noscc.qcow2
+  INSTANCE_ID: '00'
+  INSTANCE_SID: QAD
+  INSTANCE_TYPE: ASCS
+  MAX_JOB_TIME: '14400'
+  PATCH: '1'
+  ROOTONLY: '1'
+  SHUTDOWN_NEEDS_AUTH: '0'
+  SLES4SAP_MODE: sles4sap
+  SLE_PRODUCT: sles4sap
+  SYSTEM_ROLE: default
+  UPGRADE: '1'
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - update/patch_sle
+  - migration/record_disk_info
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - installation/bootloader
+  - installation/welcome
+  - installation/upgrade_select
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - migration/post_upgrade
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/sapconf
+  - sles4sap/saptune
+  - sles4sap/netweaver_test_instance

--- a/schedule/sles4sap/migration_online_sles4sap.yaml
+++ b/schedule/sles4sap/migration_online_sles4sap.yaml
@@ -1,0 +1,41 @@
+---
+name: migration_online_zypper_sles4sap
+description: >
+  Online migration from installed SLES4SAP.
+
+  This test does an online migration with SCC registration.
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: gnome
+  FULL_UPDATE: '1'
+  HDDSIZEGB: '60'
+  HDD_1: sle-%HDDVERSION%-%ARCH%-sap-nw-noscc.qcow2
+  INSTANCE_ID: '00'
+  INSTANCE_SID: QAD
+  INSTANCE_TYPE: ASCS
+  MAX_JOB_TIME: '14400'
+  MIGRATION_METHOD: zypper
+  ONLINE_MIGRATION: '1'
+  ROOTONLY: '1'
+  SCC_ADDONS: ha
+  SCC_PROXY_URL: '%SCC_URL%'
+  SCC_REGISTER: installation
+  SLES4SAP_MODE: sles4sap
+  SLE_PRODUCT: sles4sap
+schedule:
+  - migration/version_switch_origin_system
+  - installation/isosize
+  - installation/bootloader
+  - migration/online_migration/online_migration_setup
+  - migration/online_migration/register_system
+  - migration/online_migration/zypper_patch
+  - installation/install_service
+  - migration/version_switch_upgrade_target
+  - migration/online_migration/pre_migration
+  - migration/online_migration/zypper_migration
+  - migration/online_migration/post_migration
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/sapconf
+  - sles4sap/saptune
+  - sles4sap/netweaver_test_instance

--- a/schedule/sles4sap/sles4sap_gnome_saptune_v2.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_v2.yaml
@@ -1,0 +1,23 @@
+---
+name: sles4sap_gnome_saptune_v2
+description: >
+  saptune V2 test
+
+  MR_TEST variable should be set in the YAML file
+vars:
+  BOOTFROM: c
+  BOOT_HDD_IMAGE: '1'
+  DM_NEEDS_USERNAME: '1'
+  HDDSIZEGB: '60'
+  HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
+  QEMU_DISABLE_SNAPSHOTS: '1'
+  ROOTONLY: '1'
+  SHUTDOWN_NEEDS_AUTH: '0'
+  SLES4SAP_MODE: sles4sap
+  SLE_PRODUCT: sles4sap
+  START_AFTER_TEST: create_hdd_sles4sap_gnome
+  SYSTEM_ROLE: default
+  TIMEOUT_SCALE: '3'
+schedule:
+  - boot/boot_to_desktop
+  - sles4sap/saptune/mr_test


### PR DESCRIPTION
This PR adds YAML files for online/offline migrations and a change for saptune tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: None, as there is too much tests to do, and these are only for SLES4SAP 15-SP3, which is a new product still in Alpha stage.
