### PR TITLE
MicroOS: Fix is_microos() for Leap

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -223,7 +223,7 @@ sub is_microos {
     elsif ($filter =~ /\d\.\d\+?$/) {
         # If we use '+' it means "this or newer", which includes tumbleweed
         return ($filter =~ /\+$/) if ($version eq 'Tumbleweed' && $type eq 'opensuse');
-        return check_version($filter, $version, qr/\d\.\d/);
+        return check_version($filter, $version, qr/\d{1,}\.\d/);
     }
     else {
         return $flavor eq $filter;    # Specific FLAVOR selector

--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -34,7 +34,7 @@ sub run {
     die "/var did not grow, got $varsize B" unless $varsize > (5 * 1024 * 1024 * 1024);
 
     # Verify that combustion ran (not on Leap 15.2 and SUSE yet)
-    unless (is_microos('suse') || is_microos('15.2')) {
+    unless (is_microos('suse') || is_microos('=15.2')) {
         validate_script_output('cat /usr/share/combustion-welcome', qr/Combustion was here/);
     }
 }


### PR DESCRIPTION
Image_checks test case from microos fails with the message
    Unsupported version parameter for check_version: '15.2'

Failed test: https://openqa.opensuse.org/tests/1416328
Verification run: http://fromm.arch.suse.de/tests/318
