### PR TITLE
xfstests: Fix QAM autoyast profile on all versions

### DIFF
--- a/data/filesystem/autoyast_filesystem_withouthome.xml.ep
+++ b/data/filesystem/autoyast_filesystem_withouthome.xml.ep
@@ -10,6 +10,28 @@
     <reg_server>{{SCC_URL}}</reg_server>
     % }
     <addons config:type="list">
+      % if ($get_var->('FLAVOR') =~ /-Updates$|-Incidents/) {
+      % while (my ($key, $addon) = each (%$addons)) {
+      <addon>
+        <name><%= $addon->{name} %></name>
+        <version><%= $addon->{version} %></version>
+        <arch><%= $addon->{arch} %></arch>
+        % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sles')) {
+        <reg_code><%= $get_var->('SCC_REGCODE_WE') %></reg_code>
+        % }
+        % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sled')) {
+        <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+        % }
+        % if ($key eq 'rt') {
+        <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
+        % }
+        % if ($key eq 'ltss') {
+        <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+        % }
+      </addon>
+      % }
+      % }
+      % unless ($get_var->('FLAVOR') =~ /-Updates$|-Incidents/) {
       <addon>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
@@ -35,13 +57,6 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
-      % if ($get_var->('SCC_ADDONS') =~ /ltss/) {
-      <addon>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <arch>{{ARCH}}</arch>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
-      </addon>
       % }
     </addons>
   </suse_register>
@@ -54,10 +69,19 @@
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
   <software>
+    % if ($get_var->('FLAVOR') =~ /-Updates$|-Incidents/) {
+    <patterns config:type="list">
+      % for my $pattern (@$patterns) {
+      <pattern><%= $pattern %></pattern>
+      % }
+    </patterns>
+    % }
+    % unless ($get_var->('FLAVOR') =~ /-Updates$|-Incidents/) {
     <patterns config:type="list">
       <pattern>enhanced_base</pattern>
       <pattern>minimal_base</pattern>
     </patterns>
+    % }
     <products config:type="list">
       <product>SLES</product>
     </products>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -440,7 +440,7 @@ sub adjust_network_conf {
 sub expand_variables {
     my ($profile) = @_;
     # Expand other variables
-    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_REGCODE_WE SCC_URL ARCH LOADER_TYPE NTP_SERVER_ADDRESS SCC_REGCODE_LTSS);
+    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_REGCODE_WE SCC_URL ARCH LOADER_TYPE NTP_SERVER_ADDRESS);
     # Push more variables to expand from the job setting
     my @extra_vars = push @vars, split(/,/, get_var('AY_EXPAND_VARS', ''));
     if (get_var 'SALT_FORMULAS_PATH') {

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -382,7 +382,7 @@ sub run {
     select_console('root-console');
 
     # Get wrapper
-    assert_script_run('wget --quiet ' . data_url('xfstests/wrapper.sh') . " -O $TEST_WRAPPER");
+    assert_script_run("curl -o $TEST_WRAPPER " . data_url('xfstests/wrapper.sh'));
     assert_script_run("chmod a+x $TEST_WRAPPER");
 
     # Get test list


### PR DESCRIPTION
expanding SCC_REGCODE_LTSS is not needed for QA and QAM tests take the addon list from SCC_ADDONS

- Related ticket: https://progress.opensuse.org/issues/70993
- Verification run: 
http://10.100.12.155/tests/16431 12-SP5
http://10.100.12.155/tests/16432 15-SP1
http://10.100.12.155/tests/16433 15
http://10.100.1.2155/tests/16436 15-SP2 with curl
https://openqa.suse.de/tests/4704074 12-SP5