### PR TITLE
Add project name handling for GCE

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -126,6 +126,16 @@ sub terraform_apply {
     return $self->SUPER::terraform_apply(%args);
 }
 
+
+# In GCE we need to account for project name, if given
+sub get_image_id {
+    my ($self, $img_url) = @_;
+    my $image   = $self->SUPER::get_image_id($img_url);
+    my $project = get_var('PUBLIC_CLOUD_IMAGE_PROJECT');
+    $image = "$project/$image" if ($project);
+    return $image;
+}
+
 sub describe_instance
 {
     my ($self, $instance) = @_;


### PR DESCRIPTION
To create instance with the correct image, we need to include the
project name of the image as well on Google Compute engine. This
commit accounts for this by including the setting
`PUBLIC_CLOUD_IMAGE_PROJECT`, if it is present.

I decided to incorporate this change in `gce.pm` and not in the
scheduling bot, because `PUBLIC_CLOUD_IMAGE_ID` should only contain
the image ID and not the project name.

- Related ticket: https://progress.opensuse.org/issues/80960
- Needles: -
- Verification run: http://phoenix-openqa.qam.suse.de/tests/4355 and http://phoenix-openqa.qam.suse.de/tests/4358
