### PR TITLE
Export HA logs in case of fencing in cluster_md test + Fix missing die in HA code

### DIFF
--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -19,7 +19,8 @@ use lockapi;
 use hacluster;
 
 sub run {
-    my $mdadm_conf         = '/etc/mdadm.conf';
+    my ($self) = @_;
+    my $mdadm_conf = '/etc/mdadm.conf';
     my $clustermd_lun_01   = get_lun(use_once => 0);
     my $clustermd_lun_02   = get_lun(use_once => 0);
     my $clustermd_rsc      = 'cluster_md';
@@ -81,6 +82,20 @@ sub run {
 
     # Wait until cluster-md resource is created
     barrier_wait("CLUSTER_MD_RESOURCE_CREATED_$cluster_name");
+
+    # Currently we are seeing a sporadic issue in osd with nodes getting fenced during
+    # cluster_md setup right after the resource is created. So far this issue cannot be
+    # reproduced manually, and test passes with no issues in the development environment.
+    # Worse still, the nature of the failure prevents openQA from gathering logs. The
+    # following lines attempt to work around the issue
+    if (check_screen('grub2')) {
+        my $timeout = get_var('UEFI') ? 140 : 80;
+        record_soft_failure 'poo#80532 -- Unexpected node fence';
+        $self->wait_boot(bootloader_time => $timeout, nologin => 1);
+        reset_consoles;
+        select_console 'root-console';
+        ha_export_logs;
+    }
 
     # Wait for the resource to appear before testing the device
     # Otherwise sporadic failure can happen


### PR DESCRIPTION
Currently we are seeing a sporadic issue in osd with nodes getting fenced during cluster_md setup right after the resource is created. So far this issue cannot be reproduced manually, and test passes with no issues in the development environment. Worse still, the nature of the failure prevents openQA from gathering logs.

Also during analysis, we saw that some functions in HA code check if variables are defined, but don't do anything if the variables are undefined. This can lead to weird failures sometimes (https://openqa.suse.de/tests/5069278#step/cluster_md/21) and make debugging more difficult.

- Related ticket: https://progress.opensuse.org/issues/80532
- Needles: N/A
- Verification runs: [15sp3-node01](http://1b210.qa.suse.de/tests/7979), [15sp3-node02](http://1b210.qa.suse.de/tests/7980)
- Regression tests: [12sp5-node01](http://1b210.qa.suse.de/tests/7997), [12sp5-node02](http://1b210.qa.suse.de/tests/7996)

**NOTE:** the new added code in `cluster_md.pm` can't be tested on my lab, because I can't reproduce the issue. It can't also be tested on o.s.d. simply because testing a git PR with MM jobs can't be done currently. So verification runs only can be done.