### PR TITLE
Mitigations: Update specify_disk info in MITIGATION_ENV_SETUP

### DIFF
--- a/tests/cpu_bugs/mitigation_env_setup.pm
+++ b/tests/cpu_bugs/mitigation_env_setup.pm
@@ -18,15 +18,9 @@ use utils;
 
 sub run {
     my $self     = shift;
-    my $newlabel = 'Test';
+    my $newlabel = get_required_var('SPECIFIC_DISK') . '-' . get_required_var('DISTRI') . '-' . get_required_var('VERSION') . '-';
 
-    get_required_var('SPECIFIC_DISK') =~ /\d/;
-    $newlabel .= $& . '_';
-    get_required_var('MACHINE') =~ /[v|p]h\d{3}/;
-    $newlabel .= $& . '-';
-    $newlabel .= get_required_var('DISTRI') . '-' . get_required_var('VERSION') . '-';
-
-    # for mitigation test, disk label with build tag, while with Build number
+    # for mitigation test, add build tag or build number to disk label
     if (lc(get_var('MYBUILD')) =~ /alpha|beta|rc|gm/) {
         $newlabel .= get_var('MYBUILD');
     }


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://trello.com/c/iTGCgtA3/434-p0autoupdate-specifydisk-info-in-mitigationenvsetup
- Needles: N/A
- Verification run: http://openqa.qa2.suse.asia/tests/18969