### PR TITLE
xfstests: Fix tests name issue cause by group include

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -202,9 +202,9 @@ sub include_grouplist {
     my @tests_list;
     foreach my $group_name (@GROUPLIST) {
         next if ($group_name =~ /^\!/);
-        my $cmd = "awk '/$group_name/ {printf \"$FSTYPE/\"}{printf \$1}{printf \",\"}' $INST_DIR/tests/$FSTYPE/group > tmp.group";
+        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$FSTYPE/group | awk '{printf \"$FSTYPE/\"}{printf \$1}{printf \",\"}' > tmp.group";
         script_run($cmd);
-        $cmd = "awk '/$group_name/ {printf \"generic/\"}{printf \$1}{printf \",\"}' $INST_DIR/tests/generic/group >> tmp.group";
+        $cmd = "awk '/$group_name/' $INST_DIR/tests/generic/group | awk '{printf \"generic/\"}{printf \$1}{printf \",\"}' >> tmp.group";
         script_run($cmd);
         $cmd = "cat tmp.group";
         my $tests = substr(script_output($cmd), 0, -1);


### PR DESCRIPTION
The feature include tests by group name has some problem with test name created. This PR will fix test name problem.

- Related ticket: https://progress.opensuse.org/issues/81270
- Verification run: http://openqa.suse.de/tests/5207252