### PR TITLE
Revert "Install systemd-coredump when needed"

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -87,8 +87,6 @@ sub run {
             services::registered_addons::full_registered_check;
         }
     }
-
-    assert_script_run 'rpm -q systemd-coredump || zypper -n in systemd-coredump' if get_var('COLLECT_COREDUMPS');
 }
 
 sub test_flags {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#11419

Due to https://openqa.suse.de/tests/5011598#step/system_prepare/12