### PR TITLE
Fix the baremetal installation with needles on sonic and tails

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1406,7 +1406,7 @@ sub reconnect_mgmt_console {
     elsif (check_var('ARCH', 'x86_64')) {
         if (check_var('BACKEND', 'ipmi')) {
             select_console 'sol', await_console => 0;
-            assert_screen [qw(qa-net-selection prague-pxe-menu)], 300;
+            assert_screen([qw(qa-net-selection prague-pxe-menu)], 300) unless get_var('IPXE_CONSOLE');
             # boot to hard disk is default
             send_key 'ret';
         }

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -32,8 +32,10 @@ schedule:
     - installation/user_settings_root
     - installation/resolve_dependency_issues
     - installation/installation_overview
-    - installation/disable_grub_timeout
     - installation/start_install
     - installation/await_install
+    - installation/logs_from_installation_system
     - installation/reboot_after_installation
+    - boot/reconnect_mgmt_console
+    - installation/first_boot
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -33,8 +33,10 @@ schedule:
     - installation/user_settings_root
     - installation/resolve_dependency_issues
     - installation/installation_overview
-    - installation/disable_grub_timeout
     - installation/start_install
     - installation/await_install
+    - installation/logs_from_installation_system
     - installation/reboot_after_installation
+    - boot/reconnect_mgmt_console
+    - installation/first_boot
     - kernel/ibtests


### PR DESCRIPTION
This fixes the baremetal installation, by loading the appropriate test
modules, setting the correct kernel commandline for the installer and
handling the first boot using grub.


- Related ticket: https://progress.opensuse.org/issues/75163
- Needles: - 
- Verification run: http://baremetal-support.qa.suse.de/tests/501 and http://baremetal-support.qa.suse.de/tests/502
