### PR TITLE
Adjust modules to host opensuse based test with SLE base container

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -21,8 +21,10 @@ use utils;
 use strict;
 use warnings;
 use version_utils;
+use containers::utils 'can_build_sle_base';
+use containers::common 'test_image_zyp_ref_and_verify';
 
-our @EXPORT = qw(build_container_image build_with_zypper_docker build_with_sle2docker test_opensuse_based_image exec_on_container);
+our @EXPORT = qw(build_container_image build_with_zypper_docker build_with_sle2docker test_suse_based_image exec_on_container);
 
 # Build any container image using a basic Dockerfile
 sub build_container_image {
@@ -86,7 +88,13 @@ sub build_with_zypper_docker {
 
 
     record_info("Testing derived");
-    test_opensuse_based_image(image => $derived_image, runtime => $runtime);
+    test_suse_based_image(image => $derived_image, runtime => $runtime);
+}
+
+sub test_suse_based_image {
+    my %args   = @_;
+    my $distri = $args{distri} //= get_required_var("DISTRI");
+    $distri eq 'sle' ? test_sle_based_image(%args) : test_opensuse_based_image(%args);
 }
 
 # Testing openSUSE based images
@@ -95,7 +103,6 @@ sub test_opensuse_based_image {
     my $image   = $args{image};
     my $runtime = $args{runtime};
 
-    my $distri  = $args{distri}  //= get_required_var("DISTRI");
     my $version = $args{version} //= get_required_var("VERSION");
 
     die 'Argument $image not provided!'   unless $image;
@@ -103,33 +110,35 @@ sub test_opensuse_based_image {
 
     $version = 'Tumbleweed' if ($version =~ /^Staging:/);
 
-    # It is the right version
-    if ($distri eq 'sle') {
-        my $pretty_version = $version =~ s/-SP/ SP/r;
-        my $betaversion    = get_var('BETA') ? '\s\([^)]+\)' : '';
-        record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
-        validate_script_output("$runtime container run --entrypoint '/bin/bash' --rm $image -c 'grep PRETTY_NAME /etc/os-release' | cut -d= -f2",
-            sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
+    $version =~ s/^Jump://i;
+    validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
+    test_image_zyp_ref_and_verify($image, $runtime);
+}
 
+# Testing sle based images
+sub test_sle_based_image {
+    my %args    = @_;
+    my $image   = $args{image};
+    my $runtime = $args{runtime};
+
+    my $version = $args{version} //= get_required_var("VERSION");
+
+    die 'Argument $image not provided!'   unless $image;
+    die 'Argument $runtime not provided!' unless $runtime;
+
+    my $pretty_version = $version =~ s/-SP/ SP/r;
+    my $betaversion    = get_var('BETA') ? '\s\([^)]+\)' : '';
+    record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
+    validate_script_output("$runtime container run --entrypoint '/bin/bash' --rm $image -c 'grep PRETTY_NAME /etc/os-release' | cut -d= -f2",
+        sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
+
+    if (can_build_sle_base($image)) {
         my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
         assert_script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin -v'";
         script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lp'", 420;
         script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lm'", 420;
-    } else {
-        $version =~ s/^Jump://i;
-        validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
+        test_image_zyp_ref_and_verify($image, $runtime);
     }
-
-    # zypper lr
-    assert_script_run("$runtime run --rm $image zypper lr -s", 120);
-    # zypper ref
-    assert_script_run("$runtime run --name refreshed $image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
-    # Commit the image
-    assert_script_run("$runtime commit refreshed refreshed-image", 120);
-    # Remove it
-    assert_script_run("$runtime rm refreshed", 120);
-    # Verify the image works
-    assert_script_run("$runtime run --rm refreshed-image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
 }
 
 sub exec_on_container {

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use version_utils;
 
-our @EXPORT = qw(test_seccomp basic_container_tests set_up get_vars build_img test_built_img);
+our @EXPORT = qw(test_seccomp basic_container_tests set_up get_vars build_img test_built_img can_build_sle_base);
 
 sub test_seccomp {
     my $no_seccomp = script_run('docker info | tee /tmp/docker_info.txt | grep seccomp');
@@ -177,6 +177,22 @@ sub test_built_img {
     assert_script_run("$runtime ps -a");
     script_retry('curl http://localhost:8888/ | grep "Networking test shall pass"', delay => 5, retry => 6);
     assert_script_run("rm -rf /root/templates");
+}
+
+=head2 can_build_sle_base
+
+C<can_build_sle_base> should be used to identify if sle base image runs against a
+system that it does not support registration and SUSEConnect.
+In this case the build of the container engine is not going to work as the base images
+lacks of the repos.
+
+The call should return false if you try to test sle base container on osd but host is not sle
+true otherwise.
+
+=cut
+sub can_build_sle_base {
+    my $has_sle_registration = script_run("test -e /etc/zypp/credentials.d/SCCcredentials");
+    return check_os_release('sles', 'ID') && $has_sle_registration;
 }
 
 1;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -577,7 +577,7 @@ sub get_os_release {
     my ($go_to_target, $os_release_file) = @_;
     $go_to_target    //= '';
     $os_release_file //= '/etc/os-release';
-    my %os_release = script_output("$go_to_target cat $os_release_file") =~ /^(\S+)="?([^"\r\n]+)"?$/gm;
+    my %os_release = script_output("$go_to_target cat $os_release_file") =~ /^([^#]\S+)="?([^"\r\n]+)"?$/gm;
     %os_release = map { uc($_) => $os_release{$_} } keys %os_release;
     my ($os_version, $os_service_pack) = split(/\.|-sp/i, $os_release{VERSION});
     $os_service_pack //= 0;

--- a/schedule/containers/sle_image_on_opensuse_host.yaml
+++ b/schedule/containers/sle_image_on_opensuse_host.yaml
@@ -1,0 +1,7 @@
+name:           sle_image_on_opensuse_host
+description:    >
+    Test for SLE base image in opensuse
+schedule:
+    - boot/boot_to_desktop
+    - containers/host_configuration
+    - containers/docker_image

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -23,6 +23,7 @@ use Mojo::Base qw(consoletest);
 use testapi;
 use utils;
 use containers::common;
+use containers::utils 'can_build_sle_base';
 use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
@@ -30,25 +31,28 @@ use version_utils qw(get_os_release check_os_release);
 sub run {
     my ($image_names, $stable_names) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $runtime = "docker";
-
-    install_docker_when_needed($host_distri);
-    allow_selected_insecure_registries(runtime => $runtime);
+    my $container_engine  = "docker";
+    my $is_build_possible = can_build_sle_base($image_names);
+    install_docker_when_needed($host_distri, $is_build_possible);
+    allow_selected_insecure_registries(runtime => $container_engine);
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
     for my $iname (@{$image_names}) {
-        test_container_image(image => $iname, runtime => $runtime);
-        build_container_image(image => $iname, runtime => $runtime);
+        record_info 'image name', '$iname';
+        test_container_image(image => $iname, runtime => $container_engine);
+        build_container_image(image => $iname, runtime => $container_engine) if can_build_sle_base($iname);
+
         if (check_os_release('suse', 'PRETTY_NAME')) {
-            test_opensuse_based_image(image => $iname, runtime => $runtime);
-            build_with_zypper_docker(image => $iname, runtime => $runtime);
+            test_suse_based_image(image => $iname, runtime => $container_engine);
+            build_with_zypper_docker(image => $iname, runtime => $container_engine) if can_build_sle_base($iname);
         }
         else {
-            exec_on_container($iname, $runtime, 'cat /etc/os-release');
+            #TODO this is repeated in other places.
+            exec_on_container($iname, $container_engine, 'cat /etc/os-release');
         }
     }
     scc_restore_docker_image_credentials();
-    clean_container_host(runtime => $runtime);
+    clean_container_host(runtime => $container_engine);
 }
 
 1;

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -19,24 +19,26 @@ use containers::common;
 use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
+use containers::utils 'can_build_sle_base';
 
 sub run {
     my ($image_names, $stable_names) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $runtime = "podman";
-    install_podman_when_needed($host_distri);
-    allow_selected_insecure_registries(runtime => $runtime);
+    my $container_engine  = "podman";
+    my $is_build_possible = can_build_sle_base($image_names);
+    install_podman_when_needed($host_distri, $is_build_possible);
+    allow_selected_insecure_registries(runtime => $container_engine);
     for my $iname (@{$image_names}) {
-        test_container_image(image => $iname, runtime => $runtime);
-        build_container_image(image => $iname, runtime => $runtime);
+        test_container_image(image => $iname, runtime => $container_engine);
+        build_container_image(image => $iname, runtime => $container_engine) if can_build_sle_base($iname);
         if (check_os_release('suse', 'PRETTY_NAME')) {
-            test_opensuse_based_image(image => $iname, runtime => $runtime);
+            test_suse_based_image(image => $iname, runtime => $container_engine);
         }
         else {
-            exec_on_container($iname, $runtime, 'cat /etc/os-release');
+            exec_on_container($iname, $container_engine, 'cat /etc/os-release');
         }
     }
-    clean_container_host(runtime => $runtime);
+    clean_container_host(runtime => $container_engine);
 }
 
 1;


### PR DESCRIPTION
Small adjustment for os that does not support SLE base image. Because the
limitations we cannot run as we do for SLE systems.
We treat this case as we did with ubuntu and Centos
but I think we need to improve the aproach here.
I adjusted also the regex of get_os_release as it breaks the mapping when a
variable is commented out (starts with #).
For the base operating system i used the opensuse-15.2-x86_64-695.1-textmode
which is the GM Leap.


- Related ticket: https://progress.opensuse.org/issues/76771
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- [Verification run](http://aquarius.suse.cz/tests/3882#details)
[OSD](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2311351&version=15-SP3&distri=sle)
[o3](https://openqa.opensuse.org/tests/1467890#details) 