### PR TITLE
Fix check_interactive_flag for opensuse scenario

### DIFF
--- a/tests/console/check_interactive_flag.pm
+++ b/tests/console/check_interactive_flag.pm
@@ -27,7 +27,7 @@ sub run {
     $self->select_serial_terminal;
 
     # Get the maintenance updates of the corresponding packages
-    my $result = script_output q(zypper lp -a | grep -v 'zypper-' | awk '/libsolv/||/libzypp/||/zypper/||/PackageKit/ {print $3}');
+    my $result = script_output q(zypper lp -a | awk -F\| '(/libsolv/||/libzypp/||/zypper/||/PackageKit/) && !/zypper-/ { gsub(/ /,""); print $2}');
     my @patch_array = split ' ', $result;
 
     # Check that the creation date of the updates is after the year of 2020


### PR DESCRIPTION
Correction of the name repo search

- Related ticket: https://progress.opensuse.org/issues/76855
- Needles: N/A
- Verification run:  [opensuse-15.2-JeOS](https://openqa.opensuse.org/tests/1458837#step/check_interactive_flag/1) | [SLE 15-SP2](http://anna-openqa/tests/1478#step/check_interactive_flag/1)