### PR TITLE
Fix 15 LTSS issue in 15-SP1 rolling upgrade tests

### DIFF
--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01.yaml
@@ -8,6 +8,7 @@ schedule:
   - console/suseconnect_scc
   - update/zypper_up
   - console/console_reboot
+  - '{{register_without_ltss}}'
   - ha/wait_barriers
   - console/system_prepare
   - console/consoletest_setup
@@ -49,3 +50,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/console_reboot
+  register_without_ltss:
+    ORIGIN_SYSTEM_VERSION:
+      15:
+        - migration/online_migration/register_without_ltss

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02.yaml
@@ -8,6 +8,7 @@ schedule:
   - console/suseconnect_scc
   - update/zypper_up
   - console/console_reboot
+  - '{{register_without_ltss}}'
   - ha/wait_barriers
   - console/system_prepare
   - console/consoletest_setup
@@ -49,3 +50,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/console_reboot
+  register_without_ltss:
+    ORIGIN_SYSTEM_VERSION:
+      15:
+        - migration/online_migration/register_without_ltss


### PR DESCRIPTION
15 GA LTSS is mandatory when we update the SLE15 qcow2 system.

- Related ticket: https://progress.opensuse.org/issues/71650
- Failed test: https://openqa.suse.de/tests/4710559#step/zypper_up/13
- Needles: N/A
- Verification run: 
15-SP1 [node1](http://1a102.qa.suse.de/tests/5432) - [node2](http://1a102.qa.suse.de/tests/5433) - [supportserver](http://1a102.qa.suse.de/tests/5431)
