### PR TITLE
Unify the backup path on the validate_encrypt module

### DIFF
--- a/lib/validate_encrypt_utils.pm
+++ b/lib/validate_encrypt_utils.pm
@@ -205,6 +205,7 @@ sub verify_restoring_luks_backups {
     validate_script_output("file $backup_path", sub { m/$backup_file_info/ });
     assert_script_run("cryptsetup -v --batch-mode luksHeaderRestore $mapped_dev_path" .
           " --header-backup-file $backup_path");
+    assert_script_run("rm -rf $backup_path");
 }
 
 1;

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -44,6 +44,4 @@ schedule:
 test_data:
   crypttab:
     num_devices_encrypted: 1
-  cr_scsi-1IET_00010001-part2:
-    backup_path: '/root/bkp_luks_header_cr_scsi-1IET_00010001-part2'
   <<: !include test_data/yast/encryption/default_enc.yaml

--- a/test_data/yast/encryption/autoyast_multi_btrfs.yaml
+++ b/test_data/yast/encryption/autoyast_multi_btrfs.yaml
@@ -9,5 +9,4 @@ cryptsetup:
       key_location: dm-crypt
       mode: read/write
 backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
-cr_test:
-  backup_path: '/root/bkp_luks_header_cr_test'
+backup_path: '/root/bkp_luks_header'

--- a/test_data/yast/encryption/encrypt_home.yaml
+++ b/test_data/yast/encryption/encrypt_home.yaml
@@ -9,9 +9,4 @@ cryptsetup:
       key_location: dm-crypt
       mode: read/write
 backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
-cr_root:
-  backup_path: '/root/bkp_luks_header_cr_root'
-cr_home:
-  backup_path: '/root/bkp_luks_header_cr_home'
-cr_swap:
-  backup_path: '/root/bkp_luks_header_cr_swap'
+backup_path: '/root/bkp_luks_header'

--- a/test_data/yast/encryption/encrypt_no_lvm.yaml
+++ b/test_data/yast/encryption/encrypt_no_lvm.yaml
@@ -1,9 +1,3 @@
 crypttab:
   num_devices_encrypted: 3
 <<: !include test_data/yast/encryption/default_enc.yaml
-cr_root:
-  backup_path: '/root/bkp_luks_header_cr_root'
-cr_home:
-  backup_path: '/root/bkp_luks_header_cr_home'
-cr_swap:
-  backup_path: '/root/bkp_luks_header_cr_swap'

--- a/test_data/yast/encryption/full_lvm_enc.yaml
+++ b/test_data/yast/encryption/full_lvm_enc.yaml
@@ -1,5 +1,3 @@
 crypttab:
   num_devices_encrypted: 1
 <<: !include test_data/yast/encryption/default_enc.yaml
-cr_vda2:
-  backup_path: '/root/bkp_luks_header_cr_vda2'

--- a/test_data/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/test_data/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -1,5 +1,3 @@
 crypttab:
   num_devices_encrypted: 1
 <<: !include test_data/yast/encryption/default_enc.yaml
-cr_vda3:
-  backup_path: '/root/bkp_luks_header_cr_vda3'

--- a/tests/console/validate_encrypt.pm
+++ b/tests/console/validate_encrypt.pm
@@ -48,7 +48,7 @@ sub run {
         verify_restoring_luks_backups(
             encrypted_device_path => $devices->{$dev}->{encrypted_device},
             backup_file_info      => $test_data->{backup_file_info},
-            backup_path           => $test_data->{$dev}->{backup_path}
+            backup_path           => $test_data->{backup_path}
         );
     }
 }


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/71728
- [Verification run](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2371728_validate_encrypt_powervm)
