### PR TITLE
Add needles match in FIPS_ENV_MODE and remove hotkey

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -11,7 +11,7 @@
 
 # Summary: FIPS mozilla-nss test for firefox : firefox_nss
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tag: poo#47018, poo#58079
+# Tag: poo#47018, poo#58079, poo#71458
 
 use base "x11test";
 use strict;
@@ -21,7 +21,7 @@ use testapi;
 sub quit_firefox {
     send_key "alt-f4";
     if (check_screen("firefox-save-and-quit", 10)) {
-        send_key "ret";
+        assert_and_click('firefox-click-close-tabs');
     }
 }
 
@@ -69,16 +69,24 @@ sub run {
 
     assert_screen "firefox-device-manager";
 
-    send_key "alt-shift-f";    # Enable FIPS mode
+    # Add condition in FIPS_ENV_MODE & Remove hotkey
+    if (get_var('FIPS_ENV_MODE')) {
+        assert_and_click('firefox-click-enable-fips');
+        wait_still_screen 2;
+    }
+
+    # Enable FIPS mode
+    # Remove send_key "alt-shift-f";
     assert_screen "firefox-confirm-fips_enabled";
-    send_key "esc";            # Quit device manager
+    send_key "esc";    # Quit device manager
 
     quit_firefox;
     assert_screen "generic-desktop";
 
     # "start_firefox" will be not used, since the master password is
     # required when firefox launching in FIPS mode
-    x11_start_program('firefox --setDefaultBrowser https://html5test.opensuse.org', target_match => 'firefox-fips-password-inputfiled');
+    x11_start_program('firefox --setDefaultBrowser https://html5test.opensuse.org', target_match => 'firefox-fips-password-inputfiled', match_timeout => 360);
+
     type_string $fips_password;
     send_key "ret";
     assert_screen "firefox-url-loaded";


### PR DESCRIPTION
Description: 
The PR is going to fix the firefox_nss Needles match and 3-key combined hotkey fail problem for the new firefox version in s390x ENV mode and also the launch firefox fail and quit_firefox fail in aarch64 ENV mode randomly.  

1. Remove alt-shift-f hotkey usage
2. Add needles match in FIPS_ENV_MODE to enable FIPS
3. Add match_timeout in the second firefox launch
4. Add needles match for the quit_firefox close tab

- Related ticket: 
 https://progress.opensuse.org/issues/71458
 https://progress.opensuse.org/issues/71866
- Needles: 2 Needles are merged in O.S.D.
- Verification run: 

  https://openqa.suse.de/tests/4729682 (15SP3 B44.1 on x86_64 - ENV mode)
  https://openqa.suse.de/tests/4729683 (15SP3 B44.1 on x86_64 - Kernel mode)
https://openqa.suse.de/tests/4729964 (15SP3 B44.1 on s390x - ENV mode)
https://openqa.suse.de/tests/4729665 (15SP3 B44.1 on s390x - Kernel mode)
https://openqa.suse.de/tests/4729927  (15SP3 B44.1 on aarch64 - ENV mode)
https://openqa.suse.de/tests/4729685 (15SP3 B44.1 on aarch64 - Kernel mode)
https://openqa.suse.de/tests/4729688 (QAM test on 15 SP2 Updates)
