### PR TITLE
Add platform check for kernel_config verification

### DIFF
--- a/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
+++ b/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
@@ -27,7 +27,16 @@ use utils;
 
 sub run {
     # check the kernel configuration file to make sure the parameter is there
-    validate_script_output "cat /boot/config-`uname -r`|grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
+    if (!check_var('ARCH', 's390x')) {
+        validate_script_output "cat /boot/config-`uname -r`|grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
+    }
+    else {
+        my $results = script_run("grep CONFIG_STACKPROTECTOR_STRONG=y /boot/config-`uname -r`");
+        if (!$results) {
+            die("Error: the kernel parameter is wrongly configured on s390x platform");
+        }
+    }
+
 }
 
 1;


### PR DESCRIPTION
The kernel parameter CC_STACKPROTECTOR_STRONG is not introduced into s390x platform,
so add the platform check logic to skip vefifying it.

- Related ticket: https://progress.opensuse.org/issues/73528
- Needles: N/A
- Verification run:
   s390x:   https://openqa.suse.de/tests/4858855
   x86_64: https://openqa.suse.de/tests/4860050
