### PR TITLE
Add Azure-Priority to imgproof

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -38,6 +38,7 @@ our $img_proof_tests = {
     'Azure-CHOST-BYOS'       => $azure_byos,
     'Azure-HPC'              => $azure_on_demand,
     'Azure-HPC-BYOS'         => $azure_byos,
+    'AZURE-Priority-Updates' => $azure_on_demand,
 
     'EC2-CHOST-BYOS'       => $ec2_byos_chost,
     'EC2-HVM'              => $ec2_on_demand,


### PR DESCRIPTION
Add missing selection switch for Azure-Priority updates

- Related ticket: https://progress.opensuse.org/issues/78082
- Needles: -
- Verification run: http://phoenix-openqa.qam.suse.de/t3922 (`imgproof` runs successfully)