### PR TITLE
Test OneClickInstallUI in openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1577,7 +1577,6 @@ sub load_extra_tests_opensuse {
     return unless is_opensuse;
     loadtest "console/rabbitmq";
     loadtest "console/rails";
-    loadtest "console/oneclick_install" if is_tumbleweed;
     loadtest "console/pcre";
     loadtest "console/openqa_review";
     loadtest "console/zbar";

--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -13,9 +13,10 @@ sub yast2_console_exec {
     my $y2_start    = y2_module_basetest::with_yast_env_variables() . ' yast2 ';
     my $module_name = 'yast2-' . $args{yast2_module} . '-status';
     $y2_start .= (defined($args{yast2_opts})) ?
-      $args{yast2_opts} . ' ' . $args{yast2_module} . ';' :
-      $args{yast2_module} . ';';
-
+      $args{yast2_opts} . ' ' . $args{yast2_module} :
+      $args{yast2_module};
+    $y2_start .= " \"$args{args}\"" if (defined($args{args}));
+    $y2_start .= ';';
     # poo#40715: Hyper-V 2012 R2 serial console is unstable (a Hyper-V product bug)
     # and is in many cases loosing the 15th character, so e.g. instead of the expected
     # 'yast2-scc-status-0' we get 'yast2-scc-statu-0' (sic, see the missing 's').

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -44,7 +44,6 @@ conditional_schedule:
                 - appgeo/gdal
                 - console/rabbitmq
                 - console/rails
-                - console/oneclick_install
                 - console/pcre
                 - console/openqa_review
                 - console/zbar

--- a/schedule/yast/yast_oneclick_install.yaml
+++ b/schedule/yast/yast_oneclick_install.yaml
@@ -1,0 +1,6 @@
+name:           yast_oneclick_install
+description:    >
+    Test OneClickInstallCLI and OneClickInstallUI
+schedule:
+  - boot/boot_to_desktop
+  - console/oneclick_install

--- a/tests/console/oneclick_install.pm
+++ b/tests/console/oneclick_install.pm
@@ -1,14 +1,14 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Test OneClickInstallCLI
-# Maintainer: Dominik Heidler <dheidler@suse.de>
+# Summary: Test OneClickInstallCLI and OneClickInstallUI
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use base "consoletest";
 use strict;
@@ -16,12 +16,36 @@ use warnings;
 use testapi;
 use utils;
 
-sub run {
-    select_console 'root-console';
+use y2_module_consoletest;
 
-    assert_script_run 'which OneClickInstallCLI || zypper -n in yast2-metapackage-handler',                                                   200;
-    assert_script_run 'yes | OneClickInstallCLI https://software.opensuse.org/ymp/openSUSE:Factory/standard/xosview.ymp || [ "$?" = "141" ]', 200;
-    assert_script_run 'which xosview';
+sub run {
+    # Prerequisites
+    my $url_ymp = 'https://software.opensuse.org/ymp/openSUSE:Factory/standard/xosview.ymp';
+    select_console('root-console');
+    assert_script_run('which OneClickInstallCLI || zypper -n in yast2-metapackage-handler', 200);
+    assert_script_run("which OneClickInstallUI");
+
+    # Validate OneClickInstallCLI
+    assert_script_run('yes | OneClickInstallCLI ' . $url_ymp . ' || [ "$?" = "141" ]', 200);
+    assert_script_run('which xosview');
+
+    # Remove package
+    zypper_call('rm xosview');
+
+    # Validate OneClickInstallUI: it is just a simple wrapper script
+    # calling the yast module, should suffice to run the module directly
+    my $module_name = y2_module_consoletest::yast2_console_exec(
+        yast2_module => 'OneClickInstallUI', args => $url_ymp);
+    assert_screen('yast2_OneClickInstallUI_description');
+    send_key($cmd{next});
+    assert_screen('yast2_OneClickInstallUI_proposal');
+    send_key($cmd{next});
+    assert_screen('yast2_OneClickInstallUI_warning');
+    send_key('alt-y');
+    assert_screen('yast2_OneClickInstallUI_summary');
+    send_key($cmd{finish});
+    wait_serial("$module_name-0", 240) || die "'OneClickInstallUI' didn't finish";
+    assert_script_run('which xosview');
 }
 
 1;


### PR DESCRIPTION
Test OneClickInstallUI in openSUSE using existing test module oneclick_install and adding a new test suite to not interfere with the system under test when adding and using an external repo, which could produce false positives or breaks in the next tests to be executed.

See [poo#71116](https://progress.opensuse.org/issues/71116)
Verification run: [tw-x86_64](https://openqa.opensuse.org/tests/1423554) & [tw-aarch64](https://openqa.opensuse.org/tests/1423556)