### PR TITLE
Adapt procps.pm for hyperv and vmware guest testing 

### DIFF
--- a/tests/console/procps.pm
+++ b/tests/console/procps.pm
@@ -38,11 +38,15 @@ sub run {
     validate_script_output("pgrep 1", sub { m/\d+/ });
     validate_script_output("pmap 1",  sub { m/1:\s+(.*systemd|init)/ });
     validate_script_output("pwdx 1",  sub { m/1:\s+\// });
-    validate_script_output("vmstat",  sub { m/(procs\s-+memory-+\s-+swap-+\s-+io-+\s-+system-+\s-+cpu-+)\n.*\n(\s+|\d+)+/ });
-    validate_script_output("w", sub { m/\d+:\d+:\d+\sup\s+(\d+|:)+(\s\w+|),\s+\d\s\w+,\s+load average:.*\nUSER\s+TTY\s+FROM\s+LOGIN@\s+IDLE\s+JCPU\s+PCPU\s+WHAT(\n.*)+/ });
+    validate_script_output("vmstat",
+        qr/(procs\s-+memory-+\s-+swap-+\s-+io-+\s-+system-+\s-+cpu-+).*(\s+|\d+)+/s);
+    validate_script_output("w",
+        qr/\d+:\d+:\d+\sup\s+(\d+|:)+(\s\w+|),\s+\d\s\w+,\s+load average:.*USER\s+TTY\s+FROM\s+LOGIN@\s+IDLE\s+JCPU\s+PCPU\s+WHAT.*\w+/s);
     validate_script_output("sysctl kernel.random", sub { m/kernel\.random\.\w+\s=\s((\d+|\w+)|-)+/ });
-    validate_script_output("ps -p 1",              sub { m/PID\sTTY\s+TIME\sCMD\n\s+1\s\?\s+\d+:\d+:\d+\s(systemd|init)/ });
-    validate_script_output("top -b -n 1", sub { m/top - \d+:\d+:\d+ up\s+((\d+:\d+)|(\d+ \w+)|(\d+ \w+,\s+\d+:\d+)),\s+\d+ \w+,\s+load average: \d+.\d+, \d+.\d+, \d+.\d+\nTasks:\s+\d+ total,\s+\d+ running,\s+\d+ sleeping(.*|\n)+/ });
+    validate_script_output("ps -p 1",
+        qr/PID\sTTY\s+TIME\sCMD\s+1\s\?\s+\d+:\d+:\d+\s(systemd|init)/);
+    validate_script_output("top -b -n 1",
+qr/top - \d+:\d+:\d+ up\s+((\d+:\d+)|(\d+ \w+)|(\d+ \w+,\s+\d+:\d+)),\s+\d+ \w+,\s+load average: \d+.\d+, \d+.\d+, \d+.\d+\s+Tasks:\s+\d+\s+total,\s+\d+\s+running,\s+\d+\s+sleeping.*top/s);
 }
 
 1;


### PR DESCRIPTION
Treat multiline strings as a single line by using regex modifier `s`.

Motivation:

* [Adapt procps for vmware and hyperv machines](https://progress.opensuse.org/issues/77269)

VRs:

* [Build20.160-jeos-extratest@svirt-hyperv](http://kepler.suse.cz/tests/2734#step/procps/1)
* [Build20.160-jeos-extratest@64bit-virtio-vga](http://kepler.suse.cz/tests/2733#step/procps/1)
* [Build20.160-jeos-extratest@svirt-vmware65](http://kepler.suse.cz/tests/2742#step/procps/32)
* [sle-15-SP3-Online-s390x](https://openqa.suse.de/tests/5156642#step/procps/87)
* [sle-15-SP3-Online-aarch64](https://openqa.suse.de/tests/5156644#step/procps/87)
* [sle-15-SP3-Online-ppc64le](https://openqa.suse.de/tests/5156643#step/procps/87)
