### PR TITLE
[virt_autotest] Add call parent post_fail_hook for virsh snapshot management

### DIFF
--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -89,4 +89,10 @@ sub run_test {
     }
 }
 
+sub post_fail_hook {
+    my $self = shift;
+
+    $self->SUPER::post_fail_hook;
+}
+
 1;

--- a/tests/virt_autotest/virsh_internal_snapshot.pm
+++ b/tests/virt_autotest/virsh_internal_snapshot.pm
@@ -30,6 +30,9 @@ use virt_autotest::utils;
 
 sub run_test {
     my ($self) = @_;
+
+    # Except failur to ensure call post_fail_hook here
+    die "ensure call parent post_fail_hook for virsh snapshot management";
     #Snapshots are supported on KVM VM Host Servers only
     return unless is_kvm_host;
 


### PR DESCRIPTION
Refer to the current virsh snapshot management test code, which were missed call parent `post_fail_hook()` after trigger virsh snapshot management new failure. 

So, need to call parent post_fail_hook for virsh snapshot management as this PR purpose: 
```
tests/virt_autotest/virsh_external_snapshot.pm
tests/virt_autotest/virsh_internal_snapshot.pm
```

- Verification run: 
[gi-guest_developing-on-host_sles15sp2-kvm](http://149.44.176.58/t5052653)
[gi-guest_developing-on-host_sles15sp2-xen](http://149.44.176.58/t5052654)
