### PR TITLE
Partitioning smalldisk storage ng

### DIFF
--- a/schedule/sles4sap/hana/pvm_hana.yaml
+++ b/schedule/sles4sap/hana/pvm_hana.yaml
@@ -1,0 +1,83 @@
+---
+name: pvm_hana
+description: >
+  SLES4SAP Installation on pvm_hmc and HANA installation and test.
+  Set HANA to the installation master path over NFS or SMB in the yaml job group.
+vars:
+  AUTOMATED_REGISTER: 'false'
+  DESKTOP: 'textmode'
+  INSTANCE_ID: '00'
+  INSTANCE_SID: 'HA1'
+  INSTANCE_TYPE: 'HDB'
+  MULTIPATH_CONFIRM: 'yes'
+schedule:
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - '{{multipath}}'
+  - '{{sles4sap12_product}}'
+  - installation/addon_products_sle
+  - '{{sles4sap15_product}}'
+  - installation/partitioning
+  - installation/partitioning_smalldisk_storageng
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - '{{sles4sap12_desktop}}'
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/hana_install
+  - sles4sap/hana_test
+conditional_schedule:
+  multipath:
+    MULTIPATH:
+      1:
+        - installation/multipath
+  sles4sap12_product:
+    VERSION:
+      12-SP2:
+        - installation/sles4sap_product_installation_mode
+      12-SP3:
+        - installation/sles4sap_product_installation_mode
+      12-SP4:
+        - installation/sles4sap_product_installation_mode
+      12-SP5:
+        - installation/sles4sap_product_installation_mode
+  sles4sap15_product:
+    VERSION:
+      15:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP1:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP2:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP3:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+  sles4sap12_desktop:
+    VERSION:
+      12-SP2:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues
+      12-SP3:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues
+      12-SP4:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues
+      12-SP5:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues

--- a/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
@@ -48,7 +48,7 @@ schedule:
   - installation/addon_products_sle
   - '{{sles4sap15_product}}'
   - installation/partitioning
-  - installation/partitioning_firstdisk
+  - installation/partitioning_smalldisk_storageng
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings_root

--- a/tests/installation/partitioning_smalldisk_storageng.pm
+++ b/tests/installation/partitioning_smalldisk_storageng.pm
@@ -25,7 +25,12 @@ sub run {
         return take_first_disk;
     }
 
-    select_console 'root-ssh';
+    if (get_var('BACKEND', '') =~ /ikvm|ipmi|spvm|pvm_hmc/) {
+        select_console 'root-ssh';
+    }
+    else {
+        select_console 'root-console';
+    }
     my $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME -d -e 7,11 -b | sort -n | awk '(NR == 1) {print $2}')]"/;
     $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME,TYPE -e 7,11 -b | sort -n | awk '($3 == "mpath" && NR == 1) {print $2}')]"/
       if (get_var('MULTIPATH') and (get_var('MULTIPATH_CONFIRM') !~ /\bNO\b/i));

--- a/tests/installation/partitioning_smalldisk_storageng.pm
+++ b/tests/installation/partitioning_smalldisk_storageng.pm
@@ -1,0 +1,88 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test to take the smallest disk in storage_ng scenarios
+#    Otherwise the partitioning proposal will use a free disk, which makes
+#    rebooting a game of chance on real hardware
+# Maintainer: Alvaro Carvajal <acarvajal@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use version_utils qw(is_storage_ng);
+use partition_setup qw(take_first_disk);
+
+sub run {
+    if (!is_storage_ng) {
+        record_info "Requires storage_ng", "This module only works with storage_ng which is not present. Selecting first disk instead";
+        return take_first_disk;
+    }
+
+    select_console 'root-ssh';
+    my $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME -d -e 7,11 -b | sort -n | awk '(NR == 1) {print $2}')]"/;
+    $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME,TYPE -e 7,11 -b | sort -n | awk '($3 == "mpath" && NR == 1) {print $2}')]"/
+      if (get_var('MULTIPATH') and (get_var('MULTIPATH_CONFIRM') !~ /\bNO\b/i));
+    my $output = script_output $lsblkcmd;
+    $output =~ /\[([\w\.]+)\]/;
+    my $device = $1;
+    record_info "$device selected", "Will use disk [$device] for installation";
+
+    select_console 'installation';
+    send_key $cmd{guidedsetup};    # select guided setup
+    assert_screen 'select-hard-disks';
+    # Ensure all devices are deselected. We deselect at least one
+    my $extra_disks_to_deselect = 0;
+    check_screen [qw(select-hard-disks-two-selected select-hard-disks-three-selected)];
+    $extra_disks_to_deselect += 1 if match_has_tag 'select-hard-disks-two-selected';
+    $extra_disks_to_deselect += 2 if match_has_tag 'select-hard-disks-three-selected';
+    # First focus on disks list
+    send_key 'tab';
+    # Deselect the disks. Scrolling through the list of devices is different in textmode
+    my $scrolldown = check_var('VIDEOMODE', 'text') ? 'tab'       : 'down';
+    my $scrollup   = check_var('VIDEOMODE', 'text') ? 'shift-tab' : 'up';
+    for (0 .. $extra_disks_to_deselect) { send_key 'spc'; send_key $scrolldown; }
+    wait_still_screen 3;
+
+    # Select $device
+    if (check_var('VIDEOMODE', 'text')) {
+        for (0 .. $extra_disks_to_deselect) { send_key $scrollup; }    # Return to top of devices' list
+        send_key_until_needlematch "hard-disk-dev-$device-not-selected", $scrolldown;
+        send_key 'spc';
+        # At this time, only one device should be selected. Send shift-tabs until focus is out of the devices' list
+        send_key_until_needlematch 'select-hard-disks-one-selected', 'shift-tab';
+    }
+    else {
+        assert_and_click "hard-disk-dev-$device-not-selected";
+    }
+    # Check only one disk was selected
+    assert_screen 'select-hard-disks-one-selected';
+    send_key $cmd{next};
+
+    assert_screen [qw(existing-partitions partition-scheme)];
+    if (match_has_tag 'existing-partitions') {
+        if (check_var('BACKEND', 'ipmi') && !check_var('VIDEOMODE', 'text')) {
+            send_key_until_needlematch("remove-menu", "tab");
+            while (check_screen('remove-menu', 3)) {
+                send_key 'spc';
+                send_key 'down';
+                send_key 'ret';
+                send_key 'tab';
+            }
+            save_screenshot;
+        }
+        else {
+            send_key $cmd{next};
+            assert_screen 'partition-scheme';
+        }
+    }
+    send_key_until_needlematch 'after-partitioning', $cmd{next}, 10, 3;
+}
+
+1;


### PR DESCRIPTION
In some scenarios (for example SAP HANA installation on pvm LPAR, IPMI, etc) we may need to require the OS to be installed in the smallest available device, so the larger disk(s) can be used for applications such as SAP HANA.

This PR introduces the module `tests/installation/partitioning_smalldisk_storageng` which goes through the guided partitioning of storage ng during installation to select the smallest disk for the OS installation.

Also included in the PR are the updates to the yaml schedule files using this new module.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1438
- Verification run: [pvm lpar textmode](http://mango.qa.suse.de/tests/3191); [pvm lpar](http://mango.qa.suse.de/tests/3193); [HanaSR on pvm_hmc node1](http://mango.qa.suse.de/tests/3198) & [HanaSR on pvm_hmc node2](http://mango.qa.suse.de/tests/3199)
