### PR TITLE
Small updates for JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1812,7 +1812,7 @@ sub load_extra_tests_filesystem {
         loadtest 'console/snapper_thin_lvm' unless is_jeos;
     }
     loadtest 'console/snapper_used_space' if (is_sle('15-SP1+') || (is_opensuse && !is_leap('<15.1')));
-    loadtest "console/udisks2" unless is_sle('<=15-SP2');
+    loadtest "console/udisks2" unless (is_sle('<=15-SP2') || get_var('VIRSH_VMM_FAMILY') =~ /xen/);
     loadtest "console/zfs" if (is_leap(">=15.1") && is_x86_64 && !is_jeos);
     loadtest "network/cifs";
 }

--- a/schedule/jeos/sle/hyperv/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-base+sdk+desktop.yaml
@@ -1,6 +1,6 @@
 description: 'Test suite verifies functionality and integration of Development-Tools (sdk) and Desktop-Applications (desktop) patterns'
 name: 'jeos-base+sdk+desktop'
-schedule:  
+schedule:
   - installation/bootloader_hyperv
   - jeos/grub2
   - jeos/firstrun
@@ -12,6 +12,8 @@ schedule:
   - jeos/build_key
   - console/suseconnect_scc
   - console/consoletest_setup
+  - console/textinfo
+  - jeos/kiwi_templates
   - console/zypper_ref
   - console/command_not_found
   - console/libvorbis

--- a/schedule/jeos/sle/kvm/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/kvm/jeos-base+sdk+desktop.yaml
@@ -12,6 +12,7 @@ schedule:
   - jeos/build_key
   - console/suseconnect_scc
   - console/consoletest_setup
+  - console/textinfo
   - jeos/kiwi_templates
   - console/zypper_ref
   - console/zypper_lr

--- a/schedule/jeos/sle/xen/hvm/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-base+sdk+desktop.yaml
@@ -1,6 +1,6 @@
 description: 'Test suite verifies functionality and integration of Development-Tools (sdk) and Desktop-Applications (desktop) patterns'
 name: 'jeos_base+sdk+desktop_patterns'
-schedule:  
+schedule:
   - installation/bootloader_svirt
   - jeos/grub2
   - jeos/firstrun
@@ -12,6 +12,8 @@ schedule:
   - jeos/build_key
   - console/suseconnect_scc
   - console/consoletest_setup
+  - console/textinfo
+  - jeos/kiwi_templates
   - console/zypper_ref
   - console/command_not_found
   - console/libvorbis

--- a/schedule/jeos/sle/xen/pv/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-base+sdk+desktop.yaml
@@ -1,6 +1,6 @@
 description: 'Test suite verifies functionality and integration of Development-Tools (sdk) and Desktop-Applications (desktop) patterns'
 name: 'jeos_base+sdk+desktop_patterns'
-schedule:  
+schedule:
   - installation/bootloader_svirt
   - jeos/firstrun
   - jeos/record_machine_id
@@ -11,6 +11,8 @@ schedule:
   - jeos/build_key
   - console/suseconnect_scc
   - console/consoletest_setup
+  - console/textinfo
+  - jeos/kiwi_templates
   - console/zypper_ref
   - console/command_not_found
   - console/libvorbis


### PR DESCRIPTION
1. Remove `udisk2` from Xen environment
2. Add `textinfo` and `kiwi_templates` test cases
3. Pull `sysvinit-tools` for `gdb` testing in JeOS

- Related tickets: 
   * [[qac][JeOS] add kiwi_templates.pm to hvm,pv and hyperv test scenarios](https://progress.opensuse.org/issues/65274)
   * [https://progress.opensuse.org/issues/68902](https://progress.opensuse.org/issues/68902)
- Verification runs: 
  * **textinfo and kiwi_templates and gdb code update**
     * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build20.86-jeos-base+sdk+desktop@uefi-virtio-vga](http://kepler.suse.cz/tests/2508) 
     * [sle-15-SP3-JeOS-for-MS-HyperV-x86_64-Build20.86-jeos-base+sdk+desktop_hyperv](http://kepler.suse.cz/tests/2513#)
     * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build20.86-jeos-base+sdk+desktop_xenhvm](http://kepler.suse.cz/tests/2514)
     * [ sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build20.86-jeos-base+sdk+desktop_xenpv](http://kepler.suse.cz/tests/2512)
  * **udisk2 unscheduled on xens**
    * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build20.86-jeos-filesystem_xenpv](http://kepler.suse.cz/tests/2510)
    * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build20.86-jeos-filesystem_xenhvm](http://kepler.suse.cz/tests/2509#)
