### PR TITLE
Containers: Use remote private registry to pull images

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -44,16 +44,19 @@ sub test_seccomp {
 sub basic_container_tests {
     my $runtime = shift;
     die "You must define the runtime!" unless $runtime;
+    my $registry = get_var('REGISTRY', 'docker.io');
+    record_info('Registry', "Images available in $registry:\n" . script_output("curl $registry/v2/_catalog")) if ($registry !~ /docker.io/);
 
-    # Search and pull images from the Docker Hub
+    # Test search feature
     validate_script_output("$runtime search --no-trunc tumbleweed", sub { m/Official openSUSE Tumbleweed images/ });
+
     #   - pull minimalistic alpine image of declared version using tag
     #   - https://store.docker.com/images/alpine
     my $alpine_image_version = '3.6';
-    record_soft_failure('poo#76993') if (script_run("$runtime image pull alpine:$alpine_image_version", timeout => 300) != 0);
+    script_run("$runtime image pull $registry/library/alpine:$alpine_image_version", timeout => 300);
     #   - pull typical docker demo image without tag. Should be latest.
     #   - https://store.docker.com/images/hello-world
-    record_soft_failure('poo#76993') if (script_run("$runtime image pull hello-world", timeout => 300) != 0);
+    script_run("$runtime image pull $registry/library/hello-world", timeout => 300);
     #   - pull image of last released version of openSUSE Leap
     if (!check_var('ARCH', 's390x')) {
         assert_script_run("$runtime image pull registry.opensuse.org/opensuse/leap", timeout => 600);
@@ -67,9 +70,9 @@ sub basic_container_tests {
     # Local images can be listed
     assert_script_run("$runtime image ls none");
     #   - filter with tag
-    record_soft_failure('poo#76993') if (script_run(qq{$runtime image ls alpine:$alpine_image_version | grep "alpine\\s*$alpine_image_version"}) != 0);
+    script_run(qq{$runtime image ls alpine:$alpine_image_version | grep "alpine\\s*$alpine_image_version"});
     #   - filter without tag
-    record_soft_failure('poo#76993') if (script_run(qq{$runtime image ls hello-world | grep "hello-world\\s*latest"}) != 0);
+    script_run(qq{$runtime image ls hello-world | grep "hello-world\\s*latest"});
     #   - all local images
     my $local_images_list = script_output("$runtime image ls");
     die("$runtime image opensuse/tumbleweed not found") unless ($local_images_list =~ /opensuse\/tumbleweed\s*latest/);
@@ -77,13 +80,13 @@ sub basic_container_tests {
 
     # Containers can be spawned
     #   - using 'run'
-    record_soft_failure('poo#76993') if (script_run("$runtime container run --name test_1 hello-world | grep 'Hello from Docker\!'"));
+    script_run("$runtime container run --name test_1 hello-world | grep 'Hello from Docker\!'");
     #   - using 'create', 'start' and 'logs' (background container)
-    record_soft_failure('poo#76993') if (script_run("$runtime container create --name test_2 alpine:$alpine_image_version /bin/echo Hello world") != 0);
+    script_run("$runtime container create --name test_2 alpine:$alpine_image_version /bin/echo Hello world");
     assert_script_run("$runtime container start test_2 | grep test_2");
     assert_script_run("$runtime container logs test_2 | grep 'Hello world'");
     #   - using 'run --rm'
-    record_soft_failure('poo#76993') if (script_run(qq{$runtime container run --name test_ephemeral --rm alpine:$alpine_image_version /bin/echo Hello world | grep "Hello world"}) != 0);
+    script_run(qq{$runtime container run --name test_ephemeral --rm alpine:$alpine_image_version /bin/echo Hello world | grep "Hello world"});
     #   - using 'run -d' and 'inspect' (background container)
     my $container_name = 'tw';
     assert_script_run("$runtime container run -d --name $container_name opensuse/tumbleweed tail -f /dev/null");
@@ -158,9 +161,10 @@ sub build_img {
     die "You must define the directory!" unless $dir;
     my $runtime = shift;
     die "You must define the runtime!" unless $runtime;
+    my $registry = get_var('REGISTRY', 'docker.io');
 
     assert_script_run("cd $dir");
-    assert_script_run("$runtime pull python:3", timeout => 300);
+    assert_script_run("$runtime image pull $registry/library/python:3", timeout => 300);
     assert_script_run("$runtime build -t myapp BuildTest");
     assert_script_run("$runtime images| grep myapp");
 }


### PR DESCRIPTION
docker.io (DockerHub) is restricted to a number of pulls per period
of time. Therefore, many tests are failing with error
"toomanyrequests: You have reached your pull rate limit."
The idea is to setup a remote registry where the tests will pull
the images from. In this case, it will apply for Alpine, Hello-world
and Python images, but there could be more in the future.

- Related ticket: https://progress.opensuse.org/issues/76993
