### PR TITLE
Adapt custom firstboot to have sidebar and banner

### DIFF
--- a/data/yast2/firstboot/firstboot_custom-sle.xml
+++ b/data/yast2/firstboot/firstboot_custom-sle.xml
@@ -30,6 +30,12 @@
 	<!-- The default value of "Automatic Login" checkbox -->
 	<enable_autologin config:type="boolean">false</enable_autologin>
 
+    <!-- Configuration of the installation/firstboot layout -->
+	<installation_layout>
+		<mode>steps</mode>
+		<banner config:type="boolean">true</banner>
+	</installation_layout>
+
 	<!--
 	For more variables that can be in this section, look into the control file
 	(/etc/YaST2/control.xml or root directory of installation media)


### PR DESCRIPTION
According to [bsc#1176608](https://bugzilla.suse.com/show_bug.cgi?id=1176608#c2) defaults changed and we need to adapt this custom scenario to still test using the sidebar.
- MR Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1436
- Verification run: http://rivera-workstation.suse.cz/tests/1308#step/yast2_firstboot/4
