### PR TITLE
MicroOS: increase reboot timeout before needle match

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -44,7 +44,7 @@ sub microos_reboot {
 
     # No grub bootloader on xen-pv
     # grub2 needle is unreliable (stalls during timeout) - poo#28648
-    assert_screen 'grub2', 150;
+    assert_screen 'grub2', 300;
     send_key('ret') if match_has_tag('grub2');
 
     microos_login;


### PR DESCRIPTION
Aarch64 jobs are randomly failing after reboot with Stall detected.
This doesn't happen in x86_64 jobs.

failed runs:
https://openqa.suse.de/tests/5214965#step/transactional_update/53
https://openqa.suse.de/tests/5214967#step/transactional_update/55

fix: 
https://openqa.suse.de/tests/5215003
https://openqa.suse.de/tests/5215002

