### PR TITLE
Fix sles4sap_remote_desktop tests

### DIFF
--- a/schedule/sles4sap/remote_desktop/sles4sap_remote_desktop_server.yaml
+++ b/schedule/sles4sap/remote_desktop/sles4sap_remote_desktop_server.yaml
@@ -12,5 +12,4 @@ vars:
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
 schedule:
   - boot/boot_to_desktop
-  - x11/window_system
   - x11/remote_desktop/xrdp_server


### PR DESCRIPTION
After investigating failures in sles4sap_remote_desktop QAM test we found that the 'window_system' module is not needed in the test, so better to remove it.

A bad needle that was the origin of the failure could also be removed.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1468
- Verification run: http://1b210.qa.suse.de/tests/8081 (the test was manually canceled but the modification is validated)