### PR TITLE
Allow SR-IOV network pci passthrough tests run on SUT with one SR-IOV…

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -129,11 +129,17 @@ sub setup_console_in_grub {
             die "Host Hypervisor is not xen or kvm";
         }
 
+        #enable Intel VT-d for SR-IOV test running on intel SUTs
+        my $intel_option = "";
+        if (get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH") && script_run("grep Intel /proc/cpuinfo") == 0) {
+            $intel_option = "intel_iommu=on";
+        }
+
         $cmd
           = "cp $grub_cfg_file ${grub_cfg_file}.org "
           . "\&\& sed -ri '/($bootmethod\\s*.*$search_pattern)/ "
           . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
-          . "/$bootmethod\\s*.*$search_pattern/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}; "
+          . "/$bootmethod\\s*.*$search_pattern/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5 $intel_option/;}; "
           . "s/timeout=-{0,1}[0-9]{1,}/timeout=30/g;"
           . "' $grub_cfg_file";
         assert_script_run($cmd);

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -307,6 +307,17 @@ sub upload_virt_logs {
 sub generate_guest_asset_name {
     my $guest = shift;
 
+    #get build number
+    my $build_num;
+    #for clone job, get build number from SCC proxy which is set in Media
+    if (get_var('CASEDIR')) {
+        get_var('SCC_URL') =~ /^http.*all-([\d\.]*)\.proxy\.*/;
+        $build_num = $1;
+    }
+    else {
+        $build_num = get_required_var('BUILD');
+    }
+
     my $composed_name
       = 'guest_'
       . $guest
@@ -314,7 +325,7 @@ sub generate_guest_asset_name {
       . get_required_var('DISTRI') . '-'
       . get_required_var('VERSION')
       . '_build'
-      . get_required_var('BUILD') . '_'
+      . $build_num . '_'
       . lc(get_required_var('SYSTEM_ROLE')) . '_'
       . get_required_var('ARCH');
 
@@ -348,6 +359,8 @@ sub compress_single_qcow2_disk {
 sub get_guest_list {
 
     #get the guest pattern from test suite settings
+    #GUEST_PATTERN, GUEST_LIST, or GUEST_LIST is used in different test suites,
+    #thus I use GUEST_LIST uniformly.
     if (get_var('GUEST_PATTERN')) {
         set_var('GUEST_LIST', get_var('GUEST_PATTERN'));
     }


### PR DESCRIPTION
… network device only

- To support one SR-IOV network card only on a SUT, impi sol console has to be used instead of ssh connection during reloading network device driver.
- Improve a little about the network shared function.
- Allow clone jobs download guest assets for reusing
- NIC is changed after virtual function is enabled, restore br0 to keep the network connection.
- Enable intel_iommu for intel CPUs.
- Test the SR-IOV network card with carriers only because PF is required to be brought up when attaching its vfs to vms.
- Regarding of difficulties above, try to find a better way,  to enable VFs by modify SYS PCI and not use sol console anymore

Verification run: 
[sriov_network_card_pci_passthrough-kvm](http://10.67.129.51/tests/1745)

more verification runs are underway in OSD, but progress is slow until the MR is got merged to add more sriov workers. 
