### PR TITLE
sles4sap: Move sapconf module after saptune in migration tests

### DIFF
--- a/schedule/sles4sap/migration/migration_offline_sles4sap.yaml
+++ b/schedule/sles4sap/migration/migration_offline_sles4sap.yaml
@@ -42,6 +42,6 @@ schedule:
   - migration/post_upgrade
   - console/system_prepare
   - sles4sap/patterns
-  - sles4sap/sapconf
   - sles4sap/saptune
   - sles4sap/netweaver_test_instance
+  - sles4sap/sapconf

--- a/schedule/sles4sap/migration/migration_online_sles4sap.yaml
+++ b/schedule/sles4sap/migration/migration_online_sles4sap.yaml
@@ -36,6 +36,6 @@ schedule:
   - migration/online_migration/post_migration
   - console/system_prepare
   - sles4sap/patterns
-  - sles4sap/sapconf
   - sles4sap/saptune
   - sles4sap/netweaver_test_instance
+  - sles4sap/sapconf


### PR DESCRIPTION
Fix sapconf module in migration tests by disabling tuned.

Verification run:
http://ix64hae1001.qa.suse.de/tests/2158