### PR TITLE
Adjust tests to the changes in yast2 lan module

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -18,7 +18,7 @@ use warnings FATAL => 'all';
 use parent 'susedistribution';
 use Installation::Partitioner::LibstorageNG::GuidedSetupController;
 use Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerController;
-use YaST::NetworkSettings::v4::NetworkSettingsController;
+use YaST::NetworkSettings::v4_3::NetworkSettingsController;
 
 sub get_partitioner {
     return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
@@ -29,7 +29,7 @@ sub get_expert_partitioner {
 }
 
 sub get_network_settings {
-    return YaST::NetworkSettings::v4::NetworkSettingsController->new();
+    return YaST::NetworkSettings::v4_3::NetworkSettingsController->new();
 }
 
 1;

--- a/lib/YaST/NetworkSettings/v4_3/NetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/v4_3/NetworkSettingsController.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for Network Settings Dialog
+# (yast2 lan module) version 4.3, minor differences to v4.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::NetworkSettings::v4_3::NetworkSettingsController;
+use parent 'YaST::NetworkSettings::v4::NetworkSettingsController';
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    return $class->SUPER::new($args);
+}
+
+sub view_bond_slave_without_editing {
+    my ($self) = @_;
+    $self->get_overview_tab()->select_device('bond');
+    $self->get_overview_tab()->press_edit();
+    $self->get_bond_slaves_tab_on_edit()->select_tab();
+    $self->get_bond_slaves_tab_on_edit()->press_next();
+}
+
+1;


### PR DESCRIPTION
We now do not have a warning about already configured devices in version
4.3+ when viewing device, adjusting controller to handle this.

See [poo#80632](https://progress.opensuse.org/issues/80632).

[Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23yast_lan&distri=sle&version=15-SP3)

NOTE: changed module is not used in TW testing, but is same version as in SLES 15 SP3.