### PR TITLE
Add 2 condition check when firefox fail to react in Firefox_nss

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -6,21 +6,24 @@
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
+#
 # Case #1560076 - FIPS: Firefox Mozilla NSS
-
+#
 # Summary: FIPS mozilla-nss test for firefox : firefox_nss
+#
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tag: poo#47018, poo#58079, poo#71458
+# Tag: poo#47018, poo#58079, poo#71458, poo#77140, poo#77143
 
 use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use utils;
+use Utils::Architectures 'is_aarch64';
 
 sub quit_firefox {
     send_key "alt-f4";
-    if (check_screen("firefox-save-and-quit", 10)) {
+    if (check_screen("firefox-save-and-quit", 30)) {
         assert_and_click('firefox-click-close-tabs');
     }
 }
@@ -80,7 +83,30 @@ sub run {
 
     # Close Firefox
     quit_firefox;
-    assert_screen("generic-desktop", 20);
+
+    # Add more time for aarch64 due to worker performance problem
+    my $waittime = 60;
+    $waittime += 60 if is_aarch64;
+    assert_screen("generic-desktop", $waittime);
+
+    # Use the ps check if the bug happened bsc#1178552
+    # Add the ps to list which process is not closed while timeout
+    select_console 'root-console';
+
+    my $ret = script_run("ps -ef | grep firefox | grep childID | wc -l | grep '0'");
+    diag "---$ret---";
+    if ($ret == 1) {
+        script_run('ps -ef | grep firefox');
+        diag "---ret_pass---";
+        record_info('Firefox_ps', "Firefox process is already closed.");
+    }
+    else {
+        script_run('ps -ef | grep firefox | grep childID');
+        diag "---ret_fail---";
+        die 'firefox is not correctly closed';
+    }
+
+    select_console 'x11', await_console => 0;    # Go back to X11
 
     # "start_firefox" will be not used, since the master password is
     # required when firefox launching in FIPS mode
@@ -94,6 +120,16 @@ sub run {
     # Add max_interval while type password and extend time of click needle match
     type_string($fips_password, max_interval => 2);
     assert_and_click("firefox-enter-password-OK", 120);
+    wait_still_screen 10;
+
+    # Add a condition to avoid the password missed input
+    # Retype password again once the password missed input
+    # The problem frequently happaned in aarch64
+    if (match_has_tag('firefox-password-typefield-miss')) {
+        record_soft_failure "Firefox password is missing to input, see poo#77143";
+        type_string($fips_password, max_interval => 2);
+        send_key "ret";
+    }
     assert_screen("firefox-url-loaded", 20);
 
     # Firfox Preferences


### PR DESCRIPTION
**Description:**
 
This PR is attempting to fix the 2 poo ticket. First, adding the process check after the Firefox quit, we met sometimes the process is not closed totally and then block the following test. Add a condition to listing the process if Firefox is not closed after the timeout. We can observe which process is not closed successfully once the issue triggered again. 

Second, adding 1 more Needle check with **record_soft_failure** if the password input fails to react sometimes on aarch64 randomly, the patch will retype the password again until the password was input successfully.

1. Add ps check when Firefox is not closed successfully
2. Fix Firefox Needles OK button that doesn't work

- Related ticket: 
https://progress.opensuse.org/issues/77140
https://progress.opensuse.org/issues/77143
- Needles: 1 Needle merged
- Verification run: 

  https://openqa.suse.de/t5009297 (aarch64 - SLE15 SP3 ENV mode)
 https://openqa.suse.de/t5009298  (aarch64 - SLE15 SP3 KER mode)
 https://openqa.suse.de/tests/5009332 (x86_64 - SLE15 SP3 ENV mode)
 https://openqa.suse.de/t5009312 (x86_64 - SLE15 SP3 KER mode)
 https://openqa.suse.de/t5009329 (x86_64 - QAM 15 SP2 )
 https://openqa.suse.de/tests/4995129#step/firefox_nss/36 (record_soft_failure when the password input fails and then retype)


