### PR TITLE
qam-gnome: Schedule console/force_scheduled_tasks before reboot

### DIFF
--- a/schedule/qam/15-SP1/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP1/qam-allpatterns.yaml
@@ -11,6 +11,7 @@ schedule:
 - autoyast/repos
 - autoyast/clone
 - autoyast/logs
+- console/force_scheduled_tasks
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
@@ -21,7 +22,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - locale/keymap_or_locale
-- console/force_scheduled_tasks
 - console/textinfo
 - console/hostname
 - console/installation_snapshots

--- a/schedule/qam/15-SP1/qam-gnome.yaml
+++ b/schedule/qam/15-SP1/qam-gnome.yaml
@@ -10,6 +10,7 @@ schedule:
 - autoyast/repos
 - autoyast/clone
 - autoyast/logs
+- console/force_scheduled_tasks
 - autoyast/autoyast_reboot
 - '{{grub}}'
 - installation/first_boot
@@ -20,7 +21,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - locale/keymap_or_locale
-- console/force_scheduled_tasks
 - console/textinfo
 - console/hostname
 - console/installation_snapshots

--- a/schedule/qam/15-SP2/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP2/qam-allpatterns.yaml
@@ -11,6 +11,7 @@ schedule:
 - autoyast/repos
 - autoyast/clone
 - autoyast/logs
+- console/force_scheduled_tasks
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
@@ -21,7 +22,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - locale/keymap_or_locale
-- console/force_scheduled_tasks
 - console/textinfo
 - console/hostname
 - console/installation_snapshots

--- a/schedule/qam/15-SP2/qam-gnome.yaml
+++ b/schedule/qam/15-SP2/qam-gnome.yaml
@@ -10,6 +10,7 @@ schedule:
 - autoyast/repos
 - autoyast/clone
 - autoyast/logs
+- console/force_scheduled_tasks
 - autoyast/autoyast_reboot
 - '{{grub}}'
 - installation/first_boot
@@ -20,7 +21,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - locale/keymap_or_locale
-- console/force_scheduled_tasks
 - console/textinfo
 - console/hostname
 - console/installation_snapshots

--- a/schedule/qam/15/qam-allpatterns.yaml
+++ b/schedule/qam/15/qam-allpatterns.yaml
@@ -11,6 +11,7 @@ schedule:
 - autoyast/repos
 - autoyast/clone
 - autoyast/logs
+- console/force_scheduled_tasks
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
@@ -21,7 +22,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - locale/keymap_or_locale
-- console/force_scheduled_tasks
 - console/textinfo
 - console/hostname
 - console/installation_snapshots

--- a/schedule/qam/15/qam-gnome.yaml
+++ b/schedule/qam/15/qam-gnome.yaml
@@ -10,6 +10,7 @@ schedule:
 - autoyast/repos
 - autoyast/clone
 - autoyast/logs
+- console/force_scheduled_tasks
 - autoyast/autoyast_reboot
 - '{{grub}}'
 - installation/first_boot
@@ -20,7 +21,6 @@ schedule:
 - console/prepare_test_data
 - console/consoletest_setup
 - locale/keymap_or_locale
-- console/force_scheduled_tasks
 - console/textinfo
 - console/hostname
 - console/installation_snapshots


### PR DESCRIPTION
When btrfsmaintenance is active before reboot, it can happen that
we can't login in first_boot due to btrfs activity blocks user
interaction

Related ticket: https://progress.opensuse.org/issues/80572
