### PR TITLE
Adjusts the test_data for encrypt validation on ppc64le

### DIFF
--- a/tests/console/validate_encrypt.pm
+++ b/tests/console/validate_encrypt.pm
@@ -45,10 +45,12 @@ sub run {
         verify_cryptsetup_properties($test_data->{cryptsetup}->{device_status}->{properties}, $status->{properties});
     }
     foreach my $dev (sort keys %{$devices}) {
+        # This does not solve the problem with the multi-disks for ppc64le-hmc-single-disk
+        my $backup_name = check_var("MACHINE", "ppc64le-hmc-single-disk") ? '/root/bkp_luks_header_cr_scsi' : $test_data->{$dev}->{backup_path};
         verify_restoring_luks_backups(
             encrypted_device_path => $devices->{$dev}->{encrypted_device},
             backup_file_info      => $test_data->{backup_file_info},
-            backup_path           => $test_data->{$dev}->{backup_path}
+            backup_path           => $backup_name
         );
     }
 }


### PR DESCRIPTION
<s>https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/286</s>
in fact i chose to not change the test data but handle them in the validate_encrypt module.                                                                                                                                                  
This will not handle the multi disks in the ppc64le-hmc-single-disk machines so we will have to                                                                                                                                              
enhance it in the future. The reason of why i did not provide just simple test_data is because the                                                                                                                                           
device name is not completely static.

- [Verification run](https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2311050&version=15-SP3)