### PR TITLE
Update onetime_vncsession_xvnc_remmina to fix poo#71785

### DIFF
--- a/tests/x11/remote_desktop/onetime_vncsession_xvnc_remmina.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_xvnc_remmina.pm
@@ -33,6 +33,11 @@ sub run {
 
     # Start Remmina and login the remote server
     x11_start_program('remmina', target_match => 'remmina-launched');
+    # The remmmina news turned off screen appears since the remmina got updated in 15SP3
+    if (is_sle('15-SP3+')) {
+        assert_screen("remmina-news-turned-off", 60);
+        assert_and_click("remmina-close-news-turned-off");
+    }
 
     # The default host key is right Ctrl which is not supported by openQA
     # Change the host key to 'z'


### PR DESCRIPTION
Add code to handle the remmina news turned off screen
The remmina news turned off screen appears since it's updated to 1.4.8
This test case is not enabled for TW yet, so TW is not taken into consideration.

- Related ticket: https://progress.opensuse.org/issues/71785
- Needles: the needles are created directly from o.s.d webUI, here are the details 
[onetime_vncsession_xvnc_remmina-remmina-quality-20201020](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/6e274848dfe9d0a4b54cc4a632293f549100dd2c)
[onetime_vncsession_xvnc_remmina-remmina-color-depth-20201020](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/4ca0e5bc554bb465ad38842719a1aaf0dd9eabf3)
[onetime_vncsession_xvnc_remmina-remmina-server-url-20201020](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/f08f3688aa9c970cff8a7c82dfbee0d06a0b531c)
[onetime_vncsession_xvnc_remmina-close-news-turned-off-20201020](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/c7c391dcf74309ccffc6d702c7b68d80f1952b12)
[onetime_vncsession_xvnc_remmina-remmina-news-turned-off-20201020](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/79449715d7e96a8b04d459a1865e0ceb92815067)

- Verification run: https://openqa.nue.suse.com/tests/4854188