### PR TITLE
Add KEEP_DISKS variable to prevent disk wiping

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -126,7 +126,7 @@ sub prepare_pvm_installation {
     }
     assert_screen("run-yast-ssh", 300);
 
-    if (!is_upgrade) {
+    if (!is_upgrade && !get_var('KEEP_DISKS')) {
         prepare_disks;
     }
     # Switch to installation console (ssh or vnc)

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -187,7 +187,7 @@ sub run {
                 assert_screen $ssh_vnc_tag, $ssh_vnc_wait_time;
             }
         }
-        if (!is_upgrade) {
+        if (!is_upgrade && !get_var('KEEP_DISKS')) {
             prepare_disks;
         }
         save_screenshot;

--- a/variables.md
+++ b/variables.md
@@ -75,6 +75,7 @@ INSTLANG | string | en_US | Installation locale settings.
 IPXE | boolean | false | Indicates ipxe boot.
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
+KEEP_DISKS | boolean | false | Prevents disks wiping for remote backends without snaphots support, e.g. ipmi, powerVM, zVM 
 KEEP_ONLINE_REPOS | boolean | false | openSUSE specific variable, not to replace original repos in the installed system with snapshot mirrors which are not yet published.
 LAPTOP |||
 LINUX_BOOT_IPV6_DISABLE | boolean | false | If set, boots linux kernel with option named "ipv6.disable=1" which disables IPv6 from startup.


### PR DESCRIPTION
Outcome of #11325 as for some specific cases we don't need to wipe
disks, like performance tests. Upgrade scenarios were excluded already.
With the new setting wiping can be explicitly disabled.