### PR TITLE
Remove system_state from the yast scheduling

### DIFF
--- a/schedule/yast/encryption/cryptlvm_opensuse.yaml
+++ b/schedule/yast/encryption/cryptlvm_opensuse.yaml
@@ -32,7 +32,6 @@ schedule:
   - update/zypper_up
   - console/system_prepare
   - console/check_network
-  - console/system_state
   - console/prepare_test_data
   - console/consoletest_setup
   - locale/keymap_or_locale

--- a/schedule/yast/lvm/lvm+resize_root.yaml
+++ b/schedule/yast/lvm/lvm+resize_root.yaml
@@ -36,7 +36,6 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - console/check_network
-  - console/system_state
   - console/prepare_test_data
   - console/consoletest_setup
   - locale/keymap_or_locale

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -30,7 +30,6 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - console/check_network
-  - console/system_state
   - console/prepare_test_data
   - console/consoletest_setup
   - locale/keymap_or_locale

--- a/schedule/yast/textmode/textmode@svirt-xen.yaml
+++ b/schedule/yast/textmode/textmode@svirt-xen.yaml
@@ -23,7 +23,6 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - console/check_network
-  - console/system_state
   - console/prepare_test_data
   - console/consoletest_setup
   - locale/keymap_or_locale

--- a/tests/console/system_state.pm
+++ b/tests/console/system_state.pm
@@ -1,16 +1,25 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2020 SUSE LLC
 #
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
-
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
 # Summary:  Export the existing status of running tasks and system load
 # for future reference
 # - Collect running process list
 # - Collect system load average
+# - Upload the gatherings to the job's logs
 # Maintainer: Zaoliang Luo <zluo@suse.de>
 
 use base "consoletest";
@@ -21,9 +30,12 @@ use strict;
 use warnings;
 
 sub run {
+    my ($self) = shift;
     check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
-    script_run "ps axf > /tmp/psaxf.log";
-    script_run "cat /proc/loadavg > /tmp/loadavg_consoletest_setup.txt";
+    script_run "mkdir /tmp/system_state";
+    script_run "ps axf > /tmp/system_state/psaxf.log";
+    script_run "cat /proc/loadavg > /tmp/system_state/loadavg_consoletest_setup.txt";
+    $self->tar_and_upload_log('/tmp/system_state', '/tmp/stats_during_installation.tar.bz2');
 }
 
 1;


### PR DESCRIPTION
there is save_system_logs subroutine which collects the running processes and the cpu loads
during the post_fail_hook of each installation module. For that reason i remove the system_state
from yast modules. Although i enhanced the module and it can be used in case of a successful test
to provide those info in the logs of the job.

- Related ticket: https://progress.opensuse.org/issues/70153
- [Verification run](http://aquarius.suse.cz/tests/3350#downloads)
