### PR TITLE
Virtualization: Improve perf and networking part

### DIFF
--- a/tests/console/perf.pm
+++ b/tests/console/perf.pm
@@ -22,7 +22,7 @@ sub run {
 
     # test 1
     # Installing and testing options -a -d -p
-    zypper_call 'in perf';
+    zypper_call('in perf', exitcode => [0, 102, 103, 106]) if (script_run("which perf") != 0);
     assert_script_run('perf stat -a -d -p 1 sleep 5');
     # test 2
     # Counting with perf stat

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -57,6 +57,7 @@ sub run_test {
     my $gate = script_output "ip r s | grep 'default via ' | cut -d' ' -f3";
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "HOST BRIDGE NETWORK for $guest";
+        ensure_online $guest, skip_network => 1;
 
         if (is_sle('=11-sp4') && is_xen_host) {
             $affecter  = "--persistent";

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -49,6 +49,7 @@ sub run_test {
     my $gate = '192.168.127.1';    # This host exists but should not work as a gate in the ISOLATED NETWORK
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "ISOLATED NETWORK for $guest";
+        ensure_online $_, skip_network => 1;
 
         if (is_sle('=11-sp4') && is_xen_host) {
             $affecter  = "--persistent";

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -51,6 +51,7 @@ sub run_test {
     my $gate = '192.168.128.1';
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "NAT BASED NETWORK for $guest";
+        ensure_online $guest, skip_network => 1;
 
         if (is_sle('=11-sp4') && is_xen_host) {
             $affecter  = "--persistent";


### PR DESCRIPTION
 * Fixing `zypper_call('in ` for `perf.pm` test so the test continues even when some repository is broken.
 * Adding `skip_network` parameter for `ensure_online()` for preventing this [networking issue](http://openqa.qam.suse.cz/tests/13771#step/libvirt_nated_virtual_network/136).

- Verification run: [SLE 15 SP1 KVM](http://pdostal-server.suse.cz/tests/10273)
