### PR TITLE
Test SAP HANA on SLES for SAP Applications in backends with NVDIMM

### DIFF
--- a/data/sles4sap/udev-settle-override.conf
+++ b/data/sles4sap/udev-settle-override.conf
@@ -1,0 +1,3 @@
+[Service]
+TimeoutSec=1200s
+ExecStart=/usr/bin/udevadm settle -t 300

--- a/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
+++ b/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
@@ -3,7 +3,6 @@ name: sles4sap_online_dvd_gnome_hana
 description: >
   HANA tests for SLES4SAP with the hdblcm cli
 vars:
-  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46_0/%ARCH%
   HANA_PARTITIONING_BY: yast
   INSTANCE_ID: '00'
   INSTANCE_SID: NDB

--- a/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
+++ b/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
@@ -1,0 +1,42 @@
+---
+name: sles4sap_online_dvd_gnome_hana
+description: >
+  HANA tests for SLES4SAP with the hdblcm cli
+vars:
+  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46_0/%ARCH%
+  HANA_PARTITIONING_BY: yast
+  INSTANCE_ID: '00'
+  INSTANCE_SID: NDB
+schedule:
+  - boot/boot_from_pxe
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/sles4sap_product_installation_mode
+  - installation/partitioning
+  - installation/partitioning_firstdisk
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/reclaim_free_space_in_pv
+  - '{{ndctl}}'
+  - sles4sap/hana_install
+  - sles4sap/hana_test
+  - sles4sap/forkbomb
+conditional_schedule:
+  ndctl:
+    NVDIMM:
+      1:
+        - console/ndctl

--- a/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
+++ b/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
@@ -3,7 +3,6 @@ name: sles4sap_online_dvd_gnome_hana
 description: >
   HANA tests for SLES4SAP with the hdblcm cli
 vars:
-  HANA_PARTITIONING_BY: yast
   INSTANCE_ID: '00'
   INSTANCE_SID: NDB
 schedule:

--- a/tests/console/ndctl.pm
+++ b/tests/console/ndctl.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: install ndctl. Destroy and configure NVDIMM namespaces
+# Maintainer: Alvaro Carvajal <acarvajal@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    return unless get_var('NVDIMM');
+    $self->select_serial_terminal;
+    zypper_call('in ndctl');
+    assert_script_run 'ndctl destroy-namespace --force all';
+    my $total = get_var('NVDIMM_NAMESPACES_TOTAL', 2);
+    foreach my $i (0 .. ($total - 1)) {
+        my $device = script_output 'ndctl create-namespace --force --mode=memory --map=dev';
+        ($device) = $device =~ /\"blockdev\":\"(pmem\d+)\"/;
+        assert_script_run "test -b /dev/$device";
+        assert_script_run "wipefs -a /dev/$device";
+    }
+    assert_script_run 'ndctl list';
+    assert_script_run 'ndctl list -H -N -D -F > /tmp/ndctl-list 2>&1';
+    upload_logs('/tmp/ndctl-list', failok => 1);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
This pull request includes:

1. The new test module `console/ndctl` which can be used to configure NVDIMM namespaces on a system using the `ndctl` command. The module will install `ndctl`, destroy the existing namespaces, and create as many namespaces as configured in the `NVDIMM_NAMESPACES_TOTAL` setting.
2. Changes to the `sles4sap/hana_install` test module so it configures pmem on NVDIMM to be used by the installed HANA. 
3. Recommended settings for `systemd-udev-settle` required by HANA on NVDIMM on SLES for SAP Applications.
4. Changes to the `sles4sap/hana_test` test module so it can verify HANA is configured as expected in the NVDIMM scenario.
5. The yaml schedule for the full test.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/4802540 - [ndctl list -H -N -D -F output](https://openqa.suse.de/tests/4802540/file/ndctl-ndctl-list), [pmems configured](https://openqa.suse.de/tests/4802540#step/ndctl/21), [pmem configuration for HANA](https://openqa.suse.de/tests/4802540#step/hana_install/101), [pmem use verification](https://openqa.suse.de/tests/4802540#step/hana_test/42)
- Extra verification runs: [With HANA_PARTITIONING_BY=yast (currently failing due to bsc#1177392)](https://openqa.suse.de/t4783515); [Without using the NVDIMM devices](https://openqa.suse.de/tests/4801107); [Regression test Power9](http://mango.qa.suse.de/tests/3221); [Regression test x86_64](https://openqa.suse.de/t4804800); [Test with HANA 2 SPS04rev46](https://openqa.suse.de/t4810767); [Test wit HANA 2 SPS04rev46 - No NVDIMMs](https://openqa.suse.de/tests/4809966)
