### PR TITLE
Upload autoupg.xml in reboot_and_wait_up_upgrade module

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -53,7 +53,10 @@ sub post_fail_hook {
     my ($self) = shift;
     reset_consoles;
     select_console('root-console');
-    $self->upload_y2logs if (check_var('offline_upgrade', 'yes'));
+    if (check_var('offline_upgrade', 'yes')) {
+        upload_logs("/root/autoupg.xml", failok => 1);
+        $self->upload_y2logs;
+    }
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
* **It** seems that reboot_and_wait_up_upgrade has different base module to date back if failure happens. So upload autoupg.xml file here explicitly.
* **Related ticket:** n/a
* **Needles:** n/a
* **Verification run:**
  No need actually, but verified by using perl online compiler
