### PR TITLE
Mitigations: Add specify_disk info to MITIGATION_ENV_SETUP

### DIFF
--- a/tests/cpu_bugs/mitigation_env_setup.pm
+++ b/tests/cpu_bugs/mitigation_env_setup.pm
@@ -17,9 +17,14 @@ use testapi;
 use utils;
 
 sub run {
-    my $self = shift;
+    my $self     = shift;
+    my $newlabel = 'Test';
 
-    my $newlabel = get_required_var('DISTRI') . '-' . get_required_var('VERSION') . '-';
+    get_required_var('SPECIFIC_DISK') =~ /\d/;
+    $newlabel .= $& . '_';
+    get_required_var('MACHINE') =~ /[v|p]h\d{3}/;
+    $newlabel .= $& . '-';
+    $newlabel .= get_required_var('DISTRI') . '-' . get_required_var('VERSION') . '-';
 
     # for mitigation test, disk label with build tag, while with Build number
     if (lc(get_var('MYBUILD')) =~ /alpha|beta|rc|gm/) {


### PR DESCRIPTION
Mitigation installation need specify info to select root partition, add
this to disk label to prevent override by build info.

- Related ticket: https://trello.com/c/ak1oxK5s/414-p1autofunc-add-partition-information-to-disk-label-in-setupenvironment-script
- Needles: N/A
- Verification run: http://openqa.qa2.suse.asia/tests/17856#step/mitigation_env_setup/1
