### PR TITLE
Allow a specific error for twopence package installation

### DIFF
--- a/tests/kernel/ibtests.pm
+++ b/tests/kernel/ibtests.pm
@@ -88,7 +88,7 @@ sub ibtest_master {
 
     # do all test preparations and setup
     zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);
-    zypper_call('in git-core twopence-shell-client bc iputils python');
+    zypper_call('in git-core twopence-shell-client bc iputils python', exitcode => [0, 65, 107]);
 
     # pull in the testsuite
     assert_script_run("git clone $hpc_testing --branch $hpc_testing_branch");


### PR DESCRIPTION
In case we install twopence, we get an error with tmpfiles configuration. However, we should be able to safely ignore this error and proceed for this specific test. This is a workaround until we have resolved https://progress.opensuse.org/issues/66640

- Related ticket: https://progress.opensuse.org/issues/66640
- Needles: 
- Verification run: http://baremetal-support.qa.suse.de/tests/631
