### PR TITLE
Update azure terraform profile

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -22,6 +22,14 @@ variable "image_id" {
     default = ""
 }
 
+variable "offer" {
+    default=""
+}
+
+variable "sku" {
+    default="gen1"
+}
+
 variable "extra-disk-size" {
     default = "100"
 }
@@ -126,6 +134,7 @@ resource "azurerm_image" "image" {
     name                      = "${azurerm_resource_group.openqa-group.name}-disk1"
     location                  = var.region
     resource_group_name       = azurerm_resource_group.openqa-group.name
+    count = var.image_id != "" ? 1 : 0
 
     os_disk {
         os_type = "Linux"
@@ -144,7 +153,11 @@ resource "azurerm_virtual_machine" "openqa-vm" {
     count                 = var.instance_count
 
     storage_image_reference {
-        id = azurerm_image.image.id
+        id = var.image_id != "" ? azurerm_image.image.0.id : ""
+        publisher = var.image_id != "" ? "" : "SUSE"
+        offer     = var.image_id != "" ? "" : var.offer
+        sku       = var.image_id != "" ? "" : var.sku
+        version   = var.image_id != "" ? "" : "latest"
     }
 
     storage_os_disk {

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -88,6 +88,14 @@ sub resource_exist {
     return ($output ne '[]');
 }
 
+sub get_image_id {
+    my ($self, $img_url) = @_;
+    $img_url //= get_var('PUBLIC_CLOUD_IMAGE_LOCATION');
+    # Very special case for Azure. Ignore the image id and only use OFFER and SKU
+    return "" if ((!$img_url) && get_var('PUBLIC_CLOUD_AZURE_OFFER') && get_var('PUBLIC_CLOUD_AZURE_SKU'));
+    return $self->SUPER::get_image_id($img_url);
+}
+
 sub find_img {
     my ($self, $name) = @_;
 
@@ -193,6 +201,17 @@ sub img_proof {
     }
 
     return $self->run_img_proof(%args);
+}
+
+sub terraform_apply {
+    my ($self, %args) = @_;
+    $args{vars} //= {};
+    my $offer = get_var("PUBLIC_CLOUD_AZURE_OFFER");
+    my $sku   = get_var("PUBLIC_CLOUD_AZURE_SKU");
+    $args{vars}->{offer} = $offer if ($offer);
+    $args{vars}->{sku}   = $sku   if ($sku);
+
+    $self->SUPER::terraform_apply(%args);
 }
 
 sub on_terraform_apply_timeout {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -359,7 +359,13 @@ sub terraform_apply {
 
     my $cmd = 'terraform plan -no-color ';
     if (!get_var('PUBLIC_CLOUD_SLES4SAP')) {
-        $cmd .= "-var 'image_id=" . $image . "' ";
+        # Some auxiliary variables, requires for fine control and public cloud provider specifics
+        for my $key (keys %{$args{vars}}) {
+            my $value = $args{vars}->{$key};
+            $value =~ s/'/'"'"'/;    # ensure values are escaped properly
+            $cmd .= sprintf(q(-var '%s=%s' ), $key, $value);
+        }
+        $cmd .= "-var 'image_id=" . $image . "' " if ($image);
         $cmd .= "-var 'instance_count=" . $args{count} . "' ";
         $cmd .= "-var 'type=" . $instance_type . "' ";
         $cmd .= "-var 'region=" . $self->region . "' ";


### PR DESCRIPTION
Update azure terraform profile to make it possible to create azure instances given on publisher/offer/sku instead of image file.

This PR paves the road to schedule QEM Public cloud runs which are using the current published images.

- Related ticket: https://progress.opensuse.org/issues/80614
- Needles: -
- Verification runs:

New behaviour: [15-SP2 Azure BYOS](http://phoenix-openqa.qam.suse.de/tests/4176) | [15-SP2 EC2](http://phoenix-openqa.qam.suse.de/tests/4177) | [15-SP2 GCE](http://phoenix-openqa.qam.suse.de/tests/4178)

Old behaviour: [15-SP2 Azure BYOS](http://phoenix-openqa.qam.suse.de/tests/4179) | [15-SP2 EC2 BYOS](http://phoenix-openqa.qam.suse.de/tests/4180) | [15-SP2 GCE BYOS](http://phoenix-openqa.qam.suse.de/tests/4181)