### PR TITLE
Fix profile for zvm_sles_product_reg

### DIFF
--- a/data/autoyast_sle15/autoyast_sles_zvm.xml
+++ b/data/autoyast_sle15/autoyast_sles_zvm.xml
@@ -614,7 +614,6 @@
         <service>cio_ignore</service>
         <service>cron</service>
         <service>display-manager</service>
-        <service>iscsi</service>
         <service>issue-generator</service>
         <service>kbdsettings</service>
         <service>kdump-early</service>


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1177958 and
https://github.com/yast/patterns-yast/pull/31/files
The test (https://openqa.suse.de/tests/4921801) fails as open-iscsi is a dependency of yast2-iscsi-client
which used to be part of the yast2_basis pattern, but now part of
the yast2_server pattern

VR https://openqa.suse.de/tests/4941521# test is still broken, but not due to that iscsi missing anymore