### PR TITLE
Remove partition_alignment section from SLE 15 ay profiles

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -31,7 +31,6 @@ pre init scripts feature. See poo#20818.
       <final_reboot config:type="boolean">true</final_reboot>
     </mode>
     <storage>
-      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
     <signature-handling>

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -49,7 +49,6 @@
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
     <storage>
-      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -114,7 +114,6 @@ find / -name YaST2-Second-Stage.service
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
     <storage>
-      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>

--- a/data/autoyast_sle15/bug-877438_ix64ph1029.xml
+++ b/data/autoyast_sle15/bug-877438_ix64ph1029.xml
@@ -76,7 +76,6 @@
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
     <storage>
-      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>

--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -64,7 +64,6 @@
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
     <storage>
-      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -88,7 +88,6 @@
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
     <storage>
-      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>


### PR DESCRIPTION
As per discussion in [bsc#1176974](https://bugzilla.suse.com/show_bug.cgi?id=1176974).

Section was dropped, and it's documented. So fixing profiles which use
this node.

See [poo#71719](https://progress.opensuse.org/issues/71719).