### PR TITLE
Fix yast2_apparmor issue: add sent_key

### DIFF
--- a/tests/security/yast2_apparmor/manually_add_profile.pm
+++ b/tests/security/yast2_apparmor/manually_add_profile.pm
@@ -51,6 +51,7 @@ sub run {
     # "marked as a program that should not have its own profile",
     # it should be failed
     assert_and_click("AppArmor-Manually-Add-Profile");
+    send_key "alt-l";
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file");
     send_key "alt-o";
@@ -65,6 +66,7 @@ sub run {
     # *NOT* "marked as a program that should not have its own profile",
     # it should be succeeded
     assert_and_click("AppArmor-Manually-Add-Profile");
+    send_key "alt-l";
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_bk");
     send_key "alt-o";
@@ -82,6 +84,7 @@ sub run {
     # Enter "yast2 apparmor" again
     type_string("yast2 apparmor &\n");
     assert_and_click("AppArmor-Manually-Add-Profile");
+    send_key "alt-l";
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_vsftpd");
     send_key "alt-o";

--- a/tests/security/yast2_apparmor/scan_audit_logs.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs.pm
@@ -44,6 +44,7 @@ sub run {
     type_string("yast2 apparmor &\n");
     # Enter "Scan Audit logs" and check there should no records
     assert_and_click("AppArmor-Scan-Audit-logs");
+    send_key "alt-l";
     assert_screen("AppArmor-Scan-Audit-logs-no-records");
     # Exit "yast2 apparmor"
     wait_screen_change { send_key "alt-o" };
@@ -71,6 +72,7 @@ sub run {
     type_string("yast2 apparmor &\n");
     # Enter "Scan Audit logs" and check there should have records
     assert_and_click("AppArmor-Scan-Audit-logs");
+    send_key "alt-l";
     assert_screen("AppArmor-Scan-Audit-logs-scan-records");
 
     # Audit the entry


### PR DESCRIPTION
Fix yast2_apparmor issue: add sent_key

Fix poo#75049 - yast2_apparmor test fails in "scan_audit_logs" +
"manually_add_profile" modules, add send_key to launch next page
as assert_and_click() did not launch next page.

- Related ticket: https://progress.opensuse.org/issues/75049
- Needles: NA
- Verification run: http://openqa.suse.de/tests/4887308
