### PR TITLE
Enable boot menu for x86_64 uefi workaround, see bsc#1180080

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -46,11 +46,21 @@ use lockapi 'mutex_wait';
 use bootloader_setup;
 use registration;
 use utils;
-use version_utils qw(is_jeos is_microos);
+use version_utils qw(is_jeos is_microos is_sle);
 
 # hint: press shift-f10 trice for highest debug level
 sub run {
     my ($self) = @_;
+
+    # Enable boot menu for x86_64 uefi workaround, see bsc#1180080 for details
+    # Case setting also need BOOT_MENU=1 to support it
+    if (is_sle && get_required_var('FLAVOR') =~ /Migration/ && check_var('ARCH', 'x86_64')) {
+        record_soft_failure 'bsc#1180080';
+        tianocore_select_bootloader;
+        send_key_until_needlematch("ovmf-boot-HDD", 'down', 5, 1);
+        send_key "ret";
+        return;
+    }
 
     if (get_var("IPXE")) {
         sleep 60;


### PR DESCRIPTION
Enable boot menu for x86_64 uefi workaround, see bsc#1180080
- Related ticket: https://progress.opensuse.org/issues/81086
- Needles: na
- Verification run: https://openqa.suse.de/tests/5210911#


