### PR TITLE
Call parents's methods on cifs module

### DIFF
--- a/tests/network/cifs.pm
+++ b/tests/network/cifs.pm
@@ -98,11 +98,15 @@ sub cleanup() {
 }
 
 sub post_fail_hook {
+    my $self = shift;
     cleanup();
+    $self->SUPER::post_fail_hook;
 }
 
 sub post_run_hook {
+    my $self = shift;
     cleanup();
+    $self->SUPER::post_run_hook;
 }
 
 1;


### PR DESCRIPTION
Job fails here: https://openqa.suse.de/tests/4862409#step/cifs/1 as consequence of bsc#1178028, but it will also fail later, due to bsc#1152524

VR: https://openqa.suse.de/t4873770