### PR TITLE
[virt_autotest] ensure guest online for virtual routed network

### DIFF
--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -66,7 +66,9 @@ sub run_test {
         assert_script_run("rm -rf $guest.clone");
         assert_script_run("virt-clone -o $guest -n $guest.clone -f /var/lib/libvirt/images/$guest.clone");
         assert_script_run("virsh start $guest");
+        ensure_online $guest, skip_network => 1;
         assert_script_run("virsh start $guest.clone");
+        ensure_online "$guest.clone", skip_network => 1;
 
         if (is_sle('=11-sp4') && is_xen_host) {
             $affecter  = "--persistent";


### PR DESCRIPTION
Refer to the https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11255, add `ensure_online() `for virtual routed network test: 
tests/virt_autotest/libvirt_routed_virtual_network

- Verification run: 
WIP [gi-guest_developing-on-host_sles12sp5-xen](http://openqa.suse.de/tests/4888129)
