### PR TITLE
Wipe the disks on ipmi before fresh installations

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -17,11 +17,12 @@ use strict;
 use warnings;
 use lockapi;
 use testapi;
-use bootloader_setup qw(bootmenu_default_params specific_bootmenu_params);
+use bootloader_setup qw(bootmenu_default_params specific_bootmenu_params prepare_disks);
 use registration 'registration_bootloader_cmdline';
 use utils 'type_string_slow';
 use Utils::Backends 'is_remote_backend';
 use Utils::Architectures qw(is_aarch64 is_orthos_machine is_supported_suse_domain);
+use version_utils 'is_upgrade';
 
 sub run {
     my ($image_path, $image_name, $cmdline);
@@ -185,6 +186,9 @@ sub run {
                 send_key "ret";
                 assert_screen $ssh_vnc_tag, $ssh_vnc_wait_time;
             }
+        }
+        if (!is_upgrade) {
+            prepare_disks;
         }
         save_screenshot;
         select_console 'installation';


### PR DESCRIPTION
Due to traces of previous installations, we might have different
conditions when start new installation. This not only complicates
automation process, but also leads to instabilities, like guided
partitioning, for instance.

Wiping the disks before installations also required some changes in the
methods to select first disk, as it expects preexisting partitions, and
sometimes is even called when there is only one disk in the SUT.

See [poo#73363](https://progress.opensuse.org/issues/73363).

[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%23yast).

NOTE: Some jobs are cancelled, as affected steps have succeeded.
