### PR TITLE
Prevent DHCP from rolling back hostname changes

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -31,8 +31,8 @@ use version_utils "is_sle";
 sub run {
     select_console 'root-console';
 
-    # Since 15SP1 DHCLIENT_SET_HOSTNAME must be disable bsc#1153402
-    file_content_replace('/etc/sysconfig/network/dhcp', 'DHCLIENT_SET_HOSTNAME="yes"' => 'DHCLIENT_SET_HOSTNAME="no"') if is_sle('15-SP1+');
+    # Prevent HOSTNAME from being reset by DHCP
+    file_content_replace('/etc/sysconfig/network/dhcp', 'DHCLIENT_SET_HOSTNAME="yes"' => 'DHCLIENT_SET_HOSTNAME="no"');
 
     set_hostname(get_var('HOSTNAME', 'susetest'));
 }


### PR DESCRIPTION
When changing the hostname of a SUT, it is possible that the hostname set by `tests/console/hostname.pm` gets is re-assigned to the one supplied by the DHCP server that leased the IP address to the SUT, which can lead to unexpected results with tests dealing with the names set by `tests/console/hostname.pm`, for example iSCSI client setup or HA cluster bootstrap.

This behavior was first observed 8 months ago in SLES 15-SP1+, so PRs #8637 & #9336 were submitted to work around the issue.

However, recent tests on 15-GM and [12-SP3](https://openqa.suse.de/tests/4680399#step/iscsi_client/7) show the issue is now also present in older versions of SLES with upgrades.

The changes here prevent the hostname from being set by DHCP if `test/console/hostname.pm` is scheduled as part of the test on all versions of SLES and openSUSE.

This behavior should be in sync with wicked & sysconfig as commented on [bsc#1153402](https://bugzilla.suse.com/show_bug.cgi?id=1153402#c14)

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1153402
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/3145 & http://mango.qa.suse.de/tests/3146, https://openqa.suse.de/tests/4707236