### PR TITLE
Install systemd-coredump when needed and available

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -87,6 +87,8 @@ sub run {
             services::registered_addons::full_registered_check;
         }
     }
+
+    assert_script_run 'rpm -q systemd-coredump || zypper -n in systemd-coredump || true' if get_var('COLLECT_COREDUMPS');
 }
 
 sub test_flags {


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/62864
Verification: http://kazhua.qa.suse.de/tests/128#step/system_prepare/10
http://kazhua.qa.suse.de/tests/132#step/system_prepare/10

I don't want to add a repo / register the product based on the COREDUMP_COLLECT var as it might break other stuff.
So I made the error non-fatal if the pkg is not available.