### PR TITLE
Increase timeout for java installation

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -39,7 +39,7 @@ sub run {
     # java-10-openjdk & java-1_8_0-ibm  -> Legacy
     my $cmd = 'install --auto-agree-with-licenses ';
     $cmd .= (is_sle('15+') || is_leap) ? 'java-11-openjdk* java-1_*' : 'java-*';
-    zypper_call($cmd, timeout => 1500);
+    zypper_call($cmd, timeout => 2000);
 
     if (script_run 'rpm -q wget') {
         zypper_call 'in wget';


### PR DESCRIPTION
to avoid failure on slow machines.
This can be due to slower network connection on remote workers, and/or slower disk access.

Seen on RPi3 test: https://openqa.opensuse.org/tests/1399366#step/java/3

VR: https://openqa.opensuse.org/t1402791