### PR TITLE
Containers: Use remote private registry to pull images

### DIFF
--- a/data/containers/registries.conf
+++ b/data/containers/registries.conf
@@ -8,7 +8,7 @@ registries = ["registry.opensuse.org", "docker.io"]
 # Registries that do not use TLS when pulling images or uses self-signed
 # certificates.
 [registries.insecure]
-registries = ["localhost:5000", "registry.suse.de"]
+registries = ["localhost:5000", "registry.suse.de", "REGISTRY"]
 
 # Blocked Registries, blocks the `docker daemon` from pulling from the blocked registry.  If you specify
 # "*", then the docker daemon will only be allowed to pull from registries listed above in the search

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -99,6 +99,7 @@ sub allow_selected_insecure_registries {
     my %args    = @_;
     my $runtime = $args{runtime};
     die "You must define the runtime!" unless $runtime;
+    my $registry = get_var('REGISTRY', 'docker.io');
 
     assert_script_run "echo $runtime ...";
     if ($runtime =~ /docker/) {
@@ -106,12 +107,13 @@ sub allow_selected_insecure_registries {
         assert_script_run("mkdir -p /etc/docker");
         assert_script_run('cat /etc/docker/daemon.json; true');
         assert_script_run(
-            'echo "{ \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\"] }" > /etc/docker/daemon.json');
+            'echo "{ \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\", \"' . $registry . '\"] }" > /etc/docker/daemon.json');
         assert_script_run('cat /etc/docker/daemon.json');
         systemctl('restart docker');
     } elsif ($runtime =~ /podman/) {
         assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
         assert_script_run "chmod 644 /etc/containers/registries.conf";
+        assert_script_run("sed -i 's/REGISTRY/$registry/' /etc/containers/registries.conf");
     } else {
         die "You must define the runtime!";
     }

--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Database for URLs of docker images to be tested
+# Summary: Database for URLs of container images to be tested
 # Maintainer: Fabian Vogt <fvogt@suse.com>
 
 package suse_container_urls;
@@ -75,20 +75,20 @@ sub get_suse_container_urls {
     }
     elsif (is_tumbleweed || is_microos("Tumbleweed")) {
         push @image_names,  "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";
-        push @stable_names, "docker.io/opensuse/tumbleweed";
+        push @stable_names, "registry.opensuse.org/opensuse/tumbleweed";
     }
     elsif ($version eq "Jump:15.2") {
         # Jump 15.2 uses opensuse/leap:15.2.1, just hardcode this special case
         push @image_names,  "registry.opensuse.org/opensuse/jump/15.2/images/totest/containers/opensuse/leap:15.2.1";
-        push @stable_names, "docker.io/opensuse/leap:15.2.1";
+        push @stable_names, "registry.opensuse.org/opensuse/leap:15.2.1";
     }
     elsif (is_leap(">15.0") && check_var('ARCH', 'x86_64')) {
         push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
-        push @stable_names, "docker.io/opensuse/leap:${version}";
+        push @stable_names, "registry.opensuse.org/opensuse/leap:${version}";
     }
     elsif (is_leap(">15.0") && (check_var('ARCH', 'aarch64') || check_var('ARCH', 'arm'))) {
         push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/arm/images/totest/containers/opensuse/leap:${version}";
-        push @stable_names, "docker.io/opensuse/leap:${version}";
+        push @stable_names, "registry.opensuse.org/opensuse/leap:${version}";
     }
     elsif (is_leap(">15.0") && check_var('ARCH', 'ppc64le')) {
         # No image set up yet :-(

--- a/tests/containers/docker.pm
+++ b/tests/containers/docker.pm
@@ -47,6 +47,7 @@ sub run {
 
     install_docker_when_needed($host_distri);
     test_seccomp();
+    allow_selected_insecure_registries(runtime => 'docker');
 
     # Run basic docker tests
     basic_container_tests("docker");

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -41,7 +41,9 @@ sub run {
     assert_script_run('mkdir rootfs');
 
     # export alpine via Docker into the rootfs directory (see bsc#1152508)
-    assert_script_run('docker export $(docker create alpine) | tar -C rootfs -xvf -');
+    my $registry = get_var('REGISTRY', 'docker.io');
+    my $alpine   = "$registry/library/alpine:3.6";
+    assert_script_run('docker export $(docker create ' . $alpine . ') | tar -C rootfs -xvf -');
 
     foreach my $runc (@runtimes) {
         record_info "$runc", "Testing $runc";

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -42,6 +42,7 @@ sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_podman_when_needed($host_distri);
+    allow_selected_insecure_registries(runtime => 'podman');
 
     # Run basic tests for podman
     basic_container_tests("podman");

--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -37,7 +37,7 @@ sub run {
     # install zypper-docker and verify installation
     zypper_call('in zypper-docker');
     validate_script_output("zypper-docker -h", sub { m/zypper-docker - Patching Docker images safely/ }, 180);
-    my $testing_image = 'opensuse/leap';
+    my $testing_image = 'registry.opensuse.org/opensuse/leap';
 
     # Leap container image is missing in s390x
     if ((check_var('ARCH', 's390x')) && ($testing_image =~ /leap/)) {

--- a/variables.md
+++ b/variables.md
@@ -75,7 +75,7 @@ INSTLANG | string | en_US | Installation locale settings.
 IPXE | boolean | false | Indicates ipxe boot.
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
-KEEP_DISKS | boolean | false | Prevents disks wiping for remote backends without snaphots support, e.g. ipmi, powerVM, zVM 
+KEEP_DISKS | boolean | false | Prevents disks wiping for remote backends without snaphots support, e.g. ipmi, powerVM, zVM
 KEEP_ONLINE_REPOS | boolean | false | openSUSE specific variable, not to replace original repos in the installed system with snapshot mirrors which are not yet published.
 LAPTOP |||
 LINUX_BOOT_IPV6_DISABLE | boolean | false | If set, boots linux kernel with option named "ipv6.disable=1" which disables IPv6 from startup.
@@ -113,6 +113,7 @@ PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
 QA_TESTSUITE | string | | Comma or semicolon separated a list of the automation cases' name, and these cases will be installed and triggered if you call "start_testrun" function from qa_run.pm
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
 REBOOT_TIMEOUT | integer | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
+REGISTRY | string | Registry to pull third-party container images from (default: docker.io)
 REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.
 REMOTE_REPOINST | boolean | | Use linuxrc features to install OS from specified repository (install) while booting installer from DVD (instsys)
 REPO_* | string | | Url pointing to the mirrored repo. REPO_0 contains installation iso.

--- a/variables.md
+++ b/variables.md
@@ -112,8 +112,8 @@ PKGMGR_ACTION_AT_EXIT | string | "" | Set the default behavior of the package ma
 PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
 QA_TESTSUITE | string | | Comma or semicolon separated a list of the automation cases' name, and these cases will be installed and triggered if you call "start_testrun" function from qa_run.pm
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
-REBOOT_TIMEOUT | integer | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
-REGISTRY | string | Registry to pull third-party container images from (default: docker.io)
+REBOOT_TIMEOUT | integer | 0 | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
+REGISTRY | string | docker.io | Registry to pull third-party container images from
 REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.
 REMOTE_REPOINST | boolean | | Use linuxrc features to install OS from specified repository (install) while booting installer from DVD (instsys)
 REPO_* | string | | Url pointing to the mirrored repo. REPO_0 contains installation iso.


### PR DESCRIPTION
docker.io (DockerHub) is restricted to a number of pulls per period
of time. Therefore, many tests are failing with error
"toomanyrequests: You have reached your pull rate limit."
The idea is to setup a remote registry where the tests will pull
the images from. In this case, it will apply for Alpine, Hello-world
and Python images, but there could be more in the future.

- Related ticket: https://progress.opensuse.org/issues/76993
- Verification run: http://fromm.arch.suse.de/tests/764
