### PR TITLE
Using serial terminal instead of root-console

### DIFF
--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -21,7 +21,7 @@ use apachetest;
 use utils 'clear_console';
 
 sub run {
-    select_console 'root-console';
+    $self->select_serial_terminal;
     clear_console;
     setup_apache2(mode => 'SSL');
 }


### PR DESCRIPTION
As suggested in the ticket using serial terminal instead of the root
console to save some time

- Related ticket: https://progress.opensuse.org/issues/75319

@foursixnine 