### PR TITLE
Revert "VLC: test video rendering"

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -43,10 +43,6 @@ sub run {
         wait_still_screen(1);
         assert_and_click 'close_vlc';
     }
-
-    x11_start_program('vlc --no-autoscale --start-paused --start-time=19.5 data/Big_Buck_Bunny_8_seconds_bird_clip.ogv', target_match => 'vlc-playing');
-    assert_screen 'vlc-playing';
-    assert_and_click 'close_vlc';
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#11464

The test is currently way to unstable and causes too many failures, including in stagings (none attributed to product bugs so far)

A more stable approach is in the works, but not ready yet. So in order to unblock product development, I request a revert of this change