### PR TITLE
Fix docker-compose for Public Cloud on-demand images

### DIFF
--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -74,8 +74,8 @@ sub run {
     assert_script_run 'cd';
 
     # De-registration is disabled for on-demand instances
-    remove_suseconnect_product(get_addon_fullname('phub'))    if (is_sle() && !is_ondemand());
-    remove_suseconnect_product(get_addon_fullname('python2')) if is_sle('=15-sp1');
+    remove_suseconnect_product(get_addon_fullname('phub'))    if (is_sle()          && !is_ondemand());
+    remove_suseconnect_product(get_addon_fullname('python2')) if (is_sle('=15-sp1') && !is_ondemand());
     clean_container_host(runtime => 'docker');
 }
 


### PR DESCRIPTION
Fixing `SUSEConnect -d` [sle-15-SP1-GCE-Updates](https://openqa.suse.de/tests/5080451#step/docker_compose/86) failure.
This was discovered by @dzedro on #11397.

- Related ticket: [poo#](https://progress.opensuse.org/issues/80530)
- Verification run: [sle-15-SP1-GCE-Updates](http://pdostal-server.suse.cz/tests/10485#live)
