### PR TITLE
Check trigger for restart

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1555,6 +1555,7 @@ sub load_extra_tests_zypper {
     unless (is_jeos) {
         loadtest "console/zypper_info";
     }
+    loadtest "console/check_interactive_flag";
     # Check for availability of packages and the corresponding repository, as of now only makes sense for SLE
     loadtest 'console/validate_packages_and_patterns' if is_sle '12-sp2+';
     loadtest 'console/zypper_extend';

--- a/tests/console/check_interactive_flag.pm
+++ b/tests/console/check_interactive_flag.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Check that the maintenance updates of the following packages contain a trigger for restarting the update client
+# - libsolv
+# - libzypp
+# - zypper
+# - PackageKit
+# Maintainer: Anna Minou <anna.minou@suse.com>
+# Tags: poo#71443
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Get the maintenance updates of the corresponding packages
+    my $result = script_output q(zypper lp -a | grep -v 'zypper-' | awk '/libsolv/||/libzypp/||/zypper/||/PackageKit/ {print $3}');
+    my @patch_array = split ' ', $result;
+
+    # Check that the creation date of the updates is after the year of 2020
+    foreach my $i (@patch_array) {
+        my $creation_date = script_output("zypper info -t patch $i | grep Created");
+        my @year = split ' ', $creation_date;
+        if ($year[7] >= 2020) {
+            # Check that the maintenance update contains a trigger for restart
+            my $flag = script_output("zypper info -t patch $i | grep Interactive");
+            my @year_date = split ' ', $flag;
+            die "Trigger for restart is missing! See poo#71443" if ($year_date[2] != "restart");
+        }
+        else {
+            record_info("The cases before 2020 are not tested", "$creation_date");
+        }
+    }
+}
+
+1;


### PR DESCRIPTION
All maintenance updates of the following packages must contain a trigger
for restarting the update client:
--> libsolv
--> libzypp
--> zypper
--> PackageKit

- Related ticket: https://progress.opensuse.org/issues/71443
- Needles: N/A
- Verification run: SLE [15-SP2](http://10.161.229.247/tests/1433) [15-SP1](http://10.161.229.247/tests/1434) [12-SP5](http://10.161.229.247/tests/1435) [12-SP4](http://10.161.229.247/tests/1436) [12-SP3](http://10.161.229.247/tests/1433)
