### PR TITLE
Fix installtest autoyast profile for !x86_64

### DIFF
--- a/data/autoyast_qam/15_installtest.xml.ep
+++ b/data/autoyast_qam/15_installtest.xml.ep
@@ -11,7 +11,7 @@
         <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/<%= $get_var->('VERSION') %>-LTSS/<%= $get_var->('ARCH') %>/update/]]></media_url>
       </listentry>
       % }
-      % if (!$check_var->('VERSION', '15') and $check_var->('ARCH', 'x86_64')) {
+      % if (!($check_var->('VERSION', '15') and $check_var->('ARCH', 'aarch64'))) {
       <listentry>
         <name>sle-module-containers:<%= $get_var->('VERSION') %>::pool</name>
         <alias>sle-module-containers:<%= $get_var->('VERSION') %>::pool</alias>


### PR DESCRIPTION
002e19c3bfb1f8ba3248769a7f1f19c2e35b2e90 meant to exclude container
module for 15/aarch64, but indeed excluded it for all !x86_64 on all !15

So ease the logic to express what was said in the commmit log

Related ticket: https://progress.opensuse.org/issues/76981