### PR TITLE
Drop workaround for autofs not using /usr/etc/nsswitch.conf

### DIFF
--- a/lib/autofs_utils.pm
+++ b/lib/autofs_utils.pm
@@ -135,11 +135,6 @@ sub configure_service {
         test_conf_file_content => $test_conf_file_content,
         test_mount_dir         => $test_mount_dir);
 
-    if (script_run('test -f /etc/nsswitch.conf')) {
-        record_soft_failure('boo#1175238 openQA test fails in autofs - glibc-devel installs /usr/include/netdb.h which wrongly defines _PATH_NSSWITCH_CONF="/etc/nsswitch.conf" (/etc/nsswitch.conf was moved to /usr/etc/nsswitch.conf)');
-        assert_script_run 'cp /usr/etc/nsswitch.conf /etc/nsswitch.conf';
-    }
-
     common_service_action 'autofs', $service_type, 'restart';
 }
 


### PR DESCRIPTION
The issue got fixed meanwhile.

Verification run: https://openqa.opensuse.org/tests/1500220