### PR TITLE
Set pipefail for root and root-virtio consoles

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-extratest.yaml
@@ -12,6 +12,7 @@ schedule:
     - installation/bootloader_hyperv
     - jeos/grub2
     - jeos/firstrun
+    - console/consoletest_setup
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
@@ -19,7 +20,6 @@ schedule:
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc
-    - console/consoletest_setup
     - console/integration_services
     - console/zypper_lr_validate
     - console/zypper_ref

--- a/schedule/jeos/sle/kvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/kvm/jeos-extratest.yaml
@@ -11,6 +11,7 @@ conditional_schedule:
 schedule:
     - jeos/grub2
     - jeos/firstrun
+    - console/consoletest_setup
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
@@ -18,7 +19,6 @@ schedule:
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc
-    - console/consoletest_setup
     - console/zypper_lr_validate
     - console/zypper_ref
     - console/validate_packages_and_patterns

--- a/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
@@ -12,6 +12,7 @@ schedule:
     - installation/bootloader_svirt
     - jeos/grub2
     - jeos/firstrun
+    - console/consoletest_setup
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
@@ -19,7 +20,6 @@ schedule:
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc
-    - console/consoletest_setup
     - console/zypper_lr_validate
     - console/zypper_ref
     - console/validate_packages_and_patterns

--- a/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
@@ -11,6 +11,7 @@ conditional_schedule:
 schedule:
     - installation/bootloader_svirt
     - jeos/firstrun
+    - console/consoletest_setup
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
@@ -18,7 +19,6 @@ schedule:
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc
-    - console/consoletest_setup
     - console/zypper_lr_validate
     - console/zypper_ref
     - console/validate_packages_and_patterns

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -69,8 +69,13 @@ sub run {
     script_run '. /etc/bash.bashrc.local';
     disable_and_stop_service('packagekit.service', mask_service => 1);
 
-    # init
-    check_console_font if has_ttys();
+    # switch to root console and print the current console font to stdout
+    # make a use of selected root-console in check_console_font to apply
+    # the same environment changes as to root-virtio
+    if (has_ttys()) {
+        check_console_font;
+        script_run '. /etc/bash.bashrc.local';
+    }
 }
 
 sub post_fail_hook {

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -156,8 +156,10 @@ sub run {
 
     ensure_serialdev_permissions;
 
-    select_console 'user-console';
+    my $console = select_console 'user-console';
     verify_user_info;
+    type_string "exit\n";
+    $console->reset();
 
     select_console 'root-console';
     if ($lang ne 'en_US') {


### PR DESCRIPTION
Bash option `pipefail` [is not set for all consoles](http://kepler.suse.cz/tests/1871#step/validate_packages_and_patterns/2) leading to false positive results as in below test job.
Issue occurs only in test jobs using virtio console.

- False positive: [jeos-extratest_kvm@64bit-virtio-vga ](https://openqa.suse.de/tests/4726367#step/validate_packages_and_patterns/10)
- Verification runs: 
  * [Build20.35-jeos-extratest_kvm@64bit-virtio-vga](http://kepler.suse.cz/tests/1929#step/validate_packages_and_patterns/13)
  * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build15.39-jeos-extratest_kvm@64bit-virtio-vga; BETA=1](http://kepler.suse.cz/tests/1931#step/validate_packages_and_patterns/14)
   * [Build20.44-jeos-extratest_xenpv@svirt-xen-pv](http://kepler.suse.cz/tests/1927#step/validate_packages_and_patterns/13)
   * [Build20.44-jeos-extratest_xenhvm@svirt-xen-hvm](http://kepler.suse.cz/tests/1925#step/validate_packages_and_patterns/13)
   * [Build20.44-jeos-extratest_hyperv@svirt-hyperv](http://kepler.suse.cz/tests/1926#step/validate_packages_and_patterns/14)
   * [Build48.1-extra_tests_textmode@64bit](http://kepler.suse.cz/tests/1928#step/validate_packages_and_patterns/13)
   * [Build20200929-jeos@64bit_virtio](http://kepler.suse.cz/tests/1930#)
- [Missing upgrade packages](https://bugzilla.suse.com/show_bug.cgi?id=1177118)