### PR TITLE
Fix sbd config file for 12SP2 HA tests

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -79,7 +79,7 @@ sub run {
     # This may be necessary if your cluster nodes reboot so fast that the
     # other nodes are still waiting in the fence acknowledgement phase.
     # This is an occasional issue with virtual machines.
-    file_content_replace("$sbd_cfg", "SBD_DELAY_START=no" => "SBD_DELAY_START=yes");
+    file_content_replace("$sbd_cfg", "SBD_DELAY_START=.*" => "SBD_DELAY_START=yes");
 
     # Initialize the cluster with diskless or shared storage SBD (default)
     $fencing_opt = '-S' if (get_var('USE_DISKLESS_SBD'));


### PR DESCRIPTION
In 12SP2, the sbd sysconfig file is different than the other SLE versions:

* 12SP2: the sbd delay start is `SBD_DELAY_START=`
* 12SP3+: the sbd delay start is `SBD_DELAY_START=no`

So this line of code does not work in 12-SP2:
`file_content_replace("$sbd_cfg", "SBD_DELAY_START=no" => "SBD_DELAY_START=yes");`

This PR changes it in order to set the option also in 12-SP2.

- Related ticket: https://progress.opensuse.org/issues/70747
- Failed test: https://openqa.suse.de/tests/4723213#step/ha_cluster_init/32
- Needles: N/A
- Verification run: 
12-SP2: [node1](http://1a102.qa.suse.de/tests/5466#step/ha_cluster_init/15)
15-SP2: [node1](http://1a102.qa.suse.de/tests/5473#step/ha_cluster_init/15)
