### PR TITLE
workaround: Uninstall btrfsmaintenance bsc#1174436

### DIFF
--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 SUSE LLC
+# Copyright (C) 2015-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,8 +24,13 @@ use base 'basetest';
 use testapi;
 use power_action_utils 'power_action';
 use version_utils 'is_sle';
+use utils qw(zypper_call);
 
 sub run {
+    if (is_sle('=15-sp2')) {
+        record_soft_failure('bsc#1174436');
+        zypper_call('rm btrfsmaintenance');
+    }
     # We are already in console, so reboot from it and do not switch to x11 or root console
     # Note, on s390x with SLE15 VNC is not running even if enabled in the profile
     power_action('reboot', textmode => 1, keepconsole => 1);


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1174436
- Verification run:
http://10.100.12.155/tests/16952#step/autoyast_reboot/1
https://openqa.suse.de/tests/4960247 qam-allpatterns
https://openqa.suse.de/tests/4960248 qam-gnome