### PR TITLE
Fix autoyast_systemd_timesync

### DIFF
--- a/tests/console/verify_systemd_timesync.pm
+++ b/tests/console/verify_systemd_timesync.pm
@@ -46,7 +46,7 @@ sub run {
     my $not_synced = 1;
     {
         do {
-            $not_synced = script_run("journalctl -u yast-timesync | grep \"Started One time sync configured by YaST\"");
+            $not_synced = script_run("journalctl -u yast-timesync | egrep \"Started\|Finished One time sync configured by YaST\"");
             last unless ($not_synced);
             $uptime = script_output("uptime | cut -c19,20");
             script_run("echo \"Waiting 10 seconds before rechecking logs for One time synchronization\"");


### PR DESCRIPTION
systemd now logs "Finished One time sync configured by YaST" instead of
"Started One time sync configured by YaST" so the test fails, see here:
https://openqa.suse.de/tests/4857076

- Verification run: http://waaa-amazing.suse.cz/tests/13307