### PR TITLE
Add extra expect command to avoid timing issue

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -79,7 +79,7 @@ sub run {
     assert_script_run("echo \"PS1='# '\" >> ~$ssh_testman/.bashrc") unless check_var('VIRTIO_CONSOLE', '0');
 
     # Make interactive SSH connection as the new user
-    type_string "expect -c 'spawn ssh $ssh_testman\@localhost -t;expect \"Are you sure\";send yes\\n;expect sword:;send $ssh_testman_passwd\\n;interact'\n";
+    type_string "expect -c 'spawn ssh $ssh_testman\@localhost -t;expect \"Are you sure\";send yes\\n;expect sword:;send $ssh_testman_passwd\\n;expect #;send \\n;interact'\n";
     sleep(1);
 
     # Check that we are really in the SSH session


### PR DESCRIPTION
Sometimes the sleep(1) is not enough in following code, assert_script_run(1>>) start to execute before former type_string(2>>) finish.
So i am try to add extra expect command to make sure user already login before next command start execute.

1>>>     type_string "expect -c 'spawn ssh $ssh_testman\@localhost -t;expect \"Are you sure\";send yes\\n;expect sword:;   send $ssh_testman_passwd\\n;";
     sleep(1);
 
     # Check that we are really in the SSH session
2>>>     assert_script_run 'echo $SSH_TTY | grep "\/dev\/pts\/"';


- Related ticket: https://progress.opensuse.org/issues/80676
- Needles: n/a
- Verification run: http://openqa.suse.de/t5155329
