### PR TITLE
Add parsec

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1699,6 +1699,7 @@ sub load_extra_tests_console {
     loadtest 'console/valgrind'       unless is_sle('<=12-SP3');
     loadtest 'console/sssd_samba'     unless (is_sle("<15") || is_sle(">=15-sp2") || is_leap('>=15.2') || is_tumbleweed);
     loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1') || is_jeos || is_public_cloud);
+    loadtest "console/parsec" if is_tumbleweed;
 }
 
 sub load_extra_tests_sdk {

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -76,6 +76,10 @@ conditional_schedule:
                 - console/supportutils
                 - console/zziplib
                 - console/vsftpd
+    tumbleweed_tests:
+        VERSION:
+            'Tumbleweed':
+                - console/parsec
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
@@ -139,4 +143,5 @@ schedule:
     - console/aaa_base
     - console/osinfo_db
     - '{{opensuse_tests}}'
+    - '{{tumbleweed_tests}}'
     - console/coredump_collect

--- a/tests/console/parsec.pm
+++ b/tests/console/parsec.pm
@@ -17,6 +17,7 @@ use testapi;
 use utils;
 
 sub run {
+    my $self = shift;
     # Install requirements
     select_console 'root-console';
     my $pkg_list = "parsec parsec-tool";
@@ -26,6 +27,9 @@ sub run {
     # Add user to 'parsec-clients' group and force relogin
     assert_script_run("usermod -a -G parsec-clients $testapi::username");
     select_console('user-console');
+    type_string("exit\n");
+    # Exit from serial_terminal before reseting consoles, as a workaround until https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11405 get merged
+    $self->select_serial_terminal;
     type_string("exit\n");
     reset_consoles;
     select_console('user-console', ensure_tty_selected => 0, skip_setterm => 1);

--- a/tests/console/parsec.pm
+++ b/tests/console/parsec.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test parsec service with parsec-tool
+# Maintainer: Guillaume Gardet <guillaume@opensuse.org>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    # Install requirements
+    select_console 'root-console';
+    my $pkg_list = "parsec parsec-tool";
+    zypper_call("in $pkg_list");
+    systemctl 'start parsec';
+
+    # Add user to 'parsec-clients' group and force relogin
+    assert_script_run("usermod -a -G parsec-clients $testapi::username");
+    select_console('user-console');
+    type_string("exit\n");
+    reset_consoles;
+    select_console('user-console', ensure_tty_selected => 0, skip_setterm => 1);
+
+    # Run tests as user with 'parsec-clients' permissions, with default config
+    record_info('ping');
+    assert_script_run 'parsec-tool ping';
+    save_screenshot;
+
+    record_info('list-opcodes');
+    assert_script_run 'parsec-tool list-opcodes';
+    save_screenshot;
+
+    record_info('list-providers');
+    assert_script_run 'parsec-tool list-providers';
+    save_screenshot;
+
+    record_info('list-keys');
+    assert_script_run 'parsec-tool list-keys';
+    save_screenshot;
+
+    # Clean-up
+    select_console 'root-console';
+    systemctl 'stop parsec';
+    zypper_call("rm -u $pkg_list");
+}
+
+1;


### PR DESCRIPTION
New submission after it needed to be reverted: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11415
This move the test to `extra_tests_console` and workaround the problem with `reset_consoles`.

- Verification run: https://openqa.opensuse.org/t1479692
