### PR TITLE
Fix all patterns not selected

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -212,12 +212,12 @@ available patterns.
 =cut
 sub select_all_patterns_by_menu {
     my ($self) = @_;
-    # move mouse on patterns and open menu
-    mouse_set 100, 400;
-    mouse_click 'right';
-    wait_still_screen 3;
+    # Ensure mouse on certain pattern then right click
+    assert_and_click("minimal-system", button => 'right');
+    assert_screen 'selection-menu';
     # select action on all patterns
     wait_screen_change { send_key 'a'; };
+    assert_screen 'all-select-install';
     # confirm install
     wait_screen_change { send_key 'ret'; };
     mouse_hide;


### PR DESCRIPTION
It failed to get the select menu by right click because the (100,400) is on the pattern group while not a pattern, so I changed the code from mouse_click to assert_and_click('right'), this is easy and can avoid such issue that can't show selection menu by right click on consistent position. Besides, add assert screen to make the test more robust.

- Related ticket: https://progress.opensuse.org/issues/77149
- Needles: Already created in OSD.
- Verification run: https://openqa.nue.suse.com/tests/5193164#step/select_patterns/14   #SLES12SP4  ppc64le
                            https://openqa.nue.suse.com/tests/5199764#step/select_patterns/15   #SLES15SP3  ppc64le