### PR TITLE
ntp_client: Step clock as skew sync might exceed 400s

### DIFF
--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -42,9 +42,12 @@ sub run {
     systemctl 'is-enabled chronyd';
     systemctl 'is-active chronyd';
     systemctl 'status chronyd';
-    assert_script_run 'chronyc tracking';
     assert_script_run 'chronyc sources';
+    assert_script_run 'chronyc tracking';
+    assert_script_run 'chronyc makestep';
+    assert_script_run 'chronyc tracking';
     assert_script_run 'chronyc waitsync 40 0.01', 400;
+    assert_script_run 'chronyc tracking';
 }
 
 1;


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/72244
Verification: https://openqa.opensuse.org/t1419822