### PR TITLE
Schedule disk_activation on s390x backend

### DIFF
--- a/schedule/functional/allpatterns.yaml
+++ b/schedule/functional/allpatterns.yaml
@@ -11,7 +11,7 @@ description:    >
     the setting ENABLE_ALL_SCC_MODULES=1 to the test suite
 conditional_schedule:
     disk_activation:
-        ARCH:
+        BACKEND:
             's390x':
                 - installation/disk_activation
     grub_or_reconnect:


### PR DESCRIPTION
z/VM is handled by `ARCH=s390x BACKEND=s390x`
z/SLE/KVM is handled by `ARCH=s390x BACKEND=svirt`

- Failed test: https://openqa.suse.de/tests/5056190#step/disk_activation/1
- Verification run: https://openqa.suse.de/tests/5058631
