### PR TITLE
Add cifs to mau-filesystem schedule

### DIFF
--- a/schedule/qam/12-SP2/mau-filesystem.yaml
+++ b/schedule/qam/12-SP2/mau-filesystem.yaml
@@ -18,6 +18,7 @@ schedule:
 - console/btrfs_send_receive
 - console/snapper_undochange
 - console/snapper_create
-- console/coredump_collect
+- network/cifs
 - console/udisks2
+- console/coredump_collect
 ...

--- a/schedule/qam/12-SP3/mau-filesystem.yaml
+++ b/schedule/qam/12-SP3/mau-filesystem.yaml
@@ -19,6 +19,7 @@ schedule:
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm
-- console/coredump_collect
+- network/cifs
 - console/udisks2
+- console/coredump_collect
 ...

--- a/schedule/qam/12-SP4/mau-filesystem.yaml
+++ b/schedule/qam/12-SP4/mau-filesystem.yaml
@@ -19,6 +19,7 @@ schedule:
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm
-- console/coredump_collect
+- network/cifs
 - console/udisks2
+- console/coredump_collect
 ...

--- a/schedule/qam/12-SP5/mau-filesystem.yaml
+++ b/schedule/qam/12-SP5/mau-filesystem.yaml
@@ -19,6 +19,7 @@ schedule:
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm
-- console/coredump_collect
+- network/cifs
 - console/udisks2
+- console/coredump_collect
 ...

--- a/schedule/qam/15-SP1/mau-filesystem.yaml
+++ b/schedule/qam/15-SP1/mau-filesystem.yaml
@@ -21,8 +21,9 @@ schedule:
 - console/snapper_create
 - console/snapper_thin_lvm
 - console/snapper_used_space
-- console/coredump_collect
+- network/cifs
 - console/udisks2
+- console/coredump_collect
 conditional_schedule:
   boot:
     ARCH:

--- a/schedule/qam/15-SP2/mau-filesystem.yaml
+++ b/schedule/qam/15-SP2/mau-filesystem.yaml
@@ -20,8 +20,9 @@ schedule:
 - console/snapper_create
 - console/snapper_thin_lvm
 - console/snapper_used_space
-- console/coredump_collect
+- network/cifs
 - console/udisks2
+- console/coredump_collect
 conditional_schedule:
   boot:
     ARCH:

--- a/schedule/qam/15/mau-filesystem.yaml
+++ b/schedule/qam/15/mau-filesystem.yaml
@@ -19,6 +19,7 @@ schedule:
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm
-- console/coredump_collect
+- network/cifs
 - console/udisks2
+- console/coredump_collect
 ...


### PR DESCRIPTION
Add `cifs` test for mau-filesystem to the yaml schedule. Also move `udisks2` test before `coredump_collect`.

- Related ticket: https://progress.opensuse.org/issues/71344
- Needles: -
- Verification runs: I'm only checking if the schedule is correct:

[SLES15-SP2](http://phoenix-openqa.qam.suse.de/tests/3075)
[SLES15-SP1](http://phoenix-openqa.qam.suse.de/tests/3076)
[SLES15](http://phoenix-openqa.qam.suse.de/tests/3077)
[SLES12-SP5](http://phoenix-openqa.qam.suse.de/tests/3078)
[SLES12-SP4](http://phoenix-openqa.qam.suse.de/tests/3079)
[SLES12-SP3](http://phoenix-openqa.qam.suse.de/tests/3080)
[SLES12-SP2](http://phoenix-openqa.qam.suse.de/tests/3081)
