### PR TITLE
Change sles4sap shortcut for quarterly iso tests

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -79,6 +79,7 @@ use constant {
           is_server
           is_transactional
           is_livecd
+          is_quarterly_iso
           has_product_selection
           has_license_on_welcome_screen
           has_license_to_accept
@@ -696,4 +697,12 @@ sub package_version_cmp {
     }
 
     return 0;
+}
+
+=head2 is_quarterly_iso
+
+Returns true if called in quaterly iso testing
+=cut
+sub is_quarterly_iso {
+    return 1 if get_var('FLAVOR', '') =~ /QR/;
 }

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -70,7 +70,7 @@ sub get_product_shortcuts {
             : 'i',
             sled => 'x',
             sles4sap => is_ppc64le() ? 'i'
-            : (is_sle('15-SP2+') && is_x86_64()) ? 't'
+            : (is_sle('15-SP2+') && is_x86_64() && !is_quarterly_iso()) ? 't'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',
             rt  => is_x86_64() ? 't' : undef


### PR DESCRIPTION
This PR changes the sles4sap shortcut when we are testing quarterly iso on 15SP2.
As the quarterly ISO contains updates, it looks like that the welcome page has changed a little bit.

- Related ticket: https://progress.opensuse.org/issues/58328
- Failed test: https://openqa.suse.de/tests/5121200#step/welcome/5
- Needles: N/A
- Verification run: 
[15-SP2-QR](http://1b143.qa.suse.de/tests/5961)
- Regression tests:
[15-SP3 SAP](http://1b143.qa.suse.de/tests/5962)
[15-SP2 QAM](http://1b143.qa.suse.de/tests/5963)
[15-SP3 SLE gnome](http://1b143.qa.suse.de/tests/5964)