### PR TITLE
zypper_lifecycle: Fix in case of "Product:" prefix in output

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -122,8 +122,8 @@ sub run {
 
     my $product_eol;
     for my $l (split /\n/, $overview) {
-        if ($l =~ /^(?<!Codestream:)\s+$product_name\s*(\S*)/) {
-            $product_eol = $1;
+        if ($l =~ /^(?<!Codestream:)\s+(Product: )?$product_name\s*(\S*)/) {
+            $product_eol = $2;
             last;
         }
     }


### PR DESCRIPTION
In SLE15SP3 build >= 50.1 there is an additional prefix in output
"Product:" before the product string itself.

See https://openqa.suse.de/tests/4774488#step/zypper_lifecycle/9

Verification runs:

```
okurz@linux-28d7:~/local/os-autoinst/opensuse 6 (fix/lifecycle) $ for i in https://openqa.suse.de/tests/4774488 https://openqa.suse.de/tests/4772458; do openqa-clone-custom-git-refspec https://github.com/okurz/os-autoinst-distri-opensuse/tree/fix/lifecycle $i; done
```

Created job #4776057: sle-15-SP3-Online-x86_64-Build50.1-xen@64bit -> https://openqa.suse.de/t4776057
Created job #4776058: sle-15-SP2-Server-DVD-Updates-x86_64-Build20201005-1-qam-minimal+base@64bit -> https://openqa.suse.de/t4776058