### PR TITLE
Proceed on failures in show_oom_info

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1417,11 +1417,11 @@ Show logs about an out of memory process kill.
 =cut
 sub show_oom_info {
     if (script_run('dmesg | grep "Out of memory"') == 0) {
-        my $oom = script_output('dmesg | grep "Out of memory"');
+        my $oom = script_output('dmesg | grep "Out of memory"', proceed_on_failure => 1);
         if (has_ttys) {
             send_key 'alt-sysrq-m';
-            $oom .= "\n\n" . script_output('journalctl -kb | tac | grep -F -m1 -B1000 "sysrq: Show Memory" | tac');
-            $oom .= "\n\n% free -h\n" . script_output('free -h');
+            $oom .= "\n\n" . script_output('journalctl -kb | tac | grep -F -m1 -B1000 "sysrq: Show Memory" | tac', proceed_on_failure => 1);
+            $oom .= "\n\n% free -h\n" . script_output('free -h', proceed_on_failure => 1);
         }
         record_info('OOM KILL', $oom, result => 'fail');
     }


### PR DESCRIPTION
`show_oom_info` is called in post fail hooks, and in case `script_output`
calls will fail, no further steps will be executed.
As other logs are extremely useful for the investigations, we should
attempt to collect them.

[Verification run](https://openqa.suse.de/tests/4831831#)
