### PR TITLE
Add to modify update_package.pm as it is missing in PR#10849

### DIFF
--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -18,6 +18,7 @@ use testapi;
 use lockapi;
 use mmapi;
 use virt_utils 'upload_supportconfig_log';
+use virt_autotest::utils qw(is_xen_host);
 
 sub run {
     my ($self) = @_;
@@ -33,7 +34,7 @@ sub run {
     my $src_ip       = $self->get_var_from_child("SRC_IP");
     my $src_user     = $self->get_var_from_child("SRC_USER");
     my $src_pass     = $self->get_var_from_child("SRC_PASS");
-    my $hypervisor   = get_var("HOST_HYPERVISOR", "kvm");
+    my $hypervisor   = (is_xen_host) ? 'xen' : 'kvm';
     my $args         = "-d $src_ip -v $hypervisor -u $src_user -p $src_pass";
     my $pre_test_cmd = "/usr/share/qa/virtautolib/lib/guest_migrate.sh " . $args;
     type_string("$pre_test_cmd \n");

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -20,6 +20,7 @@ use mmapi;
 use virt_utils;
 use Data::Dumper;
 use Utils::Architectures;
+use virt_autotest::utils qw(is_xen_host);
 
 sub get_script_run {
     my ($self) = @_;
@@ -28,8 +29,8 @@ sub get_script_run {
     my $dst_user = $self->get_var_from_parent('DST_USER');
     my $dst_pass = $self->get_var_from_parent('DST_PASS');
     handle_sp_in_settings_with_sp0("GUEST_LIST");
-    my $guests       = get_var("GUEST_LIST",       "");
-    my $hypervisor   = get_var("HOST_HYPERVISOR",  "kvm");
+    my $guests       = get_var("GUEST_LIST", "");
+    my $hypervisor   = (is_xen_host) ? 'xen' : 'kvm';
     my $test_time    = get_var("MAX_MIGRATE_TIME", "10800") - 90;
     my $args         = "-d $dst_ip -v $hypervisor -u $dst_user -p $dst_pass -i \"$guests\" -t $test_time";
     my $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-guest-migrate-run " . $args;
@@ -135,7 +136,7 @@ sub run {
 
     # clean up logs from prevous tests
     $self->execute_script_run('[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/',     30) if !get_var('SKIP_GUEST_INSTALL');
-    $self->execute_script_run('[ -d /var/log/qa/ctcs2/ ] && rm -r /var/log/qa/ctcs2/*',                     30);
+    $self->execute_script_run('[ -d /var/log/qa/ctcs2/ ] && rm -rf /var/log/qa/ctcs2/',                     30);
     $self->execute_script_run('[ -d /tmp/prj3_migrate_admin_log/ ] && rm -rf /tmp/prj3_migrate_admin_log/', 30);
 
     $self->run_test($timeout, "", "yes", "yes", "$log_dirs", "$upload_log_name");

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -18,6 +18,7 @@ use testapi;
 use virt_utils;
 use utils;
 use Utils::Backends 'is_remote_backend';
+use virt_autotest::utils qw(is_xen_host);
 
 sub install_package {
 
@@ -93,7 +94,7 @@ sub install_package {
     }
 
     if (get_var("PROXY_MODE")) {
-        if (get_var("XEN")) {
+        if (is_xen_host) {
             zypper_call("in -t pattern xen_server", 1800);
         }
     }

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -18,6 +18,7 @@ use File::Basename;
 use testapi;
 use Utils::Backends qw(use_ssh_serial_console is_remote_backend);
 use ipmi_backend_utils;
+use virt_autotest::utils qw(is_xen_host);
 use IPC::Run;
 
 sub login_to_console {
@@ -77,7 +78,7 @@ sub login_to_console {
     }
 
     if (!get_var("reboot_for_upgrade_step")) {
-        if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+        if (is_xen_host) {
             #send key 'up' to stop grub timer counting down, to be more robust to select xen
             send_key 'up';
             save_screenshot;

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -20,6 +20,7 @@ use ipmi_backend_utils;
 use Utils::Backends 'is_remote_backend';
 use Utils::Architectures;
 use version_utils 'is_sle';
+use virt_autotest::utils qw(is_xen_host is_kvm_host);
 
 sub update_package {
     my $self           = shift;
@@ -51,10 +52,10 @@ sub update_package {
 
 sub run {
     my $self = shift;
-    $self->update_package() unless (is_sle('=15-SP2') && (check_var("HOST_HYPERVISOR", "xen") || check_var("SYSTEM_ROLE", "xen")));
+    $self->update_package() unless is_sle('=15-SP2') && is_xen_host;    #workaroud: skip update package as there are conflicts on sles15sp2 XEN
     if (!check_var('ARCH', 's390x')) {
-        set_serial_console_on_vh('', '', 'xen') if (get_var("XEN")                      || check_var("HOST_HYPERVISOR", "xen"));
-        set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE",     "kvm"));
+        set_serial_console_on_vh('', '', 'xen') if is_xen_host;
+        set_serial_console_on_vh('', '', 'kvm') if is_kvm_host;
     }
     update_guest_configurations_with_daily_build();
     if (is_remote_backend && check_var('ARCH', 'aarch64') && !check_var('LINUX_CONSOLE_OVERRIDE', 'ttyAMA0') && (get_var('VIRT_PRJ2_HOST_UPGRADE') || get_var('VIRT_PRJ4_GUEST_UPGRADE'))) {

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -40,10 +40,10 @@ sub update_package {
         upload_asset "/tmp/update_virt_rpms.log", 1, 1;
     }
     else {
-        $ret = $self->execute_script_run($update_pkg_cmd, 7200);
+        $self->execute_script_run($update_pkg_cmd, 7200);
         upload_logs("/tmp/update_virt_rpms.log");
         save_screenshot;
-        if ($ret !~ /Need to reboot system to make the rpms work/m) {
+        if ($self->{script_output} !~ /Need to reboot system to make the rpms work/m) {
             die " Update virt rpms fail, going to terminate following test!";
         }
     }


### PR DESCRIPTION
two commit:

- Use is_xen_host instead of reading test suite settings
- Add to modify update_package.pm as it is missing in [PR#10849 Log Enhancement -- Traditional projects post_fail_hook transformation](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10849)

@alice-suse @xguo @waynechen55

- Failures in OSD: https://openqa.nue.suse.com/tests/4673809#step/update_package/9
- Verification run: https://openqa.suse.de/tests/4674006#
