### PR TITLE
Add a workaround for shutdown module on s390

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -914,8 +914,8 @@ sub handle_broken_autologin_boo1102563 {
     wait_screen_change { send_key 'alt-f4' };
 }
 
-sub handle_additional_polkit_windows_bsc1157928 {
-    record_soft_failure 'bsc#1157928 - deal with additional polkit windows';
+sub handle_additional_polkit_windows_bsc1177446 {
+    record_soft_failure 'bsc#1177446 - polkit popup appears at first login, again';
     wait_still_screen(3);
     ensure_unlocked_desktop;
     # deal with potential followup authentication window which is not
@@ -1000,7 +1000,7 @@ sub wait_boot_past_bootloader {
     handle_emergency_if_needed;
 
     handle_broken_autologin_boo1102563()          if match_has_tag('displaymanager');
-    handle_additional_polkit_windows_bsc1157928() if match_has_tag('authentication-required-user-settings');
+    handle_additional_polkit_windows_bsc1177446() if match_has_tag('authentication-required-user-settings');
     if (match_has_tag('guest-disable-display')) {
         record_soft_failure 'bsc#1169723 - [Build 174.1] openQA test fails in first_boot - Guest disabled display shown when boot up after migration';
         send_key 'ret';

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -25,7 +25,9 @@ use power_action_utils 'power_action';
 use utils;
 
 sub run {
-    power_action('poweroff');
+    my $keep = check_var('ARCH', 's390x');
+    record_soft_failure "bsc#1177446 - polkit popup appears at first login, again" if $keep;
+    power_action('poweroff', keepconsole => $keep, textmode => $keep);
 }
 
 sub test_flags {


### PR DESCRIPTION
We noticed a frequent failure when we have an authentication pop-up,
looks like button is clicked before being asserted.
The proposed solution is the cheapest, but it makes us lose a little of coverage, as we skip testing shutdown from GUI on zVM.
Also removed workaround for bsc1157928 as the bug is closed, and monitor bsc#1177446 to revert the current workaround once bug is fixed,

- Related ticket: https://progress.opensuse.org/issues/68507

- Verification run: 
ZVM: https://openqa.suse.de/tests/4792409
64bit: http://waaa-amazing.suse.cz/tests/13009