### PR TITLE
MicroOS: Enable UEFI tests

### DIFF
--- a/schedule/microos/suse_microos_dvd.yaml
+++ b/schedule/microos/suse_microos_dvd.yaml
@@ -3,7 +3,7 @@ description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE MicroOS tests
 schedule:
-    - installation/bootloader
+    - installation/bootloader_start
     - installation/welcome
     - installation/accept_license
     - installation/scc_registration


### PR DESCRIPTION
We are currently running only legacy mode, it would be interesting
to test also UEFI mode as we do for openSUSE. Also, this is needed
for aarch64 jobs

- Verification run: [64bit](http://fromm.arch.suse.de/tests/528#) [uefi](http://fromm.arch.suse.de/tests/529#)
