### PR TITLE
Fix expert partitioner type too long issue

### DIFF
--- a/tests/installation/partitioning_specific_disk.pm
+++ b/tests/installation/partitioning_specific_disk.pm
@@ -59,7 +59,13 @@ sub run {
     my $disk = get_required_var('SPECIFIC_DISK');
     send_key 'alt-s';
     send_key 'tab';
-    send_key_until_needlematch("expert-partitioner-$disk", "down", 20, 2);
+    for (1 ... 10) {
+        send_key 'down';
+        send_key_until_needlematch("expert-partitioner-label", "right", 50, 1);
+        if (check_screen "expert-partitioner-$disk", 2) {
+            last;
+        }
+    }
     send_key 'ret';
 
     # Edit device


### PR DESCRIPTION
Fix issue about NVME type too long to capture OS disk lable during openqa install OS
- Related ticket: https://trello.com/c/ps2ieAzY/602-p1automationci-investigate-solution-for-nvme-type-too-long-to-capture-os-disk-lable-during-openqa-install-os
- Needles:https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1454
- Verification run: http://10.67.129.4/tests/21057
http://10.67.129.4/tests/21073
