### PR TITLE
leap to SLE with zypper migration need to add --allow-vendor-change

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -39,7 +39,8 @@ sub run {
 
     my $zypper_migration_signing_key = qr/^Do you want to reject the key, trust temporarily, or trust always?[\s\S,]* \[r/m;
     # start migration
-    script_run("(zypper migration;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
+    my $option = (is_leap_migration) ? " --allow-vendor-change " : " ";
+    script_run("(zypper migration $option; echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
     # migration process take long time
     my $timeout          = 7200;
     my $migration_checks = [


### PR DESCRIPTION
When migration from leap 15.2 to SLES15SP2, We need to use 'zypper migration
--allow-vendor-change' to accept the vendor change.

- Related ticket: https://progress.opensuse.org/issues/71497
- Needles: N/A
- Verification run:  
 https://openqa.nue.suse.com/tests/4710147#step/zypper_migration/2
 https://openqa.nue.suse.com/tests/4710151
regression:
https://openqa.nue.suse.com/tests/4714491