### PR TITLE
Follow itlb kernel changes and replace error by softfail

### DIFF
--- a/lib/Mitigation.pm
+++ b/lib/Mitigation.pm
@@ -299,15 +299,25 @@ sub check_sysfs {
         foreach my $sysfs_name_item (@{$self->{sysfs_name}}) {
             assert_script_run('cat ' . $syspath . $sysfs_name_item);
             if (@_ == 2) {
-                assert_script_run(
+                my $ret = script_run(
                     'cat ' . $syspath . $sysfs_name_item . '| grep ' . '"' . $self->{sysfs}->{$value}->{$sysfs_name_item} . '"');
+                if (defined $ret and $ret != 0) {
+                    my $real_output = script_output('cat ' . $syspath . $sysfs_name_item);
+                    record_soft_failure("ERROR/BUG please check sysfs output for: " . $syspath . $sysfs_name_item .
+                          " EXPECT: \"" . $self->{sysfs}->{$value}->{$sysfs_name_item} . "\",ACTUAL: \"" . $real_output . "\"");
+                }
             }
         }
     } else {
         assert_script_run('cat ' . $syspath . $self->sysfs_name());
         if (@_ == 2) {
-            assert_script_run(
+            my $ret = script_run(
                 'cat ' . $syspath . $self->sysfs_name() . '| grep ' . '"' . $self->sysfs($value) . '"');
+            if (defined $ret and $ret != 0) {
+                my $real_output = script_output('cat ' . $syspath . $self->sysfs_name());
+                record_soft_failure("ERROR/BUG please check sysfs output for: " . $syspath . $self->sysfs_name() .
+                      " EXPECT: \"" . $self->sysfs($value) . "\",ACTUAL: \"" . $real_output . "\"");
+            }
         }
     }
 }

--- a/tests/cpu_bugs/mitigations.pm
+++ b/tests/cpu_bugs/mitigations.pm
@@ -32,15 +32,15 @@ my %mitigations_list =
     sysfs_name => ["itlb_multihit", "l1tf", "mds", "meltdown", "spec_store_bypass", "spectre_v1", "spectre_v2", "tsx_async_abort"],
     sysfs      => {
         auto => {
-            itlb_multihit => "KVM: Mitigation: Split huge pages",
+            itlb_multihit => "KVM: Mitigation: VMX disabled",
             spectre_v1    => "Mitigation: usercopy/swapgs barriers and __user pointer sanitization",
         },
         'auto,nosmt' => {
-            itlb_multihit => "KVM: Mitigation: Split huge pages",
+            itlb_multihit => "KVM: Mitigation: VMX disabled",
             spectre_v1    => "Mitigation: usercopy/swapgs barriers and __user pointer sanitization",
         },
         off => {
-            itlb_multihit => "KVM: Vulnerable",
+            itlb_multihit => "KVM: Mitigation: VMX disabled",
             spectre_v1    => "Vulnerable: __user pointer sanitization and usercopy barriers only; no swapgs barriers",
         },
     },
@@ -193,9 +193,9 @@ sub run {
             $mitigations_list{sysfs}->{off}->{'itlb_multihit'}          = "Not affected";
             $mitigations_list{sysfs}->{'auto,nosmt'}->{'itlb_multihit'} = "Not affected";
         } else {
-            $mitigations_list{sysfs}->{off}->{'itlb_multihit'}          = "KVM: Vulnerable";
-            $mitigations_list{sysfs}->{auto}->{'itlb_multihit'}         = "KVM: Vulnerable";
-            $mitigations_list{sysfs}->{'auto,nosmt'}->{'itlb_multihit'} = "KVM: Vulnerable";
+            $mitigations_list{sysfs}->{off}->{'itlb_multihit'}          = "KVM: Mitigation: VMX unsupported";
+            $mitigations_list{sysfs}->{auto}->{'itlb_multihit'}         = "KVM: Mitigation: VMX unsupported";
+            $mitigations_list{sysfs}->{'auto,nosmt'}->{'itlb_multihit'} = "KVM: Mitigation: VMX unsupported";
         }
     }
 


### PR DESCRIPTION
kernel-sources commit 52699f0f6a3a905d203dbea53c8936e3b6badba0 modify itlb sysfs behaviour, follow it and make testing as expected.  
Verification URL: http://openqa.qa2.suse.asia/tests/20932

Due to make the functional failure not block remaining test cases, replace assert by record_soft_failure.
Verification URL: http://openqa.qa2.suse.asia/tests/21094
