### PR TITLE
Fix serialdev path and retry_ssh_command params on lib/publiccloud/instance.pm

### DIFF
--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -23,7 +23,7 @@ sub run {
     my ($self, $args) = @_;
     select_host_console();    # select console on the host, not the PC instance
 
-    $args->{my_instance}->run_ssh_command(cmd => "sudo zypper ref", timeout => 360);
+    $args->{my_instance}->retry_ssh_command(cmd => "sudo zypper -n ref", timeout => 240, retry => 6);
     ssh_fully_patch_system($args->{my_instance}->public_ip);
     $args->{my_instance}->softreboot();
 }

--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -45,7 +45,8 @@ sub run {
             }
         }
     }
-    $args->{my_instance}->run_ssh_command(cmd => "sudo zypper lr", rc_only => 1);
+    record_info('LR', $args->{my_instance}->run_ssh_command(cmd => "sudo zypper lr || true"));
+    record_info('LS', $args->{my_instance}->run_ssh_command(cmd => "sudo zypper ls || true"));
 }
 
 1;


### PR DESCRIPTION
This is fixing two things:

 * The `/dev/$serialdev` path as the variable contains only `ttyS0` so the `/dev/` was missing,
 * The `retry_ssh_command` params so they are defined the same way as for `run_ssh_command`.


- Verification run: [SLES15 SP2 Azure BYOS](http://pdostal-server.suse.cz/tests/10480#step/patch_and_reboot/3)
