### PR TITLE
Reuse autoyast_boot_params in zkvm bootloader

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -26,6 +26,7 @@ use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_POR
 
 our @EXPORT = qw(
   add_custom_grub_entries
+  autoyast_boot_params
   boot_grub_item
   stop_grub_timeout
   boot_local_disk

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -37,10 +37,8 @@ sub set_svirt_domain_elements {
             $cmdline .= "upgrade=1 ";
         }
 
-        if (my $autoyast = get_var('AUTOYAST')) {
-            $autoyast = data_url($autoyast) if $autoyast !~ /^slp$|:\/\//;
-            $cmdline .= " autoyast=" . $autoyast;
-            set_var('AUTOYAST', $autoyast);
+        if (get_var('AUTOYAST')) {
+            $cmdline .= ' ' . join(' ', autoyast_boot_params);
         }
 
         $cmdline .= ' ' . get_var("EXTRABOOTPARAMS") if get_var("EXTRABOOTPARAMS");


### PR DESCRIPTION
For reinstall scenario we need to expand ASSET variable value, and we
already have a method which does exactly that, as well as normal
expansion to url for common installations.

[Verification run](https://openqa.suse.de/tests/4908279#).

