### PR TITLE
Don't run shim key management by default

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -606,7 +606,7 @@ sub wait_grub {
     my $bootloader_time = $args{bootloader_time} // 100;
     my $in_grub         = $args{in_grub}         // 0;
     my @tags;
-    push @tags, 'shim-key-management' unless get_var('DISABLE_SECUREBOOT');
+    push @tags, 'shim-key-management'           if get_var('CHECK_MOK_IMPORT');
     push @tags, 'bootloader-shim-verification'  if get_var('MOK_VERBOSITY');
     push @tags, 'bootloader-shim-import-prompt' if get_var('UEFI');
     push @tags, 'grub2';


### PR DESCRIPTION
OSD workers are too slow to react to shim key management prompt which breaks some UEFI tests. Only run shim key management if the job explicitly asks for it through `CHECK_MOK_IMPORT=1`, otherwise always wait for GRUB menu.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - skip key management: https://openqa.suse.de/tests/4796757
  - run key management: https://openqa.suse.de/tests/4796758

Note: There's no usable kernel incident at the moment so both verification runs are expected to fail in install_ltp. First job will fail looking for `'linux-login, emergency-shell, emergency-mode'` needles. The second job will fail looking for either `'shim-perform-mok-management'` (worker is too slow) or `'shim-imported-mock-cert'` (the kernel cert issuer is `Devel:Kernel OBS Project`).