### PR TITLE
Increase root partition size for the splitusr scenario

### DIFF
--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -46,7 +46,7 @@ sub run {
     wait_screen_change { send_key $cmd{resize} };                          # Resize
     send_key 'alt-u';                                                      # Custom size
     send_key $cmd{size_hotkey} if is_storage_ng;
-    type_string '1.5G';
+    type_string '5G';
     send_key(is_storage_ng() ? $cmd{next} : 'ret');
     if (is_storage_ng) {
         # warning: / should be >= 10 GiB or disable snapshots


### PR DESCRIPTION
We have 1.5G disk size, which is not enough on leap to install extra
packages we need for further tests. Changing this limit to 5G and
schedule refactoring of the module using shared code library as a next
step.

See [poo#65801](https://progress.opensuse.org/issues/65801).

[Verification run](https://openqa.opensuse.org/tests/1400601#).
