### PR TITLE
Containers: configure docker-compose module to pull from insecure registry

### DIFF
--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -50,6 +50,7 @@ sub run {
     assert_script_run("curl -O " . data_url("containers/docker-compose.yml"));
     assert_script_run("curl -O " . data_url("containers/haproxy.cfg"));
 
+    allow_selected_insecure_registries(runtime => 'docker');
     my $registry = get_var('REGISTRY', 'docker.io');
     assert_script_run("docker image pull $registry/library/nginx", timeout => 300);
     assert_script_run 'docker-compose pull', 600;


### PR DESCRIPTION
If this is not configured, we can get errors like
`Error response from daemon: Get https://18.192.99.66:5000/v2/: http: server gave HTTP response to HTTPS client`

Failing test example: https://openqa.suse.de/tests/5128980#step/docker_compose/48
