### PR TITLE
Get around Bug 1177790 by disabling DNSSEC validation on sles15sp2/3 …

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -62,6 +62,14 @@ sub run {
     # turn on debug for libvirtd & enable journal with previous reboot
     enable_debug_logging if is_x86_64;
 
+    #workaround of bsc#1177790
+    if (is_sle('=15-sp2') || is_sle('=15-sp3')) {
+        record_soft_failure("Guests installation is blocked by bsc#1177790, we workaroud it by disabling DNSSEC validation in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11226");
+        script_run "sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf";
+        script_run "grep 'dnssec-validation' /etc/named.conf";
+        save_screenshot;
+    }
+
 }
 
 sub test_flags {

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -219,12 +219,6 @@ sub handle_sp_in_settings_with_sp0 {
 sub update_guest_configurations_with_daily_build {
     repl_repo_in_sourcefile;
     repl_module_in_sourcefile;
-    #workaround of bsc#1177790
-    if (is_sle('=15-sp2') || is_sle('=15-sp3')) {
-        record_soft_failure("Guests installation is blocked by bsc#1177790, we workaroud it by using ip instead of domain name in medium URL in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11226");
-        script_run "sed -i 's/openqa.suse.de/10.160.0.207/g' /usr/share/qa/virtautolib/data/sources.*";
-        save_screenshot;
-    }
     # qa_lib_virtauto pkg will handle replacing module url with module link in source.xx for sle15 and 15+
     # repl_guest_autoyast_addon_with_daily_build_module;
 }


### PR DESCRIPTION
…hosts

- Related ticket: bsc#1177790
- Verification run: 
[gi-guest_sles12sp5-on-host_developing-kvm](http://10.67.129.51/tests/1608)
[gi-guest_developing-on-host_sles15sp2-kvm](http://10.67.129.51/tests/1610)
[gi-guest_developing-on-host_sles12sp5-kvm](http://10.67.129.51/tests/1607) to which pr is not applied.

@alice-suse @guoxuguang @waynechen55 

