### PR TITLE
Add regeneration of initrd for minimal tests

### DIFF
--- a/schedule/qam/12-SP2/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP2/qam-minimal-base.yaml
@@ -25,6 +25,7 @@ schedule:
 - installation/grub_test
 - installation/first_boot
 - qa_automation/patch_and_reboot
+- console/dracut
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/12-SP3/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP3/qam-minimal-base.yaml
@@ -25,6 +25,7 @@ schedule:
 - installation/grub_test
 - installation/first_boot
 - qa_automation/patch_and_reboot
+- console/dracut
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/12-SP4/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP4/qam-minimal-base.yaml
@@ -24,6 +24,7 @@ schedule:
 - '{{grub}}'
 - installation/first_boot
 - qa_automation/patch_and_reboot
+- console/dracut
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/12-SP5/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-base.yaml
@@ -24,6 +24,7 @@ schedule:
 - '{{grub}}'
 - installation/first_boot
 - qa_automation/patch_and_reboot
+- console/dracut
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/15-SP1/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP1/qam-minimal-base.yaml
@@ -24,6 +24,7 @@ schedule:
 - '{{grub}}'
 - installation/first_boot
 - qa_automation/patch_and_reboot
+- console/dracut
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/15-SP2/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP2/qam-minimal-base.yaml
@@ -24,6 +24,7 @@ schedule:
 - '{{grub}}'
 - installation/first_boot
 - qa_automation/patch_and_reboot
+- console/dracut
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/15/qam-minimal-base.yaml
+++ b/schedule/qam/15/qam-minimal-base.yaml
@@ -24,6 +24,7 @@ schedule:
 - '{{grub}}'
 - installation/first_boot
 - qa_automation/patch_and_reboot
+- console/dracut
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/58541
- Needles: no needles
- Verification run: 
15-SP1 http://10.161.229.176/tests/44
15     http://10.161.229.176/tests/43
12-SP5 http://10.161.229.176/tests/45
12-SP4 http://10.161.229.176/tests/47
12-SP3 http://10.161.229.176/tests/51
12-SP2 http://10.161.229.176/tests/52 