### PR TITLE
Fix sync timeout in force_scheduled_tasks module

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -58,7 +58,7 @@ sub run {
     if (!get_var('SOFTFAIL_BSC1063638') && script_run("! [ -d /usr/share/btrfsmaintenance/ ]")) {
         assert_script_run('find /usr/share/btrfsmaintenance/ -type f -exec ln -fs /bin/true {} \;', timeout => 300);
     }
-    assert_script_run "sync";
+    assert_script_run 'sync', 600;
     settle_load;
 
     # return dmesg output to normal


### PR DESCRIPTION
In assert_script_run function the default timeout value is 90 seconds.
In force_scheduled_tasks module, the 'sync' command will not return in
90 seconds if the btrfs-balance and btrfs-scrub was still working. 
We add it to 600 seconds as it was set in in patch_sle.pm.

- Related ticket: https://progress.opensuse.org/issues/75433
- Needles: N/A
- Verification run:  
   https://openqa.nue.suse.com/tests/4918445