### PR TITLE
Disable DNSSEC on more releases to work around bsc#1177790

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -63,7 +63,7 @@ sub run {
     enable_debug_logging if is_x86_64;
 
     #workaround of bsc#1177790
-    if (is_sle('=15-sp2') || is_sle('=15-sp3')) {
+    if (is_sle('>=12-sp5')) {
         record_soft_failure("Guests installation is blocked by bsc#1177790, we workaroud it by disabling DNSSEC validation in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11226");
         script_run "sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf";
         script_run "grep 'dnssec-validation' /etc/named.conf";


### PR DESCRIPTION
12sp5 host & 12sp2 host met this issue as well, so add more release to get around bsc#1177790.

- failing tests on sles12sp2 host: http://10.67.129.4/tests/22062
- Verification run: 
[gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.nue.suse.com/tests/4893470)
[prj2_host_upgrade_sles12sp5_to_developing_kvm](https://openqa.nue.suse.com/tests/4895891)
[prj1 on sles12sp5 on arm](https://openqa.nue.suse.com/tests/4893505)
