### PR TITLE
Create test for btrfs docker storage driver

### DIFF
--- a/data/autoyast_sle15/autoyast_containers_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_containers_x86_64.xml
@@ -56,10 +56,51 @@
           <filesystem config:type="symbol">swap</filesystem>
           <mount>swap</mount>
         </partition>
+        
         <partition>
           <mountby config:type="symbol">device</mountby>
           <filesystem config:type="symbol">btrfs</filesystem>
           <mount>/</mount>
+          <subvolumes config:type="list">
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>opt</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>tmp</path>
+            </subvolume>
+            <subvolume>
+              <path>usr/local</path>
+            </subvolume>
+            <subvolume>
+              <path>home</path>
+            </subvolume>
+            <subvolume>
+              <path>srv</path>
+            </subvolume>
+            <subvolume>
+              <path>boot/grub2/x86_64-efi</path>
+            </subvolume>
+            <subvolume>
+              <path>boot/grub2/x86_64-i386-pc</path>
+            </subvolume>
+          </subvolumes>
+          <!-- Create empty prefix, see bsc#1090095 -->
+          <subvolumes_prefix>@</subvolumes_prefix>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>rw,relatime,nobarrier,nodatacow</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/var</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
         </partition>
       </partitions>
       <use>all</use>

--- a/lib/containers/runtime.pm
+++ b/lib/containers/runtime.pm
@@ -1,0 +1,145 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Abstraction layer to operate docker and podman containers through same interfaces
+# Maintainer: qac team <qa-c@suse.de>
+
+package containers::runtime;
+use Mojo::Base -base;
+use testapi;
+use Test::Assert 'assert_equals';
+
+has runtime => undef;
+
+sub _rt_assert_script_run {
+    my ($self, $cmd, @args) = @_;
+    assert_script_run($self->runtime . " " . $cmd, @args);
+}
+
+sub _rt_script_run {
+    my ($self, $cmd, @args) = @_;
+    return script_run($self->runtime . " " . $cmd, @args);
+}
+
+sub _rt_script_output {
+    my ($self, $cmd, @args) = @_;
+    return script_output($self->runtime . " " . $cmd, @args);
+}
+
+=head2 build
+
+Build a container.
+C<dockerfile_path> is the directory with the Dockerfile as well as the root of the build context.
+C<container_tag> will be the name of the container.
+
+=cut
+sub build {
+    my ($self, $dockerfile_path, $container_tag) = @_;
+    die 'wrong number of arguments' if @_ < 3;
+    #TODO add build with URL https://docs.docker.com/engine/reference/commandline/build/
+    $self->_rt_assert_script_run("build -f $dockerfile_path/Dockerfile -t $container_tag $dockerfile_path");
+    record_info "$container_tag created";
+}
+
+=head2 up
+
+Run a container.
+C<image_name> is required and can be the image id, the name or name with tag.
+If C<daemon> is enabled then container will run in the detached mode. Otherwise will be in the 
+interactive mode.
+if C<cmd> found then it will execute the given command into the container.
+The container is always removed after exit.
+
+=cut
+sub up {
+    my ($self, $image_name, %args) = @_;
+    die 'image name or id is required' unless $image_name;
+    my $mode   = $args{daemon} ? '-d'    : '-it';
+    my $remote = $args{cmd}    ? 'sh -c' : '';
+    my $ret    = $self->_rt_script_run(sprintf qq(run --rm %s %s %s '%s'), $mode, $image_name, $remote, $args{cmd});
+    record_info "Remote run on $image_name", $args{cmd};
+    return $ret;
+}
+
+=head2 pull
+
+Pull a container with the given C<image_name>
+where C<image_name> can be the name or id of the image.
+
+=cut
+sub pull {
+    my ($self, $image_name) = @_;
+    my $ret = $self->_rt_script_run("pull $image_name");
+    return $ret;
+}
+
+=head2 enum_images
+
+Return an array ref of the images
+
+=cut
+sub enum_images {
+    my ($self) = shift;
+    my $images_s = $self->_rt_script_output("images -q");
+    record_info "Images", $images_s;
+    my @images = split /[\n\t]/, $images_s;
+    return \@images;
+}
+
+=head2 enum_images
+
+Return an array ref of the containers
+
+=cut
+sub enum_containers {
+    my ($self) = shift;
+    my $containers_s = $self->_rt_script_output("container ls -q");
+    record_info "Containers", $containers_s;
+    my @containers = split /[\n\t]/, $containers_s;
+    return \@containers;
+}
+
+=head2 info
+
+Assert a C<property> against given expected C<value> if C<value> is given.
+Otherwise it prints the output of info.
+
+=cut
+sub info {
+    my ($self, %args) = shift;
+    my $property = $args{property} ? qq(--format '{{.$args{property}}}') : '';
+    my $expected = $args{value}    ? qq( | grep $args{value})            : '';
+    $self->_rt_assert_script_run(sprintf("info %s %s", $property, $expected));
+}
+
+=head2 remove_image
+
+Remove a image from the pool.
+
+=cut
+sub remove_image {
+    my ($self, $image_name) = @_;
+    $self->_rt_assert_script_run("rmi -f $image_name");
+}
+
+=head2 cleanup_system_host
+
+Remove containers and then all the images respectively and then make sure that everything was cleaned up.
+
+=cut
+sub cleanup_system_host {
+    my ($self) = shift;
+    # copy from common > clean_container_host
+    $self->_rt_assert_script_run("stop \$($self->{runtime} ps -q)", 180) if script_output("$self->{runtime} ps -q | wc -l") != '0';
+    $self->_rt_assert_script_run("system prune -a -f",              180);
+    assert_equals(0, scalar @{$self->enum_containers()}, "containers have not been removed");
+    assert_equals(0, scalar @{$self->enum_images()},     "images have not been removed");
+}
+
+1;

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -8,5 +8,6 @@ schedule:
     - containers/host_configuration
     - containers/podman_image
     - containers/docker_image
+    - containers/validate_btrfs
     # - containers/container_diff
     # Re-enable after 15-SP3 GA

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -1,0 +1,82 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test Docker’s btrfs storage driver features for image and container management
+# Among these features are block-level operations, thin provisioning, copy-on-write snapshots,
+# and ease of administration. You can easily combine multiple physical block devices into a single Btrfs filesystem.
+# The scenario illustrates the build of a sle image and then reuse the same Dockerfile to check that
+# the thin partitioning are used. Then we check the block subvolumes.
+# Finally we test the disk administration filling up the subvolume mounted for the images
+# and try to pull another image. With btrfs we should be able to add another disk and be able to
+# continue when the docker partition is fulled up.
+# Maintainer: qac team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use containers::runtime;
+
+sub _sanity_test_btrfs {
+    my ($rt, $dev_path) = @_;
+    my $dockerfile_path = '/root/sle_base_image/docker_build';
+    my $btrfs_head      = '/tmp/subvolumes_saved';
+    $rt->info(property => 'Driver', value => 'btrfs');
+    $rt->build($dockerfile_path, 'huge_image');
+    assert_script_run "btrfs fi df $dev_path/btrfs/";
+    assert_script_run "ls -td $dev_path/btrfs/subvolumes/* | head -n 1 > $btrfs_head";
+    validate_script_output "df -h |grep var", sub { m/\/dev\/vda.+[1-6]\d?%/ };
+    # /var is using its own partition which is size of 10G. Create file in the container
+    # enough to fill up the partition up to ~99%
+    $rt->up('huge_image', cmd => 'fallocate -l 8.7G bigfile.stty');
+    # partition should be full
+    validate_script_output "df -h |grep var",       sub { m/\/dev\/vda.+\s+(9[7-9]|100)%/ };
+    validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=8.*GiB, used=8.*GiB/ };
+}
+
+sub _test_btrfs_balancing {
+    my ($dev_path) = shift;
+    assert_script_run qq(btrfs balance start --full-balance $dev_path), timeout => 600;
+    assert_script_run "btrfs fi show $dev_path/btrfs";
+    validate_script_output "btrfs fi show $dev_path/btrfs", sub { m/devid\s+2.+20.00G.+1.\d+G.+\/dev\/vdb/ };
+}
+
+sub _test_btrfs_thin_partitioning {
+    my ($rt, $dev_path) = @_;
+    my $dockerfile_path = '/root/sle_base_image/docker_build';
+    my $btrfs_head      = '/tmp/subvolumes_saved';
+    $rt->build($dockerfile_path, 'thin_image');
+    # validate that new subvolume has been created. This should be improved.
+    assert_script_run qq{test \$(ls -td $dev_path/btrfs/subvolumes/* | head -n 1) == \$(cat $btrfs_head)};
+    validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=8.*GiB, used=8.*GiB/ };
+}
+
+sub _test_btrfs_device_mgmt {
+    my ($rt, $dev_path) = @_;
+    my $tw         = 'registry.suse.de/home/favogt/jumpmeta/images_tw/opensuse/tumbleweed:latest';
+    my $btrfs_head = '/tmp/subvolumes_saved';
+    # Due to disk space this should fail
+    record_info "test";
+    die("pull still works") if ($rt->pull("$tw") == 0);
+    assert_script_run "btrfs device add /dev/vdb $dev_path";
+    validate_script_output "lsblk | grep vdb",              sub { m/vdb.+20G/ };
+    validate_script_output "btrfs fi show $dev_path/btrfs", sub { m/devid\s+2\s+size\s20.00GiB\sused\s0.00B.+\/dev\/vdb/ };
+    $rt->pull($tw);
+    assert_script_run qq{test \$(ls -td $dev_path/btrfs/subvolumes/* | head -n 1) != \$(cat $btrfs_head)};
+}
+
+sub run {
+    my $docker    = containers::runtime->new(runtime => 'docker');
+    my $btrfs_dev = '/var/lib/docker';
+    _sanity_test_btrfs($docker, $btrfs_dev);
+    _test_btrfs_thin_partitioning($docker, $btrfs_dev);
+    _test_btrfs_device_mgmt($docker, $btrfs_dev);
+    _test_btrfs_balancing($btrfs_dev);
+    $docker->cleanup_system_host;
+}
+
+1;


### PR DESCRIPTION
Without touching other modules for now i implemented a class for the runtime                                                                                                                                                                 
which could be used for containers' management.                                                                                                                                                                                              
The test exercices the management of the subvolume that holds the images' layers.                                                                                                                                                            
We can retrieve information, test thin_partitioning and scale up when the                                                                                                                                                                    
partition is full in order to pull additional images.

- Related ticket: https://progress.opensuse.org/issues/73636
- [Verification run OSD](https://openqa.suse.de/tests/4945777) The failure is due to the qcow is not configured yet so it is use the old one. I have http://aquarius.suse.cz/tests/3856# locally
