### PR TITLE
Enable lvm full encrypt in s390x

### DIFF
--- a/test_data/yast/encryption/full_lvm_enc_s390x.yaml
+++ b/test_data/yast/encryption/full_lvm_enc_s390x.yaml
@@ -1,0 +1,28 @@
+disks:
+  - name: vda
+    partitions:
+      - size: 300MiB
+        role: raw-volume
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot/zipl
+      - role: raw-volume
+        id: linux-lvm
+        encrypt_device: 1
+lvm:
+  volume_groups:
+  - name: vg-system
+    devices:
+      - /dev/vda2
+    logical_volumes:
+      - name: lv-swap
+        size: 2000MiB
+        role: swap
+      - name: lv-root
+        role: operating-system
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/yast/encryption/default_enc.yaml

--- a/test_data/yast/encryption/lvm_encrypt_separate_boot_s390x.yaml
+++ b/test_data/yast/encryption/lvm_encrypt_separate_boot_s390x.yaml
@@ -1,0 +1,36 @@
+disks:
+  - name: vda
+    partitions:
+      - size: 300MiB
+        role: raw-volume
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot/zipl
+      - size: 500MiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot
+      - role: raw-volume
+        id: linux-lvm
+        encrypt_device: 1
+lvm:
+  volume_groups:
+  - name: vg-system
+    devices:
+      - /dev/vda3
+    logical_volumes:
+      - name: lv-swap
+        size: 2000MiB
+        role: swap
+      - name: lv-root
+        role: operating-system
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/yast/encryption/default_enc.yaml

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,7 +21,8 @@ use warnings;
 use bootloader_setup;
 use registration;
 use testapi;
-use utils qw(OPENQA_FTP_URL type_line_svirt);
+use utils qw(OPENQA_FTP_URL type_line_svirt save_svirt_pty);
+use YuiRestClient;
 
 sub set_svirt_domain_elements {
     my ($svirt) = shift;
@@ -84,6 +85,8 @@ sub run {
             type_string("TERM=linux yast.ssh\n") && record_soft_failure('bsc#1054448');
         }
         else {
+            # On s390x zKVM we have to process startshell in bootloader
+            YuiRestClient::setup_libyui() if YuiRestClient::is_libyui_rest_api;
             wait_serial(' Starting YaST2 ', 300) || die "yast didn't start";
             select_console('installation');
         }

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2017-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -68,6 +68,9 @@ sub run {
     if (YuiRestClient::is_libyui_rest_api) {
         if (is_pvm) {
             select_console 'powerhmc-ssh', await_console => 0;
+            YuiRestClient::teardown_libyui();
+        } elsif (get_var('S390_ZKVM')) {
+            select_console 'svirt';
             YuiRestClient::teardown_libyui();
         } elsif (check_var('BACKEND', 'svirt')) {
             YuiRestClient::teardown_libyui();

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -31,8 +31,8 @@ my $ip_regexp    = qr/(?<ip>(\d+\.){3}\d+)/i;
 my $boot_timeout = 500;
 
 sub run {
-    # We setup libyui in bootloader on powerVM
-    return if is_pvm;
+    # We setup libyui in bootloader on PowerVM and s390x zKVM
+    return if (is_pvm || get_var('S390_ZKVM'));
     YuiRestClient::process_start_shell();
 
     if (is_hyperv) {

--- a/tests/installation/teardown_libyui.pm
+++ b/tests/installation/teardown_libyui.pm
@@ -23,11 +23,12 @@ use warnings;
 use base "installbasetest";
 use testapi;
 
-use Utils::Backends 'is_pvm';
+use Utils::Backends 'is_remote_backend';
 use YuiRestClient;
 
 sub run {
-    return if is_pvm || check_var('BACKEND', 'svirt');
+    # We setup libyui in bootloader on remote backends
+    return if is_remote_backend;
     YuiRestClient::teardown_libyui();
 }
 


### PR DESCRIPTION
Adapt test scenarios full-lvm-encrypt and lvm-encrypt-separate-boot with libyui in s390x (zKVM):
    - Add test data for full-lvm-encrypt in s390x
    - Handle setup/teardown of libyui in s390x (zKVM)

- Related ticket: [poo#78016](https://progress.opensuse.org/issues/78016)
- Job Group MR: [MR#321](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/321)
- Verification run: [lvm-full-encrypt](https://openqa.suse.de/tests/5107421) | [lvm-encrypt-separate-boot](https://openqa.suse.de/tests/5107445)