### PR TITLE
Enable libyui REST API for RAID tests on all architectures

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
@@ -17,7 +17,7 @@ use warnings;
 use testapi;
 use parent 'Installation::Partitioner::LibstorageNG::ExpertPartitionerPage';
 
-use YuiRestClient;
+use YuiRestClient::Wait;
 
 sub new {
     my ($class, $args) = @_;
@@ -44,11 +44,11 @@ sub init {
 sub select_item_in_system_view_table {
     my ($self, $item) = @_;
 
-    YuiRestClient::wait_until(object => sub {
+    YuiRestClient::Wait::wait_until(object => sub {
             $self->{tree_system_view}->exist();
     }, message => 'Cannot access system view tree');
 
-    YuiRestClient::wait_until(object => sub {
+    YuiRestClient::Wait::wait_until(object => sub {
             $self->{tree_system_view}->select($item);
     });
 
@@ -58,7 +58,7 @@ sub select_item_in_system_view_table {
 sub open_clone_partition_dialog {
     my ($self, $disk) = @_;
 
-    YuiRestClient::wait_until(object => sub {
+    YuiRestClient::Wait::wait_until(object => sub {
             $self->{tree_system_view}->exist();
     }, message => 'Cannot access system view tree');
     $self->select_item_in_system_view_table('Hard Disks');

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
@@ -44,13 +44,8 @@ sub init {
 sub select_item_in_system_view_table {
     my ($self, $item) = @_;
 
-    YuiRestClient::Wait::wait_until(object => sub {
-            $self->{tree_system_view}->exist();
-    }, message => 'Cannot access system view tree');
-
-    YuiRestClient::Wait::wait_until(object => sub {
-            $self->{tree_system_view}->select($item);
-    });
+    $self->{tree_system_view}->exist();
+    $self->{tree_system_view}->select($item);
 
     return $self;
 }
@@ -58,9 +53,7 @@ sub select_item_in_system_view_table {
 sub open_clone_partition_dialog {
     my ($self, $disk) = @_;
 
-    YuiRestClient::Wait::wait_until(object => sub {
-            $self->{tree_system_view}->exist();
-    }, message => 'Cannot access system view tree');
+    $self->{tree_system_view}->exist();
     $self->select_item_in_system_view_table('Hard Disks');
     # Cloning option is disabled if any partition is selected, so selecting disk
     $self->{tbl_devices}->select(row => 0);

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -39,27 +39,6 @@ sub get_app {
     return $app;
 }
 
-sub wait_until {
-    my (%args) = @_;
-    $args{timeout}  //= $timeout;
-    $args{interval} //= $interval;
-    $args{message}  //= '';
-
-    die "No object passed to the method" unless $args{object};
-
-    my $counter = $args{timeout} / $args{interval};
-    my $result;
-    while ($counter--) {
-        eval { $result = $args{object}->() };
-        return $result if $result;
-        sleep($interval);
-    }
-
-    my $error = "Timed out: @{[$args{message}]}\n";
-    $error .= "\n$@" if $@;
-    die $error;
-}
-
 sub setup_libyui {
     record_info('PORT',   "Used port for libyui: " . get_var('YUI_PORT'));
     record_info('SERVER', "Connecting to: " . get_var('YUI_SERVER'));
@@ -72,6 +51,15 @@ sub setup_libyui {
     # As we start installer, REST API is not instantly available
     $app->connect(timeout => 500, interval => 10);
     set_app($app);
+}
+
+sub teardown_libyui {
+    assert_screen('startshell', timeout => 100);
+    type_string "exit\n";
+}
+
+sub is_libyui_rest_api {
+    return get_var('YUI_REST_API');
 }
 
 1;

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -17,7 +17,9 @@ use constant API_VERSION => 'v1';
 
 use testapi;
 use utils 'type_string_slow';
+use Utils::Backends 'is_pvm';
 use YuiRestClient::App;
+
 
 our $interval = 1;
 our $timeout  = 10;
@@ -40,14 +42,14 @@ sub get_app {
 }
 
 sub setup_libyui {
-    record_info('PORT',   "Used port for libyui: " . get_var('YUI_PORT'));
-    record_info('SERVER', "Connecting to: " . get_var('YUI_SERVER'));
+    my $port = get_var('YUI_PORT');
+    my $host = get_var('YUI_SERVER');
+    record_info('PORT',   "Used port for libyui: $port");
+    record_info('SERVER', "Connecting to: $host");
     assert_screen('startshell', timeout => 500);
     type_string_slow "extend libyui-rest-api\n";
     type_string_slow "exit\n";
-    my $port = get_var('YUI_PORT');
-    my $host = get_var('YUI_SERVER');
-    my $app  = YuiRestClient::App->new({port => $port, host => $host});
+    my $app = YuiRestClient::App->new({port => $port, host => $host, api_version => API_VERSION});
     # As we start installer, REST API is not instantly available
     $app->connect(timeout => 500, interval => 10);
     set_app($app);
@@ -55,11 +57,32 @@ sub setup_libyui {
 
 sub teardown_libyui {
     assert_screen('startshell', timeout => 100);
-    type_string "exit\n";
+    type_string_slow "exit\n";
 }
 
 sub is_libyui_rest_api {
     return get_var('YUI_REST_API');
+}
+
+sub set_libyui_backend_vars {
+    my $yuiport = get_var('YUI_START_PORT', 39000);
+    $yuiport += get_var('VNC') =~ /(?<vncport>\d+)/ ? $+{vncport} : int(rand(1000));
+    die "Cannot set port for YUI REST API" unless $yuiport;
+
+    set_var('YUI_PORT', $yuiport);
+    set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '')
+          . " startshell=1 YUI_HTTP_PORT=$yuiport YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1");
+
+    my $server;
+    if (check_var('BACKEND', 'qemu')) {
+        # On qemu we connect to the worker using port forwarding
+        $server = 'localhost';
+        set_var('NICTYPE_USER_OPTIONS', "hostfwd=tcp::$yuiport-:$yuiport");
+    } elsif (is_pvm) {
+        $server = get_var('SUT_IP');
+    }
+    die "Cannot set libyui REST API server" unless $server;
+    set_var('YUI_SERVER', $server);
 }
 
 1;

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -13,11 +13,15 @@ package YuiRestClient;
 use strict;
 use warnings;
 
+use constant API_VERSION => 'v1';
+
+use testapi;
+use utils 'type_string_slow';
+use YuiRestClient::App;
+
 our $interval = 1;
 our $timeout  = 10;
 our $app;
-
-use constant API_VERSION => 'v1';
 
 sub set_interval {
     $interval = shift;
@@ -54,6 +58,20 @@ sub wait_until {
     my $error = "Timed out: @{[$args{message}]}\n";
     $error .= "\n$@" if $@;
     die $error;
+}
+
+sub setup_libyui {
+    record_info('PORT',   "Used port for libyui: " . get_var('YUI_PORT'));
+    record_info('SERVER', "Connecting to: " . get_var('YUI_SERVER'));
+    assert_screen('startshell', timeout => 500);
+    type_string_slow "extend libyui-rest-api\n";
+    type_string_slow "exit\n";
+    my $port = get_var('YUI_PORT');
+    my $host = get_var('YUI_SERVER');
+    my $app  = YuiRestClient::App->new({port => $port, host => $host});
+    # As we start installer, REST API is not instantly available
+    $app->connect(timeout => 500, interval => 10);
+    set_app($app);
 }
 
 1;

--- a/lib/YuiRestClient/App.pm
+++ b/lib/YuiRestClient/App.pm
@@ -28,10 +28,10 @@ sub new {
     return bless {
         port              => $args->{port},
         host              => $args->{host},
+        timeout           => $args->{timeout},
+        interval          => $args->{interval},
         widget_controller =>
-          YuiRestClient::Http::WidgetController->new({
-                port => $args->{port}, host => $args->{host}
-          })
+          YuiRestClient::Http::WidgetController->new($args)
     }, $class;
 }
 

--- a/lib/YuiRestClient/App.pm
+++ b/lib/YuiRestClient/App.pm
@@ -13,9 +13,9 @@ package YuiRestClient::App;
 use strict;
 use warnings;
 
-use YuiRestClient;
 use YuiRestClient::Http::HttpClient;
 use YuiRestClient::Http::WidgetController;
+use YuiRestClient::Wait;
 use YuiRestClient::Widget::Button;
 use YuiRestClient::Widget::MenuCollection;
 use YuiRestClient::Widget::SelectionBox;
@@ -38,7 +38,7 @@ sub new {
 sub connect {
     my ($self, %args) = @_;
     my $uri = YuiRestClient::Http::HttpClient::compose_uri(host => $self->{host}, port => $self->{port});
-    YuiRestClient::wait_until(object => sub {
+    YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_get($uri);
             return 1 if $response;
         },
@@ -85,7 +85,5 @@ sub tree {
             filter            => $filter
     });
 }
-
-
 
 1;

--- a/lib/YuiRestClient/Http/HttpClient.pm
+++ b/lib/YuiRestClient/Http/HttpClient.pm
@@ -13,7 +13,6 @@ package YuiRestClient::Http::HttpClient;
 use strict;
 use warnings;
 
-use YuiRestClient;
 use Mojo::UserAgent;
 
 my $ua = Mojo::UserAgent->new;

--- a/lib/YuiRestClient/Http/WidgetController.pm
+++ b/lib/YuiRestClient/Http/WidgetController.pm
@@ -13,7 +13,6 @@ package YuiRestClient::Http::WidgetController;
 use strict;
 use warnings;
 
-use YuiRestClient;
 use YuiRestClient::Wait;
 use YuiRestClient::Http::HttpClient;
 
@@ -21,8 +20,11 @@ sub new {
     my ($class, $args) = @_;
 
     return bless {
-        host => $args->{host},
-        port => $args->{port},
+        api_version => $args->{api_version},
+        host        => $args->{host},
+        port        => $args->{port},
+        timeout     => $args->{timeout},
+        interval    => $args->{interval}
     }, $class;
 }
 
@@ -32,13 +34,15 @@ sub find {
     my $uri = YuiRestClient::Http::HttpClient::compose_uri(
         host   => $self->{host},
         port   => $self->{port},
-        path   => YuiRestClient::API_VERSION . '/widgets',
+        path   => $self->{api_version} . '/widgets',
         params => $args
     );
 
     YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_get($uri);
-            return $response->json if $response; }
+            return $response->json if $response; },
+        timeout  => $self->{timeout},
+        interval => $self->{interval}
     );
 }
 
@@ -48,13 +52,15 @@ sub send_action {
     my $uri = YuiRestClient::Http::HttpClient::compose_uri(
         host   => $self->{host},
         port   => $self->{port},
-        path   => YuiRestClient::API_VERSION . '/widgets',
+        path   => $self->{api_version} . '/widgets',
         params => $args
     );
 
     YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_post($uri);
-            return $response if $response; }
+            return $response if $response; },
+        timeout  => $self->{timeout},
+        interval => $self->{interval}
     );
 }
 

--- a/lib/YuiRestClient/Http/WidgetController.pm
+++ b/lib/YuiRestClient/Http/WidgetController.pm
@@ -14,6 +14,7 @@ use strict;
 use warnings;
 
 use YuiRestClient;
+use YuiRestClient::Wait;
 use YuiRestClient::Http::HttpClient;
 
 sub new {
@@ -35,7 +36,7 @@ sub find {
         params => $args
     );
 
-    YuiRestClient::wait_until(object => sub {
+    YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_get($uri);
             return $response->json if $response; }
     );
@@ -51,7 +52,7 @@ sub send_action {
         params => $args
     );
 
-    YuiRestClient::wait_until(object => sub {
+    YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_post($uri);
             return $response if $response; }
     );

--- a/lib/YuiRestClient/Wait.pm
+++ b/lib/YuiRestClient/Wait.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YuiRestClient::Wait;
+use strict;
+use warnings;
+use YuiRestClient;
+
+
+sub wait_until {
+    my (%args) = @_;
+    $args{timeout}  //= $YuiRestClient::timeout;
+    $args{interval} //= $YuiRestClient::interval;
+    $args{message}  //= '';
+
+    die "No object passed to the method" unless $args{object};
+
+    my $counter = $args{timeout} / $args{interval};
+    my $result;
+    while ($counter--) {
+        eval { $result = $args{object}->() };
+        return $result if $result;
+        sleep($args{interval});
+    }
+
+    my $error = "Timed out: @{[$args{message}]}\n";
+    $error .= "\n$@" if $@;
+    die $error;
+}
+
+1;

--- a/lib/YuiRestClient/Wait.pm
+++ b/lib/YuiRestClient/Wait.pm
@@ -12,13 +12,12 @@
 package YuiRestClient::Wait;
 use strict;
 use warnings;
-use YuiRestClient;
 
 
 sub wait_until {
     my (%args) = @_;
-    $args{timeout}  //= $YuiRestClient::timeout;
-    $args{interval} //= $YuiRestClient::interval;
+    $args{timeout}  //= 10;
+    $args{interval} //= 1;
     $args{message}  //= '';
 
     die "No object passed to the method" unless $args{object};

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -25,6 +25,7 @@ use bootloader_setup;
 use registration 'registration_bootloader_params';
 use utils qw(get_netboot_mirror type_string_slow);
 use version_utils 'is_upgrade';
+use YuiRestClient;
 
 our @EXPORT = qw(
   boot_pvm
@@ -124,6 +125,10 @@ sub prepare_pvm_installation {
         die "Boot process restarted too many times" if ($boot_attempt > 3);
         return (bootloader_pvm::prepare_pvm_installation $boot_attempt);
     }
+    if (get_var('YUI_REST_API')) {
+        YuiRestClient::setup_libyui();
+    }
+
     assert_screen("run-yast-ssh", 300);
 
     if (!is_upgrade && !get_var('KEEP_DISKS')) {

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -125,7 +125,8 @@ sub prepare_pvm_installation {
         die "Boot process restarted too many times" if ($boot_attempt > 3);
         return (bootloader_pvm::prepare_pvm_installation $boot_attempt);
     }
-    if (get_var('YUI_REST_API')) {
+    # On powerVM we have to process startshell in bootloader
+    if (YuiRestClient::is_libyui_rest_api) {
         YuiRestClient::setup_libyui();
     }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -3226,17 +3226,24 @@ sub load_kernel_baremetal_tests {
 }
 
 sub setup_yui_rest_api {
+    my $yuiport = get_var('YUI_START_PORT', 39000);
+    $yuiport += get_var('VNC') =~ /(?<vncport>\d+)/ ? $+{vncport} : int(rand(1000));
+    die "Cannot set port for YUI REST API" unless $yuiport;
+
+    set_var('YUI_PORT', $yuiport);
+    set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '')
+          . " startshell=1 YUI_HTTP_PORT=$yuiport YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1");
+
+    my $server;
     if (check_var('BACKEND', 'qemu')) {
         # On qemu we connect to the worker using port forwarding
-        set_var('YUI_SERVER', 'localhost');
-        my $yuiport = get_var('YUI_START_PORT', 39000);
-        $yuiport += get_var('VNC') =~ /(?<vncport>\d+)/ ? $+{vncport} : int(rand(1000));
-        die "Cannot set port for YUI REST API" unless $yuiport;
-        set_var('YUI_PORT', $yuiport);
-        set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '')
-              . " startshell=1 YUI_HTTP_PORT=$yuiport YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1");
+        $server = 'localhost';
         set_var('NICTYPE_USER_OPTIONS', "hostfwd=tcp::$yuiport-:$yuiport");
+    } elsif (is_pvm) {
+        $server = get_var('SUT_IP');
     }
+    die "Cannot set libyui REST API server" unless $server;
+    set_var('YUI_SERVER', $server);
 }
 
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -116,7 +116,6 @@ our @EXPORT = qw(
   rescuecdstep_is_applicable
   set_defaults_for_username_and_password
   setup_env
-  setup_yui_rest_api
   snapper_is_applicable
   ssh_key_import
   unregister_needle_tags
@@ -3223,27 +3222,6 @@ sub load_kernel_baremetal_tests {
     loadtest "toolchain/install";
     # some tests want to build and run a custom kernel
     loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
-}
-
-sub setup_yui_rest_api {
-    my $yuiport = get_var('YUI_START_PORT', 39000);
-    $yuiport += get_var('VNC') =~ /(?<vncport>\d+)/ ? $+{vncport} : int(rand(1000));
-    die "Cannot set port for YUI REST API" unless $yuiport;
-
-    set_var('YUI_PORT', $yuiport);
-    set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '')
-          . " startshell=1 YUI_HTTP_PORT=$yuiport YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1");
-
-    my $server;
-    if (check_var('BACKEND', 'qemu')) {
-        # On qemu we connect to the worker using port forwarding
-        $server = 'localhost';
-        set_var('NICTYPE_USER_OPTIONS', "hostfwd=tcp::$yuiport-:$yuiport");
-    } elsif (is_pvm) {
-        $server = get_var('SUT_IP');
-    }
-    die "Cannot set libyui REST API server" unless $server;
-    set_var('YUI_SERVER', $server);
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -126,7 +126,7 @@ logcurrentenv(
 );
 
 if (load_yaml_schedule) {
-    setup_yui_rest_api if YuiRestClient::is_libyui_rest_api;
+    YuiRestClient::set_libyui_backend_vars if YuiRestClient::is_libyui_rest_api;
     return 1;
 }
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -26,6 +26,8 @@ use utils;
 use version_utils qw(is_jeos is_gnome_next is_krypton_argon is_leap is_tumbleweed is_rescuesystem is_desktop_installed is_opensuse is_sle is_staging);
 use main_common;
 use known_bugs;
+use YuiRestClient;
+
 init_main();
 
 sub cleanup_needles {
@@ -124,7 +126,7 @@ logcurrentenv(
 );
 
 if (load_yaml_schedule) {
-    setup_yui_rest_api if get_var('YUI_REST_API');
+    setup_yui_rest_api if YuiRestClient::is_libyui_rest_api;
     return 1;
 }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -33,6 +33,7 @@ use utils;
 use main_common;
 use main_pods;
 use known_bugs;
+use YuiRestClient;
 
 init_main();
 
@@ -596,7 +597,7 @@ $testapi::distri->set_expected_serial_failures(create_list_of_serial_failures())
 $testapi::distri->set_expected_autoinst_failures(create_list_of_autoinst_failures());
 
 if (load_yaml_schedule) {
-    setup_yui_rest_api if get_var('YUI_REST_API');
+    YuiRestClient::set_libyui_backend_vars if YuiRestClient::is_libyui_rest_api;
     return 1;
 }
 

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 0.
 vars:
   RAIDLEVEL: 0
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 0.
 vars:
   RAIDLEVEL: 0
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -9,8 +9,10 @@ vars:
   RAIDLEVEL: 0
   DESKTOP: textmode
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -28,6 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - boot/reconnect_mgmt_console
   - installation/grub_test
   - installation/first_boot

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 0.
 vars:
   RAIDLEVEL: 0
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 10.
 vars:
   RAIDLEVEL: 10
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 10.
 vars:
   RAIDLEVEL: 10
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -9,8 +9,10 @@ vars:
   RAIDLEVEL: 10
   DESKTOP: textmode
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -28,6 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - boot/reconnect_mgmt_console
   - installation/grub_test
   - installation/first_boot

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 10.
 vars:
   RAIDLEVEL: 10
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 1.
 vars:
   RAIDLEVEL: 1
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 1.
 vars:
   RAIDLEVEL: 1
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -9,8 +9,10 @@ vars:
   RAIDLEVEL: 1
   DESKTOP: textmode
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -28,6 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - boot/reconnect_mgmt_console
   - installation/grub_test
   - installation/first_boot

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 1.
 vars:
   RAIDLEVEL: 1
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 5.
 vars:
   RAIDLEVEL: 5
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 5.
 vars:
   RAIDLEVEL: 5
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -9,8 +9,10 @@ vars:
   RAIDLEVEL: 5
   DESKTOP: textmode
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -28,6 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - boot/reconnect_mgmt_console
   - installation/grub_test
   - installation/first_boot

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 5.
 vars:
   RAIDLEVEL: 5
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 6.
 vars:
   RAIDLEVEL: 6
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 6.
 vars:
   RAIDLEVEL: 6
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -9,8 +9,10 @@ vars:
   RAIDLEVEL: 6
   DESKTOP: textmode
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -27,6 +29,7 @@ schedule:
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
+  - installation/teardown_libyui
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/grub_test

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -5,8 +5,10 @@ description:    >
   them for RAID 6.
 vars:
   RAIDLEVEL: 6
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -25,6 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -64,8 +64,8 @@ sub run {
         # socket end
         send_key 'alt-o';
     }
-    # Process exiting from startshell
-    if(YuiRestClient::is_libyui_rest_api && is_pvm) {
+    # Process exiting from the startshell
+    if (YuiRestClient::is_libyui_rest_api && is_pvm) {
         select_console 'powerhmc-ssh', await_console => 0;
         YuiRestClient::teardown_libyui();
     }

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -22,7 +22,8 @@ use testapi;
 use utils;
 use mmapi;
 use power_action_utils 'power_action';
-use Utils::Backends 'has_ttys';
+use Utils::Backends qw(is_pvm has_ttys);
+use YuiRestClient;
 
 sub run {
     select_console 'installation' unless get_var('REMOTE_CONTROLLER');
@@ -62,6 +63,11 @@ sub run {
         # vanish immediately after the initial key press loosing the remote
         # socket end
         send_key 'alt-o';
+    }
+    # Process exiting from startshell
+    if(YuiRestClient::is_libyui_rest_api && is_pvm) {
+        select_console 'powerhmc-ssh', await_console => 0;
+        YuiRestClient::teardown_libyui();
     }
     if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL')) {
         # "Press ESC for boot menu"

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -25,6 +25,7 @@ use Utils::Backends 'is_pvm';
 
 use YuiRestClient;
 
+
 sub run {
     # We setup libyui in bootloader on powerVM
     return if is_pvm;

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -21,23 +21,14 @@
 use strict;
 use warnings;
 use base "installbasetest";
-use testapi;
+use Utils::Backends 'is_pvm';
 
 use YuiRestClient;
-use YuiRestClient::App;
-use YuiRestClient::Http::HttpClient;
 
 sub run {
-    record_info('PORT', "Used port for libyui: " . get_var('YUI_PORT'));
-    assert_screen('startshell', timeout => 500);
-    assert_script_run('extend libyui-rest-api');
-    type_string "exit\n";
-    my $port = get_var('YUI_PORT');
-    my $host = get_var('YUI_SERVER');
-    my $app  = YuiRestClient::App->new({port => $port, host => $host});
-    # As we start installer, REST API is not instantly available
-    $app->connect(timeout => 500, interval => 10);
-    YuiRestClient::set_app($app);
+    # We setup libyui in bootloader on powerVM
+    return if is_pvm;
+    YuiRestClient::setup_libyui();
 }
 
 1;

--- a/tests/installation/teardown_libyui.pm
+++ b/tests/installation/teardown_libyui.pm
@@ -23,9 +23,12 @@ use warnings;
 use base "installbasetest";
 use testapi;
 
+use Utils::Backends 'is_pvm';
+use YuiRestClient;
+
 sub run {
-    assert_screen('startshell', timeout => 100);
-    type_string "exit\n";
+    return if is_pvm;
+    YuiRestClient::teardown_libyui();
 }
 
 1;


### PR DESCRIPTION
We have enabled changes for staging and TW on qemu. This PR enables solution for SLES for all architectures and backends which we have for RAID.

#### Verification runs
* [aarch64](https://openqa.suse.de/tests/5030625) Fails with https://bugzilla.suse.com/show_bug.cgi?id=1178832
* [powerkvm](https://openqa.suse.de/tests/5030448)
* [powerVM](https://openqa.suse.de/tests/5031608#)

See [poo#76864](https://progress.opensuse.org/issues/76864).

