### PR TITLE
Enable remote vnc installation on openSUSE aarch64

### DIFF
--- a/schedule/yast/remote_vnc/remote_vnc_target_opensuse.yaml
+++ b/schedule/yast/remote_vnc/remote_vnc_target_opensuse.yaml
@@ -4,7 +4,6 @@ description: >
   Boot with vnc=1 parameter and wait for parallel job (remote_vnc_controller)  to
   install the system.
 schedule:
-  - installation/isosize
-  - installation/bootloader
+  - installation/bootloader_start
   - remote/remote_target
   - console/validate_vnc_from_target

--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -129,7 +129,7 @@ sub run {
         $timeout -= 30;
         diag("left total await_install timeout: $timeout");
         if (!$ret) {
-            if (get_var('LIVECD')) {
+            if (get_var('LIVECD') || get_var('SUPPORT_SERVER')) {
                 # The workaround with mouse moving was added, because screen
                 # become disabled after some time without activity on aarch64.
                 # Mouse is moved by 10 pixels, waited for 1 second (this is


### PR DESCRIPTION
Two issues are fixed here, first is bootloader selection, as we have UEFI on arm. Secondly, we also face issue of support server going to sleep during installation of the packages, so using same trick to move mouse, as on live installations.

I did try to disable all sleep/hibernation services in the support server image, on top of what we do for gnome setup, but that didn't help.

See [poo#68717](https://progress.opensuse.org/issues/68717).

#### Verification run
* [controller](https://openqa.opensuse.org/tests/1440638#)
* [target](https://openqa.opensuse.org/tests/1440639#)