### PR TITLE
xfstests: reload loop device after crash

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -377,6 +377,18 @@ END_CMD
     type_string("$cmd\n");
 }
 
+sub reload_loop_device {
+    my $self = shift;
+    assert_script_run("losetup -fP test_dev");
+    my $scratch_amount = script_output("ls scratch_dev* | wc -l");
+    my $scratch_num    = 0;
+    while ($scratch_amount >= $scratch_num) {
+        assert_script_run("losetup -fP scratch_dev$scratch_num", 300);
+        $scratch_num += 1;
+    }
+    script_run('losetup -a');
+}
+
 sub run {
     my $self = shift;
     select_console('root-console');
@@ -456,6 +468,11 @@ sub run {
 
         # Add test status to STATUS_LOG file
         log_add($STATUS_LOG, $test, $status, $time);
+
+        # Reload loop device after a reboot
+        if (get_var('XFSTESTS_LOOP_DEVICE')) {
+            reload_loop_device;
+        }
 
         # Prepare for the next test
         heartbeat_start;


### PR DESCRIPTION
xfstests could continue test when unexpected crash happen. But if use loop device it need to be reload after a reboot. Add this behavior when unexpected reboot happen.

- Related ticket: https://progress.opensuse.org/issues/72148
- Verification run: 
http://openqa.suse.de/tests/4823746
http://openqa.suse.de/tests/4823869