### PR TITLE
Add autofs service check for SLE11SP4

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -137,7 +137,7 @@ our $default_services = {
     autofs => {
         srv_pkg_name       => 'autofs',
         srv_proc_name      => 'autofs',
-        support_ver        => $support_ver_def,
+        support_ver        => $support_ver_ge11,
         service_check_func => \&full_autofs_check
     },
     cups => {

--- a/lib/services/ntpd.pm
+++ b/lib/services/ntpd.pm
@@ -54,8 +54,8 @@ sub stop_service {
 }
 
 sub check_service {
-    common_service_action($service_name, $service_type, 'is-enabled');
     common_service_action($service_name, $service_type, 'is-active');
+    common_service_action($service_name, $service_type, 'is-enabled');
 }
 
 sub check_function {
@@ -73,7 +73,7 @@ sub full_ntpd_check {
     $service_type = $type;
     $service_name = ($service_type eq 'SystemV') ? 'ntp' : 'ntpd';
     $stage //= '';
-    if ($stage eq 'before') {
+    if ((get_var('ORIGIN_SYSTEM_VERSION') eq '11-SP4') || $stage eq 'before') {
         install_service();
         config_service();
         enable_service();


### PR DESCRIPTION
We'd add autofs service check for SLE11SP4. For  SLE11SP4 we just check the service
start/enable/status, no function check by now,  because it's different to verify the autofs 
function on SLES11SP4.

- Related ticket: https://progress.opensuse.org/issues/73516
- Needles: N/A
- Verification run:  
  https://openqa.nue.suse.com/tests/5032726 
 regression run: 
 https://openqa.nue.suse.com/t5032825
 https://openqa.nue.suse.com/t5032826
 https://openqa.nue.suse.com/t5009683

latest run:
https://openqa.nue.suse.com/tests/5075208
https://openqa.nue.suse.com/tests/5075209
https://openqa.nue.suse.com/tests/5075210


run autofs regression test:
https://openqa.nue.suse.com/tests/5081804#step/autofs/58
https://openqa.nue.suse.com/tests/5082128#step/autofs/58

ntp regression test
https://openqa.nue.suse.com/tests/5094067#step/ntp/38