### PR TITLE
Fix leap to SLES gnome zdup migration can't boot into desktop

### DIFF
--- a/tests/installation/leap2sle_zdup.pm
+++ b/tests/installation/leap2sle_zdup.pm
@@ -42,8 +42,11 @@ sub run {
     assert_script_run "SUSEConnect --list-extensions";
     register_product();
     register_addons_cmd("base,serverapp,legacy,desktop,phub");
-    zypper_call('dup --force-resolution', timeout => 1200);
+    zypper_call('dup --force-resolution', timeout => 1800);
     zypper_call "rm \$(zypper --no-refresh packages --orphaned | gawk '{print \$5}' | tail -n +5)";
+    if (is_desktop_installed) {
+        systemctl 'set-default graphical.target';
+    }
     power_action('reboot', keepconsole => 1, textmode => 1);
 }
 


### PR DESCRIPTION
In leap to SLES gnome zdup migration test we set the system runlevel to multi-user
before migration. we need reset it to graphic target after the zdup migration done.

And I also enlarged the zypper dup timeout value because it failed in 1200 in  
verify run https://openqa.nue.suse.com/tests/4799379#step/leap2sle_zdup/67 

- Related ticket: https://progress.opensuse.org/issues/72049
- Needles: N/A
- Verification run: 
      gnome     
                      https://openqa.nue.suse.com/tests/4799399
                      https://openqa.nue.suse.com/tests/4799490
      textmode 
                     https://openqa.nue.suse.com/tests/4799424