### PR TITLE
Enable sle base test on opensuse

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -22,7 +22,8 @@ use warnings;
 use testapi;
 use registration;
 use utils qw(zypper_call systemctl);
-use version_utils qw(is_sle is_leap is_microos is_opensuse is_jeos is_public_cloud get_os_release check_os_release);
+use version_utils qw(is_sle is_leap is_microos is_opensuse is_jeos is_public_cloud);
+use containers::utils 'can_build_sle_base';
 
 our @EXPORT = qw(install_podman_when_needed install_docker_when_needed allow_selected_insecure_registries clean_container_host
   test_container_runtime test_container_image scc_apply_docker_image_credentials scc_restore_docker_image_credentials);
@@ -78,7 +79,7 @@ sub install_docker_when_needed {
             }
             else {
                 # We may run openSUSE with DISTRI=sle and openSUSE does not have SUSEConnect
-                if ($host_os =~ 'sles' && script_run("SUSEConnect --status-text | grep Containers") != 0) {
+                if (can_build_sle_base && script_run("SUSEConnect --status-text | grep Containers") != 0) {
                     is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
                 }
 

--- a/lib/containers/runtime.pm
+++ b/lib/containers/runtime.pm
@@ -43,7 +43,7 @@ sub build {
     my ($self, $dockerfile_path, $container_tag) = @_;
     die 'wrong number of arguments' if @_ < 3;
     #TODO add build with URL https://docs.docker.com/engine/reference/commandline/build/
-    $self->_rt_assert_script_run("build -f $dockerfile_path/Dockerfile -t $container_tag $dockerfile_path");
+    $self->_rt_assert_script_run("build -f $dockerfile_path/Dockerfile -t $container_tag $dockerfile_path", 300);
     record_info "$container_tag created";
 }
 

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use version_utils;
 
-our @EXPORT = qw(test_seccomp basic_container_tests set_up get_vars build_img test_built_img);
+our @EXPORT = qw(test_seccomp basic_container_tests set_up get_vars build_img test_built_img can_build_sle_base);
 
 sub test_seccomp {
     my $no_seccomp = script_run('docker info | tee /tmp/docker_info.txt | grep seccomp');
@@ -177,6 +177,22 @@ sub test_built_img {
     assert_script_run("$runtime ps -a");
     script_retry('curl http://localhost:8888/ | grep "Networking test shall pass"', delay => 5, retry => 6);
     assert_script_run("rm -rf /root/templates");
+}
+
+=head2 can_build_sle_base
+
+C<can_build_sle_base> should be used to identify if sle base image runs against a
+system that it does not support registration and SUSEConnect.
+In this case the build of the container engine is not going to work as the base images
+lacks of the repos.
+
+The call should return false if you try to test sle base container on osd but host is not sle
+true otherwise.
+
+=cut
+sub can_build_sle_base {
+    my $has_sle_registration = script_run("test -e /etc/zypp/credentials.d/SCCcredentials");
+    return check_os_release('sles', 'ID') && $has_sle_registration;
 }
 
 1;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -577,7 +577,7 @@ sub get_os_release {
     my ($go_to_target, $os_release_file) = @_;
     $go_to_target    //= '';
     $os_release_file //= '/etc/os-release';
-    my %os_release = script_output("$go_to_target cat $os_release_file") =~ /^(\S+)="?([^"\r\n]+)"?$/gm;
+    my %os_release = script_output("$go_to_target cat $os_release_file") =~ /^([^#]\S+)="?([^"\r\n]+)"?$/gm;
     %os_release = map { uc($_) => $os_release{$_} } keys %os_release;
     my ($os_version, $os_service_pack) = split(/\.|-sp/i, $os_release{VERSION});
     $os_service_pack //= 0;

--- a/schedule/containers/sle_image_on_opensuse_host.yaml
+++ b/schedule/containers/sle_image_on_opensuse_host.yaml
@@ -1,0 +1,8 @@
+name:           sle_image_on_opensuse_host
+description:    >
+  Test for SLE base image in opensuse
+schedule:
+  - boot/boot_to_desktop
+  - containers/host_configuration
+  - containers/podman_image
+  - containers/docker_image


### PR DESCRIPTION
Add yaml scheduler for sle container test on opensuse
fix rexex in get_os_release with reverse lookup for comments
And Add fuction to check if the host can build sle base

- Related ticket: https://progress.opensuse.org/issues/76771
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1466
- Verification run: 
[extra_tests_textmode_containers from o3](http://aquarius.suse.cz/tests/4100)
[containers_sle_image_on_sle_host sle host](http://aquarius.suse.cz/tests/4098)
[containers_sle_image_on_sle_host opesuse host](http://aquarius.suse.cz/tests/4097)
[](http://aquarius.suse.cz/tests/4102)
