### PR TITLE
ntp_client: Make wait for sources response robust

### DIFF
--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -25,7 +25,7 @@ sub run {
         systemctl 'enable chronyd';
         systemctl 'start chronyd';
         # bsc#1179022 avoid '503 No such source' error while chrony does pick responding sources after start
-        assert_script_run 'until chronyc sources|grep "Number of sources = 4"; do sleep 1; echo "waiting for 4 ntp sources response"; done';
+        assert_script_run 'until chronyc activity|grep "0 sources doing burst.*online"; do sleep 1; echo "waiting for ntp sources response"; done';
     }
 
     # ensure that ntpd is neither installed nor enabled nor active


### PR DESCRIPTION
When picking and responding of sources is done 0 sources doing burst and return
to online state.
Number of sources can vary, checking activity is more flexible and won't
fail on s390x with 7 sources or TW, if it would be needed, with 16 sources.

- Related ticket: https://progress.opensuse.org/issues/67099
- Verification run: 
http://dzedro.suse.cz/tests/17014#step/ntp_client/22 15-SP2
http://dzedro.suse.cz/tests/17013#step/ntp_client/22 15-SP1
https://openqa.suse.de/tests/5069389#step/ntp_client/22 aarch64
https://openqa.suse.de/tests/5070258#step/ntp_client/22 s390x