### PR TITLE
Add parameter to boot_from_pxe and ipmi_to_qemu for mitigation workaround

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -143,6 +143,12 @@ sub run {
         # 'ssh=1' and 'sshd=1' are equal, both together don't work
         # so let's just set the password here
         $cmdline .= "sshpassword=$testapi::password ";
+
+        # add extra parameter if needed, such as workaround
+        if (get_var("EXTRA_PXE_CMDLINE")) {
+            $cmdline .= get_var("EXTRA_PXE_CMDLINE") . ' ';
+        }
+
         type_string_slow $cmdline;
     }
 

--- a/tests/cpu_bugs/ipmi_to_qemu.pm
+++ b/tests/cpu_bugs/ipmi_to_qemu.pm
@@ -37,9 +37,15 @@ my $zypper_add_pkgs = get_var('IPMI2QEMU_PKGS', 'openQA-worker,perl-DBIx-Class-D
 sub run {
     my $self = shift;
     my $current_dist;
+    my $sles_running_version;
+    my $sles_running_sp;
     script_run("systemctl disable apparmor.service");
     script_run("aa-teardown");
-    my ($sles_running_version, $sles_running_sp) = get_os_release();
+    if (get_var("DIST_FOR_REPO")) {
+        ($sles_running_version, $sles_running_sp) = split(/sp/i, get_var("DIST_FOR_REPO"));
+    } else {
+        ($sles_running_version, $sles_running_sp) = get_os_release();
+    }
     if ($sles_running_sp gt '0') {
         $current_dist = sprintf("SLE_%s_SP%s", $sles_running_version, $sles_running_sp);
     } else {


### PR DESCRIPTION
1.     Add parameter DIST_FOR_REPO to set repo url
    
    Generally, SLES repo is not ready before beta test. This parameter provide
    a way to set os-version to generate repo url.

2.     Add extra parameter in cmdline when needed
    
    Sometimes, we want to add a parameter in cmdline. Such as for a
    workaround.


- Related ticket: https://progress.opensuse.org/issues/78324
https://progress.opensuse.org/issues/78322
- Needles: N/A
- Verification run: http://10.67.134.217/tests/11791
http://10.67.134.217/tests/11803
