### PR TITLE
Install yast2-nfs-client alongside yast2-nis-client

### DIFF
--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -116,7 +116,7 @@ sub run {
     turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     become_root;
     setup_static_mm_network($setup_nis_nfs_x11{client_address});
-    zypper_call 'in yast2-nis-server';
+    zypper_call 'in yast2-nis-server yast2-nfs-client';
 
     # we have to stop the firewall, see bsc#999873 and bsc#1083487#c36
     systemctl 'stop ' . $self->firewall;


### PR DESCRIPTION
Modilication of nis_client test suite, so that package yast2-nfs-client will be manually installed as it is no longer installed by default.

- Related ticket: https://progress.opensuse.org/issues/73624
- VRs for 
   * opensuse: https://openqa.opensuse.org/tests/1466496
   * sle: https://openqa.suse.de/tests/4971529
