### PR TITLE
Get back utt.repo in transactional updates in SLE

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -21,7 +21,7 @@ use warnings;
 use testapi;
 use microos 'microos_reboot';
 use power_action_utils 'power_action';
-use version_utils qw(is_opensuse is_microos);
+use version_utils qw(is_opensuse is_microos is_sle);
 use utils 'reconnect_mgmt_console';
 
 our @EXPORT = qw(
@@ -36,6 +36,9 @@ our @EXPORT = qw(
 
 # Download files needed for transactional update tests
 sub get_utt_packages {
+    # SLE needs an additional repo for testing
+    assert_script_run 'curl -O ' . data_url("microos/utt.repo") if is_sle;
+
     # Different testfiles for SUSE MicroOS and openSUSE MicroOS
     my $tarball = 'utt-';
     $tarball .= is_opensuse() ? 'opensuse' : 'sle';


### PR DESCRIPTION
After [this change](https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/c76dc2ee6318735528a3ed8413deab73c0bd4045#diff-8539d41e20a368f8214c6cfe6fdf48ceL40), it seems that we still need for sle utt.repo to be added to avoid [this](https://openqa.suse.de/tests/4693169#step/transactional_update/61).

Verification run: [x86_64 & ppc64le](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_repo_name_transactional)
