### PR TITLE
Disable podman test on SLE <15

### DIFF
--- a/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
@@ -2,6 +2,13 @@
 name: mau-extratests-docker-publiccloud
 description: |
   Run mau-extratests-docker on public cloud instances
+conditional_schedule:
+  podman:
+    VERSION:
+      15-SP1:
+        - containers/podman
+      15-SP2:
+        - containers/podman
 schedule:
   - boot/boot_to_desktop
   - publiccloud/download_repos
@@ -14,7 +21,7 @@ schedule:
   - console/system_prepare
   - console/prepare_test_data
   - console/consoletest_setup
-  - containers/podman
+  - '{{podman}}'
   - containers/docker
   - containers/docker_runc
   - containers/containers_3rd_party


### PR DESCRIPTION
Returning in `podman.pm` when **SLE >15** as otherwise we would need to create separate YAML file.

- Reported by @dzedro in #11505 
- Verification run: [SLES12-SP5](http://pdostal-server.suse.cz/tests/10658) [SLES15-SP2](http://pdostal-server.suse.cz/tests/10659)
