### PR TITLE
Fix sles4sap::reboot() for IPMI backend

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -397,7 +397,7 @@ sub reboot {
     if (check_var('BACKEND', 'ipmi')) {
         power_action('reboot', textmode => 1, keepconsole => 1);
         switch_from_ssh_to_sol_console;
-        $self->wait_boot(textmode => 1, nologin => 1);
+        $self->wait_boot(textmode => 1, nologin => get_var('NOAUTOLOGIN', '0'));
     }
     else {
         power_action('reboot', textmode => 1);


### PR DESCRIPTION
The `sles4sap::reboot()` method is used to reboot the SUT, but also to have a live SUT after the reboot; to that end, it uses a call to the `opensusebasetest::wait_boot()` method to ensure that the SUT is back online after the reboot so it can be used further in the test. This method in turn calls `opensusebasetest::wait_boot_past_bootloader()`, which does a `select_console('x11')` when called on IPMI backends. Additionally, `wait_boot_past_bootloader()` will call the `handle_display_manager_login()` method when called with `nologin => 1` or when the `NOAUTOLOGIN` setting is set to true, to handle the login process in the displaymanager, but this causes a problem as `select_console('x11')` calls internally the method `x11utils::ensure_unlocked_desktop()`, so by the time `handle_display_manager_login()` is called on IPMI, the SUT is already logged in the generic desktop which in turn leads to a failure in `assert_screen('displaymanager')`.

This commit changes the call to wait_boot() in sles4sap::reboot() so it uses whatever value it gets passed on NOAUTOLOGIN or 0 by default to avoid the call to `handle_display_manager_login()` in `opensusebasetest::wait_boot_past_bootloader()`.

- Related ticket: N/A
- Needles: N/A
- Failing Test: https://openqa.suse.de/tests/4775655#step/mr_test/34
- Verification run: https://openqa.suse.de/t4776180
