### PR TITLE
Separate test data from schedule for btrfs+warnings

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -61,8 +61,3 @@ conditional_schedule:
         - installation/grub_test
       pvm_hmc:
         - installation/grub_test
-test_data:
-  disks:
-    - name: vda
-  errors:
-    no_root: There is no device mounted at '/'

--- a/test_data/yast/btrfs/btrfs+warnings.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings.yaml
@@ -1,0 +1,4 @@
+disks:
+  - name: vda
+errors:
+  no_root: There is no device mounted at '/'

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -1,0 +1,4 @@
+disks:
+  - name: sda
+errors:
+  no_root: There is no device mounted at '/'


### PR DESCRIPTION
'sda' disk is used on hmc, 'vda' is used on other backends.

The commit separates test data for btrfs+warnings test suite.

Please, also merge MR in schedule repo: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/325
