### PR TITLE
Re-establish dns domain name access to virtual machines due to ip change

### DIFF
--- a/data/virt_autotest/setup_dns_service.sh
+++ b/data/virt_autotest/setup_dns_service.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-
+#This script can be executed multiple times consecutively to facilitate establishing dns domain name access to virtual machines even virtual machine ip changes
+#The ability of consecutive multiple runs is achieved by detecting signature "$0" written to various configuration files by this script, so the backup original configuration 
+#files can be restored before executing this script again. In order to do so, please make sure the way in which this script is called is always the same every time
 #Usage and help info for the script
 help_usage(){
         echo "script usage: $(basename $0) [-f DNS forward domain name is mandatory(testvirt.net)] [-r DNS reverse domain name is mandatory(123.168.192)] [-s DNS server ip is mandatory (192.168.123.1)] [-h help]"

--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -187,6 +187,15 @@ sub run_test {
     my ($self) = @_;
     my ($sles_running_version, $sles_running_sp) = get_os_release;
 
+    if ($sles_running_version eq '15' && get_var("VIRT_AUTOTEST")) {
+        record_info("DNS Setup", "SLE 15+ host may have more strict rules on dhcp assigned ip conflict prevention, so guest ip may change");
+        my $dns_bash_script_url = data_url("virt_autotest/setup_dns_service.sh");
+        script_output("curl -s -o ~/setup_dns_service.sh $dns_bash_script_url", 180, type_command => 0, proceed_on_failure => 0);
+        script_output("chmod +x ~/setup_dns_service.sh && ~/setup_dns_service.sh -f testvirt.net -r 123.168.192 -s 192.168.123.1", 180, type_command => 0, proceed_on_failure => 0);
+        upload_logs("/var/log/virt_dns_setup.log");
+        save_screenshot;
+    }
+
     # 1. Add network interfaces
     my %mac = ();
     record_info "Virtual network", "Adding virtual network interface";


### PR DESCRIPTION
* **Cloned** virtual machine in network tests causes ip address change to original virtual machine. So re-establish dns domain name access to the original virtual machine by executing setup_dns_service.sh again in hotplugging module
* **The** ip change caused by cloned virtual machine is a mechanism employed by dhcp service to prevent ip conflict. SLE 12 dhcp service can free and re-assign conflicted ip if virtual machine insists on requesting conflicted ip. It seems that SLE 15+ imposes more strict rules on this ip conflict prevention mechanism, so conflicted ipv4 address can not be re-assigned until abandon timer expires. Newer [dhcp service documentation](https://www.isc.org/dhcp) really drops such "can be re-assigned" description that exists with older ones.
* **It** seems that abandon-lease-time timer can be configured to reduce the abandoned period length. But configuring it can incur much more verification work, especially on older SLE releases. It is not very easy to guarantee that it works error free across all releases and platforms
* **setup_dns_service.sh** is originally designed to be able to be executed multiple times consecutively to conquer such ip address change problem. So calling setup_dns_service.sh is quite easy, simple, fast, quality-guaranteed and validation-proved
* **Related ticket:** n/a
* **Needles:** n/a
* **Verification run:**
   * Manual verification to validate setup_dns_service.sh really works with such scenario
   * [gi-guest_developing-on-host_developing-kvm](https://openqa.nue.suse.com/tests/5128463)
   * [gi-guest_developing-on-host_developing-xen](https://openqa.nue.suse.com/tests/5128464)
   * [gi-guest_sles15sp2-on-host_developing-xen](https://openqa.nue.suse.com/tests/5128720)
   * [gi-guest_developing-on-host_sles15sp2-kvm](https://openqa.suse.de/tests/5128721)
