### PR TITLE
Fix aarch64 zdup to boot from hard disk

### DIFF
--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -30,8 +30,9 @@ sub run {
 
     # Reboot from Installer media for upgrade
     # Aarch64 need BOOT_HDD_IMAGE=1 to keep the correct flow to boot from disk for x11/reboot_gnome.
+    # but in Aarch64 zdup migration we need to set it to 0, this will make it boot from hard disk.
     if (get_var('UPGRADE') || get_var('AUTOUPGRADE')) {
-        set_var('BOOT_HDD_IMAGE', 0) unless check_var('ARCH', 'aarch64');
+        set_var('BOOT_HDD_IMAGE', 0) unless (check_var('ARCH', 'aarch64') && !check_var('ZDUP', '1'));
     }
     assert_script_run "sync", 300;
     type_string "reboot\n";


### PR DESCRIPTION
 In Aarch64 ZDUP migration test, before do zdup we need to make it boot from
 hard disk.

- Related ticket: https://progress.opensuse.org/issues/71353
- Needles: N/A
- Verification run: 
https://openqa.nue.suse.com/tests/4685501
https://openqa.nue.suse.com/tests/4746034
https://openqa.nue.suse.com/tests/4746372

run without the unless conditions:
https://openqa.nue.suse.com/tests/4746534
https://openqa.nue.suse.com/tests/4746535
https://openqa.nue.suse.com/tests/4746615
regression:
https://openqa.nue.suse.com/tests/4741889
https://openqa.nue.suse.com/tests/4743678 ->with reboot_gnome passed