### PR TITLE
Upload solver test cases for patch_sle.pm

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -315,6 +315,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
+    $self->export_logs();
     y2_installbase::save_upload_y2logs;
 }
 1;


### PR DESCRIPTION
Since we need create solve test case for software debug, so we need upload it if patch_sle.pm failed. NOTE: Solve related function called in self->export_logs.

- Related ticket: https://progress.opensuse.org/issues/71572
- Needles: na
- Verification run:  http://openqa.suse.de/t4715113
