### PR TITLE
autoyast: Remove script section to manipulate /etc/default/grub

### DIFF
--- a/data/autoyast_sle12/autoyast_wicked_aarch64.xml
+++ b/data/autoyast_sle12/autoyast_wicked_aarch64.xml
@@ -25,23 +25,6 @@
       </listentry>
     </add_on_products>
   </add-on>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle12/autoyast_wicked_ppc64le.xml
+++ b/data/autoyast_sle12/autoyast_wicked_ppc64le.xml
@@ -38,23 +38,6 @@
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle12/autoyast_wicked_x86_64.xml
+++ b/data/autoyast_sle12/autoyast_wicked_x86_64.xml
@@ -25,23 +25,6 @@
       </listentry>
     </add_on_products>
   </add-on>
-   <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle12/autoyast_wicked_x86_64.xml.ep
+++ b/data/autoyast_sle12/autoyast_wicked_x86_64.xml.ep
@@ -35,24 +35,6 @@
       </addon>
     </addons>
   </suse_register>
-
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/autoyast_containers_aarch64.xml
+++ b/data/autoyast_sle15/autoyast_containers_aarch64.xml
@@ -44,23 +44,6 @@
   <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/autoyast_containers_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_containers_ppc64le.xml
@@ -63,23 +63,6 @@
   <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/autoyast_containers_s390x.xml
+++ b/data/autoyast_sle15/autoyast_containers_s390x.xml
@@ -84,23 +84,6 @@
   <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            sed -i 's/GRUB_CMDLINE_LINUX="/GRUB_CMDLINE_LINUX="plymouth.enable=0\ /' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
    <drive>
      <device>/dev/disk/by-path/ccw-0.0.0000</device>

--- a/data/autoyast_sle15/autoyast_containers_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_containers_x86_64.xml
@@ -45,23 +45,6 @@
   <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/autoyast_hpc_aarch64.xml
+++ b/data/autoyast_sle15/autoyast_hpc_aarch64.xml
@@ -62,23 +62,6 @@
       <append>splash=verbose</append>
     </global>
   </bootloader>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/autoyast_hpc_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_hpc_x86_64.xml
@@ -62,23 +62,6 @@
       <append>splash=verbose</append>
     </global>
   </bootloader>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/autoyast_wicked_aarch64.xml
+++ b/data/autoyast_sle15/autoyast_wicked_aarch64.xml
@@ -32,23 +32,6 @@
       <append>splash=verbose</append>
     </global>
   </bootloader>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
@@ -50,23 +50,6 @@
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/autoyast_wicked_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_wicked_x86_64.xml
@@ -37,23 +37,6 @@
       <append>splash=verbose</append>
     </global>
   </bootloader>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source>
-          <![CDATA[
-            #!/bin/sh
-            sed -i 's/resume=\/dev\/vda.//' /etc/default/grub
-            sed -i 's/splash=silent\ quiet//' /etc/default/grub
-            sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-            ]]>
-        </source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>

--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -98,10 +98,6 @@
                 <source>
                     <![CDATA[
                         #!/bin/sh
-                        sed -i 's/resume=\/dev\/sda.//' /etc/default/grub
-                        sed -i 's/splash=silent\ quiet//' /etc/default/grub
-                        sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
-                        grub2-mkconfig -o /boot/grub2/grub.cfg
                         update-alternatives --install /usr/bin/python python /usr/bin/python2 1
                         update-alternatives --install /usr/bin/python python /usr/bin/python3 2
                         ]]>


### PR DESCRIPTION
The chroot-script section is executed before boot loader is configured [1].
Because of this, the /etc/default/grub file is "empty" at that time and our script just doesn't do anything.
We could do our trick in a `<post-scripts>` section, but it looks like this hole trick isn't needed!

[1] https://documentation.suse.com/sles/12-SP5/single-html/SLES-autoyast/index.html#chroot-scripts


- Verification run: http://openqa.wicked.suse.de/tests/overview?build=TEST_AUTOYAST

Currently SLE_12_SP4 is failing, but I think it is some scc problem during installation http://openqa.wicked.suse.de/tests/2306#step/installation/4
