### PR TITLE
Fix leap to SLES rollback service inactive after migration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -20,7 +20,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key);
+use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key common_service_start);
 use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
@@ -728,11 +728,12 @@ sub registration_bootloader_params {
 
 sub yast_scc_registration {
     my (%args) = @_;
-    # for leap to sle migration, we need to install yast2-registration
-    # before running yast2 registration module.
+    # For leap to sle migration, we need to install yast2-registration and rollback-helper
+    # and start/enable rollback.service before running yast2 registration module.
     my $client_module = 'scc';
     if (is_leap_migration) {
-        zypper_call('in yast2-registration');
+        zypper_call('in yast2-registration rollback-helper');
+        common_service_start('rollback', 'Systemd');
         $client_module = 'registration';
     }
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module, yast2_opts => $args{yast2_opts});

--- a/tests/installation/leap2sle_zdup.pm
+++ b/tests/installation/leap2sle_zdup.pm
@@ -28,6 +28,10 @@ sub run {
     $self->wait_boot(textmode => !is_desktop_installed(), bootloader_time => 300, ready_time => 600);
 
     select_console('root-console');
+    # We need to install rollback-helper and enable/start rollback.service
+    # before creating a snapshot.
+    zypper_call 'in rollback-helper';
+    common_service_start('rollback', 'Systemd');
     # Create a snapshot with specified description to do snapper rollback
     assert_script_run "snapper create --type pre --cleanup-algorithm=number --print-number --userdata important=yes --description 'b_zdup migration'";
 


### PR DESCRIPTION
In leap to SLES migration, To make the rollback service to work, We need to install 
rollback-helper package and enable/start the rollback.service on the base system.

This action should be done before we create a snapshot by zdup migration.

- Related ticket: https://progress.opensuse.org/issues/73222
- Needles: N/A
- Verification run: 

textmode:
  https://openqa.nue.suse.com/tests/4812784
  https://openqa.nue.suse.com/tests/4812785
  https://openqa.nue.suse.com/tests/4812791

gnome : 
  zypper: https://openqa.nue.suse.com/tests/4810660  
  zdup:    https://openqa.nue.suse.com/tests/4812866 
  yast:     https://openqa.nue.suse.com/tests/4812868