### PR TITLE
Microos: Avoid 'Stall detected' problems

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -22,7 +22,7 @@ our @EXPORT = qw(microos_reboot microos_login);
 
 # Assert login prompt and login as root
 sub microos_login {
-    assert_screen 'linux-login-microos', 150;
+    assert_screen('linux-login-microos', 150) unless match_has_tag('linux-login-microos');
 
     # Workers installed using autoyast have no password - bsc#1030876
     return if get_var('AUTOYAST');
@@ -47,7 +47,7 @@ sub microos_reboot {
 
     # No grub bootloader on xen-pv
     # grub2 needle is unreliable (stalls during timeout) - poo#28648
-    assert_screen 'grub2', 150;
+    assert_screen [qw(grub2 linux-login-microos)], 150;
     send_key('ret') if match_has_tag('grub2');
 
     microos_login;

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -67,7 +67,10 @@ sub process_reboot {
     $args{trigger}            //= 0;
     $args{automated_rollback} //= 0;
 
-    handle_first_grub if ($args{automated_rollback});
+    # MicroOS raw image's Grub might timeout after 10s before matching the needle
+    if ($args{automated_rollback} && get_var('FLAVOR') !~ 'MicroOS-Image') {
+        handle_first_grub if ($args{automated_rollback});
+    }
 
     if (is_microos) {
         microos_reboot $args{trigger};


### PR DESCRIPTION
It's not possible to disable grub timeout in RAW image
due to its RO filesystem nature. Sometimes, OpenQA
takes more than 10 seconds to match a needle and the
grub2 screen is gone and fails with "Stall detected"
error.
This way, we match either grub2 or login screen.

Example VRs:
microos-5.0-MicroOS-Image-A-Staging-x86_64-BuildA.10.10
[bad](https://openqa.suse.de/tests/4836727#step/transactional_update/57) [fixed](http://fromm.arch.suse.de/tests/467)

microos-5.0-DVD-A-Staging-x86_64-BuildA.44.3
[bad](https://openqa.suse.de/tests/4848974#step/transactional_update/29) [fixed](http://fromm.arch.suse.de/tests/468)

Regression in openSUSE:
[microos-15.2-MicroOS-Image-x86_64-Build35.53-microos@64bit_virtio](http://fromm.arch.suse.de/tests/473)
[microos-15.2-DVD-x86_64-Build35.53-microos@64bit_virtio](http://fromm.arch.suse.de/tests/474)
[microos-Tumbleweed-DVD-x86_64-Build20201017-microos@64bit](http://fromm.arch.suse.de/tests/471)
[microos-Tumbleweed-MicroOS-Image-x86_64-Build20201017-microos@64bit](http://fromm.arch.suse.de/tests/472)
NOTE: Errors in Leap are due to something else. 