### PR TITLE
Sync setting lvm volume group when setting up lvm

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AddVolumeGroupPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AddVolumeGroupPage.pm
@@ -60,6 +60,7 @@ sub select_available_device {
 
 sub set_volume_group_name {
     my ($self, $vg_name) = @_;
+    $self->{txtbox_vg_name}->exist();
     return $self->{txtbox_vg_name}->set($vg_name);
 }
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
@@ -94,6 +94,7 @@ sub press_add_raid_button {
 
 sub press_accept_button {
     my ($self) = @_;
+    $self->{btn_accept}->exist();
     return $self->{btn_accept}->click();
 }
 


### PR DESCRIPTION
On aarch64 we set textbox value too early and UI thinks that field is
empty. To avoid such situation, check that widget is available upfront.

See [poo#77767](https://progress.opensuse.org/issues/77767).

[VR](https://openqa.suse.de/tests/5098923#).
