### PR TITLE
Increase dracut boot timeout

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -28,7 +28,7 @@ sub run {
     validate_script_output("dracut --list-modules 2>&1", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
 
     power_action('reboot', textmode => 1);
-    $self->wait_boot;
+    $self->wait_boot(bootloader_time => 200);
 }
 
 1;


### PR DESCRIPTION
to make sure it runs on slower architectures



- Related ticket: https://progress.opensuse.org/issues/58541
- Needles: no needles
- Verification run: https://openqa.suse.de/tests/4876223

Failing due to timeout before fix: https://openqa.suse.de/tests/4872328#step/dracut/49


