### PR TITLE
Remove golang test from QAM SLE12SP2 tests

### DIFF
--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -24,7 +24,6 @@ schedule:
 - console/git
 - console/cups
 - console/java
-- console/golang
 - console/sqlite3
 - console/ant
 - console/perf


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/80760