### PR TITLE
Move the sbd configuration after the HA bootstrap

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -75,11 +75,6 @@ sub run {
     # Ensure that ntp service is activated/started
     activate_ntp;
 
-    # Configure SBD_DELAY_START to yes
-    # This may be necessary if your cluster nodes reboot so fast that the
-    # other nodes are still waiting in the fence acknowledgement phase.
-    # This is an occasional issue with virtual machines.
-    file_content_replace("$sbd_cfg", "SBD_DELAY_START=.*" => "SBD_DELAY_START=yes");
 
     # Initialize the cluster with diskless or shared storage SBD (default)
     $fencing_opt = '-S' if (get_var('USE_DISKLESS_SBD'));
@@ -87,6 +82,12 @@ sub run {
 
     # If we failed to initialize the cluster with 'ha-cluster-init', trying again with crm in debug mode
     cluster_init('crm-debug-mode', $fencing_opt, $unicast_opt, $qdevice_opt) if (!wait_serial("ha-cluster-init-finished-0", $join_timeout));
+
+    # Configure SBD_DELAY_START to yes
+    # This may be necessary if your cluster nodes reboot so fast that the
+    # other nodes are still waiting in the fence acknowledgement phase.
+    # This is an occasional issue with virtual machines.
+    file_content_replace("$sbd_cfg", "SBD_DELAY_START=.*" => "SBD_DELAY_START=yes");
 
     # Set wait_for_all option to 0 if we are in a two nodes cluster situation
     # We need to set it for reproducing the same behaviour we had with no-quorum-policy=ignore


### PR DESCRIPTION
The `SBD_DELAY_START` option is overridden by the ha bootstrap script.
So we need to change it just after bootstrapping the cluster. 
A restart of the cluster is not needed in our case, the value will be taken into account while the fencing step.

Moreover, a cluster restart just happens next if the cluster is a two-nodes one (`wait_for_all: 0` option).

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
