### PR TITLE
Assert root-console to wait snapper to settle down

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -123,6 +123,10 @@ sub run {
     my $target_version = get_var("VERSION");
     assert_script_run("grep VERSION= /etc/os-release | grep $target_version");
 
+    select_console('root-console', await_console => 0);
+    # wait long time for snapper to settle down
+    assert_screen 'root-console', 600;
+
     # We can't use 'keepconsole' here, because sometimes a display-manager upgrade can lead to a screen change
     # during restart of the X/GDM stack
     power_action('reboot', textmode => 1);


### PR DESCRIPTION
The default value for timeout of assert_screen for root-console is 30 which is not enough, so just increase it to 60 to fix this issue.

- Related ticket: https://progress.opensuse.org/issues/71149
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/4669062#
