### PR TITLE
xfstests: enable KEEP_DMESG to debug

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -184,6 +184,11 @@ sub create_loop_device_by_rootsize {
     script_run('sync');
 }
 
+sub set_config {
+    my $self = shift;
+    script_run("echo 'export KEEP_DMESG=yes' >> $CONFIG_FILE");
+}
+
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
@@ -218,6 +223,7 @@ sub run {
             do_partition_for_xfstests(\%para);
         }
     }
+    set_config;
 }
 
 sub test_flags {


### PR DESCRIPTION
Using export KEEP_DMESG=yes in local.config to pin down what's going
wrong in fail tests.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1177610#c1
- Verification run: http://openqa.suse.de/tests/4823754
