### PR TITLE
Add SecureBoot status check to boot_ltp

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -45,6 +45,11 @@ sub run {
 
     $self->select_serial_terminal;
 
+    if (get_var('SECUREBOOT')) {
+        my $sbstate = script_output('efivar -dn 8be4df61-93ca-11d2-aa0d-00e098032b8c-SecureBoot');
+        die 'SecureBoot is not enabled' if $sbstate !~ m/^[0-9]+/i || $sbstate == 0;
+    }
+
     download_whitelist if get_var('LTP_KNOWN_ISSUES');
 
     # check kGraft patch if KGRAFT=1

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -325,6 +325,8 @@ sub run {
         install_from_repo();
     }
 
+    zypper_call('in efivar') if is_sle('12+') || is_opensuse;
+
     $grub_param .= ' console=hvc0'     if (get_var('ARCH') eq 'ppc64le');
     $grub_param .= ' console=ttysclp0' if (get_var('ARCH') eq 's390x');
     if (!is_sle('<12') && defined $grub_param) {


### PR DESCRIPTION
Make sure that SecureBoot tests don't accidentally boot from HDD image that has SecureBoot disabled. The test would pass just fine but the results would be useless.

- Related ticket: N/A
- Needles: N/A
- Verification runs: see below

`ltp_syscalls_secureboot` is expected to pass the SecureBoot check but fail when switching to LTP work directory. This is because the job installs LTP on the fly and I had to disable the installation because the incident repo was already purged. There is no usable kernel incident open at the moment.