### PR TITLE
wicked: Collect and upload logs in second virtconsole

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -691,6 +691,9 @@ sub pre_run_hook {
         add_serial_console($serial_terminal);
     }
 
+    $self->select_console('root-console');
+    $self->type_marker('## START: ' . $self->{name});
+
     if (get_var('VIRTIO_CONSOLE_NUM', 1) > 1){
         select_console('root-virtio-terminal1');
         $self->type_marker('## START: ' . $self->{name});

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -673,7 +673,7 @@ sub post_run {
 
 
 sub type_marker {
-    my $marker = shift;
+    my ($self, $marker) = @_;
     wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
     type_string($marker);
     wait_serial($marker, undef, 0, no_regex => 1);


### PR DESCRIPTION
This avoid problems,if a command during the test doesn't end
successfully and is blocking the serial terminal.
Also it removes unneeded output from the test serial console.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
