### PR TITLE
Create conditional yaml for SLE11SP4 regression test on s390x

### DIFF
--- a/schedule/install/11sp4_s390_install.yaml
+++ b/schedule/install/11sp4_s390_install.yaml
@@ -13,3 +13,9 @@ schedule:
   - installation/await_install
   - installation/install_11sp4_configuration
   - update/patch_sle
+  - '{{install_service_test}}'
+conditional_schedule:
+  install_service_test:
+    REGRESSIONTEST:
+      1:
+        - installation/install_service

--- a/schedule/migration/s390x-zVM-Upgrade.yaml
+++ b/schedule/migration/s390x-zVM-Upgrade.yaml
@@ -20,3 +20,50 @@ schedule:
   - console/system_prepare
   - console/consoletest_setup
   - console/zypper_lr
+  - '{{regression_tests}}'
+conditional_schedule:
+  regression_tests:
+    REGRESSIONTEST:
+      1:
+        - console/system_prepare
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - locale/keymap_or_locale
+        - console/check_upgraded_service
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/textinfo
+        - console/hostname
+        - console/upgrade_snapshots
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/zypper_in
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/mysql_srv
+        - console/rsync
+        - console/http_srv
+        - console/apache
+        - console/dns_srv
+        - console/postgresql_server
+        - console/shibboleth
+        - console/pcre
+        - console/php7
+        - console/php7_mysql
+        - console/php7_postgresql
+        - console/apache_ssl
+        - console/apache_nss
+        - console/zypper_lifecycle
+        - console/orphaned_packages_check
+        - x11/reboot_gnome


### PR DESCRIPTION
We need create SLE11SP4 regression test on s390x, it is better to update the yaml file to add conditional schedule for these regression test related modules.

- Related ticket: https://progress.opensuse.org/issues/73426
- Needles: N/A
- Verification run: 
                     REGRESSIONTEST=1 with regression test related modules:
                            https://openqa.nue.suse.com/tests/4854119#.  #Add install-service in sles11SP4 installation test
                            https://openqa.nue.suse.com/tests/4854120#   #Add regression test in migration test, blocked by bsc#1175517
                    REGRESSIONTEST not set and wont affect normal test without regression test:                            
                            https://openqa.nue.suse.com/tests/4854121#   
                            https://openqa.nue.suse.com/tests/4854122