### PR TITLE
Containers: enable docker compose test case

### DIFF
--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -12,24 +12,16 @@ conditional_schedule:
             'opensuse':
                 - containers/docker_image
                 - containers/container_diff
-    containers_3rd_party:
-        DISTRI:
-            'opensuse':
-                - containers/containers_3rd_party
-    docker_compose:
-        DISTRI:
-            'opensuse':
-                - containers/docker_compose
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
     - containers/podman
     - '{{podman_image}}'
     - containers/docker
-    - containers/docker_runc
     - '{{docker_image}}'
-    - '{{containers_3rd_party}}'
-    - '{{docker_compose}}'
-    - containers/registry
+    - containers/docker_runc
+    - containers/docker_compose
     - containers/zypper_docker
+    - containers/containers_3rd_party
+    - containers/registry
     - console/coredump_collect

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -8,9 +8,8 @@ schedule:
   - containers/host_configuration
   - containers/podman_image
   - containers/docker_image
+  - containers/container_diff
   - '{{validate_btrfs}}'
-  # - containers/container_diff
-  # Re-enable after 15-SP3 GA
 conditional_schedule:
   validate_btrf:
     ARCH:


### PR DESCRIPTION
Docker compose has been disabled since it requires packagehub
to be enabled for the current distri/version.

VR:
[containers_sle_image_on_sle_host](http://fromm.arch.suse.de/tests/34)
[containers_basic](http://fromm.arch.suse.de/tests/35) -> error expected due to packagehub
