### PR TITLE
Remove phub repo metadata related soft fail

### DIFF
--- a/tests/network/cifs.pm
+++ b/tests/network/cifs.pm
@@ -48,10 +48,7 @@ sub run {
     my $smb_remote = get_var("CIFS_TEST_REMOTE") // "currywurst.qam.suse.de";
     $self->select_serial_terminal;
     add_suseconnect_product(get_addon_fullname('phub')) if is_sle;    # samba-client requires package hub
-    my $ret = zypper_call('in cifs-utils samba-client nmap', exitcode => [0, 106]);
-    if ($ret == 106) {
-        record_soft_failure 'bsc#1152524 - [Build 18.1] openQA test fails whenever package hub repo is added: Valid metadata not found at specified URL';
-    }
+    my $ret = zypper_call 'in cifs-utils samba-client nmap';
     # Use local samba server, if defined or if defined SMB server is not accessible
     my $is_local = get_var("CIFS_TEST_REMOTE") eq 'local';
     if ($is_local || script_run("nmap -p 139,445 $smb_remote | grep open") != 0) {


### PR DESCRIPTION
Package Hub has been enabled for sle15sp3

- Related ticket: [openQA test fails whenever package hub repo is added: Valid metadata not found at specified URL](https://bugzilla.suse.com/show_bug.cgi?id=1152524)
- Verification run: [Build20.174-jeos-base+phub@uefi-virtio-vg](http://kepler.suse.cz/tests/2930#step/cifs/1) 
