### PR TITLE
[WIP] Implement interactive encryption for home partition

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/EditPartitionPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/EditPartitionPage.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: The class introduces all accessing methods for Edit Partition
+# Page of Expert Partitioner Wizard, that are common for all the versions of the
+# page (e.g. for both Libstorage and Libstorage-NG).
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+package Installation::Partitioner::LibstorageNG::EditPartitionPage;
+use strict;
+use warnings;
+use testapi;
+use parent 'Installation::WizardPage';
+
+use constant {
+    EDIT_PARTITION_PAGE => 'edit-partition'
+};
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        encrypt_checkbox => $args->{encrypt_checkbox}
+    }, $class;
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->SUPER::press_next(EDIT_PARTITION_PAGE);
+}
+
+sub select_enable_disk_encryption_checkbox {
+    my ($self) = shift;
+    assert_screen(EDIT_PARTITION_PAGE);
+    send_key($self->{encrypt_checkbox});
+}
+
+1;

--- a/lib/Installation/Partitioner/LibstorageNG/EncryptPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/EncryptPage.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: The class introduces all accessing methods for Encrypt
+# Page of Expert Partitioner Wizard, that are common for all the versions of the
+# page (e.g. for both Libstorage and Libstorage-NG).
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+package Installation::Partitioner::LibstorageNG::EncryptPage;
+use strict;
+use warnings;
+use testapi;
+use parent 'Installation::WizardPage';
+
+use constant {
+    ENCRYPT => 'encrypt_password',
+};
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        password_textfield        => $args->{password_textfield},
+        password_verify_textfield => $args->{password_verify_textfield}
+    }, $class;
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->SUPER::press_next(ENCRYPT);
+}
+
+sub enter_password {
+    my ($self) = shift;
+    assert_screen(ENCRYPT);
+    send_key($self->{password_textfield});
+    type_password();
+}
+
+sub enter_password_confirmation {
+    my ($self) = shift;
+    assert_screen(ENCRYPT);
+    send_key($self->{password_verify_textfield});
+    type_password();
+}
+
+1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -290,13 +290,15 @@ sub integration_services_check {
 
 Check whether the system under test has an encrypted partition and attempts to unlock it.
 C<$check_typed_password> will default to C<0>.
+C<$skip_decryption> defines explicitly that the module should not try to decrypt the disks even if B<ENCRYPTION> is defined somewhere else. In any case set the value to 0 to enable decryption. it will default to C<1>.
 
 =cut
 sub unlock_if_encrypted {
     my (%args) = @_;
     $args{check_typed_password} //= 0;
+    $args{skip_decryption}      //= 1;
 
-    return unless get_var("ENCRYPT");
+    return unless $args{skip_decryption} || get_var("ENCRYPT");
 
     if (get_var('S390_ZKVM')) {
         my $password = $testapi::password;
@@ -495,7 +497,7 @@ sub zypper_call {
     my $command          = shift;
     my %args             = @_;
     my $allow_exit_codes = $args{exitcode} || [0];
-    my $timeout          = $args{timeout}  || 700;
+    my $timeout          = $args{timeout} || 700;
     my $log              = $args{log};
     my $dumb_term        = $args{dumb_term} // is_serial_terminal;
 
@@ -920,7 +922,7 @@ sub addon_decline_license {
         if (check_screen 'next-button-is-active', 5) {
             send_key $cmd{next};
             assert_screen "license-refuse";
-            send_key 'alt-n';         # no, don't refuse agreement
+            send_key 'alt-n';    # no, don't refuse agreement
             wait_still_screen 2;
             send_key $cmd{accept};    # accept license
         }

--- a/schedule/yast/encryption/crypt_home.yaml
+++ b/schedule/yast/encryption/crypt_home.yaml
@@ -1,0 +1,30 @@
+---
+description: >
+  Conduct installation with encrypted home partition.
+name: crypt_home
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/separate_home_encrypted
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/verify_separate_home
+  - console/validate_encrypt
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/test_data/yast/encryption/home_encrypted.yaml
+++ b/test_data/yast/encryption/home_encrypted.yaml
@@ -1,0 +1,18 @@
+---
+crypttab:
+  num_devices_encrypted: 1
+cryptsetup:
+  device_status:
+    message: is active and is in use.
+    properties:
+      type: LUKS1
+      cipher: aes-xts-plain64
+      device: /dev/vda3
+      key_location: dm-crypt
+      mode: read/write
+backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
+cr_home:
+  backup_path: '/root/bkp_luks_header_cr_home'
+partitioner_table: 'hard-disks'
+partitioner_proposal: current
+partition: vda3

--- a/tests/installation/partitioning/separate_home_encrypted.pm
+++ b/tests/installation/partitioning/separate_home_encrypted.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: The test module to select encryption for the home partition
+# with current suggested Partitioning wizard,
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings FATAL => 'all';
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my $test_data   = get_test_suite_data();
+    my $partitioner = $testapi::distri->get_expert_partitioner();
+    $partitioner->run_expert_partitioner($test_data->{partitioner_proposal});
+    $partitioner->encrypt_partition($test_data);
+}
+
+1;


### PR DESCRIPTION
Extends Expert_Partitioning Framework to tackle current proposal's pages.
Those are Edit Partition and Encrypt Partition.
In general we do not have integrated code for current proposal option and some of the code is dublicated.


- Related ticket: https://progress.opensuse.org/issues/66862
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1433
- [Verification run](http://aquarius.suse.cz/tests/3344)
- [jobgroup MR](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/281)