### PR TITLE
sles4sap: Fix sapconf migration on SLE-15 GA

### DIFF
--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -91,6 +91,8 @@ sub run {
         # Stop & disable tuned service to avoid conflict with active saptune
         systemctl "stop tuned";
         systemctl "disable tuned";
+        # Some versions of sapconf check for this directory and refuse to start
+        assert_script_run "rm -rf /var/lib/saptune/saved_state";
         systemctl "enable sapconf";
         systemctl "start sapconf";
     }


### PR DESCRIPTION
The version of sapconf in SLE-15 GA refuses to start if the `/var/lib/saptune/saved_state` directory exists.

Verification run:
http://ix64hae1001.qa.suse.de/tests/2180