### PR TITLE
Boot from hard disk for migration test on uefi

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -656,7 +656,7 @@ sub wait_grub {
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";
         send_key "ret";
-        if (get_var('ONLINE_MIGRATION') && check_var('BOOTFROM', 'd')) {
+        if (is_upgrade && check_var('BOOTFROM', 'd')) {
             assert_screen 'inst-bootmenu';
             # Select boot from HDD
             send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';


### PR DESCRIPTION
Boot from hard disk for migration test on uefi
For uefi, it will start the system from installation. As our migration test need start system from hard disk. So change the boot sequence .

- Related ticket: https://progress.opensuse.org/issues/75397
- Verification run:
http://openqa.suse.de/tests/4934303
https://openqa.suse.de/tests/4934327