### PR TITLE
More complete supportconfig logs and less retries inside guest console

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -691,11 +691,14 @@ sub perform_guest_restart {
 #Please refer to virt_logs_collector.sh and fetch_logs_from_guest.sh in data/virt_autotest for their detailed functionality, implementation and usage
 sub collect_host_and_guest_logs {
     my ($guest_wanted, $host_extra_logs, $guest_extra_logs) = @_;
+    $guest_wanted     //= '';
+    $host_extra_logs  //= '';
+    $guest_extra_logs //= '';
 
     my $logs_collector_script_url = data_url("virt_autotest/virt_logs_collector.sh");
     script_output("curl -s -o ~/virt_logs_collector.sh $logs_collector_script_url", 180, type_command => 0, proceed_on_failure => 0);
     save_screenshot;
-    script_output("chmod +x ~/virt_logs_collector.sh && ~/virt_logs_collector.sh -l \"$host_extra_logs\" -g \"$guest_wanted\" -e \"$guest_extra_logs\"", 1800, type_command => 1, proceed_on_failure => 1);
+    script_output("chmod +x ~/virt_logs_collector.sh && ~/virt_logs_collector.sh -l \"$host_extra_logs\" -g \"$guest_wanted\" -e \"$guest_extra_logs\"", 3600 / get_var('TIMEOUT_SCALE', 1), type_command => 1, proceed_on_failure => 1);
     save_screenshot;
 
     my $logs_fetching_script_url = data_url("virt_autotest/fetch_logs_from_guest.sh");
@@ -716,6 +719,7 @@ sub collect_host_and_guest_logs {
 #Please refer to clean_up_virt_logs.sh data/virt_autotest for its detailed functionality, implementation and usage
 sub cleanup_host_and_guest_logs {
     my ($extra_logs_to_cleanup) = @_;
+    $extra_logs_to_cleanup //= '';
 
     #Clean dhcpd and named services up explicity
     if (get_var('VIRT_AUTOTEST')) {


### PR DESCRIPTION
* **Use** supportconfig -y and -A options to collect more complete logs, including full y2logs, many other complete logs instead of last 500 lines and etc.
* **Use** expect script variables fail_string and pass_string to set logs collecting result explicitly to avoid unnecessary "false negative" failures during logs collecting inside guest console before final success after retries, which also speeds up logs collecting process.
* **Increase** virt_logs_collector timeout to 3600 and timeout inside guest console to 1200 to tolerate more comprehensive logs collecting and more extreme situations that can happen to guests.
* **Initialize**     $guest_wanted, $host_extra_logs, $guest_extra_logs and $extra_logs_to_cleanup if they are not.
* **Related ticket:** n/a
* **Needles:** n/a
* **Verification runs:**
  * [Logs collecting via ssh on 15sp3 host with 11sp4/12sp5/15sp3 guest](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5739731/virt_logs_collector_ssh.log)
  * [Logs collecting via console on 15sp3 host with 11sp4/12sp5/15sp3 guest](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5739734/virt_logs_collector_console.log)
  * [Logs collecting via ssh on 12sp5 host with 11sp4/12sp5/15sp3 guest](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5739739/virt_logs_collector_ssh.log)
  * [Logs collecting via console on 12sp5 host with 11sp4/12sp5/15sp3 guest](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5739749/virt_logs_collector_console.log)
  * [Logs collecting via ssh on 11sp4 host with 11sp4/12sp5/15sp3 guest](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5739755/virt_logs_collector_ssh.log)
  * [Logs collecting via console on 11sp4 host with 11sp4/12sp5/15sp3 guest](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5739761/virt_logs_collector_console.log)
  * [Fail to collect logs example](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/5739767/virt_logs_collector_console_fail.log)
  * [openQA run on kvm host with 11sp4/12sp5/15sp3 guest](http://10.67.129.106/tests/552)
  * [openQA run on xen host with 11sp4/12sp5/15sp3 guest](http://10.67.129.106/tests/554)







