### PR TITLE
Fix ant on aarch64

### DIFF
--- a/tests/console/ant.pm
+++ b/tests/console/ant.pm
@@ -95,9 +95,9 @@ sub run {
     assert_script_run "echo '$build_file_xml' >> build.xml";
 
     # Check that ant builds succesfully
-    assert_script_run "ant";
+    assert_script_run "ant --noconfig";
     # Check that ant runs the application succesfully
-    assert_script_run 'ant run| grep "Hello World"';
+    assert_script_run 'ant --noconfig run| grep "Hello World"';
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/71974
- Needles: No needles
- Verification runs: 
[SLE12-SP5 aarch64](https://openqa.suse.de/tests/4937600)|[SLE12-SP5 s390x](https://openqa.suse.de/tests/4937963)|[SLE12-SP5 x86_64](https://openqa.suse.de/tests/4937610)|[SLE12-SP4 x86_64](https://openqa.suse.de/tests/4937634)|[SLE12-SP3 x86_64](https://openqa.suse.de/tests/4937635)
