### PR TITLE
Set options for supportconfig to support needed system info

### DIFF
--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -23,8 +23,9 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
+    my $options = get_var('SUPPORTCOFIG_OPTIONS', '');
     assert_script_run "rm -rf nts_* scc_* ||:";
-    assert_script_run "supportconfig -t . -B test", 800;
+    assert_script_run "supportconfig $options -t . -B test", 2000;
 
     # bcc#1166774
     if (script_run("test -d scc_test") == 0) {


### PR DESCRIPTION
Doing "full" supportconfig report every run is wasteful, we can run only few specific features e.g. supportconfig -i BOOT,BTRFS,DAEMONS,CRASH,MEM,NET,PROC,SYSCONFIG, which would by default options but could be overwritten with variable e.g. SUPPORTCOFIG_OPTIONS=whatever options.

- Related ticket: https://progress.opensuse.org/issues/77668
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/5140027 #default options
                            http://openqa.nue.suse.com/tests/5144208#step/supportutils/5 #SUPPORTCOFIG_OPTIONS='BOOT,BTRFS,DAEMONS'