### PR TITLE
Avoid host key checking on sshxterm

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -26,7 +26,7 @@ sub run {
     my ($self) = @_;
     mouse_hide(1);
     x11_start_program('xterm');
-    type_string("ssh -XC root\@localhost xterm\n");
+    type_string("ssh -o StrictHostKeyChecking=no -XC root\@localhost xterm\n");
     assert_screen "ssh-second-xterm";
     $self->set_standard_prompt();
     $self->enter_test_text('ssh-X-forwarding', cmd => 1);


### PR DESCRIPTION
Just for those cases where for some reason, the SUT asks for key verification

https://openqa.suse.de/tests/4782707
https://openqa.suse.de/tests/4782706

Failing job: https://openqa.suse.de/tests/4781423

Passing on other jobs for the same arch: https://openqa.suse.de/tests/overview?arch=aarch64&machine=&modules=sshxterm&modules_result=passed&distri=sle&version=15-SP3&build=51.1&groupid=110#