### PR TITLE
Fix zypper_lifecycle_toolchain as gcc10 was released

### DIFF
--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -25,46 +25,26 @@ use utils 'zypper_call';
 
 sub run {
     my %expiration = (
-        gcc6                              => 'Now',
-        gcc7                              => 'Now',
-        libada7                           => 'Now',
-        libada9                           => '2024-10-31',
-        cpp9                              => '2024-10-31',
-        'sle-module-toolchain-release-cd' => '2024-10-31',
-    );
-
-    my %timezone_workaround = (
-        '2024-10-31' => '2024-10-30',
+        gcc6  => 'Now',
+        gcc7  => 'Now',
+        gcc8  => 'Now',
+        gcc9  => '2024-10',
+        gcc10 => '2024-10',
     );
 
     select_console 'root-console';
-    # Get gcc packages, ignore conflicting gcc6-ada and libada6 and cross-nvptx-newlib7 packages
-    # Ignore gcc8 due to bsc#1141474 (missing gcc8 dependencies)
-    my $gcc_packages
-      = script_output "zypper -q se -ur SLE-Module-Toolchain12-Updates -t package | awk -F '|' '{print \$2}' | tail -n +3 | grep -vE '(gcc6-ada|libada6|cross-nvptx-newlib7|gcc8)'", 300;
-    # Create list by removing blank symbols and new lines
-    $gcc_packages =~ s/(\R|\s)+/ /g;
-    # Install gcc packages
-    zypper_call("in $gcc_packages", timeout => 1500);
-    # Get lifecycle information for installed toolchain packages
-    my $output = script_output "zypper lifecycle $gcc_packages", 300;
-    diag($output);
-    # Verify that for gcc5 "now" is shown as expiration date, for gcc6 C<$expected_date>
-    for my $package (split(/ /, $gcc_packages)) {
-        while (my ($package_regexp, $expected_date) = each %expiration) {
-            if ($package =~ m/.*$package_regexp.*/ && $output !~ m/.*\Q$package\E\s*$expected_date.*/) {
-                my $error_msg         = "For toolchain module $package expected $expected_date as expiration date, lifecycle output:\n $output";
-                my $new_expected_date = (exists($timezone_workaround{$expected_date})) ? $timezone_workaround{$expected_date} : undef;
-                if (defined $new_expected_date && $package =~ m/.*$package_regexp.*/ && $output =~ m/.*\Q$package\E\s*$new_expected_date.*/) {
-                    record_soft_failure "bsc#1143453 - zypper lifecycle shows expiration date in wrong timezone - using workaround checking for $new_expected_date:\n$error_msg";
-                }
-                else {
-                    die($error_msg);
-                }
-            }
+    zypper_call("in sle-module-toolchain-release " . join(' ', keys %expiration), timeout => 1500);
+    script_run("zypper lifecycle");
+    script_run("zypper lifecycle " . join(' ', keys %expiration));
+    for my $package (sort keys %expiration) {
+        # Get lifecycle information for installed toolchain packages
+        my $output = script_output "zypper lifecycle $package", 300;
+        diag($output);
+        my $expected_date = $expiration{$package};
+        if ($output !~ m/.*\Q$package\E\s*$expected_date.*/) {
+            die("For toolchain module $package expected $expected_date as expiration date, lifecycle output:\n $output");
         }
     }
-
 }
 
 1;

--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -34,8 +34,6 @@ sub run {
 
     select_console 'root-console';
     zypper_call("in sle-module-toolchain-release " . join(' ', keys %expiration), timeout => 1500);
-    script_run("zypper lifecycle");
-    script_run("zypper lifecycle " . join(' ', keys %expiration));
     for my $package (sort keys %expiration) {
         # Get lifecycle information for installed toolchain packages
         my $output = script_output "zypper lifecycle $package", 300;


### PR DESCRIPTION
With gcc9 we have now 5 different gcc versions in the toolchain module
and the old way of installing all packages in the module to verify some
package's EOL data is just no longer feasible.

So simplify the test by just checking if all gcc versions but gcc9 and gcc10
are out of maintenance

Related issue: https://progress.opensuse.org/issues/77788

- Verification run: https://openqa.suse.de/tests/4998382