### PR TITLE
Run steamcmd only on x86_64 as per poo#77653

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -9,6 +9,10 @@ conditional_schedule:
                 - console/lshw
             ppc64le:
                 - console/lshw
+    steamcmd:
+        ARCH:
+            x86_64:
+                - console/steamcmd
     yast2_lan_device_settings:
         ARCH:
             aarch64:
@@ -51,7 +55,7 @@ conditional_schedule:
                 - console/znc
                 - console/weechat
                 - console/nano
-                - console/steamcmd
+                - '{{steamcmd}}'
                 - console/libqca2
                 - console/kdump_and_crash
     validate_packages_and_patterns:


### PR DESCRIPTION
package in :NonFree project.

- Related ticket: https://progress.opensuse.org/issues/77653  only for steamcmd