### PR TITLE
Fix yast2_apparmor issue: hotkey, buffer time

### DIFF
--- a/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
+++ b/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
@@ -47,6 +47,8 @@ sub run {
     send_key "alt-e";
     assert_screen("AppArmor-Settings-Enable-Apparmor");
     wait_screen_change { send_key "alt-q" };
+    clear_console;
+    assert_screen("root-console-x11");
     type_string("systemctl status apparmor | tee \n");
     assert_screen("AppArmor_Active");
 

--- a/tests/security/yast2_apparmor/settings_toggle_profile_mode.pm
+++ b/tests/security/yast2_apparmor/settings_toggle_profile_mode.pm
@@ -41,9 +41,11 @@ sub run {
     assert_screen("AppArmor-Settings-Profile-List-Show-Active-only");
 
     # Toggle profile modes and check "nscd" was changed from "enforcing" to "complain"
+    # Set to "complain"
     send_key "alt-c";
     assert_screen("AppArmor-Settings-Profile-toggled");
-    send_key "alt-c";
+    # Set to "enforce"
+    send_key "alt-e";
     assert_screen("AppArmor-Settings-Profile-List-Show-Active-only");
 
     # List all profiles


### PR DESCRIPTION
Fix yast2_apparmor issue: revise hotkey and add buffer time

The hotkey is changed on sle15sp3 build54.1 then revise it.
When exiting "yast2" and entering the console the command line is not very ready to accept "type_string $str",
added assert screen of root console.


- Related ticket: 
  https://progress.opensuse.org/issues/73117
  https://progress.opensuse.org/issues/72241
- Needles: NA
- Verification run: 
  all passed: http://openqa.suse.de/tests/4809509