### PR TITLE
Register python2 module for older sle15 than sp2

### DIFF
--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -36,7 +36,8 @@ sub run {
     $self->select_serial_terminal;
 
     install_docker_when_needed;
-    add_suseconnect_product(get_addon_fullname('phub')) if is_sle();
+    add_suseconnect_product(get_addon_fullname('phub'))    if is_sle();
+    add_suseconnect_product(get_addon_fullname('python2')) if is_sle('<15-sp2');
 
     record_info 'Test #1', 'Test: Installation';
     zypper_call("in docker-compose");
@@ -71,7 +72,8 @@ sub run {
     assert_script_run 'cd';
 
     # De-registration is disabled for on-demand instances
-    remove_suseconnect_product(get_addon_fullname('phub')) if (is_sle() && !is_ondemand());
+    remove_suseconnect_product(get_addon_fullname('phub'))    if (is_sle() && !is_ondemand());
+    remove_suseconnect_product(get_addon_fullname('python2')) if is_sle('<15-sp2');
     clean_container_host(runtime => 'docker');
 }
 


### PR DESCRIPTION
Older distris than sle15sp2 pull docker-compose based on python2. In such a case dependencies can be found in a specific python2 module that needs to be additionally registered. 
- Verification run: [jeos-base+phub](https://openqa.suse.de/tests/5063506#step/docker_compose/1)