### PR TITLE
Fix img_proof for EC2-BYOS-update runs

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -43,6 +43,7 @@ our $img_proof_tests = {
     'EC2-HVM'              => $ec2_on_demand,
     'EC2-HVM-ARM'          => $ec2_on_demand,
     'EC2-Updates'          => $ec2_on_demand,
+    'EC2-BYOS-Updates'     => $ec2_byos,
     'EC2-HVM-BYOS'         => $ec2_byos,
     'EC2-HVM-BYOS-Updates' => $ec2_byos,
     'EC2-HVM-HPC-BYOS'     => $ec2_byos,


### PR DESCRIPTION
Add `EC2-BYOS-Updates` to `img_proof` types

- Related ticket: https://progress.opensuse.org/issues/69625
- Needles: 
- Verification run: http://phoenix-openqa.qam.suse.de/tests/3352
