### PR TITLE
Public Cloud: Add various debug output

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -79,6 +79,8 @@ sub run_ssh_command {
     } elsif ($rc_only) {
         # Increase the hard timeout for script_run, otherwise our 'timeout $args{timeout} ...' has no effect
         $args{timeout} += 2;
+        # Pipe both the standard and error output serial for debug purposes
+        $ssh_cmd .= " 2>&1 | tee $serialdev";
         # Run the command and return only the returncode here
         my $ret = script_run($ssh_cmd, %args);
         die("Timeout on $ssh_cmd") unless (defined($ret));

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -28,6 +28,7 @@ sub run {
     assert_script_run("uname -a");
 
     assert_script_run("cat /etc/os-release");
+    script_run("ec2metadata --api latest --document") if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2'));
 
     assert_script_run("ps aux | nl");
 

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -35,6 +35,8 @@ sub run {
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
+
+        $args->{my_instance}->run_ssh_command(cmd => "zypper lr");
     }
 }
 


### PR DESCRIPTION
 * The `run_ssh_command` is currently 'hiding' the output - see [1](http://pdostal-server.suse.cz/tests/10380#step/register_system/2) or [2](https://openqa.suse.de/tests/5008640#step/register_system/45) for example
 * The `ec2metadata --api latest --document` produces useful output - see verification run

- Verification run: [SLE 15 SP1](http://pdostal-server.suse.cz/tests/10403#step/register_system/3)
