### PR TITLE
Enhance ima/evm output filter for ima appraisal signature

### DIFF
--- a/tests/security/ima/ima_appraisal_digital_signatures.pm
+++ b/tests/security/ima/ima_appraisal_digital_signatures.pm
@@ -55,7 +55,7 @@ sub run {
 
         # Allow "No such file" message for the files in /proc because they are mutable
         my @finds = split /\n/, $findret;
-        $_ =~ m/\/proc\/.*No such file/ or die "Failed to create security.ima for $_" foreach (@finds);
+        $_ =~ m/\/proc\/.*No such file|evm\/ima signature|hash\(sha256\)|^\w{530}$/ or die "Failed to create security.ima for $_" foreach (@finds);
     }
 
     validate_script_output "getfattr -m security.ima -d $sample_app", sub {


### PR DESCRIPTION
IMA appraisal with digital signatures along with hash type and value
are shown up after issuing the evm sign command. So enhance the log filter
here to check them

- Related ticket: https://progress.opensuse.org/issues/81346
- Needles: N/A
- Verification run: http://openqa.suse.de/t5220113
   (Please don't be surprised by the subsequent failure, it is an known issue which is already tracked via bug 1155890)
