### PR TITLE
Update Public Cloud public AMIs list on ec2utils.conf

### DIFF
--- a/data/publiccloud/ec2utils.conf
+++ b/data/publiccloud/ec2utils.conf
@@ -26,7 +26,7 @@ security_group_ids_eu-central-1=
 # The ami, instance_type, and user are needed for those utilities that require
 # a running instance in Amazon EC2 to perform their operations.
 [region-ap-northeast-1]
-ami = ami-383c1956
+ami = ami-017c51aa4445fa7e8
 instance_type = t2.micro
 aki_i386 = aki-136bf512
 aki_x86_64 = aki-176bf516
@@ -37,7 +37,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-ap-northeast-2]
-ami = ami-249b554a
+ami = ami-0bb00af12ab4446d2
 instance_type = t2.micro
 aki_i386 = aki-01a66b6f
 aki_x86_64 = aki-01a66b6f
@@ -48,9 +48,9 @@ user = ec2-user
 # ssh_private_key =
 
 [region-ap-southeast-1]
-ami = ami-c9b572aa
+ami = ami-0e615bfa6ebacf593
 instance_type = t2.micro
-aki_i386 = aki-ae3973fc
+aki_i386 = aki-ae3973fc	
 aki_x86_64 = aki-503e7402
 g2_aki_x86_64 = aki-ca755498
 user = ec2-user
@@ -59,7 +59,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-ap-southeast-2]
-ami = ami-48d38c2b
+ami = ami-0b048d724fa38e794
 instance_type = t2.micro
 aki_i386 = aki-cd62fff7
 aki_x86_64 = aki-c362fff9
@@ -70,7 +70,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-cn-north-1]
-ami = ami-bcc45885
+ami = ami-0671ccf63b2c220e6
 instance_type = t2.micro
 aki_i386 = aki-908f1da9
 aki_x86_64 = aki-9e8f1da7
@@ -81,8 +81,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-eu-central-1]
-# suse-sles-15-sp1-v20200226-hvm-ssd-x86_64
-ami = ami-0d63f0d5c7bc514dd
+ami = ami-0f242a26eb9754f9e
 instance_type = t2.micro
 aki_i386 = aki-3e4c7a23
 aki_x86_64 = aki-184c7a05
@@ -92,8 +91,19 @@ user = ec2-user
 # ssk_key_name =
 # ssh_private_key =
 
+[region-eu-north-1]
+ami = ami-0d866e23f10ac8fca
+instance_type = t2.micro
+aki_i386 = None
+aki_x86_64 = None
+g2_aki_x86_64 = None
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
 [region-eu-west-1]
-ami = ami-bff32ccc
+ami = ami-07171305581009fd9
 instance_type = t2.micro
 aki_i386 = aki-68a3451f
 aki_x86_64 = aki-52a34525
@@ -104,7 +114,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-sa-east-1]
-ami = ami-6817af04
+ami = ami-060272278049124dc
 instance_type = t2.micro
 aki_i386 = aki-5b53f446
 aki_x86_64 = aki-5553f448
@@ -118,7 +128,7 @@ user = ec2-user
 #Amazon Linux
 #ami = ami-4b814f22
 # SLES 12
-ami = ami-60b6c60a
+ami = ami-0854245e554858119
 instance_type = t2.micro
 aki_i386 = aki-8f9dcae6
 aki_x86_64 = aki-919dcaf8
@@ -130,7 +140,7 @@ backing-store = mag,ssd
 # ssh_private_key =
 
 [region-us-east-2]
-ami = ami-71ca9114
+ami = ami-0f7664bdb7d796cba
 instance_type = t2.micro
 aki_i386 = aki-da055ebf
 aki_x86_64 = aki-d83a61bd
@@ -140,8 +150,19 @@ backing-store = ssd
 # ssk_key_name =
 # ssh_private_key =
 
+[region-us-gov-east-1]
+ami = ami-0594a8c4e325d1853
+instance_type = t2.micro
+aki_i386 = None
+aki_x86_64 = None
+g2_aki_x86_64 = None
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
 [region-us-gov-west-1]
-ami = ami-c2b5d7e1
+ami = ami-da4960bb
 instance_type = t2.micro
 aki_i386 = aki-1fe98d3c
 aki_x86_64 = aki-1de98d3e
@@ -152,7 +173,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-us-west-1]
-ami = ami-d5ea86b5
+ami = ami-03e765b6357195bc2
 instance_type = t2.micro
 aki_i386 = aki-8e0531cb
 aki_x86_64 = aki-880531cd
@@ -163,7 +184,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-us-west-2]
-ami = ami-f0091d91
+ami = ami-0035ad09399a3a946
 instance_type = t2.micro
 aki_i386 = aki-f08f11c0
 aki_x86_64 = aki-fc8f11cc
@@ -174,7 +195,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-ca-central-1]
-ami = ami-a954d1cd
+ami = ami-08a1ac0aedd3ed323
 instance_type = t2.micro
 user = ec2-user
 # Allow a region to overwrite the account key
@@ -182,7 +203,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-eu-west-2]
-ami = ami-403e2524
+ami = ami-06fefe39dff905811
 instance_type = t2.micro
 user = ec2-user
 # Allow a region to overwrite the account key
@@ -190,7 +211,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-eu-west-3]
-ami = ami-8ee056f3
+ami = ami-00b2f7798f4b288da
 instance_type = t2.micro
 user = ec2-user
 # Allow a region to overwrite the account key
@@ -198,7 +219,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-ap-south-1]
-ami = ami-531a4c3c
+ami = ami-0e7db32ee52bb185b
 instance_type = t2.micro
 user = ec2-user
 # Allow a region to overwrite the account key
@@ -206,7 +227,7 @@ user = ec2-user
 # ssh_private_key =
 
 [region-cn-northwest-1]
-ami = ami-23978241
+ami = ami-00ccdc515e9ad601c
 instance_type = t2.micro
 user = ec2-user
 # Allow a region to overwrite the account key


### PR DESCRIPTION
As `ec2uploadimg` command uses helper AMI this AMI now must have `lsblk >= 2.27` which our don't.
To use those new AMIs we also need to regenerate the `publiccloud_tools.qcow2` which I will do later.

- Related ticket: [poo#80196](https://progress.opensuse.org/issues/80196)
- Related upstream commit: [ec2imgutils#a8fe87e](https://github.com/SUSE-Enceladus/ec2imgutils/commit/a8fe87e3cd1be4edfa0030ef0ee1b25cf3d2cced)