### PR TITLE
Use DASD_PATH and default to 0.0.0150

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -269,11 +269,11 @@ sub format_dasd {
     }
 
     # bring DASD down again to test the activation during the installation
-    if (script_run('timeout --preserve-status 20 bash -x /sbin/dasd_configure 0.0.0150 0') != 0) {
+    if (script_run("timeout --preserve-status 20 bash -x /sbin/dasd_configure $dasd_path 0") != 0) {
         record_soft_failure('bsc#1151436');
         script_run('dasd_reload');
         assert_script_run('dmesg');
-        assert_script_run("bash -x /sbin/dasd_configure -f 0.0.0150 0");
+        assert_script_run("bash -x /sbin/dasd_configure -f $dasd_path 0");
     }
 }
 


### PR DESCRIPTION
Some machines are not setup to use 0.0.0150

- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/2861#step/bootloader_s390/60
