### PR TITLE
apache2: Stop using legacy htpasswd2 symlink, use the real htpasswd name

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -171,7 +171,7 @@ sub run {
     assert_script_run 'touch /srv/www/vhosts/localhost/authtest/.htpasswd';
     assert_script_run 'chmod 640 /srv/www/vhosts/localhost/authtest/.htpasswd';
     assert_script_run 'chown root:www /srv/www/vhosts/localhost/authtest/.htpasswd';
-    assert_script_run 'htpasswd2 -s -b /srv/www/vhosts/localhost/authtest/.htpasswd joe secret';
+    assert_script_run 'htpasswd -s -b /srv/www/vhosts/localhost/authtest/.htpasswd joe secret';
 
     # Paste the .htaccess file
     assert_script_run "echo 'AuthType Basic


### PR DESCRIPTION
- Related ticket: https://build.opensuse.org/request/show/853601
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1499268 (passed)
