### PR TITLE
Use virtio console on maintenance incident installation test

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -91,7 +91,7 @@ sub run {
     my $incident_id = get_required_var('INCIDENT_ID');
     my $repos       = get_required_var('INCIDENT_REPO');
 
-    select_console 'root-console';
+    $self->select_serial_terminal;
 
     zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);
 


### PR DESCRIPTION
VIRTIO_CONSOLE is already enabled, can be turned on/off with the variable

- Verification run:
http://10.100.12.155/tests/16962
https://openqa.suse.de/tests/4982140 12-SP5
https://openqa.suse.de/tests/4982141 15-SP1

