### PR TITLE
Implement test for PAM module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2442,6 +2442,16 @@ sub load_security_tests_check_kernel_config {
     loadtest "security/check_kernel_config/CC_STACKPROTECTOR_STRONG";
 }
 
+sub load_security_tests_pam {
+    load_security_console_prepare;
+
+    loadtest "security/pam/pam_basic_function";
+    loadtest "security/pam/pam_login";
+    loadtest "security/pam/pam_su";
+    loadtest "security/pam/pam_config";
+    loadtest "security/pam/pam_mount";
+}
+
 sub load_security_tests_tpm2 {
     if (is_sle('>=15-SP2')) {
         load_security_console_prepare;
@@ -2552,6 +2562,7 @@ sub load_security_tests {
       system_check
       check_kernel_config
       tpm2
+      pam
     );
 
     # Check SECURITY_TEST and call the load functions iteratively.

--- a/tests/security/pam/pam_basic_function.pm
+++ b/tests/security/pam/pam_basic_function.pm
@@ -1,0 +1,63 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Basic function check for PAM, and prepare the setup for other
+#          pam tests, e.g., create user, install some packages
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#70345, tc#1767569
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Install the pam-config package, and make sure it can list all modules
+    zypper_call 'in pam-config';
+    assert_script_run 'rpm -qi pam';
+    assert_script_run 'pam-config --list-modules';
+
+    # Make sure all corresponding files are there
+    assert_script_run 'ls /etc/pam.d';
+    assert_script_run 'ls /lib64/security';
+    assert_script_run 'ls /etc/security';
+
+    # Make sure the binaries are controlled by PAM
+    assert_script_run 'ldd `which login` | grep pam';
+    assert_script_run 'ldd `which su `| grep pam';
+    assert_script_run 'ldd `which passwd` | grep pam';
+
+    # Add user "suse",and use this user for later tests
+    my $user   = 'suse';
+    my $passwd = 'susetesting';
+    assert_script_run "useradd -d /home/$user -m $user";
+    assert_script_run "echo $user:$passwd | chpasswd";
+
+    # Install expect package for later tests
+    zypper_call 'in expect';
+
+    # Backup the /etc/pam.d directory
+    assert_script_run 'cp -pr /etc/pam.d /mnt';
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/security/pam/pam_config.pm
+++ b/tests/security/pam/pam_config.pm
@@ -1,0 +1,61 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: PAM tests for pam-config, create, add or delete service
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#70345, tc#1767580
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use registration qw(add_suseconnect_product remove_suseconnect_product);
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Create a simple Unix authentication configuration, all backup files will not be deleted
+    assert_script_run 'pam-config --create';
+    assert_script_run 'ls /etc/pam.d | grep config-backup';
+
+    # Add a new authentication method, add the module to install the "pam_ldap" package
+    add_suseconnect_product('sle-module-legacy');
+    zypper_call 'in pam_ldap';
+    assert_script_run 'pam-config --add --ldap';
+    assert_script_run 'find /etc/pam.d -type f | grep common | xargs egrep ldap';
+    assert_script_run 'pam-config --add --ldap-debug';
+    assert_script_run 'journalctl | grep ldap';
+
+    # Delete a method
+    assert_script_run 'pam-config --delete --ldap';
+    assert_script_run 'pam-config --delete --ldap-debug';
+    validate_script_output "find /etc/pam.d -type f | grep common | xargs egrep ldap || echo 'check pass'", sub { m/check pass/ };
+    upload_logs("/var/log/messages");
+
+    # Tear down, remove the added module
+    remove_suseconnect_product('sle-module-legacy');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+sub post_fail_hook {
+    assert_script_run 'cp -pr /mnt/pam.d /etc';
+}
+
+1;

--- a/tests/security/pam/pam_login.pm
+++ b/tests/security/pam/pam_login.pm
@@ -1,0 +1,86 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: PAM tests for login, user login should fail without authentication
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#70345, tc#1767577
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Define the user and password, which are already configured in previous milestone
+    my $user   = 'suse';
+    my $passwd = 'susetesting';
+
+    # Modify the login/sshd files to set the PAM authentication
+    my $deny_user_file = '/etc/deniedusers';
+    my $pam_sshd       = '/etc/pam.d/sshd';
+    my $pam_login      = '/etc/pam.d/login';
+    my $pam_sshd_bak   = '/tmp/sshd_bak';
+    my $pam_login_bak  = '/tmp/login_bak';
+    assert_script_run "echo $user > $deny_user_file";
+    assert_script_run "cp $pam_sshd $pam_sshd_bak";
+    assert_script_run "cp $pam_login $pam_login_bak";
+    assert_script_run "sed -i '\$a auth      required   pam_listfile.so   onerr=succeed  item=user  sense=deny  file=$deny_user_file' $pam_sshd";
+    assert_script_run "sed -i '\$a auth      required   pam_listfile.so   onerr=succeed  item=user  sense=deny  file=$deny_user_file' $pam_login";
+    upload_logs($pam_sshd);
+    upload_logs($pam_login);
+
+    # Try to login to the OS with user suse, access should fail
+    assert_script_run(
+        "expect -c 'spawn ssh $user\@localhost; \\
+expect \"Password: \"; send \"$passwd\\n\"; \\
+expect \"Password: \"; send \"$passwd\\n\"; \\
+expect \"Password: \"; send \"$passwd\\n\"; \\
+expect \"*password: \"; send \"$passwd\\n\"; \\
+expect \"*password: \"; send \"$passwd\\n\"; \\
+expect {
+    \"*authentication failures\" {
+      exit 0
+   }
+   eof {
+       exit 1
+   }
+}'"
+    );
+
+    # Make sure your current user is not "suse"
+    validate_script_output "whoami | grep $user|| echo 'check pass'", sub { m/check pass/ };
+
+    # Make sure login can succeed for user who is not defined in deny user file
+    my $new_user = 'bernhard';
+    assert_script_run "ssh -4v $new_user\@localhost bash -c 'whoami | grep $new_user'";
+
+    # Tear down, clear pam configuration changes
+    assert_script_run "rm -rf $deny_user_file";
+    assert_script_run "mv $pam_sshd_bak $pam_sshd";
+    assert_script_run "mv $pam_login_bak $pam_login";
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+sub post_fail_hook {
+    assert_script_run 'cp -pr /mnt/pam.d /etc';
+}
+
+1;

--- a/tests/security/pam/pam_mount.pm
+++ b/tests/security/pam/pam_mount.pm
@@ -1,0 +1,135 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: PAM tests for pam-mount, the encrypted volume should be mounted
+#          and unmounted during user login and logout
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#70345, tc#1767581
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use utils 'script_run_interactive';
+use base 'consoletest';
+
+sub run {
+    # There is some issue with script_run_interactive script,
+    # it fails to match the serial console output sometimes,
+    # so switch to root-console here
+    select_console 'root-console';
+
+    # Install the pam-mount package, since this service package is not installed by default
+    zypper_call 'in pam_mount';
+
+    # Define the uesr and encrypt key for the volume
+    my $user     = 'bernhard';
+    my $key      = 'SUSE_t595_qw';
+    my $testfile = 'testfile';
+    my $loopdev  = script_output 'losetup -f';
+    my $loop_vol = 'enc_loop';
+
+    # Setup a loop device to be used as encrypted volume
+    assert_script_run "dd if=/dev/zero of=$testfile bs=1024k count=500";
+    assert_script_run "losetup $loopdev $testfile";
+    assert_script_run "losetup -a | grep $testfile";
+    script_run_interactive(
+        "cryptsetup luksFormat --type luks2 $loopdev",
+        [
+            {
+                prompt => qr/Are you sure.*/m,
+                string => "YES\n",
+            },
+            {
+                prompt => qr/Enter passphrase.*/m,
+                string => "$key\n",
+            },
+            {
+                prompt => qr/Verify passphrase.*/m,
+                string => "$key\n",
+            },
+        ],
+        400
+    );
+
+    # Create file "/etc/pam_mount_keys/enc_key" with a password contained
+    my $key_dir  = '/etc/pam_mount_keys';
+    my $key_file = 'enc_key';
+    assert_script_run "mkdir -p $key_dir";
+    assert_script_run "echo '$key' > $key_dir/$key_file";
+    assert_script_run(
+        "expect -c 'spawn cryptsetup luksAddKey $loopdev $key_dir/$key_file; \\
+expect \"Enter any existing passphrase: \"; send \"$key\\n\"; interact'"
+    );
+    assert_script_run(
+        "expect -c 'spawn cryptsetup luksOpen $loopdev $loop_vol; \\
+expect \"Enter passphrase for \/dev\/$loopdev: \"; send \"$key\\n\"; interact'"
+    );
+    assert_script_run "mkfs.ext4 -L $user /dev/mapper/$loop_vol";
+    assert_script_run "cryptsetup luksClose $loop_vol";
+
+    # Configure the "/etc/security/pam_mount.conf.xml" file
+    my $pam_mount_cfg     = '/etc/security/pam_mount.conf.xml';
+    my $pam_mount_cfg_bak = '/etc/security/pam_mount.conf.xml.bak';
+    assert_script_run "cp $pam_mount_cfg $pam_mount_cfg_bak";
+    assert_script_run "sed -i '/<pam_mount>/,/<\\/pam_mount>/d' $pam_mount_cfg";
+    assert_script_run(
+        "echo \"\$(cat <<EOF
+<pam_mount>
+  <volume user=\"$user\" path=\"$loopdev\" mountpoint=\"~\" fstype=\"crypt\" fskeycipher=\"none\" fskeyhash=\"md5\" fskeypath=\"$key_dir/$key_file\" />
+</pam_mount>
+EOF
+        )\" >> $pam_mount_cfg"
+    );
+
+    # Modify the pam common-session and common-auth files
+    my $pam_session     = '/etc/pam.d/common-session';
+    my $pam_session_bak = '/etc/pam.d/common-session.bak';
+    my $pam_auth        = '/etc/pam.d/common-auth';
+    my $pam_auth_bak    = '/etc/pam.d/common-auth.bak';
+    assert_script_run "cp $pam_session $pam_session_bak";
+    assert_script_run "cp $pam_auth $pam_auth_bak";
+    assert_script_run "sed -i '\$a session \[success=1 default=ignore\] pam_succeed_if.so service = systemd-user' $pam_session";
+    assert_script_run "sed -i '\$a session optional        pam_mount.so   disable_interactive' $pam_session";
+    assert_script_run "sed -i '\$a auth \[success=1 default=ignore\] pam_succeed_if.so service = systemd-user' $pam_auth";
+    assert_script_run "sed -i '\$a auth    optional        pam_mount.so   disable_interactive' $pam_auth";
+    upload_logs($pam_auth);
+    upload_logs($pam_session);
+    upload_logs($pam_mount_cfg);
+
+    # Test and make sure user's home directory can mount/unmount during login/logout
+    type_string "su - $user\n";
+    assert_script_run "df -k | grep /home/$user";
+    type_string "exit\n";
+    validate_script_output "df -k | grep /home/$user || echo 'check pass'", sub { m/check pass/ };
+
+    # Tear down, clear the pam configuration changes
+    assert_script_run "mv $pam_session_bak $pam_session";
+    assert_script_run "mv $pam_auth_bak $pam_auth";
+    assert_script_run "mv $pam_mount_cfg_bak $pam_mount_cfg";
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+sub post_fail_hook {
+    select_console 'root-console';
+    assert_script_run 'cp -pr /mnt/pam.d /etc';
+}
+
+1;
+

--- a/tests/security/pam/pam_su.pm
+++ b/tests/security/pam/pam_su.pm
@@ -1,0 +1,82 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: PAM tests for su, su to root should fail if user is not in group "wheel"
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#70345, tc#1167579
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use base 'consoletest';
+use utils 'clear_console';
+
+sub run {
+    select_console 'root-console';
+
+    # User will not be able to su to root since it is not belong to group "wheel"
+    my $user   = 'bernhard';
+    my $passwd = 'nots3cr3t';
+    my $group  = 'wheel';
+    validate_script_output "id $user | grep $group || echo 'check pass'", sub { m/check pass/ };
+
+    # Modify the PAM configuration files
+    my $su_file      = '/etc/pam.d/su';
+    my $su_file_bak  = '/tmp/su';
+    my $sul_file     = '/etc/pam.d/su-l';
+    my $sul_file_bak = '/tmp/su-l';
+    assert_script_run "cp $su_file $su_file_bak";
+    assert_script_run "cp $sul_file $sul_file_bak";
+    assert_script_run "sed -i '\$a auth     required       pam_wheel.so use_uid' $su_file";
+    assert_script_run "sed -i '\$a auth     required       pam_wheel.so use_uid' $sul_file";
+    upload_logs($su_file);
+    upload_logs($sul_file);
+
+    # Switch to user console
+    clear_console;
+    select_console 'user-console';
+
+    # Then su to root should fail
+    assert_script_run "expect -c 'spawn su - root; \\
+expect \"Password: \"; send \"$passwd\\n\"; \\
+expect {
+    \"*Permission denied\" {
+      exit 0
+   }
+   eof {
+       exit 1
+   }
+}'";
+
+    # Make sure your current user "suse"
+    validate_script_output "whoami | grep $user && echo 'check pass'", sub { m/check pass/ };
+    # Tear down, clear the pam configuration changes
+    clear_console;
+    select_console 'root-console';
+    assert_script_run "mv $su_file_bak $su_file";
+    assert_script_run "mv $sul_file_bak $sul_file";
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+sub post_fail_hook {
+    select_console 'root-console';
+    assert_script_run 'cp -pr /mnt/pam.d /etc';
+}
+
+1;


### PR DESCRIPTION
Implement test for pam.
I added some basic function tests for PAM module, for example, "su", "login", "pam_config" and "pam_mount". 
At the same time, in"pam_mount" test, I covered the test case mentioned in bugs below:

https://bugzilla.suse.com/show_bug.cgi?id=1153627
https://bugzilla.suse.com/show_bug.cgi?id=1153630

- Related ticket: https://progress.opensuse.org/issues/70345
- Needles: N/A
- Verification run: http://10.67.17.9/tests/307