### PR TITLE
Public Cloud: Add support for ha-sap-terraform-deployments v6

### DIFF
--- a/data/publiccloud/terraform/sap/azure.tfvars
+++ b/data/publiccloud/terraform/sap/azure.tfvars
@@ -1,42 +1,79 @@
-# Launch SLES-HAE of SLES4SAP cluster nodes
+# No bastion connection
+bastion_enabled = false
 
-# Instance type to use for the cluster nodes
-hana_vm_size = "%MACHINE_TYPE%"
-
-# Disk type for HANA
-hana_data_disk_type = "Premium_LRS"
-
-# Caching used for HANA disk
-hana_data_disk_caching = "ReadWrite"
-
-# Number of nodes in the cluster
-hana_count = "2"
+# Enable all some pre deployment steps (disabled by default)
+pre_deployment = true
 
 # Region where to deploy the configuration
 az_region = "%REGION%"
 
-# Installation type
-# Value can be all, skip-hana, skip-cluster
-init_type = "all"
+# Use an already existing resource group
+#resource_group_name = "my-resource-group"
+
+# Use an already existing virtual network
+#vnet_name = "my-vnet"
+
+# Use an already existing subnet in this virtual network
+#subnet_name = "my-subnet"
+
+# vnet address range in CIDR notation
+# Only used if the vnet is created by terraform or the user doesn't have read permissions in this
+# resource. To use the current vnet address range set the value to an empty string
+# To define custom ranges
+#vnet_address_range = "10.74.0.0/16"
+#subnet_address_range = "10.74.1.0/24"
+# Or to use already existing address ranges
+#vnet_address_range = ""
+#subnet_address_range = ""
+
+# HANA configuration (this example shows the demo option values.Find more options in the README file)
+# VM size to use for the cluster nodes
+#hana_vm_size = "Standard_E4s_v3"
+
+# Number of nodes in the cluster
+hana_count = "2"
+
+# Instance number for the HANA database. 00 by default.
+hana_instance_number = "00"
+
+# Network options
+#hana_enable_accelerated_networking = false
+
+# Disk configuration
+#hana_data_disks_configuration = {
+#  disks_type       = "Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS"
+#  disks_size       = "512,512,512,512,64,1024"
+#  caching          = "ReadOnly,ReadOnly,ReadOnly,ReadOnly,ReadOnly,None"
+#  writeaccelerator = "false,false,false,false,false,false"
+#  luns             = "0,1,2#3#4#5"
+#  names            = "datalog#shared#usrsap#backup"
+#  lv_sizes         = "70,100#100#100#100"
+#  paths            = "/hana/data,/hana/log#/hana/shared#/usr/sap#/hana/backup"
+#}
 
 # SLES4SAP image information
 # If custom uris are enabled public information will be omitted
 # Custom sles4sap image
+#sles4sap_uri = "/path/to/your/image"
 sles4sap_uri = "https://openqa.blob.core.windows.net/sle-images/%SLE_IMAGE%"
 
 # Custom iscsi server image
-# iscsi_srv_uri = "/path/to/your/iscsi/image"
+#iscsi_srv_uri = "/path/to/your/iscsi/image"
+#iscsi_srv_uri = "https://openqa.blob.core.windows.net/sle-images/SLES15-SP2-SAP-BYOS.x86_64-0.9.14-Azure-Build2.3.vhd"
+iscsi_srv_uri = "https://openqa.blob.core.windows.net/sle-images/%SLE_IMAGE%"
 
 # Custom monitoring server image
-# monitoring_uri = "/path/to/your/monitoring/image"
+#monitoring_uri = "/path/to/your/monitoring/image"
 
 # Custom drbd nodes image
+#drbd_image_uri = "/path/to/your/monitoring/image"
+#drbd_image_uri = "https://openqa.blob.core.windows.net/sle-images/SLES15-SP2-SAP-BYOS.x86_64-0.9.14-Azure-Build2.3.vhd"
 drbd_image_uri = "https://openqa.blob.core.windows.net/sle-images/%SLE_IMAGE%"
 
-# Public SLES4SAP image
+# Public sles4sap image
 hana_public_publisher = "SUSE"
 hana_public_offer     = "SLES-SAP-BYOS"
-hana_public_sku       = "15"
+hana_public_sku       = "12-sp4"
 hana_public_version   = "latest"
 
 # Public iscsi server image
@@ -60,11 +97,11 @@ drbd_public_version   = "latest"
 # Admin user
 admin_user = "azureuser"
 
+# SSH Public key to configure access to the remote instances
+public_key_location = "~/.ssh/id_rsa.pub"
+
 # Private SSH Key location
 private_key_location = "~/.ssh/id_rsa"
-
-# SSH public key file
-public_key_location = "~/.ssh/id_rsa.pub"
 
 # Azure storage account name
 storage_account_name = "%STORAGE_ACCOUNT_NAME%"
@@ -74,50 +111,77 @@ storage_account_key = "%STORAGE_ACCOUNT_KEY%"
 
 # Azure storage account path where HANA installation master is located
 hana_inst_master = "%HANA_BUCKET%"
+# Or you can combine the `hana_inst_master with` `hana_platform_folder` variable.
+#hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/path/to/your/hana/installation/master
+# Specify the path to already extracted HANA platform installation media, relative to hana_inst_master mounting point.
+# This will have preference over hana archive installation media
+#hana_platform_folder = "51053381"
+
+# Or specify the path to the HANA installation archive file in either of SAR, RAR, ZIP, EXE formats, relative to the 'hana_inst_media' mounting point
+# For multipart RAR archives, you only need to provide the first part EXE file name.
+# If using hana sar archive, please also provide the compatible version of sapcar executable to extract the sar archive
+# HANA installation archives be extracted to path specified at hana_extract_dir (optional, by default /sapmedia/HANA)
+#hana_archive_file = "IMDB_SERVER.SAR"
+#hana_sapcar_exe = "SAPCAR"
+#hana_extract_dir = "/sapmedia/HDBSERVER"
 
 # Local folder where HANA installation master will be mounted
 hana_inst_folder = "/root/hana_inst_media/"
 
-# Device used by node where HANA will be installed
-hana_disk_device = "/dev/sdc"
+# SBD related variables
+# In order to enable SBD, an ISCSI server is needed as right now is the unique option
+# All the clusters will use the same mechanism
+# In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
 
-# Device used by the iSCSI server to provide LUNs
-iscsidev = "/dev/sdc"
-
-# IP address of the iSCSI server
+# IP address of the iSCSI server. If it's not set the address will be auto generated from the provided vnet address range
 iscsi_srv_ip = "10.74.1.14"
+# Number of LUN (logical units) to serve with the iscsi server. Each LUN can be used as a unique sbd disk
+iscsi_lun_count = 3
+# Disk size in GB used to create the LUNs and partitions to be served by the ISCSI service
+iscsi_disk_size = 4
 
 # Path to a custom ssh public key to upload to the nodes
 # Used for cluster communication for example
-cluster_ssh_pub = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
+cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
 
 # Path to a custom ssh private key to upload to the nodes
 # Used for cluster communication for example
-cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
+cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 
-# Each host IP address (sequential order).
-# example : host_ips = ["10.0.1.0", "10.0.1.1"]
-host_ips = ["10.74.1.11", "10.74.1.12"]
+# Enable system replication and HA cluster
+hana_ha_enabled = true
 
-# Each drbd cluster host IP address (sequential order).
-# example : drbd_host_ips = ["10.0.1.10", "10.0.1.11"]
-drbd_ips = ["10.74.1.21", "10.74.1.22"]
+# Each host IP address (sequential order). If it's not set the addresses will be auto generated from the provided vnet address range
+hana_ips = ["10.74.1.11", "10.74.1.12"]
+hana_cluster_vip = "10.74.1.13"
 
-# Enable drbd cluster
-drbd_enabled = true
+# Enable SBD for the hana cluster
+hana_cluster_sbd_enabled = true
 
-# HA packages repository
-ha_sap_deployment_repo = "%HA_SAP_REPO%/SLE_%SLE_VERSION%"
+# Enable Active/Active HANA setup (read-only access in the secondary instance)
+#hana_active_active = true
+
+# Repository url used to install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
+# To auto detect the SLE version
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
+# Specific SLE version used in all the created machines
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
+ha_sap_deployment_repo = "%HA_SAP_REPO%"
 
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
+reg_code = "%SCC_REGCODE_SLES4SAP%"
+
+# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
 #reg_additional_modules = {
 #    "sle-module-adv-systems-management/12/x86_64" = ""
 #    "sle-module-containers/12/x86_64" = ""
 #    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
 #}
-reg_code = "%SCC_REGCODE_SLES4SAP%"
 
 # Cost optimized scenario
 #scenario_type: "cost-optimized"
@@ -131,27 +195,74 @@ reg_code = "%SCC_REGCODE_SLES4SAP%"
 # Monitoring variables
 
 # Enable the host to be monitored by exporters
-monitoring_enabled = false
+#monitoring_enabled = true
 
-# IP address of the machine where prometheus and grafana are running
+# IP address of the machine where Prometheus and Grafana are running. If it's not set the address will be auto generated from the provided vnet address range
 #monitoring_srv_ip = "10.74.1.13"
+
+# Enable drbd cluster
+drbd_enabled = true
+
+# Each drbd cluster host IP address (sequential order). If it's not set the addresses will be auto generated from the provided vnet address range
+drbd_ips = ["10.74.1.21", "10.74.1.22"]
+drbd_cluster_vip = "10.74.1.23"
+
+# Enable SBD for the drbd cluster
+drbd_cluster_sbd_enabled = true
 
 # Netweaver variables
 
 #netweaver_enabled = true
+# If the addresses are not set they will be auto generated from the provided vnet address range
 #netweaver_ips = ["10.74.1.30", "10.74.1.31", "10.74.1.32", "10.74.1.33"]
 #netweaver_virtual_ips = ["10.74.1.35", "10.74.1.36", "10.74.1.37", "10.74.1.38"]
+
+# Enabling this option will create a ASCS/ERS HA available cluster
+#netweaver_ha_enabled = true
+# Application servers number. The 1st one will be a PAS instance, and the rest AAS servers
+#netweaver_app_server_count = 2
+
+# VM sizes
+#netweaver_xscs_vm_size = Standard_D2s_v3
+#netweaver_app_vm_size = Standard_D2s_v3
+
+# Set the Netweaver product id for HA (this is just an example)
+#netweaver_product_id = NW750.HDB.ABAPHA
+# Fon non HA
+#netweaver_product_id = NW750.HDB.ABAP
+
+# Enable SBD for the netweaver cluster
+#netweaver_cluster_sbd_enabled = true
+
+# This storage account must contain the next software (select the version you want to install of course)
+#SWPM - `IND:SLTOOLSET:2.0:SWPM:*:LINUX_X86_64:*x`
+#Netweaver export - `SAP:NETWEAVER:750:DVD_EXPORT:SAP NetWeaver 750 Installation Export DVD 1/1:D51050829_2`
+#HANA Platform- `HDB:HANA:2.0:LINUX_X86_64:SAP HANA PLATFORM EDITION 2.0::BD51053787`
+#Sapexe folder files:
+#igsexe_23-20007790.sar  igshelper_4-10010245.sar  SAPEXE_501-80002573.SAR  SAPEXEDB_501-80002572.SAR  SAPHOSTAGENT45_45-20009394.SAR
+
 #netweaver_storage_account_key = "YOUR_STORAGE_ACCOUNT_KEY"
 #netweaver_storage_account_name = "YOUR_STORAGE_ACCOUNT_NAME"
 #netweaver_storage_account = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/path/to/your/nw/installation/master"
+# Netweaver installation required folders
+# SAP SWPM installation folder, relative to the netweaver_storage_account mounting point
+#netweaver_swpm_folder     =  "your_swpm"
+# Or specify the path to the sapcar executable & SWPM installer sar archive, relative to the netweaver_storage_account mounting point
+# The sar archive will be extracted to path specified at netweaver_extract_dir under SWPM directory (optional, by default /sapmedia/NW/SWPM)
+#netweaver_sapcar_exe = "your_sapcar_exe_file_path"
+#netweaver_swpm_sar = "your_swpm_sar_file_path"
+# Folder where needed SAR executables (sapexe, sapdbexe) are stored, relative to the netweaver_storage_account mounting point
+#netweaver_sapexe_folder   =  "kernel_nw75_sar"
+# Additional media archives or folders (added in start_dir.cd), relative to the netweaver_storage_account mounting point
+#netweaver_additional_dvds = ["dvd1", "dvd2"]
 
 # QA variables
 
 # Define if the deployment is using for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
-# true or false
-qa_mode = true
+# true or false (default)
+#qa_mode = false
 
 # Execute HANA Hardware Configuration Check Tool to bench filesystems
 # qa_mode must be set to true for executing hwcct

--- a/data/publiccloud/terraform/sap/ec2.tfvars
+++ b/data/publiccloud/terraform/sap/ec2.tfvars
@@ -1,75 +1,142 @@
 # Launch SLES-HAE of SLES4SAP cluster nodes
 
-# Instance type to use for the cluster nodes
-instancetype = "%MACHINE_TYPE%"
+# Enable all some pre deployment steps (disabled by default)
+pre_deployment = true
+
+# Region where to deploy the configuration
+aws_region = "%REGION%"
+
+# Use an already existing vpc. Make sure the vpc has the internet gateway already attached
+#vpc_id = "vpc-xxxxxxxxxxxxxxxxx"
+
+# Use an already existing security group
+#security_group_id = "sg-xxxxxxxxxxxxxxxxx"
+
+# vpc address range in CIDR notation
+# Only used if the vpc is created by terraform or the user doesn't have read permissions in this
+# resource. To use the current vpc address range set the value to an empty string
+# To define custom ranges
+vpc_address_range = "10.0.0.0/16"
+# Or to use already existing vpc address ranges
+#vpc_address_range = ""
+
+# Instance type to use for the hana cluster nodes
+hana_instancetype = "%MACHINE_TYPE%"
 
 # Disk type for HANA
 hana_data_disk_type = "gp2"
 
 # Number of nodes in the cluster
-ninstances = "2"
+hana_count = "2"
 
-# Region where to deploy the configuration
-aws_region = "%REGION%"
-
-# SSH private key file
-private_key_location = "~/.ssh/id_rsa"
-
-# SSH public key file
+# SSH Public key location to configure access to the remote instances
 public_key_location = "~/.ssh/id_rsa.pub"
 
+# Private SSH Key location
+private_key_location = "~/.ssh/id_rsa"
+
 # Custom AMI for nodes
+#hana_os_image = "ami-xxxxxxxxxxxxxxxxx"
+# Or use a pattern to find the image
+#hana_os_image = "suse-sles-sap-15-sp1-byos"
 hana_os_image = "%SLE_IMAGE%"
+
+# Custom owner for private AMI
 hana_os_owner = "self"
 
+# aws-cli credentials data
+# access keys parameters have preference over the credentials file (they are self exclusive)
+#aws_access_key_id = my-access-key-id
+#aws_secret_access_key = my-secret-access-key
 # aws-cli credentials file. Located on ~/.aws/credentials on Linux, MacOS or Unix or at C:\Users\USERNAME\.aws\credentials on Windows
 aws_credentials = "/root/amazon_credentials"
 
 # Hostname, without the domain part
 name = "hana"
 
+# Enable system replication and HA cluster
+hana_ha_enabled = true
+
 # S3 bucket where HANA installation master is located
+#hana_inst_master = "s3://path/to/your/hana/installation/master/51053381"
+# Or you can combine the `hana_inst_master` with `hana_platform_folder` variable.
+#hana_inst_master = "s3://path/to/your/hana/installation/master"
+# Specify the path to already extracted HANA platform installation media, relative to hana_inst_master mounting point.
+# This will have preference over hana archive installation media
+#hana_platform_folder = "51053381"
 hana_inst_master = "%HANA_BUCKET%"
 
-# Local folder where HANA installation master will be downloaded from S3
-hana_inst_folder = "/root/hana_inst_media/"
+# Or specify the path to the HANA installation archive file in either of SAR, RAR, ZIP, EXE formats, relative to the 'hana_inst_media' mounting point
+# For multipart RAR archives, you only need to provide the first part EXE file name.
+# If using hana sar archive, please also provide the compatible version of sapcar executable to extract the sar archive
+# HANA installation archives be extracted to path specified at hana_extract_dir (optional, by default /sapmedia/HANA)
+#hana_archive_file = "IMDB_SERVER.SAR"
+#hana_sapcar_exe = "SAPCAR"
+#hana_extract_dir = "/sapmedia/HDBSERVER"
 
 # Device used by node where HANA will be installed
-hana_disk_device = "/dev/xvdd"
-
-# Variable for init-nodes.tpl script. Can be all, skip-hana or skip-cluster
-init_type = "all"
-
-# Device used by the iSCSI server to provide LUNs
-iscsidev = "/dev/xvdd"
-
-# Path to a custom ssh public key to upload to the nodes
-# Used for cluster communication for example
-cluster_ssh_pub = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
-
-# Path to a custom ssh private key to upload to the nodes
-# Used for cluster communication for example
-cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
+#hana_disk_device = "/dev/xvdd"
 
 # IP address used to configure the hana cluster floating IP. It must be in other subnet than the machines!
 hana_cluster_vip = "192.168.1.10"
 
-# Each host IP address (sequential order).
-# example : host_ips = ["10.0.0.5", "10.0.1.6"]
-host_ips = ["10.0.0.5", "10.0.1.6"]
+# Enable SBD for the hana cluster
+#hana_cluster_sbd_enabled = true
 
-# HA packages repository
-ha_sap_deployment_repo = "%HA_SAP_REPO%/SLE_%SLE_VERSION%"
+# Enable Active/Active HANA setup (read-only access in the secondary instance)
+#hana_active_active = true
+
+# SBD related variables
+# In order to enable SBD, an ISCSI server is needed as right now is the unique option
+# All the clusters will use the same mechanism
+# In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
+
+# iSCSI OS image
+#iscsi_os_image = "ami-xxxxxxxxxxxxxxxxx"
+#iscsi_os_owner = "self"
+
+# iSCSI server address. It should be in same iprange as hana_ips
+#iscsi_srv_ip = "10.0.0.254"
+# Number of LUN (logical units) to serve with the iscsi server. Each LUN can be used as a unique sbd disk
+#iscsi_lun_count = 3
+# Disk size in GB used to create the LUNs and partitions to be served by the ISCSI service
+#iscsi_disk_size = 10
+
+# Path to a custom ssh public key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
+
+# Path to a custom ssh private key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
+
+# Each host IP address (sequential order). The first ip must be in 10.0.0.0/24 subnet and the second in 10.0.1.0/24 subnet
+hana_ips = ["10.0.1.5", "10.0.2.5"]
+
+# Repository url used to install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
+# To auto detect the SLE version
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
+# Specific SLE version used in all the created machines
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
+ha_sap_deployment_repo = "%HA_SAP_REPO%"
 
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
+reg_code = "%SCC_REGCODE_SLES4SAP%"
+
+# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
 #reg_additional_modules = {
 #    "sle-module-adv-systems-management/12/x86_64" = ""
 #    "sle-module-containers/12/x86_64" = ""
 #    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
 #}
-reg_code = "%SCC_REGCODE_SLES4SAP%"
+
+# Cost optimized scenario
+#scenario_type: "cost-optimized"
 
 # To disable the provisioning process
 #provisioner = ""
@@ -77,53 +144,85 @@ reg_code = "%SCC_REGCODE_SLES4SAP%"
 # Run provisioner execution in background
 #background = true
 
-# Enable the host to be monitored by exporters
-monitoring_enabled = false
+# Monitoring variables
 
-# IP address of the machine where Prometheus and Grafana are running
-#monitoring_srv_ip = "10.0.1.2"
+# Enable the host to be monitored by exporters
+#monitoring_enabled = true
+
+#monitoring_os_image = "ami-xxxxxxxxxxxxxxxxx"
+#monitoring_os_owner = "self"
+
+# IP address of the machine where Prometheus and Grafana are running. Must be in 10.0.0.0/24 subnet
+#monitoring_srv_ip = "10.0.0.253"
 
 # QA variables
 
-# Define if the deployement is using for testing purpose
+# Define if the deployment is using for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
-# true or false
-qa_mode = true
+# true or false (default)
+#qa_mode = false
 
 # Execute HANA Hardware Configuration Check Tool to bench filesystems
 # qa_mode must be set to true for executing hwcct
 # true or false (default)
 #hwcct = false
 
-# DRBD variables
+# drbd related variables
 
+# netweaver will use AWS efs for nfs share by default, unless drbd is enabled
+# Enable drbd cluster
 drbd_enabled = true
-#drbd_machine_type = "t2.xlarge"
+#drbd_instancetype = "t2.micro"
 drbd_os_image = "%SLE_IMAGE%"
 drbd_os_owner = "self"
-#drbd_data_disk_size = "10"
-#drbd_data_disk_type = "gp2"
-drbd_ips = ["10.0.4.10", "10.0.5.11"]
-drbd_cluster_vip = "192.168.1.30"
+#drbd_data_disk_size = 15
+#drbd_data_disk_type = gp2
+
+# Each drbd cluster host IP address (sequential order).
+drbd_ips = ["10.0.5.20", "10.0.6.21"]
+drbd_cluster_vip = "192.168.1.20"
 
 # Netweaver variables
 
 #netweaver_enabled = true
 #netweaver_instancetype = "r3.8xlarge"
+#netweaver_os_image = "ami-xxxxxxxxxxxxxxxxx"
+#netweaver_os_owner = "self"
+#AWS efs performance mode used by netweaver nfs share, if efs storage is used
 #netweaver_efs_performance_mode = "generalPurpose"
 #netweaver_ips = ["10.0.2.7", "10.0.3.8", "10.0.2.9", "10.0.3.10"]
 #netweaver_virtual_ips = ["192.168.1.20", "192.168.1.21", "192.168.1.22", "192.168.1.23"]
+
+
+# Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers
+# Set to false to only create a ASCS and PAS instances
+#netweaver_ha_enabled = true
+
+# Set the Netweaver product id for HA (this is just an example)
+#netweaver_product_id = NW750.HDB.ABAPHA
+# Fon non HA
+#netweaver_product_id = NW750.HDB.ABAP
+
+# Enable SBD for the netweaver cluster
+#netweaver_cluster_sbd_enabled = true
+
 # Netweaver installation required folders
+# This S3 bucket must contain the next software (select the version you want to install of course)
+#SWPM - `IND:SLTOOLSET:2.0:SWPM:*:LINUX_X86_64:*x`
+#Netweaver export - `SAP:NETWEAVER:750:DVD_EXPORT:SAP NetWeaver 750 Installation Export DVD 1/1:D51050829_2`
+#HANA Platform- `HDB:HANA:2.0:LINUX_X86_64:SAP HANA PLATFORM EDITION 2.0::BD51053787`
+#Sapexe folder files:
+#igsexe_23-20007790.sar  igshelper_4-10010245.sar  SAPEXE_501-80002573.SAR  SAPEXEDB_501-80002572.SAR  SAPHOSTAGENT45_45-20009394.SAR
+
 #netweaver_s3_bucket = "s3://path/to/your/netweaver/installation/s3bucket"
 # SAP SWPM installation folder, relative to the netweaver_s3_bucket folder
 #netweaver_swpm_folder     =  "your_swpm"
+# Or specify the path to the sapcar executable & SWPM installer sar archive, relative to the netweaver_s3_bucket folder
+# The sar archive will be extracted to path specified at netweaver_extract_dir under SWPM directory (optional, by default /sapmedia/NW/SWPM)
+#netweaver_sapcar_exe = "your_sapcar_exe_file_path"
+#netweaver_swpm_sar = "your_swpm_sar_file_path"
 # Folder where needed SAR executables (sapexe, sapdbexe) are stored, relative to the netweaver_s3_bucket folder
 #netweaver_sapexe_folder   =  "kernel_nw75_sar"
-# Additional folders (added in start_dir.cd), relative to the netweaver_s3_bucket folder
+# Additional media archives or folders (added in start_dir.cd), relative to the netweaver_s3_bucket folder
 #netweaver_additional_dvds = ["dvd1", "dvd2"]
-
-# Pre deployment
-
-# Enable all some pre deployment steps (disabled by default)
-#pre_deployment = true

--- a/data/publiccloud/terraform/sap/gce.tfvars
+++ b/data/publiccloud/terraform/sap/gce.tfvars
@@ -1,35 +1,29 @@
-# Launch SLES-HAE of SLES4SAP cluster nodes
-
-# Project name in GCP
+# GCP project id
 project = "suse-css-qa"
+
+# Enable all some pre deployment steps (disabled by default)
+pre_deployment = true
 
 # Credentials file for GCP
 gcp_credentials_file = "/root/google_credentials.json"
 
-# Internal IPv4 range
+# Region where to deploy the configuration
+region = "%REGION%"
+
+# Use an already existing vpc
+#vpc_name = "my-vpc"
+
+# Use an already existing subnet in this virtual network
+#subnet_name = "my-subnet"
+
+# vpc address range in CIDR notation
+# Only used if the vpc is created by terraform or the user doesn't have read permissions in this
+# resource. To use the current vpc address range set the value to an empty string
+# To define custom ranges
+#ip_cidr_range = "10.0.0.0/24"
+# Or to use already existing address ranges
+#ip_cidr_range = ""
 ip_cidr_range = "10.0.0.0/24"
-
-# IP for iSCSI server
-iscsi_ip = "10.0.0.253"
-
-# Type of VM (vCPUs and RAM)
-machine_type = "%MACHINE_TYPE%"
-machine_type_iscsi_server = "custom-1-2048"
-
-# Disk type for HANA
-hana_data_disk_type = "pd-ssd"
-
-# Disk size for HANA in GB
-hana_data_disk_size = "240"
-
-# Disk type for HANA backup
-hana_backup_disk_type = "pd-standard"
-
-# Disk size for HANA backup in GB
-hana_backup_disk_size = "120"
-
-# HANA cluster vip
-hana_cluster_vip = "10.0.1.200"
 
 # SSH private key file
 private_key_location = "~/.ssh/id_rsa"
@@ -37,35 +31,88 @@ private_key_location = "~/.ssh/id_rsa"
 # SSH public key file
 public_key_location = "~/.ssh/id_rsa.pub"
 
-# Region where to deploy the configuration
-region = "%REGION%"
+# SBD related variables
+# In order to enable SBD, an ISCSI server is needed as right now is the unique option
+# All the clusters will use the same mechanism
+# In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
 
-# Variable for init-nodes.tpl script. Can be all, skip-hana or skip-all
-init_type = "all"
+# iSCSI server address
+#iscsi_srv_ip = "10.0.0.253"
+# Number of LUN (logical units) to serve with the iscsi server. Each LUN can be used as a unique sbd disk
+#iscsi_lun_count = 3
+# Disk size in GB used to create the LUNs and partitions to be served by the ISCSI service
+#iscsi_disk_size = 10
+
+# Type of VM (vCPUs and RAM)
+machine_type = "%MACHINE_TYPE%"
+
+# Disk type for HANA
+hana_data_disk_type = "pd-ssd"
+
+# Disk size for HANA in GB
+hana_data_disk_size = "834"
+
+# Disk type for HANA backup
+hana_backup_disk_type = "pd-standard"
+
+# Disk size for HANA backup in GB
+hana_backup_disk_size = "416"
+
+# HANA cluster vip
+hana_cluster_vip = "10.0.1.200"
+
+# Enable system replication and HA cluster
+hana_ha_enabled = true
+
+# Enable SBD for the hana cluster
+#hana_cluster_sbd_enabled = true
+
+# Enable Active/Active HANA setup (read-only access in the secondary instance)
+#hana_active_active = true
 
 # The name of the GCP storage bucket in your project that contains the SAP HANA installation files
 sap_hana_deployment_bucket = "%HANA_BUCKET%"
+
+# Or you can combine the `sap_hana_deployment_bucket` with `hana_platform_folder` variable.
+#sap_hana_deployment_bucket = "MyHanaBucket"
+# Specify the path to already extracted HANA platform installation media, relative to sap_hana_deployment_bucket.
+# This will have preference over hana archive installation media
+#hana_platform_folder = "51053381"
+
+# Or specify the path to the HANA installation archive file in either of SAR, RAR, ZIP, EXE formats, relative to the 'hana_inst_media' mounting point
+# For multipart RAR archives, you only need to provide the first part EXE file name.
+# If using hana sar archive, please also provide the compatible version of sapcar executable to extract the sar archive
+# HANA installation archives be extracted to path specified at hana_extract_dir (optional, by default /sapmedia/HANA)
+#hana_archive_file = "IMDB_SERVER.SAR"
+#hana_sapcar_exe = "SAPCAR"
+#hana_extract_dir = "/sapmedia/HDBSERVER"
 
 # Custom sles4sap image
 sles4sap_boot_image = "%SLE_IMAGE%"
 
 # Path to a custom ssh public key to upload to the nodes
 # Used for cluster communication for example
-cluster_ssh_pub = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
+cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
 
 # Path to a custom ssh private key to upload to the nodes
 # Used for cluster communication for example
-cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
+cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 
 # Each host IP address (sequential order).
-# example : host_ips = ["10.0.0.2", "10.0.0.3"]
-host_ips = ["10.0.0.2", "10.0.0.3"]
+hana_ips = ["10.0.0.2", "10.0.0.3"]
 
 # Local folder where HANA installation master will be mounted
-hana_inst_folder = "/root/hana_inst_media"
+hana_inst_folder = "/sapmedia/HANA"
 
-# HA packages repository
-ha_sap_deployment_repo = "%HA_SAP_REPO%/SLE_%SLE_VERSION%"
+# Repository url used to install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
+# To auto detect the SLE version
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
+# Specific SLE version used in all the created machines
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
+ha_sap_deployment_repo = "%HA_SAP_REPO%"
 
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"
@@ -76,11 +123,12 @@ reg_code = "%SCC_REGCODE_SLES4SAP%"
 #reg_additional_modules = {
 #    "sle-module-adv-systems-management/12/x86_64" = ""
 #    "sle-module-containers/12/x86_64" = ""
+#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
 #}
 
 # Cost optimized scenario
 #scenario_type: "cost-optimized"
-#
+
 # To disable the provisioning process
 #provisioner = ""
 
@@ -90,7 +138,7 @@ reg_code = "%SCC_REGCODE_SLES4SAP%"
 # Monitoring variables
 
 # Enable the host to be monitored by exporters
-monitoring_enabled = false
+#monitoring_enabled = true
 
 # IP address of the machine where Prometheus and Grafana are running
 #monitoring_srv_ip = "10.0.0.4"
@@ -100,13 +148,15 @@ monitoring_enabled = false
 # Define if the deployment is using for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
-# true or false
-qa_mode = true
+# true or false (default)
+#qa_mode = false
 
 # Execute HANA Hardware Configuration Check Tool to bench filesystems
 # qa_mode must be set to true for executing hwcct
 # true or false (default)
 #hwcct = false
+
+# drbd related variables
 
 # Enable drbd cluster
 drbd_enabled = true
@@ -121,9 +171,11 @@ drbd_image = "%SLE_IMAGE%"
 #drbd_data_disk_type = pd-standard
 
 # Each drbd cluster host IP address (sequential order).
-# example : drbd_host_ips = ["10.0.0.10", "10.0.0.11"]
 drbd_ips = ["10.0.0.10", "10.0.0.11"]
 drbd_cluster_vip = "10.0.1.201"
+
+# Enable SBD for the drbd cluster
+#drbd_cluster_sbd_enabled = true
 
 # netweaver related variables
 
@@ -134,8 +186,39 @@ drbd_cluster_vip = "10.0.1.201"
 
 #netweaver_image = suse-byos-cloud/sles-15-sap-byos
 
+# This storage bucket must contain the next software (select the version you want to install of course)
+#SWPM - `IND:SLTOOLSET:2.0:SWPM:*:LINUX_X86_64:*x`
+#Netweaver export - `SAP:NETWEAVER:750:DVD_EXPORT:SAP NetWeaver 750 Installation Export DVD 1/1:D51050829_2`
+#HANA Platform- `HDB:HANA:2.0:LINUX_X86_64:SAP HANA PLATFORM EDITION 2.0::BD51053787`
+#Sapexe folder files:
+#igsexe_23-20007790.sar  igshelper_4-10010245.sar  SAPEXE_501-80002573.SAR  SAPEXEDB_501-80002572.SAR  SAPHOSTAGENT45_45-20009394.SAR
+
 #netweaver_software_bucket = "MyNetweaverBucket"
+
+# Netweaver installation required folders
+# SAP SWPM installation folder, relative to netweaver_software_bucket folder
+#netweaver_swpm_folder     =  "your_swpm"
+# Or specify the path to the sapcar executable & SWPM installer sar archive, relative to netweaver_software_bucket folder
+# The sar archive will be extracted to path specified at netweaver_extract_dir under SWPM directory (optional, by default /sapmedia/NW/SWPM)
+#netweaver_sapcar_exe = "your_sapcar_exe_file_path"
+#netweaver_swpm_sar = "your_swpm_sar_file_path"
+# Folder where needed SAR executables (sapexe, sapdbexe) are stored, relative to netweaver_software_bucket folder
+#netweaver_sapexe_folder   =  "kernel_nw75_sar"
+# Additional media archives or folders (added in start_dir.cd), relative to netweaver_software_bucket folder
+#netweaver_additional_dvds = ["dvd1", "dvd2"]
 
 #netweaver_ips = ["10.0.0.20", "10.0.0.21", "10.0.0.22", "10.0.0.23"]
 
 #netweaver_virtual_ips = ["10.0.1.25", "10.0.1.26", "10.0.0.27", "10.0.0.28"]
+
+# Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers
+# Set to false to only create a ASCS and PAS instances
+#netweaver_ha_enabled = true
+
+# Set the Netweaver product id for HA (this is just an example)
+#netweaver_product_id = NW750.HDB.ABAPHA
+# Fon non HA
+#netweaver_product_id = NW750.HDB.ABAP
+
+# Enable SBD for the netweaver cluster
+#netweaver_cluster_sbd_enabled = true

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -286,4 +286,16 @@ sub start
     return $self->wait_for_ssh(timeout => $args{timeout});
 }
 
+=head2 get_state
+
+    get_state();
+
+Get the status of the instance using the CSP api calls.
+=cut
+sub get_state
+{
+    my $self = shift;
+    return $self->provider->get_state_from_instance($self, @_);
+}
+
 1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -47,10 +47,8 @@ sub init {
         my $cloud_name = $self->conv_openqa_tf_name;
         assert_script_run('cd ' . TERRAFORM_DIR);
         assert_script_run('git clone --depth 1 --branch ' . get_var('HA_SAP_GIT_TAG', 'master') . ' ' . get_required_var('HA_SAP_GIT_REPO') . ' .');
-        assert_script_run("cp pillar_examples/automatic/${_}/* salt/${_}_node/files/pillar/") foreach (qw(hana drbd));
         assert_script_run('cd');    # We need to ensure to be in the home directory
         assert_script_run('curl ' . data_url("publiccloud/terraform/sap/$file.tfvars") . ' -o ' . TERRAFORM_DIR . "/$cloud_name/terraform.tfvars");
-        $self->create_ssh_key(ssh_private_key_file => TERRAFORM_DIR . '/salt/hana_node/files/sshkeys/cluster.id_rsa');
     }
     else {
         assert_script_run('curl ' . data_url("publiccloud/terraform/$file.tf") . ' -o ' . TERRAFORM_DIR . '/plan.tf');
@@ -333,11 +331,11 @@ sub terraform_apply {
         assert_script_run('cd ' . TERRAFORM_DIR . "/$cloud_name");
         my $sap_media            = get_required_var('HANA');
         my $sap_regcode          = get_required_var('SCC_REGCODE_SLES4SAP');
-        my $ha_sap_repo          = get_required_var('HA_SAP_REPO');
         my $storage_account_name = get_var('STORAGE_ACCOUNT_NAME');
         my $storage_account_key  = get_var('STORAGE_ACCOUNT_KEY');
         my $sle_version          = get_var('FORCED_DEPLOY_REPO_VERSION') ? get_var('FORCED_DEPLOY_REPO_VERSION') : get_var('VERSION');
         $sle_version =~ s/-/_/g;
+        my $ha_sap_repo = get_var('HA_SAP_REPO') ? get_var('HA_SAP_REPO') . '/SLE_' . $sle_version : '';
         file_content_replace('terraform.tfvars',
             q(%MACHINE_TYPE%)         => $instance_type,
             q(%REGION%)               => $self->region,
@@ -631,6 +629,16 @@ This function implements a provider specifc start call for a given instance.
 sub start_instance
 {
     die('start_instance() isn\'t implemented');
+}
+
+=head2 get_state_from_instance
+
+This function implements a provider specifc get_state call for a given instance.
+
+=cut
+sub get_state_from_instance
+{
+    die('get_state_from_instance() isn\'t implemented');
 }
 
 1;

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -21,8 +21,7 @@ use testapi;
 use utils;
 use version_utils;
 
-our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand is_ec2);
-
+our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand is_ec2 is_azure is_gce);
 
 # Select console on the test host, regardless of the TUNNELED variable.
 sub select_host_console() {
@@ -48,9 +47,20 @@ sub is_ondemand() {
     # Check all the other flavors, and if they don't match, it must be on_demand.
     return is_publiccloud && (!is_byos());    # When introducing new flavors, add checks here accordingly.
 }
+
 # Check if we are on an AWS test run
 sub is_ec2() {
     return is_publiccloud && check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+}
+
+# Check if we are on an Azure test run
+sub is_azure() {
+    return is_publiccloud && check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+}
+
+# Check if we are on an GCP test run
+sub is_gce() {
+    return is_publiccloud && check_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
 }
 
 1;

--- a/tests/publiccloud/sles4sap.pm
+++ b/tests/publiccloud/sles4sap.pm
@@ -16,6 +16,7 @@ use testapi;
 use Mojo::File 'path';
 use Mojo::JSON;
 use version_utils 'is_sle';
+use publiccloud::utils;
 
 # Global variables
 my $crm_mon_cmd = 'crm_mon -R -r -n -N -1';
@@ -28,43 +29,51 @@ Upload the HA/SAP logs from instance C<$instance> on the Webui.
 =cut
 sub upload_ha_sap_logs {
     my ($self, $instance) = @_;
-    my @logfiles = qw(provisioning.log salt-deployment.log salt-formula.log salt-pre-installation.log);
+    my @logfiles = qw(salt-deployment.log salt-os-setup.log salt-pre-deployment.log salt-result.log);
 
     # Upload logs from public cloud VM
-    $instance->run_ssh_command(cmd => 'sudo chmod o+r /tmp/*.log');
+    $instance->run_ssh_command(cmd => 'sudo chmod o+r /var/log/salt-*');
     foreach my $file (@logfiles) {
-        $instance->upload_log("/tmp/$file", log_name => $instance->{instance_id});
+        $instance->upload_log("/var/log/$file", log_name => $instance->{instance_id});
     }
 }
 
 =head2 wait_until_resources_started
 
-    wait_until_resources_started();
+    wait_until_resources_started( [ timeout => $timeout ] );
 
-Wait for HA cluster to be started.
+Wait for resources to be started. Runs C<crm cluster wait_for_startup> in SUT as well
+as other verifications on newer versions of SLES (12-SP3+), for up to B<$timeout> seconds
+for each command. Timeout must be specified by the named argument B<timeout> (defaults
+to 120 seconds). This timeout is scaled by the factor specified in the B<TIMEOUT_SCALE>
+setting. Croaks on timeout.
 =cut
 sub wait_until_resources_started {
     my ($self, %args) = @_;
     my @cmds    = ('crm cluster wait_for_startup');
     my $timeout = bmwqemu::scale_timeout($args{timeout} // 60);
 
+    # At least one node needs to be online
+    push @cmds, "$crm_mon_cmd | grep -q Node\\ .*\\ online:";
+
     # HANA cluster doesn't restart all resources after fencing in some configurations
     if ($args{cluster_type} ne 'hana') {
         # Some CRM options can only been added on recent versions
         push @cmds, "$crm_mon_cmd | grep -iq no\\ inactive\\ resources" if is_sle '12-sp3+';
+        # This code is a little bit complicated, but we have to invert the RC for the while loop
+        push @cmds, "$crm_mon_cmd | grep -iq starting && RC=false || RC=true; eval \$RC";
     }
 
     # Execute each comnmand to validate that the cluster is running
     # This can takes time, so a loop is a good idea here
     foreach my $cmd (@cmds) {
         # Each command execution has its own timeout, so we need to reset the counter
-        my $starttime = time;
+        my $start_time = time;
 
         # Check for cluster/resources status and exit loop when needed
-        my $ret;
-        while ($ret = $self->{my_instance}->run_ssh_command(cmd => "sudo $cmd", rc_only => 1)) {
+        while ($self->{my_instance}->run_ssh_command(cmd => "sudo $cmd", rc_only => 1)) {
             # Otherwise wait a while if timeout is not reached
-            if (time - $starttime < $timeout) {
+            if (time - $start_time < $timeout) {
                 sleep 5;
             }
             else {
@@ -87,10 +96,15 @@ sub run_cmd {
     die('Argument <cmd> missing') unless ($args{cmd});
     my $timeout = bmwqemu::scale_timeout($args{timeout} // 60);
     my $title   = $args{title} // $args{cmd};
-    $title =~ s/[[:blank:]].+// if !defined $args{title};
+    $title =~ s/[[:blank:]].+// unless defined $args{title};
+    my $cmd = $args{cmd};
 
-    my $out = $self->{my_instance}->run_ssh_command(cmd => "sudo $args{cmd}", timeout => $timeout);
-    record_info("$title output - $self->{my_instance}->{instance_id}", $out) unless ($timeout == 0);
+    delete($args{cmd});
+    delete($args{title});
+    delete($args{timeout});
+    my $out = $self->{my_instance}->run_ssh_command(cmd => "sudo $cmd", timeout => $timeout, %args);
+    record_info("$title output - $self->{my_instance}->{instance_id}", $out) unless ($timeout == 0 or $args{quiet} or $args{rc_only});
+    return $out;
 }
 
 =head2 fence_node
@@ -106,35 +120,53 @@ sub fence_node {
     $args{hostname} //= $self->{my_instance}->{instance_id};
 
     # Do the fencing!
-    record_info('Fencing info', 'Fencing done with systemctl poweroff');
-    $self->run_cmd(cmd => 'systemctl poweroff --force', timeout => 0);
-
-    # skip the one minute waiting
-    sleep 60;
-    my $start_time = time();
+    if (check_var('USE_FENCING', 'poweroff')) {
+        record_info('Fencing info', 'Fencing done with systemctl poweroff');
+        $self->run_cmd(cmd => 'systemctl poweroff --force', timeout => 0, quiet => 1);
+    } else {    # Default fencing uses CRM
+        record_info('Fencing info', 'Fencing done with crm');
+        $self->run_cmd(cmd => "crm -F node fence $args{hostname}", quiet => 1);
+    }
 
     # Wait till ssh disappear
-    while ((time() - $start_time) < $timeout) {
-        last unless (defined($self->{my_instance}->wait_for_ssh(timeout => 1, proceed_on_failure => 1)));
+    my $start_time = time;
+    while ((time - $start_time) < $timeout) {
+        last unless (defined($self->{my_instance}->wait_for_ssh(timeout => 1, proceed_on_failure => 1, quiet => 1)));
     }
-    my $fencing_time = time() - $start_time;
+    my $fencing_time = time - $start_time;
     die("Waiting for fencing failed!") unless ($fencing_time < $timeout);
     record_info('Fencing finished!', "Fencing done in ${fencing_time}s");
 
+    # We need to be sure that the server is stopped (if applicable)
+    if (is_ec2) {
+        my $start_time = time;
+        while ($self->{my_instance}->get_state ne 'stopped') {
+            if (time - $start_time < $timeout * 2) {
+                sleep 5;
+            } else {
+                # VM takes to much time to shutdown
+                die "Server $args{hostname} takes too much time to shutdown!";
+            }
+        }
+    }
+
     # We have to wait "a little" to ensure that resources are moved to the other node
-    sleep $timeout;
+    sleep $timeout / 2;
 
     # Wait for the node to restart
-    record_info("Restart $args{hostname}", 'Restart done using CSP API');
-    $self->{my_instance}->start(timeout => $timeout);
-
-    # Let's time for the resources to came back
-    sleep $timeout;
+    if (is_ec2) {
+        record_info("Restart $args{hostname}", 'Restart done using CSP API');
+        $self->{my_instance}->start(timeout => $timeout);
+    }
+    else {
+        record_info("Restart $args{hostname}", 'Restart done using Fencing Agent');
+        $self->{my_instance}->wait_for_ssh(timeout => $timeout);
+    }
 }
 
 sub run {
     my ($self)        = @_;
-    my $timeout       = bmwqemu::scale_timeout(60);
+    my $timeout       = 120;
     my @cluster_types = split(',', get_required_var('CLUSTER_TYPES'));
 
     $self->select_serial_terminal;
@@ -145,30 +177,6 @@ sub run {
     # Upload all TF/SALT logs first!
     foreach my $instance (@instances) {
         $self->upload_ha_sap_logs($instance);
-    }
-
-    # Workaround bsc#1170037
-    foreach my $instance (@instances) {
-        $self->{my_instance} = $instance;
-
-        # Get the hostname of the VM, it contains the cluster type
-        my $hostname = $instance->run_ssh_command(cmd => 'uname -n');
-
-        # Only on HA node
-        foreach my $cluster_type (@cluster_types) {
-            # Wait for HANA sync to be done
-            # NOTE: this is done in the 'foreach' section below, but needs to be done before restarting pacemaker
-            sleep $timeout * 2 if ($cluster_type eq 'hana');    # A 'sleep' should be enough here
-            if ($hostname =~ m/${cluster_type}/) {
-                # Check if sbd service is activated
-                if ($instance->run_ssh_command(cmd => 'systemctl is-enabled sbd', proceed_on_failure => 1) eq 'disabled') {
-                    record_soft_failure("bsc#1170037 - All nodes not shown by sbd list command on node $hostname");
-                    $self->run_cmd(cmd => 'sudo systemctl enable sbd');
-                    $self->run_cmd(cmd => 'sudo systemctl restart pacemaker');
-                    sleep $timeout;                             # We have to wait a little for the cluster to update its stack
-                }
-            }
-        }
     }
 
     foreach my $instance (@instances) {
@@ -182,17 +190,50 @@ sub run {
             if ($hostname =~ m/${cluster_type}01$/) {
                 if ($cluster_type eq 'hana') {
                     # Before doing anything on the cluster we have to wait for the HANA sync to be done
-                    $instance->run_ssh_command(cmd => 'sudo sh -c \'until SAPHanaSR-showAttr | grep -q SOK; do sleep 1; done\'', timeout => $timeout * 2);
+                    $instance->run_ssh_command(cmd => 'sudo sh -c \'until SAPHanaSR-showAttr | grep -q SOK; do sleep 1; done\'', timeout => $timeout);
                     # Show HANA replication state
                     $self->run_cmd(cmd => 'SAPHanaSR-showAttr');
+                }
+
+                # Workaround bsc#1179529 on DRBD cluster (only for GCP)
+                if (is_gce and $cluster_type eq 'drbd' and $hostname =~ m/${cluster_type}01$/) {
+                    record_soft_failure 'bsc#1179529 - [ha-sap-terraform-deployments_v6] DRBD resource fails after reboot on GCE';
+                    # Get the UUID of DRBD device
+                    my $drbd_conf_file = '/etc/drbd.d/sapdata.res';
+                    my $drbd_device = $self->run_cmd(cmd => "awk '/[[:blank:]]+disk[[:blank:]]+/ { print \$NF }' $drbd_conf_file | sed -n '/\\/dev\\//s/;//p'", quiet => 1);
+                    die "DRBD device can't be found!" unless defined $drbd_device;
+                    my $drbd_uuid_device = $self->run_cmd(cmd => "blkid -o export $drbd_device | awk -F'=' '/^UUID=/ { print \$NF }'", quiet => 1);
+                    die "DRBD UUID can't be found!" unless defined $drbd_uuid_device;
+
+                    # Replace current device name by its UUID in config file and sync cluster conf
+                    $self->run_cmd(cmd => "sed -i '/[[:blank:]]*disk[[:blank:]]*\\/dev\\//s;\\(^[[:blank:]]*\\).*;\\1disk /dev/disk/by-uuid/${drbd_uuid_device}\\;;' $drbd_conf_file", quiet => 1);
+                    $self->run_cmd(cmd => 'csync2 -xF', quiet => 1);
+
+                    # Cleanup DRBD resource
+                    $self->run_cmd(cmd => 'crm resource cleanup drbd-sapdata', quiet => 1);
+                }
+
+                # Workaround bsc#1179782 - Check if STONITH is disabled
+                unless ($instance->run_ssh_command(cmd => 'sudo sh -c \'crm configure show\' | grep -q stonith-enabled=false', rc_only => 1)) {
+                    record_soft_failure 'bsc#1179782 - [ha-sap-terraform-deployments_v6] stonith-enabled is set to false instead of true';
+                    $self->run_cmd(cmd => 'crm configure property stonith-enabled=true', quiet => 1);
                 }
 
                 # Check cluster status
                 $self->run_cmd(cmd => $crm_mon_cmd);
 
                 # Fence the node and let time for HA resources to restart
-                $self->fence_node(hostname => $hostname);
-                $self->wait_until_resources_started(cluster_type => $cluster_type);
+                $self->wait_until_resources_started(cluster_type => $cluster_type, timeout => $timeout); # We need to be sure that the cluster is OK before a fencing test
+                $self->fence_node(hostname => $hostname, timeout => $timeout);
+
+                # Workaround bsc#1179838 on GCP - Pacemaker doesn't start correctly after a STONITH
+                unless ($instance->run_ssh_command(cmd => 'systemctl --no-pager status pacemaker | grep -iq \'Active: inactive (dead)\'', rc_only => 1)) {
+                    record_soft_failure 'bsc#1179838 - [ha-sap-terraform-deployments_v6] Pacemaker doesn\'t start correctly after a STONITH';
+                    $self->run_cmd(cmd => 'systemctl --no-pager restart pacemaker', quiet => 1);
+                    sleep 30;                                                                            # We need to wait a "little" before
+                }
+
+                $self->wait_until_resources_started(cluster_type => $cluster_type, timeout => $timeout);
                 $self->run_cmd(cmd => $crm_mon_cmd);
 
                 # Do the HANA "magic" if needed
@@ -202,10 +243,9 @@ sub run {
                     my $hana_cmd = "hdbnsutil -sr_register --name=HDB --remoteHost=$remoteHost --remoteInstance=00 --replicationMode=sync --operationMode=logreplay";
                     $self->run_cmd(cmd => "-i -u prdadm $hana_cmd",                        title => 'HANA register');
                     $self->run_cmd(cmd => '-i crm resource cleanup msl_SAPHana_PRD_HDB00', title => 'Resources cleanup');
-                    sleep $timeout;    # We have to wait a little for the cluster to update its stack
 
                     # Check cluster resources
-                    $self->wait_until_resources_started(timeout => 120);
+                    $self->wait_until_resources_started(timeout => $timeout);
                     $self->run_cmd(cmd => $crm_mon_cmd);
                 }
 


### PR DESCRIPTION
SLES4SAP 15-SP3 needs a newer version of ha-sap-terraform-deployments.
This commit also adds some workarounds for GCE.

- Related ticket: N/A
- Needles: N/A
- Verification run: [Azure](http://1b210.qa.suse.de/tests/8220) (the failure is due to [bsc#1179698](https://bugzilla.suse.com/show_bug.cgi?id=1179698)), [AWS](http://1b210.qa.suse.de/tests/8225), [GCP](http://1b210.qa.suse.de/tests/8228) (the failure is due to [bsc#1178343](https://bugzilla.suse.com/show_bug.cgi?id=1178343))

**Note:** because of bugs in Azure and GCP it's not very easy to validate this PR, but as it works on AWS and as the current version fails on all Public Cloud I suggest to merge it and check after for Azure and GCP.