### PR TITLE
Fix imgproof schedule for GCP OnDemand runs

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -48,6 +48,7 @@ our $img_proof_tests = {
     'EC2-HVM-HPC-BYOS'     => $ec2_byos,
 
     GCE                => $gce_on_demand,
+    'GCE-Updates'      => $gce_on_demand,
     'GCE-BYOS'         => $gce_byos,
     'GCE-BYOS-Updates' => $gce_byos,
     'GCE-CHOST-BYOS'   => $gce_byos,


### PR DESCRIPTION
Fix for failing imgproof runs on Google Cloud Platform OnDemand

- Related ticket: https://progress.opensuse.org/issues/69625
- Verification run: http://phoenix-openqa.qam.suse.de/t3211 - `img_proof` runs but fails due to [other issue](https://progress.opensuse.org/issues/75025)
