### PR TITLE
wicked: remove obsoleted tag from AutoYaST profile for ppc64le

### DIFF
--- a/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
@@ -47,7 +47,6 @@
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
     <storage>
-      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>


### PR DESCRIPTION
remove obsoleted tag from AutoYaST profile for ppc64le

VR : http://openqa.suse.de/t4715754