### PR TITLE
Increase timeout to wait for grub for autoyast on s390x

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1380,7 +1380,7 @@ sub reconnect_mgmt_console {
                       diag 'Could not find boot selection, continuing nevertheless, trying to boot';
                     type_line_svirt '';
                 }
-                wait_serial('GNU GRUB') ||
+                wait_serial('GNU GRUB', $args{grub_timeout}) ||
                   diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
                 type_line_svirt '', expect => $login_ready, timeout => $args{timeout}, fail_message => 'Could not find login prompt';
             }

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -318,7 +318,7 @@ sub run {
 
     # Cannot verify second stage properly on s390x, so reconnect to already installed system
     if (check_var('ARCH', 's390x')) {
-        reconnect_mgmt_console(timeout => 500);
+        reconnect_mgmt_console(timeout => 500, grub_timeout => 180);
         return;
     }
     # For powerVM need to switch to mgmt console to handle the reboot properly


### PR DESCRIPTION
We have sporadic failures, as we cannot connect to the VM during second
stage properly with svirt, we expect it to finish and connect to the
booted system. With certain delays we can the line to boot grub entry
too early and system won't boot in case of disabled grub timeout.

See [poo#80276](https://progress.opensuse.org/issues/80276).

[Verification run](https://openqa.suse.de/tests/5155954).