### PR TITLE
Added tests steps for leap to sle zdup migration test

### DIFF
--- a/schedule/migration/leaptosle_zdup.yaml
+++ b/schedule/migration/leaptosle_zdup.yaml
@@ -6,7 +6,7 @@ schedule:
   - migration/record_disk_info
   - migration/reboot_to_upgrade
   - migration/version_switch_upgrade_target
-  - installation/setup_zdup
+  - installation/leap2sle_zdup
   - migration/version_switch_upgrade_target
   - boot/boot_to_desktop
   - boot/grub_test_snapshot

--- a/tests/installation/leap2sle_zdup.pm
+++ b/tests/installation/leap2sle_zdup.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Those are steps for leap to sle zypper dup. Includes: switch to a tty, full patch
+# leap system, install SUSEConnect, Register at SCC to get SLE repo, List and disable all
+# openSUSE repo, add modules need for installation, Migrate installed packages to SLES repo,
+# Remove orphaned packages, reboot the system
+# Maintainer: Yutao Wang <yuwang@suse.com>
+
+use base "installbasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use registration;
+use version_utils 'is_desktop_installed';
+use power_action_utils 'power_action';
+
+sub run {
+    my ($self) = @_;
+
+    $self->wait_boot(textmode => !is_desktop_installed(), bootloader_time => 300, ready_time => 600);
+
+    select_console('root-console');
+    # Create a snapshot with specified description to do snapper rollback
+    assert_script_run "snapper create --type pre --cleanup-algorithm=number --print-number --userdata important=yes --description 'b_zdup migration'";
+
+    systemctl 'set-default --force multi-user.target';
+    fully_patch_system();
+    zypper_call 'in SUSEConnect';
+    my $version = get_var("VERSION");
+    $version =~ s/\-SP/./;
+    add_suseconnect_product("SLES", $version, get_var("ARCH"), " -r " . get_var("SCC_REGCODE"), 300, 1);
+    zypper_call 'lr';
+    zypper_call '-n mr --all --disable';
+    assert_script_run "SUSEConnect --list-extensions";
+    register_product();
+    register_addons_cmd("base,serverapp,legacy,desktop,phub");
+    zypper_call 'dup --force-resolution';
+    zypper_call "rm \$(zypper --no-refresh packages --orphaned | gawk '{print \$5}' | tail -n +5)";
+    power_action('reboot', keepconsole => 1, textmode => 1);
+}
+
+1;


### PR DESCRIPTION
This is for leap to sle zdup migration test, save the test
steps to one file leap2sle_zdup.pm
Includes: switch to a tty, full patch leap system, install SUSEConnect, Register at SCC to get SLE repo, List and disable all
 openSUSE repo, add modules need for installation, Migrate installed packages to SLES repo,  Remove orphaned packages, reboot the system

- Related ticket: https://progress.opensuse.org/issues/71287
- Verification run:http://openqa.suse.de/tests/4706206#