### PR TITLE
system_prepare: remount /run with 50% RAM size

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -18,7 +18,7 @@
 use base 'consoletest';
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_livecd is_tumbleweed);
 use serial_terminal 'prepare_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use registration;
@@ -36,6 +36,12 @@ sub run {
 
     # Make sure packagekit is not running, or it will conflict with SUSEConnect.
     pkcon_quit unless check_var('DESKTOP', 'textmode');
+
+    # on live media, increase the size of /run to 50% of RAM (workaround boo#1176709)
+    if (is_livecd && is_tumbleweed) {
+        record_soft_failure('bsc#1176709 - livecd runs out of storage on overlayfs');
+        assert_script_run("mount -o remount,size=\$[\$(awk '/MemTotal/ {print \$2}' /proc/meminfo)/2]K /run");
+    }
 
     # Register the modules after media migration, so it can do regession
     if (get_var('SCC_ADDONS') && get_var('MEDIA_UPGRADE') && (get_var('FLAVOR') =~ /Regression/)) {


### PR DESCRIPTION
systemd 246 limits /run to 20% of the RAM size by default.
On the live media, we store the entire overlayfs in /run/overlayfs,
which makes us run out of disk space.

Work around https://bugzilla.opensuse.org/show_bug.cgi?id=1176709

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1176709
- Needles: N/A
- Verification run:
  *  KDE LIve: https://openqa.opensuse.org/tests/1398298
  * GNOME Live: https://openqa.opensuse.org/tests/1398301
