### PR TITLE
Add test data for xfs scenario in PowerVM

### DIFF
--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -34,4 +34,4 @@ schedule:
   - installation/first_boot
   - console/validate_fs_table
 test_data:
-  <<: !include test_data/yast/xfs/xfs_partition.yaml
+  <<: !include test_data/yast/xfs/xfs_partition_spvm.yaml

--- a/test_data/yast/msdos/msdos.yaml
+++ b/test_data/yast/msdos/msdos.yaml
@@ -1,8 +1,7 @@
 ---
-table_type: msdos
-partition_table_disk: vda
 disks:
   - name: vda
+    table_type: msdos
     allowed_unpartitioned: 0.00GB
     partitions:
       - size: 9250Mib

--- a/test_data/yast/msdos/msdos_hmc.yaml
+++ b/test_data/yast/msdos/msdos_hmc.yaml
@@ -1,8 +1,7 @@
 ---
-table_type: msdos
-partition_table_disk: sda
 disks:
   - name: sda
+    table_type: msdos
     allowed_unpartitioned: 0.00GB
     partitions:
       - size: 8Mib

--- a/test_data/yast/msdos/msdos_hvm.yaml
+++ b/test_data/yast/msdos/msdos_hvm.yaml
@@ -1,8 +1,7 @@
 ---
-table_type: msdos
-partition_table_disk: xvdb
 disks:
   - name: xvdb
+    table_type: msdos
     allowed_unpartitioned: 0.00GB
     partitions:
       - size: 9250Mib

--- a/test_data/yast/msdos/msdos_ppc64le.yaml
+++ b/test_data/yast/msdos/msdos_ppc64le.yaml
@@ -1,8 +1,7 @@
 ---
-table_type: msdos
-partition_table_disk: vda
 disks:
   - name: vda
+    table_type: msdos
     allowed_unpartitioned: 0.00GB
     partitions:
       - size: 8Mib

--- a/test_data/yast/msdos/msdos_pv.yaml
+++ b/test_data/yast/msdos/msdos_pv.yaml
@@ -1,8 +1,7 @@
 ---
-table_type: msdos
-partition_table_disk: xvdb
 disks:
   - name: xvdb
+    table_type: msdos
     allowed_unpartitioned: 0.00GB
     partitions:
       - size: 9250Mib

--- a/test_data/yast/msdos/msdos_s390x.yaml
+++ b/test_data/yast/msdos/msdos_s390x.yaml
@@ -1,8 +1,7 @@
 ---
-table_type: msdos
-partition_table_disk: vda
 disks:
   - name: vda
+    table_type: msdos
     allowed_unpartitioned: 0.00GB
     partitions:
       - size: 9250Mib

--- a/test_data/yast/nvme.yaml
+++ b/test_data/yast/nvme.yaml
@@ -8,10 +8,9 @@ model: QEMU NVMe Ctrl
 namespace_count: 1
 nvm_block_size: 512
 nvm_ns: 0x1
-table_type: gpt
-partition_table_disk: nvme0n1
 disks:
   - name: nvme0n1
+    table_type: gpt
     allowed_unpartitioned: 0.00GB
     partitions:
       - role: operating-system

--- a/test_data/yast/xfs/xfs_partition.yaml
+++ b/test_data/yast/xfs/xfs_partition.yaml
@@ -1,8 +1,7 @@
 ---
-table_type: gpt
-partition_table_disk: vda
 disks:
   - name: vda
+    table_type: gpt
     allowed_unpartitioned: 0.00GB
     partitions:
       - role: operating-system

--- a/test_data/yast/xfs/xfs_partition_spvm.yaml
+++ b/test_data/yast/xfs/xfs_partition_spvm.yaml
@@ -1,6 +1,6 @@
 ---
 disks:
-  - name: dasda
+  - name: sda
     table_type: gpt
     allowed_unpartitioned: 0.00GB
     partitions:
@@ -13,6 +13,15 @@ disks:
         mounting_options:
           should_mount: 1
           mount_point: /
+      - role: data
+        partition_type: primary
+        validation_flag: 1
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: /home
       - role: swap
         partition_type: primary
         validation_flag: 0

--- a/test_data/yast/xfs/xfs_partition_svirt-xen.yaml
+++ b/test_data/yast/xfs/xfs_partition_svirt-xen.yaml
@@ -1,8 +1,7 @@
 ---
-table_type: gpt
-partition_table_disk: xvdb
 disks:
   - name: xvdb
+    table_type: gpt
     allowed_unpartitioned: 0.00GB
     partitions:
       - role: operating-system

--- a/tests/console/validate_fs_table.pm
+++ b/tests/console/validate_fs_table.pm
@@ -7,8 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Validation of filesystem table type, filesystem partitioning, reading and writting in specified partitions, check of unpartitioned disk space.
-# Maintainer: Sofia Syrianidou <ssyrianidou@suse.com>
+# Summary: Validation of filesystem table type, filesystem partitioning,
+# reading and writting in specified partitions, check of unpartitioned disk space.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use strict;
 use warnings;
@@ -21,24 +23,28 @@ use partitions_validator_utils qw(
   validate_partition_creation
   validate_filesystem
   validate_read_write
-  validate_unpartitioned_space);
+  validate_unpartitioned_space
+);
 
 sub run {
-
     select_console "root-console";
-    my $test_data = get_test_suite_data();
-    if (defined $test_data->{table_type}) {
-        # Validate that the partition table type is the expected one.
-        validate_partition_table({device => "/dev/" . $test_data->{partition_table_disk}, table_type => $test_data->{table_type}});
-    }
+    my $test_data = get_test_suite_data;
 
     foreach my $disk (@{$test_data->{disks}}) {
+        if (my $table = $disk->{table_type}) {
+            # Validate that the partition table type is the expected one.
+            validate_partition_table({device => "/dev/" . $disk->{name},
+                    table_type => $table});
+        }
+
         foreach my $partition (@{$disk->{partitions}}) {
             # Validate that all partitions were created.
             my $mnt = $partition->{mounting_options}->{mount_point};
-            # Avoiding checking prep-boot partition creation, which does not have a defined mount point.
+            # Avoiding checking prep-boot partition creation, which does not have
+            # a defined mount point.
             validate_partition_creation({mount_point => $mnt}) if $mnt;
-            # "validation_flag" is used in order to avoid validating filesystem type and ability to read-write in swap and boot partitions.
+            # "validation_flag" is used in order to avoid validating filesystem
+            # type and ability to read-write in swap and boot partitions.
             if ($partition->{validation_flag} == 1) {
                 # Validate the partitions' filesystem is the expected one.
                 my $fmt = $partition->{formatting_options}->{filesystem};
@@ -47,12 +53,11 @@ sub run {
             }
         }
 
-        if (defined $disk->{allowed_unpartitioned}) {
-            validate_unpartitioned_space({disk => $disk->{name}, allowed_unpartitioned => $disk->{allowed_unpartitioned}});
+        if (my $allowed_unpartitioned = $disk->{allowed_unpartitioned}) {
+            validate_unpartitioned_space({disk => $disk->{name},
+                    allowed_unpartitioned => $allowed_unpartitioned});
         }
     }
 }
 
 1;
-
-

--- a/tests/installation/partitioning/msdos_partition_table.pm
+++ b/tests/installation/partitioning/msdos_partition_table.pm
@@ -6,29 +6,30 @@
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
+#
 # Summary: Create new partition table during installation.
-# Maintainer: Sofia Syrianidou <ssyrianidou@suse.com>
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use strict;
 use warnings;
 use parent 'installbasetest';
 use testapi;
-use version_utils ':VERSION';
 use scheduler 'get_test_suite_data';
 
 sub run {
-    my $test_data   = get_test_suite_data();
-    my $partitioner = $testapi::distri->get_expert_partitioner();
-    $partitioner->run_expert_partitioner();
-    $partitioner->create_new_partition_table({disk => $test_data->{partition_table_disk}, table_type => $test_data->{table_type}});
+    my $test_data   = get_test_suite_data;
+    my $partitioner = $testapi::distri->get_expert_partitioner;
+    $partitioner->run_expert_partitioner;
     foreach my $disk (@{$test_data->{disks}}) {
+        $partitioner->create_new_partition_table({disk => $disk->{name},
+                table_type => $disk->{table_type}});
         foreach my $partition (@{$disk->{partitions}}) {
-            $partitioner->add_partition_msdos({disk => $disk->{name}, partition => $partition});
+            $partitioner->add_partition_msdos({disk => $disk->{name},
+                    partition => $partition});
         }
     }
-    $partitioner->accept_changes_and_press_next();
+    $partitioner->accept_changes_and_press_next;
 }
+
 1;
-
-


### PR DESCRIPTION
Add test data for xfs scenario in PowerVM.
Additionally, move partition table inside disk in test data for test suites: msdos,xfs,nvme

- Related ticket: [poo#71731](https://progress.opensuse.org/issues/71731)
- Verification run: [validate_fs_table in msdos,xfs & nvme](https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23validate_fs_table)