### PR TITLE
Fix yamls and autoyast for aarch64

### DIFF
--- a/data/autoyast_qam/12_installation.xml.ep
+++ b/data/autoyast_qam/12_installation.xml.ep
@@ -203,12 +203,58 @@
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
   </general>
+  % if ($check_var->('ARCH', 'aarch64')) {
   <partitioning config:type="list">
-  <drive>
+    <drive>
+      <initialize config:type="boolean">true</initialize>
+      <use>all</use>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">vfat</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/boot/efi</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">259</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>300M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>max</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>2G</size>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
+  % }
+  % unless ($check_var->('ARCH', 'aarch64')) {
+  <partitioning config:type="list">
+    <drive>
     <initialize config:type="boolean">true</initialize>
     <use>all</use>
     </drive>
   </partitioning>
+  % }
   <networking>
     <interfaces config:type="list">
       <interface>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -63,10 +63,11 @@ sub expand_patterns {
         }
         elsif (is_sle('12+') && check_var('SLE_PRODUCT', 'sles')) {
             my @sle12;
-            push @sle12, qw(Minimal apparmor base documentation 32bit)                 if check_var('DESKTOP', 'textmode');
-            push @sle12, qw(Minimal apparmor base x11 documentation gnome-basic 32bit) if check_var('DESKTOP', 'gnome');
-            push @sle12, qw(desktop-base desktop-gnome)                                if get_var('SCC_ADDONS') =~ m/we/;
-            push @sle12, qw(yast2)                                                     if is_sle('>=12-sp3');
+            push @sle12, qw(Minimal apparmor base documentation)                 if check_var('DESKTOP', 'textmode');
+            push @sle12, qw(Minimal apparmor base x11 documentation gnome-basic) if check_var('DESKTOP', 'gnome');
+            push @sle12, qw(desktop-base desktop-gnome)                          if get_var('SCC_ADDONS') =~ m/we/;
+            push @sle12, qw(yast2)                                               if is_sle('>=12-sp3');
+            push @sle12, qw(32bit)                                               if !check_var('ARCH', 'aarch64') && get_var('DESKTOP') =~ /gnome|textmode/;
             return [@sle12];
         }
         # SLED12 has different patterns

--- a/schedule/qam/12-SP4/qam-gnome.yaml
+++ b/schedule/qam/12-SP4/qam-gnome.yaml
@@ -2,7 +2,7 @@
 name: qam-gnome
 schedule:
 - autoyast/prepare_profile
-- '{{boot}}'
+- installation/bootloader_start
 - autoyast/installation
 - autoyast/console
 - autoyast/login
@@ -60,18 +60,13 @@ schedule:
 - shutdown/cleanup_before_shutdown
 - shutdown/shutdown
 conditional_schedule:
-  boot:
-    ARCH:
-      s390x:
-        - installation/bootloader_zkvm
-      x86_64:
-        - installation/isosize
-        - installation/bootloader
   grub:
     ARCH:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   x86_64_tests:
     ARCH:

--- a/schedule/qam/12-SP4/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP4/qam-minimal-base.yaml
@@ -1,7 +1,7 @@
 ---
 name: qam-minimal-base
 schedule:
-- '{{boot}}'
+- installation/bootloader_start
 - installation/welcome
 - installation/accept_license
 - installation/scc_registration
@@ -61,13 +61,6 @@ schedule:
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
-  boot:
-    ARCH:
-      s390x:
-        - installation/bootloader_zkvm
-      x86_64:
-        - installation/isosize
-        - installation/bootloader
   system_role:
     ARCH:
       x86_64:
@@ -77,6 +70,8 @@ conditional_schedule:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   glibc_sanity:
     ARCH:

--- a/schedule/qam/12-SP5/qam-gnome.yaml
+++ b/schedule/qam/12-SP5/qam-gnome.yaml
@@ -2,7 +2,7 @@
 name: qam-gnome
 schedule:
 - autoyast/prepare_profile
-- '{{boot}}'
+- installation/bootloader_start
 - autoyast/installation
 - autoyast/console
 - autoyast/login
@@ -72,6 +72,8 @@ conditional_schedule:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   x86_64_tests:
     ARCH:

--- a/schedule/qam/12-SP5/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-base.yaml
@@ -1,7 +1,7 @@
 ---
 name: qam-minimal-base
 schedule:
-- '{{boot}}'
+- installation/bootloader_start
 - installation/welcome
 - installation/accept_license
 - installation/scc_registration
@@ -61,18 +61,13 @@ schedule:
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
-  boot:
-    ARCH:
-      s390x:
-        - installation/bootloader_zkvm
-      x86_64:
-        - installation/isosize
-        - installation/bootloader
   grub:
     ARCH:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   glibc_sanity:
     ARCH:

--- a/schedule/qam/15-SP1/qam-gnome.yaml
+++ b/schedule/qam/15-SP1/qam-gnome.yaml
@@ -2,7 +2,7 @@
 name: qam-gnome
 schedule:
 - autoyast/prepare_profile
-- '{{boot}}'
+- installation/bootloader_start
 - autoyast/installation
 - autoyast/console
 - autoyast/login
@@ -73,6 +73,8 @@ conditional_schedule:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   x86_64_tests:
     ARCH:

--- a/schedule/qam/15-SP1/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP1/qam-minimal-base.yaml
@@ -1,7 +1,7 @@
 ---
 name: qam-minimal-base
 schedule:
-- '{{boot}}'
+- installation/bootloader_start
 - installation/welcome
 - installation/accept_license
 - installation/scc_registration
@@ -74,6 +74,8 @@ conditional_schedule:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   glibc_sanity:
     ARCH:

--- a/schedule/qam/15-SP2/qam-gnome.yaml
+++ b/schedule/qam/15-SP2/qam-gnome.yaml
@@ -2,7 +2,7 @@
 name: qam-gnome
 schedule:
 - autoyast/prepare_profile
-- '{{boot}}'
+- installation/bootloader_start
 - autoyast/installation
 - autoyast/console
 - autoyast/login
@@ -61,13 +61,6 @@ schedule:
 - shutdown/cleanup_before_shutdown
 - shutdown/shutdown
 conditional_schedule:
-  boot:
-    ARCH:
-      s390x:
-        - installation/bootloader_zkvm
-      x86_64:
-        - installation/isosize
-        - installation/bootloader
   grub:
     ARCH:
       s390x:

--- a/schedule/qam/15-SP2/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP2/qam-minimal-base.yaml
@@ -1,7 +1,7 @@
 ---
 name: qam-minimal-base
 schedule:
-- '{{boot}}'
+- installation/bootloader_start
 - installation/welcome
 - installation/accept_license
 - installation/scc_registration
@@ -62,18 +62,13 @@ schedule:
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
-  boot:
-    ARCH:
-      s390x:
-        - installation/bootloader_zkvm
-      x86_64:
-        - installation/isosize
-        - installation/bootloader
   grub:
     ARCH:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   glibc_sanity:
     ARCH:

--- a/schedule/qam/15/qam-gnome.yaml
+++ b/schedule/qam/15/qam-gnome.yaml
@@ -2,7 +2,7 @@
 name: qam-gnome
 schedule:
 - autoyast/prepare_profile
-- '{{boot}}'
+- installation/bootloader_start
 - autoyast/installation
 - autoyast/console
 - autoyast/login
@@ -61,18 +61,13 @@ schedule:
 - shutdown/cleanup_before_shutdown
 - shutdown/shutdown
 conditional_schedule:
-  boot:
-    ARCH:
-      s390x:
-        - installation/bootloader_zkvm
-      x86_64:
-        - installation/isosize
-        - installation/bootloader
   grub:
     ARCH:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   x86_64_tests:
     ARCH:

--- a/schedule/qam/15/qam-minimal-base.yaml
+++ b/schedule/qam/15/qam-minimal-base.yaml
@@ -1,7 +1,7 @@
 ---
 name: qam-minimal-base
 schedule:
-- '{{boot}}'
+- installation/bootloader_start
 - installation/welcome
 - installation/accept_license
 - installation/scc_registration
@@ -62,18 +62,13 @@ schedule:
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
-  boot:
-    ARCH:
-      s390x:
-        - installation/bootloader_zkvm
-      x86_64:
-        - installation/isosize
-        - installation/bootloader
   grub:
     ARCH:
       s390x:
         - boot/reconnect_mgmt_console
       x86_64:
+        - installation/grub_test
+      aarch64:
         - installation/grub_test
   glibc_sanity:
     ARCH:


### PR DESCRIPTION
Also add missing grub_test on aarch64

- Related ticket: https://progress.opensuse.org/issues/70276
- Verification run:
https://openqa.suse.de/tests/4682341#next_previous qam-gnome 15-SP2
https://openqa.suse.de/tests/4682342#next_previous qam-minimal+base 15-SP2
https://openqa.suse.de/tests/4688551 12-SP5 no 32bit pattern & efi boot autoyast change