### PR TITLE
Fix container URLs for MicroOS 15.2

### DIFF
--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -82,11 +82,11 @@ sub get_suse_container_urls {
         push @image_names,  "registry.opensuse.org/opensuse/jump/15.2/images/totest/containers/opensuse/leap:15.2.1";
         push @stable_names, "registry.opensuse.org/opensuse/leap:15.2.1";
     }
-    elsif (is_leap(">15.0") && check_var('ARCH', 'x86_64')) {
+    elsif ((is_leap(">15.0") || is_microos(">15.0")) && check_var('ARCH', 'x86_64')) {
         push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
         push @stable_names, "registry.opensuse.org/opensuse/leap:${version}";
     }
-    elsif (is_leap(">15.0") && (check_var('ARCH', 'aarch64') || check_var('ARCH', 'arm'))) {
+    elsif ((is_leap(">15.0") || is_microos(">15.0")) && (check_var('ARCH', 'aarch64') || check_var('ARCH', 'arm'))) {
         push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/arm/images/totest/containers/opensuse/leap:${version}";
         push @stable_names, "registry.opensuse.org/opensuse/leap:${version}";
     }


### PR DESCRIPTION
Fixes unknown container URL on MicroOS 15.2, see
https://openqa.opensuse.org/tests/1492452#step/podman_image/2

Can't really verify as I don't have an openQA test setup atm.