### PR TITLE
KLP fixes

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -45,10 +45,9 @@ sub install_klp_product {
         $lp_module  = 'SLE-Live-Patching';
     }
 
-    #install kgraft product
-    zypper_call("ar http://download.suse.de/ibs/SUSE/Products/$lp_module/$version/$arch/product/ kgraft-pool");
-    zypper_call("ar $release_override http://download.suse.de/ibs/SUSE/Updates/$lp_module/$version/$arch/update/ kgraft-update");
-    zypper_call("ref");
+    # install kgraft product
+    zypper_ar("http://download.suse.de/ibs/SUSE/Products/$lp_module/$version/$arch/product/",                 name => "kgraft-pool");
+    zypper_ar("$release_override http://download.suse.de/ibs/SUSE/Updates/$lp_module/$version/$arch/update/", name => "kgraft-update");
     zypper_call("in -l -t product $lp_product", exitcode => [0, 102, 103]);
     zypper_call("mr -e kgraft-update");
 }

--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -24,8 +24,9 @@ our @EXPORT = qw(
 );
 
 sub install_klp_product {
-    my $arch    = get_required_var('ARCH');
-    my $version = get_required_var('VERSION');
+    my $arch           = get_required_var('ARCH');
+    my $version        = get_required_var('VERSION');
+    my $livepatch_repo = get_var('REPO_SLE_MODULE_LIVE_PATCHING');
     my $release_override;
     my $lp_product;
     my $lp_module;
@@ -43,6 +44,10 @@ sub install_klp_product {
     else {
         $lp_product = 'sle-live-patching';
         $lp_module  = 'SLE-Live-Patching';
+    }
+
+    if ($livepatch_repo) {
+        zypper_ar("$utils::OPENQA_FTP_URL/$livepatch_repo", name => "repo-live-patching");
     }
 
     # install kgraft product

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -25,6 +25,7 @@ use utils;
 use main_common qw(boot_hdd_image load_bootloader_s390x load_kernel_baremetal_tests);
 use 5.018;
 use Utils::Backends 'is_pvm';
+use version_utils 'is_opensuse';
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
 # use warnings;
 
@@ -90,7 +91,8 @@ sub load_kernel_tests {
         loadtest_kernel 'qa_test_klp';
         unless (get_var('KOTD_REPO') ||
             get_var('INSTALL_KOTD') ||
-            get_var('AZURE')) {
+            get_var('AZURE')        ||
+            is_opensuse) {
             loadtest_kernel 'install_klp_product';
         }
     }


### PR DESCRIPTION
* install_klp_product: Add livepatch repo

This fixes error, which is a correct complain:
`No installed kernel livepatch package for current kernel found at /var/lib/openqa/share/tests/sle/tests/kernel/install_klp_product.pm line 47.`

* install_klp_product: Use only for SLE (it wasn't mentioned to be used on openSUSE)

Verification run: 
- SLE15 SP3 http://quasar.suse.cz/tests/5450
- Tumbleweed http://quasar.suse.cz/tests/5451 (here failure not related to the change)
NOTE: QAM is not using it yet, therefore I didn't test it