### PR TITLE
Adjust lvm+resize_root test suite for UI changes in the Expert Partitioner

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
@@ -197,6 +197,17 @@ sub resize_partition {
     $self->get_resize_page()->press_next();
 }
 
+sub resize_logical_volume {
+    my ($self, $args) = @_;
+    $self->get_expert_partitioner_page()->select_logical_volume({
+            volume_group   => $args->{volume_group},
+            logical_volume => $args->{logical_volume}
+    });
+    $self->get_expert_partitioner_page()->open_resize_device();
+    $self->get_resize_page()->set_custom_size($args->{size});
+    $self->get_resize_page()->press_next();
+}
+
 sub edit_partition_on_gpt_disk {
     my ($self, $args) = @_;
     my $part = $args->{partition};

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
@@ -142,8 +142,8 @@ sub select_volume_group {
 
 sub select_logical_volume {
     my ($self, $args) = @_;
-    $self->select_volume_group($args->{vg});
-    $self->{tbl_lvm_devices}->select(value => '/dev/' . $args->{vg} . '|' . $args->{lv});
+    $self->select_volume_group($args->{volume_group});
+    $self->{tbl_lvm_devices}->select(value => '/dev/' . $args->{volume_group} . '|' . $args->{logical_volume});
     send_key('up');
     send_key('down');
 }

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -40,19 +40,8 @@ schedule:
   - console/consoletest_finish
   - console/validate_modify_existing_partition
 test_data:
-  disks:
-    - name: vda
-      partitions:
-        - name: root
-          size: 45G
-          formatting_options:
-            filesystem: btrfs
-          mounting_options:
-            mount_point: /
   volume_groups:
     - name: system
-      devices:
-        - /dev/md0p1
       logical_volumes:
         - name: root
           size: 45G

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -1,0 +1,62 @@
+---
+name: lvm+resize_root
+description: |
+  Select LVM during installation and try to resize
+  the root LV to span more than 40GB which is selected as default.
+  See  bsc#989976, bsc#1000165
+vars:
+  DESKTOP: textmode
+  HDDSIZEGB: 50
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/lvm_no_separate_home
+  - installation/partitioning/resize_existing_lv
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/teardown_libyui
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/check_network
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - locale/keymap_or_locale
+  - console/consoletest_finish
+  - console/validate_modify_existing_partition
+test_data:
+  disks:
+    - name: vda
+      partitions:
+        - name: root
+          size: 45G
+          formatting_options:
+            filesystem: btrfs
+          mounting_options:
+            mount_point: /
+  volume_groups:
+    - name: system
+      devices:
+        - /dev/md0p1
+      logical_volumes:
+        - name: root
+          size: 45G
+          formatting_options:
+            filesystem: btrfs
+          mounting_options:
+            mount_point: /

--- a/schedule/yast/lvm/lvm+resize_root.yaml
+++ b/schedule/yast/lvm/lvm+resize_root.yaml
@@ -42,9 +42,9 @@ schedule:
   - console/consoletest_finish
   - console/validate_modify_existing_partition
 test_data:
-  disks:
-    - name: vda
-      partitions:
+  volume_groups:
+    - name: system
+      logical_volumes:
         - name: root
           size: 45G
           formatting_options:

--- a/tests/console/validate_modify_existing_partition.pm
+++ b/tests/console/validate_modify_existing_partition.pm
@@ -22,7 +22,21 @@ sub run {
 
     select_console "root-console";
 
-    my @partitions = @{$test_data->{disks}[0]->{partitions}};
+    my @partitions = ();
+    # Module is used to validate logical volumes too, so if no plain partitions
+    if (ref $test_data->{disks} eq 'ARRAY') {
+        foreach my $disk (@{$test_data->{disks}}) {
+            push @partitions, @{$disk->{partitions}};
+        }
+    }
+    if (ref $test_data->{volume_groups} eq 'ARRAY') {
+        foreach my $vg (@{$test_data->{volume_groups}}) {
+            push @partitions, @{$vg->{logical_volumes}};
+        }
+    }
+
+    die "No test data provided to validate" unless @partitions;
+
     foreach my $part (@partitions) {
         record_info("Check $part->{name}", "Verify that the partition filesystem is $part->{formatting_options}->{filesystem}");
 

--- a/tests/installation/partitioning/resize_existing_lv.pm
+++ b/tests/installation/partitioning/resize_existing_lv.pm
@@ -21,7 +21,7 @@ sub run {
     my $test_data   = get_test_suite_data();
     my $partitioner = $testapi::distri->get_expert_partitioner();
     $partitioner->run_expert_partitioner('current');
-    foreach my $vg (@{$args->{volume_groups}}) {
+    foreach my $vg (@{$test_data->{volume_groups}}) {
         foreach my $lv (@{$vg->{logical_volumes}}) {
             $partitioner->resize_logical_volume({
                     volume_group   => $vg->{name},

--- a/tests/installation/partitioning/resize_existing_lv.pm
+++ b/tests/installation/partitioning/resize_existing_lv.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: modify and resize existing logical volume on a pre-configured disk.
+# Maintainer: QE YaST <qa-sle-yast@suse.com>
+
+use strict;
+use warnings;
+use parent 'y2_installbase';
+use testapi;
+use version_utils ':VERSION';
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my $test_data   = get_test_suite_data();
+    my $partitioner = $testapi::distri->get_expert_partitioner();
+    $partitioner->run_expert_partitioner('current');
+    foreach my $vg (@{$args->{volume_groups}}) {
+        foreach my $lv (@{$vg->{logical_volumes}}) {
+            $partitioner->resize_logical_volume({
+                    volume_group   => $vg->{name},
+                    logical_volume => $lv->{name},
+                    size           => $lv->{size}
+            });
+        }
+    }
+    $partitioner->accept_changes_and_press_next();
+}
+
+1;


### PR DESCRIPTION
Another set of changes to make test suites work fine using libyui REST API.

See [poo#80204](https://progress.opensuse.org/issues/80204).

[Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23resize_lvm&distri=sle).