### PR TITLE
Fix usr_sbin_smbd failure by using mouse instead of hot key

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -136,8 +136,9 @@ sub samba_client_access {
     assert_screen("nautilus-sharedir-opened");
 
     # Do some operations, e.g., create a test folder then delete it
-    send_key "shift-ctrl-n";
-    wait_still_screen(2);
+    assert_and_click("nautilus-open-menu");
+    assert_and_click("nautilus-new-folder");
+    assert_screen("nautilus-folder-name-input-box");
     type_string("sub-testdir", wait_screen_changes => 10);
     send_key "ret";
     send_key_until_needlematch("nautilus-sharedir-delete", "delete", 5, 2);


### PR DESCRIPTION
Fix apparmor_profile issue in usr_sbin_smbd module, sometimes hot key does not
work when creating a new folder.

- Related ticket: https://progress.opensuse.org/issues/77689
- Needles: added to gitlab already
- Verification run:
  s390x: http://openqa.suse.de/tests/4995132#
  x86_64: http://openqa.suse.de/tests/4991823#
  
  
