### PR TITLE
Install kernel-default-extra if needed in libgpiod module boo#1176090

### DIFF
--- a/tests/console/libgpiod.pm
+++ b/tests/console/libgpiod.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use utils;
 use Utils::Architectures qw(is_aarch64 is_arm);
+use version_utils qw(is_sle is_leap);
 
 sub run {
     select_console 'root-console';
@@ -28,6 +29,11 @@ sub run {
 
     record_info('gpiochip', "$gpiochipX");
 
+    my $version = get_var('VERSION', '');
+    if (is_sle || is_leap('>15.2') || $version =~ /^Jump/) {
+        record_info('kernel extra', 'boo#1176090 install kernel-default-extra');
+        zypper_call 'in kernel-default-extra';
+    }
     # Create a fake $gpiochipX, with 32 lines
     assert_script_run("modprobe gpio_mockup gpio_mockup_ranges=-1,32");
     # Check that $gpiochipX is found, with 32 lines


### PR DESCRIPTION
This is at least required for Jump
to avoid gpio-mockup modprobe failure.
https://bugzilla.opensuse.org/show_bug.cgi?id=1176090

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1176090
- Needles: none
- Verification run: 
Jump15.2: to verify install kernel-default-extra
  x86_64: https://openqa.opensuse.org/tests/1394404#step/libgpiod/8
  ppc64le: https://openqa.opensuse.org/tests/1394460#step/libgpiod/13
  aarch64: https://openqa.opensuse.org/tests/1394405#step/libgpiod/8
TW: to verify no install kernel-default-extra
  ppc64le: https://openqa.opensuse.org/tests/1394463#step/libgpiod/8
 
