### PR TITLE
ipxe_install: Print autoyast profile

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -109,6 +109,12 @@ boot
 END_BOOTSCRIPT
 
     diag "setting iPXE bootscript to: $bootscript";
+
+    diag "===== autoyast $autoyast =====";
+    my $curl = `curl -s $autoyast`;
+    diag $curl;
+    diag "===== END bootscript $autoyast =====";
+
     my $response = HTTP::Tiny->new->request('POST', $url, {content => $bootscript, headers => {'content-type' => 'text/plain'}});
     diag "$response->{status} $response->{reason}\n";
 }


### PR DESCRIPTION
Makes debugging easier (to compare that the profile used by installer is really the same as the one uploaded).
    
Download with curl (used with backticks - I'd prefer to use WWW::Curl::Simple, but it's not worth to add new dependency).

NOTE: during server run there are tags not visible in "Live log" (they're interpreted as HTML :( ).

Verification run: https://openqa.suse.de/tests/4794511/file/autoinst-log.txt
