### PR TITLE
Fix SLES4SAP clusters

### DIFF
--- a/schedule/sles4sap/ha_supportserver.yaml
+++ b/schedule/sles4sap/ha_supportserver.yaml
@@ -21,7 +21,6 @@ description: >
 vars:
   BOOT_HDD_IMAGE: '1'
   DESKTOP: textmode
-  NICTYPE: tap
   SUPPORT_SERVER: '1'
   SUPPORT_SERVER_ROLES: dhcp,dns,ntp,ssh,iscsi
   VIDEOMODE: text

--- a/schedule/sles4sap/hana/hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/hana_cluster_node.yaml
@@ -34,7 +34,6 @@ vars:
   INSTANCE_IP_CIDR: '10.0.2.200/24'
   INSTANCE_SID: 'HA1'
   INSTANCE_TYPE: HDB
-  NICTYPE: tap
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
 schedule:

--- a/schedule/sles4sap/netweaver/netweaver_cluster_node.yaml
+++ b/schedule/sles4sap/netweaver/netweaver_cluster_node.yaml
@@ -28,7 +28,6 @@ vars:
   HDD_SCC_REGISTERED: '1'
   VIRTIO_CONSOLE: '0'
   HA_CLUSTER: '1'
-  NICTYPE: tap
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
 schedule:

--- a/schedule/sles4sap/remote_desktop/sles4sap_remote_desktop_server.yaml
+++ b/schedule/sles4sap/remote_desktop/sles4sap_remote_desktop_server.yaml
@@ -5,7 +5,6 @@ description: >
 vars:
   BOOTFROM: c
   NETWORKS: fixed
-  NICTYPE: tap
   REGRESSION: remote
   REMOTE_DESKTOP_TYPE: xrdp_server
   VIRTIO_CONSOLE: '0'

--- a/schedule/sles4sap/remote_desktop/sles4sap_remote_desktop_windows_client.yaml
+++ b/schedule/sles4sap/remote_desktop/sles4sap_remote_desktop_windows_client.yaml
@@ -5,7 +5,6 @@ description: >
 vars:
   BOOTFROM: c
   NETWORKS: fixed
-  NICTYPE: tap
   REGRESSION: remote
   REMOTE_DESKTOP_TYPE: win_client
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML


### PR DESCRIPTION
'NICTYPE' variable have to be defined in the YAML scheduler file and not in the YAML testsuite file, otherwise the WebUI can't get the information and thus can't calculate the appropriate value for the network tag.

- Related ticket: N/A
- Needles: N/A
- Scheduler YAML file: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/193
- Verification run: [NW node 01](http://1b210.qa.suse.de/tests/7414), [NW node 02](http://1b210.qa.suse.de/tests/7415), [WMP node 01](http://1b210.qa.suse.de/tests/7417), [WMP node 02](http://1b210.qa.suse.de/tests/7418), [HANA node01](http://1b210.qa.suse.de/tests/7423), [HANA node02](http://1b210.qa.suse.de/tests/7424)

NOTE: failures on some tests seem to be related to timeout issues, as the 3 clusters were started on the same worker at the same time...