### PR TITLE
Use ip instead of domain name in medium URL on sles15sp2/3 host to get around bsc#1177790

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -58,8 +58,10 @@ sub run {
         set_serial_console_on_vh('', '', 'kvm') if is_kvm_host;
     }
     update_guest_configurations_with_daily_build();
+
     # turn on debug for libvirtd & enable journal with previous reboot
     enable_debug_logging if is_x86_64;
+
 }
 
 sub test_flags {

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -219,6 +219,12 @@ sub handle_sp_in_settings_with_sp0 {
 sub update_guest_configurations_with_daily_build {
     repl_repo_in_sourcefile;
     repl_module_in_sourcefile;
+    #workaround of bsc#1177790
+    if (is_sle('=15-sp2') || is_sle('=15-sp3')) {
+        record_soft_failure("Guests installation is blocked by bsc#1177790, we workaroud it by using ip instead of domain name in medium URL in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11226");
+        script_run "sed -i 's/openqa.suse.de/10.160.0.207/g' /usr/share/qa/virtautolib/data/sources.*";
+        save_screenshot;
+    }
     # qa_lib_virtauto pkg will handle replacing module url with module link in source.xx for sle15 and 15+
     # repl_guest_autoyast_addon_with_daily_build_module;
 }


### PR DESCRIPTION
bsc#1177790: [named]DNS client fail to resolve domain due to 'no valid signature found' in DNS server 
The bug blocked virtualization tests on host with sles15sp2 or sles15sp3 on which bind-9.16 is installed. Installing guest with medium url written ip way can succeed.

- Verification run:
[gi-guest_developing-on-host_sles15sp2-xen](https://openqa.suse.de/tests/4849563)
[gi-guest_developing-on-host_developing-kvm](http://10.67.129.51/tests/1603)
