### PR TITLE
LTP: Install wireguard-tools

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -127,6 +127,7 @@ sub install_runtime_dependencies_network {
 
     my @maybe_deps = qw(
       telnet-server
+      wireguard-tools
       xinetd
     );
     for my $dep (@maybe_deps) {


### PR DESCRIPTION
Required by new tests in ltp_net_features
https://patchwork.ozlabs.org/project/ltp/list/?series=208068&state=*

Don't require the package (old releases won't have it).

- Related ticket: none
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
Verification run:
- 15-SP3
http://quasar.suse.cz/tests/5611/file/serial_terminal.txt
`Retrieving: wireguard-tools-1.0.20200513-5.3.1.x86_64.rpm [done]`

- 12-SP3-Server-DVD-TERADATA
http://quasar.suse.cz/tests/5616/file/serial_terminal.txt
`'wireguard-tools' not found in package names. Trying capabilities.`
`Retrieving: wireguard-tools-1.0.20200827-1.1.x86_64.rpm [done]`

- Tumbleweed
http://quasar.suse.cz/tests/5612/file/serial_terminal.txt

Example of running tests:
- 15-SP3 http://quasar.suse.cz/tests/5619#step/wireguard01/8
- 15-SP3 KOTD http://quasar.suse.cz/tests/5620#step/wireguard01/8
- Tumbleweed http://quasar.suse.cz/tests/5618#step/wireguard01/8