### PR TITLE
Mitigations: Add ipmi_fake_server to occupy worker

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2505,6 +2505,9 @@ sub load_mitigation_tests {
     if (get_var('IPMI_TO_QEMU')) {
         loadtest "cpu_bugs/ipmi_to_qemu";
     }
+    if (get_var('IPMI_FAKE_SERVER')) {
+        loadtest "cpu_bugs/ipmi_fake_server";
+    }
     if (get_var('XEN_GRUB_SETUP')) {
         loadtest "cpu_bugs/xen_grub_setup";
     }

--- a/tests/cpu_bugs/ipmi_fake_server.pm
+++ b/tests/cpu_bugs/ipmi_fake_server.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Create fake server to occupy worker
+# openQA scheduler cannot deal with test suites which on differents workers,
+# use locking API to workaround test sequence in job group.
+
+# Maintainer: An Long <lan@suse.com>
+
+use warnings;
+use strict;
+use base "opensusebasetest";
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+
+sub run {
+    # unlock by creating the lock
+    mutex_create 'qemu_worker_ready';
+
+    # wait until all children finish
+    wait_for_children;
+}
+
+1;


### PR DESCRIPTION
openQA scheduler cannot deal with test suites which on differents workers,
use locking API to workaround test sequence in job group.

- Related ticket: https://progress.opensuse.org/issues/75118
- Needles: N/A
- Verification run: http://mitigations.qa2.suse.asia/tests/11633
