### PR TITLE
Fix the Firefox_NSS password input missing in aarch64

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -125,7 +125,7 @@ sub run {
     # Add a condition to avoid the password missed input
     # Retype password again once the password missed input
     # The problem frequently happaned in aarch64
-    if (match_has_tag('firefox-password-typefield-miss')) {
+    if (check_screen('firefox-password-typefield-miss')) {
         record_soft_failure "Firefox password is missing to input, see poo#77143";
         type_string($fips_password, max_interval => 2);
         send_key "ret";


### PR DESCRIPTION
**Description:** 

The random issue is showing up again in aarch64 ENV mode, (it is not showing in x86_64 and s390x platform).  **match_has_tag**($Needles) looks sometimes fail to match in this scenario randomly, and try changing to **check_screen**($Needles) looks better. No detailed idea why **match_has_tag** will mismatch sometimes. :-/

Password input missing in aarch64: https://openqa.suse.de/tests/5069088#step/firefox_nss/35

- Related ticket: https://progress.opensuse.org/issues/77143
- Needles: NA
- Verification run:
 https://openqa.suse.de/tests/5076990#step/firefox_nss/37 [**Soft-Failed** while input password missing]
 https://openqa.suse.de/tests/5078483 [Passed]
 https://openqa.suse.de/tests/5082097 [Passed]
