### PR TITLE
Create yaml schedules for publiccloud

### DIFF
--- a/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
@@ -1,0 +1,24 @@
+---
+name: mau-extratests-docker-publiccloud
+description: |
+  Run mau-extratests-docker on public cloud instances
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/download_repos
+  - publiccloud/ssh_interactive_init
+  - publiccloud/register_system
+  - publiccloud/transfer_repos
+  - publiccloud/patch_and_reboot
+  - publiccloud/img_proof
+  - publiccloud/ssh_interactive_start
+  - publiccloud/instance_overview
+  - console/system_prepare
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - containers/podman
+  - containers/docker
+  - containers/docker_runc
+  - containers/containers_3rd_party
+  - containers/registry
+  - containers/zypper_docker
+  - publiccloud/ssh_interactive_end

--- a/schedule/publiccloud/mau-extratests-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-publiccloud.yml
@@ -1,0 +1,60 @@
+---
+name: mau-extratests-publiccloud
+description: |
+  Run mau-extratests on public cloud instances
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/download_repos
+  - publiccloud/ssh_interactive_init
+  - publiccloud/register_system
+  - publiccloud/transfer_repos
+  - publiccloud/patch_and_reboot
+  - publiccloud/ssh_interactive_start
+  - publiccloud/instance_overview
+  - console/system_prepare
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/cleanup_qam_testrepos
+  - console/openvswitch
+  - console/shar
+  - console/sshd
+  - console/update_alternatives
+  - console/rpm
+  - console/slp
+  - console/pkcon
+  - console/libvorbis
+  - console/command_not_found
+  - console/openssl_alpn
+  - console/cron
+  - console/syslog
+  - console/mta
+  - console/check_default_network_manager
+  - console/sqlite3
+  - console/gdb
+  - console/sysctl
+  - console/sysstat
+  - console/wget_ipv6
+  - console/ca_certificates_mozilla
+  - console/gpg
+  - console/clamav
+  - console/shells
+  - console/sudo
+  - console/dstat
+  - console/supportutils
+  - console/journalctl
+  - console/quota
+  - console/rpcbind
+  - sysauth/sssd
+  - console/timezone
+  - console/procps
+  - console/kmod
+  - console/suse_module_tools
+  - console/zziplib
+  - console/firewalld
+  - console/aaa_base
+  - console/osinfo_db
+  - console/libgcrypt
+  - console/orphaned_packages_check
+  - console/valgrind
+  - publiccloud/ssh_interactive_end

--- a/schedule/publiccloud/publiccloud_upload_img.yml
+++ b/schedule/publiccloud/publiccloud_upload_img.yml
@@ -1,0 +1,8 @@
+---
+name: publiccloud_upload_img
+description: |
+  Upload a public-cloud image to the CSP. How the image gets uploaded depends on
+  the CSP. If the image already exists, the upload gets skipped.Maintainer: cfamullaconrad@suse.com
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/upload_image

--- a/schedule/publiccloud/qem_publiccloud_img_proof.yml
+++ b/schedule/publiccloud/qem_publiccloud_img_proof.yml
@@ -1,0 +1,12 @@
+---
+name: qem_publiccloud_img_proof
+description: |
+  img_proof publiccloud test
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/download_repos
+  - publiccloud/ssh_interactive_init
+  - publiccloud/register_system
+  - publiccloud/transfer_repos
+  - publiccloud/patch_and_reboot
+  - publiccloud/img_proof


### PR DESCRIPTION
Following up the work from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11454
which update the scheduler with test_context capabilities.
files do not contains variables which will defined in the jobgroup.
vars per job can be found poo#71314
files created for:
 - mau-extratests-docker-publiccloud
 - mau-extratests-publiccloud
 - publiccloud_upload_img
 - qem_publiccloud_img_proof

- Related ticket: https://progress.opensuse.org/issues/71314
- Verification run https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2311505&version=15-SP2
