### PR TITLE
Increase retry for rmt sync

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -274,7 +274,7 @@ Function to sync rmt server
 
 =cut
 sub rmt_sync {
-    script_retry 'rmt-cli sync', delay => 30, retry => 3, timeout => 1800;
+    script_retry 'rmt-cli sync', delay => 60, retry => 6, timeout => 1800;
 }
 
 =head2 rmt_enable_pro


### PR DESCRIPTION
Increasing retry and delay to see up to which extent the SCC connection sporadically fails with error 504. More info on related ticket.


- Related ticket: https://progress.opensuse.org/issues/72118
- Needles: no needles
- Verification run: no runs since there is no significant change
