### PR TITLE
Unregister MicroOS needles for SLE

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -42,6 +42,9 @@ sub is_new_installation {
 
 sub cleanup_needles {
     remove_common_needles;
+    for my $distri (qw(sle microos)) {
+        unregister_needle_tags("ENV-DISTRI-$distri") unless check_var('DISTRI', $distri);
+    }
     if ((get_var('VERSION', '') ne '15') && (get_var('BASE_VERSION', '') ne '15')) {
         unregister_needle_tags("ENV-VERSION-15");
     }


### PR DESCRIPTION
Avoid matching needles with tag ENV-MICROOS for SLE runs.
There are not so many yet, but there will be more and we could
save some time avoiding matching those.

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1460