### PR TITLE
Fix yast2 kdump configure font distortion

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -84,6 +84,9 @@ sub prepare_for_kdump {
     quit_packagekit;
     if ($test_type eq 'before') {
         zypper_call('in yast2-kdump kdump');
+        # In service check, sometimes the system's console font will failed
+        # to set the correct font, we need to reset it here.
+        check_console_font;
     }
     else {
         zypper_call('in yast2-kdump kdump crash');


### PR DESCRIPTION
In service check, sometimes the system's console font will failed
to set the correct font, we need to reset it before yast2 --ncurses
kdump configure.

- Related ticket: https://progress.opensuse.org/issues/81090
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/5206741
   https://openqa.nue.suse.com/tests/5206886
   
   
