### PR TITLE
Add SSH serial terminal

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1208,6 +1208,8 @@ sub select_serial_terminal {
         } else {
             $console = $root ? 'root-virtio-terminal' : 'virtio-terminal';
         }
+    } elsif (get_var('SUT_IP') || get_var('VIRSH_GUEST')) {
+        $console = $root ? 'root-serial-ssh' : 'user-serial-ssh';
     } elsif ($backend eq 'svirt') {
         if (check_var('SERIAL_CONSOLE', 0)) {
             $console = $root ? 'root-console' : 'user-console';

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -403,6 +403,28 @@ sub init_consoles {
         }
     }
 
+    if (get_var('SUT_IP') || get_var('VIRSH_GUEST')) {
+        my $hostname = get_var('SUT_IP', get_var('VIRSH_GUEST'));
+
+        $self->add_console(
+            'root-serial-ssh',
+            'ssh-serial',
+            {
+                hostname => $hostname,
+                password => $testapi::password,
+                user     => 'root'
+            });
+
+        $self->add_console(
+            'user-serial-ssh',
+            'ssh-serial',
+            {
+                hostname => $hostname,
+                password => $testapi::password,
+                user     => $testapi::username
+            });
+    }
+
     # svirt backend, except s390x ARCH
     if (is_svirt_except_s390x) {
         my $hostname = get_var('VIRSH_GUEST');
@@ -846,7 +868,7 @@ sub console_selected {
     }
     $args{await_console} //= 1;
     $args{tags}          //= $console;
-    $args{ignore}        //= qr{sut|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary};
+    $args{ignore}        //= qr{sut|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary|serial-ssh};
     $args{timeout}       //= 30;
 
     if ($args{tags} =~ $args{ignore} || !$args{await_console} || (get_var('FLAVOR') eq 'WSL')) {


### PR DESCRIPTION
Initialize SSH serial terminal implemented in os-autoinst/os-autoinst#1599 and use it as the primary serial terminal for all backends where the SUT is reachable over network (including localhost).

This PR is blocked until os-autoinst/os-autoinst#1599 gets merged and deployed into production. Otherwise it'll break all tests.

Experimental run with slight changes and terminal backend code copied to os-autoinst-distri-opensuse: https://openqa.suse.de/tests/5175184
Job cloned from: https://openqa.suse.de/tests/5173600

- Related ticket: https://progress.opensuse.org/issues/80996
- Needles: N/A
- Verification runs:
  - ZKVM: https://openqa.suse.de/tests/5243478
  - SPVM: https://openqa.suse.de/tests/5246420
  - IPMI: http://openqa.qam.suse.cz/tests/16110