### PR TITLE
Fix snapper_rollback sometimes can't catch displaymanager

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -26,9 +26,7 @@ sub run {
         assert_screen 'generic-desktop', 90;
     }
     else {
-        if (!check_screen 'linux-login', 200) {
-            assert_screen 'displaymanager', 90;
-        }
+        assert_screen [qw(linux-login displaymanager)], 200;
     }
     select_console 'root-console';
     # 1)


### PR DESCRIPTION
Use multi-tag to catch displaymanager or linux-login instead of catch them in sequence.

- Related ticket: https://progress.opensuse.org/issues/71953
- Needles: N/A
- Verification run: wait verification log on OSD:
                             https://openqa.nue.suse.com/tests/4899252#step/snapper_rollback/1
                           To avoid regression for passed case:
                              http://openqa.nue.suse.com/tests/4899254#step/snapper_rollback/1
                              http://openqa.nue.suse.com/tests/4899429#step/snapper_rollback/1