### PR TITLE
Adjust version variables to be compared for host upgrade test

### DIFF
--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -33,7 +33,7 @@ sub run {
     my $self = shift;
 
     #Install qa test repo
-    if ((is_x86_64 || is_aarch64) && is_sle('=12-SP5', get_var('VERSION_TO_INSTALL', get_var('VERSION', ''))) && is_sle('>=15-SP2')) {
+    if ((is_x86_64 || is_aarch64) && is_sle('=12-SP5', get_var('VERSION_TO_INSTALL')) && is_sle('>=15-SP2', get_var('TARGET_DEVELOPING_VERSION'))) {
         my ($upgrade_release) = lc(get_required_var('UPGRADE_PRODUCT')) =~ /sles-([0-9]+-sp[0-9]+)/;
         my $qa_test_repo = 'http://dist.nue.suse.com/ibs/QA:/Head/SLE-' . uc($upgrade_release);
         script_run("zypper rm -n -y qa_lib_virtauto", 300);


### PR DESCRIPTION
* **Keep** the judgement simpler, clearer and more relevant for host upgrade scenario
* **Just** use VERSION_TO_INSTALL to get base product version and TARGET_DEVELOPING_VERSION to get upgrade product version to do comparsion.
* **Related ticket:** n/a
* **Needles:**
* **Verification run:**
  Perl online compiler to verify is_sle and if judgement
  