### PR TITLE
Fix partitioning_specific_disk cursor position issue

### DIFF
--- a/tests/installation/partitioning_specific_disk.pm
+++ b/tests/installation/partitioning_specific_disk.pm
@@ -57,7 +57,7 @@ sub run {
 
     # Select device
     my $disk = get_required_var('SPECIFIC_DISK');
-    send_key 'tab';
+    send_key 'alt-s';
     send_key 'tab';
     send_key_until_needlematch("expert-partitioner-$disk", "down", 20, 2);
     send_key 'ret';


### PR DESCRIPTION
Cursor position changed in partitioning window on sle15sp3, set it to
system view as a common inital position. This backward compatible.

- Related ticket: https://trello.com/c/2LLV5SuH/424-p0fix-buildinstall-issue-on-build-431
- Needles: N/A
- Verification run: http://openqa.qa2.suse.asia/tests/18326
