### PR TITLE
Call base module post_fail_hook on failure in hotplugging

### DIFF
--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -231,6 +231,10 @@ sub clean_guest {
 }
 
 sub post_fail_hook {
+    my ($self) = @_;
+
+    # Call parent post_fail_hook to collect logs on failure
+    $self->SUPER::post_fail_hook;
     # Ensure guests remain in a consistent state also on failure
     clean_guest($_) foreach (keys %virt_autotest::common::guests);
 }


### PR DESCRIPTION
* **It** seems that hotplugging module has its own post_fail_hook now. Need to call base module post_fail_hook explicitly to collect logs on failure
* **This** change has no impact on following operations in hotplugging module
* **Calling** base module post_fail_hook has already been validated effective and stable over time, so verification run is not needed here. And this is a very simple case.
* **Related ticket:** n/a
* **Needles:** n/a
* **Verification run:** n/a
