### PR TITLE
Remove workaround for bug 980337

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -36,7 +36,6 @@ our @EXPORT = qw(
   record_disk_info
   check_rollback_system
   reset_consoles_tty
-  boot_into_ro_snapshot
   set_scc_proxy_url
 );
 
@@ -183,27 +182,6 @@ sub reset_consoles_tty {
     console('x11')->set_tty(get_x11_console_tty);
     console('root-console')->set_tty(get_root_console_tty);
     reset_consoles;
-}
-
-# Assert read-only snapshot before migrated
-# Assert screen 'linux-login' with 200s
-# Workaround known issue: bsc#980337
-# In this case try to select tty1 with multi-times then select root console
-sub boot_into_ro_snapshot {
-    unlock_if_encrypted(check_typed_password => 1);
-    if (!check_screen('linux-login', 200)) {
-        record_soft_failure 'bsc#980337';
-        for (1 .. 10) {
-            check_var('VIRSH_VMM_FAMILY', 'hyperv') ? send_key 'alt-f1' : send_key 'ctrl-alt-f1';
-            if (check_screen('tty1-selected', 12)) {
-                return 1;
-            }
-            else {
-                record_info('not in tty1', 'switch to tty1 failed', result => 'softfail');
-            }
-        }
-        die "Boot into read-only snapshot failed over 5 minutes, considering a product issue";
-    }
 }
 
 # Register the already installed system on a specific SCC server/proxy if needed

--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,14 +15,16 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use migration qw(check_rollback_system boot_into_ro_snapshot);
+use migration 'check_rollback_system';
 use power_action_utils 'power_action';
 use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
 
-    boot_into_ro_snapshot;
+    if (!check_screen 'linux-login', 200) {
+        assert_screen 'displaymanager', 90;
+    }
     select_console 'root-console';
     # 1)
     script_run('touch NOWRITE;test ! -f NOWRITE', 0);

--- a/tests/migration/online_migration/snapper_rollback.pm
+++ b/tests/migration/online_migration/snapper_rollback.pm
@@ -1,6 +1,6 @@
 # SLE12 online migration tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,12 +16,14 @@ use warnings;
 use testapi;
 use power_action_utils 'power_action';
 use version_utils 'is_desktop_installed';
-use migration qw(check_rollback_system boot_into_ro_snapshot);
+use migration 'check_rollback_system';
 
 sub run {
     my ($self) = @_;
 
-    boot_into_ro_snapshot;
+    if (!check_screen 'linux-login', 200) {
+        assert_screen 'displaymanager', 90;
+    }
     select_console 'root-console';
     script_run "snapper rollback";
 


### PR DESCRIPTION
As the bug 980337 is already fixed, we need remove the workaround and update code to match current process.

- Related ticket: https://progress.opensuse.org/issues/63934
- Needles: N/A
- Verification run: 
  http://openqa.suse.de/tests/4692931#step/snapper_rollback/2     # offline SLES15GA
  http://openqa.suse.de/tests/4685480#step/snapper_rollback/2     # online SLES15SP1 online_migration/snapper_rollback
  http://openqa.suse.de/tests/4685451#step/snapper_rollback/1     # offline SLES15SP1 boot/snapper_rollback
  http://openqa.suse.de/tests/4692932#step/snapper_rollback/2     # offline SLES15SP2

  http://openqa.suse.de/tests/4685454#step/snapper_rollback/1    # offline SLES12SP3 ltss
  http://openqa.suse.de/tests/4685456#step/snapper_rollback/1    # offline SLES12SP4 ltss
  https://openqa.suse.de/tests/4685721#step/snapper_rollback/1  # offline SLES12SP5
