### PR TITLE
Increase timeout on slow aarch64 yast2 bootloader

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -37,8 +37,8 @@ sub run {
 
     # OK => Close
     send_key "alt-o";
-    # Our Hyper-V host is slow when initrd is being re-generated
-    my $timeout = (is_hyperv) ? 600 : 200;
+    # Our Hyper-V host & aarch64 is slow when initrd is being re-generated
+    my $timeout = (is_hyperv || check_var('ARCH', 'aarch64')) ? 600 : 200;
     assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], $timeout);
     if (match_has_tag('yast2_bootloader-missing_package')) {
         wait_screen_change { send_key 'alt-i'; };


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/4699851
- Verification run: https://openqa.suse.de/tests/4701268
