### PR TITLE
Do test result judgement directly from test run output

### DIFF
--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -78,14 +78,14 @@ sub analyzeResult {
 sub post_execute_script_assertion {
     my $self = shift;
 
+    my $output = $self->{script_output};
     # display test result
     # print the test output to the openQA output
     $self->{script_output} = script_output "cd /tmp; zcat $self->{compressed_log_name}.tar.gz | sed -n '/Overall guest upgrade result/,/[0-9]* fail [0-9]* succeed/p'";
     save_screenshot;
-
-    my $output = $self->{script_output};
+    # Determine test result from test output directly
     $output =~ s/"|'|`//g;
-    my $guest_upgrade_assert_pattern = "Overall[[:space:]]guest[[:space:]]upgrade[[:space:]]result[[:space:]]is:.*(Fail|Timeout).*Test[[:space:]]done";
+    my $guest_upgrade_assert_pattern = "Test[[:space:]]in[[:space:]]progress.*(fail|timeout).*Test[[:space:]]run[[:space:]]complete";
     script_output("shopt -s nocasematch;[[ ! \"$output\" =~ $guest_upgrade_assert_pattern ]]", type_command => 0, proceed_on_failure => 0);
     save_screenshot;
 }


### PR DESCRIPTION
* **It** seems that guest upgrade log folder does not have enough information for test run to query test result sometimes. It can return empty. 
* **But** there definitely is more reliable source to do final test result judgement, so it should be the direct test output from test_virtualization-guest-upgrade-run which is also recorded in serial log file.
* **Related ticket:**
  [Nothing returns after test result query](https://openqa.suse.de/tests/4716718#step/guest_upgrade_run/30)
* **Needles:** n/a
* **Verification run:**
  This method has been used in guest installation test
  [This also works for guest upgrade](http://10.67.133.40/tests/509#)