### PR TITLE
Use bootloader_start module in remote_ssh_target

### DIFF
--- a/schedule/yast/remote_ssh_target.yaml
+++ b/schedule/yast/remote_ssh_target.yaml
@@ -4,6 +4,5 @@ description: >
   Boot with ssh=1 parameter and wait for parallel job (remote_ssh_controller)  to
   install the system.
 schedule:
-  - installation/isosize
-  - installation/bootloader
+  - installation/bootloader_start
   - remote/remote_target


### PR DESCRIPTION
To make it work on setups with UEFI, we should use bootloader_start
wrapper module. Also unscheduling `iso_size` module as is already
covered in other scenarios and is irrelevant in remote ssh scenario.

### Verification runs
* [controller](https://openqa.opensuse.org/tests/1441137)
* [target](https://openqa.opensuse.org/tests/1441138)