### PR TITLE
Add support for Jump 15.2 containers

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -69,6 +69,7 @@ sub build_with_zypper_docker {
         validate_script_output("$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'", sub { /PRETTY_NAME="SUSE Linux Enterprise Server $pretty_version"/ });
     }
     else {
+        $version =~ s/^Jump://i;
         validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
     }
 
@@ -114,6 +115,7 @@ sub test_opensuse_based_image {
             script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lm'", 420;
         }
     } else {
+        $version =~ s/^Jump://i;
         validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
     }
 

--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -78,6 +78,11 @@ sub get_suse_container_urls {
         push @image_names,  "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";
         push @stable_names, "docker.io/opensuse/tumbleweed";
     }
+    elsif ($version eq "Jump:15.2") {
+        # Jump 15.2 uses opensuse/leap:15.2.1, just hardcode this special case
+        push @image_names,  "registry.opensuse.org/opensuse/jump/15.2/images/totest/containers/opensuse/leap:15.2.1";
+        push @stable_names, "docker.io/opensuse/leap:15.2.1";
+    }
     elsif (is_leap(">15.0") && check_var('ARCH', 'x86_64')) {
         push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
         push @stable_names, "docker.io/opensuse/leap:${version}";


### PR DESCRIPTION
This is somewhat of a special case and likely a one-off, so just hardcode this.

Fixes https://progress.opensuse.org/issues/71902
Verification run: http://10.160.67.86/tests/788
