### PR TITLE
Add validation to ssh -X scenario

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+# Summary: Package for ssh service tests
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package services::sshd;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+sub check_sshd_port {
+    assert_script_run q(ss -pnl4 | egrep 'tcp.*LISTEN.*:22.*sshd');
+    assert_script_run q(ss -pnl6 | egrep 'tcp.*LISTEN.*:22.*sshd');
+}
+
+sub check_sshd_service {
+    systemctl 'show -p ActiveState sshd|grep ActiveState=active';
+    systemctl 'show -p SubState sshd|grep SubState=running';
+}
+
+1;

--- a/schedule/yast/ssh-x.yaml
+++ b/schedule/yast/ssh-x.yaml
@@ -31,6 +31,8 @@ schedule:
   # Called on powerVM BACKEND
   - '{{grub_test}}'
   - installation/first_boot
+  - installation/validation/validate_sshd_reachable
+  - console/sshd
 conditional_schedule:
   disk_activation:
     BACKEND:

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -30,6 +30,7 @@ use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
 use utils qw(systemctl exec_and_insert_password zypper_call random_string clear_console);
 use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap);
+use services::sshd;
 
 sub run {
     my $self = shift;
@@ -63,8 +64,7 @@ sub run {
     systemctl 'status sshd';
 
     # Check that the daemons listens on right addresses/ports
-    assert_script_run q(ss -pnl4 | egrep 'tcp.*LISTEN.*:22.*sshd');
-    assert_script_run q(ss -pnl6 | egrep 'tcp.*LISTEN.*:22.*sshd');
+    services::sshd::check_sshd_port();
 
     # create a new user to test sshd
     my $changepwd = $ssh_testman . ":" . $ssh_testman_passwd;

--- a/tests/console/sshd_running.pm
+++ b/tests/console/sshd_running.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,10 +18,10 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use services::sshd;
 
 sub run {
-    systemctl 'show -p ActiveState sshd|grep ActiveState=active';
-    systemctl 'show -p SubState sshd|grep SubState=running';
+    services::sshd::check_sshd_service();
 }
 
 1;

--- a/tests/installation/validation/validate_sshd_reachable.pm
+++ b/tests/installation/validation/validate_sshd_reachable.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# Summary: Validate the sshd is running *and* that port 22 is opened,as
+# admins may want to connect with ssh right after an ssh installation.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use services::sshd;
+use testapi "select_console";
+
+sub run {
+    select_console 'root-console';
+    services::sshd::check_sshd_service();
+    services::sshd::check_sshd_port();
+}
+
+1;


### PR DESCRIPTION
Related ticket https://progress.opensuse.org/issues/80780

As of now we only check that system boots, but do not even verify that ssh connection is available after the initial reboot.

We already have modules to validate ssh service is running and port is open.
Check tests/console/sshd.pm and tests/console/sshd_running.pm
However, one only checks if the service is up the other one shuts the firewall down, so we need a new module, or to modify the existing ones.
I chose to create a new one as those modules are used by different teams, and the sshd test is overkill for what we want here.

VRs:
PVM https://openqa.suse.de/tests/5249481
zVM https://openqa.suse.de/tests/5249482
remote_ssh_target_ftp https://openqa.suse.de/tests/5249485
