### PR TITLE
Fix setup zdup stall

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -742,7 +742,8 @@ sub wait_grub_to_boot_on_local_disk {
         }
     }
 
-    assert_screen(\@tags, 15);
+    # We need to wait more time for aarch64's tianocore-mainmenu
+    (check_var('ARCH', 'aarch64')) ? assert_screen(\@tags, 30) : assert_screen(\@tags, 15);
     if (match_has_tag('tianocore-mainmenu')) {
         opensusebasetest::handle_uefi_boot_disk_workaround();
         check_screen('encrypted-disk-password-prompt', 10);


### PR DESCRIPTION
For Aarch64, We need wait more time for the tianocore main menu to
show up, when it was called from wait_grub_to_boot_on_local_disk.
We changed the wait time from 15 to 30 seconds.

- Related ticket: https://progress.opensuse.org/issues/81092
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/5213317
  https://openqa.nue.suse.com/tests/5213318
  https://openqa.nue.suse.com/tests/5213916
  https://openqa.nue.suse.com/tests/5214027
 https://openqa.nue.suse.com/tests/5214206