### PR TITLE
Add prefix SLE- in clamav for jira feature jsc#id in record_soft_failure

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -48,7 +48,7 @@ sub run {
     record_info("Clamav_ver", "Current Clamav package version: $current_ver");
 
     if (is_sle('>=15-SP3') && ($current_ver < 0.101)) {
-        record_soft_failure("jsc#16780: upgrade Clamav SLE feature is not yet released");
+        record_soft_failure("jsc#SLE-16780: upgrade Clamav SLE feature is not yet released");
     }
     # Initialize and download ClamAV database which needs time
     assert_script_run('freshclam', 700);


### PR DESCRIPTION
**Description:**

The PR is adding prefix SLE- `jsc# $id` in record_soft_failure, adjust feature id from `jsc#16780` to `jsc#SLE-16780`. If only use jsc#16780, the hyperlink will fail to access. Changing to jsc#SLE-16780 can show the correct hyperlink in [record_soft_failure](https://openqa.suse.de/tests/5094264#step/clamav/16).

Once PR #11519 is merged. this PR CI check will be passed.

- Related ticket: https://progress.opensuse.org/issues/80590
- Needles: NA
- Verification run: 
  https://openqa.suse.de/tests/5094264#step/clamav/16
