### PR TITLE
Get guest console output by matching non-empty content directly

### DIFF
--- a/data/virt_autotest/guest_console_monitor.sh
+++ b/data/virt_autotest/guest_console_monitor.sh
@@ -55,50 +55,22 @@ local vmguest=$1
 
 expect -c "
 set timeout 60
-
-##hide echo
-log_user 0
-spawn -noecho virsh console ${vmguest}
+spawn virsh console ${vmguest}
 
 #wait connection
 sleep 3
 send \"\r\n\r\n\r\n\"
 
-#condition expect
-expect {
-        \"*login:\" {
-                send \"root\r\"
-                exp_continue
-        }
-        -nocase \"password:\" {
-                send \"novell\r\"
-                exp_continue
-        }
-        \"*:~ #\" {
-                send -- \"ip route get 1\r\"
-        }
-        timeout {
-                send -- \"exit\r\"
-                exp_continue        
-        }                 
-}
-
 ## -1 means never timeout
 set timeout -1
 
-expect -re {dev.*\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})[^0-9]}
-
-if {![info exists expect_out(1,string)]} {
-        puts \"Match did not happen :(\"
+#Match non-empty output
+expect \".*\S.*\" {set output \$expect_out(buffer);puts \"\$output\n\";exp_continue -continue_timer}
 }
-set output \$expect_out(buffer)
-expect eof
-
-puts \"\$output\"
 "
-
 }
 
+#Please use "cat path_to_guest_console_log" to view pretty guest console output. Text editor may just show raw characters.
 function open_console() {
 
     #open guest console


### PR DESCRIPTION
* **Actually** there is no need to do login and typing something inside guest console which may introduce unnecessary waste in terms of both time and log content
* **Constant** guest console output collection by matching non-empty output directly is enough to guarantee entirety and integrity
* **Modification** is limited to embedded expect script that is responsible for guest console connecting and output matching and collecting. So there will be no impact on original design structure
* **Related ticket:** n/a
* **Needles:** n/a
* **Verification run:**
  * [Manual verify guest_console_monitor.sh can resume console output collection even when fv guest reboots, namely console connection is lost](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5486598/sles-15-sp2-64-fv-def-net_console.log)
  * [Manual verify guest_console_monitor.sh can resume console output collection even when pv guest reboots, namely console connection is lost](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5486599/sles-15-sp2-64-pv-def-net_console.log)
  * [openQA test when test fails with guest log collection via ssh](http://10.67.129.106/tests/517/file/storage2%231-virt_logs_all.tar.gz)
  * [openQA test when test fails with guest log collection via guest console](http://10.67.129.106/tests/515/file/storage2%231-virt_logs_all.tar.gz)
  (Please use "cat path_to_guest_console_log" to view pretty  guest console output.)