### PR TITLE
Unschedule cifs from jeos15.1

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1814,7 +1814,7 @@ sub load_extra_tests_filesystem {
     loadtest 'console/snapper_used_space' if (is_sle('15-SP1+') || (is_opensuse && !is_leap('<15.1')));
     loadtest "console/udisks2" unless (is_sle('<=15-SP2') || get_var('VIRSH_VMM_FAMILY') =~ /xen/);
     loadtest "console/zfs" if (is_leap(">=15.1") && is_x86_64 && !is_jeos);
-    loadtest "network/cifs";
+    loadtest "network/cifs" unless (is_jeos && is_sle('<15-sp3'));
 }
 
 sub get_wicked_tests {


### PR DESCRIPTION
`cifs` is missing support in `kernel-default-base` for already released sle-images.
- Verification runs: 
   * [sle-15-SP2-JeOS](http://kepler.suse.cz/tests/2542)
   * [sle-15-SP3-JeOS](http://kepler.suse.cz/tests/2543#)
