### PR TITLE
MicroOS: enable container tests

### DIFF
--- a/schedule/microos/suse_microos_containers.yaml
+++ b/schedule/microos/suse_microos_containers.yaml
@@ -1,0 +1,9 @@
+name:           suse_microos
+description:    >
+    Maintainer: jalausuch@suse.com, qa-c@suse.de.
+    SUSE MicroOS tests
+schedule:
+    - microos/disk_boot
+    - console/suseconnect_scc
+    - containers/containers_3rd_party
+    - containers/podman


### PR DESCRIPTION
Docker is not supported in SUSE MicroOS and Podman comes preinstalled
by default, so we should only run Podman tests.

- Related ticket: https://progress.opensuse.org/issues/76915
- Verification run: http://fromm.arch.suse.de/tests/20
