### PR TITLE
Wait more time for confirmlicense

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -89,7 +89,7 @@ sub run {
             return;
         }
         wait_screen_change { send_key 'alt-o' } if match_has_tag('inst-overview-error-found', 0);
-        while (check_screen([qw(confirmlicense startinstall activate_flag_not_set)], 5)) {
+        while (check_screen([qw(confirmlicense startinstall activate_flag_not_set)], 20)) {
             last if match_has_tag("startinstall");
             if (match_has_tag("confirmlicense")) {
                 send_key $cmd{acceptlicense};


### PR DESCRIPTION
Sometimes 5s is not enough to wait for 'confirmlicense', change it to 20s.

- Related ticket: https://progress.opensuse.org/issues/71419
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/4695498#step/start_install/1
