### PR TITLE
Remove soft-failure for bsc#1054782

### DIFF
--- a/tests/console/sle15_workarounds.pm
+++ b/tests/console/sle15_workarounds.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2017 SUSE LLC
+# Copyright (C) 2014-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,31 +13,18 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 # Summary: performing extra actions specific to sle 15 which are not available normally
-# - If sle15+, switch to text console (ctrl-alt-f2)
-# - If system still in graphic, record failure
 # - Stop packagekit service
 # Maintainer: Rodion Iafarov <riafarov@suse.com>
 
-use base qw(consoletest distribution);
+use base 'consoletest';
 use strict;
 use warnings;
 use testapi;
-use utils qw(zypper_call pkcon_quit);
+use utils 'pkcon_quit';
 use version_utils 'is_sle';
 
-
 sub run {
-    my $self = shift;
     return unless is_sle('15+');
-    # try to detect bsc#1054782 only on the backend which can handle
-    # 'ctrl-alt-f2' directly
-    if (check_var('BACKEND', 'qemu')) {
-        send_key('ctrl-alt-f2');
-        assert_screen(["tty2-selected", 'text-login', 'text-logged-in-root', 'generic-desktop']);
-        if (match_has_tag 'generic-desktop') {
-            record_soft_failure 'bsc#1054782';
-        }
-    }
     select_console('root-console');
     # Stop packagekit
     pkcon_quit;


### PR DESCRIPTION
As per discussion in [bsc#1054782](https://bugzilla.suse.com/show_bug.cgi?id=1054782).

As there is only one call remaining in the module, we will schedule
moving it to appropriate place and get rid of this test module
completely, see [poo#75328](https://progress.opensuse.org/issues/75328).

[Verification run](https://openqa.suse.de/tests/4888196#).