### PR TITLE
Wait for screen loaded in Installation Settings

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -116,6 +116,7 @@ sub go_to_patterns {
         send_key 'alt-s';
     }
     else {
+        assert_screen 'installation-settings-overview-loaded',  60;
         send_key_until_needlematch 'packages-section-selected', 'tab';
         send_key 'ret';
     }


### PR DESCRIPTION
Wait for screen loaded in Installation Settings when selecting Software.

- Related ticket: [poo#71842](https://progress.opensuse.org/issues/71842)
- Verification run: [5x ssh_X](https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_select_partterns_menu_selection)