### PR TITLE
Fix regular expression for getting guest ip

### DIFF
--- a/data/mitigation/xen/get_guest_ip.sh
+++ b/data/mitigation/xen/get_guest_ip.sh
@@ -41,7 +41,7 @@ expect {
 }
 
 #submatch for output
-expect -re {dev.*\s([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})[^0-9]}
+expect -re {dev.*([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})[^0-9]}
 
 if {![info exists expect_out(1,string)]} {
         puts \"Match did not happen :(\"


### PR DESCRIPTION
Fix regular expression to get guest ip address due to output of ip command prints some chars with color.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
