### PR TITLE
Fix hexchat_ssl send key error and needles mismatch

### DIFF
--- a/tests/x11/hexchat_ssl.pm
+++ b/tests/x11/hexchat_ssl.pm
@@ -49,11 +49,16 @@ sub run {
         assert_screen "$name-connection-complete-dialog";
         assert_and_click "$name-join-channel";
 
+        assert_screen "$name-join-channel-select";
+        wait_still_screen 2;
         send_key "ctrl-a";
         send_key "delete";
+        wait_still_screen 2;
+
         type_string "#openqa-test_irc_from_openqa\n";
         assert_screen "$name-join-openqa-test_irc_from_openqa";
-        send_key "ret";
+        assert_and_click "$name-join-channel-OK";
+
     }
     assert_screen "$name-main-window";
     type_string "hello, this is openQA running $name with FIPS Enabled!\n";


### PR DESCRIPTION
**Description:** 
The send key function sometimes fail or delay due to the racing condition problem in hexchat_ssl case and cause the login into the wrong channel. Adding 2 new needles match to fix the sendkey fail issue.

- Related ticket: https://progress.opensuse.org/issues/73489
- Needles: 2 Needles were merged in OSD
- Verification run: https://openqa.suse.de/tests/4855632
