### PR TITLE
Add failback/takeback test on HANA cluster

### DIFF
--- a/schedule/sles4sap/hana/hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/hana_cluster_node.yaml
@@ -55,10 +55,14 @@ schedule:
   - '{{wmp_basic_test}}'
   - '{{sap_suse_cluster_connector}}'
   - ha/fencing
-  - '{{boot_to_desktop}}'
+  - '{{boot_to_desktop_node01}}'
   - ha/check_after_reboot
-  - ha/check_logs
   - '{{wmp_basic_test}}'
+  - ha/fencing
+  - '{{boot_to_desktop_node02}}'
+  - ha/check_after_reboot
+  - '{{wmp_basic_test}}'
+  - ha/check_logs
 conditional_schedule:
   cluster_setup:
     HA_CLUSTER_SETUP:
@@ -70,9 +74,13 @@ conditional_schedule:
     HA_CLUSTER_INIT:
       1:
         - sles4sap/sap_suse_cluster_connector
-  boot_to_desktop:
-    HA_CLUSTER_INIT:
-      1:
+  boot_to_desktop_node01:
+    HA_CLUSTER_SETUP:
+      init:
+        - boot/boot_to_desktop
+  boot_to_desktop_node02:
+    HA_CLUSTER_SETUP:
+      join:
         - boot/boot_to_desktop
   wmp_setup:
     WMP:

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -56,7 +56,7 @@ sub run {
         }
         assert_script_run "scp -qr /usr/sap/$sid/SYS/global/security/rsecssfs/* root\@$node2:/usr/sap/$sid/SYS/global/security/rsecssfs/";
         assert_script_run qq(su - $sapadm -c "hdbsql -u system -p $sles4sap::instance_password -i $instance_id -d SYSTEMDB \\"BACKUP DATA FOR FULL SYSTEM USING FILE ('backup')\\""), 300;
-        assert_script_run "su - $sapadm -c 'hdbnsutil -sr_enable --name=NODE1'";
+        assert_script_run "su - $sapadm -c 'hdbnsutil -sr_enable --name=$node1'";
 
         # Synchronize the nodes
         barrier_wait "HANA_INIT_CONF_$cluster_name";
@@ -73,7 +73,7 @@ sub run {
 
         assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StopSystem HDB'";
         assert_script_run "until su - $sapadm -c 'hdbnsutil -sr_state' | grep -q 'online: false' ; do sleep 1 ; done", 120;
-        assert_script_run "su - $sapadm -c 'hdbnsutil -sr_register --remoteHost=$node1 -remoteInstance=$instance_id --replicationMode=sync --name=NODE2 --operationMode=logreplay'";
+        $self->do_hana_takeover(node => $node1);
         assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StartSystem HDB'";
         assert_script_run "until su - $sapadm -c 'hdbnsutil -sr_state' | grep -q 'online: true' ; do sleep 1 ; done";
 


### PR DESCRIPTION
A HANA cluster as some specificities like takeover/takeback mechanism.
Current version of the test does a takeover of the HANA resources, but there is no failback/takeback.

This PR adds it.

- Related ticket: N/A
- Needles: N/A
- Verification runs: [node01](http://1b210.qa.suse.de/tests/7661), [node02](http://1b210.qa.suse.de/tests/7662)
- Regression tests: [NW node01](http://1b210.qa.suse.de/tests/7664), [NW node02](http://1b210.qa.suse.de/tests/7665), [ha_maintenance_2nodes_01_15-SP2](http://1b210.qa.suse.de/tests/7836), [ha_maintenance_2nodes_02_15-SP2](http://1b210.qa.suse.de/tests/7837), [qam-sles4sap_hana_node01](http://1b210.qa.suse.de/tests/7857), [qam-sles4sap_hana_node02](http://1b210.qa.suse.de/tests/7856), [qam_alpha_cluster_01](http://1b210.qa.suse.de/tests/7879), [qam_alpha_cluster_02](http://1b210.qa.suse.de/tests/7878)