### PR TITLE
Fix reboot on PowerVM for klp installation

### DIFF
--- a/tests/kernel/install_klp_product.pm
+++ b/tests/kernel/install_klp_product.pm
@@ -21,11 +21,13 @@ use klp;
 use power_action_utils 'power_action';
 use serial_terminal 'prepare_serial_console';
 use Utils::Architectures qw(is_s390x);
+use Utils::Backends qw(is_pvm);
 
 sub do_reboot {
     my $self = shift;
 
-    power_action('reboot', textmode => 1);
+    power_action('reboot', textmode => 1, keepconsole => is_pvm);
+    reconnect_mgmt_console if is_pvm;
     $self->wait_boot;
 
     if (is_s390x) {


### PR DESCRIPTION
Fix poo#71755: PowerVM needs keepconsole option and reconnection to
management console for reboot.

- Related ticket: https://progress.opensuse.org/issues/71755
- Needles: none
- Verification run: http://black-bit.suse.cz/tests/5173#
