### PR TITLE
Upload schema files for the autoyast tests

### DIFF
--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -10,7 +10,17 @@ use Exporter 'import';
 use Utils::Architectures;
 
 
-our @EXPORT_OK = qw(select_conflict_resolution workaround_dependency_issues break_dependency verify_license_has_to_be_accepted accept_license verify_license_translations get_available_compression);
+our @EXPORT_OK = qw(
+  select_conflict_resolution
+  workaround_dependency_issues
+  break_dependency
+  verify_license_has_to_be_accepted
+  accept_license
+  verify_license_translations
+  get_available_compression
+  upload_autoyast_profile
+  upload_autoyast_schema
+);
 
 
 # select the conflict resolution for dependency issues
@@ -136,5 +146,44 @@ sub get_available_compression {
     return "";
 }
 
+=head2 upload_autoyast_profile
+
+    upload_autoyast_profile($self);
+
+Uploads autoyast profile used for the installation, as well as modified profile,
+in case feature to modify the profile dynamically was used.
+Non existing files will be ignored.
+=cut
+sub upload_autoyast_profile {
+    # Upload autoyast profile if file exists
+    if (script_run('test -e /tmp/profile/autoinst.xml') == 0) {
+        upload_logs '/tmp/profile/autoinst.xml';
+    }
+    # Upload cloned system profile if file exists
+    if (script_run('test -e /root/autoinst.xml') == 0) {
+        upload_logs '/root/autoinst.xml';
+    }
+    # Upload modified profile if pre-install script uses this feature
+    if (script_run('test -e /tmp/profile/modified.xml') == 0) {
+        upload_logs '/tmp/profile/modified.xml';
+    }
+    save_screenshot;
+}
+
+=head2 upload_autoyast_schema
+
+    upload_autoyast_schema($self);
+
+Uploads autoyast schema files shipped in the distribution as a tarball.
+If expected directory doesn't exist, no attempt to upload logs occurs.
+=cut
+sub upload_autoyast_schema {
+    my ($self) = @_;
+    my $xml_schema_path = "/usr/share/YaST2/schema/autoyast/rng";
+    # Upload schema files if directory exists
+    if (script_run("test -e $xml_schema_path") == 0) {
+        $self->tar_and_upload_log("$xml_schema_path/*.rng", '/tmp/autoyast_schema.tar.bz2');
+    }
+}
 
 1;

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -46,6 +46,7 @@ use x11utils 'untick_welcome_on_next_startup';
 use Utils::Backends 'is_pvm';
 use scheduler 'get_test_suite_data';
 use autoyast 'test_ayp_url';
+use y2_logs_helper qw(upload_autoyast_profile upload_autoyast_schema);
 
 my $confirmed_licenses = 0;
 my $stage              = 'stage1';
@@ -71,18 +72,6 @@ sub save_and_upload_stage_logs {
     # save_y2logs is not present
     assert_script_run "tar czf /tmp/logs-stage.tar.bz2 /var/log";
     upload_logs "/tmp/logs-stage1-error$i.tar.bz2";
-}
-
-sub upload_autoyast_profile {
-    # Upload autoyast profile if file exists
-    if (script_run '! test -e /tmp/profile/autoinst.xml') {
-        upload_logs '/tmp/profile/autoinst.xml';
-    }
-    # Upload modified profile if pre-install script uses this feature
-    if (script_run '! test -e /tmp/profile/modified.xml') {
-        upload_logs '/tmp/profile/modified.xml';
-    }
-    save_screenshot;
 }
 
 sub handle_expected_errors {
@@ -409,6 +398,7 @@ sub post_fail_hook {
     my ($self) = shift;
     $self->SUPER::post_fail_hook;
     $self->upload_autoyast_profile;
+    $self->upload_autoyast_schema;
 }
 
 1;

--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -18,8 +18,7 @@ use testapi;
 use version_utils qw(is_sle is_opensuse is_staging);
 use utils 'zypper_call';
 use repo_tools 'get_repo_var_name';
-
-my $xml_schema_path = "/usr/share/YaST2/schema/autoyast/rng";
+use y2_logs_helper qw(upload_autoyast_profile upload_autoyast_schema);
 
 sub run {
     my $self = shift;
@@ -52,7 +51,7 @@ sub run {
 
     zypper_call 'install jing';
     zypper_call "rr devel-repo" if (is_staging);
-    my $rc_jing = script_run "jing $xml_schema_path/profile.rng $ay_profile_path";
+    my $rc_jing = script_run "jing /usr/share/YaST2/schema/autoyast/rng/profile.rng $ay_profile_path";
 
     if ($rc_jing) {
         if (is_sle('<15')) {
@@ -83,7 +82,8 @@ sub get_ftp_uri {
 sub post_fail_hook {
     my $self = shift;
     $self->SUPER::post_fail_hook;
-    $self->tar_and_upload_log("$xml_schema_path/*.rng", '/tmp/autoyast_schema.tar.bz2');
+    $self->upload_autoyast_profile;
+    $self->upload_autoyast_schema;
 }
 
 1;


### PR DESCRIPTION
We don't upload schema files as of now, which is very usefull for the
investigation. Adding those steps to relevant post-fail hooks.

See [poo#71719](https://progress.opensuse.org/issues/71719).

[Verification runs](https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%23yast) NOTE: those test post fail hooks, so intended to fail, schema tarballs have to be uploaded though
