### PR TITLE
Add cleanup_qam_testrepos test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1607,6 +1607,7 @@ sub load_extra_tests_geo_desktop {
 sub load_extra_tests_console {
     loadtest "console/check_os_release";
     loadtest "console/orphaned_packages_check";
+    loadtest "console/cleanup_qam_testrepos" if has_test_issues;
     # JeOS kernel is missing 'openvswitch' kernel module
     loadtest "console/openvswitch" unless is_jeos;
     loadtest "console/pam"         unless is_leap;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -81,6 +81,7 @@ use constant {
           has_license_on_welcome_screen
           has_license_to_accept
           uses_qa_net_hardware
+          has_test_issues
           )
     ]
 };
@@ -593,4 +594,28 @@ Returns true if called in a leap to sle migration scenario
 =cut
 sub is_leap_migration {
     return is_upgrade && get_var('ORIGIN_SYSTEM_VERSION') =~ /leap/;
+}
+
+=head2 has_test_issues
+
+Returns true if test issues are present (i.e. is update tests are present)
+
+=cut
+
+sub has_test_issues() {
+    if (is_opensuse) {
+        return 1 if (get_var('OS_TEST_ISSUES') ne "");
+    } elsif (is_sle) {
+        return 1 if (get_var('BASE_TEST_ISSUES') ne "");
+        return 1 if (get_var('CONTM_TEST_ISSUES') ne "");
+        return 1 if (get_var('DESKTOP_TEST_ISSUES') ne "");
+        return 1 if (get_var('LEGACY_TEST_ISSUES') ne "");
+        return 1 if (get_var('OS_TEST_ISSUES') ne "");
+        return 1 if (get_var('PYTHON2_TEST_ISSUES') ne "");
+        return 1 if (get_var('SCRIPT_TEST_ISSUES') ne "");
+        return 1 if (get_var('SDK_TEST_ISSUES') ne "");
+        return 1 if (get_var('SERVERAPP_TEST_ISSUES') ne "");
+        return 1 if (get_var('WE_TEST_ISSUES') ne "");
+    }
+    return 0;
 }


### PR DESCRIPTION
Add the `cleanup_qam_testrepos` test, which checks for invalid test repositories. Use the setting `QAM_TESTREPO_FAIL` to control the behaviour for failing repositories (fail, softfail, ignore, clear or purge).

This test is important for test development, where we need to clone existing tests, which could contain repositories that are not valid/existing anymore. With this test we can automatically remove those repos.

- Related ticket: https://progress.opensuse.org/issues/72121
- Needles: -
- Verification runs:

failing ones are clones `mau-extratest` runs without setting `QAM_TESTREPO_FAIL`, "cleaned" runs are with `QAM_TESTREPO_FAIL=clean`

- SLE15-SP2 [failing](https://openqa.suse.de/t4763781) | [cleaned](https://openqa.suse.de/t4763789)

- SLE15-SP1 [failing](https://openqa.suse.de/t4763698) | [cleaned](https://openqa.suse.de/t4763701)
- SLE15 [failing](https://openqa.suse.de/t4763699) | [cleaned](https://openqa.suse.de/t4763702)
- SLE12-SP5 [failing](https://openqa.suse.de/t4762973) | [cleaned](http://openqa.suse.de/t4763472)
- SLE12-SP4 [failing](https://openqa.suse.de/t4762974) | [cleaned](http://openqa.suse.de/t4763473)
- SLE12-SP3 [failing](https://openqa.suse.de/t4762975) | [cleaned](http://openqa.suse.de/t4763481)
- SLE12-SP2 [failing](https://openqa.suse.de/t4762976) | [cleaned](http://openqa.suse.de/t4763189)
