### PR TITLE
Don't ignore if systemd-network fails to install on openSUSE

### DIFF
--- a/tests/console/check_default_network_manager.pm
+++ b/tests/console/check_default_network_manager.pm
@@ -23,12 +23,10 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    zypper_call('in systemd-network', exitcode => [0, 104]);
-
     assert_script_run 'ip a';
 
     if (is_opensuse) {
-        # check for systemd-networkd
+        zypper_call 'in systemd-network';
         systemctl 'is-enabled systemd-networkd', expect_false => 1;
         systemctl 'is-active systemd-networkd',  expect_false => 1;
         assert_script_run 'networkctl status';


### PR DESCRIPTION
All supported versions have it, so install iff running on openSUSE.
This avoids trying to install it on SLE and also ensures that it was actually
installed for use by the following checks.

Verification runs:
http://10.160.67.86/tests/802 (should fail, boo#1176088)
http://10.160.67.86/tests/803

