### PR TITLE
Install glibc-lang in TW,sle15sp3 and leap15.3

### DIFF
--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -140,7 +140,7 @@ sub run {
     select_console('root-console');
     # it is expected that SLE12 has glibc preinstalled
     my @pkgs = qw(glibc-locale);
-    push @pkgs, 'glibc-lang' if (is_tumbleweed);
+    push @pkgs, 'glibc-lang' if (is_tumbleweed || is_sle('>15-sp2') || is_leap('>15.2'));
     zypper_call("install @pkgs") if (is_sle('15+') || is_opensuse);
 
     my $output = script_output("localectl list-locales | tee -a /dev/$serialdev | grep -E '$lang_new_short\.(UTF-8|utf8)'");


### PR DESCRIPTION
- Related issue: [missing glibc-lang package](https://openqa.suse.de/tests/4718384#step/glibc_locale/35)
- Verification runs: 
   * [ sle-15-SP3-JeOS](http://kepler.suse.cz/tests/1791#step/glibc_locale/35)
   * [sle15sp2](http://kepler.suse.cz/tests/1790#step/glibc_locale/35)
