### PR TITLE
Make libreoffice macros tests more stable

### DIFF
--- a/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
+++ b/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
@@ -40,7 +40,7 @@ sub run {
     send_key 'down';
     assert_and_click 'ooffice-writer-libreofficemacros';
     wait_still_screen(2);
-    type_string "python\n";
+    type_string "py\n";
 
     assert_and_click 'ooffice-python-samples';
     wait_still_screen(2);


### PR DESCRIPTION
When typing string 'python', from time to time PythonSamples are not selected, but with typing string 'py', it works in all cases.

- Related ticket: https://progress.opensuse.org/issues/73111
- Needles: N/A
- Verification run: SLE [15-SP2](http://10.161.229.247/tests/1354) [15-SP1](http://10.161.229.247/tests/1356)
