### PR TITLE
Remove invalid script from the multipath AY profile

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -597,18 +597,6 @@ fi
         </source>
       </script>
     </pre-scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <filename>cp-resolv.sh</filename>
-        <chrooted config:type="boolean">false</chrooted>
-        <interpreter>shell</interpreter>
-        <notification>Copying resolv.conf into chroot</notification>
-        <source><![CDATA[
-cp /etc/resolv.conf /mnt/etc
-]]>
-        </source>
-      </script>
-    </chroot-scripts>
   </scripts>
   <timezone>
     <hwclock>UTC</hwclock>


### PR DESCRIPTION
See [poo#75097](https://progress.opensuse.org/issues/75097).

[Verification run](https://openqa.suse.de/tests/4893170#) Fails with https://bugzilla.suse.com/show_bug.cgi?id=1177036
