### PR TITLE
Wait for other machine before copying ssh key

### DIFF
--- a/tests/kernel/ibtests.pm
+++ b/tests/kernel/ibtests.pm
@@ -116,6 +116,9 @@ sub run {
     # unload firewall. MPI- and libfabric-tests require too many open ports
     systemctl("stop " . opensusebasetest::firewall);
 
+    # wait for both machines to boot up before we continue
+    barrier_wait('IBTEST_SETUP');
+
     # create a ssh key if we don't have one
     script_run('[ ! -f /root/.ssh/id_rsa ] && ssh-keygen -b 2048 -t rsa -q -N "" -f /root/.ssh/id_rsa');
     # distribute the ssh key to the machines
@@ -124,7 +127,6 @@ sub run {
     exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$slave");
     script_run("/usr/bin/clear");
 
-    barrier_wait('IBTEST_SETUP');
 
     if ($role eq 'IBTEST_MASTER') {
         ibtest_master;


### PR DESCRIPTION
When we don't wait for IBTEST_SETUP barrier prior copying the ssh key to
the other machine, we end up in a race between boot times of both
machines. We should wait for it before we try any interaction between
both hosts.

- Related ticket: https://progress.opensuse.org/issues/80208
- Needles: -
- Verification run: http://baremetal-support.qa.suse.de/tests/617 and http://baremetal-support.qa.suse.de/tests/618

Please note: the installation of twopence is reporting an error, thus the test fails shortly after, see also: https://progress.opensuse.org/issues/66640
