### PR TITLE
Improve udev symlink debug output

### DIFF
--- a/tests/kernel/udev_no_symlink.pm
+++ b/tests/kernel/udev_no_symlink.pm
@@ -29,7 +29,8 @@ sub run {
 
     # Prepare HDD
     zypper_call('-q in parted');
-    my $hdd2           = '/dev/vdb';
+    my $udev_label     = "/run/udev/links/*by-partlabel*{primary,logical}/*";
+    my $udev_no_label  = "/run/udev/links/*by-partlabel*/*";
     my $num_primary    = 101;
     my $num_openqapart = 10;
     my $cnt;
@@ -49,7 +50,8 @@ sub run {
     assert_script_run('journalctl -u detect-part-label-duplicates.service --no-pager | grep "Warning: a high number of partitions uses"');
     assert_script_run('test $(grep -r "E:ID_PART_ENTRY_NAME=primary" /run/udev/data | wc -l) -eq ' . $num_primary);
     assert_script_run('test $(grep -r "E:ID_PART_ENTRY_NAME=openqapart" /run/udev/data | wc -l) -eq ' . $num_openqapart);
-    assert_script_run('test $(ls -l /run/udev/links/*by-partlabel*{primary,logical}/* | wc -l) -eq 0');
+    script_run('ls -laR ' . $udev_label);
+    assert_script_run("test \$(ls -l ${udev_label} | wc -l) -eq 0");
     assert_script_run('test $(ls -l /run/udev/links/*by-partlabel*openqapart/* | wc -l) -eq ' . $num_openqapart);
     record_info('OK', 'No symlinks created for partitions with label "primary" and warning appeared');
 
@@ -60,7 +62,8 @@ sub run {
     $self->select_serial_terminal;
     assert_script_run('test $(grep -r "E:ID_PART_ENTRY_NAME=primary" /run/udev/data | wc -l) -eq ' . $num_primary);
     assert_script_run('test $(grep -r "E:ID_PART_ENTRY_NAME=openqapart" /run/udev/data | wc -l) -eq ' . $num_openqapart);
-    assert_script_run('test $(ls -l /run/udev/links/*by-partlabel*/* | wc -l) -eq 0');
+    script_run('ls -laR ' . $udev_no_label);
+    assert_script_run("test \$(ls -l ${udev_no_label} | wc -l) -eq 0");
     record_info('OK', 'No symlinks created with udev.no-partlabel-links enabled');
 }
 


### PR DESCRIPTION
Fix poo#75103: Udev symlink error output was not clear enough, addition
debug output was added to show information from filesystem.
* Removed not used variable hhd2;
* Increased verbosity for both branches of the test.
    
- Related ticket: https://progress.opensuse.org/issues/75103
- Needles: none
- Verification run: 
    15-SP3: https://openqa.suse.de/tests/4923530


