### PR TITLE
Skip empty repository and fix rsync installation

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -42,8 +42,13 @@ sub run {
             record_soft_failure("Download failed (rc=$ret):\n$maintrepo");
         } else {
             assert_script_run("echo -en '# $maintrepo:\\n\\n' >> /tmp/repos.list.txt");
-            assert_script_run("sed -i \"1 s/\\]/_\$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 4)]/\" $parent*.repo");
-            assert_script_run("find $parent >> /tmp/repos.list.txt");
+            if (script_run("ls $parent*.repo") == 0) {
+                assert_script_run("sed -i \"1 s/\\]/_\$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 4)]/\" $parent*.repo");
+                assert_script_run("find $parent >> /tmp/repos.list.txt");
+            } else {
+                record_soft_failure("No .repo file found in $parent. This directory will be removed.");
+                assert_script_run("rm -rf $parent");
+            }
         }
     }
 

--- a/tests/virtualization/universal/download_image.pm
+++ b/tests/virtualization/universal/download_image.pm
@@ -25,7 +25,7 @@ sub run {
     assert_script_run "mount " . get_var('VIRT_IMAGE_PATH') . " /mnt/virt_images";
 
     # Pull images from server if necessary
-    zypper_call("install rsync") if (script_run("which rsync") != 0);
+    zypper_call("install rsync", exitcode => [0, 102, 103, 106]) if (script_run("which rsync") != 0);
     assert_script_run "if [ ! -f \"$virt_autotest::common::imports{$_}->{disk}\" ]; then rsync -v --progress $virt_autotest::common::imports{$_}->{source} $virt_autotest::common::imports{$_}->{disk}; fi", 600 foreach (keys %virt_autotest::common::imports);
 
     assert_script_run "umount /mnt/virt_images";


### PR DESCRIPTION
Hello,

 * In `tests/publiccloud/download_repos.pm` the repositories without `.repo` file are now skipped and removed.
 * In `tests/virtualization/universal/download_image.pm` the `zypper_call('in wget'` tolerates minor failures.
 
- Verification run: [bad](https://openqa.suse.de/tests/4797308#step/download_repos/187) [good](http://pdostal-server.suse.cz/tests/10263)
