### PR TITLE
Remove "hardened_usercopy=off" as a parameter after verified bugfix (bsc#1156053)

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -83,8 +83,7 @@ sub prepare_parmfile {
     $params .= " " . get_var('S390_NETWORK_PARAMS');
     $params .= " " . get_var('EXTRABOOTPARAMS');
     if ((is_sle('>=15-SP2') || is_tumbleweed()) && get_var('WORKAROUND_BUGS') =~ 'bsc1156047') {
-        $params .= ' hardened_usercopy=off hvc_iucv=8';
-        record_soft_failure('bsc#1156053 - hardened_usercopy=off to avoid "/dev/hvc0: cannot get controlling tty: Operation not permitted" (Kernel memory overwrite attempt detected to SLUB object - illegal operation)');
+        $params .= ' hvc_iucv=8';
     }
 
     $params .= remote_install_bootmenu_params;


### PR DESCRIPTION
Verification of bugfix in openQA for bsc#1156053 
- Related bug: https://bugzilla.suse.com/show_bug_cgi?id=1156053
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.opensuse.org/tests/1523828#step/bootloader_s390/5
