### PR TITLE
Add max_interval to avoid typing password loss in firefox_nss

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -89,9 +89,11 @@ sub run {
     x11_start_program('xterm');
     mouse_hide(1);
     type_string("firefox --setDefaultBrowser https://html5test.opensuse.org\n");
-    assert_screen("firefox-passowrd-typefield", 240);
-    type_string $fips_password;
-    assert_and_click "firefox-enter-password-OK";
+    assert_screen("firefox-passowrd-typefield", 120);
+
+    # Add max_interval while type password and extend time of click needle match
+    type_string($fips_password, max_interval => 2);
+    assert_and_click("firefox-enter-password-OK", 120);
     assert_screen("firefox-url-loaded", 20);
 
     # Firfox Preferences


### PR DESCRIPTION
**Description:**
Enhance the previous PR #11303, which still can happen password loss during the 2nd firefox launch in the new build sometimes. I've run 3 times and get passed in aarch64.

1. Add max_interval to avoid password loss in 2nd launch
2. Extend match timeout of assert click needle match

- Related ticket: https://progress.opensuse.org/issues/75283
- Needles: NA
- Verification run: 
  https://openqa.suse.de/tests/4934429 (aarch64)