### PR TITLE
Fix HANA on NVD test for QAM

### DIFF
--- a/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
+++ b/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
@@ -10,6 +10,7 @@ schedule:
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
+  - '{{update_test_repo}}'
   - installation/addon_products_sle
   - installation/system_role
   - installation/sles4sap_product_installation_mode
@@ -38,3 +39,7 @@ conditional_schedule:
     NVDIMM:
       1:
         - console/ndctl
+  update_test_repo:
+    QAM_INCI:
+      1:
+        - installation/add_update_test_repo


### PR DESCRIPTION
Schedule for HANA test does not load test module for maintenance updates verification.

This PR adds the test module based on the value of the `QAM_INCI` setting.

- Related ticket: N/A
- Needles: N/A
- Verification run: [without QAM_INCI setting](https://openqa.suse.de/t4818888); [with QAM_INCI setting (test cancelled after verifying scheduled modules)](https://openqa.suse.de/t4818978)
