### PR TITLE
Use loopback ip when checking AutoYaST profile

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -523,11 +523,15 @@ EOF
 sub test_ayp_url {
     my $ayp_url = get_var('AUTOYAST');
     if ($ayp_url =~ /^http/) {
+        # replace default qemu gateway by loopback
+        $ayp_url =~ s/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/localhost/;
+
         if (head($ayp_url)) {
-            record_info("ayp url ok", "Autoyast profile url $ayp_url is reachable");
+            record_info("ayp url ok", "Autoyast profile url $ayp_url is reachable from the worker");
         } else {
-            record_info("Failure", "Autoyast profile url $ayp_url is unreachable");
+            record_info("Failure", "Autoyast profile url $ayp_url is unreachable from the worker");
         }
     }
 }
+
 1;


### PR DESCRIPTION
- Related ticket: [poo#72277](https://progress.opensuse.org/issues/72277)
- Verification run: [TW autoyast_multi_btrfs](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=jknphy%2Fos-autoinst-distri-opensuse%23check_ay_profile_reachable&version=Tumbleweed) & [SLE autoyast_multi_btrfs](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23check_ay_profile_reachable&version=15-SP3)