### PR TITLE
Increase public cloud timeout and script_retry for terraform

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -105,6 +105,8 @@ sub run {
         }
         $instance->run_ssh_command(cmd => 'rpm -qa > /tmp/rpm_qa.txt', no_quote => 1);
         upload_logs('/tmp/rpm_qa.txt');
+        $instance->run_ssh_command(cmd => 'sudo journalctl -b > /tmp/journalctl_b.txt', no_quote => 1);
+        upload_logs('/tmp/journalctl_b.txt');
     }
 }
 


### PR DESCRIPTION
This does:
 * Increase timeouts for `terraform` and `img_proof` commands
 * Retry `terraform` commands as the cloud providers often have glitches.

- Related ticket: 
- Verification run: [SLE 15 SP2 EC2 PAYG](http://pdostal-server.suse.cz/tests/10484#)
