### PR TITLE
Remove workarounds for offline host upgrade and orthos huawei arm64 machine

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -21,7 +21,7 @@ use version_utils qw(is_storage_ng is_sle);
 use utils;
 use power_action_utils 'prepare_system_shutdown';
 
-our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot boot_local_disk_arm_huawei ipmitool);
+our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot ipmitool);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
@@ -366,26 +366,6 @@ sub set_serial_console_on_vh {
         umount_installation_disk("$mount_point");
     }
 
-}
-
-#Huawei arm machines require password login after "boot from local disk" is selected.
-#Before the desired grub menu is shown, you need to navigate into the boot menu and
-#select the "sles" boot item.
-sub boot_local_disk_arm_huawei {
-    assert_screen('input-password-huawei', 180);
-    type_string_slow "Huawei12#\$";
-    send_key 'ret';
-    assert_screen('default-password-huawei', 180);
-    send_key 'ret';
-
-    assert_screen('setup-menu-huawei', 180);
-    save_screenshot;
-    send_key_until_needlematch('exit-menu-huawei', 'right', 10, 5);
-    save_screenshot;
-    send_key_until_needlematch('boot-sles-huawei', 'down', 10, 5);
-    save_screenshot;
-    send_key 'ret';
-    save_screenshot;
 }
 
 #ipmitool to perform server management

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -72,9 +72,6 @@ sub login_to_console {
         }
     }
 
-    my $sut_machine = get_var('SUT_IP', 'nosutip');
-    boot_local_disk_arm_huawei if (is_remote_backend && check_var('ARCH', 'aarch64') && ($sut_machine =~ /huawei/img));
-
     if (!check_screen([qw(grub2 grub1 prague-pxe-menu)], 210)) {
         ipmitool("chassis power reset");
         reset_consoles;
@@ -131,28 +128,6 @@ sub login_to_console {
             #grub may not showup after upgrade because default GRUB_TERMINAL setting
             #when fixed in separate PR, will uncomment following line
             #assert_screen([qw(grub2 grub1)], 120);
-            my $upgrade_machine = get_var('SUT_IP', 'nosutip');
-            if (is_remote_backend && check_var('ARCH', 'aarch64') && ($upgrade_machine =~ /huawei/img)) {
-                wait_still_screen 10;
-                boot_local_disk_arm_huawei;
-            }
-            my $host_installed_version = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
-            ($host_installed_version) = $host_installed_version =~ /^(\d+)/im;
-            my $host_upgrade_version  = get_required_var('UPGRADE_PRODUCT');    #format sles-15-sp0
-            my ($host_upgrade_relver) = $host_upgrade_version =~ /sles-(\d+)-sp/i;
-            my ($host_upgrade_spver)  = $host_upgrade_version =~ /sp(\d+)$/im;
-            if (($host_installed_version eq '11') && (($host_upgrade_relver eq '15' && $host_upgrade_spver eq '0') || ($host_upgrade_relver eq '12' && $host_upgrade_spver eq '5'))) {
-                assert_screen('sshd-server-started-config', 180);
-                use_ssh_serial_console;
-                save_screenshot;
-                #start system first configuration after finishing upgrading from sles-11-sp4
-                type_string("yast.ssh\n");
-                assert_screen('will-linux-login', $timeout);
-                select_console('sol', await_console => 0);
-                save_screenshot;
-                send_key 'ret';
-                save_screenshot;
-            }
         }
         #setup vars
         set_var("reboot_for_upgrade_step", undef);


### PR DESCRIPTION
* **I** implemented some workarounds for offline host upgrade in regard to 11-SP4 to 15/12-SP5 and orthos huawei arm64 machines which are obsolete and not necessary anymore. They are only temporary instead of permanent answers to long live questions
* **Currently** there are no other references to boot_local_disk_arm_huawei that was originally defined in ipmi_backend_utils.pm
* **These** outdated workarounds are only related to specific scenarios and their applications were also confined to specific areas by using conditional expressions, so removing them will have no impact on other tests. Verification run not needed.
* **Related ticket:** n/a
* **Needles:** n/a
* **Verification run:** n/a
