### PR TITLE
Restart services explicitly instead of calling another script

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -655,7 +655,12 @@ sub collect_host_and_guest_logs {
 sub cleanup_host_and_guest_logs {
     my ($extra_logs_to_cleanup) = @_;
 
-    script_run("source /usr/share/qa/qa_test_virtualization/shared/standalone") if get_var('VIRT_AUTOTEST');
+    #Clean dhcpd and named services up explicity
+    if (get_var('VIRT_AUTOTEST')) {
+        script_run("brctl addbr br123;brctl setfd br123 0;ip addr add 192.168.123.1/24 dev br123;ip link set br123 up");
+        script_run("service dhcpd restart") if (script_run("systemctl restart dhcpd") ne '0');
+        script_run("service named restart") if (script_run("systemctl restart named") ne '0');
+    }
     my $logs_cleanup_script_url = data_url("virt_autotest/clean_up_virt_logs.sh");
     script_output("curl -s -o ~/clean_up_virt_logs.sh $logs_cleanup_script_url", 180, type_command => 0, proceed_on_failure => 0);
     save_screenshot;


### PR DESCRIPTION
* **It** seems that calling standalone script is not always a good choice, although it is very handy. But it may lead to duplicate entries written into some configuration files, for example, named.conf, because it is not designed to run multiple times consecutively. So some operating systems may not be able to resolve this. Then dns service may malfunction at the last.
* **Change** to restart all required services explicitly by using linux administration commands in script_run to get clean start.
* **Related ticket:**
  [dns stops work here](https://openqa.suse.de/tests/4689750#step/hotplugging/45)
* **Needles:** n/a
* **Verification run:**
  [11sp4 xen host](http://10.67.133.40/tests/503)
  [15sp3 xen host](http://10.67.133.40/tests/504)
