### PR TITLE
Fix 'snapper list' timeout in snapper_rollback

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -38,7 +38,7 @@ sub run {
     script_run("cat /etc/os-release", 0);
     # rollback
     script_run("snapper rollback -d rollback-before-migration");
-    assert_script_run("snapper list | tail -n 2 | grep rollback", 180);
+    assert_script_run("snapper list --disable-used-space | tail -n 2 | grep rollback", 180);
     power_action('reboot', textmode => 1, keepconsole => 1);
     reconnect_mgmt_console if is_pvm;
     $self->wait_boot(ready_time => 300, bootloader_time => 300);


### PR DESCRIPTION
It will take some time for 'snapper list' to finish and give us the snapshot information.
It will timeout if the system have lots of snapshots, to fix this we'd add 
disable-used-space option to save time to avoid timeout. Calculating the used space
needs some time. Thus this option can speedup the listing.

- Related ticket: https://progress.opensuse.org/issues/70681
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/4887299