### PR TITLE
Send EOF to serial terminal

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -107,6 +107,9 @@ sub login {
     # after reboot and start typing the username before the console is actually
     # ready to accept it
     wait_serial(qr/login:\s*$/i, timeout => 5, quiet => 1);
+    # make sure that login prompt appears even when the console has been
+    # previously used
+    type_string(qq(\cd));
     # newline nudges the guest to display the login prompt, if this behaviour
     # changes then remove it
     type_string("\n");

--- a/schedule/functional/extra_tests_textmode_mod_desktop.yaml
+++ b/schedule/functional/extra_tests_textmode_mod_desktop.yaml
@@ -17,5 +17,5 @@ schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup
-    - '{{tests_requiring_soundcard}}'
-    - console/libvorbis
+    - console/snapper_undochange
+    - console/btrfsmaintenance

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -75,6 +75,7 @@ sub run {
     if (has_ttys()) {
         check_console_font;
         script_run '. /etc/bash.bashrc.local';
+        reset_consoles;
     }
 }
 


### PR DESCRIPTION
Motivation: [Failed login](https://openqa.opensuse.org/tests/1466407#step/btrfsmaintenance/1)

Transition from `rescue` to `default` target terminates both user sessions on both previously logged consoles (tty and ttyS) in QEMU.
Unfortunately in case of failure, serial terminal might not been able to match login prompt and eating the stale buffer does not help to recover login prompt.
Issuing `ctrl+d` might work for now. 

- Verification run: [Build20201109-jeos-filesystem@64bit_virtio](http://kepler.suse.cz/tests/2659#step/btrfsmaintenance/1)
