### PR TITLE
Public Cloud: Fix img_proof test boot

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -71,9 +71,9 @@ sub run {
         $self->{provider} = $args->{my_provider};    # required for cleanup
         select_host_console();
     } else {
+        $self->select_serial_terminal;
         $provider = $self->provider_factory();
         $instance = $provider->create_instance();
-        $self->select_serial_terminal;
     }
     if ($tests eq "default") {
         $tests = $img_proof_tests->{$flavor};


### PR DESCRIPTION
The problem was spotted when the test was trying to run a command
on the login prompt without performing the login first.
With this fix, we ensure we select the right console and then
continue with the execution flow.

Failed run: https://openqa.suse.de/tests/5010326#step/img_proof/1
VR: https://openqa.suse.de/tests/5011373
