### PR TITLE
SUSE MicroOS: Remove zypper tests

### DIFF
--- a/schedule/microos/suse_microos.yaml
+++ b/schedule/microos/suse_microos.yaml
@@ -20,9 +20,6 @@ schedule:
     - microos/libzypp_config
     - microos/one_line_checks
     - microos/services_enabled
-    - update/zypper_clear_repos
-    - console/zypper_ar
-    - console/zypper_ref
     - transactional/filesystem_ro
     - transactional/transactional_update
     - transactional/rebootmgr


### PR DESCRIPTION
Those tests are mainly meaningful in openSUSE case where
we need to do some cleanup and just leave default repo.
For SUSE MicroOS, this are not doing anything.

- Verification run: http://fromm.arch.suse.de/tests/232
