### PR TITLE
Generate DUD dynamically before installation

### DIFF
--- a/data/add_on_products.xml
+++ b/data/add_on_products.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<add_on_products xmlns="http://www.suse.com/1.0/yast2ns"
+  xmlns:config="http://www.suse.com/1.0/configns">
+  <product_items config:type="list">
+    <product_item>
+      <name>SUSE Linux Enterprise Development Tools Module</name>
+      <url><![CDATA[ftp://openqa.suse.de/{{REPO_SLE_MODULE_DEVELOPMENT_TOOLS}}]]></url>
+      <priority config:type="integer">50</priority>
+      <ask_user config:type="boolean">true</ask_user>
+      <selected config:type="boolean">true</selected>
+      <check_name config:type="boolean">true</check_name>
+    </product_item>
+  </product_items>
+</add_on_products>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -440,7 +440,9 @@ sub adjust_network_conf {
 sub expand_variables {
     my ($profile) = @_;
     # Expand other variables
-    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_REGCODE_WE SCC_URL ARCH LOADER_TYPE NTP_SERVER_ADDRESS);
+    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC
+      SCC_REGCODE_WE SCC_URL ARCH LOADER_TYPE NTP_SERVER_ADDRESS
+      REPO_SLE_MODULE_DEVELOPMENT_TOOLS);
     # Push more variables to expand from the job setting
     my @extra_vars = push @vars, split(/,/, get_var('AY_EXPAND_VARS', ''));
     if (get_var 'SALT_FORMULAS_PATH') {

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -718,6 +718,11 @@ sub specific_bootmenu_params {
             if ($dud =~ /^(http|https|ftp):\/\//) {
                 push @params, "dud=$dud";
             }
+            elsif ($dud =~ /^ASSET_\d+$/) {
+                # In case dud is uploaded as an ASSET we need just filename
+                $dud = basename(get_required_var($dud));
+                push @params, 'dud=' . autoinst_url("/assets/other/$dud");
+            }
             else {
                 push @params, 'dud=' . data_url($dud);
             }

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -7,7 +7,6 @@ description: >
   Also development tools module requires desktop applications module as a
   dependency, so DESKTOP is set to gnome.
 vars:
-  DUD: dev_tools.dud
   DUD_ADDONS: sdk
   DESKTOP: gnome
   SCC_ADDONS: base,serverapp,desktop
@@ -39,7 +38,7 @@ schedule:
   - console/orphaned_packages_check
 test_data:
   dud_repos:
-    # The URI is the same as set in 'data/dev_tools.dud' file.
-    - URI: 'ftp://openqa.suse.de/SLE-15-Module-Development-Tools-POOL-x86_64-Media1-CURRENT'
-      Enabled: Yes
-      Autorefresh: On
+    # repos here should correspond with repos in 'data/add_on_products.xml'
+    REPO_SLE_MODULE_DEVELOPMENT_TOOLS:
+      Enabled: 'Yes'
+      Autorefresh: 'On'

--- a/schedule/yast/generate_dud.yaml
+++ b/schedule/yast/generate_dud.yaml
@@ -1,0 +1,11 @@
+name:           generate_dud
+description:    >
+  Generate DUD dynamically:
+  - (1) Boot an image where module phub can be added successfully
+        (repo is consolidated for the product) allowing to install mkdud
+        (from a product not under development).
+  - (2) Create DUD expanding variables using values configured for the product.
+  - (3) Upload the DUD as an asset to be used by a chained job.
+schedule:
+  - boot/boot_to_desktop
+  - console/generate_dud

--- a/tests/console/generate_dud.pm
+++ b/tests/console/generate_dud.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Generate DUD dynamically using mkdud and xml file where variables
+# are expanded for the corresponding product/build.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use utils qw(zypper_call);
+use autoyast qw(expand_variables);
+use registration qw(add_suseconnect_product get_addon_fullname);
+
+sub run {
+    select_console 'root-console';
+
+    my $xml = 'add_on_products.xml';
+    my $dud = get_required_var('DUD');
+
+    my $content = expand_variables(get_test_data($xml));
+    save_tmp_file($xml, $content);
+    add_suseconnect_product(get_addon_fullname('phub'));
+    zypper_call('in mkdud');
+    assert_script_run('wget -P inst-sys ' . autoinst_url . "/files/$xml");
+    assert_script_run("mkdud --create $dud --dist sle15 " .
+          "--install instsys,repo --obs-keys --name 'Update' inst-sys");
+    upload_asset($dud);
+}
+
+1;

--- a/tests/console/validate_dud_addon_repos.pm
+++ b/tests/console/validate_dud_addon_repos.pm
@@ -20,13 +20,18 @@ use warnings;
 use testapi;
 use repo_tools 'validate_repo_properties';
 use scheduler 'get_test_suite_data';
-use Test::Assert ':all';
 
 sub run {
-    my $test_data = get_test_suite_data();
+    my $test_data = get_test_suite_data;
     select_console 'root-console';
-    foreach my $expected_dud_repo (@{$test_data->{dud_repos}}) {
-        validate_repo_properties($expected_dud_repo);
+
+    foreach my $repo (keys %{$test_data->{dud_repos}}) {
+        validate_repo_properties({
+                URI => 'ftp://' . get_required_var('OPENQA_HOSTNAME') . '/' .
+                  get_required_var($repo),
+                Enabled     => $test_data->{dud_repos}->{$repo}->{Enabled},
+                Autorefresh => $test_data->{dud_repos}->{$repo}->{Autorefresh}
+        });
     }
     assert_script_run('zypper -v ref | grep "All repositories have been refreshed"', 120);
 }


### PR DESCRIPTION
See [poo#70726](https://progress.opensuse.org/issues/70726)
MR in job groups: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/279
Verification run: [generated_dud](https://openqa.suse.de/tests/4709792) & [dud_development_tools_dev](https://openqa.suse.de/tests/4709793)

Notes:
 - Using [this textmode job](https://openqa.suse.de/tests/4709170) to create [an image](https://openqa.suse.de/tests/4709734) while we resolve the problems with support server creation.
 - Tested with 33.1 latest build where dud was working before [bsc#1176607](https://bugzilla.suse.com/show_bug.cgi?id=1176607)
