### PR TITLE
is_tumbleweed should return true if is_gnome_next

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -238,6 +238,7 @@ sub is_tumbleweed {
     # Tumbleweed and its stagings
     return 0 unless check_var('DISTRI', 'opensuse');
     return 1 if get_var('VERSION') =~ /Tumbleweed/;
+    return 1 if is_gnome_next;
     return get_var('VERSION') =~ /^Staging:/;
 }
 


### PR DESCRIPTION
The GNOME:Next live CD is a variation, resp. a projection of Tumbleweed
together with a development project on top of it.

All hack and tweaks that count for Tumbleweed (if there are any) implicitly
should also apply to GNOME:Next. So instead of repeatedly do
  if (is_tumbleweed || is_gnome_next)
we just let is_tumbleweed return true if is_gnome_next would apply.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1419829
