### PR TITLE
Workaround 'zypper lifecycle' build metadata cache directory error

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -33,17 +33,30 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_jeos);
+use version_utils qw(is_sle is_jeos is_upgrade);
+use Utils::Architectures;
 
 our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 
 sub run {
     diag('fate#320597: Introduce \'zypper lifecycle\' to provide information about life cycle of individual products and packages');
+
+    # Workaround for bsc#1166549, zypper lifecycle error with 'Error building the cache'.
+    # Currently the only workaround option is to run zypper-lifecycle as root.
+
+    # Now we just hit bsc#1166549 on s390x and ppc64le, so we just need root console
+    # on these two platforms.
+    my $needs_root_console = 0;
+    if ((is_s390x || is_ppc64le) && is_sle('>=15-SP3') && is_upgrade) {
+        $needs_root_console = 1;
+        record_soft_failure 'bsc#1166549 - zypper lifecycle failed to create metadata cache directory';
+    }
+    select_console 'root-console';
+
     # We add 'zypper ref' here to download and preparse the metadata of packages,
     # which will make the follow 'zypper lifecycle' runs faster.
-    select_console 'root-console';
     script_run('zypper ref');
-    select_console 'user-console';
+    select_console 'user-console' unless $needs_root_console;
     my $overview = script_output('zypper lifecycle', 600);
     die "Missing header line:\nOutput: '$overview'" unless $overview =~ /Product end of support/;
     die "Missing link to lifecycle page:\nOutput: '$overview'"
@@ -97,7 +110,7 @@ sub run {
     mkdir -p /var/lib/lifecycle/data
     echo '$package, *, $testdate' > /var/lib/lifecycle/data/$prod.lifecycle";
     # verify eol from lifecycle data
-    select_console 'user-console';
+    select_console 'user-console' unless $needs_root_console;
     $output = script_output "zypper lifecycle $package", 300;
     die "$package lifecycle entry incorrect:\nOutput: '$output'" unless $output =~ /$package(-\S+)?\s+$testdate/;
 
@@ -129,7 +142,7 @@ sub run {
     }
     die "baseproduct eol not found in overview\nOutput: '$product_name'" unless $product_eol;
 
-    select_console 'user-console';
+    select_console 'user-console' unless $needs_root_console;
     # verify that package eol defaults to product eol
     $output = script_output "zypper lifecycle $package", 300;
     unless ($output =~ /$package(-\S+)?\s+$product_eol/) {
@@ -143,7 +156,7 @@ sub run {
         mv /var/lib/lifecycle/data/$prod.lifecycle.orig /var/lib/lifecycle/data/$prod.lifecycle
     fi";
     #
-    select_console 'user-console';
+    select_console 'user-console' unless $needs_root_console;
     # 4. verify that "zypper lifecycle --days N" and "zypper lifecycle --date
     # D" shows correct results
     assert_script_run 'zypper lifecycle --help';


### PR DESCRIPTION
For bsc#1166549, zypper lifecycle can't create metadata cache directory
on ppc64le and s390x sometimes. The developer don't know if it's intentional, 
the only option for now is to run zypper-lifecycle as root.

- Related ticket: https://progress.opensuse.org/issues/73198
- Needles: N/A
- Verification run: 

https://openqa.nue.suse.com/tests/4813036
https://openqa.nue.suse.com/tests/4823715
https://openqa.nue.suse.com/tests/4823715  
https://openqa.nue.suse.com/tests/4823721  
https://openqa.nue.suse.com/tests/4823760 