### PR TITLE
Update HanaSR schedule for pvm_hmc for takeover & takeback

### DIFF
--- a/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
@@ -80,6 +80,9 @@ schedule:
   - ha/fencing
   - '{{boot_to_desktop}}'
   - ha/check_after_reboot
+  - ha/fencing
+  - '{{boot_to_desktop_non_init}}'
+  - ha/check_after_reboot
   - ha/check_logs
 conditional_schedule:
   multipath:
@@ -101,8 +104,14 @@ conditional_schedule:
       1:
         - sles4sap/sap_suse_cluster_connector
   boot_to_desktop:
-    HA_CLUSTER_INIT:
-      1:
+    HA_CLUSTER_SETUP:
+      init:
+        - boot/reconnect_mgmt_console
+        - installation/grub_test
+        - installation/first_boot
+  boot_to_desktop_non_init:
+    HA_CLUSTER_SETUP:
+      join:
         - boot/reconnect_mgmt_console
         - installation/grub_test
         - installation/first_boot


### PR DESCRIPTION
This PR updates the HanaSR yaml schedule for the `pvm_hmc` BACKEND, so the test does a fencing & takeback test to node 1, after it has done a fencing and takeover test on node 2.

- Related ticket: https://jira.suse.com/browse/TEAM-2812
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/3281 & http://mango.qa.suse.de/tests/3282
