### PR TITLE
Enable btrfs+warnings test suite on powerVM

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
+  - '{{hostname_inst}}'
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
@@ -41,11 +41,21 @@ schedule:
   - '{{grub_test}}'
   - installation/first_boot
 conditional_schedule:
+  hostname_inst:
+    BACKEND:
+      qemu:
+        - installation/hostname_inst
+      svirt:
+        - installation/hostname_inst
   reconnect_mgmt_console:
     BACKEND:
       svirt:
         - boot/reconnect_mgmt_console
+      pvm_hmc:
+        - boot/reconnect_mgmt_console
   grub_test:
     BACKEND:
       qemu:
+        - installation/grub_test
+      pvm_hmc:
         - installation/grub_test

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -38,7 +38,7 @@ sub process_missing_special_partitions {
     if (is_storage_ng && check_var('ARCH', 's390x')) {    # s390x needs /boot/zipl on ext partition
         process_warning(warning => 'no-boot-zipl', key => 'alt-n');
     }
-    elsif (get_var('OFW')) {                              # ppc64le needs PReP /boot
+    elsif (check_var('ARCH', 'ppc64le')) {                # ppc64le needs PReP /boot
         process_warning(warning => 'no-prep-boot', key => 'alt-n');
     }
     elsif (get_var('UEFI')) {


### PR DESCRIPTION
See [poo#68977](https://progress.opensuse.org/issues/68977).

Related [job group changes](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/295).

[Verification run](https://openqa.suse.de/tests/4767535).
