### PR TITLE
Stop clamav daemons after test is done

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -98,6 +98,8 @@ sub run {
 
 sub post_run_hook {
     assert_script_run("swapoff /var/lib/swap/swapfile") if is_jeos && !(is_opensuse && check_var('ARCH', 'aarch64'));
+    systemctl('stop clamd', timeout => 500);
+    systemctl('stop freshclam');
 }
 
 sub test_flags {


### PR DESCRIPTION
Clamav daemon is causing reboot on SLE 15 s390x being too slow

- Related ticket: https://openqa.suse.de/tests/4618657
- Verification run: https://openqa.suse.de/tests/4680942#next_previous