### PR TITLE
Update path to HANA yast2 partitioning module

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -99,7 +99,7 @@ sub run {
     # Partition disks for Hana
     if (check_var('HANA_PARTITIONING_BY', 'yast')) {
         my $yast_partitioner = is_sle('15+') ? 'sap_create_storage_ng' : 'sap_create_storage';
-        assert_script_run "yast $yast_partitioner /usr/share/YaST2/include/sap-installation-wizard/hana_partitioning.xml", 120;
+        assert_script_run "yast $yast_partitioner /usr/share/YaST2/data/y2sap/hana_partitioning.xml", 120;
     }
     else {
         # If running on QEMU and with a second disk configured, then configure


### PR DESCRIPTION
In [bsc#1177392](https://bugzilla.suse.com/show_bug.cgi?id=1177392#c7) information for the new path to the YaST2 HANA partitioning XML file was provided.

This updates the path in the test.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/t5303593
