### PR TITLE
Refer to third-party GitHub Actions by hash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - name: "CI: Generate documentation"
       run: script/generateLibDocs.sh
     - name: "CI: Deploy documentation"
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs


### PR DESCRIPTION
The action has wide permissions to the repo, so make sure that only a manually
approved version runs. The tag can be freely modified, which can be a security
issue, see also
https://julienrenaux.fr/2019/12/20/github-actions-security-risk/