### PR TITLE
Remove SECTEST_DVD_SRC parameter from krb5 test group

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2278,16 +2278,18 @@ sub load_security_tests_crypt_tool {
 }
 
 sub load_security_tests_crypt_krb5kdc {
-    set_var('SECTEST_DVD_SRC', 1);
-    load_security_console_prepare;
+
+    loadtest "console/consoletest_setup";
+    loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
 
     loadtest "security/krb5/krb5_crypt_prepare";
     loadtest "security/krb5/krb5_crypt_setup_kdc";
 }
 
 sub load_security_tests_crypt_krb5server {
-    set_var('SECTEST_DVD_SRC', 1);
-    load_security_console_prepare;
+
+    loadtest "console/consoletest_setup";
+    loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
 
     loadtest "security/krb5/krb5_crypt_prepare";
     loadtest "security/krb5/krb5_crypt_setup_server";
@@ -2296,8 +2298,9 @@ sub load_security_tests_crypt_krb5server {
 }
 
 sub load_security_tests_crypt_krb5client {
-    set_var('SECTEST_DVD_SRC', 1);
-    load_security_console_prepare;
+
+    loadtest "console/consoletest_setup";
+    loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
 
     loadtest "security/krb5/krb5_crypt_prepare";
     loadtest "security/krb5/krb5_crypt_setup_client";

--- a/tests/security/krb5/krb5_crypt_prepare.pm
+++ b/tests/security/krb5/krb5_crypt_prepare.pm
@@ -1,4 +1,4 @@
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2020 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 #
 # Summary: Prepare environment for cryptographic function testing of krb5
 # Maintainer: Ben Chou <bchou@suse.com>
-# Ticket: poo#51560
+# Ticket: poo#51560, poo#81236
 
 use base "consoletest";
 use strict;
@@ -98,6 +98,8 @@ EOF
     (is_sle('<15')) ? systemctl('stop SuSEfirewall2') : systemctl('stop firewalld');
 
     # Prepare krb5 application and config files
+    zypper_call('ref');
+    zypper_call('lr -u');
     zypper_call('in krb5 krb5-server krb5-client');
     assert_script_run("echo 'export KRB5CCNAME=/root/kcache' >> /etc/profile.d/krb5.sh");    # Make ticket permanent
     assert_script_run("source /etc/profile.d/krb5.sh");


### PR DESCRIPTION
**Description:**

The krb5 related packages are not able to get from the DVD source. The fix is removing SECTEST_DVD_SRC parameter from krb5 test group, these packages can be retrieved from the Online repository currently.

1. Pull out krb5 related packages from Online repository instead of DVD source
2. Amend krb5_crypt_prepare case and test sequence

- Related ticket: https://progress.opensuse.org/issues/81236
- Needles: NA
- Verification run: 
  Test cases are running in Development job group.
https://openqa.suse.de/tests/5213373 (krb5_kdc)
https://openqa.suse.de/tests/5213374 (krb5_Server)
https://openqa.suse.de/tests/5213375 (krb5_Client)
