### PR TITLE
Add encrypted /home installation test

### DIFF
--- a/lib/Installation/Partitioner/FormattingOptionsPage.pm
+++ b/lib/Installation/Partitioner/FormattingOptionsPage.pm
@@ -19,21 +19,23 @@ use testapi;
 use parent 'Installation::WizardPage';
 
 use constant {
-    FORMATTING_OPTIONS_PAGE => 'partition-format',
-    FILESYSTEM_TYPE         => 'partitioning_%s-format-selected',
-    PARTITION_ID_PREP_BOOT  => 'filesystem-prep',
-    PARTITION_ID_EFI_SYSTEM => 'partition-selected-efi-type',
-    PARTITION_ID_BIOS_BOOT  => 'partition-selected-bios-boot-type',
-    PARTITION_ID_LINUX_RAID => 'partition-selected-raid-type'
+    FORMATTING_OPTIONS_PAGE       => 'partition-format',
+    FILESYSTEM_TYPE               => 'partitioning_%s-format-selected',
+    PARTITION_ID_PREP_BOOT        => 'filesystem-prep',
+    PARTITION_ID_EFI_SYSTEM       => 'partition-selected-efi-type',
+    PARTITION_ID_BIOS_BOOT        => 'partition-selected-bios-boot-type',
+    PARTITION_ID_LINUX_RAID       => 'partition-selected-raid-type',
+    ENCRYPT_DEVICE_OPTION_CHECKED => 'partition-encrypt'
 };
 
 sub new {
     my ($class, $args) = @_;
     my $self = bless {
-        do_not_format_shortcut => $args->{do_not_format_shortcut},
-        format_shortcut        => $args->{format_shortcut},
-        filesystem_shortcut    => $args->{filesystem_shortcut},
-        do_not_mount_shortcut  => $args->{do_not_mount_shortcut}
+        do_not_format_shortcut  => $args->{do_not_format_shortcut},
+        format_shortcut         => $args->{format_shortcut},
+        filesystem_shortcut     => $args->{filesystem_shortcut},
+        do_not_mount_shortcut   => $args->{do_not_mount_shortcut},
+        encrypt_device_shortcut => $args->{encrypt_device_shortcut}
     }, $class;
 }
 
@@ -110,5 +112,10 @@ sub fill_in_mount_point_field {
     type_string($mount_point);
 }
 
+sub check_encrypt_device_checkbox {
+    my ($self) = @_;
+    send_key($self->{encrypt_device_shortcut});
+    assert_screen(ENCRYPT_DEVICE_OPTION_CHECKED);
+}
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/EncryptionPasswordPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/EncryptionPasswordPage.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: The class introduces all accessing methods for Encryption Password.
+# Page of Expert Partitioner Wizard, that are common for all the versions of the
+# page (e.g. for both Libstorage and Libstorage-NG).
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+package Installation::Partitioner::LibstorageNG::EncryptionPasswordPage;
+use strict;
+use warnings;
+use testapi;
+use parent 'Installation::WizardPage';
+
+use constant {
+    ENCRYPT_PASSWORD_PAGE => 'encrypt_password_page',
+};
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        enter_password_shortcut  => $args->{enter_password_shortcut},
+        verify_password_shortcut => $args->{verify_password_shortcut}
+    }, $class;
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->SUPER::press_next(ENCRYPT_PASSWORD_PAGE);
+}
+
+sub assert_password_page {
+    my ($self) = @_;
+    assert_screen(ENCRYPT_PASSWORD_PAGE);
+}
+
+sub enter_password {
+    my ($self) = @_;
+    send_key($self->{enter_password_shortcut});
+    type_password();
+}
+
+sub enter_password_verification {
+    my ($self) = @_;
+    send_key($self->{verify_password_shortcut});
+    type_password();
+}
+
+1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
@@ -26,6 +26,7 @@ use Installation::Partitioner::RolePage;
 use Installation::Partitioner::LibstorageNG::FormattingOptionsPage;
 use Installation::Partitioner::RaidTypePage;
 use Installation::Partitioner::RaidOptionsPage;
+use Installation::Partitioner::LibstorageNG::EncryptionPasswordPage;
 
 sub new {
     my ($class, $args) = @_;
@@ -63,14 +64,19 @@ sub new {
                 do_not_mount_shortcut  => 'alt-u'
         }),
         EditFormattingOptionsPage => Installation::Partitioner::LibstorageNG::FormattingOptionsPage->new({
-                do_not_format_shortcut => 'alt-t',
-                format_shortcut        => 'alt-a',
-                filesystem_shortcut    => 'alt-f',
-                do_not_mount_shortcut  => 'alt-o'
+                do_not_format_shortcut  => 'alt-t',
+                format_shortcut         => 'alt-a',
+                filesystem_shortcut     => 'alt-f',
+                do_not_mount_shortcut   => 'alt-o',
+                encrypt_device_shortcut => 'alt-e'
         }),
         RaidTypePage    => Installation::Partitioner::RaidTypePage->new(),
         RaidOptionsPage => Installation::Partitioner::RaidOptionsPage->new({
                 chunk_size_shortcut => 'alt-u'
+        }),
+        EncryptionPasswordPage => Installation::Partitioner::LibstorageNG::EncryptionPasswordPage->new({
+                enter_password_shortcut  => 'alt-e',
+                verify_password_shortcut => 'alt-v'
         })
     }, $class;
 }
@@ -83,6 +89,11 @@ sub get_edit_formatting_options_page {
 sub get_edit_partition_size_page {
     my ($self) = @_;
     return $self->{EditPartitionSizePage};     # Same as get_formatting_options_edit_page
+}
+
+sub get_encrypt_password_page {
+    my ($self) = @_;
+    return $self->{EncryptionPasswordPage};
 }
 
 sub add_raid_partition {
@@ -139,6 +150,26 @@ sub edit_partition_on_gpt_disk {
     $self->get_edit_formatting_options_page()->select_mount_device_radiobutton();
     $self->get_edit_formatting_options_page()->fill_in_mount_point_field($args->{mount_point});
     $self->get_edit_formatting_options_page()->press_next();
+}
+
+sub edit_partition_encrypt {
+    my ($self, $args) = @_;
+    $self->get_expert_partitioner_page()->go_top_in_system_view_table();
+    $self->get_expert_partitioner_page()->select_item_in_system_view_table($args->{disk});
+    $self->get_expert_partitioner_page()->expand_item_in_system_view_table();
+    $self->get_expert_partitioner_page()->select_item_in_system_view_table($args->{partition});
+    $self->get_expert_partitioner_page()->press_edit_partition_button();
+    $self->get_edit_formatting_options_page()->check_encrypt_device_checkbox();
+    $self->get_edit_formatting_options_page()->press_next();
+    $self->set_encryption_password();
+}
+
+sub set_encryption_password {
+    my ($self) = @_;
+    $self->get_encrypt_password_page()->assert_password_page();
+    $self->get_encrypt_password_page()->enter_password();
+    $self->get_encrypt_password_page()->enter_password_verification();
+    $self->get_encrypt_password_page()->press_next();
 }
 
 sub clone_partition_table {

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -1,0 +1,45 @@
+---
+name: home_encrypted
+description: >
+  Test interactive installation with encrypted home partition.
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/edit_proposal_encrypt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/system_prepare
+  - console/verify_separate_home
+  - console/validate_encrypt
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  cryptsetup:
+    device_status:
+      message: is active and is in use.
+      properties:
+        type: LUKS1
+        cipher: aes-xts-plain64
+        device: /dev/vda3
+        key_location: dm-crypt
+        mode: read/write
+  backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
+  backup_path: '/root/bkp_luks_header_cr_home'
+  partitions_to_encrypt:
+    - disk: vda
+      partition: vda3

--- a/tests/console/validate_encrypt.pm
+++ b/tests/console/validate_encrypt.pm
@@ -36,8 +36,8 @@ use testapi;
 sub run {
     select_console 'root-console';
     my $test_data = get_test_suite_data();
-    my $devices   = parse_devices_in_crypttab();
     verify_crypttab_file_existence();
+    my $devices = parse_devices_in_crypttab();
     verify_number_of_encrypted_devices($test_data->{crypttab}->{num_devices_encrypted}, scalar keys %{$devices});
     foreach my $dev (sort keys %{$devices}) {
         my $status = parse_cryptsetup_status($dev);

--- a/tests/installation/partitioning/edit_proposal_encrypt.pm
+++ b/tests/installation/partitioning/edit_proposal_encrypt.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Edit suggested partitioning proposal and encrypt specified partitions.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use parent 'y2_installbase';
+use testapi;
+use version_utils ':VERSION';
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my $test_data   = get_test_suite_data();
+    my $partitioner = $testapi::distri->get_expert_partitioner();
+    $partitioner->run_expert_partitioner('current');
+    foreach my $partition (@{$test_data->{partitions_to_encrypt}}) {
+        $partitioner->edit_partition_encrypt($partition);
+    }
+    $partitioner->accept_changes_and_press_next();
+}
+
+1;


### PR DESCRIPTION
Installation test suite with edition of partitioning proposal, so that /home partition is encrypted.

- Related ticket: https://progress.opensuse.org/issues/66862
- Verification run: https://openqa.suse.de/tests/4914132
- https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/307
