### PR TITLE
Make scheduler takes RunArgs and loadtest with it

### DIFF
--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -32,9 +32,8 @@ our @EXPORT = qw(load_yaml_schedule get_test_suite_data);
 
 my $test_suite_data;
 my $root_project_dir = dirname(__FILE__) . '/../';
-
-my $include = YAML::PP::Schema::Include->new(paths => ($root_project_dir));
-my $ypp     = YAML::PP->new(schema => ['Core', $include, 'Merge']);
+my $include          = YAML::PP::Schema::Include->new(paths => ($root_project_dir));
+my $ypp              = YAML::PP->new(schema => ['Core', $include, 'Merge']);
 $include->yp($ypp);
 
 sub parse_vars {
@@ -120,12 +119,14 @@ Parse variables and test modules from a yaml file representing a test suite to b
 
 sub load_yaml_schedule {
     if (my $yamlfile = get_var('YAML_SCHEDULE')) {
-        my $schedule      = $ypp->load_file($root_project_dir . $yamlfile);
-        my %schedule_vars = parse_vars($schedule);
+        my $schedule              = $ypp->load_file($root_project_dir . $yamlfile);
+        my %schedule_vars         = parse_vars($schedule);
+        my $test_context_instance = undef;
         while (my ($var, $value) = each %schedule_vars) { set_var($var, $value) }
         my @schedule_modules = parse_schedule($schedule);
         parse_test_suite_data($schedule);
-        loadtest($_) for (@schedule_modules);
+        $test_context_instance = get_var('TEST_CONTEXT')->new() if defined get_var('TEST_CONTEXT');
+        loadtest($_, run_args => $test_context_instance) for (@schedule_modules);
         return 1;
     }
     return 0;

--- a/variables.md
+++ b/variables.md
@@ -135,6 +135,7 @@ SPLITUSR | boolean | false | Enables `installation/partitioning_splitusr` test m
 SUSEMIRROR | string | | Mirror url of the installation medium.
 SYSAUTHTEST | boolean | false | Enable system authentication test (`sysauth/sssd`)
 TEST | string | | Name of the test suite.
+TEST_CONTEXT | string | | Defines the class name to be used as the context instance of the test. This is used in the scheduler to pass the `run_args` into the loadtest function. If it is not given it will be undef.
 TOGGLEHOME | boolean | false | Changes the state of partitioning to have or not to have separate home partition in the proposal.
 TUNNELED | boolean | false | Enables the use of normal consoles like "root-consoles" on a remote SUT while configuring the tunnel in a local "tunnel-console"
 TYPE_BOOT_PARAMS_FAST | boolean | false | When set, forces `bootloader_setup::type_boot_parameters` to use the default typing interval.


### PR DESCRIPTION
We introduce the TEST_CONTEXT openqa variable which can take the name of                                                                                                                                                                     
the class that can be used as in the loadtest. The class should be in the                                                                                                                                                                    
`OpenQA::Test` namespace and when it is present                                                                                                                                                                                              
it will create an instance before the loadtest call from inside the yaml                                                                                                                                                                     
schedule loader.                                                                                                                                                                                                                             
The `run_args` is passed as parameter to all the modules but it is up to                                                                                                                                                                     
the module if it will be used or not. That means that it should not cause                                                                                                                                                                    
any issue with any other job which is using the yaml scheduler.                                                                                                                                                                              
                                                                                                                                                                                                                                             
Another way we could use it could be via the test_data but this does not                                                                                                                                                                     
work as the required data are not static.

- Related ticket: https://progress.opensuse.org/issues/71314
- [VR](http://aquarius.suse.cz/tests/4068)
- [VR from yast](https://openqa.suse.de/tests/5076652)