### PR TITLE
bootloader_setup: type more backspace when clenaup repository URL

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -561,7 +561,7 @@ sub select_installation_source {
     if ($m_protocol eq "http") {
         for (1 .. 2) {
             # just type enough backspaces
-            for (1 .. 32) { send_key "backspace" }
+            for (1 .. 34) { send_key "backspace" }
             send_key "tab";
         }
     }


### PR DESCRIPTION
The default repository of Jump is 34 characters, type 32 times won't cleanup the input field.

Fixes https://openqa.opensuse.org/tests/1437554
Verification run: https://openqa.opensuse.org/tests/1438865