### PR TITLE
Add softfailure in container tests for s390x

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -116,6 +116,7 @@ sub test_opensuse_based_image {
     } else {
         validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
     }
+
     # zypper lr
     assert_script_run("$runtime run --rm $image zypper lr -s", 120);
     # zypper ref

--- a/tests/containers/containers_3rd_party.pm
+++ b/tests/containers/containers_3rd_party.pm
@@ -34,8 +34,14 @@ sub run_image_tests {
     my $engine = shift;
     my @images = @_;
     foreach my $image (@images) {
-        test_container_image(image => $image, runtime => $engine);
-        script_run("echo 'OK: $engine - $image:latest' >> /var/tmp/containers_3rd_party_log.txt");
+        if ((check_var('ARCH', 's390x')) && ($image =~ /leap/)) {
+            record_soft_failure("bsc#1171672 Missing Leap:latest container image for s390x");
+        } elsif ((check_var('ARCH', 's390x')) && ($image =~ /centos/)) {
+            record_info("Skip centos image", "Missing centos container image for s390x.");
+        } else {
+            test_container_image(image => $image, runtime => $engine);
+            script_run("echo 'OK: $engine - $image:latest' >> /var/tmp/containers_3rd_party_log.txt");
+        }
     }
 }
 


### PR DESCRIPTION
- bsc#1171672 Missing Leap:latest container image for s390x

- Related ticket: N/A
- Needles: N/A
- Verification run: 
s390x : [SLE15-SP2 ](https://openqa.suse.de/tests/4673889)[SLE15-SP1](https://openqa.suse.de/tests/4673890)
X86_64 : [SLE15-SP2](https://openqa.suse.de/tests/4677094), [SLE15-SP1](https://openqa.suse.de/tests/4673941), [TW](https://openqa.opensuse.org/tests/1390860), [Leap JeOS](https://openqa.opensuse.org/tests/1390861)
aarch64 : [SLE15-SP2](https://openqa.suse.de/tests/4683371)
