### PR TITLE
PC: fix 'rc_only' option in 'run_ssh_command'

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -80,7 +80,7 @@ sub run_ssh_command {
         # Increase the hard timeout for script_run, otherwise our 'timeout $args{timeout} ...' has no effect
         $args{timeout} += 2;
         # Pipe both the standard and error output serial for debug purposes
-        $ssh_cmd .= " 2>&1 | tee /dev/$serialdev";
+        $ssh_cmd .= " >/dev/$serialdev 2>&1";
         # Run the command and return only the returncode here
         my $ret = script_run($ssh_cmd, %args, quiet => 0);
         die("Timeout on $ssh_cmd") unless (defined($ret));


### PR DESCRIPTION
`run_ssh_command` as an `rc_only` option if we want to get only the Return Code instead of the full execution, but this option always return 0 since a change made in [PR#11428](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11428).

Comment added in [PR#11428](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11428):

_In fact no it's not good: the purpose of `rc_only` is to return the "return code" of `$ssh_cmd`, right? In that case adding `| tee $serialdev` is bad, as the last return code of `$ssh_cmd` will be the one from the `tee` command, and in many case it's always 0._

_Here an example of a failing test: http://1b210.qa.suse.de/tests/8007#step/sles4sap/420, it should returned RC=102 but in fact it returned 0._

- Related ticket: N/A
- Needles: N/A
- Failing test: http://1b210.qa.suse.de/tests/8007
- Verification run: TO_BE_DONE

In the log of the failing test we can see that the return code is 0:
```
# timeout 90 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i '/root/.ssh/id_rsa' "root@34.91.166.251" -- 'sudo crm cluster wait_for_startup' 2>&1 | tee ttyS0; echo X~PHg-$?-
ERROR: cluster.wait_for_startup: Timed out waiting for cluster (rc = 102)
X~PHg-0-
```