### PR TITLE
Add sles4sap robot framework tests

### DIFF
--- a/schedule/qam/robot_fw.yaml
+++ b/schedule/qam/robot_fw.yaml
@@ -1,0 +1,8 @@
+---
+name:  robot_fw
+description: >
+ Test basics settings with the robot framework
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/robot_fw

--- a/tests/sles4sap/robot_fw.pm
+++ b/tests/sles4sap/robot_fw.pm
@@ -1,0 +1,54 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Check sles4sap settings with and without tuning using robot framework.
+#          This test is configured to be used with a 2 GB RAM system.
+#          Some values depend of the hardware configuration.
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base "sles4sap";
+use testapi;
+use strict;
+use warnings;
+use version_utils 'is_sle';
+
+sub run {
+    my ($self)           = @_;
+    my $robot_fw_version = '3.2.2';
+    my $test_repo        = "/robot/tests/" . get_var('SLE_PRODUCT') . "-" . get_var('VERSION');
+    my $robot_tar        = "robot.tar.gz";
+    my $python_bin       = is_sle('15+') ? 'python3' : 'python';
+
+    # Download and prepare the test environment
+    assert_script_run "cd /; curl -f -v qa-css-hq.qa.suse.de/$robot_tar -o $robot_tar";
+    assert_script_run "tar -xzf $robot_tar";
+
+    # Install the robot framework
+    assert_script_run "unzip /robot/bin/robotframework-$robot_fw_version.zip";
+    assert_script_run "cd robotframework-$robot_fw_version";
+    assert_script_run "$python_bin setup.py install";
+
+    # Disable specific tuning if we are testing SLES
+    if (check_var('SLE_PRODUCT', 'sles')) {
+        assert_script_run "systemctl disable sapconf";
+        $self->reboot;
+        select_console 'root-console';
+    }
+
+    # Execute each test and upload its results
+    assert_script_run "cd $test_repo";
+    foreach my $robot_test (split /\n/, script_output "ls $test_repo") {
+        record_info("$robot_test", "Starting $robot_test");
+        script_run "robot --log $robot_test.html --xunit $robot_test.xml $robot_test";
+        parse_extra_log("XUnit", "$test_repo/$robot_test.xml");
+        upload_logs("$test_repo/$robot_test.html", failok => 1);
+    }
+}
+
+1;


### PR DESCRIPTION
This PR adds a robot framework test suite for SLES4SAP, the idea of this test is to make sure that some standard settings are not changed by updates. Those tests will be added to Maintenance Test Repo from 12-SP2 to 15SP2 version.

If the product is `sles`, we disable sapconf and reboot before testing, otherwise, we just execute the test with sapconf enabled.

The tests are checking:

```
- /etc/os-release file
- system limits
- standard user limits
- sysctl settings
```

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[SLES4SAP 15 SP2 without sapconf](http://1a102.qa.suse.de/tests/5731)
[SLES4SAP 15 SP2 with sapconf](http://1a102.qa.suse.de/tests/5730)
[SLES4SAP 15 SP1 without sapconf](http://1a102.qa.suse.de/tests/5732)
[SLES4SAP 15 SP1 with sapconf](http://1a102.qa.suse.de/tests/5733)
[SLES4SAP 15 GA without sapconf](http://1a102.qa.suse.de/tests/5735)
[SLES4SAP 15 GA with sapconf](http://1a102.qa.suse.de/tests/5734)
[SLES4SAP 12 SP5 without sapconf](http://1a102.qa.suse.de/tests/5736)
[SLES4SAP 12 SP5 with sapconf](http://1a102.qa.suse.de/tests/5737)


Each test generates 2 log files, one in xml format parsed by openQA and another one in html format:
```
robot_fw-etc_os-release.robot.html
robot_fw-etc_os-release.robot.xml
robot_fw-sysctl.robot.html
robot_fw-sysctl.robot.xml
...
```