### PR TITLE
Fix expect script time racing issue in pam_mount test

### DIFF
--- a/tests/security/pam/pam_mount.pm
+++ b/tests/security/pam/pam_mount.pm
@@ -70,9 +70,15 @@ sub run {
     my $key_file = 'enc_key';
     assert_script_run "mkdir -p $key_dir";
     assert_script_run "echo '$key' > $key_dir/$key_file";
-    assert_script_run(
-        "expect -c 'spawn cryptsetup luksAddKey $loopdev $key_dir/$key_file; \\
-expect \"Enter any existing passphrase: \"; send \"$key\\n\"; interact'"
+    script_run_interactive(
+        "cryptsetup luksAddKey $loopdev $key_dir/$key_file",
+        [
+            {
+                prompt => qr/Enter any existing passphrase.*/m,
+                string => "$key\n",
+            },
+        ],
+        100
     );
     assert_script_run(
         "expect -c 'spawn cryptsetup luksOpen $loopdev $loop_vol; \\


### PR DESCRIPTION
During the pam_mount test run, we often hit an stange issue for expect script,
it seems has some time racing issue, sometime,it types the word before expected text
shows up, so use "script_run_interactive" api instead

Based on my tests, the issue is not seen with 3 iterations, so I think it is strong enough to submit.

- Related ticket: https://progress.opensuse.org/issues/71779
                          https://progress.opensuse.org/issues/72322
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/4812867#
