### PR TITLE
gnuhealth: Add check for correct QEMUCPU (boo#1178453)

### DIFF
--- a/tests/gnuhealth/gnuhealth_client_first_time.pm
+++ b/tests/gnuhealth/gnuhealth_client_first_time.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,6 +17,7 @@ use testapi;
 use version_utils 'is_leap';
 
 sub run {
+    die "Need QEMUCPU=host, see https://bugzilla.opensuse.org/show_bug.cgi?id=1178453" unless check_var('QEMUCPU', 'host') || is_leap('<15.3');
     my $gnuhealth    = get_var('GNUHEALTH_CLIENT', 'gnuhealth-client');
     my $gnuhealth_34 = is_leap('<15.2');
     wait_screen_change { send_key 'tab' };


### PR DESCRIPTION
Verification run:

```sh
for i in 1472570 1475911; do \
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11414 \
https://openqa.opensuse.org/tests/$i; done
```

* with `QEMUCPU=`, expected to fail: https://openqa.opensuse.org/t1476138
* with `QEMUCPU=host`, passed: https://openqa.opensuse.org/tests/1475916


Related bug: https://bugzilla.opensuse.org/show_bug.cgi?id=1178453