### PR TITLE
[virt_autotest] Add call parent post_fail_hook to virtual network test

### DIFF
--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -90,8 +90,7 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
-    #Upload debug log
-    virt_autotest::virtual_network_utils::upload_debug_log();
+    $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
     virt_autotest::utils::restart_libvirtd();

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -88,8 +88,7 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
-    #Upload debug log
-    virt_autotest::virtual_network_utils::upload_debug_log();
+    $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
     virt_autotest::utils::restart_libvirtd();

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -81,8 +81,7 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
-    #Upload debug log
-    virt_autotest::virtual_network_utils::upload_debug_log();
+    $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
     virt_autotest::utils::restart_libvirtd();

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -115,8 +115,7 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
-    #Upload debug log
-    virt_autotest::virtual_network_utils::upload_debug_log();
+    $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
     virt_autotest::utils::restart_libvirtd();

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -83,6 +83,8 @@ sub run_test {
 sub post_fail_hook {
     my ($self) = @_;
 
+    $self->SUPER::post_fail_hook;
+
     #Restart libvirtd service
     virt_autotest::utils::restart_libvirtd();
 
@@ -94,9 +96,6 @@ sub post_fail_hook {
 
     #Restore Guest systems
     virt_autotest::virtual_network_utils::restore_guests();
-
-    #Upload debug log
-    virt_autotest::virtual_network_utils::upload_debug_log();
 }
 
 1;


### PR DESCRIPTION
Refer to the failure job https://openqa.suse.de/tests/4840195, which fail at isolated network test, two main issues:
- no parent post_fail_hook is triggered
- although in the test pm file , it shows failed as https://openqa.suse.de/tests/4840195#step/libvirt_isolated_virtual_network/113, but the junit log does not show its info at all

So, need to add call parent post_fail_hook to the following virtual network test

                tests/virt_autotest/libvirt_virtual_network_init
                tests/virt_autotest/libvirt_host_bridge_virtual_network
                tests/virt_autotest/libvirt_nated_virtual_network
                tests/virt_autotest/libvirt_routed_virtual_network
                tests/virt_autotest/libvirt_isolated_virtual_network

- Verification run: 
[gi-guest_developing-on-host_sles15sp2-kvm](http://149.44.176.58/tests/4912208)
[gi-guest_developing-on-host_sles15sp2-xen](http://149.44.176.58/tests/4913844)
