### PR TITLE
Fix SUSEConnect conflict with zypper

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -34,8 +34,12 @@ sub run {
 
     prepare_serial_console;
 
-    # Make sure packagekit is not running, or it will conflict with SUSEConnect.
-    pkcon_quit unless check_var('DESKTOP', 'textmode');
+    if (!check_var('DESKTOP', 'textmode')) {
+        # Make sure packagekit is not running, or it will conflict with SUSEConnect.
+        pkcon_quit;
+        # poo#77134 wait for packagekit related zypper process to exit
+        assert_script_run 'until ! pgrep zypper; do sleep 1; done';
+    }
 
     # Register the modules after media migration, so it can do regession
     if (get_var('SCC_ADDONS') && get_var('MEDIA_UPGRADE') && (get_var('FLAVOR') =~ /Regression/)) {


### PR DESCRIPTION
After quit the packagekit, it need wait a while to exit related zypper process, then can start the SUSUConnect cmds.

- Related ticket: https://progress.opensuse.org/issues/77134
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/4981864#step/system_prepare/14
