### PR TITLE
Check if there's a generic-desktop instead of failing

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -112,7 +112,8 @@ sub ensure_unlocked_desktop {
         if ((match_has_tag 'displaymanager-password-prompt') || (match_has_tag 'screenlock-password')) {
             if ($password ne '') {
                 type_password;
-                assert_screen [qw(locked_screen-typed_password login_screen-typed_password)];
+                assert_screen [qw(locked_screen-typed_password login_screen-typed_password generic-desktop)];
+                next if match_has_tag 'generic-desktop';
             }
             send_key 'ret';
         }


### PR DESCRIPTION
There might be cases where the check for the
locked_screen-typed_password takes just enough time so that the second
time of the ensure_unlocked_desktop loop runs, the actual screen that is
detected would still be locked_screen-typed_password  but by the time we
enter that branch, the screen has already changed, since we don't really
know the state, using the same assert_screen to check also for
generic-desktop should cover the scenario, and by jumping to the next
loop, we can get the system to keep going instead of dying, due to a
test setup problem

See job: https://openqa.suse.de/tests/4805496#step/consoletest_finish/17

VR: https://openqa.suse.de/t4811286

In the autoinst log can be seen how the locked_screen branch, is ran twice, failing on the second round.