### PR TITLE
Add new test: ensure password hash is SHA512

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2360,6 +2360,12 @@ sub load_security_tests_yast2_apparmor {
     loadtest "security/yast2_apparmor/manually_add_profile";
 }
 
+sub load_security_tests_yast2_users {
+    load_security_console_prepare;
+
+    loadtest "security/yast2_users/add_users";
+}
+
 sub load_security_tests_openscap {
     # ALWAYS run following tests in sequence because of the dependencies
 
@@ -2555,7 +2561,7 @@ sub load_security_tests {
       fips_setup crypt_core crypt_web crypt_kernel crypt_x11 crypt_tool
       crypt_krb5kdc crypt_krb5server crypt_krb5client
       ipsec mmtest
-      apparmor apparmor_profile yast2_apparmor selinux
+      apparmor apparmor_profile yast2_apparmor yast2_users selinux
       openscap
       mok_enroll ima_measurement ima_appraisal evm_protection
       system_check

--- a/tests/security/yast2_users/add_users.pm
+++ b/tests/security/yast2_users/add_users.pm
@@ -1,0 +1,94 @@
+# Copyright (C) 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test "# yast2 users" can add users and the created user has a
+#          SHA512 hashed password in /etc/shadow (starts with $6$);
+#          Test to create a user on CLI by means of adduser,
+#          change the password using passwd, check it is SHA512 hashed too.
+#          Also verify bsc#1176714 - Password being truncated to 8 characters
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#71740 bsc#1176714
+
+use base apparmortest;
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $testuser = "testuser";
+    my $pw       = "T3stpassw0rd!";
+    my $f_shadow = "/etc/shadow";
+
+    # Create a test user
+    script_run("userdel -rf $testuser");
+    assert_script_run("useradd -m -d \/home\/$testuser $testuser");
+    assert_script_run(
+        "expect -c 'spawn passwd $testuser; expect \"New password:\"; send \"$pw\\n\"; expect \"Retype new password:\"; send \"$pw\\n\"; interact'");
+
+    # Check the password is SHA512 hashed
+    validate_script_output("grep $testuser $f_shadow", sub { m/$testuser:\$6\$.*/ });
+
+    # Cleanup: delete the test user
+    assert_script_run("userdel -rf $testuser");
+
+    # Turn to x11 and start "xterm"
+    select_console("x11");
+    x11_start_program("xterm");
+    become_root;
+
+    # Run "# yast2 users" to create a user
+    type_string("yast2 users &\n");
+    # Check "SHA-512" is selected by default
+    assert_and_click("Yast2-Users-Expert-Options", timeout => 180);
+    assert_and_click("Yast2-Users-Expert-Options-Password-Encryption");
+    assert_screen("Password-Encryption-SHA512-Selected-Bydefault");
+    # Untouch the default settings and exit
+    send_key "alt-c";
+    # Add a user
+    assert_and_click("Yast2-Users-Add");
+    assert_screen("Yast2-Users-Add-User-Data");
+    send_key "alt-f";
+    assert_screen("Yast2-Users-Add-User-Data-UFN");
+    type_string("$testuser");
+    send_key "alt-p";
+    assert_screen("Yast2-Users-Add-User-Data-PW");
+    type_string("$pw");
+    send_key "alt-c";
+    assert_screen("Yast2-Users-Add-User-Data-CPW");
+    type_string("$pw");
+    send_key "alt-o";
+    # There should be no this message in next window:
+    # "The password is too long for the current encryption method."
+    # "It will be truncated to 8 characters."
+    # If no, check the user was created successfully
+    assert_screen("Yast2-Users-Add-User-Created");
+    wait_screen_change { send_key "alt-o" };
+
+    # Exit x11 and turn to console
+    send_key "alt-f4";
+    assert_screen("generic-desktop");
+    select_console("root-console");
+    send_key "ctrl-c";
+    clear_console;
+
+    # Check the password is SHA512 hashed
+    validate_script_output("grep $testuser $f_shadow", sub { m/$testuser:\$6\$.*/ });
+
+    # Cleanup: delete the test user
+    assert_script_run("userdel -rf $testuser");
+}
+
+1;


### PR DESCRIPTION
Add new test: ensure password hash is SHA512

- Create a new user using yast2 users (explicitly check the
'encryption' dialog, ensure SHA512 is preselected);
ensure the created user has a SHA512 hashed password in
/etc/shadow (starts with $6$)
- Create a user on CLI by means of 'adduser', change the password
using 'passwd', check it is SHA512 hashed (starts with $6$)

- Related ticket: https://progress.opensuse.org/issues/71740
- Needles: added to osd already
- Verification run: https://openqa.suse.de/tests/4750952#