### PR TITLE
Add a workaround for docker_runc on sle15

### DIFF
--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -38,8 +38,8 @@ sub run {
     # create the rootfs directory
     assert_script_run('mkdir rootfs');
 
-    # export busybox via Docker into the rootfs directory
-    assert_script_run('docker export $(docker create busybox) | tar -C rootfs -xvf -');
+    # export alpine via Docker into the rootfs directory (see bsc#1152508)
+    assert_script_run('docker export $(docker create alpine) | tar -C rootfs -xvf -');
 
     foreach my $runc (@runtimes) {
         record_info "$runc", "Testing $runc";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/71479
- Needles: N/A
- Verification run: 
s390x : [SLE-15](https://openqa.suse.de/tests/4792288) [SLE-15SP1](https://openqa.suse.de/tests/4792307)
x86_64 : [SLE-15](http://10.161.229.247/tests/1181)
[Tumbleweed](https://openqa.opensuse.org/tests/1423635)
