### PR TITLE
Replace send_key esc by click_lastmatch for gnucash

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -24,7 +24,7 @@ sub run {
     my @gnucash_tags = qw(gnucash gnucash-tip-close gnucash-assistant-close);
     x11_start_program('gnucash', target_match => \@gnucash_tags);
     if (match_has_tag('gnucash-tip-close')) {
-        send_key 'esc';
+        click_lastmatch();
         assert_screen([qw(gnucash gnucash-assistant-close)]);
     }
     if (match_has_tag('gnucash-assistant-close')) {
@@ -32,7 +32,7 @@ sub run {
         assert_and_click 'gnucash-assistant-show-again-no';
         assert_screen([qw(gnucash gnucash-tip-close)]);
         if (match_has_tag('gnucash-tip-close')) {
-            send_key 'esc';
+            click_lastmatch();
         }
     }
     # < gnucash 3.3


### PR DESCRIPTION
Assumption: all needles with 'gnucash-tip-close' supposed to have
close button last matching area.

This is like a revert of old pr#7101
"Fix sporadic issue with closing Tip of Day (gnucash)"
that replaced assert_and_click by send_key 'esc'
Revert because of above Assumption.

To solve sporadic failure for ppc64le like:
https://openqa.opensuse.org/tests/1500187#step/gnucash/26

To solve also sporadic aarch64 issue
https://progress.opensuse.org/issues/70963
Assumption: Remove...tip-no-focus-on-tip-window... needles
as per new needle pull request:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/706

- Related ticket: https://progress.opensuse.org/issues/70963
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/706
- Verification run: 
ppc64le: https://openqa.opensuse.org/tests/1501044#next_previous  multiple trials, no side effect.
ppc64le: https://openqa.opensuse.org/t1503471 passed
aarch64: https://openqa.opensuse.org/t1508566 passed gnucash module
x86_64:  https://openqa.opensuse.org/t1503468  passed gnucash module
x86_64:  https://openqa.opensuse.org/t1503472  passed TW 20201210 extra_tests_on_kde 

  

