### PR TITLE
Remove "alt-shift-d" hotkey to enter firefox security device via Needles match in firefox_nss

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -63,12 +63,15 @@ sub run {
     send_key "tab";
     wait_still_screen 2;
 
-    send_key "alt-shift-d";        # Device Manager
+    # Change from "alt-shift-d" hotkey to needles match Security Device
+    # send_key "alt-shift-d" is fail to react in s390x/aarch64 usually
+    assert_and_click('firefox-click-security-device');
+
     assert_screen "firefox-device-manager";
 
-    send_key "alt-shift-f";        # Enable FIPS mode
+    send_key "alt-shift-f";    # Enable FIPS mode
     assert_screen "firefox-confirm-fips_enabled";
-    send_key "esc";                # Quit device manager
+    send_key "esc";            # Quit device manager
 
     quit_firefox;
     assert_screen "generic-desktop";
@@ -89,7 +92,11 @@ sub run {
     type_string "certificates";    # Search "Certificates" section
     send_key "tab";
     wait_still_screen 2;
-    send_key "alt-shift-d";        # Device Manager
+
+    # Change from "alt-shift-d" hotkey to needles match Security Device
+    # send_key "alt-shift-d" is fail to react in s390x/aarch64 usually
+    assert_and_click('firefox-click-security-device');
+
     assert_screen "firefox-device-manager";
     assert_screen "firefox-confirm-fips_enabled";
 


### PR DESCRIPTION
1. Change from "alt-shift-d" hotkey usage to needles match Security Device
2. Fix the send_key "alt-shift-d" is fail to react in s390x/aarch64 usually
3. The problem cannot be reproduced in x86_64

- Related ticket: https://progress.opensuse.org/issues/71299
- Needles: Needles Merged
- Verification run: 
  SLE15 SP3 x86_64 - https://openqa.suse.de/tests/4681516 (no regression)
  SLE15 SP3 s390x - https://openqa.suse.de/t4674425
  SLE15 SP2 QAM - https://openqa.suse.de/t4681370