### PR TITLE
Remove pv sf serialconsole

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -306,11 +306,6 @@ sub run {
         type_string "echo -en '\\033[B' > \$pty\n" for (1 .. $max);                                       # $max-times key down
         type_string "echo -en '\\033[K' > \$pty\n";                                                       # end of line
 
-        if (is_jeos && is_sle('>=15-sp2')) {
-            record_soft_failure('bsc#1175514 cannot login to rescue when JeOS image is loaded as xen pv domain');
-            type_string "echo -en '\\010' > \$pty\n" for (1 .. length('console=ttyS0,115200 console=tty0 quiet'));
-        }
-
         if (is_sle '12-SP2+') {
             type_string "echo -en ' xen-fbfront.video=32,1024,768 xen-kbdfront.ptr_size=1024,768' > \$pty\n";    # set kernel framebuffer
             type_string "echo -en ' console=hvc console=tty' > \$pty\n";                                         # set consoles


### PR DESCRIPTION
`kvm-and-xen` image hardcodes ttyS0 among kernel parameters in kiwi template which caused problems to `sulogin` when entering rescue mode. 

- Related ticket: [[Build 19.9] cannot login to rescue when JeOS image is loaded as xen pv domain](https://bugzilla.suse.com/show_bug.cgi?id=1175514)
- Verification runs: 
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build15.59-jeos-filesystem_xenpv@svirt-xen-pv](http://kepler.suse.cz/tests/2977#step/snapper_undochange/23)
   * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build20.194-jeos-filesystem_xenpv@svirt-xen-pv](http://kepler.suse.cz/tests/2974#step/snapper_undochange/23)