### PR TITLE
Grub2 test fails in 12-SP4 Incidents

### DIFF
--- a/tests/boot/grub2_test.pm
+++ b/tests/boot/grub2_test.pm
@@ -62,8 +62,8 @@ sub run {
     }
     zypper_call 'in kernel-vanilla';
     assert_script_run 'uname -r >kernel.txt';
+    my $boot_entry = script_output(q(grub2-once --list | grep $(uname -r) | grep -v 'recovery mode' | awk '{print $1}'));
     reboot;
-    my $boot_entry = is_sle('=12-sp2') || is_sle('=12-sp3') ? '5' : '3';
     boot_grub_item(2, $boot_entry);
     assert_screen 'linux-login', 200;
     select_console 'root-console';


### PR DESCRIPTION
- Added a new check for kernel version before and after the reboot
process

- Related ticket: https://progress.opensuse.org/issues/71437
- Needles: N/A
- Verification run: SLES [12-SP4](http://10.161.229.247/tests/1139) | [12-SP5](http://10.161.229.247/tests/1138) | [15-SP1](http://10.161.229.247/tests/1140) | [15-SP2](http://10.161.229.247/tests/1141)
