### PR TITLE
Containers: pull leap and tumbleweed from openSUSE registry

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -56,13 +56,13 @@ sub basic_container_tests {
     record_soft_failure('poo#76993') if (script_run("$runtime image pull hello-world", timeout => 300) != 0);
     #   - pull image of last released version of openSUSE Leap
     if (!check_var('ARCH', 's390x')) {
-        assert_script_run("$runtime image pull opensuse/leap", timeout => 600);
+        assert_script_run("$runtime image pull registry.opensuse.org/opensuse/leap", timeout => 600);
     }
     else {
         record_soft_failure("bsc#1171672 Missing Leap:latest container image for s390x");
     }
     #   - pull image of openSUSE Tumbleweed
-    assert_script_run("$runtime image pull opensuse/tumbleweed", timeout => 600);
+    assert_script_run("$runtime image pull registry.opensuse.org/opensuse/tumbleweed", timeout => 600);
 
     # Local images can be listed
     assert_script_run("$runtime image ls none");


### PR DESCRIPTION
Due to docker.io limitation, we can pull openSUSE images from registry.opensuse.org.

Failure: https://openqa.suse.de/tests/5058225#step/zypper_docker/3
VR: https://openqa.suse.de/tests/5060881
