### PR TITLE
Increase timeout for creation of loop devices

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -162,8 +162,8 @@ sub create_loop_device_by_rootsize {
         else {
             $filename = "test_dev";
         }
-        script_run("dd if=/dev/zero bs=$bsize count=$count of=$INST_DIR/$filename");
-        script_run("losetup -fP $INST_DIR/$filename");
+        assert_script_run("dd if=/dev/zero bs=$bsize count=$count of=$INST_DIR/$filename", 300);
+        assert_script_run("losetup -fP $INST_DIR/$filename",                               300);
         $num += 1;
     }
     script_run("losetup -a");


### PR DESCRIPTION
Make the dd and losetup command failure stop the test, xfs tests can't continue without patition setup

- Fail: https://openqa.suse.de/tests/4668551
- Verification run: https://openqa.suse.de/tests/4669207