### PR TITLE
Adjust firefox_nss test_flags as fatal from always_rollback

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -153,6 +153,6 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {fatal => 1, milestone => 1};
 }
 1;


### PR DESCRIPTION
**Description:**
Change the test_flags to fatal from always_rollback in order to
easily debug the firefox crash issue reproduced randomly

- Related ticket: https://progress.opensuse.org/issues/80712
- Needles: NA
- Verification run: 
 https://openqa.suse.de/tests/5123762#step/firefox_nss/38 (PASSED)
 https://openqa.suse.de/tests/5123761#step/firefox_nss/21 (ERROR)
