### PR TITLE
Add sle15_workarounds to nvme test

### DIFF
--- a/schedule/yast/nvme.yaml
+++ b/schedule/yast/nvme.yaml
@@ -26,6 +26,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/sle15_workarounds
   - console/nvme_checks
   - console/validate_fs_table
 test_data:


### PR DESCRIPTION
Scheduling this module we can fix the [issue in this scenario](https://openqa.suse.de/tests/4922123#step/nvme_checks/8): 
- Verification run: [nvme](https://openqa.suse.de/tests/4930696)
