### PR TITLE
Test warning when no boot partition is configured

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ConfirmationWarning.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ConfirmationWarning.pm
@@ -26,6 +26,7 @@ sub new {
 sub init {
     my $self = shift;
     $self->{btn_yes}     = $self->{app}->button({id => 'yes'});
+    $self->{btn_no}      = $self->{app}->button({id => 'no'});
     $self->{lbl_warning} = $self->{app}->label({type => 'YLabel'});
     return $self;
 }
@@ -33,6 +34,11 @@ sub init {
 sub press_yes {
     my ($self) = @_;
     return $self->{btn_yes}->click();
+}
+
+sub press_no {
+    my ($self) = @_;
+    return $self->{btn_no}->click();
 }
 
 sub text {

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ConfirmationWarningRichText.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ConfirmationWarningRichText.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces methods in Expert Partitioner to handle
+# a generic confirmation warning containing the warning message in YRichText Widget.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Partitioner::LibstorageNG::v4_3::ConfirmationWarningRichText;
+use strict;
+use warnings;
+use parent 'Installation::Partitioner::LibstorageNG::v4_3::ConfirmationWarning';
+
+sub init {
+    my $self = shift;
+    $self->{rt_warning} = $self->{app}->label({type => 'YRichText'});
+    return $self;
+}
+
+sub text {
+    my ($self) = @_;
+    return $self->{rt_warning}->text();
+}
+
+1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
@@ -22,6 +22,7 @@ use Installation::Partitioner::LibstorageNG::v4_3::AddLogicalVolumePage;
 use Installation::Partitioner::LibstorageNG::v4_3::AddVolumeGroupPage;
 use Installation::Partitioner::LibstorageNG::v4_3::ClonePartitionsDialog;
 use Installation::Partitioner::LibstorageNG::v4_3::ConfirmationWarning;
+use Installation::Partitioner::LibstorageNG::v4_3::ConfirmationWarningRichText;
 use Installation::Partitioner::LibstorageNG::v4_3::CreatePartitionTablePage;
 use Installation::Partitioner::LibstorageNG::v4_3::DeletingCurrentDevicesWarning;
 use Installation::Partitioner::LibstorageNG::v4_3::ErrorDialog;
@@ -45,6 +46,7 @@ sub init {
     $self->{ExpertPartitionerPage}         = Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerPage->new({app => YuiRestClient::get_app()});
     $self->{ClonePartitionsDialog}         = Installation::Partitioner::LibstorageNG::v4_3::ClonePartitionsDialog->new({app => YuiRestClient::get_app()});
     $self->{ConfirmationWarning}           = Installation::Partitioner::LibstorageNG::v4_3::ConfirmationWarning->new({app => YuiRestClient::get_app()});
+    $self->{ConfirmationWarningRichText}   = Installation::Partitioner::LibstorageNG::v4_3::ConfirmationWarningRichText->new({app => YuiRestClient::get_app()});
     $self->{CreatePartitionTablePage}      = Installation::Partitioner::LibstorageNG::v4_3::CreatePartitionTablePage->new({app => YuiRestClient::get_app()});
     $self->{DeletingCurrentDevicesWarning} = Installation::Partitioner::LibstorageNG::v4_3::DeletingCurrentDevicesWarning->new({app => YuiRestClient::get_app()});
     $self->{ErrorDialog}                   = Installation::Partitioner::LibstorageNG::v4_3::ErrorDialog->new({app => YuiRestClient::get_app()});
@@ -77,6 +79,11 @@ sub get_clone_partition_dialog {
 sub get_confirmation_warning {
     my ($self) = @_;
     return $self->{ConfirmationWarning};
+}
+
+sub get_confirmation_warning_rich_text {
+    my ($self) = @_;
+    return $self->{ConfirmationWarningRichText};
 }
 
 sub get_create_new_partition_table_page {
@@ -272,14 +279,24 @@ sub get_error_dialog_text {
     $self->get_error_dialog()->text();
 }
 
-sub get_warning_text {
+sub get_warning_label_text {
     my ($self) = @_;
     $self->get_confirmation_warning()->text();
+}
+
+sub get_warning_rich_text {
+    my ($self) = @_;
+    $self->get_confirmation_warning_rich_text()->text();
 }
 
 sub confirm_warning {
     my ($self) = @_;
     $self->get_confirmation_warning()->press_yes();
+}
+
+sub decline_warning {
+    my ($self) = @_;
+    $self->get_confirmation_warning()->press_no();
 }
 
 sub edit_partition_encrypt {

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -5,11 +5,8 @@ description: >
   something is missing during manual partitioning using Expert Partitioner.
   Following warning are verified:
     - Missing root partition;
-    - Invalid boot partitioning (bios boot,/boot/zipl/,EFI, prep-boot),
-      only storage NG;
-    - Minimal size for the root with btrfs and snapshots and non-btrfs
-      (only storage-ng);
-    - No swap partition.
+    - Minimal size for the root with btrfs and snapshots
+    - Missing boot partition (bios boot,/boot/zipl/,EFI, prep-boot).
 vars:
   FILESYSTEM: btrfs
   YUI_REST_API: 1
@@ -24,6 +21,7 @@ schedule:
   - installation/partitioning
   - installation/partitioning/warning/no_root
   - installation/partitioning/warning/snapshots_small_root
+  - installation/partitioning/warning/no_boot
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -4,7 +4,9 @@ description: >
   Test suite verifies variety of warning which are expected to be shown when
   something is missing during manual partitioning using Expert Partitioner.
   Following warning are verified:
-    - Missing root partition.
+    - Missing root partition;
+    - Minimal size for the root with btrfs and snapshots
+    - Missing boot partition.
 vars:
   FILESYSTEM: btrfs
   YUI_REST_API: 1
@@ -19,6 +21,7 @@ schedule:
   - installation/partitioning
   - installation/partitioning/warning/no_root
   - installation/partitioning/warning/snapshots_small_root
+  - installation/partitioning/warning/no_boot
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
@@ -48,7 +51,15 @@ test_data:
           mounting_options:
             should_mount: 1
             mount_point: /
+      no_boot:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+          mount_point: /
   errors:
     no_root: There is no device mounted at '/'
   warnings:
     snapshots_small_root: Your root device is very small for snapshots
+    no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
@@ -1,0 +1,6 @@
+<<: !include test_data/yast/btrfs/common/btrfs+warnings_disks.yaml
+errors:
+  no_root: There is no device mounted at '/'
+warnings:
+  snapshots_small_root: Your root device is very small for snapshots
+  no_boot: Missing device for /boot/efi with size equal or bigger than 256 MiB and filesystem vfat

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -10,7 +10,15 @@ disks:
         mounting_options:
           should_mount: 1
           mount_point: /
+      no_boot:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+          mount_point: /
 errors:
   no_root: There is no device mounted at '/'
 warnings:
   snapshots_small_root: Your root device is very small for snapshots
+  no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
@@ -1,0 +1,6 @@
+<<: !include test_data/yast/btrfs/common/btrfs+warnings_disks.yaml
+errors:
+  no_root: There is no device mounted at '/'
+warnings:
+  snapshots_small_root: Your root device is very small for snapshots
+  no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
@@ -1,0 +1,6 @@
+<<: !include test_data/yast/btrfs/common/btrfs+warnings_disks.yaml
+errors:
+  no_root: There is no device mounted at '/'
+warnings:
+  snapshots_small_root: Your root device is very small for snapshots
+  no_boot: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs

--- a/test_data/yast/btrfs/btrfs+warnings_x64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_x64.yaml
@@ -1,0 +1,6 @@
+<<: !include test_data/yast/btrfs/common/btrfs+warnings_disks.yaml
+errors:
+  no_root: There is no device mounted at '/'
+warnings:
+  snapshots_small_root: Your root device is very small for snapshots
+  no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/test_data/yast/btrfs/common/btrfs+warnings_disks.yaml
+++ b/test_data/yast/btrfs/common/btrfs+warnings_disks.yaml
@@ -10,7 +10,10 @@ disks:
         mounting_options:
           should_mount: 1
           mount_point: /
-errors:
-  no_root: There is no device mounted at '/'
-warnings:
-  snapshots_small_root: Your root device is very small for snapshots
+      no_boot:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+          mount_point: /

--- a/tests/installation/partitioning/warning/no_boot.pm
+++ b/tests/installation/partitioning/warning/no_boot.pm
@@ -7,8 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Verify "There is no device mounted at '/'" Error Dialog is
-# shown when saving partitioner settings with no root mounted.
+# Summary: Verify Warning Dialog for missed boot partition is
+# shown when saving partitioner settings with no boot partition.
 # Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use base 'y2_installbase';
@@ -28,16 +28,17 @@ sub run {
     $partitioner->run_expert_partitioner();
     $partitioner->add_partition_on_gpt_disk({
             disk      => $disk->{name},
-            partition => $disk->{partitions}->{snapshots_small_root}
+            partition => $disk->{partitions}->{no_boot}
     });
+    $partitioner->accept_changes();
 
-    assert_matches(qr/$test_data->{warnings}->{snapshots_small_root}/, $partitioner->get_warning_label_text(),
-        "'Root is too small for snapshots' Warning Dialog did not appear, while it is expected.");
+    assert_matches(qr/$test_data->{warnings}->{no_boot}/, $partitioner->get_warning_rich_text(),
+        "Warning Dialog for missed boot partition did not appear, while it is expected.");
 }
 
 sub post_run_hook {
     save_screenshot;
-    $partitioner->confirm_warning();
+    $partitioner->decline_warning();
     $partitioner->cancel_changes({accept_modified_devices_warning => 1});
 }
 


### PR DESCRIPTION
The commit adds test module to check that the appropriate warning
message appears when boot partition is not configured.

- Related ticket: https://progress.opensuse.org/issues/78007
- Verification run: 
   - TW: https://openqa.opensuse.org/tests/1511998
   - sle: https://openqa.suse.de/tests/overview?groupid=96&build=102.1_oorlov&version=15-SP3&distri=sle

**For reviewers:** 
Please, also merge MR in schedule: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/326