### PR TITLE
Support baremetal installation with iPXE without autoyast

### DIFF
--- a/schedule/kernel/ibtest-master-autoyast.yaml
+++ b/schedule/kernel/ibtest-master-autoyast.yaml
@@ -1,0 +1,27 @@
+name:           ibtest-master-autoyast
+description:    >
+    The master node for the infiniband testsuite (hpc-testing)
+vars:
+    AUTOYAST: autoyast_mlx_con5.xml
+    AUTOYAST_PREPARE_PROFILE: 1
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
+    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
+    GRUB_TIMEOUT: 300
+    IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
+    IBTEST_IP1: 10.162.2.93
+    IBTEST_IP2: 10.162.2.94
+    IBTEST_ROLE: IBTEST_MASTER
+    IPXE: 1
+    IPXE_CONSOLE: ttyS1,115200
+    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+    SCC_ADDONS: sdk
+    VIDEOMODE: ssh-x
+schedule:
+    - kernel/ibtests_barriers
+    - autoyast/prepare_profile
+    - installation/ipxe_install
+    - console/suseconnect_scc
+    - toolchain/install
+    - kernel/ibtests

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -2,8 +2,7 @@ name:           ibtest-master
 description:    >
     The master node for the infiniband testsuite (hpc-testing)
 vars:
-    AUTOYAST: autoyast_mlx_con5.xml
-    AUTOYAST_PREPARE_PROFILE: 1
+    DESKTOP: textmode
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
     GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
@@ -15,11 +14,26 @@ vars:
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+    IPXE_CONSOLE: ttyS1,115200
+    PATTERNS: base,minimal
     SCC_ADDONS: sdk
 schedule:
     - kernel/ibtests_barriers
-    - autoyast/prepare_profile
     - installation/ipxe_install
-    - console/suseconnect_scc
-    - toolchain/install
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/reboot_after_installation
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave-autoyast.yaml
+++ b/schedule/kernel/ibtest-slave-autoyast.yaml
@@ -1,0 +1,27 @@
+name:           ibtest-slave-autoyast
+description:    >
+    The slave node for the infiniband testsuite (hpc-testing)
+vars:
+    AUTOYAST: autoyast_mlx_con5.xml
+    AUTOYAST_PREPARE_PROFILE: 1
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/home:/MMoese:/branches:/devel:/tools/SLE_12_SP4/home:MMoese:branches:devel:tools.repo
+    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
+    GRUB_TIMEOUT: 300
+    IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
+    IBTEST_IP1: 10.162.2.93
+    IBTEST_IP2: 10.162.2.94
+    IBTEST_ROLE: IBTEST_SLAVE
+    IPXE: 1
+    IPXE_CONSOLE: ttyS1,115200
+    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+    PARALLEL_WITH: ibtest-master
+    SCC_ADDONS: sdk
+schedule:
+    - kernel/ibtests_barriers
+    - autoyast/prepare_profile
+    - installation/ipxe_install
+    - console/suseconnect_scc
+    - toolchain/install
+    - kernel/ibtests

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -2,9 +2,8 @@ name:           ibtest-slave
 description:    >
     The slave node for the infiniband testsuite (hpc-testing)
 vars:
-    AUTOYAST: autoyast_mlx_con5.xml
-    AUTOYAST_PREPARE_PROFILE: 1
-    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/home:/MMoese:/branches:/devel:/tools/SLE_12_SP4/home:MMoese:branches:devel:tools.repo
+    DESKTOP: textmode
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
     GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
@@ -15,12 +14,27 @@ vars:
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+    IPXE_CONSOLE: ttyS1,115200
     PARALLEL_WITH: ibtest-master
+    PATTERNS: base,minimal
     SCC_ADDONS: sdk
 schedule:
     - kernel/ibtests_barriers
-    - autoyast/prepare_profile
     - installation/ipxe_install
-    - console/suseconnect_scc
-    - toolchain/install
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/reboot_after_installation
     - kernel/ibtests


### PR DESCRIPTION
When autoyast is not working as intended, deployment of baremetal machines is currently blocked. This adds support to simply use the graphical installer, and makes this the default, while still supporting the installation with autoyast.

- Related ticket: https://progress.opensuse.org/issues/75163
- Needles: none
- Verification run: http://baremetal-support.qa.suse.de/tests/272
