### PR TITLE
Fix leap to SLES gnome migration waiting for display manager issue

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -18,12 +18,17 @@ use warnings;
 use migration 'check_rollback_system';
 use power_action_utils 'power_action';
 use Utils::Backends 'is_pvm';
+use version_utils;
 
 sub run {
     my ($self) = @_;
-
-    if (!check_screen 'linux-login', 200) {
-        assert_screen 'displaymanager', 90;
+    if (is_leap_migration && check_var('DESKTOP', 'gnome')) {
+        assert_screen 'generic-desktop', 90;
+    }
+    else {
+        if (!check_screen 'linux-login', 200) {
+            assert_screen 'displaymanager', 90;
+        }
     }
     select_console 'root-console';
     # 1)

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -138,7 +138,7 @@ sub run {
     # with other than the SAP Administrator
     #
     # sometimes reboot takes longer time after online migration, give more time
-    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => (is_sles4sap || is_leap_migration));
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => is_sles4sap);
 }
 
 1;


### PR DESCRIPTION
In leap to SLES gnome zypper migration test, we need to skip the wait for display
manager step. 
Because in the creating of qcow file phrase, we choose the auto login option in the 
installation. After the installation the system will boot directly into the generic desktop. 
So in our migration test the leap will boot directly into the generic desktop.We don't 
need to wait the display manager as the SLES do. 

- Related ticket: 
  https://progress.opensuse.org/issues/71824
  https://progress.opensuse.org/issues/71887

- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/4738957
   https://openqa.nue.suse.com/tests/4736144
   https://openqa.nue.suse.com/tests/4743563
   https://openqa.nue.suse.com/tests/4743620
   Regression:
   https://openqa.nue.suse.com/tests/4743562