### PR TITLE
Execute csync2 after changing the sbd file content

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -89,6 +89,9 @@ sub run {
     # This is an occasional issue with virtual machines.
     file_content_replace("$sbd_cfg", "SBD_DELAY_START=.*" => "SBD_DELAY_START=yes");
 
+    # Execute csync2 to synchronise the sysconfig sbd file
+    exec_csync;
+
     # Set wait_for_all option to 0 if we are in a two nodes cluster situation
     # We need to set it for reproducing the same behaviour we had with no-quorum-policy=ignore
     if (!check_var('TWO_NODES', 'no')) {

--- a/tests/ha/yast_cluster_init.pm
+++ b/tests/ha/yast_cluster_init.pm
@@ -113,11 +113,11 @@ sub run {
     diag 'Waiting for other nodes to configure csync2...';
     barrier_wait("CSYNC2_CONFIGURED_$cluster_name");
 
-    # Synchronize files with csync2
+    # Synchronise files with csync2
     exec_csync;
 
-    # Files are synchronized, pacemaker could be start in the other nodes
-    diag 'Waiting for other nodes to synchronize files...';
+    # Files are synchronised, pacemaker could be start in the other nodes
+    diag 'Waiting for other nodes to synchronise files...';
     barrier_wait("CSYNC2_SYNC_$cluster_name");
 
     # Waiting for the other nodes to join
@@ -131,7 +131,7 @@ sub run {
     assert_script_run "crm configure op_defaults timeout=600 record-pending=true";
     sleep 5;
 
-    # Synchronize files with csync2
+    # Synchronise files with csync2
     exec_csync;
     save_state;
 }


### PR DESCRIPTION
We must execute csync2 to update the db after changing the sbd file content.

- Related ticket: https://progress.opensuse.org/issues/70747
- Failed test: https://openqa.suse.de/tests/4960281#step/ha_cluster_init/28
- Needles: N/A
- Verification run: [12-SP2 node1](http://1a102.qa.suse.de/tests/5805)
- Regression tests: [15-SP2 node1](http://1a102.qa.suse.de/tests/5811)