### PR TITLE
Adjust expected /boot/efi partition size

### DIFF
--- a/test_data/yast/modify_existing_partition/modify_existing_partition@aarch.yaml
+++ b/test_data/yast/modify_existing_partition/modify_existing_partition@aarch.yaml
@@ -12,7 +12,7 @@ disks:
       should_mount: 1
       mount_point: /
   - name: vda1
-    size: 256M
+    size: 128M
     role: raw-volume
     formatting_options:
       should_format: 1


### PR DESCRIPTION
Partition size in modify_existing_partition scenario comes from the
existing partition in the parent test suite and it's value has changed
from 256M by default to 128M.

[Verification run](https://openqa.suse.de/tests/5150950).