### PR TITLE
libgpiod: ACPI gpiochip0 presence depends on qemu/firmware version

### DIFF
--- a/tests/console/libgpiod.pm
+++ b/tests/console/libgpiod.pm
@@ -24,8 +24,11 @@ sub run {
     # Record libgpiod version
     record_info('Version', script_output('gpiodetect --version | head -n1'));
 
-    # ARM qemu has already gpiochip0 [ARMH0061:00] (8 lines) for ACPI
-    my $gpiochipX = (is_aarch64 || is_arm) ? 'gpiochip1' : 'gpiochip0';
+    # ARM qemu _may_ have already gpiochip0 [ARMH0061:00] (8 lines) for ACPI (depends on qemu version)
+    my $gpiochipX = 'gpiochip0';
+    if (script_run('gpioinfo | grep gpiochip0') == 0) {
+        $gpiochipX = 'gpiochip1';
+    }
 
     record_info('gpiochip', "$gpiochipX");
 


### PR DESCRIPTION
so, use gpiochip1, if gpiochip0 is already present.
For the record, qemu 3.1.1.1 adds the ACPI gpiochip0, but qemu 4.2 does not.

- Verification run: 
  * x86_64: https://openqa.opensuse.org/tests/1458208#step/libgpiod/9
  * aarch64: https://openqa.opensuse.org/tests/1458209#step/libgpiod/9