### PR TITLE
Fix support server image generation for openSUSE

### DIFF
--- a/tests/support_server/configure.pm
+++ b/tests/support_server/configure.pm
@@ -22,15 +22,14 @@ use warnings;
 use testapi;
 use utils;
 use y2_module_basetest;
+use version_utils 'is_opensuse';
 
 sub _remove_installation_media_and_add_network_repos {
     # this is supposed to run during SUPPORTSERVER_GENERATOR
     #
     # remove the installation media
-    my $script = "
-    zypper lr
-    zypper rr 1
-    ";
+    my $script = "zypper lr\n";
+    $script .= "zypper rr 1\n" unless is_opensuse;
     # optionally add network repos
     if (get_var("POOL_REPO")) {
         $script .= "zypper -n --no-gpg-checks ar --refresh '" . get_var("POOL_REPO") . "' pool\n";
@@ -80,4 +79,3 @@ sub test_flags {
 }
 
 1;
-

--- a/tests/support_server/configure.pm
+++ b/tests/support_server/configure.pm
@@ -59,17 +59,14 @@ sub _turnoff_gnome_screensaver_and_suspend {
     assert_script_run "gsettings set org.gnome.desktop.session idle-delay 0";
     assert_script_run "gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type 'nothing'";
 }
-sub _switch_to_wicked_if_require {
-    my ($self) = shift;
-    return unless is_network_manager_default;
-    $self->use_wicked_network_manager;
-}
+
 sub run {
+    my ($self) = shift;
     _remove_installation_media_and_add_network_repos;
     # We use create_hdd
     if (!check_var('SUPPORT_SERVER_GENERATOR', 1)) {
         _install_packages;
-        _switch_to_wicked_if_require;
+        $self->use_wicked_network_manager      if is_network_manager_default;
         _turnoff_gnome_screensaver_and_suspend if check_var('DESKTOP', 'gnome');
     }
 }


### PR DESCRIPTION
Multiple fixes to make it work for TW.

Job group settings should look like:
```
    - supportserver_generator_from_hdd_gnome:
        settings:
          BOOTFROM: c
          BOOT_HDD_IMAGE: '1'
          CONSOLE_JUST_ACTIVATED: '0'
          DESKTOP: gnome
          HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-gnome@%MACHINE%.qcow2'
          START_AFTER_TEST: create_hdd_gnome
          PUBLISH_HDD_1: openqa_support_server_%DISTRI%-%VERSION%_%ARCH%_%BUILD%@%MACHINE%_%DESKTOP%.qcow2
          UEFI_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-gnome@%MACHINE%-uefi-vars.qcow2'
          YAML_SCHEDULE: schedule/supportserver_generator_from_hdd.yaml
        testsuite: null
```

[Verification run](https://openqa.opensuse.org/tests/1436380#details).