### PR TITLE
Enhance code to avoid time racing on yast2_users

### DIFF
--- a/tests/security/yast2_users/add_users.pm
+++ b/tests/security/yast2_users/add_users.pm
@@ -87,6 +87,10 @@ sub run {
     assert_screen("Yast2-Users-Add-User-Created");
     wait_screen_change { send_key "alt-o" };
 
+    # Enhence code for stability: avoid time racing
+    clear_console;
+    assert_screen("root-console-x11");
+
     # Exit x11 and turn to console
     send_key "alt-f4";
     assert_screen("generic-desktop");


### PR DESCRIPTION
Enhance code to avoid time racing on yast2_users

Sometime the following actions can not be executed properly so add some
time buffer code.

- Related ticket: https://progress.opensuse.org/issues/71740
- Needles: added to gitlab already
- Verification run: https://openqa.opensuse.org/tests/1436098#