### PR TITLE
Use SCC proxy URL for MicroOS images

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -33,7 +33,7 @@ sub run {
     my $cmd        = "SUSEConnect -r $reg_code";
     my $scc_addons = get_var('SCC_ADDONS', '');
 
-    if ($reg_code !~ /^INTERNAL-USE-ONLY.*/i) {
+    if ($reg_code !~ /^INTERNAL-USE-ONLY.*/i || is_microos) {
         $cmd .= ' --url ' . (get_required_var 'SCC_URL');
     }
 


### PR DESCRIPTION
MicroOS needs to use fake scc proxy to be able to register and get packages from extracted ISO in /repo/ directory, the same way the [DVD flavor](https://openqa.suse.de/tests/5100594#step/scc_registration/2) does it.


