### PR TITLE
prepare_tools: return back python3-devel

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -65,7 +65,7 @@ sub run {
     }
 
     # Install prerequesite packages test
-    zypper_call('-q in python3-pip python3-virtualenv python3-img-proof python3-img-proof-tests');
+    zypper_call('-q in python3-pip python3-devel python3-virtualenv python3-img-proof python3-img-proof-tests');
     record_info('python', script_output('python --version'));
 
     # Install AWS cli


### PR DESCRIPTION
python3-devel needed for successful compilation of azure-cli
Worth to mention that we already had it, but than it was removed
as obsolete.
VR:  https://openqa.suse.de/tests/4723136#