### PR TITLE
Use function common_service_action for all service actions

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -20,7 +20,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key common_service_start script_retry);
+use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key script_retry);
 use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_microos);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
@@ -729,7 +729,8 @@ sub yast_scc_registration {
     my $client_module = 'scc';
     if (is_leap_migration) {
         zypper_call('in yast2-registration rollback-helper');
-        common_service_start('rollback', 'Systemd');
+        systemctl("enable rollback");
+        systemctl("start rollback");
         $client_module = 'registration';
     }
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module, yast2_opts => $args{yast2_opts});

--- a/lib/services/apache.pm
+++ b/lib/services/apache.pm
@@ -54,9 +54,11 @@ sub full_apache_check {
     $stage //= '';
     if ($stage eq 'before') {
         install_service();
-        common_service_start('apache2', $type);
+        common_service_action('apache2', $type, 'enable');
+        common_service_action('apache2', $type, 'start');
     }
-    common_service_status('apache2', $type);
+    common_service_action('apache2', $type, 'is-enabled');
+    common_service_action('apache2', $type, 'is-active');
     check_function();
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -90,8 +90,6 @@ our @EXPORT = qw(
   file_content_replace
   ensure_ca_certificates_suse_installed
   is_efi_boot
-  common_service_start
-  common_service_status
   install_patterns
   common_service_action
   script_output_retry
@@ -1763,39 +1761,6 @@ sub ensure_ca_certificates_suse_installed {
 # non empty */sys/firmware/efi/* must exist in UEFI mode
 sub is_efi_boot {
     return !!script_output('test -d /sys/firmware/efi/ && ls -A /sys/firmware/efi/', proceed_on_failure => 1);
-}
-
-sub common_service_start {
-    my ($service, $type) = @_;
-
-    if ($type eq 'SystemV') {
-        assert_script_run 'chkconfig ' . $service . ' on';
-        assert_script_run '/etc/init.d/' . $service . ' start';
-        assert_script_run 'service ' . $service . ' status';
-    }
-    elsif ($type eq 'Systemd') {
-        systemctl 'enable ' . $service;
-        systemctl 'start ' . $service;
-    }
-    else {
-        die "Unsupported service type, please check it again.";
-    }
-}
-
-sub common_service_status {
-    my ($service, $type) = @_;
-
-    if ($type eq 'SystemV') {
-        assert_script_run 'chkconfig  --list | grep ' . $service;
-        assert_script_run 'service ' . $service . ' status | grep running';
-    }
-    elsif ($type eq 'Systemd') {
-        systemctl 'is-enabled ' . $service;
-        systemctl 'is-active ' . $service;
-    }
-    else {
-        die "Unsupported service type, please check it again.";
-    }
 }
 
 #   Function: parse the output from script_output to get the pattern list

--- a/tests/installation/leap2sle_zdup.pm
+++ b/tests/installation/leap2sle_zdup.pm
@@ -31,7 +31,8 @@ sub run {
     # We need to install rollback-helper and enable/start rollback.service
     # before creating a snapshot.
     zypper_call 'in rollback-helper';
-    common_service_start('rollback', 'Systemd');
+    systemctl("enable rollback");
+    systemctl("start rollback");
     # Create a snapshot with specified description to do snapper rollback
     assert_script_run "snapper create --type pre --cleanup-algorithm=number --print-number --userdata important=yes --description 'b_zdup migration'";
 


### PR DESCRIPTION
 We'd use common_service_action to replace function common_service_start
and common_service_status. This will make the code simple and clean.

- Related ticket: https://progress.opensuse.org/issues/77677 
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/4974056
   https://openqa.nue.suse.com/tests/4991590#step/register_system/10
   https://openqa.nue.suse.com/tests/4991497
   regression:
   https://openqa.nue.suse.com/tests/4991602