### PR TITLE
ec2uploadimg increase the --wait-count

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -137,6 +137,7 @@ sub upload_img {
           . "--ssh-key-pair '" . $self->ssh_key . "' "
           . "--private-key-file " . $self->ssh_key_file . " "
           . "-d 'OpenQA upload image' "
+          . "--wait-count 3 "
           . ($sec_group     ? "--security-group-ids '" . $sec_group . "' " : '')
           . ($vpc_subnet    ? "--vpc-subnet-id '" . $vpc_subnet . "' "     : '')
           . ($ami_id        ? "--ec2-ami '" . $ami_id . "' "               : '')


### PR DESCRIPTION
The `ec2uploadimg` was timing out while uploading the image as it spins temporal EC2 instance and it takes time.

- Verification run: [SLE 12 SP5](http://pdostal-server.suse.cz/tests/10396#step/upload_image/37) [SLE 15 SP2](http://pdostal-server.suse.cz/tests/10393#step/upload_image/37)
