### PR TITLE
Make public_cloud-instance_overview failures fatal

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -21,7 +21,7 @@ use testapi;
 use utils;
 use version_utils;
 
-our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand);
+our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand is_ec2);
 
 
 # Select console on the test host, regardless of the TUNNELED variable.
@@ -47,6 +47,10 @@ sub is_ondemand() {
     # By convention OnDemand images are not marked explicitly.
     # Check all the other flavors, and if they don't match, it must be on_demand.
     return is_publiccloud && (!is_byos());    # When introducing new flavors, add checks here accordingly.
+}
+# Check if we are on an AWS test run
+sub is_ec2() {
+    return is_publiccloud && check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 }
 
 1;


### PR DESCRIPTION
If the instance_overview test for public_cloud images fails, it has
little to no sense to continue with the remaining tests.  The
instance_overview test is a sanity check for the image under
test and failures there should be treated as fatal.

- Related ticket: https://progress.opensuse.org/issues/80714
- Needles: 
- Verification run: http://phoenix-openqa.qam.suse.de/tests/4323#step/instance_overview/44
