### PR TITLE
Fix docker_compose for publiccloud ondemand

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -21,7 +21,7 @@ use testapi;
 use utils;
 use version_utils;
 
-our @EXPORT = qw(select_host_console);
+our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand);
 
 
 # Select console on the test host, regardless of the TUNNELED variable.
@@ -31,6 +31,22 @@ sub select_host_console() {
     } else {
         select_console('root-console');
     }
+}
+
+sub is_publiccloud() {
+    return (get_var('PUBLIC_CLOUD') == 1);
+}
+
+# Check if we are a BYOS test run
+sub is_byos() {
+    return is_publiccloud && get_var('FLAVOR') =~ 'BYOS';
+}
+
+# Check if we are a OnDemand test run
+sub is_ondemand() {
+    # By convention OnDemand images are not marked explicitly.
+    # Check all the other flavors, and if they don't match, it must be on_demand.
+    return is_publiccloud && (!is_byos());    # When introducing new flavors, add checks here accordingly.
 }
 
 1;

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -27,6 +27,7 @@ use registration;
 use utils;
 use version_utils 'is_sle';
 use containers::common;
+use publiccloud::utils 'is_ondemand';
 use strict;
 use warnings;
 
@@ -69,7 +70,8 @@ sub run {
     assert_script_run 'docker-compose down', 180;
     assert_script_run 'cd';
 
-    remove_suseconnect_product(get_addon_fullname('phub')) if is_sle();
+    # De-registration is disabled for on-demand instances
+    remove_suseconnect_product(get_addon_fullname('phub')) if (is_sle() && !is_ondemand());
     clean_container_host(runtime => 'docker');
 }
 

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -26,11 +26,16 @@ sub run {
 
     select_host_console();    # select console on the host, not the PC instance
 
-    assert_script_run("du -sh ~/repos");
-    assert_script_run("rsync -va -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
-    $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
-    $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
-    $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
+    # Trigger to skip the download to speed up verification runs
+    if (get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD') == 1) {
+        record_info('Skip download', 'Skipping download triggered by setting (QAM_PUBLICCLOUD_SKIP_DOWNLOAD = 1)');
+    } else {
+        assert_script_run("du -sh ~/repos");
+        assert_script_run("rsync -va -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
+        $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
+        $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
+        $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
+    }
 }
 
 1;


### PR DESCRIPTION
Fix a SUSEConnect error for docker_compose in publiccloud ondemand images. Also adds the setting `QAM_PUBLICCLOUD_SKIP_DOWNLOAD` to skip downloading publiccloud test repositories. This should help to speed up verification runs a lot.

- Related ticket: https://progress.opensuse.org/issues/76789
- Needles: -
- Verification run: http://phoenix-openqa.qam.suse.de/t3462