### PR TITLE
MicroOS: Add module to disable grub timeout

### DIFF
--- a/schedule/microos/suse_microos_raw.yaml
+++ b/schedule/microos/suse_microos_raw.yaml
@@ -4,6 +4,7 @@ description:    >
     SUSE MicroOS tests
 schedule:
     - microos/disk_boot
+    - transactional/disable_grub
     - console/suseconnect_scc
     - microos/networking
     - microos/libzypp_config

--- a/tests/transactional/disable_grub.pm
+++ b/tests/transactional/disable_grub.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Disable Grub timeout by transactional update
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use transactional qw(process_reboot);
+
+sub run {
+    select_console 'root-console';
+    assert_script_run("sed -i 's/GRUB_TIMEOUT=10/GRUB_TIMEOUT=-1/' /etc/default/grub");
+    assert_script_run('transactional-update grub.cfg');
+    process_reboot(trigger => 1);
+}
+
+sub test_flags {
+    return {no_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
The reason for this is to force always match the grub selection
needle as I have observed that sometimes OpenQA takes longer than
10s to match the grub needle and it fails with "Stall detected"
error. With this approach, we always make sure we hit that screen.

For the DVD image, we already do this during installation time.

VR: 
https://openqa.suse.de/tests/4852865
http://fromm.arch.suse.de/tests/511