### PR TITLE
Remove img_proof module from mau-extratests-docker-publiccloud job

### DIFF
--- a/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
@@ -9,7 +9,6 @@ schedule:
   - publiccloud/register_system
   - publiccloud/transfer_repos
   - publiccloud/patch_and_reboot
-  - publiccloud/img_proof
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview
   - console/system_prepare


### PR DESCRIPTION
img_proof should not run here as the test does not provide
PUBLIC_CLOUD_IMG_PROOF_TESTS variable

