### PR TITLE
ignore javadoc rpms in tests_java.sh poo#72070

### DIFF
--- a/data/console/test_java.sh
+++ b/data/console/test_java.sh
@@ -53,7 +53,8 @@ clean_up() {
 find_all_installed_java() {
     # Construct temp files which are needed in order to
     # determine how many java versions are installed along with their versions
-    rpm -qa | grep ^java- > $RPM_QUERY_JAVA
+    # ignore javadoc as per issue https://progress.opensuse.org/issues/72070
+    rpm -qa | grep ^java- | grep -v javadoc > $RPM_QUERY_JAVA
 
     # File that contains all the IBM Java installed in the system
     grep "^java-" $RPM_QUERY_JAVA | grep "\-ibm" | awk -F 'ibm' '{print $1 "ibm"}' | sort -r | uniq > $LIST_INSTALLED_IBM_VERSIONS


### PR DESCRIPTION
at least required for Jump15.2 that has common noarch
and the way tests_java.sh is counting installed java rpms.

- Related ticket: https://progress.opensuse.org/issues/72070
- Needles: none
- Verification run for Jump: 
  aarch64: https://openqa.opensuse.org/tests/1412838  as expected solved this issue#72070
  and still has expected https://openqa.opensuse.org/tests/1412838#step/java/18 failure of other bug https://bugzilla.opensuse.org/show_bug.cgi?id=1172584
 x86_64: https://openqa.opensuse.org/tests/1412850#step/java/18 as expected not bad side effect of this change; and still has expected failure related to bug#1172584
