### PR TITLE
Unschedule yast2_nfs_server from s390x

### DIFF
--- a/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml
@@ -45,6 +45,5 @@ conditional_schedule:
         - console/yast2_lan
         - console/yast2_lan_hostname
         - console/yast2_dns_server
-        - console/yast2_nfs_server
         - console/yast2_nfs_client
         - console/yast2_snapper_ncurses


### PR DESCRIPTION
Test module accidentally enabled on s390x, and was never adjusted to
work there. So disabling it for now.

See [poo#72274](https://progress.opensuse.org/issues/72274).
