### PR TITLE
Avoid running investigate_yast2_failure twice

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -458,10 +458,6 @@ sub export_logs {
     $self->save_and_upload_log('systemctl status',          '/tmp/systemctl_status.log');
     $self->save_and_upload_log('systemctl',                 '/tmp/systemctl.log', {screenshot => 1});
 
-    my $compression = is_sle('=12-sp1') ? 'bz2' : 'xz';
-    if (script_run("save_y2logs /tmp/y2logs_clone.tar.$compression") == 0) {
-        upload_logs "/tmp/y2logs_clone.tar.$compression";
-    }
     if ($utils::IN_ZYPPER_CALL) {
         script_run("zypper -n patch --debug-solver --with-interactive -l");
         script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -467,7 +467,6 @@ sub export_logs {
         script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");
         upload_logs "/tmp/solverTestCase.tar.bz2 ";
     }
-    $self->investigate_yast2_failure();
 }
 
 =head2 export_logs_locale


### PR DESCRIPTION
opensusebasetest::investigate_yast2_failure is called already by y2_installbase::save_upload_y2logs

With this patch: https://openqa.suse.de/t4733217
Even more trimming: https://openqa.suse.de/tests/4733298
Without this patch: https://openqa.suse.de/tests/4733078
