### PR TITLE
Allow rw on /dev/sshserial for all

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -457,7 +457,7 @@ sub init_consoles {
                 hostname => get_required_var('SUT_IP'),
                 password => $testapi::password,
                 user     => 'root',
-                serial   => 'rm -f /dev/sshserial; mkfifo /dev/sshserial; while true; do cat /dev/sshserial; done',
+                serial   => 'rm -f /dev/sshserial; mkfifo /dev/sshserial; chmod 666 /dev/sshserial; while true; do cat /dev/sshserial; done',
                 gui      => 1
             });
     }


### PR DESCRIPTION
We cannot write to serial by users (bernhard in our case), adding 0666
permissions, similarly to generichw ssh serial for activation.

See [poo#71620](https://progress.opensuse.org/issues/71620).

### Verification runs
* https://openqa.suse.de/tests/4724267#
* https://openqa.suse.de/tests/4724255# (failure in sshd module is fixed, see https://progress.opensuse.org/issues/71641)
