### PR TITLE
docker_compose: Deregistration is disabled, use SUSEConnect --clean

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1720,9 +1720,9 @@ sub load_extra_tests_docker {
         loadtest "containers/docker_image";
         loadtest "containers/container_diff";
     }
-    loadtest "containers/docker_compose" unless (is_sle('<15') || is_sle('>=15-sp2'));
     loadtest 'containers/registry';
     loadtest "containers/zypper_docker";
+    loadtest "containers/docker_compose" unless (is_sle('<15') || is_sle('>=15-sp2'));
 }
 
 sub load_extra_tests_prepare {

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -69,7 +69,7 @@ sub run {
     assert_script_run 'docker-compose down', 180;
     assert_script_run 'cd';
 
-    remove_suseconnect_product(get_addon_fullname('phub')) if is_sle();
+    assert_script_run('SUSEConnect --cleanup', 200) if is_sle();
     clean_container_host(runtime => 'docker');
 }
 


### PR DESCRIPTION
SUSEConnect error: SUSE::Connect::UnsupportedOperation: De-registration is disabled for on-demand instances. Use `registercloudguest --clean` instead.

- Related ticket: https://progress.opensuse.org/issues/76789
- Verification run:
https://openqa.suse.de/tests/4918477#step/docker_compose/72
https://openqa.suse.de/tests/4918488#step/docker_compose/72