### PR TITLE
Increase timeout in yast2_cmdline

### DIFF
--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -33,7 +33,7 @@ sub run_yast_cli_test {
     script_run("if [ -d t ]; then echo -n 'run'; else echo -n 'skip'; fi > /dev/$serialdev", 0);
     my $action = wait_serial(['run', 'skip'], 10);
     if ($action eq 'run') {
-        assert_script_run('prove -v', timeout => 90, fail_message => 'yast cli tests failed');
+        assert_script_run('prove -v', timeout => 180, fail_message => 'yast cli tests failed');
     }
 
     script_run 'popd';


### PR DESCRIPTION
Looks like the "#prove -v" command often times out for opensuse test suite:
https://openqa.opensuse.org/tests/1421960#step/yast2_cmdline/26

Doubling it to avoid future failures.