### PR TITLE
Make user_swtich work with virtio console

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -54,7 +54,9 @@ sub get_remote_logs {
 sub switch_user {
     my ($self, $username) = @_;
     type_string("su - $username\n");
-    assert_screen 'user-nobody';
+    type_string(qq/PS1="# "\n/);
+    wait_serial(qr/PS1="# "/);
+    assert_script_run("whoami|grep $username");
 }
 
 =head2 master_node_names


### PR DESCRIPTION
With VIRTIO_CONSOLE=1 you can't use needles

- Fail: https://openqa.suse.de/tests/4859568#step/pdsh_slave/21
- Verification run: http://10.100.12.155/tests/16779#step/pdsh_slave/19