### PR TITLE
Skip listing extensions for MicroOS

### DIFF
--- a/schedule/microos/suse_microos_raw.yaml
+++ b/schedule/microos/suse_microos_raw.yaml
@@ -4,6 +4,7 @@ description:    >
     SUSE MicroOS tests
 schedule:
     - microos/disk_boot
+    - console/suseconnect_scc
     - microos/networking
     - microos/libzypp_config
     - microos/image_checks

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_microos);
 use registration;
 
 sub run {
@@ -39,10 +39,12 @@ sub run {
 
     select_console('root-console');
     assert_script_run $cmd;
-    assert_script_run 'SUSEConnect --list-extensions';
-    assert_screen 'activated-with-suseconnect';
-    assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'    \e\[1mServer Applications Module\')"';
-    assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'        \e\[1mWeb and Scripting Module\')"';
+    unless (is_microos('suse')) {
+        assert_script_run 'SUSEConnect --list-extensions';
+        assert_screen 'activated-with-suseconnect';
+        assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'    \e\[1mServer Applications Module\')"';
+        assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'        \e\[1mWeb and Scripting Module\')"';
+    }
 
     # add modules
     if (is_sle '15+') {


### PR DESCRIPTION
SUSE MicroOS doesn't have extensions and they are not even
epexted, so this step doesn't bring any benefit.
