### PR TITLE
Fix gnome zdup 'zypper dup' not finished in 700 seconds

### DIFF
--- a/tests/installation/leap2sle_zdup.pm
+++ b/tests/installation/leap2sle_zdup.pm
@@ -42,7 +42,7 @@ sub run {
     assert_script_run "SUSEConnect --list-extensions";
     register_product();
     register_addons_cmd("base,serverapp,legacy,desktop,phub");
-    zypper_call 'dup --force-resolution';
+    zypper_call('dup --force-resolution', timeout => 1200);
     zypper_call "rm \$(zypper --no-refresh packages --orphaned | gawk '{print \$5}' | tail -n +5)";
     power_action('reboot', keepconsole => 1, textmode => 1);
 }


### PR DESCRIPTION
In gnome leap to SLES zdup migration we need enlarge the timeout value
for 'zypper dup'. 

- Related ticket: https://progress.opensuse.org/issues/72049
- Needles: N/A
- Verification run: 
    https://openqa.nue.suse.com/tests/4751017
    https://openqa.nue.suse.com/tests/4751093