### PR TITLE
MicroOS: replace and remove all linux-login-casp references

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -22,7 +22,7 @@ our @EXPORT = qw(microos_reboot microos_login);
 
 # Assert login prompt and login as root
 sub microos_login {
-    assert_screen 'linux-login-casp', 150;
+    assert_screen 'linux-login-microos', 150;
 
     # Workers installed using autoyast have no password - bsc#1030876
     return if get_var('AUTOYAST');
@@ -36,7 +36,7 @@ sub microos_login {
 
     select_console 'root-console';
 
-    # Don't match linux-login-casp twice
+    # Don't match linux-login-microos twice
     assert_script_run 'clear';
 }
 
@@ -47,7 +47,7 @@ sub microos_reboot {
 
     # No grub bootloader on xen-pv
     # grub2 needle is unreliable (stalls during timeout) - poo#28648
-    assert_screen [qw(grub2 linux-login-casp)], 150;
+    assert_screen 'grub2', 150;
     send_key('ret') if match_has_tag('grub2');
 
     microos_login;

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -173,7 +173,6 @@ sub run {
     until (match_has_tag('reboot-after-installation')
           || match_has_tag('bios-boot')
           || match_has_tag('autoyast-stage1-reboot-upcoming')
-          || match_has_tag('linux-login-casp')
           || match_has_tag('inst-bootmenu')
           || match_has_tag('lang_and_keyboard'))
     {

--- a/variables.md
+++ b/variables.md
@@ -35,7 +35,7 @@ DEV_IMAGE | boolean | false | This setting is used to set veriables properly whe
 DISABLE_ONLINE_REPOS | boolean | false | Enables `installation/disable_online_repos` test module, relevant for openSUSE only. Test module explicitly disables online repos not to be used during installation.
 DISABLE_SECUREBOOT | boolean | false | Disable secureboot in firmware of the SUT or in hypervisor's guest VM settings
 DISABLE_SLE_UPDATES | boolean | false | Disables online updates for the installation. Is true if `QAM_MINIMAL` is true for SLE.
-DISTRI | string | | Defines distribution. Possible values: `sle`, `opensuse`, `casp`, `microos`.
+DISTRI | string | | Defines distribution. Possible values: `sle`, `opensuse`, `microos`.
 DOCRUN | boolean | false |
 DUALBOOT | boolean | false | Enables dual boot configuration during the installation.
 DUD | string | | Defines url or relative path to the DUD file if in [data directory of os-autoinst-distri-opensuse repo](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data)


### PR DESCRIPTION
"Caasp" references were cleaned in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10995
but there were still some strings with wrong name "casp".
This aims at finally removing all references of it.

Also, make sure we always expect grub2 screen after reboot.
The reason for this is because there are some cases where linux-login
screen is matched before grub, this happens randomly. e.g. [this](https://openqa.suse.de/tests/4809952#step/transactional_update/23) or [this](https://openqa.suse.de/tests/4812960#step/transactional_update/51)

VR:
    - [Tumbleweed DVD](http://fromm.arch.suse.de/tests/391)
    - [Tumbleweed image](http://fromm.arch.suse.de/tests/390)
    - [Leap 15.2 DVD](http://fromm.arch.suse.de/tests/392)
    - [Leap 15.2 image](http://fromm.arch.suse.de/tests/388)
    - [SUSE MicroOS 5.0 DVD](http://fromm.arch.suse.de/tests/394)
    - [SUSE MicroOS 5.0 image](http://fromm.arch.suse.de/tests/395)
Needles: 
    - [sles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1443)
    - [opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/693/files)