### PR TITLE
Fix aa_autodep/aa_status random failures

### DIFF
--- a/lib/services/apparmor.pm
+++ b/lib/services/apparmor.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -39,7 +39,13 @@ sub start_service {
 sub check_service {
     # SLE12-SP2 doesn't support systemctl to enable apparmor
     if (is_sle('12-SP3+', get_var('HDDVERSION'))) {
-        systemctl 'is-enabled apparmor.service';
+        # Do double check to avoid perfomance issue
+        my $ret = script_run 'systemctl --no-pager is-enabled apparmor.service';
+        if ($ret) {
+            # If failed try sync and then check again
+            assert_script_run 'sync';
+            systemctl 'is-enabled apparmor.service';
+        }
     }
     systemctl 'is-active apparmor';
 }


### PR DESCRIPTION
Fix aa_autodep/aa_status random failures:

Apparmor test case "aa_autodep"/"aa_status" randomly failed on arch ppc64le,
it is a time racing or performance issue, this fix added double check the execution results to avoid this.
poo#77683 - [sle][security][sle15sp3] on ppc64le apparmor test fails in aa_autodep: the profiles were not generated
poo#80672 - [sle][security][sle15sp3] on ppc64le apparmor test fails in aa_status: "# systemctl --no-pager is-enabled apparmor.service" reports "Failed to get unit file state" randomly

- Related ticket: https://progress.opensuse.org/issues/77683 https://progress.opensuse.org/issues/80672
- Needles: NA
- Verification run: 
  http://openqa.suse.de/tests/5143977 (ran for 5+  times and did not find random failure again)
