### PR TITLE
Dont force PXE boot for UEFI machines

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -137,7 +137,7 @@ sub run {
     poweroff_host;
 
     set_bootscript;
-    set_pxe_boot;
+    set_pxe_boot unless get_var('IPXE_UEFI');
 
     poweron_host;
 


### PR DESCRIPTION
Instead, make them boot from network by default and handle this in the
bootscripts stored in the support server.
Some machines dont boot in UEFI when you set PXE boot via IPMI.

- Related ticket: https://progress.opensuse.org/issues/65028
- Needles: -
- Verification run: tbd