### PR TITLE
Add validations to lvm+cancel_existing_cryptlvm

### DIFF
--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -12,6 +12,7 @@ schedule:
   - installation/accept_license
   - installation/scc_registration
   - installation/encrypted_volume_activation
+  - console/validate_encrypted_partition_not_activated
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -30,3 +31,6 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+  - console/validate_lvm
+test_data:
+  <<: !include test_data/yast/encryption/cryptlvm+cancel_existing.yaml

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -12,6 +12,7 @@ schedule:
   - installation/accept_license
   - installation/scc_registration
   - installation/encrypted_volume_activation
+  - console/validate_encrypted_partition_not_activated
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -31,3 +32,7 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+  - console/validate_lvm
+test_data:
+  <<: !include test_data/yast/encryption/cryptlvm+cancel_existing.yaml
+  mapped_device: '/dev/mapper/cr-auto-1'

--- a/tests/console/validate_encrypted_partition_not_activated.pm
+++ b/tests/console/validate_encrypted_partition_not_activated.pm
@@ -19,10 +19,11 @@ use base "installbasetest";
 use scheduler 'get_test_suite_data';
 use testapi;
 use validate_encrypt_utils;
+use Utils::Backends 'use_ssh_serial_console';
 
 sub run {
     my $test_data = get_test_suite_data();
-    select_console 'install-shell';
+    check_var('BACKEND', 'pvm_hmc') ? use_ssh_serial_console : select_console 'install-shell';
     my $status = parse_cryptsetup_status($test_data->{mapped_device});
     verify_cryptsetup_message($test_data->{device_status}->{message}, $status->{message});
     select_console 'installation';


### PR DESCRIPTION
Verify that previous paritioning is not reused, and validate lvm config.

- Related ticket: https://progress.opensuse.org/issues/69046
- Verification run: http://waaa-amazing.suse.cz/tests/12984
 PVM https://openqa.suse.de/tests/4727154

This shows that we need to use cr-auto-1 instead of cr-auto-2 for pvm:
PVM:
https://openqa.suse.de/tests/4733301#step/validate_activation_encrypted_partition/6
KVM:
https://openqa.suse.de/tests/4733300#step/validate_activation_encrypted_partition/9

We can consider that setting expectations should suffice -see [comment](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11042#issuecomment-698241153) below- but I think we may want to improve, as we may have false positives if something changes.
Example of false positive: https://openqa.suse.de/tests/4727172#step/validate_encrypted_partition_not_activated/2