### PR TITLE
If patterns set default, need skip this item at patch_sle

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -216,6 +216,8 @@ sub install_patterns {
     $pcm     = grep /Amazon-Web-Services|Google-Cloud-Platform|Microsoft-Azure/, @pt_list_in;
 
     for my $pt (@pt_list) {
+        # if pattern is set default, skip
+        next if ($pt =~ /default/);
         # Cloud patterns are conflict by each other, only install cloud pattern from single vender.
         if ($pt =~ /Amazon-Web-Services|Google-Cloud-Platform|Microsoft-Azure/) {
             next unless $pcm == 0;


### PR DESCRIPTION
As scc_registration test module must set PATTERNS setting, but
patch_sle don't resolve PATTERNS=default scenario, need update
patch_sle code to skip it

- Related ticket: https://progress.opensuse.org/issues/71695
- Verification run: https://10.160.0.207/tests/4729654#step/patch_sle/57