### PR TITLE
Revert "Use Negative Lookhead for /nothing provides/"

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -233,7 +233,7 @@ sub investigate_yast2_failure {
     my %y2log_errors = (
         "No textdomain configured"                   => undef,    # Detecting missing translations
                                                                   # Detecting specific errors proposed by the YaST dev team
-        "nothing provides (?!\/bin\/sh)"             => undef,    # Detecting missing required packages
+        "nothing provides"                           => undef,    # Detecting missing required packages
         "but this requirement cannot be provided"    => undef,    # Detecting package conflicts
         "Could not load icon|Couldn't load pixmap"   => undef,    # Detecting missing icons
         "Internal error. Please report a bug report" => undef,    # Detecting internal errors
@@ -241,7 +241,6 @@ sub investigate_yast2_failure {
     );
     # Hash with known errors which we don't want to track in each postfail hook
     my %y2log_known_errors = (
-        "<1>.*nothing provides \/bin\/sh"                 => 'bsc#1170322',
         "<3>.*QueryWidget failed.*RichText.*VScrollValue" => 'bsc#1167248',
         "<3>.*Solverrun finished with an ERROR"           => 'bsc#1170322',
         "<3>.*3 packages failed.*badlist"                 => 'bsc#1170322',


### PR DESCRIPTION
This reverts commit 9d0031fd8666a030052138eff51cb0829613756d.

[Bug](https://bugzilla.suse.com/show_bug.cgi?id=1170322) is not visible in SLE 15 SP3 anymore, so resolving.

[Verification run](https://openqa.suse.de/tests/4766573#).