### PR TITLE
Containers: Soft fail when pulling container images from docker.io

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -50,10 +50,10 @@ sub basic_container_tests {
     #   - pull minimalistic alpine image of declared version using tag
     #   - https://store.docker.com/images/alpine
     my $alpine_image_version = '3.6';
-    assert_script_run("$runtime image pull alpine:$alpine_image_version", timeout => 300);
+    record_soft_failure('poo#76993') if (script_run("$runtime image pull alpine:$alpine_image_version", timeout => 300) != 0);
     #   - pull typical docker demo image without tag. Should be latest.
     #   - https://store.docker.com/images/hello-world
-    assert_script_run("$runtime image pull hello-world", timeout => 300);
+    record_soft_failure('poo#76993') if (script_run("$runtime image pull hello-world", timeout => 300) != 0);
     #   - pull image of last released version of openSUSE Leap
     if (!check_var('ARCH', 's390x')) {
         assert_script_run("$runtime image pull opensuse/leap", timeout => 600);
@@ -67,9 +67,9 @@ sub basic_container_tests {
     # Local images can be listed
     assert_script_run("$runtime image ls none");
     #   - filter with tag
-    assert_script_run(qq{$runtime image ls alpine:$alpine_image_version | grep "alpine\\s*$alpine_image_version"});
+    record_soft_failure('poo#76993') if (script_run(qq{$runtime image ls alpine:$alpine_image_version | grep "alpine\\s*$alpine_image_version"}) != 0);
     #   - filter without tag
-    assert_script_run(qq{$runtime image ls hello-world | grep "hello-world\\s*latest"});
+    record_soft_failure('poo#76993') if (script_run(qq{$runtime image ls hello-world | grep "hello-world\\s*latest"}) != 0);
     #   - all local images
     my $local_images_list = script_output("$runtime image ls");
     die("$runtime image opensuse/tumbleweed not found") unless ($local_images_list =~ /opensuse\/tumbleweed\s*latest/);
@@ -79,11 +79,11 @@ sub basic_container_tests {
     #   - using 'run'
     assert_script_run("$runtime container run --name test_1 hello-world | grep 'Hello from Docker\!'");
     #   - using 'create', 'start' and 'logs' (background container)
-    assert_script_run("$runtime container create --name test_2 alpine:$alpine_image_version /bin/echo Hello world");
+    record_soft_failure('poo#76993') if (script_run("$runtime container create --name test_2 alpine:$alpine_image_version /bin/echo Hello world") != 0);
     assert_script_run("$runtime container start test_2 | grep test_2");
     assert_script_run("$runtime container logs test_2 | grep 'Hello world'");
     #   - using 'run --rm'
-    assert_script_run(qq{$runtime container run --name test_ephemeral --rm alpine:$alpine_image_version /bin/echo Hello world | grep "Hello world"});
+    record_soft_failure('poo#76993') if (script_run(qq{$runtime container run --name test_ephemeral --rm alpine:$alpine_image_version /bin/echo Hello world | grep "Hello world"}) != 0);
     #   - using 'run -d' and 'inspect' (background container)
     my $container_name = 'tw';
     assert_script_run("$runtime container run -d --name $container_name opensuse/tumbleweed tail -f /dev/null");
@@ -134,11 +134,11 @@ sub basic_container_tests {
     # Images can be deleted
     my $cmd_runtime_rmi = "$runtime rmi -a";
     $output_containers = script_output("$runtime container ls -a");
-    die("error: $runtime image rmi -a opensuse/leap")                if ($output_containers =~ m/Untagged: opensuse\/leap/);
-    die("error: $runtime image rmi -a opensuse/tumbleweed")          if ($output_containers =~ m/Untagged: opensuse\/tumbleweed/);
-    die("error: $runtime image rmi -a tw:saved")                     if ($output_containers =~ m/Untagged: tw:saved/);
-    die("error: $runtime image rmi -a alpine:$alpine_image_version") if ($output_containers =~ m/Untagged: alpine:$alpine_image_version/);
-    die("error: $runtime image rmi -a hello-world:latest")           if ($output_containers =~ m/Untagged: hello-world:latest/);
+    die("error: $runtime image rmi -a opensuse/leap")                                if ($output_containers =~ m/Untagged: opensuse\/leap/);
+    die("error: $runtime image rmi -a opensuse/tumbleweed")                          if ($output_containers =~ m/Untagged: opensuse\/tumbleweed/);
+    die("error: $runtime image rmi -a tw:saved")                                     if ($output_containers =~ m/Untagged: tw:saved/);
+    record_soft_failure("error: $runtime image rmi -a alpine:$alpine_image_version") if ($output_containers =~ m/Untagged: alpine:$alpine_image_version/);
+    record_soft_failure("error: $runtime image rmi -a hello-world:latest")           if ($output_containers =~ m/Untagged: hello-world:latest/);
 }
 
 # Setup environment


### PR DESCRIPTION
Alpine and Hello-world containers are pulled from docker.io,
since November 2, 2020 the pull rate was limited so many test
are failing when pulling these images. The idea of this PR
is to soft-fail those images until we find a workaround, like
mirroring those images to some registry we have more control
e.g. registry.opensuse.org

Example of failure: https://openqa.suse.de/tests/4962111#step/podman/18
This is happening in many places now. 

This PR is to be reverted when we find a workaround to not pull
from docker.io

[poo#76993](https://progress.opensuse.org/issues/76993)