### PR TITLE
Increase wait time for displaymanager

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -26,7 +26,7 @@ sub run {
         assert_screen 'generic-desktop', 90;
     }
     else {
-        assert_screen [qw(linux-login displaymanager)], 200;
+        assert_screen [qw(linux-login displaymanager)], 300;
     }
     select_console 'root-console';
     # 1)


### PR DESCRIPTION
We need increase wait time to catch displaymanager on aarch64.

- Related ticket: https://progress.opensuse.org/issues/76834
- Needles: N/A
- Verification run: wait log on OSD.
                            http://openqa.nue.suse.com/tests/4930287#live
                            http://openqa.nue.suse.com/tests/4930288#live
