### PR TITLE
Fix Travis check test_deleted_renamed_referenced_files

### DIFF
--- a/tools/test_deleted_renamed_referenced_files
+++ b/tools/test_deleted_renamed_referenced_files
@@ -5,8 +5,8 @@ success=1
 for FILE in $FILES; do
     if [ -f "$FILE" ] 
     then
-        # if file exists it means it was renamed, and then original file name is retrieved by git log
-        FILE=$(git log --follow -p $FILE | grep 'rename from test' | awk '{print $3}')
+        # if file exists it means it was renamed, and then previous file name is retrieved by git log
+        FILE=$(git log --follow -p $FILE | grep 'rename from test' | awk '{print $3}' | head -n 1)
     fi
     if [ -n "$(echo $FILE | grep '\.pm$')" ] 
     then
@@ -19,7 +19,8 @@ for FILE in $FILES; do
         file_to_verify="$FILE" 
         target_paths='schedule/'
     fi
-    if MATCHED_SCHEDULE_FILES="$(grep --recursive --ignore-case --files-with-matches "${file_to_verify}\b" $target_paths)"
+    if [[ -n  $file_to_verify ]] && [[ MATCHED_SCHEDULE_FILES="$(grep --recursive --ignore-case \
+       --files-with-matches "${file_to_verify}\b" $target_paths)" ]]
     then
         echo "\"$file_to_verify\" was removed or renamed, but it is still used in: \
               \n$MATCHED_SCHEDULE_FILES\n"


### PR DESCRIPTION
In the scenario where a file is renamed multiple times in the past, the current test_deleted_renamed_referenced_files check module will not fetch the most recent name from the git log, but all the names together, so it will not really check if the file is still in use somewhere, with the previous name. Also, it has happened variable $file_to_verify to be empty, causing the test_deleted_renamed_referenced_files check module to search if [blank] is used in any schedule, thus failing Travis.
 I have made some modifications to avoid the above scenarios.