### PR TITLE
Enable autologin in firstboot

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -60,6 +60,8 @@ sub firstboot_timezone {
 sub firstboot_user {
     assert_screen 'local_user';
     enter_userinfo(username => get_var('YAST2_FIRSTBOOT_USERNAME'));
+    # In opensuse, we expect autologin at first boot, not in SLE.
+    wait_screen_change(sub { send_key 'alt-a'; },    7) if is_opensuse;
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
     await_password_check;
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/70597
- Verification run: http://waaa-amazing.suse.cz/tests/12980#
