### PR TITLE
Apache service: install apache2-utils as part of apache2

### DIFF
--- a/lib/services/apache.pm
+++ b/lib/services/apache.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 sub install_service {
-    zypper_call('in apache2');
+    zypper_call('in apache2 apache2-utils');
 }
 
 sub enable_service {


### PR DESCRIPTION
Some tools users (and our tests) rely on (e.g apachectl) are moved
to the apache2-utils package. The main package 'apache2' recommends
-utils, but does not require it. At least for the JeOS tests where
we install --no-recommends, it has to be our own duty to install
the utils if we want to use them

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1501079
