### PR TITLE
Fix SUSEConnect and zypper service on 12.3 SLE based container image

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -77,7 +77,7 @@ sub install_docker_when_needed {
             }
             else {
                 if (is_sle() && script_run("SUSEConnect --status-text | grep Containers") != 0) {
-                    add_suseconnect_product("sle-module-containers");
+                    is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
                 }
 
                 # docker package can be installed

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -109,15 +109,10 @@ sub test_opensuse_based_image {
         validate_script_output("$runtime container run --entrypoint '/bin/bash' --rm $image -c 'grep PRETTY_NAME /etc/os-release' | cut -d= -f2",
             sub { /"SUSE Linux Enterprise Server $pretty_version"/ });
 
-        if (is_sle('=12-SP3', $version)) {
-            my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect';
-            assert_script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin'";
-        } else {
-            my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
-            assert_script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin -v'";
-            script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lp'", 420;
-            script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lm'", 420;
-        }
+        my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
+        assert_script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin -v'";
+        script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lp'", 420;
+        script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lm'", 420;
     } else {
         $version =~ s/^Jump://i;
         validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };


### PR DESCRIPTION
1) The suseconnect container extension uri for sle12 is always 12 (sle-module-containers/12/x86_64). Found in #11298 
2) SUSEConnect zypper service on SLE12-SP3 is now `container-suseconnect-zypp` instead of `container-suseconnect`.

- Related ticket: [poo#77152](https://progress.opensuse.org/issues/77152) [poo#77212](https://progress.opensuse.org/issues/77212)
- Verification run: **[12.3](http://pdostal-server.suse.cz/tests/10319)** [12.4](http://pdostal-server.suse.cz/tests/10317) [12.5](http://pdostal-server.suse.cz/tests/10316) [15](http://pdostal-server.suse.cz/tests/10315) [15.1](http://pdostal-server.suse.cz/tests/10314) [15.2](http://pdostal-server.suse.cz/tests/10313)
