### PR TITLE
Remove softfail for LVM's leaked invocation warnings

### DIFF
--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -30,7 +30,6 @@ use version_utils qw(is_opensuse is_leap is_tumbleweed);
 our @EXPORT = qw(is_network_manager_default
   continue_info_network_manager_default
   accept_warning_network_manager_default
-  workaround_suppress_lvm_warnings
   with_yast_env_variables
 );
 
@@ -86,24 +85,6 @@ sub accept_warning_network_manager_default {
     assert_screen 'yast2-lan-warning-network-manager';
     send_key $cmd{ok};
     assert_screen 'yast2_lan-global-tab';
-}
-
-=head2 workaround_suppress_lvm_warnings
-
- workaround_suppress_lvm_warnings();
-
-LVM is polluting stdout with leaked invocation warnings because of file descriptor 3 is assigned to /root/.bash_history.
-
-record_soft_failure if is 'is_tumbleweed' for issue 'bsc#1124481 - LVM is polluting stdout with leaked invocation warnings'.
-
-The workaround suppresses the warnings by setting the environment variable LVM_SUPPRESS_FD_WARNINGS.
-
-=cut
-sub workaround_suppress_lvm_warnings {
-    if (is_tumbleweed) {
-        record_soft_failure('bsc#1124481 - LVM is polluting stdout with leaked invocation warnings');
-        assert_script_run('export LVM_SUPPRESS_FD_WARNINGS=1');
-    }
 }
 
 sub post_fail_hook {

--- a/tests/console/lvm_thin_check.pm
+++ b/tests/console/lvm_thin_check.pm
@@ -16,7 +16,6 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 use utils;
-use y2_module_basetest 'workaround_suppress_lvm_warnings';
 
 sub run {
     my $self     = shift;
@@ -30,7 +29,6 @@ sub run {
 
     $self->select_serial_terminal;
     record_info('INFO', 'Print lvm setup');
-    workaround_suppress_lvm_warnings;
     assert_script_run 'lsblk';
     assert_script_run 'lvmdiskscan';
     assert_script_run 'lvscan';

--- a/tests/console/validate_lvm.pm
+++ b/tests/console/validate_lvm.pm
@@ -15,7 +15,6 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 use utils;
-use y2_module_basetest 'workaround_suppress_lvm_warnings';
 use Test::Assert ':all';
 use Mojo::JSON 'decode_json';
 use List::Util 'sum';
@@ -23,7 +22,6 @@ use List::Util 'sum';
 sub pre_run_hook {
     my ($self) = @_;
     select_console('root-console');
-    workaround_suppress_lvm_warnings;
     $self->SUPER::pre_run_hook;
 }
 


### PR DESCRIPTION
- Related ticket: [boo#1124481](https://bugzilla.suse.com/show_bug.cgi?id=1124481)
- Verification runs: [tw](http://kepler.suse.cz/tests/2654/file/serial_terminal.txt) && [tw](http://kepler.suse.cz/tests/2656#)

This PR removes `workaround_suppress_lvm_warnings` completely.