### PR TITLE
[WIP] Improve udev symlink debug output

### DIFF
--- a/tests/kernel/udev_no_symlink.pm
+++ b/tests/kernel/udev_no_symlink.pm
@@ -49,6 +49,7 @@ sub run {
     assert_script_run('journalctl -u detect-part-label-duplicates.service --no-pager | grep "Warning: a high number of partitions uses"');
     assert_script_run('test $(grep -r "E:ID_PART_ENTRY_NAME=primary" /run/udev/data | wc -l) -eq ' . $num_primary);
     assert_script_run('test $(grep -r "E:ID_PART_ENTRY_NAME=openqapart" /run/udev/data | wc -l) -eq ' . $num_openqapart);
+    script_run("ls -l /run/udev/links/*by-partlabel*{primary,logical}/*");
     assert_script_run('test $(ls -l /run/udev/links/*by-partlabel*{primary,logical}/* | wc -l) -eq 0');
     assert_script_run('test $(ls -l /run/udev/links/*by-partlabel*openqapart/* | wc -l) -eq ' . $num_openqapart);
     record_info('OK', 'No symlinks created for partitions with label "primary" and warning appeared');


### PR DESCRIPTION
Please ignore for review, just demo.

Fix poo#75103: Udev symlink error output was not clear enough, addition
debug output was added to show information from filesystem.

- Related ticket: https://progress.opensuse.org/issues/75103
- Needles: none
- Verification run: 
15-SP3:
http://black-bit.suse.cz/tests/5215#step/udev_no_symlink/388
https://openqa.suse.de/tests/4876224
15-SP2:
12-SP5:
Tumbleweed:
