### PR TITLE
Upload solver testcase for zypper_migration

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -463,9 +463,7 @@ sub export_logs {
         upload_logs "/tmp/y2logs_clone.tar.$compression";
     }
     if ($utils::IN_ZYPPER_CALL) {
-        script_run("zypper -n patch --debug-solver --with-interactive -l");
-        script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");
-        upload_logs "/tmp/solverTestCase.tar.bz2 ";
+        $self->upload_solvertestcase_logs();
     }
     $self->investigate_yast2_failure();
 }
@@ -495,6 +493,19 @@ Upload C</var/log/pk_backend_zypp>.
 sub upload_packagekit_logs {
     my ($self) = @_;
     upload_logs '/var/log/pk_backend_zypp';
+}
+
+=head2 upload_solvertestcase_logs
+
+ upload_solvertestcase_logs();
+
+Upload C</tmp/solverTestCase.tar.bz2>.
+
+=cut
+sub upload_solvertestcase_logs {
+    script_run("zypper -n patch --debug-solver --with-interactive -l");
+    script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");
+    upload_logs "/tmp/solverTestCase.tar.bz2 ";
 }
 
 =head2 set_standard_prompt

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -141,4 +141,12 @@ sub run {
     $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => (is_sles4sap || is_leap_migration));
 }
 
+sub post_fail_hook {
+    my $self = shift;
+    $self->SUPER::post_fail_hook;
+    $self->select_serial_terminal;
+    script_run("pkill zypper");
+    $self->upload_solvertestcase_logs();
+}
+
 1;


### PR DESCRIPTION
We need upload the solver test case when zypper migration failed, but currently only zypper_call can trigger solver test cases upload to openQA, but in zypper_migration we face situation which not call zypper_call function. So add post_fail_hook to upload the solver test case directly.

- Related ticket: https://progress.opensuse.org/issues/71584
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/4742248#downloads.