### PR TITLE
Add nodejs test

### DIFF
--- a/data/console/test_node.sh
+++ b/data/console/test_node.sh
@@ -12,7 +12,7 @@ test_result_wrapper(){
   # Run the test (using common and custom flags if present) and save the output
   echo "Running $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]}$FILE"
   set +e
-  $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]} $FILE > $OUTPUT 2>&1
+  $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]} $FILE &> $OUTPUT
   RESULT=$?
   set -e
 
@@ -36,14 +36,13 @@ test_node_version(){
   echo "Starting to test node version $VERSION"
 
   # Get latest sources to make sure tests contain correct patches
-  zypper -n --no-gpg-checks si --repo node_sources -D "nodejs$VERSION" #> /dev/null 2>&1
+  zypper -n --no-gpg-checks si --repo node_sources -D "nodejs$VERSION"
 
   local SOURCE_FILE=""
   SOURCE_FILE=$(cd /usr/src/packages/SOURCES/ && find . -type f -iname "node-v$VERSION*.tar.xz")
   SOURCE_FILE=${SOURCE_FILE:2} # strip ./ from name
 
-  if [ -z "$SOURCE_FILE" ]
-  then
+  if [ -z "$SOURCE_FILE" ]; then
     echo "Can't find the sources of nodejs$VERSION"
     exit 1
   fi
@@ -74,19 +73,19 @@ main(){
   local OS_VERSION="$1"
 
   # Install dependencies to apply source patches and run tests
-  zypper -n in quilt rpm-build openssl-1_1 #> /dev/null 2>&1
+  zypper -n in quilt rpm-build openssl-1_1
 
   # Get list of each nodejs version found from default repo
   local NODE_VERSIONS=$(zypper -n search nodejs | egrep -i 'nodejs[0-9]{1,2} ' | cut -d'|' -f 2 | tr -d ' '| tr -d 'nodejs' | sort -h | uniq)
   local NODE_LATEST_VERSION=$(zypper -n search nodejs | egrep -i 'nodejs[0-9]{1,2} ' | cut -d'|' -f 2 | tr -d ' '| tr -d 'nodejs' | sort -h | uniq | tail -n1)
 
   for v in $NODE_VERSIONS; do
-   echo "Found node version: $v" 
+    echo "Found node version: $v"
   done
   echo "Will test only latest version: $NODE_LATEST_VERSION" 
 
   # Install latest nodejs version
-  zypper -n in --no-recommends "nodejs$NODE_LATEST_VERSION" > /dev/null 2>&1
+  zypper -n in --no-recommends "nodejs$NODE_LATEST_VERSION"
 
   # Add sources repo to have latest source patches
   zypper -n --gpg-auto-import-keys ar -f "http://download.suse.de/ibs/home:/adamm:/node_test/$OS_VERSION/" node_sources

--- a/data/console/test_node.sh
+++ b/data/console/test_node.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+set -e
+
+test_result_wrapper(){
+  local VERSION=$1
+  local FILE=$2
+
+  local NODE="/usr/bin/node$VERSION"
+  local OUTPUT="/tmp/test_output"
+
+  # Run the test (using common and custom flags if present) and save the output
+  echo "Running $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]}$FILE"
+  set +e
+  $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]} $FILE > $OUTPUT 2>&1
+  RESULT=$?
+  set -e
+
+  # If test failed, keep track of failure and print out its output
+  if [ $RESULT -ne 0 ]; then
+    TEST_RESULT="failed"
+    echo "Node v$VERSION Test $FILE" >> $FAILED_TEST_LIST
+
+    echo "FAILED"
+    echo "Test Output:"
+    cat $OUTPUT
+  else
+    echo "OK"
+  fi
+  rm $OUTPUT
+}
+
+test_node_version(){
+  local VERSION="$1"
+
+  echo "Starting to test node version $VERSION"
+
+  # Get latest sources to make sure tests contain correct patches
+  zypper -n --no-gpg-checks si --repo node_sources -D "nodejs$VERSION" #> /dev/null 2>&1
+
+  local SOURCE_FILE=""
+  SOURCE_FILE=$(cd /usr/src/packages/SOURCES/ && find . -type f -iname "node-v$VERSION*.tar.xz")
+  SOURCE_FILE=${SOURCE_FILE:2} # strip ./ from name
+
+  if [ -z "$SOURCE_FILE" ]
+  then
+    echo "Can't find the sources of nodejs$VERSION"
+    exit 1
+  fi
+
+  local SOURCE_DIR
+  SOURCE_DIR=${SOURCE_FILE%.tar.xz} #remove extension from filename to get directory
+
+  # Unpack and apply patches to source
+  # Run the tests on the source using the installed binary
+  pushd "/usr/src/packages/SOURCES"
+    quilt setup "../SPECS/nodejs$VERSION.spec"
+    pushd "$SOURCE_DIR"
+      quilt push -a
+      # Run all test-crypto and test-tls available
+      for f in $(find test \( -path \*sequential\* -or -path \*parallel\* \) \( -name test-crypto-\* -or -name test-tls-\* \)); do
+        test_result_wrapper $VERSION $f
+      done
+    popd
+  popd
+
+  # Cleanup sources
+  rm -rf /usr/src/packages/SOURCES/*
+  rm -rf /usr/src/packages/SPECS/* 
+}
+
+main(){
+
+  local OS_VERSION="$1"
+
+  # Install dependencies to apply source patches and run tests
+  zypper -n in quilt rpm-build openssl-1_1 #> /dev/null 2>&1
+
+  # Get list of each nodejs version found from default repo
+  local NODE_VERSIONS=$(zypper -n search nodejs | egrep -i 'nodejs[0-9]{1,2} ' | cut -d'|' -f 2 | tr -d ' '| tr -d 'nodejs' | sort -h | uniq)
+  local NODE_LATEST_VERSION=$(zypper -n search nodejs | egrep -i 'nodejs[0-9]{1,2} ' | cut -d'|' -f 2 | tr -d ' '| tr -d 'nodejs' | sort -h | uniq | tail -n1)
+
+  for v in $NODE_VERSIONS; do
+   echo "Found node version: $v" 
+  done
+  echo "Will test only latest version: $NODE_LATEST_VERSION" 
+
+  # Install latest nodejs version
+  zypper -n in --no-recommends "nodejs$NODE_LATEST_VERSION" > /dev/null 2>&1
+
+  # Add sources repo to have latest source patches
+  zypper -n --gpg-auto-import-keys ar -f "http://download.suse.de/ibs/home:/adamm:/node_test/$OS_VERSION/" node_sources
+
+  test_node_version $NODE_LATEST_VERSION
+    
+  # Fail if at least one test has failed. Print list of failed tests
+  if [ "$TEST_RESULT" != "ok" ]; then
+    echo "Some tests have failed:"
+    cat $FAILED_TEST_LIST
+    echo ""
+    echo "Please look for 'FAILED' in the serial_terminal log for the full trace"
+    exit 1
+  else
+    echo "ALL tests have passed."
+  fi
+}
+
+# Hashmap of special flags required by some tests
+# Usage:   ["$VERSION $FILE"]="FLAG"
+# Example: ["10 test/directory/mytest.js"]="--myFlag"
+declare -A node_flags
+node_flags=(
+  ["10 test/parallel/test-tls-cli-max-version-1.2.js"]="--tls-max-v1.2"
+  ["10 test/parallel/test-tls-cli-min-version-1.0.js"]="--tls-min-v1.0 --tls-min-v1.1"
+  ["10 test/parallel/test-tls-cli-min-version-1.1.js"]="--tls-min-v1.1"
+  ["10 test/parallel/test-tls-cli-min-version-1.2.js"]="--tls-min-v1.2"
+  ["10 test/parallel/test-tls-cnnic-whitelist.js"]="--use-bundled-ca"
+  ["10 test/parallel/test-tls-dhe.js"]="--no-warnings"
+  ["10 test/parallel/test-tls-legacy-deprecated.js"]="--no-warnings"
+  ["10 test/parallel/test-tls-securepair-leak.js"]="--no-deprecation"
+  ["10 test/parallel/test-crypto-dh-leak.js"]="--noconcurrent-recompilation"
+)
+
+# Common flags to use on each test
+GLOBAL_FLAGS="--expose_gc --expose-internals"
+
+# Use global variables to keep track if test some test fail and which one
+FAILED_TEST_LIST="/tmp/failed_test_list"
+TEST_RESULT="ok"
+
+main "$@"
+

--- a/data/console/test_node.sh
+++ b/data/console/test_node.sh
@@ -87,6 +87,8 @@ main(){
   # Install latest nodejs version
   zypper -n in --no-recommends "nodejs$NODE_LATEST_VERSION"
 
+  # Trap for cleanup of repo
+  trap 'zypper -n rr node_sources' EXIT
   # Add sources repo to have latest source patches
   zypper -n --gpg-auto-import-keys ar -f "http://download.suse.de/ibs/home:/adamm:/node_test/$OS_VERSION/" node_sources
 

--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -24,6 +24,7 @@ schedule:
 - console/git
 - console/cups
 - console/java
+- console/nodejs
 - console/sqlite3
 - console/ant
 - console/perf

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -24,6 +24,7 @@ schedule:
 - console/git
 - console/cups
 - console/java
+- console/nodejs
 - console/sqlite3
 - console/gdb
 - console/perf

--- a/schedule/qam/15-SP2/mau-extratests.yaml
+++ b/schedule/qam/15-SP2/mau-extratests.yaml
@@ -26,6 +26,7 @@ schedule:
 - console/git
 - console/cups
 - console/java
+- console/nodejs
 - console/sqlite3
 - console/gdb
 - console/perf

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -24,6 +24,7 @@ schedule:
 - console/git
 - console/cups
 - console/java
+- console/nodejs
 - console/sqlite3
 - console/ant
 - console/gdb

--- a/tests/console/nodejs.pm
+++ b/tests/console/nodejs.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: NodeJS test to run specific checks availalble on the source code 
+#          about TLS to avoid regressions due to OpenSSL updates.
+#          The test will:
+#          - Check the latest nodejs package available and install it
+#          - Download latest sources of the package from IBS
+#          - Apply patches to the sources
+#          - Run the crypto and tls tests.
+#          - List eventually failed test in the end
+# Maintainer: Michael Grifalconi <mgrifalconi@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils;
+use repo_tools 'generate_version';
+
+sub run {
+    #Preparation
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    my $os_version = generate_version();
+
+    # Get test script and run it
+    assert_script_run 'wget --quiet ' . data_url('console/test_node.sh');
+    assert_script_run 'chmod +x test_node.sh';
+    assert_script_run './test_node.sh ' . $os_version, 900; 
+}
+
+
+1;

--- a/tests/console/nodejs.pm
+++ b/tests/console/nodejs.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: NodeJS test to run specific checks availalble on the source code 
+# Summary: NodeJS test to run specific checks availalble on the source code
 #          about TLS to avoid regressions due to OpenSSL updates.
 #          The test will:
 #          - Check the latest nodejs package available and install it
@@ -22,7 +22,6 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils;
 use repo_tools 'generate_version';
 
 sub run {
@@ -35,8 +34,8 @@ sub run {
     # Get test script and run it
     assert_script_run 'wget --quiet ' . data_url('console/test_node.sh');
     assert_script_run 'chmod +x test_node.sh';
-    assert_script_run './test_node.sh ' . $os_version, 900; 
-    
+    assert_script_run "./test_node.sh $os_version", 900;
+
     # Remove the repo used to download node latest sources from ibs
     zypper_call("rr node_sources");
 }

--- a/tests/console/nodejs.pm
+++ b/tests/console/nodejs.pm
@@ -35,9 +35,6 @@ sub run {
     assert_script_run 'wget --quiet ' . data_url('console/test_node.sh');
     assert_script_run 'chmod +x test_node.sh';
     assert_script_run "./test_node.sh $os_version", 900;
-
-    # Remove the repo used to download node latest sources from ibs
-    zypper_call("rr node_sources");
 }
 
 

--- a/tests/console/nodejs.pm
+++ b/tests/console/nodejs.pm
@@ -36,6 +36,9 @@ sub run {
     assert_script_run 'wget --quiet ' . data_url('console/test_node.sh');
     assert_script_run 'chmod +x test_node.sh';
     assert_script_run './test_node.sh ' . $os_version, 900; 
+    
+    # Remove the repo used to download node latest sources from ibs
+    zypper_call("rr node_sources");
 }
 
 


### PR DESCRIPTION
NodeJS test to run specific checks availalble on the source code  about TLS to avoid regressions due to OpenSSL updates.

The test will:
          - Check the latest nodejs package available and install it
          - Download latest sources of the package from IBS
          - Apply patches to the sources
          - Run the crypto and tls tests.
          - List eventually failed test in the end

- Related ticket: https://progress.opensuse.org/issues/73168
- Needles: no needles
- Verification run:

12-SP5  x86  https://openqa.suse.de/tests/5110481
12-SP5  arm  https://openqa.suse.de/tests/5110485
12-SP5  s390 https://openqa.suse.de/tests/5105160 

15-GA   x86  https://openqa.suse.de/tests/5110483
15-GA   arm  https://openqa.suse.de/tests/5110486
15-GA   s390 https://openqa.suse.de/t5111815

15-SP1  x86  https://openqa.suse.de/tests/5110484
15-SP1  arm  https://openqa.suse.de/t5111822
15-SP1  s390 https://openqa.suse.de/t5111821

15-SP2  x86  https://openqa.suse.de/t5111780
15-SP2  arm  https://openqa.suse.de/t5111800
15-SP2  s390 https://openqa.suse.de/t5111808