### PR TITLE
xfstests: Fix umount error issue

### DIFF
--- a/data/xfstests/wrapper.sh
+++ b/data/xfstests/wrapper.sh
@@ -71,16 +71,6 @@ fi
 
 pushd "$XFSTESTS_DIR" &> /dev/null
 
-# Umount /mnt/test and /mnt/scratch
-umount $TEST_DEV &> /dev/null
-if [[ -n "$SCRATCH_DEV_POOL" ]]; then
-    for device in $SCRATCH_DEV_POOL; do
-        umount $device &> /dev/null
-    done
-else
-    umount $SCRATCH_DEV
-fi
-
 # Run test
 log_file="/tmp/xfstests-$(echo "$1" | tr '/' '_').tmp"
 ./$(basename "$PROG") -d "$1" | tee "$log_file"

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -123,14 +123,17 @@ sub do_partition_for_xfstests {
     script_run('mkdir /mnt/test /mnt/scratch');
     # Setup configure file xfstests/local.config
     script_run("echo 'export TEST_DEV=$test_dev' >> $CONFIG_FILE");
+    set_var('XFSTESTS_TEST_DEV', $test_dev);
     script_run("echo 'export TEST_DIR=/mnt/test' >> $CONFIG_FILE");
     script_run("echo 'export SCRATCH_MNT=/mnt/scratch' >> $CONFIG_FILE");
     if ($para{amount} == 1) {
         script_run("echo 'export SCRATCH_DEV=$scratch_dev[0]' >> $CONFIG_FILE");
+        set_var('XFSTESTS_SCRATCH_DEV', $scratch_dev[0]);
     }
     else {
         my $SCRATCH_DEV_POOL = join(' ', @scratch_dev);
         script_run("echo 'export SCRATCH_DEV_POOL=\"$SCRATCH_DEV_POOL\"' >> $CONFIG_FILE");
+        set_var('XFSTESTS_SCRATCH_DEV_POOL', $SCRATCH_DEV_POOL);
     }
     # Sync
     script_run('sync');
@@ -172,13 +175,16 @@ sub create_loop_device_by_rootsize {
     script_run('mkdir /mnt/test /mnt/scratch');
     # Setup configure file xfstests/local.config
     script_run("echo 'export TEST_DEV=/dev/loop0' >> $CONFIG_FILE");
+    set_var('XFSTESTS_TEST_DEV', '/dev/loop0');
     script_run("echo 'export TEST_DIR=/mnt/test' >> $CONFIG_FILE");
     script_run("echo 'export SCRATCH_MNT=/mnt/scratch' >> $CONFIG_FILE");
     if ($amount == 1) {
         script_run("echo 'export SCRATCH_DEV=/dev/loop1' >> $CONFIG_FILE");
+        set_var('XFSTESTS_SCRATCH_DEV', '/dev/loop1');
     }
     else {
         script_run("echo 'export SCRATCH_DEV_POOL=\"/dev/loop1 /dev/loop2 /dev/loop3 /dev/loop4 /dev/loop5\"' >> $CONFIG_FILE");
+        set_var('XFSTESTS_SCRATCH_DEV_POOL', '/dev/loop1 /dev/loop2 /dev/loop3 /dev/loop4 /dev/loop5');
     }
     # Sync
     script_run('sync');

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -389,6 +389,15 @@ sub reload_loop_device {
     script_run('losetup -a');
 }
 
+# Umount TEST_DEV and SCRATCH_DEV
+sub umount_xfstests_dev {
+    script_run('umount ' . get_var('XFSTESTS_TEST_DEV') . ' &> /dev/null')    if get_var('XFSTESTS_TEST_DEV');
+    script_run('umount ' . get_var('XFSTESTS_SCRATCH_DEV') . ' &> /dev/null') if get_var('XFSTESTS_SCRATCH_DEV');
+    if (get_var('XFSTESTS_SCRATCH_DEV_POOL')) {
+        script_run("umount $_ &> /dev/null") foreach (split ' ', get_var('XFSTESTS_SCRATCH_DEV_POOL'));
+    }
+}
+
 sub run {
     my $self = shift;
     select_console('root-console');
@@ -421,6 +430,8 @@ sub run {
         if (exists($BLACKLIST{$test})) {
             next;
         }
+
+        umount_xfstests_dev;
 
         # Run test and wait for it to finish
         my ($category, $num) = split(/\//, $test);


### PR DESCRIPTION
The wrapper.sh do cleanup by umount but it not works for now. This
due to we put all settings to local.config, and no longer set any
environment variable.

Move cleanup function to run.pm.

- Related ticket: https://progress.opensuse.org/issues/81152
- Needles: N/A
- Verification run: http://10.67.134.217/tests/11863  (btrfs)
- http://10.67.134.217/tests/11865#step/run/42 (xfs)
