### PR TITLE
Fix autoyast disk as md member profile

### DIFF
--- a/data/autoyast_sle15/autoyast_disk_as_md_member.xml
+++ b/data/autoyast_sle15/autoyast_disk_as_md_member.xml
@@ -81,7 +81,7 @@
                     <size>400MiB</size>
                 </partition>
                 <partition>
-                    <raid_name>/dev/md/0</raid_name>
+                    <raid_name>/dev/md0</raid_name>
                     <size>10GiB</size>
                 </partition>
             </partitions>
@@ -93,13 +93,13 @@
             <use>all</use>
             <partitions config:type="list">
                 <partition>
-                    <raid_name>/dev/md/0</raid_name>
+                    <raid_name>/dev/md0</raid_name>
                 </partition>
             </partitions>
         </drive>
         <drive>
             <type config:type="symbol">CT_MD</type>
-            <device>/dev/md/0</device>
+            <device>/dev/md0</device>
             <disklabel>gpt</disklabel>
             <use>all</use>
             <raid_options>

--- a/schedule/yast/autoyast_disk_as_md_member.yaml
+++ b/schedule/yast/autoyast_disk_as_md_member.yaml
@@ -37,7 +37,7 @@ test_data:
           device: /dev/sda
       - drive:
           unique_key: device
-          device: /dev/md/0
+          device: /dev/md0
           raid_options:
             raid_type: raid1
           partitions:


### PR DESCRIPTION
Profile contains extra slash in the device name which started causing
failures, as device name doesn't contain slash anymore and is /dev/md0
now.

[Verification run](https://openqa.suse.de/tests/4786399).
