### PR TITLE
Redesign allmodules+allpatterns+registration

### DIFF
--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -1,10 +1,10 @@
 ---
-name: allmodules+allpatterns+registration
+name: select_modules_and_patterns+registration
 description: >
   Full Medium installation that covers the following cases:
      1. Additional modules enabled using SCC (Legacy, Development Tools,
         Web and Scripting, Containers, Desktop Applications);
-     2. All patterns installed;
+     2. Yast patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
@@ -12,7 +12,6 @@ description: >
 vars:
   SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start
@@ -28,6 +27,7 @@ schedule:
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -41,6 +41,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_installed_software
   - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
@@ -1,19 +1,21 @@
 ---
-name: allmodules+allpatterns+registration@s390x
+name:           select_modules_and_patterns+registration
 description: >
   Full Medium installation that covers the following cases:
      1. Additional modules enabled using SCC (Legacy, Development Tools,
         Web and Scripting, Containers, Desktop Applications);
-     2. All patterns installed;
+     2. Yast patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
+  On powerVM we don't want to test gnome, as is not used by customers, so setting
+  system role to textmode, even though Desktop Applications module is enabled as
+  is required for Development Tools module.
 vars:
-  SCC_REGISTER: console
-  ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS: all
-  ADDONS: all-packages
+  DESKTOP: textmode
+  SYSTEM_ROLE: textmode
+  SCC_ADDONS: desktop,legacy,sdk,script,contm
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -24,10 +26,10 @@ schedule:
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -35,14 +37,13 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
+  - installation/grub_test
   - installation/first_boot
-  - console/check_resume
   - console/sle15_workarounds
-  - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_installed_software
   - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
-  - shutdown/svirt_upload_assets

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -1,25 +1,23 @@
 ---
-name:           allmodules+allpatterns+registration
+name: select_modules_and_patterns+registration@s390x-zVM
 description: >
   Full Medium installation that covers the following cases:
      1. Additional modules enabled using SCC (Legacy, Development Tools,
         Web and Scripting, Containers, Desktop Applications);
-     2. All patterns installed;
+     2. Yast patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
      5. Registration is performed on the installed system.
-  On powerVM we don't want to test gnome, as is not used by customers, so setting
-  system role to textmode, even though Desktop Applications module is enabled as
-  is required for Development Tools module.
 vars:
-  DESKTOP: textmode
-  SYSTEM_ROLE: textmode
-  SCC_ADDONS: desktop,legacy,sdk,script,contm
+  SCC_REGISTER: console
+  ENABLE_ALL_SCC_MODULES: 1
+  ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
+  - installation/disk_activation
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
@@ -29,6 +27,7 @@ schedule:
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -36,12 +35,14 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
-  - installation/grub_test
   - installation/first_boot
+  - console/check_resume
   - console/sle15_workarounds
+  - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_installed_software
   - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -1,10 +1,10 @@
 ---
-name: allmodules+allpatterns+registration@uefi
+name: select_modules_and_patterns+registration@s390x
 description: >
   Full Medium installation that covers the following cases:
      1. Additional modules enabled using SCC (Legacy, Development Tools,
         Web and Scripting, Containers, Desktop Applications);
-     2. All patterns installed;
+     2. Yast patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
@@ -12,7 +12,6 @@ description: >
 vars:
   SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start
@@ -28,19 +27,23 @@ schedule:
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/check_resume
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_installed_software
   - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+  - shutdown/svirt_upload_assets

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
@@ -1,10 +1,10 @@
 ---
-name: allmodules+allpatterns+registration@svirt-hyperv
+name: select_modules_and_patterns+registration@svirt-hyperv
 description: >
   Full Medium installation that covers the following cases:
      1. Additional modules enabled using SCC (Legacy, Development Tools,
         Web and Scripting, Containers, Desktop Applications);
-     2. All patterns installed;
+     2. Yast patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
@@ -12,7 +12,6 @@ description: >
 vars:
   SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start
@@ -27,6 +26,7 @@ schedule:
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -39,6 +39,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_installed_software
   - shutdown/cleanup_before_shutdown
   - console/suseconnect_scc
   - shutdown/shutdown

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
@@ -1,10 +1,10 @@
 ---
-name: allmodules+allpatterns+registration@s390x-zVM
+name: select_modules_and_patterns+registration@uefi
 description: >
   Full Medium installation that covers the following cases:
      1. Additional modules enabled using SCC (Legacy, Development Tools,
         Web and Scripting, Containers, Desktop Applications);
-     2. All patterns installed;
+     2. Yast patterns installed;
      3. System registration is skipped during installation;
      4. Installation is validated by successful boot and that YaST does not
         report any issues;
@@ -12,36 +12,36 @@ description: >
 vars:
   SCC_REGISTER: console
   ENABLE_ALL_SCC_MODULES: 1
-  PATTERNS: all
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
-  - installation/disk_activation
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
+  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/grub_test
   - installation/first_boot
-  - console/check_resume
   - console/sle15_workarounds
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_installed_software
   - console/suseconnect_scc
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -1,16 +1,10 @@
 ---
-name:           allmodules+allpatterns
-description:    >
-  Perform an installation enabling all modules and selecting all patterns.
-  This test suite always registers to have access to all modules.
-  On spvm we can test in textmode only.
-  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
-  module is scheduled and OPT_KERNEL_PARAMS variable is set.
-vars:
-  DESKTOP: textmode
-  PATTERNS: all
-  ENABLE_ALL_SCC_MODULES: 1
+name: select_modules_and_patterns
+description: |
+  Perform an installation enabling some modules and selecting some
+  patterns.This test suite always registers to have access to some modules.
 schedule:
+  - installation/isosize
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
@@ -18,19 +12,30 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
+  - installation/partitioning/no_separate_home
   - installation/partitioning_finish
   - installation/installer_timezone
+  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - "{{boot_handler}}"
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup
+  - console/validate_installed_software
   - console/yast2_i
+conditional_schedule:
+  boot_handler:
+    BACKEND:
+      qemu:
+        - installation/grub_test
+      svirt:
+        - boot/reconnect_mgmt_console

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -1,10 +1,15 @@
 ---
-name: allmodules+allpatterns
-description: |
-  Perform an installation enabling all modules and selecting all
-  patterns.This test suite always registers to have access to all modules.
+name:           select_modules_and_patterns
+description:    >
+  Perform an installation enabling some modules and selecting some patterns.
+  This test suite always registers to have access to some modules.
+  On spvm we can test in textmode only.
+  For spvm we have to disable plymouth, so edit_optional_kernel_cmd_parameters
+  module is scheduled and OPT_KERNEL_PARAMS variable is set.
+vars:
+  DESKTOP: textmode
+  ENABLE_ALL_SCC_MODULES: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
@@ -12,28 +17,21 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
-  - installation/partitioning/no_separate_home
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
-  - installation/resolve_dependency_issues
+  - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - "{{boot_handler}}"
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup
+  - console/validate_installed_software
   - console/yast2_i
-conditional_schedule:
-  boot_handler:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      svirt:
-        - boot/reconnect_mgmt_console

--- a/test_data/yast/select_modules_and_patterns.yaml
+++ b/test_data/yast/select_modules_and_patterns.yaml
@@ -1,0 +1,14 @@
+---
+software:
+  packages:
+    bash:
+      installed: 1
+  patterns:
+    yast2_basis:
+      installed: 1
+    yast2_desktop:
+      installed: 1
+    yast2_server:
+      installed: 1
+    devel_yast:
+      installed: 1


### PR DESCRIPTION
Not to loose any coverage, we still need to validate that patterns can be selected and installed.
We already test this indirectly in minimal-x scenario, where disable patterns.

New test suite should validate that selected patterns were installed. As we focus on the YaST components, we could use YaST patterns in this scenario.

WIP, as validation part is missing. May require as well a lot of VRs.

- Related ticket: https://progress.opensuse.org/issues/76918
- Gitlab MR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/317
- Verification run: 
Online, normal registration (ex allmodule) http://waaa-amazing.suse.cz/tests/13701#
Full, post registration: http://waaa-amazing.suse.cz/tests/13702#

On prod:
64bit: https://openqa.suse.de/tests/5062016
aarch64: https://openqa.suse.de/tests/5062027
ppc64le: https://openqa.suse.de/tests/5062022
hyperv: https://openqa.suse.de/tests/5061975
uefi: https://openqa.suse.de/tests/5062028
