### PR TITLE
Add smbclient and CIFS test

### DIFF
--- a/data/samba/Currywurst.txt
+++ b/data/samba/Currywurst.txt
@@ -1,0 +1,24 @@
+Sauce for 4 sausages
+
+* 1 onion
+* 2 tablespoons corn or raps oil
+* 2-4 tablespoons curry powder
+* 1/4 teaspoon Cayenne pepper
+* 2-3 tablespoons tomato paste ("Tomatenmark")
+* 3 tablespoons tomato Ketchup
+* 1 tablespoon vinegar (apple vinegar preferred)
+* Salt, Pepper
+
+Chop and fry the onion in the oil.
+Put in the curry powder and cayenne pepper and shortly fry
+Add the tomato paste and fry shortly
+
+Put the pan off the flame and mix the other ingredients.
+Blend the sauce for maximum smoothness
+
+Roast the sausages until they have a nice crust, cut into slices and serve with sauce
+Consider adding additional 1/2-1 teaspoon of curry powder per sausage
+
+Serve with freshly fried fries.
+
+Enjoy! :-)

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1815,6 +1815,7 @@ sub load_extra_tests_filesystem {
     loadtest 'console/snapper_used_space' if (is_sle('15-SP1+') || (is_opensuse && !is_leap('<15.1')));
     loadtest "console/udisks2" unless is_sle;
     loadtest "console/zfs" if (is_leap(">=15.1") && is_x86_64 && !is_jeos);
+    loadtest "network/cifs";
 }
 
 sub get_wicked_tests {

--- a/tests/network/cifs.pm
+++ b/tests/network/cifs.pm
@@ -1,0 +1,108 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test samba client and CIFS mount
+# * Test smbclient directory listing
+# * Test mounting a CIFS filesystem (with different versions)
+# * Test file access on the CIFS mount (put file, stat, rm file)
+# * Test read-only access to CIFS mount
+# * force a local samba server (on the test machine) with CIFS_TEST_REMOTE=local
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils;
+use registration qw(add_suseconnect_product get_addon_fullname);
+
+# SMB version for mount.cifs to test for
+my @versions = qw(2.0 2.1 3 3.0 3.0.2 3.1.1);
+
+sub setup_local_server() {
+    # Setup a local samba server with "currywurst" and "filedrop" shares
+    zypper_call('in samba');
+    assert_script_run("useradd geekotest");
+    assert_script_run("mkdir -p /srv/samba/{currywurst,filedrop}");
+    assert_script_run("echo -e '[currywurst]\npath = /srv/samba/currywurst\nread only = yes\nbrowseable = yes\nguest ok = yes\n\n' >> /etc/samba/smb.conf");
+    assert_script_run("echo -e '[filedrop]\npath = /srv/samba/filedrop\nbrowseable = no\nwrite list = geekotest\ncreate mask = 0644\ndirectory mask = 0755\n' >> /etc/samba/smb.conf");
+    assert_script_run('curl ' . data_url('samba/Currywurst.txt') . ' -o /srv/samba/currywurst/Recipe.txt');
+    assert_script_run("chown -R geekotest /srv/samba/{currywurst,filedrop}");
+    assert_script_run("chmod -R 0755 /srv/samba/currywurst");
+    assert_script_run("chmod -R 0750 /srv/samba/filedrop");
+    systemctl("start smb");
+    assert_script_run("systemctl status smb | grep 'active (running)'");
+    assert_script_run("echo -ne 'nots3cr3t\nnots3cr3t' | smbpasswd -a -s geekotest");
+}
+
+sub run {
+    my $self       = shift;
+    my $smb_domain = get_var("CIFS_TEST_DOMAIN") // "currywurst";
+    my $smb_remote = get_var("CIFS_TEST_REMOTE") // "currywurst.qam.suse.de";
+    $self->select_serial_terminal;
+    add_suseconnect_product(get_addon_fullname('phub')) if is_sle;    # samba-client requires package hub
+    zypper_call('in cifs-utils samba-client nmap');
+    # Use local samba server, if defined or if defined SMB server is not accessible
+    my $is_local = get_var("CIFS_TEST_REMOTE") eq 'local';
+    if ($is_local || script_run("nmap -p 139,445 $smb_remote | grep open") != 0) {
+        my $reason = $is_local ? "defined by CIFS_TEST_REMOTE" : "$smb_remote unreachable";
+        record_info("local samba server", "Using a local samba server (defined by CIFS_TEST_REMOTE)");
+        setup_local_server();
+        $smb_remote = "127.0.0.1";
+    }
+    script_run("smbclient -m SMB2 -L $smb_domain -I $smb_remote -U guest -N");
+    assert_script_run("smbclient -m SMB2 -L $smb_domain -I $smb_remote -U guest -N | grep 'Disk' | grep -i 'currywurst'");
+    assert_script_run("smbclient -m SMB3 -L $smb_domain -I $smb_remote -U guest -N | grep 'Disk' | grep -i 'currywurst'");
+    # Test CIFS mount
+    assert_script_run("mkdir -p /mnt/{currywurst,filedrop}");
+    my $options = "username=geekotest,password=nots3cr3t";
+    # Test mount with the different version types
+    if (is_sle(">12-SP3")) {
+        foreach my $version (@versions) {
+            assert_script_run("mount -t cifs -o $options,vers=$version //$smb_remote/currywurst /mnt/currywurst");
+            assert_script_run("umount /mnt/currywurst");
+        }
+    } else {
+        $options .= ",vers=2.1";    # needed for SLES12-SP3 and below
+    }
+    assert_script_run("mount -t cifs -o $options //$smb_remote/currywurst /mnt/currywurst");
+    assert_script_run("mount -t cifs -o $options //$smb_remote/filedrop /mnt/filedrop");
+    # Check if test files are there
+    assert_script_run("stat /mnt/currywurst/Recipe.txt");
+    my $filename = random_string(8);    # random filename to prevent race conditions on the server
+    assert_script_run("cp /mnt/currywurst/Recipe.txt /mnt/filedrop/$filename");
+    assert_script_run("umount /mnt/currywurst");
+    assert_script_run("! stat /mnt/currywurst/Recipe.txt");
+    assert_script_run("stat /mnt/filedrop/$filename");
+    assert_script_run("md5sum /mnt/filedrop/$filename > Recipe.txt.md5sum");
+    # Check if file are in the filedrop after a remount
+    assert_script_run("umount /mnt/filedrop");
+    assert_script_run("mount -t cifs -o $options,ro //$smb_remote/filedrop /mnt/filedrop");
+    assert_script_run("stat /mnt/filedrop/$filename");
+    assert_script_run("md5sum -c Recipe.txt.md5sum");
+    assert_script_run("! rm /mnt/filedrop/$filename");
+    assert_script_run("mount -t cifs -o $options,remount,rw /mnt/filedrop");
+    assert_script_run("rm /mnt/filedrop/$filename");
+}
+
+sub cleanup() {
+    script_run("umount /mnt/{currywurst,filedrop}");
+    script_run("rmdir /mnt/{currywurst,filedrop}");
+}
+
+sub post_fail_hook {
+    cleanup();
+}
+
+sub post_run_hook {
+    cleanup();
+}
+
+1;


### PR DESCRIPTION
Add test for smbclient and CIFS mount

- Related ticket: https://progress.opensuse.org/issues/71344
- Needles: -
- Verification runs: [Tumbleweed](https://openqa.opensuse.org/t1416668) | [Tumbleweed aarch64](https://openqa.opensuse.org/t1416669) | [Leap](https://openqa.opensuse.org/t1416670) | [Leap aarch64](https://openqa.opensuse.org/t1416671)
[SLES 15-SP2](https://openqa.suse.de/t4766257) | [SLES 15-SP1](https://openqa.suse.de/t4766258) | [SLES15](https://openqa.suse.de/t4766305) | [SLES12-SP5](https://openqa.suse.de/t4766259) | [SLES12-SP4](https://openqa.suse.de/t4766260) | [SLES12-SP3](https://openqa.suse.de/t4766261) | [SLES12-SP2](https://openqa.suse.de/t4766262)