### PR TITLE
Enhance ima/evm output filter for hmacs and signature

### DIFF
--- a/tests/security/ima/evm_protection_digital_signatures.pm
+++ b/tests/security/ima/evm_protection_digital_signatures.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -53,7 +53,7 @@ sub run {
         # Allow "No such file" message for the files in /proc because they are mutable
         my @finds = split /\n/, $findret;
         foreach my $f (@finds) {
-            $f =~ m/\/proc\/.*No such file/ or die "Failed to create security.evm for $f";
+            $f =~ m/\/proc\/.*No such file|name|uuid|generation|no xattr|hash|evm\/ima signature|^\w{530}$/ or die "Failed to create security.evm for $f";
         }
     }
 

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -37,7 +37,7 @@ sub run {
     my $findret = script_output("/usr/bin/find / -fstype $fstype -type f -uid 0 -exec evmctl -a sha256 ima_hash '{}' \\;", 1800, proceed_on_failure => 1);
     # Allow "No such file" message for the files in /proc because they are mutable
     my @finds = split /\n/, $findret;
-    $_ =~ m/\/proc\/.*No such file/ or die "Failed to create security.evm for $_" foreach (@finds);
+    $_ =~ m/\/proc\/.*No such file|hash\(sha256\)/ or die "Failed to create security.evm for $_" foreach (@finds);
 
     validate_script_output "getfattr -m . -d $sample_app", sub {
         # Base64 armored security.evm and security.ima content (50 chars), we


### PR DESCRIPTION
For ima/evm tests, with newer SLES15SP3 drop, the corresponding commands produce some messages which are harmless, but we should do some enhancement code checking there to match the output.

Please be informed that the failed case is caused by bug, not code issue.

- Related ticket: https://progress.opensuse.org/issues/72232
                          https://progress.opensuse.org/issues/73159
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/4804603#