### PR TITLE
Fix ibtests barriers

### DIFF
--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -19,7 +19,6 @@ vars:
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
 schedule:
-    - kernel/ibtests_barriers
     - installation/ipxe_install
     - installation/welcome
     - installation/accept_license

--- a/tests/kernel/ibtests_barriers.pm
+++ b/tests/kernel/ibtests_barriers.pm
@@ -19,12 +19,9 @@ use lockapi;
 
 
 sub run {
-    if (get_required_var('IBTEST_ROLE') eq 'IBTEST_MASTER') {
-        barrier_create('IBTEST_SETUP', 2);
-        barrier_create('IBTEST_BEGIN', 2);
-        barrier_create('IBTEST_DONE',  2);
-    }
-
+    barrier_create('IBTEST_SETUP', 2);
+    barrier_create('IBTEST_BEGIN', 2);
+    barrier_create('IBTEST_DONE',  2);
 }
 
 1;


### PR DESCRIPTION
Since we migrated to YAML-schedule, we don't need to have a conditional in the barrier setup code if we remove loading the file also from the slave-schedule.
On top, the first barrier needs to be hit earlier, before the machines try communicating.



- Related ticket: https://progress.opensuse.org/issues/80208
- Needles: 
- Verification run: http://baremetal-support.qa.suse.de/tests/526 and http://baremetal-support.qa.suse.de/tests/527
