### PR TITLE
Fix wrong hash params in setup_lvm test module

### DIFF
--- a/tests/installation/partitioning/setup_lvm.pm
+++ b/tests/installation/partitioning/setup_lvm.pm
@@ -29,7 +29,7 @@ sub run {
     $partitioner->run_expert_partitioner('current');
 
     my $disk = $test_data->{disks}[0];
-    $partitioner->create_new_partition_table({$disk, accept_deleting_current_devices_warning => 1});
+    $partitioner->create_new_partition_table({name => $disk->{name}, accept_deleting_current_devices_warning => 1});
 
     foreach my $partition (@{$disk->{partitions}}) {
         $partitioner->add_partition_on_gpt_disk({


### PR DESCRIPTION
The PR fixes  failure in `setup_lvm` test module (https://openqa.suse.de/tests/5147838)

- Verification run: https://openqa.suse.de/tests/5151133
