### PR TITLE
Unschedule resolve_dependency_issues from remote installations

### DIFF
--- a/schedule/yast/remote_ssh_controller.yaml
+++ b/schedule/yast/remote_ssh_controller.yaml
@@ -14,7 +14,6 @@ schedule:
  - installation/partitioning_finish
  - installation/installer_timezone
  - installation/user_settings
- - installation/resolve_dependency_issues
  - installation/installation_overview
  - installation/disable_grub_timeout
  - installation/start_install

--- a/schedule/yast/remote_vnc/remote_vnc_controller.yaml
+++ b/schedule/yast/remote_vnc/remote_vnc_controller.yaml
@@ -18,7 +18,6 @@ schedule:
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
-  - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/remote_vnc/remote_vnc_controller_opensuse.yaml
+++ b/schedule/yast/remote_vnc/remote_vnc_controller_opensuse.yaml
@@ -14,7 +14,6 @@ schedule:
  - installation/partitioning_finish
  - installation/installer_timezone
  - installation/user_settings
- - installation/resolve_dependency_issues
  - installation/installation_overview
  - installation/disable_grub_timeout
  - installation/start_install


### PR DESCRIPTION
It's wrong to schedule resolve_dependency_issues as it might hide issues
when we will get software conflicts.

Removing those from the schedules.
