### PR TITLE
[WIP] update_kernel: Use serial terminal

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -22,6 +22,7 @@ use kernel 'remove_kernel_packages';
 use klp;
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
+use serial_terminal 'prepare_serial_console';
 use Utils::Backends 'use_ssh_serial_console';
 
 
@@ -300,7 +301,8 @@ sub boot_to_console {
         use_ssh_serial_console;
     }
     else {
-        select_console('root-console');
+        prepare_serial_console;
+        $self->select_serial_terminal;
     }
 }
 


### PR DESCRIPTION
to speedup run. It respects when disabled with VIRTIO_CONSOLE=0.

Serial console was disabled on older releases to avoid problems for SLES < 12-SP2. Some issues were also with ppc64le. But `prepare_serial_console()` solves problems, thus it can be used.

Related tickets:
* poo#18860 Enable console on hvc0 on SLES < 12-SP2                 
* poo#44699 Enable console on hvc1 to fix login issues on ppc64le
=> given that SLE11 is over and even SLE12 GA and SP1 have no build, it should be safe to merge this.

Verification run:
* SLE11 SP3 http://quasar.suse.cz/tests/5528 (this one I'd suspect to fail, serial console is working, just it fails due unrelated error "Patch isn't needed")
* SLE12 SP2 https://openqa.suse.de/tests/4750985 (vs. non-serial https://openqa.suse.de/tests/4750988)
* SLE12 SP3 http://quasar.suse.cz/tests/5524
* SLE12 SP5 http://quasar.suse.cz/tests/5366

Also verify the oldest non-intel archs I've found
* SLE12 SP2 ppc64le https://openqa.suse.de/tests/4750983 (vs. non-serial https://openqa.suse.de/tests/4750986)
* SLE12 SP2 s390x-kvm-sle12 https://openqa.suse.de/tests/4750984 (vs. non-serial https://openqa.suse.de/tests/4750987)
