### PR TITLE
[virt_autotest] ensure guest is online before each virtual network test

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -47,6 +47,8 @@ sub check_guest_module {
     my ($guest, %args) = @_;
     my $module = $args{module};
     my $net    = $args{net} // "br123";
+    #Ensure guest is online before each virtual network test
+    ensure_online($guest);
     if (($guest =~ m/sles-?11/i) && ($module eq "acpiphp")) {
         save_guest_ip("$guest", name => $net);
         my $status = script_run("ssh root\@$guest \"lsmod | grep $module\"");


### PR DESCRIPTION
Refer to libvirt_isolated_virtual_network on gi-guest_sles15sp2-on-host_developing-xen
https://openqa.suse.de/tests/4812770
Fail to attach isolated virtual interface to sles15sp2 guest - guest is not online status

So, before attach each virtual network interface to guest system, need to ensure guest is online status firstly.

- Verification run: 
WIP [gi-guest_sles15sp2-on-host_developing-xen](http://149.44.176.58/tests/4875909)
WIP [gi-guest_sles15sp2-on-host_developing-kvm](http://149.44.176.58/tests/4875923)