### PR TITLE
Assert needle to avoid send down key early in grub_test_snapshot for HPC product

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -265,7 +265,7 @@ sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
     # assert needle to avoid send down key early in grub_test_snapshot.
-    assert_screen('snap-default', 120) if (get_var('OFW') || is_pvm);
+    assert_screen('snap-default', 120) if (get_var('OFW') || is_pvm || check_var('SLE_PRODUCT', 'hpc'));
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);


### PR DESCRIPTION
Assert needle to avoid send down key early in grub_test_snapshot for HPC product

- Related ticket: https://progress.opensuse.org/issues/81218
- Verification run: https://openqa.suse.de/tests/5211440#step/grub_test_snapshot/10