### PR TITLE
Clear console after yast module

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -44,6 +44,7 @@ sub run {
         wait_screen_change { send_key 'alt-i'; };
     }
     wait_serial("$module_name-0", timeout => $timeout) || die "'yast2 bootloader' didn't finish";
+    $self->clear_and_verify_console;
 }
 
 1;


### PR DESCRIPTION
There can be ncurse leftovers which can break following needle match

- Fail: https://openqa.suse.de/tests/4693178
- Verification run: http://10.100.12.155/tests/16416