### PR TITLE
ipmi: Make grub2 config file more tidy

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -143,6 +143,10 @@ sub setup_console_in_grub {
         save_screenshot;
 
         if (!script_run('grep HPE /sys/class/dmi/id/board_vendor') == 0) {
+            $cmd = "sed -ri '/^terminal.*\$/ {:mylabel; n; s/^terminal.*\$//;b mylabel;}' $grub_cfg_file";
+            assert_script_run($cmd);
+            $cmd = "sed -ri '/^[[:space:]]*\$/d' $grub_cfg_file";
+            assert_script_run($cmd);
             $cmd = "sed -ri 's/^terminal.*\$/terminal_input console serial\\nterminal_output console serial\\nterminal console serial/g' $grub_cfg_file";
             assert_script_run($cmd);
         }


### PR DESCRIPTION
* **Long** time ago terminal settings were added into grub2.cfg by using sed command. There is no doubt that it works very well. 
* **But** it does have drawback in it because multiple consecutive replacement runs will result in lots of duplicate terminal settings entries in grub2.cfg. Although it has no impact on functionality and performance, it can prolong the waiting time before user can login to system because system needs to load these settings one by one which really takes time. 
* **I realized** this for a period of time and also want to solve this minor issue in order to prevent any potential inconvenience in the future if anyone or automated test suites to run grub2 setup many times in a single test suite.
* **I added** another two sed commands to keep only one terminal entry and then remove all empty lines before doing replacement to eradicate this minor problem.
* **Related ticket:** n/a
* **Needles:** n/a
* **Verification run:**
  * Manual verify that two new sed commands really serve their purpose and works very well even with multiple runs
  * [12sp5 kvm](http://10.67.129.106/tests/543)
  * [12sp5 xen](http://10.67.129.106/tests/544)
  * [15sp3 kvm](http://10.67.129.106/tests/547)
  * [15sp3 xen](http://10.67.129.106/tests/548)
