### PR TITLE
Schedule rmt test on SLE 15 updates

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -274,7 +274,7 @@ Function to sync rmt server
 
 =cut
 sub rmt_sync {
-    assert_script_run 'rmt-cli sync', 1800;
+    script_retry 'rmt-cli sync', delay => 30, retry => 3, timeout => 1800;
 }
 
 =head2 rmt_enable_pro

--- a/schedule/qam/common/qam-rmt.yaml
+++ b/schedule/qam/common/qam-rmt.yaml
@@ -1,0 +1,6 @@
+name:    qam_rmt
+description:    >
+    Run rmt test for Maintenance Updates
+schedule:
+  - boot/boot_to_desktop
+  - x11/rmt/rmt_feature


### PR DESCRIPTION
**Goal**: Run rmt test as part of maintenance updates

**Changes**:
- Retry 3 times rmt sync before failing to make test more resilient
- Schedule rmt feature test as part of 15.x updates
=================================================
- Related ticket: https://progress.opensuse.org/issues/55784
- Needles: no needles
- Verification run: 
  - 15.2 http://10.161.229.176/tests/16
  - 15.1 http://10.161.229.176/tests/17
  - 15    http://10.161.229.176/tests/18
