### PR TITLE
Add Thunderbird client-server multimachine test to the SLES15-SP2  #75409

### DIFF
--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -61,7 +61,7 @@ sub tb_setup_account {
             assert_and_click 'thunderbird_wizard-imap-pop-open';
             assert_and_click 'thunderbird_SSL_pop3-selection-click-TW';
             assert_and_click 'thunderbird_SSL_auth_click';
-            assert_and_click 'thunderbird_wizard-pop-selected-normal';
+            assert_and_click 'thunderbird_wizard-pop-done';
         }
         else {
             assert_screen 'thunderbird_wizard-imap-pop-open';
@@ -79,10 +79,9 @@ sub tb_setup_account {
 
     # If use multimachine, select correct needles to configure thunderbird.
     if ($hostname eq 'client') {
-        assert_and_click "thunderbird_SSL_advanced_config";
-        assert_and_click "thunderbird_SSL_ok_config";
-        assert_and_click "thunderbird_skip-system-integration";
+        assert_and_click "thunderbird_SSL_done_config";
         assert_and_click "thunderbird_confirm_security_exception";
+        assert_and_click "thunderbird_skip-system-integration";
         assert_and_click "thunderbird_get-messages";
     }
     else {
@@ -104,13 +103,13 @@ sub tb_setup_account {
 =head2 tb_send_message
  tb_send_message($account);
 Test sending an email using Thunderbird.
-C<$account> can be C<internal_account_A> or C<internal_account_B>.
+C<$proto> can be C<pop> or C<imap>.
+C<$account> can be C<internal_account_A> or C<internal_account_B> or C<internal_account_C> or C<internal_account_D>.
 Returns email subject.
 =cut
 sub tb_send_message {
     my $hostname = get_var('HOSTNAME');
-    my ($self, $account) = @_;
-
+    my ($self, $proto, $account) = @_;
     my $config       = $self->getconfig_emailaccount;
     my $mailbox      = $config->{$account}->{mailbox};
     my $mail_passwd  = $config->{$account}->{passwd};
@@ -130,33 +129,19 @@ sub tb_send_message {
     if ($hostname eq 'client') {
         if (check_var('SLE_PRODUCT', 'sled')) {
             assert_and_click "thunderbird_SSL_error_security_exception";
-            #for any reason, window go to behind, useing shortcut key to focus again.
-            hold_key "alt";
-            send_key "f1";
-            release_key "alt";
-            send_key "tab";
-            send_key "ret";
             assert_and_click "thunderbird_confirm_security_exception";
-            # Now, return focus to thunderbirt sent email window.
-            hold_key "alt";
-            send_key "f1";
-            release_key "alt";
-            send_key "tab";
-            send_key "tab";
-            send_key "ret";
+            assert_and_click 'thunderbird_maximized_send-message';
         }
-        if (is_tumbleweed) {
+        else {
             assert_and_click "thunderbird_SSL_error_security_exception";
-            assert_and_click "thunderbird_focus_security_exception-TW";
-            assert_and_click "thunderbird_select_security_exception-TW";
             assert_and_click "thunderbird_confirm_security_exception";
-            assert_and_click "thunderbird_focus_security_exception-TW";
-            assert_and_click "thunderbird_select_sentemail_window-TW";
+            assert_and_click 'thunderbird_maximized_send-message';
+            assert_and_click "thunderbird_get-messages";
         }
-        assert_and_click "thunderbird_maximized_send-message";
+
     }
     else {
-        assert_screen 'thunderbird_sent-folder-appeared';
+        assert_screen 'thunderbird_sent-folder-appeared', 90;
     }
 
     return $mail_subject;
@@ -173,7 +158,7 @@ sub tb_check_email {
     wait_screen_change { send_key "shift-f5" };
     send_key "ctrl-shift-k";
     wait_screen_change { type_string "$mail_search" };
-    assert_screen "thunderbird_sent-message-received";
+    assert_screen "thunderbird_sent-message-received", 120;
 
     # delete the message
     assert_and_click "thunderbird_select-message";

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -36,30 +36,33 @@ sub run {
     # Configure the internal network an  try it
     if ($hostname =~ /server|master/) {
         setup_static_mm_network('10.0.2.101/24');
-        #if server running opensuse.
+        # If server running openSUSE.
         if (is_opensuse) {
-            disable_and_stop_service('NetworkManager', ignore_failure => 1);
-            assert_script_run 'systemctl start  wicked';
+            assert_script_run 'systemctl restart  wicked';
+        }
+        # If server running on SLED
+        if (check_var('SLE_PRODUCT', 'sled')) {
+            assert_script_run "nmcli connection modify 'Wired connection 1' ifname 'eth0' ip4 '10.0.2.101/24' gw4 10.0.2.2 ipv4.method manual ";
+            assert_script_run "nmcli connection down 'Wired connection 1'";
+            assert_script_run "nmcli connection up 'Wired connection 1'";
         }
     }
     else {
         setup_static_mm_network('10.0.2.102/24');
 
-        my $base_product = get_var('SLE_PRODUCT');
-        if ($base_product eq "sled") {
+        if (check_var('SLE_PRODUCT', 'sled')) {
             if (is_sle('=15')) {
                 assert_script_run 'systemctl restart  wicked';
             }
             else {
-                disable_and_stop_service('NetworkManager', ignore_failure => 1);
-                assert_script_run 'systemctl enable wicked';
-                assert_script_run 'systemctl start  wicked';
+                assert_script_run "nmcli connection modify 'Wired connection 1' ifname 'eth0' ip4 '10.0.2.102/24' gw4 10.0.2.2 ipv4.method manual ";
+                assert_script_run "nmcli connection down 'Wired connection 1'";
+                assert_script_run "nmcli connection up 'Wired connection 1'";
             }
         }
-        #Opensuse versions
+        # To openSUSE versions
         if (is_opensuse) {
-            disable_and_stop_service('NetworkManager', ignore_failure => 1);
-            assert_script_run 'systemctl start  wicked';
+            assert_script_run 'systemctl restart  wicked';
         }
     }
 

--- a/tests/x11/thunderbird/thunderbird_imap.pm
+++ b/tests/x11/thunderbird/thunderbird_imap.pm
@@ -23,6 +23,7 @@ use testapi;
 use utils;
 use lockapi qw(mutex_wait);
 use base "thunderbird_common";
+use x11utils qw(ensure_unlocked_desktop turn_off_gnome_screensaver turn_off_gnome_suspend);
 
 sub run {
     my $self     = shift;
@@ -39,15 +40,16 @@ sub run {
     }
 
     mouse_hide(1);
+
     # clean up and start thunderbird
     x11_start_program("xterm -e \"killall -9 thunderbird; find ~ -name *thunderbird | xargs rm -rf;\"", valid => 0);
-    my $success = eval { x11_start_program("thunderbird", match_timeout => 300); 1 };
+    my $success = eval { x11_start_program("thunderbird", match_timeout => 120); 1 };
     unless ($success) {
         force_soft_failure "bsc#1131306";
     } else {
         $self->tb_setup_account('imap', $account);
 
-        my $mail_subject = $self->tb_send_message($account);
+        my $mail_subject = $self->tb_send_message('imap', $account);
         $self->tb_check_email($mail_subject);
 
         # exit Thunderbird

--- a/tests/x11/thunderbird/thunderbird_pop.pm
+++ b/tests/x11/thunderbird/thunderbird_pop.pm
@@ -43,7 +43,7 @@ sub run {
     } else {
         $self->tb_setup_account('pop', $account);
 
-        my $mail_subject = $self->tb_send_message($account);
+        my $mail_subject = $self->tb_send_message('pop', $account);
         $self->tb_check_email($mail_subject);
 
         # exit Thunderbird


### PR DESCRIPTION
Add Thunderbird client-server multimachine test to the SLES15-SP2

 Solve needles errors to the SLES15-SP1 using new  Thunderbird version
 Add Thunderbird client-server test to the SLES15SP2 - #75409
 Updates needles to run on the openSUSE Tumbleweed version
 Configured SLED NetworkManager on the setup_multimachine.pm


****Important:
    ->  certify variables in qam-mail-thunderbird test suite:
         SLE_PRODUCT=sled
    ->Schedule test "disable_screensaver" until Thunderbird tests start.

- Related ticket: https://progress.opensuse.org/issues/75409

- Needles:
  SLE =  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1467
  TW  =  https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/711

- Verification run:  
    http://10.161.228.111/group_overview/142