### PR TITLE
Add PUBLIC_CLOUD_IMAGE_ID setting

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -229,9 +229,12 @@ sub run_img_proof {
 Retrieves the CSP image id if exists, otherwise exception is thrown.
 The given C<$img_url> is optional, if not present it retrieves from
 PUBLIC_CLOUD_IMAGE_LOCATION.
+If PUBLIC_CLOUD_IMAGE_ID is set, then this value will be used
 =cut
 sub get_image_id {
     my ($self, $img_url) = @_;
+    my $predefined_id = get_var('PUBLIC_CLOUD_IMAGE_ID');
+    return $predefined_id if ($predefined_id);
     $img_url //= get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
     my ($img_name) = $img_url =~ /([^\/]+)$/;
     $self->{image_cache} //= {};


### PR DESCRIPTION
Adds the `PUBLIC_CLOUD_IMAGE_ID` setting which allows to define a publiccloud image ID manually.
This is required for scheduling QEM publiccloud runs with current published images.

- Related ticket: https://progress.opensuse.org/issues/78193
- Needles: -
- Verification runs: 

With `PUBLIC_CLOUD_IMAGE_ID` set: [EC2](http://phoenix-openqa.qam.suse.de/tests/3972) | [GCE](http://phoenix-openqa.qam.suse.de/tests/3973)
Without `PUBLIC_CLOUD_IMAGE_ID`: [EC2](http://phoenix-openqa.qam.suse.de/t3975) | [GCE](http://phoenix-openqa.qam.suse.de/t3974)