### PR TITLE
Remove workaround for bsc#1175374

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -469,14 +469,8 @@ sub validate_repo_properties {
     }
 
     if ($args->{Name}) {
-        # TODO remove workaround poo#70546
-        if ($actual_repo_data->{Name} =~ /$args->{Alias}\/?/) {
-            record_soft_failure "repo name is not set correctly - bsc#1175374 - found actual repo name $actual_repo_data->{Name}";
-        }
-        else {
-            assert_true($actual_repo_data->{Name} =~ /$args->{Name}/,
-                "Repository '$args->{Name}' has wrong name: '$actual_repo_data->{Name}'");
-        }
+        assert_true($actual_repo_data->{Name} =~ /$args->{Name}/,
+            "Repository '$args->{Name}' has wrong name: '$actual_repo_data->{Name}'");
     }
 
     if ($args->{URI}) {


### PR DESCRIPTION
[bsc#1175374](https://bugzilla.suse.com/show_bug.cgi?id=1175374) is
fixed and we can remove the workaround now.

See [poo#70546](https://progress.opensuse.org/issues/70546).

https://openqa.suse.de/tests/4840311 doesn't throw soft-failure.