### PR TITLE
Fix schedule for lvm_thin_provisioning on leap

### DIFF
--- a/schedule/yast/lvm/lvm_thin_provisioning_opensuse.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning_opensuse.yaml
@@ -30,7 +30,8 @@ schedule:
   - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
-  - installation/opensuse_welcome
+  # On Tumbleweed process Welcome pop-up screen
+  - '{{opensuse_welcome}}'
   - console/system_prepare
   - console/hostname
   - console/force_scheduled_tasks
@@ -41,3 +42,8 @@ schedule:
   - console/lvm_thin_check
 test_data:
   <<: !include test_data/yast/lvm_thin_provisioning/lvm_thin_provisioning.yaml
+conditional_schedule:
+  opensuse_welcome:
+    VERSION:
+      Tumbleweed:
+        - installation/opensuse_welcome


### PR DESCRIPTION
We don't have openSUSE welcome screen on leap, so excluding it from the
schedule.

[Verification run](https://openqa.opensuse.org/tests/1501768).