### PR TITLE
Microos: Add autoyast for aarch64

### DIFF
--- a/data/autoyast_sle15/autoyast_microos_50.xml
+++ b/data/autoyast_sle15/autoyast_microos_50.xml
@@ -12,7 +12,6 @@
       <timeout config:type="integer">-1</timeout>
       <hiddenmenu>false</hiddenmenu>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
   <general>
     <mode>

--- a/schedule/microos/suse_microos_autoyast.yaml
+++ b/schedule/microos/suse_microos_autoyast.yaml
@@ -3,7 +3,7 @@ description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE MicroOS tests
 vars:
-    AUTOYAST: autoyast_sle15/autoyast_microos_50_%ARCH%.xml
+    AUTOYAST: autoyast_sle15/autoyast_microos_50.xml
 schedule:
     - autoyast/prepare_profile
     - installation/bootloader_start

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -115,7 +115,7 @@ sub run {
     uefi_bootmenu_params;
     bootmenu_default_params;
     bootmenu_remote_target;
-    specific_bootmenu_params unless is_microos || is_jeos;
+    specific_bootmenu_params unless is_microos('opensuse') || is_jeos;
 
     # JeOS and MicroOS are never deployed with Linuxrc involved,
     # so 'regurl' does not apply there.


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/75340
- Verification run: [aarch64](https://openqa.suse.de/tests/4931769)  [64bit](https://openqa.suse.de/tests/4931768)  [64bit-uefi](https://openqa.suse.de/tests/4931798)

Need to set AUTOYAST_CONFIRM=0

