### PR TITLE
Add missing SLES4SAP tests

### DIFF
--- a/schedule/sles4sap/sles4sap_test.yaml
+++ b/schedule/sles4sap/sles4sap_test.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - boot/boot_to_desktop
   - console/system_prepare
-  - sles4sap/migrate_sles_to_sles4sap
   - sles4sap/patterns
   - '{{module_to_test}}'
 conditional_schedule:


### PR DESCRIPTION
Add some missing and new tests for SLES4SAP.

- Related ticket: N/A
- Needles: N/A
- YAML scheduler change: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/194
- Verification run: http://1b210.qa.suse.de/tests/7430

**Note:** texmode text cannot be done, because of a product bug during the installation.