### PR TITLE
Skip registration on PC on-demand images

### DIFF
--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -17,7 +17,7 @@ use warnings;
 use testapi;
 use strict;
 use utils;
-use publiccloud::utils "select_host_console";
+use publiccloud::utils qw(select_host_console);
 
 sub run {
     my ($self, $args) = @_;


### PR DESCRIPTION
On publiccloud on-demand images, the registration is not required and causes some test to fail

- Related ticket: https://progress.opensuse.org/issues/75082
- Needles: -
- Verification runs: [SLE15-SP2 Azure BYOS](http://phoenix-openqa.qam.suse.de/tests/3565) | [SLE15-SP2-AZURE-Basic-Updates](http://phoenix-openqa.qam.suse.de/tests/3595) | [SLE15-SP2-AZURE-Standard-Updates](http://phoenix-openqa.qam.suse.de/tests/3567) | [SLE15-SP1-EC2-BYOS-Updates](http://phoenix-openqa.qam.suse.de/tests/3568) | [SLE15-SP2-EC2-Updates](http://phoenix-openqa.qam.suse.de/tests/3569) | [SLE12-SP5-GCE-BYOS-Updates](http://phoenix-openqa.qam.suse.de/tests/3570) | [SLE15-SP1-GCE-Updates](http://phoenix-openqa.qam.suse.de/tests/3594)