### PR TITLE
Skip update packages on developing sles version

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -51,15 +51,15 @@ sub update_package {
 
 sub run {
     my $self = shift;
-    $self->update_package() unless is_sle('=15-SP2') && is_xen_host;    #workaroud: skip update package as there are conflicts on sles15sp2 XEN
-    if (!check_var('ARCH', 's390x')) {
+    #workaroud: skip update package for registered aarch64 tests and because there are conflicts on sles15sp2 XEN
+    $self->update_package() unless ((is_sle('=15-SP2') && is_xen_host) || (is_registered_sles && is_aarch64));
+    unless ((is_registered_sles && is_aarch64) || is_s390x) {
         set_serial_console_on_vh('', '', 'xen') if is_xen_host;
         set_serial_console_on_vh('', '', 'kvm') if is_kvm_host;
     }
     update_guest_configurations_with_daily_build();
     # turn on debug for libvirtd & enable journal with previous reboot
     enable_debug_logging if is_x86_64;
-
 }
 
 sub test_flags {

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -26,9 +26,10 @@ use List::Util 'first';
 use proxymode;
 use version_utils 'is_sle';
 use virt_autotest::utils;
+use version_utils qw(is_sle get_sles_release);
 
 our @EXPORT
-  = qw(enable_debug_logging update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk upload_supportconfig_log download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console);
+  = qw(enable_debug_logging update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk upload_supportconfig_log download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles is_registered_sles);
 
 sub enable_debug_logging {
 
@@ -707,6 +708,31 @@ sub start_monitor_guest_console {
 sub stop_monitor_guest_console {
     monitor_guest_console('stop');
     save_screenshot;
+}
+
+#Detect whether running sles is the developing version
+sub is_developing_sles {
+    my ($running_sles_rel, $running_sles_sp) = get_sles_release;
+    my $developing_sles_version = get_required_var('VERSION');
+    $developing_sles_version = get_required_var('TARGET_DEVELOPING_VERSION') if get_var('REPO_0_TO_INSTALL');
+    my ($developing_sles_rel) = $developing_sles_version =~ /^(\d+).*/img;
+    my ($developing_sles_sp)  = $developing_sles_version =~ /^.*sp(\d+)$/img;
+    if ($running_sles_rel eq $developing_sles_rel && $running_sles_sp eq $developing_sles_sp) {
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}
+
+#Detect whether SUT host is installed with scc registration
+sub is_registered_sles {
+    if (!get_var('SCC_REGISTER') || check_var('SCC_REGISTER', 'none') || check_var('SCC_REGISTER', '')) {
+        return 0;
+    }
+    else {
+        return 1;
+    }
 }
 
 1;


### PR DESCRIPTION
* **Developing** sles is under development. It seems that there is no need to do update packages on developing version. So skip the update_package subroutine if it is.
* **This** should apply to aarch64 at least
* **Related ticket:**
  [I already saw failure of trying to replace installed higher version software with lower version one](https://openqa.suse.de/tests/4702002#step/update_package/8)
* **Needles:** n/a
* **Verification run:**
  Perl online compiler to verify new subroutine and unless judgement
