### PR TITLE
clamav: Make extraction of clamav version more readable

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -44,7 +44,7 @@ sub run {
 
     # Check Clamav version
     # Jira ID SLE-16780: upgrade Clamav SLE
-    my $current_ver = script_output("zypper info clamav | grep Version | cut -d':' -f2| cut -d'-' -f1");
+    my $current_ver = script_output("rpm -q --qf '%{version}' clamav");
     record_info("Clamav_ver", "Current Clamav package version: $current_ver");
 
     if (is_sle('>=15-SP3') && ($current_ver < 0.101)) {


### PR DESCRIPTION
We are inspecting an installed package, which allows us to directly
use rpm -q --qf "%{version}" on it instead of zypper info, grepping
and cutting.

This makes the code, imho, a bit less cryptic