### PR TITLE
Adjust autoyast profiles to match the schema

### DIFF
--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -25,7 +25,6 @@
       <gfxtheme>/boot/grub2/themes/SLE/theme.txt</gfxtheme>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>true</os_prober>
-      <suse_btrfs>true</suse_btrfs>
       <timeout config:type="integer">-1</timeout>
       <xen_kernel_append> splash=silent quiet showopts</xen_kernel_append>
     </global>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -31,7 +31,6 @@
       <gfxtheme>/boot/grub2/themes/SLE/theme.txt</gfxtheme>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>true</os_prober>
-      <suse_btrfs>true</suse_btrfs>
       <terminal>gfxterm</terminal>
       <timeout config:type="integer">-1</timeout>
     </global>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -31,7 +31,6 @@
       <gfxtheme>/boot/grub2/themes/SLE/theme.txt</gfxtheme>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>true</os_prober>
-      <suse_btrfs>true</suse_btrfs>
       <terminal>gfxterm</terminal>
       <timeout config:type="integer">-1</timeout>
     </global>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -34,9 +34,6 @@
     <mode>
       <confirm config:type="boolean">false</confirm>
     </mode>
-    <mouse>
-      <id>none</id>
-    </mouse>
     <signature-handling>
       <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
       <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>


### PR DESCRIPTION
Next round of adjustments, as we have received more changes in the
latest build of SLES.
[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23yast2&medium=Online).
