### PR TITLE
Enlarge bootloader_time to catch grub2 after zypper migration

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -138,7 +138,7 @@ sub run {
     # with other than the SAP Administrator
     #
     # sometimes reboot takes longer time after online migration, give more time
-    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => is_sles4sap);
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 400, ready_time => 600, nologin => is_sles4sap);
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Sometimes 300s is not enough to catch the 'grub2' after zypper migration, we need enlarge the bootloader_time to catch 'grub2'.  

- Related ticket: https://progress.opensuse.org/issues/77257
- Needles: N/A
- Verification run:  https://openqa.nue.suse.com/tests/5150251
