### PR TITLE
Containers: Fix check_host_os() and rename it to check_os_release()

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -53,7 +53,7 @@ use constant {
           requires_role_selection
           check_version
           get_os_release
-          check_host_os
+          check_os_release
           )
     ],
     BACKEND => [
@@ -583,13 +583,17 @@ sub get_os_release {
     return $os_version, $os_service_pack, $os_release{ID};
 }
 
-=head2 check_host_os
+=head2 check_os_release
 
 Identify running os without any dependencies parsing the I</etc/os-release>.
 
 =item C<distri_name>
 
 The expected distribution name to compare.
+
+=item C<line>
+
+The line we'll be parsing and checking.
 
 =item C<os_release_file>
 
@@ -599,12 +603,13 @@ Default to I</etc/os-release>.
 Returns 1 (true) if the ID_LIKE variable contains C<distri_name>.
 
 =cut
-sub check_host_os {
-    my ($distri_name, $os_release_file) = @_;
-    die "$distri_name is not given" unless $distri_name;
+sub check_os_release {
+    my ($distri_name, $line, $os_release_file) = @_;
+    die '$distri_name is not given' unless $distri_name;
+    die '$line is not given'        unless $line;
     $os_release_file //= '/etc/os-release';
-    my $os_like_name = script_output("grep -e \"^ID_LIKE\\b\" ${os_release_file} | cut -c4- | tr -d '\"'");
-    return ($os_like_name =~ /$distri_name/);
+    my $os_like_name = script_output("grep -e \"^$line\\b\" ${os_release_file} | cut -d'\"' -f2");
+    return ($os_like_name =~ /$distri_name/i);
 }
 
 =head2 is_public_cloud

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -25,7 +25,7 @@ use utils;
 use containers::common;
 use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
-use version_utils qw(get_os_release check_host_os);
+use version_utils qw(get_os_release check_os_release);
 
 sub run {
     my ($image_names, $stable_names) = get_suse_container_urls();
@@ -39,7 +39,7 @@ sub run {
     for my $iname (@{$image_names}) {
         test_container_image(image => $iname, runtime => $runtime);
         build_container_image(image => $iname, runtime => $runtime);
-        if (check_host_os('suse')) {
+        if (check_os_release('suse', 'PRETTY_NAME')) {
             test_opensuse_based_image(image => $iname, runtime => $runtime);
             build_with_zypper_docker(image => $iname, runtime => $runtime);
         }

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -16,12 +16,12 @@
 use Mojo::Base qw(consoletest);
 use testapi;
 use utils;
-use version_utils 'check_host_os';
+use version_utils 'check_os_release';
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
-    if (check_host_os('suse')) {
+    if (check_os_release('suse', 'PRETTY_NAME')) {
         ensure_ca_certificates_suse_installed();
     }
     else {

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -18,7 +18,7 @@ use utils;
 use containers::common;
 use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
-use version_utils qw(get_os_release check_host_os);
+use version_utils qw(get_os_release check_os_release);
 
 sub run {
     my ($image_names, $stable_names) = get_suse_container_urls();
@@ -29,7 +29,7 @@ sub run {
     for my $iname (@{$image_names}) {
         test_container_image(image => $iname, runtime => $runtime);
         build_container_image(image => $iname, runtime => $runtime);
-        if (check_host_os('suse')) {
+        if (check_os_release('suse', 'PRETTY_NAME')) {
             test_opensuse_based_image(image => $iname, runtime => $runtime);
         }
         else {


### PR DESCRIPTION
As @dzedro pointed in #11223 the `check_host_os()` routine is broken as the `PRETTY_NAME` variable is not present in `ID_LIKE` in SLES 12.

- Verification run: [SLES 12 SP3](http://pdostal-server.suse.cz/tests/10309#step/docker_image/173) [SLES 15 SP2](http://pdostal-server.suse.cz/tests/10304#)
