### PR TITLE
Fix wpa_supplicant_test for Tumbleweed

### DIFF
--- a/tests/console/wpa_supplicant.pm
+++ b/tests/console/wpa_supplicant.pm
@@ -44,13 +44,18 @@ sub run {
     zypper_call 'in wpa_supplicant hostapd iw dnsmasq unzip';
     assert_script_run 'cd $(mktemp -d)';
     assert_script_run('curl -L -s ' . data_url('wpa_supplicant') . ' | cpio --make-directories --extract && cd data');
-    record_info('Info', 'Running wpa_supplicant_test.sh');
-    assert_script_run('bash -x ./wpa_supplicant_test.sh', timeout => 600);
+    assert_script_run('bash -x ./wpa_supplicant_test.sh 2>&1 | tee wpa-supplicant_test.txt', timeout => 600);
     # unregister SDK
     if (is_sle && !main_common::is_updates_tests()) {
         remove_suseconnect_product(get_addon_fullname('phub'));
         record_info('Install-Info', 'Removed package hub repository');
     }
+}
+
+sub post_fail_hook {
+    # Upload logs if present
+    upload_logs("wicked.log")              if (script_run("stat wicked.log") == 0);
+    upload_logs("wpa-supplicant_test.txt") if (script_run("stat wpa-supplicant_test.txt") == 0);
 }
 
 1;


### PR DESCRIPTION
This commit fixes the test run for Tumbleweed

- Related ticket: https://progress.opensuse.org/issues/77830
- Needles: -
- Verification run: [Tumbleweed](http://phoenix-openqa.qam.suse.de/t3967)
[SLE 15-SP2](http://phoenix-openqa.qam.suse.de/tests/3961) | [SLE 15-SP1](http://phoenix-openqa.qam.suse.de/tests/3959) | [SLE 15](http://phoenix-openqa.qam.suse.de/tests/3957)
