### PR TITLE
Skip download publiccloud repos if already existing

### DIFF
--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -31,7 +31,7 @@ sub run {
         record_info('Skip download', 'Skipping download triggered by setting (QAM_PUBLICCLOUD_SKIP_DOWNLOAD = 1)');
     } else {
         assert_script_run("du -sh ~/repos");
-        assert_script_run("rsync -va -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
+        assert_script_run("rsync -uva -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");


### PR DESCRIPTION
In publiccloud test runs we download the update repositories multiple times and this is time consuming.
With this commit, subsequent downloads of the same repositories will be skipped.
Transfer repos is now using the update flag for `rsync` to skip unnecessary duplicate transfers.

- Related ticket: https://progress.opensuse.org/issues/78195
- Needles: -
- Verification run: http://phoenix-openqa.qam.suse.de/t3933
