### PR TITLE
Remove cups workaround for SLE11SP4

### DIFF
--- a/lib/services/cups.pm
+++ b/lib/services/cups.pm
@@ -51,9 +51,9 @@ sub check_service {
 
 # check cups function
 sub check_function {
-    # if we migrated from sle11sp4, we need change the configure file.
+    # if we migrated from sle11sp4, we need to change the configure file.
+    # bsc#1180148, cups configure file was not upgraded.
     if ((get_var('ORIGIN_SYSTEM_VERSION') eq '11-SP4') && ($service_type eq 'Systemd')) {
-        record_soft_failure("bsc#1180148, cups configure file was not upgraded");
         script_run 'echo FileDevice Yes >> /etc/cups/cups-files.conf';
         validate_script_output 'cupsd -t', sub { m/is OK/ };
         common_service_action 'cups', $service_type, 'restart';


### PR DESCRIPTION
Since bug bsc#1180148 was marked as INVALID, and we have document
for manual edit the configure files after migration. We can now
remove the workaround for SLE11SP4.


- Related ticket: https://progress.opensuse.org/issues/81258
- Needles: N/A
- Verification run: N/A
