### PR TITLE
Add migration test for ESPOS

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -32,6 +32,7 @@ our @EXPORT = qw(
   setup_migration
   register_system_in_textmode
   remove_ltss
+  remove_espos
   disable_installation_repos
   record_disk_info
   check_rollback_system
@@ -114,6 +115,19 @@ sub remove_ltss {
             zypper_call 'rm sles-ltss-release-POOL';
         }
         set_var('SCC_ADDONS', join(',', grep { $_ ne 'ltss' } @$scc_addons));
+    }
+}
+
+# Remove ESPOS product before migration
+# Also remove espos from SCC_ADDONS setting for registration in upgrade target
+sub remove_espos {
+    if (get_var('SCC_ADDONS', '') =~ /espos/) {
+        my $scc_addons = get_var_array('SCC_ADDONS');
+        record_info 'remove espos', 'got all updates from espos channel, now remove espos and drop it from SCC_ADDONS before migration';
+        if (check_var('SLE_PRODUCT', 'hpc')) {
+            remove_suseconnect_product('SLE_HPC-ESPOS');
+            set_var('SCC_ADDONS', join(',', grep { $_ ne 'espos' } @$scc_addons));
+        }
     }
 }
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -87,6 +87,7 @@ our %ADDONS_REGCODE = (
     'sle-live-patching'        => get_var('SCC_REGCODE_LIVE'),
     'SLES-LTSS'                => get_var('SCC_REGCODE_LTSS'),
     'SUSE-Linux-Enterprise-RT' => get_var('SCC_REGCODE_RT'),
+    ESPOS                      => get_var('SCC_REGCODE_ESPOS'),
 );
 
 our @SLE15_ADDONS_WITHOUT_LICENSE        = qw(ha sdk wsm we hpcm live);
@@ -302,7 +303,7 @@ sub register_addons {
         last if (get_var('SMT_URL'));
         # change to uppercase to match variable
         $uc_addon = uc $addon;
-        my @addons_with_code = qw(geo live rt ltss ses);
+        my @addons_with_code = qw(geo live rt ltss ses espos);
         # WE doesn't need code on SLED
         push @addons_with_code, 'we' unless (check_var('SLE_PRODUCT', 'sled'));
         # HA doesn't need code on SLES4SAP or in migrations to 12-SP5
@@ -415,6 +416,7 @@ sub process_scc_register_addons {
     #   tsm - Transactional Server Module
     #    we - Workstation
     #   wsm - Web and Scripting Module
+    # espos - Extended Service Pack Overlap Support
     if (get_var('SCC_ADDONS')) {
         if (check_screen('scc-beta-filter-checkbox', 5)) {
             if (is_sle('12-SP3+')) {
@@ -791,7 +793,8 @@ sub get_addon_fullname {
         wsm       => 'sle-module-web-scripting',
         python2   => 'sle-module-python2',
         phub      => 'PackageHub',
-        tsm       => 'sle-module-transactional-server'
+        tsm       => 'sle-module-transactional-server',
+        espos     => 'ESPOS',
     );
     return $product_list{"$addon"};
 }

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -28,6 +28,7 @@ sub run {
     add_test_repositories;
     fully_patch_system;
     remove_ltss;
+    remove_espos;
     power_action('reboot', keepconsole => 1, textmode => 1);
     reconnect_mgmt_console if is_pvm;
 

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -94,6 +94,9 @@ sub patching_sle {
 
     #migration with LTSS is not possible, remove it before upgrade
     remove_ltss;
+
+    #migration with ESPOS is not possible, remove it before upgrade
+    remove_espos;
     if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ || get_var('KEEP_REGISTERED')) {
         # The system is registered.
         set_var('HDD_SCC_REGISTERED', 1);


### PR DESCRIPTION
Automation for ESPOS migration. Register ESPOS and fully update the system, then remove ESPOS before migration, and then perform migration.

- Related ticket: https://progress.opensuse.org/issues/77272
- Verification run: 
https://openqa.nue.suse.com/tests/5004491#step/zypper_patch/9
https://openqa.nue.suse.com/tests/5004494#step/patch_sle/165
https://openqa.nue.suse.com/tests/5004509#step/zypper_patch/9
https://openqa.nue.suse.com/tests/5004501