### PR TITLE
Unify install-shell selection for pvm_hmc backend

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -684,7 +684,7 @@ sub activate_console {
     my ($self, $console, %args) = @_;
 
     # Select configure serial and redirect to root-ssh instead
-    return use_ssh_serial_console if (get_var('BACKEND', '') =~ /ikvm|ipmi|spvm|pvm_hmc/ && $console =~ m/root-console$|install-shell|log-console/);
+    return use_ssh_serial_console if (get_var('BACKEND', '') =~ /ikvm|ipmi|spvm|pvm_hmc/ && $console =~ m/^(root-console|install-shell|log-console)$/);
     if ($console eq 'install-shell') {
         if (get_var("LIVECD")) {
             # LIVE CDa do not run inst-consoles as started by inst-linux (it's regular live run, auto-starting yast live installer)
@@ -838,7 +838,7 @@ configure a timeout value different than default.
 =cut
 sub console_selected {
     my ($self, $console, %args) = @_;
-    if ((exists $testapi::testapi_console_proxies{'root-ssh'}) && $console eq 'root-console') {
+    if ((exists $testapi::testapi_console_proxies{'root-ssh'}) && $console =~ m/^(root-console|install-shell|log-console)$/) {
         $console = 'root-ssh';
         my $ret = query_isotovideo('backend_select_console', {testapi_console => $console});
         die $ret->{error} if $ret->{error};

--- a/tests/console/validate_encrypted_partition_not_activated.pm
+++ b/tests/console/validate_encrypted_partition_not_activated.pm
@@ -23,7 +23,7 @@ use Utils::Backends 'use_ssh_serial_console';
 
 sub run {
     my $enc_disk_part = get_test_suite_data()->{enc_disk_part};
-    check_var('BACKEND', 'pvm_hmc') ? use_ssh_serial_console : select_console 'install-shell';
+    select_console 'install-shell';
     verify_locked_encrypted_partition($enc_disk_part);
     select_console 'installation';
 }

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -43,7 +43,7 @@ sub run {
     }
     # while technically SUT has a different network than the BMC
     # we require ssh installation anyway
-    if (get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/) {
+    if (get_var('BACKEND', '') =~ /ipmi|spvm/) {
         use_ssh_serial_console;
         # set serial console for xen
         set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));


### PR DESCRIPTION
There was a problem if we call `install-shell` twice on powerVM, as it
would use `root-ssh` under the hood, but second call would not set
console correctly and switching would fails.

With this patch, we now can call `install-shell` selection
unconditionally for powerVM, and have same test code as for other
backends.

NOTE: we don't see failures for `log-console` selection as it's never called twice, but only once if tests fails or when we collect logs after the installation, whereas it would face exactly same issue as in case of `install-shell`.

See [poo#69406](https://progress.opensuse.org/issues/69406).

## Verification runs
* [validate_encrypted_partition_not_activated](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23yast&version=15-SP3&distri=sle&modules=validate_encrypted_partition_not_activated).
* [ssh-x](https://openqa.suse.de/tests/4941679#)
* [ext4](https://openqa.suse.de/tests/4941697)

