### PR TITLE
Bump timeout for repos refresh in dud addon test

### DIFF
--- a/tests/console/validate_dud_addon_repos.pm
+++ b/tests/console/validate_dud_addon_repos.pm
@@ -33,7 +33,7 @@ sub run {
                 Autorefresh => $test_data->{dud_repos}->{$repo}->{Autorefresh}
         });
     }
-    assert_script_run('zypper -v ref | grep "All repositories have been refreshed"', 120);
+    assert_script_run('zypper ref', timeout => 180);
 }
 
 1;


### PR DESCRIPTION
We don't need grep, as zypper command will fail in case any of the repos is not refreshed properly.

Fixes https://openqa.suse.de/tests/4967367#step/validate_dud_addon_repos/15


