### PR TITLE
Fix rolling upgrade issue between two ltss version

### DIFF
--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
@@ -34,6 +34,7 @@ schedule:
   - '{{cluster_boot_mgmt}}'
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_migration
+  - '{{register_system}}'
   - migration/online_migration/post_migration
   - '{{cluster_boot_mgmt}}'
   - '{{console_reboot}}'
@@ -50,3 +51,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/console_reboot
+  register_system:
+    LTSS_TO_LTSS:
+      1:
+        - migration/online_migration/register_system

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
@@ -34,6 +34,7 @@ schedule:
   - '{{cluster_boot_mgmt}}'
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_migration
+  - '{{register_system}}'
   - migration/online_migration/post_migration
   - '{{cluster_boot_mgmt}}'
   - '{{console_reboot}}'
@@ -50,3 +51,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/console_reboot
+  register_system:
+    LTSS_TO_LTSS:
+      1:
+        - migration/online_migration/register_system

--- a/tests/migration/online_migration/register_system.pm
+++ b/tests/migration/online_migration/register_system.pm
@@ -15,9 +15,17 @@ use strict;
 use warnings;
 use testapi;
 use migration;
+use registration "scc_deregistration";
 
 sub run {
     select_console 'root-console';
+
+    # Sometimes in HA scenario, we need to test rolling upgrade migration from
+    # a LTSS version to another one LTSS version.
+    # In this case, we need to deregister the system and register it again for adding the
+    # LTSS of the targeted OS version.
+    scc_deregistration if get_var('LTSS_TO_LTSS');
+
     register_system_in_textmode;
 }
 


### PR DESCRIPTION
This PR fixes rolling upgrade tests between two ltss OS version.
For instance, migrate from 12SP3-LTSS to 12SP4-LTSS

As we are removing the ltss before the `zypper migration`, we have to deregister and register for adding the ltss extension to the targeted version again.

- Related ticket: https://progress.opensuse.org/issues/80378
- Needles: N/A
- Failed test: https://openqa.suse.de/tests/5053779#step/post_migration/45
- Verification run: 
[rolling upgrade from 12-SP2 LTSS to 12 SP3 LTSS](http://1b143.qa.suse.de/tests/5925)
[rolling upgrade from 12-SP3 LTSS to 12 SP4 LTSS](http://1b143.qa.suse.de/tests/5934) Failure not related to this PR, repo http://download.suse.de/ibs/SUSE:/Maintenance:/17131/ no longer available.
- Regression test:
[rolling upgrade from 12-SP4 LTSS to 12 SP5](http://1b143.qa.suse.de/tests/5937) Failure not related to this PR, repo http://download.suse.de/ibs/SUSE:/Maintenance:/17029/ no longer available.
