### PR TITLE
Extend get_os_release() and check_os_release() for containers

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -596,6 +596,10 @@ The expected distribution name to compare.
 
 The line we'll be parsing and checking.
 
+=item C<go_to_target>
+
+Command connecting to the SUT
+
 =item C<os_release_file>
 
 The full path to the Operating system identification file.
@@ -605,11 +609,12 @@ Returns 1 (true) if the ID_LIKE variable contains C<distri_name>.
 
 =cut
 sub check_os_release {
-    my ($distri_name, $line, $os_release_file) = @_;
+    my ($distri_name, $line, $go_to_target, $os_release_file) = @_;
     die '$distri_name is not given' unless $distri_name;
     die '$line is not given'        unless $line;
+    $go_to_target    //= '';
     $os_release_file //= '/etc/os-release';
-    my $os_like_name = script_output("grep -e \"^$line\\b\" ${os_release_file} | cut -d'\"' -f2");
+    my $os_like_name = script_output("$go_to_target grep -e \"^$line\\b\" ${os_release_file} | cut -d'\"' -f2");
     return ($os_like_name =~ /$distri_name/i);
 }
 

--- a/tests/console/libssh.pm
+++ b/tests/console/libssh.pm
@@ -97,7 +97,8 @@ sub run {
     #    is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
     #}
     # Host is used as server of libssh test
-    install_docker_when_needed;
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    install_docker_when_needed($host_distri);
     # zypper_call("--gpg-auto-import-keys in docker libvirt-daemon-qemu qemu-kvm qemu-block-ssh");
     zypper_call("in libvirt-daemon-qemu qemu-kvm qemu-block-ssh");
     #  systemctl("start docker.service libvirtd.service sshd.service");

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -19,13 +19,15 @@ use warnings;
 use containers::common;
 use containers::container_images;
 use suse_container_urls 'get_suse_container_urls';
-use version_utils 'is_sle';
+use version_utils qw(is_sle get_os_release);
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    install_docker_when_needed();
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
+    install_docker_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => 'docker') if (is_sle());
     zypper_call("install container-diff")                   if (script_run("which container-diff") != 0);
 

--- a/tests/containers/containers_3rd_party.pm
+++ b/tests/containers/containers_3rd_party.pm
@@ -60,6 +60,9 @@ sub upload_image_logs {
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
+
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
     # Define test images here
     my @docker_images = ('alpine', 'opensuse/leap', 'opensuse/tumbleweed', 'debian', 'ubuntu', 'centos', 'fedora');
     my @podman_images = ('alpine', 'opensuse/leap', 'opensuse/tumbleweed', 'debian', 'ubuntu', 'centos', 'fedora');
@@ -70,7 +73,7 @@ sub run {
         record_info("Skip Docker", "Docker image tests skipped");
         script_run("echo 'INFO: Docker image tests skipped' >> /var/tmp/containers_3rd_party_log.txt");
     } else {
-        install_docker_when_needed();
+        install_docker_when_needed($host_distri);
         run_image_tests('docker', @docker_images);
         clean_container_host(runtime => 'docker');
     }
@@ -80,7 +83,7 @@ sub run {
         script_run("echo 'INFO: Podman image tests skipped' >> /var/tmp/containers_3rd_party_log.txt");
     } else {
         # In SLE we need to add the Containers module
-        install_podman_when_needed();
+        install_podman_when_needed($host_distri);
         run_image_tests('podman', @podman_images);
         clean_container_host(runtime => 'podman');
     }

--- a/tests/containers/docker.pm
+++ b/tests/containers/docker.pm
@@ -33,7 +33,7 @@ use utils;
 use strict;
 use warnings;
 use containers::common;
-use version_utils qw(is_sle is_leap);
+use version_utils qw(is_sle is_leap get_os_release);
 use containers::utils;
 
 sub run {
@@ -43,7 +43,9 @@ sub run {
     my $sleep_time = 90 * get_var('TIMEOUT_SCALE', 1);
     my $dir        = "/root/DockerTest";
 
-    install_docker_when_needed();
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
+    install_docker_when_needed($host_distri);
     test_seccomp();
 
     # Run basic docker tests

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -25,7 +25,7 @@ use base "consoletest";
 use testapi;
 use registration;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle get_os_release);
 use containers::common;
 use publiccloud::utils 'is_ondemand';
 use strict;
@@ -35,7 +35,9 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    install_docker_when_needed;
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
+    install_docker_when_needed($host_distri);
     add_suseconnect_product(get_addon_fullname('phub'))    if is_sle();
     add_suseconnect_product(get_addon_fullname('python2')) if is_sle('<15-sp2');
 

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -19,7 +19,7 @@
 use base "consoletest";
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle get_os_release);
 use containers::common;
 use strict;
 use warnings;
@@ -28,12 +28,14 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
     my @runtimes = ("docker-runc");
     push @runtimes, "runc" if !is_sle('=15');
 
     record_info 'Setup', 'Setup the environment';
     # runC cannot create or extract the root filesystem on its own. Use Docker to create it.
-    install_docker_when_needed;
+    install_docker_when_needed($host_distri);
 
     # create the rootfs directory
     assert_script_run('mkdir rootfs');
@@ -59,7 +61,7 @@ sub run {
     assert_script_run("rm -rf rootfs");
 
     # install docker and docker-runc if needed
-    install_docker_when_needed;
+    install_docker_when_needed($host_distri);
 
     # remove leftover containers and images
     clean_container_host(runtime => 'docker');

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -30,7 +30,7 @@ use strict;
 use warnings;
 use registration;
 use containers::common;
-use version_utils qw(is_sle is_leap is_jeos);
+use version_utils qw(is_sle is_leap is_jeos get_os_release);
 use containers::utils;
 
 sub run {
@@ -39,7 +39,9 @@ sub run {
 
     my $dir = "/root/DockerTest";
 
-    install_podman_when_needed();
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
+    install_podman_when_needed($host_distri);
 
     # Run basic tests for podman
     basic_container_tests("podman");

--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -21,6 +21,7 @@
 use base "consoletest";
 use testapi;
 use utils;
+use version_utils 'get_os_release';
 use strict;
 use warnings;
 use containers::common;
@@ -29,7 +30,9 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    install_docker_when_needed();
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
+    install_docker_when_needed($host_distri);
 
     # install zypper-docker and verify installation
     zypper_call('in zypper-docker');


### PR DESCRIPTION
Hello,

as @b10n1k is working on testing SLE images on openSUSE host in #11351, I realised we should be able to get and check the system version on tested container.

- Verification run: [SLE image on openSUSE](http://pdostal-server.suse.cz/tests/10434), [openSUSE](http://pdostal-server.suse.cz/tests/10435), [SLES15-SP3](http://pdostal-server.suse.cz/tests/10438), [SLES15-SP2](http://pdostal-server.suse.cz/tests/10436)
