### PR TITLE
Move out firefox_nss from crypt_x11 in security_tests group

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2249,7 +2249,6 @@ sub load_security_tests_crypt_x11 {
     set_var('SECTEST_REQUIRE_WE', 1);
     load_security_console_prepare;
 
-    loadtest "fips/mozilla_nss/firefox_nss" if get_var('FIPS_ENABLED');
     # In SLE, hexchat and seahorse are provided only in WE addon which is for
     # x86_64 platform only.
     if (is_x86_64) {
@@ -2257,6 +2256,12 @@ sub load_security_tests_crypt_x11 {
         loadtest "x11/hexchat_ssl";
     }
     loadtest "x11/x3270_ssl";
+}
+
+sub load_security_tests_crypt_firefox {
+    load_security_console_prepare;
+
+    loadtest "fips/mozilla_nss/firefox_nss" if get_var('FIPS_ENABLED');
 }
 
 sub load_security_tests_crypt_tool {
@@ -2568,7 +2573,7 @@ sub load_mitigation_tests {
 
 sub load_security_tests {
     my @security_tests = qw(
-      fips_setup crypt_core crypt_web crypt_kernel crypt_x11 crypt_tool
+      fips_setup crypt_core crypt_web crypt_kernel crypt_x11 crypt_firefox crypt_tool
       crypt_krb5kdc crypt_krb5server crypt_krb5client
       ipsec mmtest
       apparmor apparmor_profile yast2_apparmor yast2_users selinux


### PR DESCRIPTION
**Description:**

1. Create a crypt_firefox in the security_tests test group
2. Make it more readable and easier to debug Firefox issue
3. Make it more suitable to append Firefox related cases

- Related ticket: https://progress.opensuse.org/issues/80838
- Needles: NA
- Verification run: 
 Currently, it's run in Development job group
 https://openqa.suse.de/tests/5157345 (fips_env_mode_Firefox_x86_64)
 https://openqa.suse.de/tests/5155443 (fips_ker_mode_Firefox_x86_64)
 https://openqa.suse.de/tests/5157343 (fips_env_mode_Firefox_s390x)
 https://openqa.suse.de/tests/5157344 (fips_ker_mode_Firefox_s390x)
 https://openqa.suse.de/tests/5157347 (fips_env_mode_Firefox_aarch64)
 https://openqa.suse.de/tests/5157348 (fips_ker_mode_Firefox_aarch64)

