### PR TITLE
Fix cloud patterns conflict

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1781,7 +1781,14 @@ sub install_patterns {
     my @pt_list;
     my @pt_list_un;
     my @pt_list_in;
+    my $pcm_list = 0;
 
+    if (is_sle('15+')) {
+        $pcm_list = 'Amazon_Web_Services|Google_Cloud_Platform|Microsoft_Azure';
+    }
+    else {
+        $pcm_list = 'Amazon-Web-Services|Google-Cloud-Platform|Microsoft-Azure';
+    }
     @pt_list_in = get_pattern_list "zypper pt -i", "i";
     # install all patterns from product.
     if (check_var('PATTERNS', 'all')) {
@@ -1802,13 +1809,13 @@ sub install_patterns {
         $installed_pt{$_} = 1;
     }
     @pt_list = sort grep(!$installed_pt{$_}, @pt_list_un);
-    $pcm     = grep /Amazon-Web-Services|Google-Cloud-Platform|Microsoft-Azure/, @pt_list_in;
+    $pcm     = grep /$pcm_list/, @pt_list_in;
 
     for my $pt (@pt_list) {
         # if pattern is set default, skip
         next if ($pt =~ /default/);
         # Cloud patterns are conflict by each other, only install cloud pattern from single vender.
-        if ($pt =~ /Amazon-Web-Services|Google-Cloud-Platform|Microsoft-Azure/) {
+        if ($pt =~ /$pcm_list/) {
             next unless $pcm == 0;
             $pt .= '*';
             $pcm = 1;


### PR DESCRIPTION
We select one group of cloud patterns from 3 groups from 3 companies, while in the code the pattern names are wrong, should use '_'  replace the '-'.

- Related ticket: https://progress.opensuse.org/issues/75436
- Needles: N/A
- Verification run: verification log on OSD:
                           http://openqa.nue.suse.com/tests/4908253
                           http://openqa.nue.suse.com/tests/4908252
  More verification besides on SLE15SP2:
  12SP3: https://openqa.nue.suse.com/tests/4906208
  12SP4: http://openqa.nue.suse.com/tests/4908249
  12SP5: http://openqa.nue.suse.com/tests/4908250
  15SP0: https://openqa.nue.suse.com/tests/4913689#step/patch_sle/146 failed for remove ltss
  15SP1: http://openqa.nue.suse.com/tests/4908252