### PR TITLE
Upload solver testcase for resolve_dependency_issues

### DIFF
--- a/tests/installation/resolve_dependency_issues.pm
+++ b/tests/installation/resolve_dependency_issues.pm
@@ -35,4 +35,11 @@ sub run {
     }
 }
 
+sub post_fail_hook {
+    my $self = shift;
+    select_console 'root-console';
+    $self->upload_solvertestcase_logs();
+    $self->SUPER::post_fail_hook;
+}
+
 1;


### PR DESCRIPTION
We need upload the solver test case when conflict happened in resolve_dependency_issues, but currently only zypper_call can trigger solver test cases upload to openQA, but in resolve_dependency_issues we face situation which not call zypper_call function. So add post_fail_hook to upload the solver test case directly.

- Related ticket: https://progress.opensuse.org/issues/71959
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/4750947#downloads
