### PR TITLE
xfstests: Add more info into log about kernel-default

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -43,7 +43,7 @@ sub log_create {
 
 sub collect_version {
     my $file = shift;
-    my $cmd  = "(rpm -qa xfsprogs xfsdump btrfsprogs kernel-default xfstests; uname -r) | tee $file";
+    my $cmd  = "(rpm -qa xfsprogs xfsdump btrfsprogs kernel-default xfstests; uname -r; rpm -qi kernel-default) | tee $file";
     script_run($cmd);
 }
 


### PR DESCRIPTION
It's not convenience for kernel developer to find kernel git tags when we report bug happened in which builds. Add this information in version related logs in xfstests.

- Refer to: https://bugzilla.suse.com/show_bug.cgi?id=1178381#c5
- Verification run: http://openqa.suse.de/tests/4934860
