### PR TITLE
Support non-autoyast installations for aarch64 on baremetal

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1414,6 +1414,13 @@ sub reconnect_mgmt_console {
             send_key 'ret';
         }
     }
+    elsif (check_var('ARCH', 'aarch64')) {
+        if (check_var('BACKEND', 'ipmi')) {
+            select_console 'sol', await_console => 0;
+            # aarch64 baremetal machine takes longer to boot than 5 minutes
+            assert_screen([qw(qa-net-selection prague-pxe-menu)], 600) unless get_var('IPXE_CONSOLE');
+        }
+    }
     else {
         diag 'nothing special needed to reconnect management console';
     }

--- a/schedule/kernel/install_ltp_uefi_baremetal.yaml
+++ b/schedule/kernel/install_ltp_uefi_baremetal.yaml
@@ -2,17 +2,33 @@ name:          UEFI_baremetal_basic
 description:    >
     basic installation testing on baremetal UEFI + install LTP
 vars:
-    AUTOYAST_PREPARE_PROFILE: 1
+    DESKTOP: textmode
     IPXE: 1
+    IPXE_CONSOLE: ttyS1,115200
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_UEFI: 1
     SCC_ADDONS: sdk
     LTP_BAREMETAL: 1
     INSTALL_LTP: from_repo
 schedule:
-    - autoyast/prepare_profile
     - installation/ipxe_install
-    - console/suseconnect_scc
-    - toolchain/install
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - boot/reconnect_mgmt_console
+    - installation/first_boot
     - kernel/install_ltp
     - kernel/shutdown_ltp

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -146,13 +146,6 @@ sub run {
         select_console 'sol', await_console => 0;
         # make sure to wait for a while befor changing the boot device again, in order to not change it too early
         sleep 120;
-        if (check_var('IPXE_UEFI', '1')) {
-            # some machines need really long to boot into the installer, make sure
-            # we wait long enough so the bootscript was loaded
-            sleep 600;
-            set_bootscript_hdd;
-            assert_screen('linux-login', 1800);
-        }
     } else {
         select_console 'sol', await_console => 0;
         sleep 300;
@@ -164,6 +157,9 @@ sub run {
             sleep 2;
         }
         save_screenshot;
+
+        set_bootscript_hdd if get_var('IPXE_UEFI');
+
         select_console 'installation';
         save_screenshot;
 


### PR DESCRIPTION
With 4ded3594cf21ae97b65a81fa4323f5dd2f8f3714, the support for non-autoyast installations on baremetal machines was fixed for x86_64.
One of those changes is also required explicitely for aarch64. Apart from this, a schedule needs to change in order to make use of this.

- Related ticket: https://progress.opensuse.org/issues/78118
- Needles: -
- Verification run: http://baremetal-support.qa.suse.de/tests/541
