### PR TITLE
Support test case "yast2_users" to be run on TW

### DIFF
--- a/tests/security/yast2_users/add_users.pm
+++ b/tests/security/yast2_users/add_users.pm
@@ -26,6 +26,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_tumbleweed';
 
 sub run {
     my $testuser = "testuser";
@@ -35,6 +36,7 @@ sub run {
     # Create a test user
     script_run("userdel -rf $testuser");
     assert_script_run("useradd -m -d \/home\/$testuser $testuser");
+    zypper_call("in expect");
     assert_script_run(
         "expect -c 'spawn passwd $testuser; expect \"New password:\"; send \"$pw\\n\"; expect \"Retype new password:\"; send \"$pw\\n\"; interact'");
 
@@ -70,6 +72,14 @@ sub run {
     assert_screen("Yast2-Users-Add-User-Data-CPW");
     type_string("$pw");
     send_key "alt-o";
+
+    # For Tumbleweed there is an extra window for "bernhard" automatic login
+    # and click "No"
+    if (is_tumbleweed) {
+        assert_screen("Yast2-Users-bernhard-automatic-login");
+        wait_screen_change { send_key "alt-n" };
+    }
+
     # There should be no this message in next window:
     # "The password is too long for the current encryption method."
     # "It will be truncated to 8 characters."


### PR DESCRIPTION
Support test case "yast2_users" to be run on TW:
Pkg "expect" pkg is not installed by default on TW.
Install "expect" pkg and revise some code to fix yast2_users error.

- Related ticket: https://progress.opensuse.org/issues/71740
- Needles: NA
- Verification run:
  TW passed: https://openqa.opensuse.org/tests/1431219
  SLE passed: http://openqa.suse.de/t4812875