### PR TITLE
Fix arguments to ndctl create-namespace command

### DIFF
--- a/tests/console/ndctl.pm
+++ b/tests/console/ndctl.pm
@@ -24,7 +24,7 @@ sub run {
     assert_script_run 'ndctl destroy-namespace --force all';
     my $total = get_var('NVDIMM_NAMESPACES_TOTAL', 2);
     foreach my $i (0 .. ($total - 1)) {
-        my $device = script_output 'ndctl create-namespace --force --mode=memory --map=dev';
+        my $device = script_output 'ndctl create-namespace --force --mode=fsdax';
         ($device) = $device =~ /\"blockdev\":\"(pmem\d+)\"/;
         assert_script_run "test -b /dev/$device";
         assert_script_run "wipefs -a /dev/$device";


### PR DESCRIPTION
Newer versions of ndctl enforce `--map=dev` argument only when also using `--mode=devdax`. Also changed mode to `fsdax` as `memory` is not listed among the valid options.

- Related ticket: N/A
- Failing test: https://openqa.suse.de/tests/4921977#step/ndctl/7
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/4930772 (15-SP3 Build 63.1, Hana2 SPS04rev46), https://openqa.suse.de/t4925772 (15-SP3 Build 72.1, Hana2 SPS04rev46. Failure is unrelated to this PR)