### PR TITLE
Fix issue in sap wmp test

### DIFF
--- a/data/sles4sap/SAP.slice
+++ b/data/sles4sap/SAP.slice
@@ -1,0 +1,2 @@
+[Service]
+Slice=SAP.slice

--- a/data/sles4sap/sap.slice
+++ b/data/sles4sap/sap.slice
@@ -1,2 +1,0 @@
-[Service]
-Slice=sap.slice

--- a/tests/sles4sap/wmp_setup.pm
+++ b/tests/sles4sap/wmp_setup.pm
@@ -34,9 +34,8 @@ sub run {
 
     # Create slice cgroup
     my $systemd_path  = '/etc/systemd/system';
-    my $sap_slice_cfg = 'sap.slice';
-    assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/$sap_slice_cfg -o /tmp/$sap_slice_cfg";
-    assert_script_run "mv -i /tmp/$sap_slice_cfg $systemd_path/$sap_slice_cfg";
+    my $sap_slice_cfg = 'SAP.slice';
+    assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/$sap_slice_cfg -o $systemd_path/$sap_slice_cfg";
     assert_script_run "cat $systemd_path/$sap_slice_cfg";
     systemctl('daemon-reload');
 


### PR DESCRIPTION
This PR fixes the WMP SAP test.
The last `sapwmp` package introduced some changes that we have to cover in our test.

- Related ticket: N/A
- Needles: N/A
- Verification run: [node1](http://1a102.qa.suse.de/tests/5406) [node2](http://1a102.qa.suse.de/tests/5407) [supportserver](http://1a102.qa.suse.de/tests/5405)

Python code already fixed [here](https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/commit/471b839431f03a1cb2c1ef7726b12e6235f161f1).