### PR TITLE
Enable basic containers test on Centos

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -25,7 +25,24 @@ use utils qw(zypper_call systemctl);
 use version_utils qw(is_sle is_leap is_microos is_opensuse is_jeos is_public_cloud);
 
 our @EXPORT = qw(install_podman_when_needed install_docker_when_needed allow_selected_insecure_registries clean_container_host
-  test_container_runtime test_container_image scc_apply_docker_image_credentials scc_restore_docker_image_credentials);
+  test_container_runtime test_container_image scc_apply_docker_image_credentials scc_restore_docker_image_credentials install_podman_centos install_docker_centos);
+
+sub install_podman_centos {
+    if (script_run("which podman") != 0) {
+        assert_script_run "dnf -y install podman", timeout => 120;
+        save_screenshot;
+    }
+}
+
+sub install_docker_centos {
+    if (script_run("which docker") != 0) {
+        assert_script_run "dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo";
+        # if podman installed allowerasing to solve conflicts
+        assert_script_run "dnf -y install docker-ce --nobest --allowerasing", timeout => 120;
+        systemctl "enable --now docker";
+        systemctl "status docker";
+    }
+}
 
 sub install_podman_when_needed {
     if (script_run("which podman") != 0) {

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use version_utils;
 
-our @EXPORT = qw(build_container_image build_with_zypper_docker build_with_sle2docker test_opensuse_based_image);
+our @EXPORT = qw(build_container_image build_with_zypper_docker build_with_sle2docker test_opensuse_based_image exec_cmd);
 
 # Build any container image using a basic Dockerfile
 sub build_container_image {
@@ -127,6 +127,13 @@ sub test_opensuse_based_image {
     assert_script_run("$runtime rm refreshed", 120);
     # Verify the image works
     assert_script_run("$runtime run --rm refreshed-image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
+}
+
+sub exec_cmd {
+    my ($image, $runtime, $command, $timeout) = @_;
+    $timeout //= 120;
+    assert_script_run("$runtime run --rm $image $command", $timeout);
+    save_screenshot;
 }
 
 1;

--- a/schedule/containers/sle_image_on_centos.yaml
+++ b/schedule/containers/sle_image_on_centos.yaml
@@ -1,0 +1,9 @@
+name:           sle_image_on_centos
+description:    |
+    Run sle container on Centos
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - containers/setup_centos
+    - containers/validate_podman_centos
+    - containers/validate_docker_centos

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -5,6 +5,7 @@ description:    >
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
+    - containers/import_ca_certs
     - containers/podman_image
     - containers/docker_image
     # - containers/container_diff

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -35,11 +35,6 @@ sub run {
 
     install_docker_when_needed();
 
-    if (is_sle()) {
-        ensure_ca_certificates_suse_installed();
-        allow_selected_insecure_registries(runtime => 'docker');
-    }
-
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
     for my $i (0 .. $#$image_names) {

--- a/tests/containers/import_ca_certs.pm
+++ b/tests/containers/import_ca_certs.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Make sure that ca certifications were installed
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use utils;
+use containers::common;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+    ensure_ca_certificates_suse_installed();
+}
+
+1;

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -22,18 +22,9 @@ use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
 sub run {
-    my ($self) = @_;
-    $self->select_serial_terminal;
-
     my ($image_names, $stable_names) = get_suse_container_urls();
-
     install_podman_when_needed();
-
-    if (is_sle()) {
-        ensure_ca_certificates_suse_installed();
-        allow_selected_insecure_registries(runtime => 'podman');
-    }
-
+    allow_selected_insecure_registries(runtime => 'podman');
     for my $i (0 .. $#$image_names) {
         test_container_image(image => $image_names->[$i], runtime => 'podman');
         build_container_image(image => $image_names->[$i], runtime => 'podman');

--- a/tests/containers/setup_centos.pm
+++ b/tests/containers/setup_centos.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Setup Centos
+# - setup networking via dhclient
+# - import SUSE CA certificates
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+    assert_script_run "dhclient -v";
+    assert_script_run "curl http://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/ssl/certs/SUSE_Trust_Root.crt";
+}
+
+1;
+

--- a/tests/containers/validate_docker_centos.pm
+++ b/tests/containers/validate_docker_centos.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test docker running on Centos host
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use utils;
+use containers::common;
+use containers::container_images;
+use suse_container_urls 'get_suse_container_urls';
+
+sub run {
+    my ($image_names, $stable_names) = get_suse_container_urls();
+    my $container_mgmt_tool = 'docker';
+
+    install_docker_centos();
+    allow_selected_insecure_registries(runtime => $container_mgmt_tool);
+
+    for my $i (0 .. $#$image_names) {
+        test_container_image(image => $image_names->[$i], runtime => $container_mgmt_tool);
+        build_container_image(image => $image_names->[$i], runtime => $container_mgmt_tool);
+        exec_cmd($image_names->[$i], $container_mgmt_tool, 'cat /etc/os-release');
+    }
+    clean_container_host(runtime => $container_mgmt_tool);
+}
+
+1;

--- a/tests/containers/validate_podman_centos.pm
+++ b/tests/containers/validate_podman_centos.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test podman running on Centos host
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use utils;
+use containers::common;
+use containers::container_images;
+use suse_container_urls 'get_suse_container_urls';
+
+sub run {
+    my ($image_names, $stable_names) = get_suse_container_urls();
+    my $container_mgmt_tool = "podman";
+    install_podman_centos();
+    allow_selected_insecure_registries(runtime => $container_mgmt_tool);
+    for my $i (0 .. $#$image_names) {
+        test_container_image(image => $image_names->[$i], runtime => $container_mgmt_tool);
+        build_container_image(image => $image_names->[$i], runtime => $container_mgmt_tool);
+        exec_cmd($image_names->[$i], $container_mgmt_tool, 'cat /etc/os-release');
+    }
+    clean_container_host(runtime => $container_mgmt_tool);
+}
+
+1;


### PR DESCRIPTION
I have removed conditions which create checks that are depended on the
variables. Secondly i have moved code around to reduce dublicity and
make module a lit bit more atomic. Doing so i can be flexible with the scheduling

The image[0] i used for the jobs is fixed qcow with the only difference on the
PS1 and the root user's credentials. PS1 is needed to overcome the condition
in [login](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/lib/serial_terminal.pm#L120)

The main problem with the images on other hosts than Suse is
that the registration of a sle container requires a sle host.
the container-suseconnect[-zypp] plugin, which is used in this case, does not work
as it run using the host machine credentials.

[0] centOS-8.2.2004-x86_64-minimal.qcow2

- Related ticket: https://progress.opensuse.org/issues/66595
- [Verification run](https://openqa.suse.de/tests/4804790#details)
