### PR TITLE
Fix missing module in cluster shutdown

### DIFF
--- a/tests/ha/prepare_shutdown.pm
+++ b/tests/ha/prepare_shutdown.pm
@@ -13,6 +13,7 @@
 use base 'opensusebasetest';
 use strict;
 use warnings;
+use testapi;
 
 sub run {
     # We need to stop the cluster stack to avoid fencing during shutdown


### PR DESCRIPTION
Testapi module is missing in the test.

- Related ticket: N/A
- Needles: N/A
- Verification run: [node1](http://1a102.qa.suse.de/tests/5382) [node2](http://1a102.qa.suse.de/tests/5383) [supportserver](http://1a102.qa.suse.de/tests/5381)
