### PR TITLE
travis: Update perl version for compile check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: perl
 matrix:
   include:
   - name: "openSUSE/SUSE production perl version, only compile check"
-    perl: "5.18"
+    perl: "5.26"
     env: TESTS=compile
   - name: "testing perl version, static checks"
     perl: "5.26"


### PR DESCRIPTION
i.e. in Leap 15.1. All tests are now using the same version.

This was required to fix bogus failure:
https://travis-ci.org/github/os-autoinst/os-autoinst-distri-opensuse/jobs/747597980

Suggested-by: Oliver Kurz <okurz@suse.de>