### PR TITLE
Adjust port check for yast2_ftp

### DIFF
--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -46,8 +46,7 @@ sub vsftd_setup_checker {
 sub vsftpd_firewall_checker {
     die "service configuration file is missing in firewalld" if script_run("[[ -e /usr/lib/firewalld/services/vsftpd.xml ]]");
     die "vsftpd is not enabled in firewalld"                 if script_run("firewall-cmd --list-services | grep vsftpd");
-    die "Port 21 is not opened"                              if script_run('iptables -L -n -v | grep "tcp dpt:21"');
-    die "Ports for passive ftp are not opened"               if script_run('iptables -L -n -v | grep "tcp dpts:30000:30100"');
+    die "Ports for passive ftp are not configured"           if script_run("firewall-cmd --permanent --service vsftpd --get-ports");
 }
 
 sub run {


### PR DESCRIPTION
Currently, the yast2_ftp module is checking if ftp and vsftpd ports are open, using iptables for SUTs with firewalld. The PR is changing to checking the configuration, instead of checking if the ports are open, which is out of the YaST scope.

- Related ticket: https://progress.opensuse.org/issues/77896
- Verification runs: 
   * SLES: http://falafel.suse.cz/tests/983
   * Tumbleweed: http://falafel.suse.cz/tests/982