### PR TITLE
.travis.yml: Bump perl versions to current "production+testing" ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: perl
 matrix:
   include:
   - name: "openSUSE/SUSE production perl version, only compile check"
-    perl: "5.18"
+    perl: "5.26"
     env: TESTS=compile
   - name: "testing perl version, static checks"
-    perl: "5.26"
+    perl: "5.32"
     env: TESTS=static
   - name: "testing perl version, unit tests"
-    perl: "5.26"
+    perl: "5.32"
     env: TESTS=unit
 env:
   global:
@@ -25,6 +25,7 @@ cache:
 before_install:
   - eval $(curl https://travis-perl.github.io/init) --perl --always-upgrade-modules
   - echo "requires 'Code::DRY';" >> cpanfile
+  - echo "requires 'Date::Parse';" >> cpanfile
   - echo "requires 'Regexp::Common';" >> cpanfile
   - echo "requires 'Perl::Tidy', '== 20201001';" >> cpanfile
   - sudo apt-get -y install yamllint


### PR DESCRIPTION
openSUSE Leap 15.1 as well as openSUSE Leap 15.2 which we use in
production on both o3 and osd use perl 5.26, whereas openSUSE:Factory
and Tumbleweed currently have 5.32 already.

Also install missing Date::Parse.

This change might also change some other unexpected problems, for
example as encountered in
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11484
which fails travis CI checks with

```
export
PERL5LIB=../..:os-autoinst:lib:tests/installation:tests/x11:tests/qa_automation:tests/virt_autotest:tests/cpu_bugs:$PERL5LIB
; ( git ls-files "*.pm" || find . -name \*.pm|grep -v /os-autoinst/ ) |
parallel perl -c 2>&1 | grep -v " OK$" && exit 2; true

[2020-12-04T14:24:27.514 UTC] [warn] !!! main_common.pm: Failed to load
main_ltp.pm:

"load_kernel_tests" is not exported by the main_ltp module
```

which can not be reproduced locally.


- Related ticket: none
- Needles: none
- Verification run: not needed
