### PR TITLE
Skip sle-module-legacy for sssd on publiccloud

### DIFF
--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -47,7 +47,7 @@ sub run {
 
     # for sle 12 we still use and support python2
     if (is_sle('<15')) {
-        add_suseconnect_product('sle-module-legacy');
+        add_suseconnect_product('sle-module-legacy') unless get_var('PUBLIC_CLOUD');
         push @test_subjects, 'python-pam';
     } else {
         push @test_subjects, 'python3-python-pam';


### PR DESCRIPTION
Skip activating the legacy module in sssd on publiccloud runs

- Related ticket: https://progress.opensuse.org/issues/81110
- Needles: -
- Verification runs: 

http://phoenix-openqa.qam.suse.de/tests/4378 (known failure in `firewalld`)
http://phoenix-openqa.qam.suse.de/tests/4379
