### PR TITLE
Use zypper_call to avoid fail when repo is released

### DIFF
--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -30,7 +30,7 @@ sub run {
     my $is_set_in_etc_host = sub { return script_run('grep ' . shift . ' /etc/hosts') == 0 };
 
     select_console 'root-console';
-    assert_script_run "zypper -n in yast2-network";    # make sure yast2 lan module is installed
+    zypper_call "in yast2-network";    # make sure yast2 lan module is installed
 
     # for debugging purposes only
     script_run('ip a');


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/5160848#step/yast2_lan_device_settings/5
- Verification run: http://10.100.12.155/tests/17042#step/yast2_lan_device_settings/2