### PR TITLE
Make sure terraform command is canceled

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -16,7 +16,7 @@ use Mojo::Base 'publiccloud::provider';
 use Mojo::JSON qw(decode_json encode_json);
 use Term::ANSIColor 2.01 'colorstrip';
 use Data::Dumper;
-use testapi;
+use testapi qw(is_serial_terminal :DEFAULT);
 
 has tenantid        => undef;
 has subscription    => undef;
@@ -223,7 +223,12 @@ sub on_terraform_apply_timeout {
             $tries = 0;
         };
         if ($@) {
-            type_string(qq(\c\\));
+            if (is_serial_terminal()) {
+                type_string(qq(\c\\));    # Send QUIT signal
+            }
+            else {
+                send_key('ctrl-\\');      # Send QUIT signal
+            }
         }
     }
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -12,7 +12,7 @@
 # Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
 
 package publiccloud::provider;
-use testapi;
+use testapi qw(is_serial_terminal :DEFAULT);
 use Mojo::Base -base;
 use publiccloud::instance;
 use Data::Dumper;
@@ -379,7 +379,12 @@ sub terraform_apply {
     assert_script_run($cmd, $terraform_timeout);
     my $ret = script_run('terraform apply -no-color -input=false myplan', $terraform_timeout);
     unless (defined $ret) {
-        type_string(qq(\c\\));        # Send QUIT signal
+        if (is_serial_terminal()) {
+            type_string(qq(\c\\));    # Send QUIT signal
+        }
+        else {
+            send_key('ctrl-\\');      # Send QUIT signal
+        }
         assert_script_run('true');    # make sure we have a prompt
         record_info('ERROR', 'Terraform apply failed with timeout', result => 'fail');
         assert_script_run('cd ' . TERRAFORM_DIR);
@@ -437,7 +442,12 @@ sub terraform_destroy {
     }
     my $ret = script_run('terraform destroy -no-color -auto-approve', get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT));
     unless (defined $ret) {
-        type_string(qq(\c\\));        # Send QUIT signal
+        if (is_serial_terminal()) {
+            type_string(qq(\c\\));    # Send QUIT signal
+        }
+        else {
+            send_key('ctrl-\\');      # Send QUIT signal
+        }
         assert_script_run('true');    # make sure we have a prompt
         record_info('ERROR', 'Terraform destroy failed with timeout', result => 'fail');
         assert_script_run('cd ' . TERRAFORM_DIR);


### PR DESCRIPTION
Make sure terraform command is correctly canceled after timeout

- Related ticket: https://progress.opensuse.org/issues/69952
- Needles: no needles
- Verification run: https://openqa.suse.de/tests/4759779

**Full work log:**
Changed "lib/publiccloud/provider.pm" to make it easier to reproduce
From "use constant TERRAFORM_TIMEOUT => 17 * 60;"
To   "use constant TERRAFORM_TIMEOUT => 2 * 60;"

Reproduced issue on run: https://openqa.suse.de/tests/4749425#step/ssh_interactive_init/51 
Error on log: "No map for '' at /usr/lib/os-autoinst/consoles/VNC.pm line 741."

Try to fix with change on "lib/publiccloud/provider.pm"

From "type_string(qq(\c\\));"
To   "type_string("\cC");"
Still same error: "No map for '' at /usr/lib/os-autoinst/consoles/VNC.pm line 741."


Turns out, "ssh_interactive_init" is running on VNC and "type_string(\cC||\c\\)" are meant for serial only.

Added a check for serial terminal on "provider.pm" not if fails as expected:
https://openqa.suse.de/tests/4751094


Changed back to "use constant TERRAFORM_TIMEOUT => 17 * 60;"

One last run without code to force reproducing the issue: https://openqa.suse.de/tests/4759779
