### PR TITLE
Fix autoyast profiles to match the schema

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -81,7 +81,7 @@ pre init scripts feature. See poo#20818.
       <activate>true</activate>
       <append>mce=dont_log_ce edd=off consoleblank=0 rd.lvm.vg=system biosdevname=0 elevator=deadline</append>
       <boot_mbr>true</boot_mbr>
-      <secure-boot>off</secure-boot>
+      <secure_boot>false</secure_boot>
       <suse_btrfs config:type="boolean">false</suse_btrfs>
       <os_prober>false</os_prober>
       <terminal>console</terminal>
@@ -125,11 +125,6 @@ pre init scripts feature. See poo#20818.
     <languages>en_US,de_DE</languages>
   </language>
 
-  <mail>
-    <listen_remote config:type="boolean">false</listen_remote>
-    <postfix_mda config:type="symbol">local</postfix_mda>
-  </mail>
-
   <networking>
     <ipv6 config:type="boolean">true</ipv6>
     <keep_install_network config:type="boolean">true</keep_install_network>
@@ -146,8 +141,6 @@ pre init scripts feature. See poo#20818.
       <nameservers config:type="list">
         <nameserver>10.0.2.3</nameserver>
       </nameservers>
-      <searchlist config:type="list">
-      </searchlist>
     </dns>
 
     <interfaces config:type="list">

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -30,8 +30,6 @@
       <xen_kernel_append> splash=silent quiet showopts</xen_kernel_append>
     </global>
     <loader_type>grub2</loader_type>
-    <sections config:type="list">
-    </sections>
   </bootloader>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
@@ -665,7 +663,6 @@
     </services>
   </services-manager>
   <software>
-    <image/>
     <instsource/>
     <packages config:type="list">
       <package>dconf</package>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -95,8 +95,6 @@ find / -name YaST2-Second-Stage.service
       <timeout config:type="integer">-1</timeout>
     </global>
     <loader_type>grub2</loader_type>
-    <sections config:type="list">
-    </sections>
   </bootloader>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
@@ -753,7 +751,6 @@ find / -name YaST2-Second-Stage.service
     </services>
   </services-manager>
   <software>
-    <image/>
     <instsource/>
     <packages config:type="list">
       <package>dconf</package>

--- a/data/autoyast_sle15/bug-877438_ix64ph1029.xml
+++ b/data/autoyast_sle15/bug-877438_ix64ph1029.xml
@@ -57,7 +57,6 @@
       </initrd_module>
     </initrd_modules>
     <loader_type>grub2</loader_type>
-    <sections config:type="list"/>
   </bootloader>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
@@ -112,10 +111,6 @@
       <timeout config:type="integer">0</timeout>
     </yesno_messages>
   </report>
-  <runlevel>
-    <default_target>multi-user</default_target>
-    <services config:type="list"/>
-  </runlevel>
   <services-manager>
     <default_target>multi-user</default_target>
     <services config:type="list"/>

--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -254,10 +254,6 @@
       <timeout config:type="integer">0</timeout>
     </yesno_messages>
   </report>
-  <runlevel>
-    <default_target>graphical</default_target>
-    <services config:type="list"/>
-  </runlevel>
   <services-manager>
     <default_target>graphical</default_target>
     <services config:type="list"/>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -360,33 +360,6 @@
       <timeout config:type="integer">0</timeout>
     </yesno_messages>
   </report>
-  <runlevel>
-    <default_target>graphical</default_target>
-    <services config:type="list">
-      <service>cron</service>
-      <service>getty@tty1</service>
-      <service>getty@tty2</service>
-      <service>getty@tty3</service>
-      <service>getty@tty4</service>
-      <service>getty@tty5</service>
-      <service>getty@tty6</service>
-      <service>haveged</service>
-      <service>irqbalance</service>
-      <service>kdump</service>
-      <service>nscd</service>
-      <service>postfix</service>
-      <service>purge-kernels</service>
-      <service>rsyslog</service>
-      <service>wicked</service>
-      <service>wickedd-auto4</service>
-      <service>wickedd-dhcp4</service>
-      <service>wickedd-dhcp6</service>
-      <service>wickedd-nanny</service>
-      <service>wickedd</service>
-      <service>YaST2-Firstboot</service>
-      <service>YaST2-Second-Stage</service>
-    </services>
-  </runlevel>
   <services-manager>
     <default_target>graphical</default_target>
     <services config:type="list">
@@ -415,7 +388,6 @@
     </services>
   </services-manager>
   <software>
-    <image/>
     <instsource/>
     <packages config:type="list">
       <package>at-spi2-atk-common</package>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -130,19 +130,6 @@
       <timeout config:type="integer">0</timeout>
     </yesno_messages>
   </report>
-  <runlevel>
-    <default>3</default>
-    <services config:type="list">
-      <service>
-        <service_name>nfs</service_name>
-        <service_status>enable</service_status>
-      </service>
-      <service>
-        <service_name>sshd</service_name>
-        <service_status>enable</service_status>
-      </service>
-    </services>
-  </runlevel>
   <scripts>
     <init-scripts config:type="list">
       <script>


### PR DESCRIPTION
Multiple fixes for the autoyast profiles as per current schema.

See [poo#71719](https://progress.opensuse.org/issues/71719).

Jobs will still fail due to following bugs:
* [bsc#1176970](https://bugzilla.suse.com/show_bug.cgi?id=1176970)
* [bsc#1176974](https://bugzilla.suse.com/show_bug.cgi?id=1176974)
* [bsc#1176991](https://bugzilla.suse.com/show_bug.cgi?id=1176991)

[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23yast).