### PR TITLE
Fix sporadic failure in nis_server

### DIFF
--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -46,8 +46,10 @@ sub nis_server_configuration {
     send_key 'tab';                              # jump to NIS domain name
     type_string $setup_nis_nfs_x11{nis_domain};
     assert_screen 'nis-server-master-server-setup-nis-domain';
-    wait_screen_change { send_key 'alt-a' };
+    # Focus on the dialog is lost sporadically, clicking somewhere solves it
+    assert_and_click 'nis-server-master-server-setup';
     # unselect active slave NIS server exists checkbox
+    wait_screen_change { send_key 'alt-a' };
     assert_screen 'nis-master-server-setup-finished';
     send_key 'alt-o';                            # other global setting button
                                                  # NIS Master Server Details Setup


### PR DESCRIPTION
Focus on the dialog is lost sporadically, clicking somewhere solves the issue.

- Related ticket: [poo#73075](https://progress.opensuse.org/issues/73075)
- Verification run: [10 runs nis_server](https://openqa.suse.de/tests/overview?arch=&machine=&modules=nis_server&distri=sle&version=15-SP3&build=102.1&groupid=96#)