### PR TITLE
Wicked basic wlan

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -20,6 +20,7 @@ use network_utils qw(iface setup_static_network);
 use serial_terminal;
 use main_common 'is_updates_tests';
 use repo_tools 'generate_version';
+use registration qw(add_suseconnect_product);
 
 sub run {
     my ($self, $ctx) = @_;
@@ -126,6 +127,10 @@ sub run {
             $repo_url = 'http://download.suse.de/ibs/home:/wicked-maintainers:/openQA/' if (is_sle());
             zypper_ar($repo_url . generate_version('_') . '/', name => 'wicked_maintainers', no_gpg_check => 1, priority => 60);
             $package_list .= ' ndisc6';
+        }
+        if (check_var('WICKED', 'wlan')) {
+            add_suseconnect_product('PackageHub');
+            $package_list .= ' iw hostapd wpa_supplicant';
         }
         $package_list .= ' openvswitch iputils';
         $package_list .= ' libteam-tools libteamdctl0 ' if check_var('WICKED', 'advanced') || check_var('WICKED', 'aggregate');

--- a/tests/wicked/wlan/sut/t00_prepare.pm
+++ b/tests/wicked/wlan/sut/t00_prepare.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Wifi preparation
+# Maintainer: cfamullaconrad@suse.com
+
+
+use Mojo::Base 'wickedbase';
+use testapi;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    assert_script_run('modprobe mac80211_hwsim radios=2');
+    assert_script_run('ip netns add wifi_master');
+    assert_script_run('ip netns list');
+    assert_script_run('iw dev');
+    assert_script_run('iw phy phy0 set netns name wifi_master');
+    assert_script_run('iw dev');
+    assert_script_run('ip netns exec wifi_master iw dev');
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/tests/wicked/wlan/sut/t03_wpa_psk.pm
+++ b/tests/wicked/wlan/sut/t03_wpa_psk.pm
@@ -1,0 +1,73 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Wifi preparation
+# Maintainer: cfamullaconrad@suse.com
+
+
+use Mojo::Base 'wickedbase';
+use testapi;
+use utils qw(zypper_call);
+use registration qw(add_suseconnect_product);
+use serial_terminal;
+
+sub run {
+    my $self = shift;
+
+    $self->select_serial_terminal;
+    assert_script_run('ip netns exec wifi_master iw dev');
+    assert_script_run('ip netns exec wifi_master ip addr add dev wlan0 10.6.6.1/24');
+
+    script_output(<<END_OF_STRING);
+cat > hostapd.conf << 'EOT'
+ctrl_interface=/var/run/hostapd
+interface=wlan0
+driver=nl80211
+country_code=DE
+ssid=Virtual Wifi
+channel=0
+hw_mode=b
+wpa=3
+wpa_key_mgmt=WPA-PSK
+wpa_pairwise=TKIP CCMP
+wpa_passphrase=TopSecretWifiPassphrase
+auth_algs=3
+beacon_int=100
+EOT
+END_OF_STRING
+    assert_script_run('ip netns exec wifi_master hostapd -B hostapd.conf');
+
+
+    assert_script_run('iw dev');
+
+    script_output(<<END_OF_STRING);
+cat > /etc/sysconfig/network/ifcfg-wlan1 << 'EOT'
+STARTMODE='auto'
+
+BOOTPROTO='static'
+IPADDR='10.6.6.2'
+NETMASK='255.255.255.0'
+
+WIRELESS_MODE='Managed'
+WIRELESS_AUTH_MODE='psk'
+WIRELESS_ESSID='Virtual Wifi'
+WIRELESS_WPA_PSK='TopSecretWifiPassphrase'
+EOT
+END_OF_STRING
+
+    $self->wicked_command('ifup', 'wlan1');
+
+    assert_script_run('ip netns exec wifi_master hostapd_cli all_sta');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Based on the ideas of https://www.suse.com/c/creating-virtual-wlan-interfaces/
we will create a simple wlan testsuite for wicked.

This first test is using WPA_PSK with TKIP and CCMP.

- Related ticket: https://progress.opensuse.org/issues/66102
- Verification run: http://openqa.wicked.suse.de/t3579

There are already existing WIFI tests in openqa:
1) https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/console/wpa_supplicant.pm
2) https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/x11/network/NM_wpa2_enterprise.pm
which we need to consider and maybe consolidate.