### PR TITLE
ntp_client: Wait for 4 sources which responded to request

### DIFF
--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -24,6 +24,8 @@ sub run {
     if (is_sle) {
         systemctl 'enable chronyd';
         systemctl 'start chronyd';
+        # bsc#1179022 avoid '503 No such source' error while chrony does pick responding sources after start
+        assert_script_run 'until chronyc sources|grep "Number of sources = 4"; do sleep 1; echo "waiting for 4 ntp sources response"; done';
     }
 
     # ensure that ntpd is neither installed nor enabled nor active


### PR DESCRIPTION
To avoid '503 No such source error' when running chronyc sources while
chronyc is resolving sources and wait for response from 4 sources by default

- Related ticket:
https://progress.opensuse.org/issues/67099
https://progress.opensuse.org/issues/67324
- Verification run: 
http://10.100.12.155/tests/16992#step/ntp_client/23 15-SP1
http://10.100.12.155/tests/16991#step/ntp_client/23 15-SP2
