### PR TITLE
Add tests in mau-extratests-security-fips

### DIFF
--- a/schedule/qam/common/qam-security-fips.yml
+++ b/schedule/qam/common/qam-security-fips.yml
@@ -8,8 +8,10 @@ schedule:
 - boot/boot_to_desktop
 - console/consoletest_setup
 - fips/fips_setup
+- fips/openssl/openssl_fips_hash
 - fips/openssl/openssl_pubkey_rsa
 - fips/openssl/openssl_pubkey_dsa
+- console/openssl_alpn
 - console/sshd
 - console/ssh_cleanup
 - fips/openssh/openssh_fips


### PR DESCRIPTION
Transfer some tests that are running in product section of openQA
to the aggregate test repo

- Related ticket: https://progress.opensuse.org/issues/58838
- Needles: N/A
- Verification run: [SLE15-SP2](http://10.161.229.247/tests/1566) | [SLE15-SP1](http://10.161.229.247/tests/1562) | [SLE15](http://10.161.229.247/tests/1563) | [SLE12SP5](http://10.161.229.247/tests/1564) | [SLE12SP4](http://10.161.229.247/tests/1565)
