### PR TITLE
Drop CONTAINER_TOTEST variable in suse_container_urls

### DIFF
--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -54,7 +54,6 @@ sub get_opensuse_registry_prefix {
 # If empty, no images available.
 sub get_suse_container_urls {
     my $version    = shift // get_required_var('VERSION');
-    my $totest     = get_var('CONTAINER_TOTEST', '');          # totest/
     my $dotversion = $version =~ s/-SP/./r;                    # 15 -> 15, 15-SP1 -> 15.1
     $dotversion = "${dotversion}.0" if $dotversion !~ /\./;    # 15 -> 15.0
 
@@ -65,13 +64,13 @@ sub get_suse_container_urls {
         my $nodashversion = $version =~ s/-sp/sp/ir;
         # No aarch64 image
         if (!check_var('ARCH', 'aarch64')) {
-            push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/${totest}images/suse/sles${nodashversion}";
+            push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/totest/images/suse/sles${nodashversion}";
             push @stable_names, "registry.suse.com/suse/sles${nodashversion}";
         }
     }
     elsif (is_sle(">=15", $version)) {
         my $lowerversion = lc $version;
-        push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/${totest}images/suse/sle15:${dotversion}";
+        push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/totest/images/suse/sle15:${dotversion}";
         push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
     }
     elsif (is_tumbleweed && get_opensuse_registry_prefix) {

--- a/variables.md
+++ b/variables.md
@@ -27,7 +27,6 @@ CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test mo
 CHECK_RELEASENOTES_ORIGIN | boolean | false | Loads `installation/releasenotes_origin` test module.
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
-CONTAINER_TOTEST | string | | The string can be "totest/" or "", depending on the URL of the image in the container image registry.
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.


### PR DESCRIPTION
If a :ToTest subproject is available, that's what must be used in any case.
It seems like this is the case for all supported versions of SLE.

No verification run, I don't have a SLE openQA setup or access to one.

This currently fails with `registry.suse.de/suse/sle-15-sp3/update/cr/totest/images/suse/sle15:15.3`, which indicates that the process wasn't started for that yet.