### PR TITLE
Use non-greed mode regular expression to get guest ip address

### DIFF
--- a/data/mitigation/xen/get_guest_ip.sh
+++ b/data/mitigation/xen/get_guest_ip.sh
@@ -41,7 +41,7 @@ expect {
 }
 
 #submatch for output
-expect -re {dev.*([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})[^0-9]}
+expect -re {dev.*?([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})[^0-9]}
 
 if {![info exists expect_out(1,string)]} {
         puts \"Match did not happen :(\"


### PR DESCRIPTION
Use non-greed mode regular expression to get guest ip address

- Related ticket: N/A
- Needles: N/A
- Verification run: http://10.67.129.4/tests/23931