### PR TITLE
Remove /tmp as subvolume in profile validation

### DIFF
--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_64bit_opensuse.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_64bit_opensuse.yaml
@@ -1,0 +1,67 @@
+paths:
+  - /var/lib/gdm/.bashrc
+  - /var/lib/empty/.bashrc
+  - /var/lib/polkit/.bashrc
+  - /var/lib/nobody/.bashrc
+  - /var/lib/pulseaudio/.bashrc
+device: vda
+table_type: gpt
+file_system:
+  /: btrfs
+swap: 1
+profile:
+  partitioning:
+    - drive:
+        unique_key: device
+        device: /dev/vda
+        disklabel: gpt
+        enable_snapshots: 'true'
+        partitions:
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 1
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 2
+              filesystem: btrfs
+              mount: /
+              subvolumes:
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: usr/local
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'false'
+                    path: var
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: srv
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: root
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: home
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: opt
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: boot/grub2/i386-pc
+                - subvolume:
+                    unique_key: path
+                    copy_on_write: 'true'
+                    path: boot/grub2/x86_64-efi
+              subvolumes_prefix: '@'
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 3
+              filesystem: swap
+              mount: swap
+        type: CT_DISK


### PR DESCRIPTION
According to https://en.opensuse.org/openSUSE:Tmp_on_tmpfs we can
remove /tmp as subvolume when validating cloned AutoYaST profile.

See [poo#70387](https://progress.opensuse.org/issues/70387)
Verification run: [autoyast_reinstall_gnome](http://rivera-workstation.suse.cz/tests/1266#step/verify_cloned_profile/6)