### PR TITLE
extra_tests_textmode: Only run aplay, soundtouch, wavpack, steamcmd on x86_64

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -23,12 +23,24 @@ conditional_schedule:
                 - update/zypper_clear_repos
                 - console/zypper_ar
                 - console/zypper_ref
-    opensuse_tests:
-        DISTRI:
-            opensuse:
+    sound_tests:
+        ARCH:
+            x86_64:
                 - console/aplay
                 - console/soundtouch
                 - console/wavpack
+            aarch64:
+                - console/aplay
+                - console/soundtouch
+                - console/wavpack
+    steamcmd:
+        ARCH:
+            x86_64:
+                - console/steamcmd
+    opensuse_tests:
+        DISTRI:
+            opensuse:
+                - '{{sound_tests}}'
                 - console/libvorbis
                 - console/ntp_client
                 - console/gdb
@@ -51,7 +63,7 @@ conditional_schedule:
                 - console/znc
                 - console/weechat
                 - console/nano
-                - console/steamcmd
+                - '{{steamcmd}}'
                 - console/libqca2
                 - console/kdump_and_crash
     validate_packages_and_patterns:


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/77653
Verification:
ppc64le: https://openqa.opensuse.org/t1468488
aarch64: https://openqa.opensuse.org/t1468490
x86_64: https://openqa.opensuse.org/t1468492