### PR TITLE
[virt_autotest] Fix up log directory cleanup in prj6 virt_v2v

### DIFF
--- a/tests/virt_autotest/virt_v2v_src.pm
+++ b/tests/virt_autotest/virt_v2v_src.pm
@@ -22,13 +22,13 @@ use virt_utils;
 sub run {
     my ($self) = @_;
 
-    my $ip_out = $self->execute_script_run('ip route show|grep kernel|cut -d" " -f9|head -1', 30);
+    my $ip_out = script_output('ip route show|grep kernel|cut -d" " -f9|head -1', 30);
     set_var('SRC_IP',   $ip_out);
     set_var('SRC_USER', "root");
     set_var('SRC_PASS', $password);
     bmwqemu::save_vars();
 
-    $self->execute_script_run("rm -r /var/log/qa/ctcs2/* /tmp/virt-v2v/* -r", 30);
+    script_run("rm -r /var/log/qa/ctcs2/* /tmp/virt-v2v/* -r", 30);
 
     mutex_create('SRC_READY_TO_START');
 


### PR DESCRIPTION
which worked in the past but does not work recently due to virt_auto_base.pm is reconstructed. because '[ rm -r /var/log/qa/ctcs2/*' will return 1 in $self->execute_script_run().


Failed test run: 
virt-v2v-win2k19fcs-from-developing-to-developing-kvm-dst
http://openqa.qa2.suse.asia/tests/18672

Verification run:
virt-v2v-developing-from-developing-to-developing-kvm-dst
http://10.67.129.4/tests/18936

virt-v2v-sles12sp5-from-developing-to-developing-kvm-dst
http://10.67.129.4/tests/18938
