### PR TITLE
Change schedule to allow img-proof for PC runs

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2791,22 +2791,26 @@ sub load_publiccloud_tests {
     if (get_var('PUBLIC_CLOUD_PREPARE_TOOLS')) {
         loadtest "publiccloud/prepare_tools";
     }
-    elsif (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
+    elsif (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS') && !get_var('PUBLIC_CLOUD_QAM')) {
         loadtest "publiccloud/img_proof";
     }
     elsif (get_var('PUBLIC_CLOUD_QAM')) {
         loadtest "publiccloud/download_repos";
         my $args = OpenQA::Test::RunArgs->new();
-        loadtest "publiccloud/ssh_interactive_init",  run_args => $args;
-        loadtest "publiccloud/register_system",       run_args => $args;
-        loadtest "publiccloud/transfer_repos",        run_args => $args;
-        loadtest "publiccloud/patch_and_reboot",      run_args => $args;
-        loadtest "publiccloud/ssh_interactive_start", run_args => $args;
-        loadtest "publiccloud/instance_overview";
-        load_extra_tests_prepare();
-        load_extra_tests_docker() if (get_var('PUBLIC_CLOUD_CONTAINERS'));
-        load_extra_tests_console() unless (get_var('PUBLIC_CLOUD_CONTAINERS'));
-        loadtest "publiccloud/ssh_interactive_end", run_args => $args;
+        loadtest "publiccloud/ssh_interactive_init", run_args => $args;
+        loadtest "publiccloud/register_system",      run_args => $args;
+        loadtest "publiccloud/transfer_repos",       run_args => $args;
+        loadtest "publiccloud/patch_and_reboot",     run_args => $args;
+        if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
+            loadtest("publiccloud/img_proof", run_args => $args);
+        } else {
+            loadtest "publiccloud/ssh_interactive_start", run_args => $args;
+            loadtest "publiccloud/instance_overview" unless get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
+            load_extra_tests_prepare();
+            load_extra_tests_docker()  if (get_var('PUBLIC_CLOUD_CONTAINERS'));
+            load_extra_tests_console() if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS'));
+            loadtest "publiccloud/ssh_interactive_end", run_args => $args;
+        }
     }
     elsif (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest 'publiccloud/run_ltp';

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Public cloud utilities
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+package publiccloud::utils;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils;
+
+our @EXPORT = qw(select_host_console);
+
+
+# Select console on the test host, regardless of the TUNNELED variable.
+sub select_host_console() {
+    if (check_var('TUNNELED', '1')) {
+        select_console('tunnel-console');
+    } else {
+        select_console('root-console');
+    }
+}
+
+1;

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -15,6 +15,8 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use Mojo::File 'path';
 use Mojo::JSON;
+use publiccloud::utils "select_host_console";
+
 
 our $azure_byos      = 'test_sles,test_sles_azure';
 our $azure_on_demand = 'test_sles_wait_on_registration,test_sles,test_sles_on_demand,test_sles_azure';
@@ -27,33 +29,46 @@ our $gce_byos      = 'test_sles_wait_on_registration,test_sles,test_sles_gce';
 our $gce_on_demand = 'test_sles_wait_on_registration,test_sles,test_update,test_sles_smt_reg,test_sles_guestregister,test_sles_on_demand,test_sles_gce';
 
 our $img_proof_tests = {
-    'Azure-BYOS'       => $azure_byos,
-    'Azure-Basic'      => $azure_on_demand,
-    'Azure-Standard'   => $azure_on_demand,
-    'Azure-CHOST-BYOS' => $azure_byos,
-    'Azure-HPC'        => $azure_on_demand,
-    'Azure-HPC-BYOS'   => $azure_byos,
+    'Azure-BYOS'         => $azure_byos,
+    'AZURE-BYOS-Updates' => $azure_byos,
+    'Azure-Basic'        => $azure_on_demand,
+    'Azure-Standard'     => $azure_on_demand,
+    'Azure-CHOST-BYOS'   => $azure_byos,
+    'Azure-HPC'          => $azure_on_demand,
+    'Azure-HPC-BYOS'     => $azure_byos,
 
-    'EC2-CHOST-BYOS'   => $ec2_byos_chost,
-    'EC2-HVM'          => $ec2_on_demand,
-    'EC2-HVM-ARM'      => $ec2_on_demand,
-    'EC2-HVM-BYOS'     => $ec2_byos,
-    'EC2-HVM-HPC-BYOS' => $ec2_byos,
+    'EC2-CHOST-BYOS'       => $ec2_byos_chost,
+    'EC2-HVM'              => $ec2_on_demand,
+    'EC2-HVM-ARM'          => $ec2_on_demand,
+    'EC2-HVM-BYOS'         => $ec2_byos,
+    'EC2-HVM-BYOS-Updates' => $ec2_byos,
+    'EC2-HVM-HPC-BYOS'     => $ec2_byos,
 
-    GCE              => $gce_on_demand,
-    'GCE-BYOS'       => $gce_byos,
-    'GCE-CHOST-BYOS' => $gce_byos,
+    GCE                => $gce_on_demand,
+    'GCE-BYOS'         => $gce_byos,
+    'GCE-BYOS-Updates' => $gce_byos,
+    'GCE-CHOST-BYOS'   => $gce_byos,
 };
 
 sub run {
-    my ($self) = @_;
+    my ($self, $args) = @_;
 
-    $self->select_serial_terminal;
+    my $flavor = get_required_var('FLAVOR');
+    my $tests  = get_required_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
+    my $provider;
+    my $instance;
 
-    my $flavor   = get_required_var('FLAVOR');
-    my $provider = $self->provider_factory();
-    my $instance = $provider->create_instance();
-    my $tests    = get_required_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
+    # QAM passes the instance as argument
+    if (get_var('PUBLIC_CLOUD_QAM')) {
+        $instance         = $args->{my_instance};
+        $provider         = $args->{my_provider};
+        $self->{provider} = $args->{my_provider};    # required for cleanup
+        select_host_console();
+    } else {
+        $provider = $self->provider_factory();
+        $instance = $provider->create_instance();
+        $self->select_serial_terminal;
+    }
     if ($tests eq "default") {
         $tests = $img_proof_tests->{$flavor};
         die("Missing img_proof tests for $flavor - plz change img_proof.pm") unless $tests;

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -17,10 +17,11 @@ use warnings;
 use testapi;
 use strict;
 use utils;
+use publiccloud::utils "select_host_console";
 
 sub run {
     my ($self, $args) = @_;
-    select_console 'tunnel-console';
+    select_host_console();    # select console on the host, not the PC instance
 
     $args->{my_instance}->run_ssh_command(cmd => "sudo zypper ref", timeout => 360);
     ssh_fully_patch_system($args->{my_instance}->public_ip);

--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -18,13 +18,14 @@ use warnings;
 use testapi;
 use strict;
 use utils;
+use publiccloud::utils "select_host_console";
 
 sub run {
     my ($self, $args) = @_;
 
     my @addons = split(/,/, get_var('SCC_ADDONS', ''));
 
-    select_console 'tunnel-console';
+    select_host_console();    # select console on the host, not the PC instance
 
     my $max_retries = 3;
     for (1 .. $max_retries) {

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -17,13 +17,14 @@ use warnings;
 use testapi;
 use strict;
 use utils;
+use publiccloud::utils "select_host_console";
 
 sub run {
     my ($self, $args) = @_;
 
     my @addons = split(/,/, get_var('SCC_ADDONS', ''));
 
-    select_console 'tunnel-console';
+    select_host_console();    # select console on the host, not the PC instance
 
     assert_script_run("du -sh ~/repos");
     assert_script_run("rsync -va -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);


### PR DESCRIPTION
Changes towards scheduling procedure to allow img-proof in QEM test runs.

- Related ticket: https://progress.opensuse.org/issues/69625
- Needles: -
- Verification runs: All verification runs are done for SLE15-SP1 Azure BYOS

* [mau-extratests-docker-publiccloud](http://phoenix-openqa.qam.suse.de/t3162) (without updates)
* [mau-extratests-publiccloud](http://phoenix-openqa.qam.suse.de/t3166) (with updates) - cancelled after the actual test cases started
* [img-proof](http://phoenix-openqa.qam.suse.de/t3164) (with updates)