### PR TITLE
Fix autofs service check failure after migration

### DIFF
--- a/lib/autofs_utils.pm
+++ b/lib/autofs_utils.pm
@@ -216,14 +216,10 @@ sub full_autofs_check {
         check_function();
     }
     else {
-        if (get_var('ORIGIN_SYSTEM_VERSION') eq '11-SP4') {
-            check_service();
-        } else {
-            configure_service();
-            check_service();
-            check_function();
-            do_cleanup();
-        }
+        check_service();
+        return (get_var('ORIGIN_SYSTEM_VERSION') eq '11-SP4');
+        check_function();
+        do_cleanup();
     }
 }
 


### PR DESCRIPTION
For autofs service check after migration, We don't need to configure the service. For SLE11SP4 we just check service status by now.

- Related ticket: https://progress.opensuse.org/issues/80674
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t5124043 
  https://openqa.nue.suse.com/t5123778

  run with sle11sp4 
  https://openqa.nue.suse.com/t5128458