### PR TITLE
[virt_autotest] fix up install_package failure for s390x host

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -29,6 +29,8 @@ use utils;
 use version_utils;
 use testapi;
 use DateTime;
+use Utils::Architectures 'is_s390x';
+use virt_utils;
 
 our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest is_xen_host is_kvm_host check_host check_guest print_cmd_output_to_file
   ssh_setup ssh_copy_id create_guest install_default_packages upload_y2logs ensure_online);
@@ -137,7 +139,11 @@ sub create_guest {
 
 sub install_default_packages {
     # Install nmap, ip, dig
-    zypper_call '-t in nmap iputils bind-utils', exitcode => [0, 4, 102, 103, 106];
+    if (is_s390x()) {
+        lpar_cmd("zypper --non-interactive in nmap iputils bind-utils");
+    } else {
+        zypper_call '-t in nmap iputils bind-utils', exitcode => [0, 4, 102, 103, 106];
+    }
 }
 
 sub ensure_online {


### PR DESCRIPTION
fix up install_package failure for s390x host

Verification run:
[gi-guest_sles15sp2-on-host_developing-kvm@virt-s390x-kvm-sle15sp3](http://10.67.131.5/tests/278)
[gi-guest_sles12sp5-on-host_developing-kvm@virt-s390x-kvm-sle15sp3 ](http://10.67.131.5/tests/277)
[gi-guest_developing-on-host_sles12sp5-kvm@virt-s390x-kvm-sle12sp5](http://10.67.131.5/tests/274)
