### PR TITLE
Add support alt-x for Expert-Partitioner button

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -500,7 +500,13 @@ sub check_warnings {
 sub enter_partitioning {
     # create partitioning
     if (is_storage_ng) {
-        send_key $cmd{expertpartitioner};
+        if (check_screen 'expert-partitioner-alt-x-button', 2) {
+            # bypass https://progress.opensuse.org/issues/59876
+            send_key 'alt-x';
+        }
+        else {
+            send_key $cmd{expertpartitioner};
+        }
         save_screenshot;
         rescan_devices;
     }


### PR DESCRIPTION
Add support alt-x for Expert-Partitioner button
as randomly displayed on openQA tests,
tracked by https://progress.opensuse.org/issues/59876

- Related ticket: https://progress.opensuse.org/issues/59876
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/4a382fa98c2b63a5d96c68804cca06a9dbeb4eb9
- Verification run: https://openqa.opensuse.org/tests/1405080
The verification only show that no side effect when random needle not detected, because flow covered by this PR is rare.