### PR TITLE
Fix expected target in minimal for ppc64le

### DIFF
--- a/test_data/yast/minimal+role_minimal_pvm.yaml
+++ b/test_data/yast/minimal+role_minimal_pvm.yaml
@@ -1,4 +1,4 @@
 ---
 <<: !include test_data/yast/minimal+role_minimal_defaults.yaml
-default_target: multi-user.target
+default_target: graphical.target
 device: sda


### PR DESCRIPTION
- Related ticket: [poo#71830](https://progress.opensuse.org/issues/71830)
- Verification run: [minimal+role_minimal@ppc64le-hmc-4disk](https://openqa.suse.de/tests/4823881#step/verify_default_target/3)
