### PR TITLE
Enlarge wait grub timeout

### DIFF
--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -27,7 +27,7 @@ sub run {
     power_action('reboot', keepconsole => 1, textmode => 1);
     reset_consoles;
     reconnect_mgmt_console if is_pvm;
-    $self->wait_grub(bootloader_time => 200);
+    $self->wait_grub(bootloader_time => 250);
     # To keep the screen at grub page
     # Refer https://progress.opensuse.org/issues/49040
     stop_grub_timeout;


### PR DESCRIPTION
After check result like following rerun test cases, the case is pass though but you can find the average wait time is around 180s, currently is 200s in code, so the risk is high if worker is slow. 
http://openqa.suse.de/t5199756
http://openqa.suse.de/t5199757

- Related ticket: https://progress.opensuse.org/issues/81050
- Needles: na
- Verification run: https://openqa.nue.suse.com/tests/5217899
