### PR TITLE
Change to detect and use correct serial console somewhere else

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -17,7 +17,6 @@ use testapi;
 use base "virt_autotest_base";
 use virt_utils;
 use ipmi_backend_utils;
-use Utils::Backends 'is_remote_backend';
 use Utils::Architectures;
 use version_utils 'is_sle';
 use virt_autotest::utils qw(is_xen_host is_kvm_host);
@@ -58,11 +57,6 @@ sub run {
         set_serial_console_on_vh('', '', 'kvm') if is_kvm_host;
     }
     update_guest_configurations_with_daily_build();
-    if (is_remote_backend && check_var('ARCH', 'aarch64') && !check_var('LINUX_CONSOLE_OVERRIDE', 'ttyAMA0') && (get_var('VIRT_PRJ2_HOST_UPGRADE') || get_var('VIRT_PRJ4_GUEST_UPGRADE'))) {
-        my $ipmi_console = get_var('LINUX_CONSOLE_OVERRIDE', 'ttyAMA0');
-        assert_script_run("sed -irn \"s/console=ttyAMA0/console=$ipmi_console/g\" /usr/share/qa/virtautolib/lib/vh-update-lib.sh");
-    }
-
     # turn on debug for libvirtd & enable journal with previous reboot
     enable_debug_logging if is_x86_64;
 


### PR DESCRIPTION
* **There** is better place to detect and use the correct and accurate serial console in grub entry used for upgrade test, please refer to pull request https://github.com/SUSE/qa-automation/pull/739
* **Related ticket:** aarch64 upgrade test
* **Needles:** n/a
* **Verification run:**
  Please refer to https://github.com/SUSE/qa-automation/pull/739