### PR TITLE
Increase assert_screen timeout in yast2_network_settings

### DIFF
--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -34,7 +34,7 @@ sub run {
     $cmd{routing_tab}        = 'alt-u';
 
     select_console 'x11';
-    $self->launch_yast2_module_x11('lan', target_match => [qw(yast2-lan-ui yast2_still_susefirewall2 yast2-lan-warning-network-manager)], match_timeout => 60);
+    $self->launch_yast2_module_x11('lan', target_match => [qw(yast2-lan-ui yast2_still_susefirewall2 yast2-lan-warning-network-manager)], match_timeout => 120);
     if (match_has_tag 'yast2_still_susefirewall2') {
         send_key $cmd{install};
         wait_still_screen;


### PR DESCRIPTION
assert_screen fails, while yast network is launched, due to small timeout.
https://openqa.suse.de/tests/4760944#step/yast2_network_settings/17


