### PR TITLE
Fix snapper list timeout issue in upgrade_snapshots

### DIFF
--- a/tests/console/upgrade_snapshots.pm
+++ b/tests/console/upgrade_snapshots.pm
@@ -23,12 +23,17 @@ sub run {
     select_console 'root-console';
 
     my $waittime = 200 * get_var('TIMEOUT_SCALE', 1);
-    script_run("snapper list | tee /dev/$serialdev", 0);
+
+    # 'snapper list' will cost a lots of time to finish if btrfs-balance.sh was triggered
+    # To make it faster, we'd check if snapper have disable-used-space option.
+    # This is a workaround for bsc#1167353.
+    record_info('workaround for bsc#1167353');
+    script_run("(snapper --help | grep -q -- --disable-used-space && snapper list --disable-used-space || snapper list) | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'before update' is there
     wait_serial('pre\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', $waittime)
       || die 'upgrade snapshots test failed';
 
-    script_run("snapper list | tee /dev/$serialdev", 0);
+    script_run("(snapper --help | grep -q -- --disable-used-space && snapper list --disable-used-space || snapper list) | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'after update' is there
     wait_serial('post\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', $waittime)
       || die 'upgrade snapshots test failed';


### PR DESCRIPTION
Snapper list will cost lots of time if we have 40+ snapshots in the system. 
Add time will not always work. We can use --disable-used-space
to make it quicker to get the snapper list.

- Related ticket:  https://progress.opensuse.org/issues/80946
- Needles: N/A
- Verification run:  
https://openqa.nue.suse.com/tests/5159444
https://openqa.nue.suse.com/tests/5169050#step/upgrade_snapshots/4

another verify run:
https://openqa.nue.suse.com/tests/5169916

x86 clone 5164146 5164147

https://openqa.nue.suse.com/t5170113
https://openqa.nue.suse.com/t5170117

s390 clone of 5164139 5164138
https://openqa.nue.suse.com/t5170139
https://openqa.nue.suse.com/t5170140

aarch64 clone of 5164126 5164124

https://openqa.nue.suse.com/t5170146
