### PR TITLE
azure_first_release(): update system before removing kernel

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -30,8 +30,8 @@ use Utils::Backends 'use_ssh_serial_console';
 sub first_azure_release {
     my $repo = shift;
 
-    remove_kernel_packages();
     fully_patch_system;
+    remove_kernel_packages();
 
     my @repos = split(",", $repo);
     while (my ($i, $val) = each(@repos)) {


### PR DESCRIPTION
System update may sometimes fail if there is no kernel installed. When using the special workaround for first kernel-azure release, update system first, remove kernel-default later.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/4969472
