### PR TITLE
Make installed versions of HPC library packages remain installed after migration to new service pack

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -29,6 +29,7 @@ use services::apparmor;
 use services::dhcpd;
 use nfs_common;
 use services::registered_addons;
+use services::hpcpackage_remain;
 use services::ntpd;
 use services::cups;
 use services::rpcbind;
@@ -57,6 +58,12 @@ our %srv_check_results = (
 );
 
 our $default_services = {
+    hpcpackage_remain => {
+        srv_pkg_name       => 'hpcpackage_remain',
+        srv_proc_name      => 'hpcpackage_remain',
+        support_ver        => $support_ver_ge15,
+        service_check_func => \&services::hpcpackage_remain::full_pkgcompare_check
+    },
     registered_addons => {
         srv_pkg_name       => 'registered_addons',
         srv_proc_name      => 'registered_addons',
@@ -187,6 +194,8 @@ sub _is_applicable {
         record_soft_failure 'bsc#1163000 - System does not come back after crash on s390x';
         return 0;
     }
+    # This feature is used only by hpc
+    return 0 if ($srv_pkg_name eq 'hpcpackage_remain' && !check_var('SLE_PRODUCT', 'hpc'));
     if (get_var('EXCLUDE_SERVICES')) {
         my %excluded = map { $_ => 1 } split(/\s*,\s*/, get_var('EXCLUDE_SERVICES'));
         return 0 if $excluded{$srv_pkg_name};

--- a/lib/services/hpcpackage_remain.pm
+++ b/lib/services/hpcpackage_remain.pm
@@ -1,0 +1,86 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Make installed versions of HPC library packages remain
+# installed after migration to new service pack
+# Steps: 1.Install previous SP (SLE-HPC text mode profile)
+# 2. Make a list of installed packages ('rpm -qa')
+# 3. Install all 'library wrappers' (packages matching -hpc, not
+#    having a version number with '_' after their name).
+# 4. Make a list of installed packages and diff against list from 2.
+# 5. From the diff extract the list of HPC library packages (packages
+#    matching *-hpc*) with 'underscored' version numbers after the
+#    package name) and save this list.
+# 6. Perform a migration
+# 7. Confirm all packages in the list generated in 5. remain installed.
+# Maintainer: Yutao Wang <yuwang@suse.com>
+
+package services::hpcpackage_remain;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+use Data::Dumper;
+use warnings;
+
+my @diffpkg;
+
+sub list_pkg {
+    my ($name) = @_;
+    $name //= '';
+    my $pkg = script_output("rpm -qa | tee -a /tmp/$name", proceed_on_failure => 1, timeout => 180);
+    diag $pkg;
+}
+
+sub install_pkg {
+    my $version = get_var('HDDVERSION');
+    # Install all 'library wrappers' (packages matching -hpc, not having a version number with '_' after their name)
+    my @pkginstall = split('\n', script_output q[zypper search -r SLE-Module-HPC] . $version . q[-Pool -r SLE-Module-HPC] . $version . q[-Updates | cut -d '|' -f 2 | sed -e 's/ *//g' | grep -E '.*-hpc.*' | grep -vE 'system|module|suse' |  grep -vE '.*_[[:digit:]]+_[[:digit:]]+.*gnu|.*_[[:digit:]]+_[[:digit:]]+.*-hpc' | grep -vE '.*-static$' | grep -vE '.*hpc-macros.*'], proceed_on_failure => 1, timeout => 180);
+    diag @pkginstall;
+    for (my $i = 1; $i < @pkginstall; $i = $i + 1) {
+        zypper_call("in $pkginstall[$i]");
+    }
+}
+
+sub compare_pkg {
+    my ($list1, $list2) = @_;
+    $list1 //= '';
+    $list2 //= '';
+    # Make a list of installed packages and diff against list from installed packages
+    @diffpkg = split('\n', script_output("diff $list1 $list2 | grep -E '^>' | cut -d' ' -f2 |  grep -E '.*-hpc.*' |   grep -vE 'system|module|suse' |  grep -E '.*_[[:digit:]]+_[[:digit:]]+.*-gnu|.*_[[:digit:]]+_[[:digit:]]+.*-hpc' |  grep -vE '.*-static\$' | tee /tmp/diffpkg.txt", proceed_on_failure => 1, timeout => 180));
+}
+
+# Confirm all packages in the list generated remain installed
+sub check_pkg {
+    my @pkglist = split('\n', script_output("rpm -qa", proceed_on_failure => 1, timeout => 180));
+    my %hash_a  = map { $_ => 1 } @pkglist;
+    my %hash_b  = map { $_ => 1 } @diffpkg;
+    diag 'After: ' . Dumper(\@pkglist);
+    diag @diffpkg;
+    my @b_only = grep { !$hash_a{$_} } @diffpkg;
+    if (@b_only) {
+        die "After migration, some packages are miss: " . Dumper(\@b_only);
+    }
+}
+
+sub full_pkgcompare_check {
+    my ($stage) = @_;
+    $stage //= '';
+    if ($stage eq 'before') {
+        list_pkg("orignalq1w2.txt");
+        install_pkg();
+        list_pkg("installe3r4.txt");
+        compare_pkg("/tmp/orignalq1w2.txt", "/tmp/installe3r4.txt");
+    }
+    else {
+        check_pkg;
+    }
+}
+
+1;


### PR DESCRIPTION
Make installed versions of HPC library packages remain installed after migration to new service pack
Refer jira: https://jira.suse.com/browse/SLE-8608 to automatic test

- Related ticket: https://progress.opensuse.org/issues/71587
- Verification run: https://openqa.suse.de/tests/4940230
