### PR TITLE
Unschedule GPT test for RPi

### DIFF
--- a/schedule/jeos/sle/rpi/jeos-main.yaml
+++ b/schedule/jeos/sle/rpi/jeos-main.yaml
@@ -36,7 +36,6 @@ schedule:
   - console/yast2_bootloader
   - console/vim
   - console/firewall_enabled
-  - console/gpt_ptable
   - console/kdump_disabled
   - console/slp
   - console/sshd_running


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/71065
Verification:  https://openqa.suse.de/t4682904

Verified with afaerber that this is expected due to RPi firmware compatibility.