### PR TITLE
Ensure to select x11 console in X11 tests

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -18,6 +18,7 @@ use testapi;
 use utils;
 
 sub run {
+    select_console 'x11';
     mouse_hide;
     ensure_installed 'chromium';
 

--- a/tests/x11/firefox_audio.pm
+++ b/tests/x11/firefox_audio.pm
@@ -25,6 +25,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
+    select_console 'x11';
     start_audiocapture;
     x11_start_program('firefox ' . data_url('1d5d9dD.oga'), target_match => [qw(command-not-found test-firefox_audio-1)], match_timeout => 90);
     #  re-try for typing issue, see https://progress.opensuse.org/issues/54401


### PR DESCRIPTION
This is just to ensure the right console is picked.

If the 'lastgood snapshot' is 'too long ago' (on GNOME, 10 Minutes' and the previous test(s) failed, we might end up loading a snapshot, then ending up on the locked screen. Unless we do the console_select (which does nothing if things are good) we potentially keep on failing all subsequent tests.

an example of this effect is in 
https://openqa.opensuse.org/tests/1499573

The first passing test after 'firefox' is ImageMagick, which happens to do the select_console dance.