### PR TITLE
Add jsc#SLE- judgement to avoid test-soft_failure-no-reference in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test-deleted-renamed-referenced-files:
 
 .PHONY: test-soft_failure-no-reference
 test-soft_failure-no-reference:
-	@! git --no-pager grep -E -e 'soft_failure\>.*\;' --and --not -e '([$$0-9a-z]+#[$$0-9]+|fate.suse.com/[0-9]|\$$[a-z]+)' lib/ tests/
+	@! git --no-pager grep -E -e 'soft_failure\>.*\;' --and --not -e '([$$0-9a-z]+#[$$0-9a-zA-Z]+|fate.suse.com/[0-9]|\$$[a-z]+)' lib/ tests/
 
 .PHONY: test-invalid-syntax
 test-invalid-syntax:


### PR DESCRIPTION
**Description:**

The PR is attepmting to fix the error in CI check **test-soft_failure-no-reference**, makefile will return error due to miss the SLE- prefix in the Regular Expression. Add the judgement of SLE- prefix in test-soft_failure-no-reference in Makefile can fix the problem.

1. CI check error: https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/jobs/746708817
2. This PR blocked the PR #11514

- Related ticket: https://progress.opensuse.org/issues/80608
- Needles: NA
- Verification run: 
  https://openqa.suse.de/tests/5106698#
