### PR TITLE
Check if gnome packagekit is already installed

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -59,8 +59,10 @@ sub run {
     my ($self) = @_;
     if (is_sle '15+') {
         select_console 'root-console';
-        zypper_call("in gnome-packagekit", timeout => 90);
-        record_soft_failure 'bsc#1081584';
+        if (script_run 'rpm -q "gnome-packagekit"') {
+            zypper_call("in gnome-packagekit", timeout => 90);
+            record_soft_failure 'bsc#1081584';
+        }
     }
     select_console 'x11', await_console => 0;
     ensure_unlocked_desktop;


### PR DESCRIPTION
And checking if we really need to record a soft failure

- Related ticket: https://progress.opensuse.org/issues/75157

@foursixnine 