### PR TITLE
Add yast2 kdump module in YaST group

### DIFF
--- a/schedule/yast/yast2_ncurses/yast2_ncurses_textmode.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_textmode.yaml
@@ -12,6 +12,7 @@ schedule:
   - console/yast2_bootloader
   - console/yast2_lan_device_settings
   - "{{yast_nfs_server}}"
+  - console/yast2_kdump
 conditional_schedule:
   bootloader_start:
     BACKEND:

--- a/schedule/yast/yast2_ncurses/yast2_ncurses_textmode_pvm.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_textmode_pvm.yaml
@@ -1,0 +1,12 @@
+---
+name:           yast2_ncurses_textmode_pvm
+description:    >
+  Test for yast2 UI, ncurses only. Running on created textmode image.
+vars:
+  FADUMP: 1
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/yast2_kdump

--- a/test_data/yast/yast2_ncurses/textmode.yaml
+++ b/test_data/yast/yast2_ncurses/textmode.yaml
@@ -1,0 +1,13 @@
+---
+kdump:
+  - path: /etc/default/grub
+    settings:
+      GRUB_CMDLINE_LINUX_DEFAULT: '.*crashkernel=\d+M.*'
+  - path: /etc/sysconfig/kdump
+    settings:
+      KDUMP_DUMPLEVEL: 31
+      KDUMP_DUMPFORMAT: compressed
+      KDUMP_SAVEDIR: '(file://|)/var/crash'
+      KDUMP_KEEP_OLD_DUMPS: 5
+      KDUMP_IMMEDIATE_REBOOT: 'yes'
+      KDUMP_COPY_KERNEL: 'yes'

--- a/test_data/yast/yast2_ncurses/textmode_lzo.yaml
+++ b/test_data/yast/yast2_ncurses/textmode_lzo.yaml
@@ -1,0 +1,13 @@
+---
+kdump:
+  - path: /etc/default/grub
+    settings:
+      GRUB_CMDLINE_LINUX_DEFAULT: '.*crashkernel=\d+M.*'
+  - path: /etc/sysconfig/kdump
+    settings:
+      KDUMP_DUMPLEVEL: 31
+      KDUMP_DUMPFORMAT: lzo
+      KDUMP_SAVEDIR: '(file://|)/var/crash'
+      KDUMP_KEEP_OLD_DUMPS: 5
+      KDUMP_IMMEDIATE_REBOOT: 'yes'
+      KDUMP_COPY_KERNEL: 'yes'

--- a/test_data/yast/yast2_ncurses/textmode_lzo_fadump.yaml
+++ b/test_data/yast/yast2_ncurses/textmode_lzo_fadump.yaml
@@ -1,0 +1,14 @@
+---
+kdump:
+  - path: /etc/default/grub
+    settings:
+      GRUB_CMDLINE_LINUX_DEFAULT: '.*crashkernel=\d+M.*'
+  - path: /etc/sysconfig/kdump
+    settings:
+      KDUMP_FADUMP: 'yes'
+      KDUMP_DUMPLEVEL: 31
+      KDUMP_DUMPFORMAT: lzo
+      KDUMP_SAVEDIR: '(file://|)/var/crash'
+      KDUMP_KEEP_OLD_DUMPS: 5
+      KDUMP_IMMEDIATE_REBOOT: 'yes'
+      KDUMP_COPY_KERNEL: 'yes'

--- a/tests/console/yast2_kdump.pm
+++ b/tests/console/yast2_kdump.pm
@@ -1,0 +1,61 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Test scenario which configures Kdump with a YaST module
+# and checks configuration without rebooting the system.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use registration;
+use kdump_utils;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+sub run {
+    select_console('root-console');
+    my @conf_files = @{get_test_suite_data()->{kdump}};
+
+    # install kdump by adding additional modules
+    add_suseconnect_product('sle-module-desktop-applications');
+    add_suseconnect_product('sle-module-development-tools');
+    zypper_call('in yast2-kdump');
+
+    # Kdump configuration with YaST module
+    kdump_utils::activate_kdump;
+
+    # check service (without restarting)
+    systemctl('is-enabled kdump');
+
+    # check configuration files
+    for my $conf_file (@conf_files) {
+        my $path        = $conf_file->{path};
+        my $conf_output = script_output("cat $path");
+        for my $setting (keys %{$conf_file->{settings}}) {
+            my ($conf_line) = grep { /$setting=/ } split(/\n/, $conf_output);
+            die "Setting '$setting' not found in $path" unless $conf_line;
+            my $value = $conf_file->{settings}->{$setting};
+            assert_matches(qr/^$setting=["]?$value["]?$/, $conf_line,
+                "Found unexpected setting value in $path.");
+        }
+    }
+
+    # delete additional modules
+    remove_suseconnect_product('sle-module-development-tools');
+    remove_suseconnect_product('sle-module-desktop-applications');
+
+    # info for next tests
+    record_info('Notice', 'If next modules scheduled after this one will require ' .
+          'a reboot, take into account that kdump options will take effect.');
+}
+
+1;


### PR DESCRIPTION
- Related ticket: [poo#75331](https://progress.opensuse.org/issues/75331)
- Job Group MR: [mr#324](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/324)
- Verification run: [existing SLE test suites](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23add_yast2_kdump_module&version=15-SP3) | [new SLE test suite](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=97.2_jrivera&groupid=96)