### PR TITLE
Add registry.suse.de to 'insecure' list

### DIFF
--- a/data/containers/registries.conf
+++ b/data/containers/registries.conf
@@ -8,7 +8,7 @@ registries = ["registry.opensuse.org", "docker.io"]
 # Registries that do not use TLS when pulling images or uses self-signed
 # certificates.
 [registries.insecure]
-registries = ["localhost:5000"]
+registries = ["localhost:5000", "registry.suse.de"]
 
 # Blocked Registries, blocks the `docker daemon` from pulling from the blocked registry.  If you specify
 # "*", then the docker daemon will only be allowed to pull from registries listed above in the search

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -75,7 +75,7 @@ sub allow_selected_insecure_registries {
         assert_script_run("mkdir -p /etc/docker");
         assert_script_run('cat /etc/docker/daemon.json; true');
         assert_script_run(
-            'echo "{ \"insecure-registries\" : [\"localhost:5000\"] }" > /etc/docker/daemon.json');
+            'echo "{ \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\"] }" > /etc/docker/daemon.json');
         assert_script_run('cat /etc/docker/daemon.json');
         systemctl('restart docker');
     } elsif ($runtime =~ /podman/) {

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -19,13 +19,15 @@ use warnings;
 use containers::common;
 use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
     install_docker_when_needed();
-    zypper_call("install container-diff") if (script_run("which container-diff") != 0);
+    allow_selected_insecure_registries(runtime => 'docker') if (is_sle());
+    zypper_call("install container-diff")                   if (script_run("which container-diff") != 0);
 
     my ($image_names, $stable_names) = get_suse_container_urls();
 

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -37,6 +37,7 @@ sub run {
 
     if (is_sle()) {
         ensure_ca_certificates_suse_installed();
+        allow_selected_insecure_registries(runtime => 'docker');
     }
 
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -27,8 +27,12 @@ sub run {
 
     my ($image_names, $stable_names) = get_suse_container_urls();
 
-    ensure_ca_certificates_suse_installed() if (is_sle());
     install_podman_when_needed();
+
+    if (is_sle()) {
+        ensure_ca_certificates_suse_installed();
+        allow_selected_insecure_registries(runtime => 'podman');
+    }
 
     for my $i (0 .. $#$image_names) {
         test_container_image(image => $image_names->[$i], runtime => 'podman');

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -23,7 +23,7 @@ use testapi;
 use strict;
 use warnings;
 use utils;
-use version_utils;
+use version_utils qw(is_sle is_tumbleweed is_leap);
 use registration;
 use containers::common;
 use containers::utils;


### PR DESCRIPTION
I removed `registry.suse.de` from the list of `insecure-registries` which was probably a mistake.
Its certificate is still unknown for some systems and as this is our internal registry I'm re-adding it.

- Related ticket: [poo#72226](https://progress.opensuse.org/issues/72226)
- Needles: None
- Verification run: [SLE12-SP4](http://pdostal-server.suse.cz/tests/10245) [SLE12-SP5](http://pdostal-server.suse.cz/tests/10244) [SLE15](http://pdostal-server.suse.cz/tests/10243) [Tumbleweed](http://pdostal-server.suse.cz/tests/10247)
