### PR TITLE
yast2_nfs_client: Add fsid=23 export option

### DIFF
--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -54,7 +54,7 @@ sub run {
         assert_script_run 'mkdir -p /tmp/nfs/server';
         assert_script_run 'echo "success" > /tmp/nfs/server/file.txt';
         # Serve the share
-        assert_script_run 'echo "/tmp/nfs/server *(ro)" >> /etc/exports';
+        assert_script_run 'echo "/tmp/nfs/server *(ro,fsid=23)" >> /etc/exports';
         systemctl 'start nfs-server';
         assert_script_run "showmount -e localhost";
     }


### PR DESCRIPTION
Since the switch of /tmp to tmpfs, NFS can no longer export the directory
created on /tmp.
tmpfs filesystems do not have a UUID so nfs doesn't know how to identify them.
In order to export a tmpfs filesystem we need to provide an identifying number using "fsid=NN".

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1176158
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1482626 (passed)
