### PR TITLE
Test the TW base container in stagings as well

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -100,6 +100,8 @@ sub test_opensuse_based_image {
     die 'Argument $image not provided!'   unless $image;
     die 'Argument $runtime not provided!' unless $runtime;
 
+    $version = 'Tumbleweed' if ($version =~ /^Staging:/);
+
     # It is the right version
     if ($distri eq 'sle') {
         my $pretty_version = $version =~ s/-SP/ SP/r;

--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -18,7 +18,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
+use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_microos);
 
 our @EXPORT = qw(
   get_opensuse_registry_prefix
@@ -74,7 +74,7 @@ sub get_suse_container_urls {
         push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/${totest}images/suse/sle15:${dotversion}";
         push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
     }
-    elsif (is_tumbleweed && get_opensuse_registry_prefix) {
+    elsif (is_tumbleweed || is_microos("Tumbleweed")) {
         push @image_names,  "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";
         push @stable_names, "docker.io/opensuse/tumbleweed";
     }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -214,15 +214,20 @@ sub is_microos {
     my $type = $version =~ /^[56]\./ ? 'suse' : 'opensuse';
     return $filter eq $type if ($filter =~ /opensuse|^suse/);
 
+    my $version_is_tw = ($version =~ /Tumbleweed/ || $version =~ /^Staging:/);
+
     if ($filter eq 'DVD') {
         return $flavor =~ /DVD/;    # DVD and Staging-?-DVD
     }
     elsif ($filter eq 'VMX') {
         return $flavor !~ /DVD/;    # If not DVD it's VMX
     }
+    elsif ($filter eq 'Tumbleweed') {
+        return $version_is_tw;
+    }
     elsif ($filter =~ /\d\.\d\+?$/) {
         # If we use '+' it means "this or newer", which includes tumbleweed
-        return ($filter =~ /\+$/) if ($version eq 'Tumbleweed' && $type eq 'opensuse');
+        return ($filter =~ /\+$/) if ($version_is_tw && $type eq 'opensuse');
         return check_version($filter, $version, qr/\d{1,}\.\d/);
     }
     else {

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -54,6 +54,7 @@ sub load_feature_tests {
     }
     elsif (check_var 'SYSTEM_ROLE', 'container-host') {
         loadtest 'containers/podman';
+        loadtest 'containers/podman_image';
     }
 }
 


### PR DESCRIPTION
The main purpose of this PR is to have the base container tested in stagings as well.
While it would be nicer to have more of the container image related tests in here, none of the currently available mediums in staging have the necessary packages installed and the full staging repo isn't available. So instead this runs just `podman_image` on the Container-Host roles.

Verification runs:
TW staging: http://10.160.67.86/tests/826
TW non-staging: http://10.160.67.86/tests/821