### PR TITLE
To register the system via RMT/SMT server by SUSEConnect command

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -252,9 +252,14 @@ sub cleanup_registration {
     register_product();
 
 Wrapper for SUSEConnect -r <regcode>. Requires SCC_REGCODE variable.
+SUSEConnect --url with SMT/RMT server.
 =cut
 sub register_product {
-    assert_script_run('SUSEConnect -r ' . get_required_var('SCC_REGCODE'), 200);
+    if (get_var('SMT_URL')) {
+        assert_script_run('SUSEConnect --url ' . get_var('SMT_URL') . ' ' . uc(get_var('SLE_PRODUCT')) . '/' . scc_version(get_var('HDDVERSION')) . '/' . get_var('ARCH'), 200);
+    } else {
+        assert_script_run('SUSEConnect -r ' . get_required_var('SCC_REGCODE'), 200);
+    }
 }
 
 sub register_addons_cmd {


### PR DESCRIPTION
To register the system via RMT/SMT server by SUSEConnect command

As powerVM use text mode, we use 'SUSEconnect' command to register the product. As our test code only include 'SUSEConnect' register the system with SCC. We need add register product with SMT/RMT

- Related ticket: https://progress.opensuse.org/issues/71947
- Verification run: https://openqa.suse.de/tests/4750964
