### PR TITLE
Get the stderr log from libvirt in case of failure

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -96,6 +96,9 @@ sub post_fail_hook {
     reset_consoles;
     select_console 'svirt';
 
+    upload_logs("/tmp/os-autoinst-openQA-SUT-" . get_var("VIRSH_INSTANCE") . "-stderr.log", failok => 1);
+    type_string "tail /tmp/os-autoinst-openQA-SUT-" . get_var("VIRSH_INSTANCE") . "-stderr.log\n";
+
     # Enter Linuxrc extra mode
     type_line_svirt 'x', expect => 'Linuxrc extras';
 


### PR DESCRIPTION
Help the reviewer to understand better a particular error by uploading the stderrlog from virsh

https://openqa.suse.de/tests/4690743#step/bootloader_zkvm/40