### PR TITLE
Enable sles+sdk+proxy_SCC_via_YaST on powerVM

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -727,6 +727,7 @@ sub registration_bootloader_params {
 }
 
 sub yast_scc_registration {
+    my (%args) = @_;
     # for leap to sle migration, we need to install yast2-registration
     # before running yast2 registration module.
     my $client_module = 'scc';
@@ -734,7 +735,7 @@ sub yast_scc_registration {
         zypper_call('in yast2-registration');
         $client_module = 'registration';
     }
-    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module);
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module, yast2_opts => $args{yast2_opts});
     assert_screen_with_soft_timeout(
         'scc-registration',
         timeout      => 90,

--- a/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
+++ b/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
@@ -1,0 +1,31 @@
+name:           sles+sdk+proxy_SCC_via_YaST
+description:    >
+  Add add-on via SCC using YaST module.
+vars:
+  ADDONS: all-packages
+  DESKTOP: textmode
+  SCC_ADDONS: sdk
+  SCC_REGISTER: console
+  SYSTEM_ROLE: textmode
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - installation/addon_products_via_SCC_yast2_ncurses

--- a/tests/installation/addon_products_via_SCC_yast2_ncurses.pm
+++ b/tests/installation/addon_products_via_SCC_yast2_ncurses.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Add an addon to SLES via SCC using YaST module in ncurses
+# Maintainer: QA SLE YaST <qa-sle-yast@suse.com>
+
+use base 'y2_module_consoletest';
+use strict;
+use warnings;
+use testapi;
+use registration;
+use version_utils 'is_sle';
+
+sub run {
+    my ($self) = @_;
+    select_console('root-console');
+    # Clean up registration in case system was previsouly registered
+    cleanup_registration if is_sle('>=15');
+    yast_scc_registration(yast2_opts => '--ncurses');
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->SUPER::post_fail_hook;
+    verify_scc;
+    investigate_log_empty_license;
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
Main challenge here is that on powerVM we cannot boot into the image,
and not to introduce extra dependency it was decided to conduct
installation before registering addon using YaST module. Other big
difference is that we don't install gnome environment on powerVM, so
module has to be executed in ncurses, which was done by creating
separate module, so that we don't have to rely on `DESKTOP` variables
and define what we need in the schedule instead. This approach will
allow to test YaST module in ncurses with gnome without any additional
changes.

* [poo#68980](https://progress.opensuse.org/issues/68980)
* [Job group changes](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/296)

* [Verification run](https://openqa.suse.de/tests/4778810).