### PR TITLE
Allow to use d:l:R:r for the Rstudio tests

### DIFF
--- a/tests/x11/rstudio_prepare.pm
+++ b/tests/x11/rstudio_prepare.pm
@@ -22,6 +22,20 @@ sub run() {
     # than the default screensaver timeout and cause random failures
     turn_off_screensaver();
 
+    # use the devel:languages:R:released repository for testing a new version of
+    # RStudio before submitting to Factory
+    if (defined get_var("RSTUDIO_USE_DEVEL_LANGUAGES_R_RELEASED")) {
+        # currently this only works on Tumbleweed
+        die unless get_var("VERSION") eq "Tumbleweed";
+        x11_start_program('xterm');
+        become_root();
+        my $repo_url = "https://download.opensuse.org/repositories/devel:/languages:/R:/released/openSUSE_Factory" . (get_var("ARCH") eq "aarch64" ? "_ARM" : "") . "/devel:languages:R:released.repo";
+        zypper_call("addrepo $repo_url");
+        zypper_call("--gpg-auto-import-keys ref");
+
+        send_key_until_needlematch('generic-desktop', "alt-f4");
+    }
+
     # increase timeout to 15 mins, shouldn't take as long, but it occasionally does
     ensure_installed('rstudio MozillaFirefox', timeout => 900);
 


### PR DESCRIPTION
This PR adds a small preparation step so that rstudio can be directly pulled in from `devel:languages:R:released` when the variable `RSTUDIO_USE_DEVEL_LANGUAGES_R_RELEASED` is set. This makes testing of new rstudio releases easier and allows me to submit fixed needles on new upstream releases. The ordinary test runs should not be affected by this.

- Related ticket: none
- Needles: not required
- Verification run: https://openqa.opensuse.org/tests/1395551
