### PR TITLE
Upload autoyast xml file if offline upgrade fails

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -53,7 +53,10 @@ sub post_fail_hook {
     my ($self) = shift;
     reset_consoles;
     select_console('root-console');
-    $self->upload_y2logs if (check_var('offline_upgrade', 'yes'));
+    if (check_var('offline_upgrade', 'yes')) {
+        $self->upload_y2logs;
+        upload_logs("/mnt/root/autoupg.xml", failok => 1);
+    }
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
* **It** seems that tests/virt_autotest/reboot_and_wait_up_upgrade.pm has different base class to date back if failure happens. Use upload_logs to upload autoyast xml file explicitly
* **When** offline upgrade fails, the autoyast xml file probably resides in /mnt/root directory
* **Verification run:** By manual verificaiton

