### PR TITLE
[virt_autotest] fix isolated virtual network failure on 15+

### DIFF
--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -104,6 +104,7 @@ sub run_test {
         assert_script_run("virsh detach-interface $guest --mac $mac1 $exclusive");
         assert_script_run("virsh detach-interface $guest.clone --mac $mac2 $exclusive");
 
+        script_run "sed -i '/ $guest.clone /d' /etc/hosts";
         assert_script_run("virsh destroy $guest.clone");
         assert_script_run("virsh undefine $guest.clone");
         assert_script_run("rm -rf /var/lib/libvirt/images/$guest.clone");


### PR DESCRIPTION
Refer to the latest libvirt_isolated_virtual_network failures both 15sp3 build92.1 kvm and xen vm host, figure out that **ACTIVE_IP_ADDRESS** (get from br123 network interface - created from **VIRT_AUTOTEST**)  was changed from 192.168.123.10 to 192.168.123.11 after libvirt_routed_virtual_network on sles15+ vm hosts(NOTE, there was not any changed for guest mac setting, just only changed with ip address here), which did block `test_network_interface()` -> call `save_guest_ip()` -> call` ping -c3 $guest `-> read **$guest** name and ip address (i.e **ACTIVE_IP_ADDRESS** ) from /etc/hosts file on vm hosts during libvirt_isolated_virtual_network on sles15+ 
**NOTE:**
Fail to ping or ssh $guest due to the guest ip address was changed or destroyed after libvirt_routed_virtual_network as the root cause.

SO, before libvirt_isolated_virtual_network on sles15+ , we need to clean up /etc/hosts file on vm hosts firstly, then 
recheck with ACTIVE_IP_ADDRESS from br123 network interface - created from VIRT_AUTOTEST for guest system for calling save_guest_ip() ,  I had created new func like `check_guest_ip()` .

Please refer to the follow osd url for more details:
[libvirt_isolated_virtual_network_kvm](https://149.44.176.58/tests/5086111) 
[libvirt_isolated_virtual_networkxen](https://149.44.176.58/tests/5086113)  

- Verification run: 
[gi-guest_developing-on-host_developing-kvm](http://149.44.176.58/tests/5094216)
[gi-guest_developing-on-host_developing-xen](http://149.44.176.58/tests/5094579)
[gi-guest_developing-on-host_sles15sp2-kvm](http://149.44.176.58/tests/5094581)
[gi-guest_developing-on-host_sles15sp2-xen](http://149.44.176.58/tests/5094583)
[gi-guest_sles15sp2-on-host_developing-xen](http://149.44.176.58/t5094584)
[gi-guest_sles15sp2-on-host_developing-kvm](http://149.44.176.58/tests/5095257)
[gi-guest_developing-on-host_sles12sp5-kvm](http://149.44.176.58/t5094551)
[gi-guest_developing-on-host_sles12sp5-xen](http://149.44.176.58/tests/5095254)
[gi-guest_sles12sp5-on-host_developing-kvm](http://149.44.176.58/tests/5095255)
[gi-guest_sles12sp5-on-host_developing-xen](http://149.44.176.58/tests/5095256)