### PR TITLE
Remove wrong call to parent pre_run_hook

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -480,7 +480,6 @@ sub pre_run_hook {
         1 if defined $testapi::selected_console;
         $prev_console = $testapi::selected_console;
     }
-    $self->SUPER::pre_run_hook;
 }
 
 sub post_run_hook {

--- a/lib/openscaptest.pm
+++ b/lib/openscaptest.pm
@@ -98,7 +98,6 @@ sub finish_remediate_validation {
 sub pre_run_hook {
     my ($self) = @_;
     select_console 'root-console';
-    $self->SUPER::pre_run_hook;
 }
 
 1;


### PR DESCRIPTION
Resolves problems introduced by #11232

VR: https://openqa.suse.de/tests/4861644