### PR TITLE
Switch to badssl.com for firefox ssl tests

### DIFF
--- a/tests/x11/firefox/firefox_ssl.pm
+++ b/tests/x11/firefox/firefox_ssl.pm
@@ -80,7 +80,7 @@ sub run {
     wait_screen_change { send_key "esc" };
     send_key "ctrl-w";
 
-    $self->firefox_open_url('https://www.hongkongpost.gov.hk');
+    $self->firefox_open_url('https://untrusted-root.badssl.com/');
     assert_screen('firefox-ssl-connection_untrusted');
 
     # Exit


### PR DESCRIPTION
Since the original website changed it's certificate, per suggestion in poo#78121 switch to badssl.com which should be more reliable

VR: https://openqa.suse.de/tests/5011005