### PR TITLE
firewalld: Add support for nftables

### DIFF
--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -38,47 +38,64 @@ sub test1 {
 # Test #2 - Temporary Rules
 sub test2 {
     record_info 'Test #2', 'Test Temporary Rules';
-    assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | wc -l > /tmp/nr_in_public.txt");
+        assert_script_run("nft list chain inet firewalld filter_FWDI_public | wc -l > /tmp/nr_fwdi_public.txt");
+    }
+    else {
+        assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+    }
+
+    assert_script_run("firewall-cmd --zone=public --add-port=25/tcp");
+    assert_script_run("firewall-cmd --zone=public --add-service=pop3");
+    assert_script_run("firewall-cmd --zone=public --add-protocol=icmp");
+    assert_script_run("firewall-cmd --zone=public --add-port=2000-3000/udp");
 
     # Check if it's tumbleweed or Leap/SLE and run the correct test accordingly
-    if (is_tumbleweed || is_sle('15-SP3+')) {
-        assert_script_run("firewall-cmd --zone=public --add-port=25/tcp");
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 25");
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 110");
+        assert_script_run("nft list chain inet firewalld filter_FWDI_public | grep icmp");
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 2000-3000");
+    }
+    elsif (is_sle('15-SP3+')) {
         assert_script_run("iptables -C IN_public_allow -p tcp --dport 25 -m conntrack --ctstate NEW,UNTRACKED -j ACCEPT");
-
-        assert_script_run("firewall-cmd --zone=public --add-service=pop3");
         assert_script_run("iptables -C IN_public_allow -p tcp --dport 110 -m conntrack --ctstate NEW,UNTRACKED -j ACCEPT");
-
-        assert_script_run("firewall-cmd --zone=public --add-protocol=icmp");
         assert_script_run("iptables -C IN_public_allow -p icmp -m conntrack --ctstate NEW,UNTRACKED -j ACCEPT");
-
-        assert_script_run("firewall-cmd --zone=public --add-port=2000-3000/udp");
         assert_script_run("iptables -C IN_public_allow -p udp --dport 2000:3000 -m conntrack --ctstate NEW,UNTRACKED -j ACCEPT");
     }
     else {
-        assert_script_run("firewall-cmd --zone=public --add-port=25/tcp");
         assert_script_run("iptables -C IN_public_allow -p tcp --dport 25 -m conntrack --ctstate NEW -j ACCEPT");
-
-        assert_script_run("firewall-cmd --zone=public --add-service=pop3");
         assert_script_run("iptables -C IN_public_allow -p tcp --dport 110 -m conntrack --ctstate NEW -j ACCEPT");
-
-        assert_script_run("firewall-cmd --zone=public --add-protocol=icmp");
         assert_script_run("iptables -C IN_public_allow -p icmp -m conntrack --ctstate NEW -j ACCEPT");
-
-        assert_script_run("firewall-cmd --zone=public --add-port=2000-3000/udp");
         assert_script_run("iptables -C IN_public_allow -p udp --dport 2000:3000 -m conntrack --ctstate NEW -j ACCEPT");
     }
 
     # Reload default configuration
     record_info 'Reload default configuration';
     assert_script_run("firewall-cmd --reload");
-    assert_script_run("if [ `iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+
+    if (is_tumbleweed) {
+        assert_script_run("if [ `nft list chain inet firewalld filter_IN_public_allow | wc -l` -eq `cat /tmp/nr_in_public.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+        assert_script_run("if [ `nft list chain inet firewalld filter_FWDI_public | wc -l` -eq `cat /tmp/nr_fwdi_public.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
+    else {
+        assert_script_run("if [ `iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
 }
 
 # Test #3 - Test Permanent Rules
 sub test3 {
     # Test Permanent Rules
     record_info 'Test #3', 'Test Permanent Rules';
-    assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | wc -l > /tmp/nr_in_public.txt");
+        assert_script_run("nft list chain inet firewalld filter_FWDI_public | wc -l > /tmp/nr_fwdi_public.txt");
+    }
+    else {
+        assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+    }
 
     assert_script_run("firewall-cmd --zone=public --permanent --add-port=25/tcp");
     assert_script_run("firewall-cmd --zone=public --permanent --add-service=pop3");
@@ -88,7 +105,13 @@ sub test3 {
     assert_script_run("firewall-cmd --reload");
 
     # Check if it's tumbleweed or Leap/SLE and run the correct test accordingly
-    if (is_tumbleweed || is_sle('15-SP3+')) {
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 25");
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 110");
+        assert_script_run("nft list chain inet firewalld filter_FWDI_public | grep icmp");
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 2000-3000");
+    }
+    elsif (is_sle('15-SP3+')) {
         assert_script_run("iptables -C IN_public_allow -p tcp --dport 25 -m conntrack --ctstate NEW,UNTRACKED -j ACCEPT");
         assert_script_run("iptables -C IN_public_allow -p tcp --dport 110 -m conntrack --ctstate NEW,UNTRACKED -j ACCEPT");
         assert_script_run("iptables -C IN_public_allow -p icmp -m conntrack --ctstate NEW,UNTRACKED -j ACCEPT");
@@ -108,47 +131,93 @@ sub test3 {
     assert_script_run("firewall-cmd --zone=public --permanent --remove-protocol=icmp");
     assert_script_run("firewall-cmd --zone=public --permanent --remove-port=2000-3000/udp");
     assert_script_run("firewall-cmd --reload");
-    assert_script_run("if [ `iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
 
+    if (is_tumbleweed) {
+        assert_script_run("if [ `nft list chain inet firewalld filter_IN_public_allow | wc -l` -eq `cat /tmp/np_in_public.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+        assert_script_run("if [ `nft list chain inet firewalld filter_FWDI_public | wc -l` -eq `cat /tmp/nr_fwdi_public.txt´ ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
+    else {
+        assert_script_run("if [ `iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
 }
 
 # Test #4 - Test Rules using Masquerading
 sub test4 {
     record_info 'Test #4', 'Test Rules using Masquerading';
-    assert_script_run("iptables -t nat -L PRE_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_pre.txt");
-    assert_script_run("iptables -t nat -L POST_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_post.txt");
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain ip firewalld nat_PRE_public_allow | wc -l > /tmp/nr_rules_nat_pre.txt");
+        assert_script_run("nft list chain ip firewalld nat_POST_public_allow | wc -l > /tmp/nr_rules_nat_post.txt");
+    }
+    else {
+        assert_script_run("iptables -t nat -L PRE_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_pre.txt");
+        assert_script_run("iptables -t nat -L POST_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_post.txt");
+    }
 
     assert_script_run("firewall-cmd --zone=public --add-masquerade");
     assert_script_run("firewall-cmd --zone=public --add-forward-port=port=2222:proto=tcp:toport=22");
-    assert_script_run("iptables -t nat -L PRE_public_allow | grep 'to::22'");
-    assert_script_run("iptables -t nat -L POST_public_allow | grep MASQUERADE");
+
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain ip firewalld nat_PRE_public_allow | grep 'redirect to :22'");
+        assert_script_run("nft list chain ip firewalld nat_POST_public_allow | grep masquerade");
+    }
+    else {
+        assert_script_run("iptables -t nat -L PRE_public_allow | grep 'to::22'");
+        assert_script_run("iptables -t nat -L POST_public_allow | grep MASQUERADE");
+    }
 
     # Reload default configuration
     record_info 'Reload default configuration';
     assert_script_run("firewall-cmd --reload");
-    assert_script_run("if [ `iptables -t nat -L PRE_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_nat_pre.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
-    assert_script_run("if [ `iptables -t nat -L POST_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_nat_post.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
+
+    if (is_tumbleweed) {
+        assert_script_run("if [ `nft list chain ip firewalld nat_PRE_public_allow | wc -l` -eq `cat /tmp/nr_rules_nat_pre.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+        assert_script_run("if [ `nft list chain ip firewalld nat_POST_public_allow | wc -l` -eq `cat /tmp/nr_rules_nat_post.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
+    else {
+        assert_script_run("if [ `iptables -t nat -L PRE_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_nat_pre.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
+        assert_script_run("if [ `iptables -t nat -L POST_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_nat_post.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
 }
 
 # Test #5 - Test ipv4 family addresses with rich rules
 sub test5 {
     record_info 'Test #5", "Test ipv4 family addresses with rich rules';
-    assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_allow.txt");
-    assert_script_run("iptables -L IN_public_deny --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_deny.txt");
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | wc -l > /tmp/nr_rules_allow.txt");
+        assert_script_run("nft list chain inet firewalld filter_IN_public_deny | wc -l > /tmp/nr_rules_deny.txt");
+    }
+    else {
+        assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_allow.txt");
+        assert_script_run("iptables -L IN_public_deny --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_deny.txt");
+    }
 
     assert_script_run("firewall-cmd --zone=public --permanent --add-rich-rule 'rule family=\"ipv4\" source address=192.168.200.0/24 accept'");
     assert_script_run("firewall-cmd --zone=public --permanent --add-rich-rule 'rule family=\"ipv4\" source address=192.168.201.0/24 drop'");
     assert_script_run("firewall-cmd --reload");
-    assert_script_run("iptables -C IN_public_allow -s 192.168.200.0/24 -j ACCEPT");
-    assert_script_run("iptables -C IN_public_deny -s 192.168.201.0/24 -j DROP");
+
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 192.168.200.0/24");
+        assert_script_run("nft list chain inet firewalld filter_IN_public_deny | grep 192.168.201.0/24");
+    }
+    else {
+        assert_script_run("iptables -C IN_public_allow -s 192.168.200.0/24 -j ACCEPT");
+        assert_script_run("iptables -C IN_public_deny -s 192.168.201.0/24 -j DROP");
+    }
 
     # Reload default configuration and flush rules
     record_info 'Remove rules used during the test and reload default configuration';
     assert_script_run("firewall-cmd --zone=public --permanent --remove-rich-rule 'rule family=\"ipv4\" source address=192.168.200.0/24 accept'");
     assert_script_run("firewall-cmd --zone=public --permanent --remove-rich-rule 'rule family=\"ipv4\" source address=192.168.201.0/24 drop'");
     assert_script_run("firewall-cmd --reload");
-    assert_script_run("if [ `iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_allow.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
-    assert_script_run("if [ `iptables -L IN_public_deny --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_deny.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
+
+    if (is_tumbleweed) {
+        assert_script_run("if [ `nft list chain inet firewalld filter_IN_public_allow | wc -l` -eq `cat /tmp/nr_rules_allow.txt´ ]; then /usr/bin/true; else /usr/bin/false; fi");
+        assert_script_run("if [ `nft list chain inet firewalld filter_IN_public_deny | wc -l` -eq `cat /tmp/nr_rules_deny.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
+    else {
+        assert_script_run("if [ `iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_allow.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
+        assert_script_run("if [ `iptables -L IN_public_deny --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_deny.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
 }
 
 # Test #6 - Change the default zone
@@ -164,11 +233,19 @@ sub test6 {
 # Test #7 - Create a rule using --timeout and verifying if the rule vanishes after the specified period
 sub test7 {
     record_info 'Test #7', 'Create a rule using timeout';
-    assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | wc -l > /tmp/nr_rules.txt");
+    }
+    else {
+        assert_script_run("iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules.txt");
+    }
 
     assert_script_run("firewall-cmd --zone=public --add-service=smtp --timeout=30");
 
-    if (is_tumbleweed || is_sle('15-SP3+')) {
+    if (is_tumbleweed) {
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 25");
+    }
+    elsif (is_sle('15-SP3+')) {
         assert_script_run("iptables -C IN_public_allow -p tcp --dport 25 -m conntrack --ctstate NEW,UNTRACKED -j ACCEPT");
     }
     else {
@@ -176,7 +253,12 @@ sub test7 {
     }
 
     assert_script_run("sleep 35");
-    assert_script_run("if [ `iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
+    if (is_tumbleweed) {
+        assert_script_run("if [ `nft list chain inet firewalld filter_IN_public_allow | wc -l` -eq `cat /tmp/nr_rules.txt` ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
+    else {
+        assert_script_run("if [ `iptables -L IN_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules.txt`  ]; then /usr/bin/true; else /usr/bin/false; fi");
+    }
 
 }
 


### PR DESCRIPTION
This change prepares firewalld tests for the change of backend from
iptables to nftables. For Tumbleweed, nftables chains are being checked
instead of iptables rules.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>