### PR TITLE
ncurses: stop the test if the console is misconfigured in openQA - poo#63026

### DIFF
--- a/tests/console/ncurses.pm
+++ b/tests/console/ncurses.pm
@@ -24,7 +24,10 @@ sub run {
     select_console 'root-console';
     zypper_call 'in dialog';
     script_run 'dialog --yesno "test for boo#1054448" 3 20', 0;
-    assert_screen 'ncurses-simple-dialog';
+    assert_screen([qw(ncurses-simple-dialog ncurses-simple-dialog-broken-poo63026)]);
+    if (match_has_tag 'ncurses-simple-dialog-broken-poo63026') {
+        die "poo#63026: Console misconfigured, ncurses UI broken!\n";
+    }
     send_key 'ret';
     clear_console;
     if (match_has_tag 'boo#1054448') {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/63026
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/730ea5764ca405bb0ec68c9cb7f331221d534555
- Verification run: https://openqa.opensuse.org/t1489339