### PR TITLE
Disable extended tests for tests with LTSS guest or host

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -773,7 +773,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {
         loadtest "virt_autotest/guest_installation_run";
-        if (!(get_var("GUEST_PATTERN") =~ /win/img) && is_x86_64) {
+        if (!(get_var("GUEST_PATTERN") =~ /win/img) && is_x86_64 && !get_var("LTSS")) {
             loadtest "virt_autotest/set_config_as_glue";
             loadtest "virt_autotest/setup_dns_service";
             if (get_var("ENABLE_VIR_NET")) {


### PR DESCRIPTION
Add a setting, LTSS=1, in prj1 test suites with LTSS guest or host to disable extended tests.

- Verification run: 
[gi-guest_developing-on-host_sles11sp4-kvm](https://openqa.nue.suse.com/tests/4731368)
[gi-guest_developing-on-host_sles15sp2-kvm](https://openqa.nue.suse.com/tests/4731375)