### PR TITLE
[virt_autotest] ensure free memory size on xen host for vir network test

### DIFF
--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -170,4 +170,13 @@ sub post_fail_hook {
     save_screenshot;
 }
 
+sub get_free_mem {
+    if (check_var('SYSTEM_ROLE', 'xen')) {
+        # ensure the free memory size on xen host
+        my $mem = script_output q@xl info | grep ^free_memory | awk '{print $3}'@;
+        $mem = int($mem / 1024);
+        return $mem;
+    }
+}
+
 1;

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -38,6 +38,13 @@ use version_utils 'is_sle';
 sub run_test {
     my ($self) = @_;
 
+    if (is_xen_host) {
+        #Ensure that there is enough free memory on xen host for virtual network test
+        my $MEM = $self->get_free_mem();
+        record_info('Detect FREE MEM', $MEM . 'G');
+        assert_script_run("test $MEM -ge 20", fail_message => "The SUT needs at least 20G FREE MEM for virtual network test");
+    }
+
     #Need to reset up environemt - br123 for virt_atuo test due to after
     #finished guest installation to trigger cleanup step on sles11sp4 vm hosts
     virt_autotest::virtual_network_utils::restore_standalone() if (is_sle('=11-sp4'));


### PR DESCRIPTION
Refer to P1: [further action for invalid bug 1178048] ensure enough memory left on host for booting guests
https://trello.com/c/3QQPMJyF/708-p1-further-action-for-invalid-bug-1178048-ensure-enough-memory-left-on-host-for-booting-guests 
Before virtual network test, we'd better to check with physical memory size on xen host.

- Verification run: 
[gi-guest_developing-on-host_sles15sp2-xen](http://149.44.176.58/tests/5052652)
[gi-guest_developing-on-host_sles15sp2-kvm](http://149.44.176.58/tests/5054071)