### PR TITLE
solve error to issue 75325 - test fails in win2019_config_AD

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -47,7 +47,7 @@ sub open_powershell_as_admin {
     #If using windows server, and logged with Administrator, only open powershell
     if (get_var('QAM_WINDOWS_SERVER')) {
         send_key 'shift-a';
-        wait_screen_change { assert_and_click('window-max', timeout => 15) };
+        wait_screen_change { assert_and_click('window-max') };
         assert_screen 'windows_server_powershel_opened', 30;
     } else {
         send_key_until_needlematch 'user-acount-ctl-allow-make-changes', 'shift-a';


### PR DESCRIPTION
solve error to issue 75325 - test fails in win2019_config_AD, 
change timeout to assert_screen verify the powershell window was opened.


- Related ticket: https://progress.opensuse.org/issues/75325

http://10.161.228.111/tests/3350#step/win2019_config/8