### PR TITLE
Fix evolution auth pop-up when it's not focused

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -322,13 +322,15 @@ sub send_meeting_request {
     }
     wait_still_screen(2);
     send_key 'f12';
-    if (check_screen 'evolution_mail-auth', 3) {
-        assert_and_click('evolution_mail-auth-unfocused') if check_screen('evolution_mail-auth-unfocused', 5);
+    wait_still_screen(2);
+    assert_and_click('evolution_mail-auth-unfocused') if check_screen('evolution_mail-auth-unfocused', 2);
+    assert_screen ['evolution_mail-auth', 'evolution_mail-max-window'];
+    if (match_has_tag "evolution_mail-auth") {
         send_key "alt-a";    #disable keyring option
         send_key "alt-p";
         type_password $mail_passwd;
-        wait_still_screen(2, 2);
         send_key "ret";
+        assert_screen "evolution_mail-max-window";
     }
     assert_screen [qw(evolution_mail-save_meeting_dialog evolution_mail-send_meeting_dialog evolution_mail-meeting_error_handle evolution_mail-max-window)];
     if (match_has_tag "evolution_mail-save_meeting_dialog") {

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -40,7 +40,14 @@ sub run {
         send_key "ret";
     }
     send_key "super-up" if (check_screen "evolution_mail-init-window", 2);
-    assert_screen "evolution_mail-max-window";
+    assert_screen ['evolution_mail-auth', 'evolution_mail-max-window'];
+    if (match_has_tag "evolution_mail-auth") {
+        send_key "alt-a";    #disable keyring option
+        send_key "alt-p";
+        type_password $mail_passwd;
+        send_key "ret";
+        assert_screen "evolution_mail-max-window";
+    }
 
     # Help
     send_key "alt-h";


### PR DESCRIPTION
- Fail:
https://openqa.suse.de/tests/4653115#step/evolution_meeting_pop/42
https://openqa.suse.de/tests/4652989#step/evolution_mail_pop/43
https://openqa.suse.de/tests/4880938#step/evolution_meeting_pop/42
- Verification run:
https://openqa.suse.de/tests/4982984 15-SP3
https://openqa.suse.de/tests/4958502 15-SP2
https://openqa.suse.de/tests/4981623 15-SP1