### PR TITLE
[virt_autotest] add required pkg for window guest installation on xen host

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -100,6 +100,10 @@ sub install_package {
     }
 
     virt_autotest::utils::install_default_packages();
+
+    ###Install required package for window guest installation on xen host
+    if (get_var('GUEST_LIST') =~ /^win-.*/ && (is_xen_host)) { zypper_call '--no-refresh --no-gpg-checks in mkisofs' }
+
 }
 
 sub run {


### PR DESCRIPTION
Confirm that there was required package as mkisofs for window(2019) guest installation on xen host. 

So, add the required package as mkisofs for window(2019) guest installation on xen host. 

- Related ticket: n/a
- Needles: n/a
- Verification run: 
[virt-v2v-win2k19fcs-from-developing-to-developing-kvm-dst](http://10.67.129.4/tests/25408#)
[virt-v2v-win2k19fcs-from-developing-to-developing-xen-src](http://10.67.129.4/tests/25407#)
