### PR TITLE
Fix default target to multi-user on PowerVM

### DIFF
--- a/test_data/yast/minimal+role_minimal_pvm.yaml
+++ b/test_data/yast/minimal+role_minimal_pvm.yaml
@@ -1,4 +1,4 @@
 ---
 <<: !include test_data/yast/minimal+role_minimal_defaults.yaml
-default_target: graphical.target
+default_target: multi-user.target
 device: sda


### PR DESCRIPTION
Target is fixed at the end for ppc64le, so the expected result is similar to other archs, so we can revert recent change in test data which breaks [this minimal scenario](https://openqa.suse.de/tests/4921669#step/verify_default_target/5)
- Verification run: [minimal+role_minimal](https://openqa.suse.de/tests/4930756#step/verify_default_target/1)
