### PR TITLE
Fix handle_emergency for emergency shell

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -971,7 +971,7 @@ behave as if the env var NOAUTOLOGIN was set.
 sub wait_boot_past_bootloader {
     my ($self, %args) = @_;
     my $textmode     = $args{textmode};
-    my $ready_time   = $args{ready_time} // ((check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 500 : 300);
+    my $ready_time   = $args{ready_time} // 500;
     my $nologin      = $args{nologin};
     my $forcenologin = $args{forcenologin};
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1052,7 +1052,11 @@ some basic logging information to the serial output.
 sub handle_emergency {
     if (match_has_tag('emergency-shell')) {
         # get emergency shell logs for bug, scp doesn't work
+        type_password;
+        send_key 'ret';
         script_run "cat /run/initramfs/rdsosreport.txt > /dev/$serialdev";
+        script_run "echo \"\n--------------Beginning of journalctl--------------\n\" > /dev/$serialdev";
+        script_run "journalctl --no-pager -o short-precise > /dev/$serialdev";
         die "hit emergency shell";
     }
     elsif (match_has_tag('emergency-mode')) {


### PR DESCRIPTION
Until now, the emergency shell is not properly handled as handle_emergency does not provide password, so rdsosreport.txt is not successfully redirected to $serialdev. This PR is fixing this and is adding journalctl messages for redirection, Additionally, increasing the bootloader wait timeout to 500 for all archs, since in some cases 300 seconds was not enough for the system to reach the emergency shell.

- Related ticket: https://progress.opensuse.org/issues/77077
- Verification run:  https://openqa.suse.de/tests/4978509
    after recent changes: http://falafel.suse.cz/tests/969
