### PR TITLE
Extend time to yast migration for spvm

### DIFF
--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -214,7 +214,7 @@ sub run {
         assert_screen 'import-untrusted-gpg-key', 60;
         send_key 'alt-t';
     }
-    assert_screen ['yast2-migration-installupdate', 'yast2-migration-proposal'], 500;
+    assert_screen ['yast2-migration-installupdate', 'yast2-migration-proposal'], 700;
     if (match_has_tag 'yast2-migration-installupdate') {
         send_key 'alt-y';
     }


### PR DESCRIPTION
Extend time to yast migration for spvm, spvm cases need more to get 'yast2-migration-installupdate', 'yast2-migration-proposal' tags needles. 

- Related ticket: https://progress.opensuse.org/issues/71776
- Verification run: 
Pre case: http://openqa.suse.de/tests/4812745
Migration case: http://openqa.suse.de/tests/4812746#
It need about 600s to get the expected needles
