### PR TITLE
Import autoyast profile for tftp server

### DIFF
--- a/data/autoyast_sle15/autoyast_tftp.xml
+++ b/data/autoyast_sle15/autoyast_tftp.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <!-- These are not supported anymore; bug 925381 -->
+  <autofs>
+    <x config:type="boolean">false</x>
+  </autofs>
+  <restore>
+    <x config:type="boolean">false</x>
+  </restore>
+
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <signature-handling>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+    </signature-handling>
+  </general>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email>
+    </email>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
+  <scripts>
+    <post-scripts config:type="list">
+      <script>
+        <filename>post-script.sh</filename>
+        <interpreter>shell</interpreter>
+        <location/>
+        <feedback config:type="boolean">false</feedback>
+        <source><![CDATA[#!/bin/sh
+chmod 755 /srv/tftpboot
+        ]]></source>
+      </script>
+    </post-scripts>
+  </scripts>
+
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>10.226.154.19</host_address>
+        <names config:type="list">
+          <name>new.entry.de h999uz</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>vagrantup.com</domain>
+      <hostname>vagrant-sles12</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>vagrantup.com</search>
+      </searchlist>
+      <write_hostname config:type="boolean">true</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <name>82540EM Gigabit Ethernet Controller</name>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+  </networking>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+
+  <software>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>minimal_base</pattern>
+    </patterns>
+    <packages config:type="list">
+      <package>tftp</package>
+      <package>yast2-tftp-server</package>
+    </packages>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+  </software>
+
+  <tftp-server>
+    <start_tftpd config:type="boolean">true</start_tftpd>
+    <tftp_directory>/srv/tftpboot</tftp_directory>
+  </tftp-server>
+
+  <!-- bug 868614 - empty services entry -->
+  <services-manager>
+    <services config:type="list"/>
+  </services-manager>
+
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>vagrant</fullname>
+      <gid>100</gid>
+      <home>/home/vagrant</home>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>vagrant</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+        <ntp_server>
+            <address>ntp.suse.de</address>
+            <iburst config:type="boolean">true</iburst>
+            <offline config:type="boolean">false</offline>
+        </ntp_server>
+    </ntp_servers>
+  </ntp-client>
+
+</profile>

--- a/data/autoyast_sle15/host.sh
+++ b/data/autoyast_sle15/host.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e -x
+
+grep -P "10.226.154.19\tnew.entry.de h999uz" /etc/hosts && echo "AUTOYAST OK"

--- a/data/autoyast_sle15/ntp_conf.sh
+++ b/data/autoyast_sle15/ntp_conf.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -x
+
+grep "pool ntp.suse.de iburst" /etc/chrony.conf
+grep "driftfile /var/lib/chrony/drift" /etc/chrony.conf
+echo "AUTOYAST OK"

--- a/data/autoyast_sle15/tftp.list
+++ b/data/autoyast_sle15/tftp.list
@@ -1,0 +1,5 @@
+tftp.sh                # tftp is running correctly
+host.sh                # host is in /etc/hosts (bsc#870998)
+unsupported_modules.sh # unsupported YaST modules were reported (bsc#925381)
+set_passwords.sh       # password are set (bsc#973639, bsc#974220, bsc#971804 and bsc#965852)
+ntp_conf.sh            # setting written to /etc/ntp.conf (bnc#1040350)

--- a/data/autoyast_sle15/tftp.sh
+++ b/data/autoyast_sle15/tftp.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -x
+
+echo test >/srv/tftpboot/test.txt
+time tftp localhost -c get test.txt test2.txt || \
+time tftp localhost -c get test.txt test2.txt
+
+diff -u /srv/tftpboot/test.txt test2.txt && echo "AUTOYAST OK"
+

--- a/data/autoyast_sle15/unsupported_modules.sh
+++ b/data/autoyast_sle15/unsupported_modules.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -x
+[[ -n $(zgrep -l\
+            'Could not process these unsupported profile sections: \["autofs", "restore"\]'\
+        /var/log/YaST2/y2log*) \
+]] && echo "AUTOYAST OK"

--- a/schedule/yast/autoyast/autoyast_tftp.yaml
+++ b/schedule/yast/autoyast/autoyast_tftp.yaml
@@ -6,9 +6,12 @@ description: >
      - Post installation script execution
      - Adding host entries to the /etc/hosts
      - ntp/chrony configuration
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_tftp.xml
+  AUTOYAST_VERIFY: autoyast_sle15/tftp.list
 schedule:
-  - installation/isosize
-  - boot/boot_from_pxe
+  - autoyast/prepare_profile
+  - installation/bootloader_start
   - autoyast/installation
   - autoyast/console
   - autoyast/login


### PR DESCRIPTION
Original files are located here
https://github.com/yast/aytests-tests/blob/master/aytests/tftp.xml
https://github.com/yast/aytests-tests/blob/master/aytests/tftp.list
The profile was oudated and needed some modifications, see diff here:
https://w3.nue.suse.com/~jrivrain/tftp-xmls.diff

- Related ticket: poo#72043

- Verification run: https://openqa.suse.de/tests/4878637
still fails but now for a different reason.
I removed https://github.com/yast/aytests-tests/blob/master/aytests/post_script.sh as it just checks for a log to be filled in, but in the case the post script just does a "chmod", hence does not produce any output, so ther'es no log: https://openqa.suse.de/tests/4878628#step/autoyast_verify/9