### PR TITLE
Check warning when root is too small for snapshots

### DIFF
--- a/lib/Installation/Partitioner/AbstractExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/AbstractExpertPartitionerController.pm
@@ -104,6 +104,9 @@ sub _set_partition_options {
             if ($formatting_options->{filesystem}) {
                 $self->get_formatting_options_page()->select_filesystem($formatting_options->{filesystem});
             }
+            if ($formatting_options->{enable_snapshots}) {
+                $self->get_formatting_options_page()->enable_snapshots();
+            }
         }
         else {
             $self->get_formatting_options_page()->select_do_not_format_device_radiobutton();

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ConfirmationWarning.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ConfirmationWarning.pm
@@ -25,13 +25,19 @@ sub new {
 
 sub init {
     my $self = shift;
-    $self->{btn_yes} = $self->{app}->button({id => 'yes'});
+    $self->{btn_yes}     = $self->{app}->button({id => 'yes'});
+    $self->{lbl_warning} = $self->{app}->label({type => 'YLabel'});
     return $self;
 }
 
 sub press_yes {
     my ($self) = @_;
     return $self->{btn_yes}->click();
+}
+
+sub text {
+    my ($self) = @_;
+    return $self->{lbl_warning}->text();
 }
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
@@ -21,9 +21,11 @@ use parent 'Installation::Partitioner::LibstorageNG::v4::ExpertPartitionerContro
 use Installation::Partitioner::LibstorageNG::v4_3::AddLogicalVolumePage;
 use Installation::Partitioner::LibstorageNG::v4_3::AddVolumeGroupPage;
 use Installation::Partitioner::LibstorageNG::v4_3::ClonePartitionsDialog;
+use Installation::Partitioner::LibstorageNG::v4_3::ConfirmationWarning;
 use Installation::Partitioner::LibstorageNG::v4_3::CreatePartitionTablePage;
 use Installation::Partitioner::LibstorageNG::v4_3::DeletingCurrentDevicesWarning;
 use Installation::Partitioner::LibstorageNG::v4_3::ErrorDialog;
+use Installation::Partitioner::LibstorageNG::v4_3::FormattingOptionsPage;
 use Installation::Partitioner::LibstorageNG::v4_3::ModifiedDevicesWarning;
 use Installation::Partitioner::LibstorageNG::v4_3::SmallForSnapshotsWarning;
 use Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerPage;
@@ -42,6 +44,7 @@ sub init {
     $self->SUPER::init($args);
     $self->{ExpertPartitionerPage}         = Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerPage->new({app => YuiRestClient::get_app()});
     $self->{ClonePartitionsDialog}         = Installation::Partitioner::LibstorageNG::v4_3::ClonePartitionsDialog->new({app => YuiRestClient::get_app()});
+    $self->{ConfirmationWarning}           = Installation::Partitioner::LibstorageNG::v4_3::ConfirmationWarning->new({app => YuiRestClient::get_app()});
     $self->{CreatePartitionTablePage}      = Installation::Partitioner::LibstorageNG::v4_3::CreatePartitionTablePage->new({app => YuiRestClient::get_app()});
     $self->{DeletingCurrentDevicesWarning} = Installation::Partitioner::LibstorageNG::v4_3::DeletingCurrentDevicesWarning->new({app => YuiRestClient::get_app()});
     $self->{ErrorDialog}                   = Installation::Partitioner::LibstorageNG::v4_3::ErrorDialog->new({app => YuiRestClient::get_app()});
@@ -50,7 +53,14 @@ sub init {
     $self->{AddVolumeGroupPage}            = Installation::Partitioner::LibstorageNG::v4_3::AddVolumeGroupPage->new({app => YuiRestClient::get_app()});
     $self->{AddLogicalVolumePage}          = Installation::Partitioner::LibstorageNG::v4_3::AddLogicalVolumePage->new({app => YuiRestClient::get_app()});
     $self->{ResizePage}                    = Installation::Partitioner::LibstorageNG::v4_3::ResizePage->new({app => YuiRestClient::get_app()});
-
+    $self->{FormattingOptionsPage}         = Installation::Partitioner::LibstorageNG::v4_3::FormattingOptionsPage->new({
+            do_not_format_shortcut  => 'alt-t',
+            format_shortcut         => 'alt-r',
+            filesystem_shortcut     => 'alt-f',
+            do_not_mount_shortcut   => 'alt-u',
+            encrypt_device_shortcut => 'alt-e',
+            app                     => YuiRestClient::get_app()
+    });
     return $self;
 }
 
@@ -62,6 +72,11 @@ sub get_add_volume_group_page {
 sub get_clone_partition_dialog {
     my ($self) = @_;
     return $self->{ClonePartitionsDialog};
+}
+
+sub get_confirmation_warning {
+    my ($self) = @_;
+    return $self->{ConfirmationWarning};
 }
 
 sub get_create_new_partition_table_page {
@@ -255,6 +270,16 @@ sub confirm_error_dialog {
 sub get_error_dialog_text {
     my ($self) = @_;
     $self->get_error_dialog()->text();
+}
+
+sub get_warning_text {
+    my ($self) = @_;
+    $self->get_confirmation_warning()->text();
+}
+
+sub confirm_warning {
+    my ($self) = @_;
+    $self->get_confirmation_warning()->press_yes();
 }
 
 sub edit_partition_encrypt {

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/FormattingOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/FormattingOptionsPage.pm
@@ -1,0 +1,26 @@
+package Installation::Partitioner::LibstorageNG::v4_3::FormattingOptionsPage;
+use strict;
+use warnings;
+use testapi;
+use YuiRestClient;
+use parent 'Installation::Partitioner::LibstorageNG::FormattingOptionsPage';
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = $class->SUPER::new($args);
+    $self->{app} = $args->{app};
+    $self->init($args);
+}
+
+sub init {
+    my $self = shift;
+    $self->{cb_enable_snapshots} = $self->{app}->checkbox({id => '"Y2Partitioner::Widgets::Snapshots"'});
+    return $self;
+}
+
+sub enable_snapshots {
+    my ($self) = @_;
+    $self->{cb_enable_snapshots}->check();
+}
+
+1;

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -23,6 +23,7 @@ schedule:
   - installation/system_role
   - installation/partitioning
   - installation/partitioning/warning/no_root
+  - installation/partitioning/warning/snapshots_small_root
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -35,7 +35,19 @@ schedule:
   - installation/opensuse_welcome
   - console/system_prepare
 test_data:
-  disks:
-    - name: vda
-  errors:
-    no_root: There is no device mounted at '/'
+disks:
+  - name: vda
+    partitions:
+      snapshots_small_root:
+        size: 9GiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          enable_snapshots: 1
+        mounting_options:
+          should_mount: 1
+          mount_point: /
+errors:
+  no_root: There is no device mounted at '/'
+warnings:
+  snapshots_small_root: Your root device is very small for snapshots

--- a/test_data/yast/btrfs/btrfs+warnings.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings.yaml
@@ -1,4 +1,16 @@
 disks:
   - name: vda
+    partitions:
+      snapshots_small_root:
+        size: 11GiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          enable_snapshots: 1
+        mounting_options:
+          should_mount: 1
+          mount_point: /
 errors:
   no_root: There is no device mounted at '/'
+warnings:
+  snapshots_small_root: Your root device is very small for snapshots

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -1,4 +1,16 @@
 disks:
   - name: sda
+    partitions:
+      snapshots_small_root:
+        size: 11GiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          enable_snapshots: 1
+        mounting_options:
+          should_mount: 1
+          mount_point: /
 errors:
   no_root: There is no device mounted at '/'
+warnings:
+  snapshots_small_root: Your root device is very small for snapshots

--- a/tests/installation/partitioning/warning/snapshots_small_root.pm
+++ b/tests/installation/partitioning/warning/snapshots_small_root.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify "There is no device mounted at '/'" Error Dialog is
+# shown when saving partitioner settings with no root mounted.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+my $partitioner;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    my $disk      = $test_data->{disks}[0];
+    $partitioner = $testapi::distri->get_expert_partitioner();
+
+    $partitioner->run_expert_partitioner();
+    $partitioner->add_partition_on_gpt_disk({
+            disk      => $disk->{name},
+            partition => $disk->{partitions}->{snapshots_small_root}
+    });
+
+    assert_matches(qr/$test_data->{warnings}->{snapshots_small_root}/, $partitioner->get_warning_text(),
+        "'Root is too small for snapshots' Warning Dialog did not appear, while it is expected.");
+}
+
+sub post_run_hook {
+    save_screenshot;
+    $partitioner->confirm_warning();
+    $partitioner->cancel_changes({accept_modified_devices_warning => 1});
+}
+
+1;


### PR DESCRIPTION
The commit adds the test module to check that the appropriate warning
appeared while trying to add partition with snapshots enabled, but the
size of the partition is too small for this.

- Related ticket: https://progress.opensuse.org/issues/78007
- Verification run: https://openqa.suse.de/tests/5161847