### PR TITLE
Test warning when BIOS boot is small for bootloader

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -23,6 +23,7 @@ schedule:
   - installation/partitioning/warning/snapshots_small_root
   - installation/partitioning/warning/no_boot
   - installation/partitioning/warning/boot_small_for_kernel
+  - installation/partitioning/warning/bios_boot_small_for_bootloader
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -23,6 +23,7 @@ schedule:
   - installation/partitioning/warning/snapshots_small_root
   - installation/partitioning/warning/no_boot
   - installation/partitioning/warning/boot_small_for_kernel
+  - installation/partitioning/warning/bios_boot_small_for_bootloader
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone

--- a/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
@@ -1,8 +1,10 @@
 disks:
   - name: vda
-    <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+    partitions:
+      <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: Missing device for /boot/efi with size equal or bigger than 256 MiB and filesystem vfat
+  bios_boot_small_for_bootloader: Missing device for /boot/efi with size equal or bigger than 256 MiB and filesystem vfat

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -1,8 +1,10 @@
 disks:
   - name: sda
-    <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+    partitions:
+      <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
+  bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
@@ -1,8 +1,10 @@
 disks:
   - name: vda
-    <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+    partitions:
+      <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
+  bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
@@ -1,8 +1,10 @@
 disks:
   - name: vda
-    <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+    partitions:
+      <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
+  bios_boot_small_for_bootloader: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs

--- a/test_data/yast/btrfs/btrfs+warnings_x64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_x64.yaml
@@ -1,8 +1,10 @@
 disks:
   - name: vda
-    <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+    partitions:
+      <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
+  bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+++ b/test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
@@ -1,33 +1,43 @@
-partitions:
-  snapshots_small_root:
+snapshots_small_root:
+  size: 11GiB
+  role: operating-system
+  formatting_options:
+    should_format: 1
+    enable_snapshots: 1
+  mounting_options:
+    should_mount: 1
+    mount_point: /
+no_boot:
+  role: operating-system
+  formatting_options:
+    should_format: 1
+  mounting_options:
+    should_mount: 1
+    mount_point: /
+boot_small_for_kernel:
+  - role: operating-system
     size: 11GiB
-    role: operating-system
-    formatting_options:
-      should_format: 1
-      enable_snapshots: 1
-    mounting_options:
-      should_mount: 1
-      mount_point: /
-  no_boot:
-    role: operating-system
     formatting_options:
       should_format: 1
     mounting_options:
       should_mount: 1
       mount_point: /
-  boot_small_for_kernel:
-    - role: operating-system
-      size: 11GiB
-      formatting_options:
-        should_format: 1
-      mounting_options:
-        should_mount: 1
-        mount_point: /
-    - role: operating-system
-      size: 40mb
-      formatting_options:
-        should_format: 1
-        filesystem: ext2
-      mounting_options:
-        should_mount: 1
-        mount_point: '/boot'
+  - role: operating-system
+    size: 40mb
+    formatting_options:
+      should_format: 1
+      filesystem: ext2
+    mounting_options:
+      should_mount: 1
+      mount_point: '/boot'
+bios_boot_small_for_bootloader:
+  - role: operating-system
+    size: 11GiB
+    formatting_options:
+      should_format: 1
+    mounting_options:
+      should_mount: 1
+      mount_point: /
+  - role: raw-volume
+    size: 1mb
+    id: bios-boot

--- a/tests/installation/partitioning/warning/bios_boot_small_for_bootloader.pm
+++ b/tests/installation/partitioning/warning/bios_boot_small_for_bootloader.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify Warning Dialog when BIOS boot partition has too small
+# size to install bootloader.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+my $partitioner;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    my $disk      = $test_data->{disks}[0];
+    $partitioner = $testapi::distri->get_expert_partitioner();
+
+    $partitioner->run_expert_partitioner();
+    foreach my $partition (@{$disk->{partitions}->{bios_boot_small_for_bootloader}}) {
+        $partitioner->add_partition_on_gpt_disk({
+                disk      => $disk->{name},
+                partition => $partition
+        });
+    }
+    $partitioner->accept_changes();
+
+    assert_matches(qr/$test_data->{warnings}->{bios_boot_small_for_bootloader}/, $partitioner->get_warning_rich_text(),
+        "Warning Dialog for 'BIOS boot partition has too small size to install bootloader' did not appear, while it is expected.");
+}
+
+sub post_run_hook {
+    save_screenshot;
+    $partitioner->decline_warning();
+    $partitioner->cancel_changes({accept_modified_devices_warning => 1});
+}
+
+1;


### PR DESCRIPTION
The commit adds test module to check that the appropriate warning
message appears when BIOS boot partition has too small size to install
bootloader.

- Related ticket: https://progress.opensuse.org/issues/78007
- Verification run: https://openqa.suse.de/tests/overview?groupid=96&distri=sle&version=15-SP3&build=109.1_oorlov
