### PR TITLE
Add cups and rpcbind service check for SLE11SP4

### DIFF
--- a/lib/services/rpcbind.pm
+++ b/lib/services/rpcbind.pm
@@ -18,6 +18,9 @@ use utils;
 use strict;
 use warnings;
 
+my $service_type = 'Systemd';
+my $nfs_server   = 'nfs-server';
+
 sub install_service {
     # rpcbind needs nfs-server for testing.
     zypper_call('in rpcbind');
@@ -35,23 +38,23 @@ sub config_service {
 }
 
 sub enable_service {
-    systemctl('enable rpcbind');
-    systemctl('enable nfs-server');
+    common_service_action('rpcbind',   $service_type, 'enable');
+    common_service_action($nfs_server, $service_type, 'enable');
 }
 
 sub start_service {
-    systemctl('start rpcbind');
-    systemctl('start nfs-server');
+    common_service_action('rpcbind',   $service_type, 'start');
+    common_service_action($nfs_server, $service_type, 'start');
 }
 
 sub stop_service {
-    systemctl('stop rpcbind');
-    systemctl('stop nfs-server');
+    common_service_action('rpcbind',   $service_type, 'stop');
+    common_service_action($nfs_server, $service_type, 'stop');
 }
 
 sub check_service {
-    systemctl('is-enabled rpcbind');
-    systemctl('is-active rpcbind');
+    common_service_action('rpcbind', $service_type, 'is-enabled');
+    common_service_action('rpcbind', $service_type, 'is-active');
 }
 
 sub check_function {
@@ -69,8 +72,10 @@ sub check_function {
 # Check rpcbind service before and after migration.
 # Stage is 'before' or 'after' system migration.
 sub full_rpcbind_check {
-    my ($stage) = @_;
+    my ($stage, $type) = @_;
     $stage //= '';
+    $service_type = $type;
+    $nfs_server   = 'nfsserver' if ($type eq 'SystemV');
     if ($stage eq 'before') {
         install_service();
         config_service();


### PR DESCRIPTION
We'd add cups and rpcbind service check for SLE11SP4. We need change the configure files
to make cups check works on SLE11SP4. In SLE11SP4 the nfs-server name is nfsserver.

- Related ticket: https://progress.opensuse.org/issues/80646
- Needles: N/A
- Verification run: 

  https://openqa.nue.suse.com/tests/5123666 
  https://openqa.nue.suse.com/tests/5124057

run with 15sp2 regression as clone of 5148648 
https://openqa.nue.suse.com/t5151684
https://openqa.nue.suse.com/t5151685

run with 15 with clone of 5148653

https://openqa.nue.suse.com/t5151686


run with sle11sp4 fix with clone of 5144852

https://openqa.nue.suse.com/t5151688

changed the code to use $hdd_base_version
11sp4 5150398

https://openqa.nue.suse.com/t5155344
https://openqa.nue.suse.com/t5155345
https://openqa.nue.suse.com/t5155346
https://openqa.nue.suse.com/t5155347

15sp2 5148648
https://openqa.nue.suse.com/t5155270
https://openqa.nue.suse.com/t5155271

cups standalone regression test
https://openqa.nue.suse.com/tests/5159633


new run

11sp4 5150398
https://openqa.nue.suse.com/tests/5169086 PASSED
https://openqa.nue.suse.com/tests/5169368 PASSED
https://openqa.nue.suse.com/tests/5169369 PASSED
https://openqa.nue.suse.com/tests/5169370 PASSED

15sp2 5148648
https://openqa.nue.suse.com/t5169042 PASSED

15sp2 5148648
https://openqa.nue.suse.com/t5169371
https://openqa.nue.suse.com/t5169372
https://openqa.nue.suse.com/t5169373
https://openqa.nue.suse.com/t5169374

new cups regression test
https://openqa.nue.suse.com/tests/5174015