### PR TITLE
Integrate Lynis into OpenQA

### DIFF
--- a/data/lynis/baseline-lynis-audit-system-nocolors-sle15sp3-x86_64-snapshot7-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-sle15sp3-x86_64-snapshot7-textmode
@@ -1,0 +1,630 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-43-default
+  Kernel version:            5.3.18
+  Hardware platform:         x86_64
+  Hostname:                  susetest
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 303
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 24 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 27 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 3 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: PAE and/or NoeXecute supported[14C [ FOUND ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 104 active modules[31C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ NO ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 24 shells (valid shells: 16).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: cramfs hfsplus squashfs udf [0C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ ENABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 10.0.2.3[33C [ OK ]
+[8CNameserver: fec0::3[34C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ OK ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 6 ports[40C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/0][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.3.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.12.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package systemd-246.9-1.2.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.12.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 4499 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (1):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  Suggestions (33):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+      https://cisofy.com/controls/NAME-4028/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+      https://cisofy.com/controls/FIRE-4513/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 87 [#################   ]
+  Tests performed : 222
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 303
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/lib/lynis/lynis_run.pm
+++ b/lib/lynis/lynis_run.pm
@@ -1,0 +1,92 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Integrate the Lynis scanner into OpenQA: run test cases/modules
+#          according to section list
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#78224, poo#78230
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use autotest;
+use lynis::lynistest;
+
+sub run {
+    my ($self, $tinfo) = @_;
+    my $section      = $tinfo->test;
+    my $section_orig = $tinfo->test;
+
+    my $baseline_file = $lynis::lynistest::lynis_baseline_file;
+    my $current_file  = $lynis::lynistest::lynis_audit_system_current_file;
+
+    my @section_content_baseline = ();
+    my @section_content_current  = ();
+
+    my $found = 0;
+    my $results;
+
+    record_info("$section", " Got: $section in \"current\" \"# lynis audit system\" output file");
+
+    # Rename the section for easier "regex match": e.g., replace special characters
+    $section = lynis::lynistest::rename_lynis_section($section);
+    $section = substr($section, 4);
+
+    # Parse the "sections" in baseline file
+    my @section_list_baseline = lynis::lynistest::parse_lynis_section_list("assets_private/$baseline_file");
+    for my $section_baseline (@section_list_baseline) {
+        # Rename the section for easier "regex match"
+        $section_baseline = lynis::lynistest::rename_lynis_section($section_baseline);
+
+        $section_baseline = substr($section_baseline, 4);
+        if ("$section" eq "$section_baseline") {
+            # Found the section in baseline
+            $found = 1;
+            last;
+        }
+    }
+
+    # Replace "\n, \r" in this section for easier show up
+    $section_orig =~ s/\n//g;
+    $section_orig =~ s/\r//g;
+    if ($found) {
+        # Do find the section in baseline, compare the results between "baseline" and "current"
+        record_info("Found", "Found \"$section_orig\" in baseline file, then compare the results between \"baseline\" and \"current\"!");
+        @section_content_baseline = lynis::lynistest::parse_lynis_section_content($section_orig, "assets_private/$baseline_file");
+        @section_content_current  = lynis::lynistest::parse_lynis_section_content($section_orig, "assets_private/$current_file");
+        $results                  = lynis::lynistest::compare_lynis_section_content($found, \@section_content_baseline, \@section_content_current);
+    }
+    else {
+        # Do not find the section in baseline, check the current file testing results
+        # It is a new section, report "WARNING" and "softfailure"
+        # Check the results according to "Settings": "LYNIS_OK", "LYNIS_ERROR", "LYNIS_WARNING"
+        record_info("NotFound", "Not found \"$section_orig\" in baseline file");
+        record_info("WARNING",  "New section \"$section_orig\" detected, please check and update the baseline!");
+        # Set softfail for checking and updating the baseline
+        record_soft_failure("poo#78224, Not found \"$section_orig\" in baseline file, set softfail and only check results in \"current\"");
+        @section_content_baseline = lynis::lynistest::parse_lynis_section_content($section_orig, "assets_private/$baseline_file");
+        @section_content_current  = lynis::lynistest::parse_lynis_section_content($section_orig, "assets_private/$current_file");
+        $results                  = lynis::lynistest::compare_lynis_section_content($found, \@section_content_baseline, \@section_content_current);
+        if ("$results" eq "ok") {
+            $results = "softfail";
+        }
+    }
+
+    $self->result("$results");
+}
+
+1;

--- a/lib/lynis/lynistest.pm
+++ b/lib/lynis/lynistest.pm
@@ -1,0 +1,289 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Base module for Lynis test cases
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#78224
+
+package lynis::lynistest;
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+use autotest;
+
+use base 'consoletest';
+use LTP::TestInfo 'testinfo';
+
+our @EXPORT = qw(
+  $testdir
+  $f_position_b
+  $f_position_c
+  @lynis_ok
+  @lynis_fail
+  @lynis_softfail
+  $lynis_baseline_file
+  $lynis_baseline_file_default
+  $lynis_audit_system_current_file
+  $lynis_audit_system_error_file
+  parse_lynis_section_list
+  load_lynis_section_tests
+  parse_lynis_section_content
+  compare_lynis_section_content
+);
+
+our $testdir = "/tmp/";
+
+# File pointer
+our $f_position_b = 0;
+our $f_position_c = 0;
+
+our $lynis_baseline_file_default = "baseline-lynis-audit-system-nocolors-sle15sp3-x86_64-snapshot7-textmode";
+our $lynis_baseline_file         = get_var("LYNIS_BASELINE_FILE", $lynis_baseline_file_default);
+
+our $lynis_audit_system_current_file = "lynis_audit_system_current_file";
+our $lynis_audit_system_error_file   = "lynis_audit_system_error_file";
+
+# Lynix test status mappping with openQA
+our @lynis_ok       = split(/,/, get_var("LYNIS_OK",      "OK,DONE,YES"));
+our @lynis_fail     = split(/,/, get_var("LYNIS_ERROR",   "ERROR,WEAK,UNSAFE"));
+our @lynis_softfail = split(/,/, get_var("LYNIS_WARNING", "WARNING,EXPOSED,NONE,SUGGESTION"));
+
+sub loadtest_lynis {
+    my ($test, %args) = @_;
+    autotest::loadtest("lib/lynis/$test.pm", %args);
+}
+
+# Parse lynis test report sections
+# input: $file - file name
+# output: @section_list - section list
+sub parse_lynis_section_list {
+    my ($file) = @_;
+    # Section token
+    my $s_tok        = '\[\+\] ';
+    my @section_list = ();
+
+    my $rf;
+    my $i = 0;
+
+    # Parse the "sections" of input file
+    open($rf, $file) or die "Can not open $file, $!";
+    while (my $line = <$rf>) {
+        if ($line =~ /$s_tok/) {
+            push @section_list, $line;
+            $i++;
+        }
+    }
+    record_info("T: $i", "Total \"$i\" sections found in file \"$file\":\n @section_list");
+    close($rf) or die "Can not close $file, $!";
+    return @section_list;
+}
+
+# Rename the section for a eaiser regex matching
+sub rename_lynis_section {
+    my ($section) = @_;
+    my @flags;
+
+    # Added "my" before parameter to fix CI check error "Loop iterator is not lexical at line 265, column 5.  See page 108 of PBP.  (Severity: 4)"
+    @flags = ('\[\+\] ');
+    foreach my $s_flag (@flags) {
+        $section =~ s/$s_flag/[+]_/g;
+    }
+
+    @flags = (' ', '\(', '\)');
+    foreach my $s_flag (@flags) {
+        $section =~ s/$s_flag/_/g;
+    }
+
+    @flags = ('\n', '\r');
+    foreach my $s_flag (@flags) {
+        $section =~ s/$s_flag//g;
+    }
+
+    return $section;
+}
+
+# Load the tests/modules according to section list
+# input: @section_list - section list
+sub load_lynis_section_tests {
+    my (@section_list) = @_;
+    my $i = 1;
+
+    # The main script which dynamically generates test modules according to different sections
+    my $script = "lynis_run";
+    my $tinfo  = testinfo({}, test => "$script");
+
+    for my $section (@section_list) {
+        $tinfo = testinfo({}, test => $section);
+        loadtest_lynis("$script", name => $i . "_" . rename_lynis_section($section), run_args => $tinfo);
+        $i++;
+    }
+}
+
+# Parse the contents of each section
+# input: $section - section name
+#        $file - file name
+# output: @section_content - section content parsed
+sub parse_lynis_section_content {
+    my ($section, $file) = @_;
+    my $rf;
+    my $str;
+    my $str_orig;
+    my $s_tok           = '\[\+\] ';
+    my $found           = 0;
+    my @section_content = ();
+
+    $section = substr($section, 4);
+
+    # Parse the "section" contents of input file
+    open($rf, "$file") or die "Can not open $file, $!";
+
+    # Seek the position to avoid duplicated section names
+    if ($file =~ /baseline/) {
+        seek($rf, $f_position_b, 0);
+    }
+    else {
+        seek($rf, $f_position_c, 0);
+    }
+
+    while (my $line = <$rf>) {
+        $str_orig = $line;
+        $str      = $str_orig;
+
+        if ($str =~ /$s_tok/) {
+            # Found a section
+            if ($found == 1) {
+                # This line of content belongs to another/following section, then exit
+                last;
+            }
+
+            # Replace "\n, \r, \(, \) " in this section for easier regex match
+            $str =~ s/\n//g;
+            $str =~ s/\r//g;
+            $str =~ s/\(/_/g;
+            $str =~ s/\)/_/g;
+
+            $section =~ s/\(/_/g;
+            $section =~ s/\)/_/g;
+
+            my $str_new = substr($str, 4);
+            if ("$section" eq "$str_new") {
+                # Found the section
+                # This line of content belongs to this section, then save
+                push @section_content, $str_orig;
+                $found = 1;
+
+                # Save the position for next search to avoid duplicated section name
+                if ($file =~ /baseline/) {
+                    $f_position_b = tell($rf);
+                }
+                else {
+                    $f_position_c = tell($rf);
+                }
+            }
+        }
+        else {
+            # Found a new line but not a section
+            if ($found == 1) {
+                # This line of content belongs to this section, then save
+                push @section_content, $str_orig;
+            }
+        }
+    }
+
+    if ($file =~ /baseline/) {
+        record_info("FYI: baseline content", "@section_content");
+    }
+    else {
+        record_info("FYI: current content", "@section_content");
+    }
+
+    close($rf) or die "Can not close $file, $!";
+
+    return @section_content;
+}
+
+# Compare the contents between "baseline" and "current"
+# input: $found - "1", this section is found in baseline file; "0", not found
+#        $arrar1 - section content of "baseline"
+#        $arrar2 - section content of "current"
+# output: $result - compare results: e.g., "ok", "softfail", "fail"
+sub compare_lynis_section_content {
+    my ($found, $array1, $array2) = @_;
+    my @section_baseline = @$array1;
+    my @section_current  = @$array2;
+
+    my $s_new;
+    my $ret    = 0;
+    my $result = "ok";
+
+    # If an old section then compare baseline and current
+    if ($found) {
+        # Do not use "if (@section_baseline ~~ @section_current) {" to avoid
+        # CI check Error "Smartmatch is experimental"
+        if ("join('', @section_baseline)" eq "join('', @section_current)") {
+            record_info("Same", "Section contents of \"Current\" and \"Baseline\" are the same, exit and pass");
+            $result = "ok";
+            return $result;
+        }
+        else {
+            record_info("NotSame", "Section contents of \"Current\" and \"Baseline\" are NOT the same, check \"Current\" only");
+        }
+    }
+
+    # Filter out "System_Tools": "[2C- Starting dbus policy check...[28C"
+    # As this will likely change rather frequently and we have good mechanisms
+    # on our side to tackle this
+    if (grep(/Starting dbus policy check/, @section_current)) {
+        $result = "ok";
+        return $result;
+    }
+
+    # If a new section then only check the current
+    record_info("CHECK", "Section contents NOT the same then check \"Current\" only");
+    for my $s_lynis (@lynis_ok) {
+        $s_new = "\\[.*$s_lynis.*\\]";
+        $ret   = grep(/$s_new/, @section_current);
+        if ($ret) {
+            $result = "ok";
+            record_info("[$s_lynis] ");
+            record_info(":$ret", "found $ret [ $s_lynis ] in current output");
+        }
+    }
+
+    for my $s_lynis (@lynis_softfail) {
+        $s_new = "\\[.*$s_lynis.*\\]";
+        $ret   = grep(/$s_new/, @section_current);
+        if ($ret) {
+            $result = "softfail";
+            record_soft_failure("poo#78224, found $ret [ $s_lynis ] in current output");
+        }
+    }
+
+    for my $s_lynis (@lynis_fail) {
+        $s_new = "\\[.*$s_lynis.*\\]";
+        $ret   = grep(/$s_new/, @section_current);
+        if ($ret) {
+            $result = "fail";
+            # Invoke record_soft_failure() for better/notable openQA show
+            record_soft_failure("poo#78224, found $ret [ $s_lynis ] in current output");
+        }
+    }
+
+    return $result;
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2379,6 +2379,15 @@ sub load_security_tests_yast2_users {
     loadtest "security/yast2_users/add_users";
 }
 
+sub load_security_tests_lynis {
+    load_security_console_prepare;
+
+    loadtest "security/lynis/lynis_setup";
+    loadtest "security/lynis/lynis_perform_system_audit";
+    loadtest "security/lynis/lynis_analyze_system_audit";
+    loadtest "security/lynis/lynis_harden_index";
+}
+
 sub load_security_tests_openscap {
     # ALWAYS run following tests in sequence because of the dependencies
 
@@ -2595,6 +2604,7 @@ sub load_security_tests {
       tpm2
       pam
       grub_auth
+      lynis
     );
 
     # Check SECURITY_TEST and call the load functions iteratively.

--- a/tests/security/lynis/lynis_analyze_system_audit.pm
+++ b/tests/security/lynis/lynis_analyze_system_audit.pm
@@ -1,0 +1,61 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Integrate the Lynis scanner into OpenQA: analyze the "system audit"
+#          current outputs with baseline
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#78224, poo#78230, poo#78330
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lynis::lynistest;
+
+sub run {
+    my $dir           = $lynis::lynistest::testdir;
+    my $baseline_file = $lynis::lynistest::lynis_baseline_file;
+    my $current_file  = $lynis::lynistest::lynis_audit_system_current_file;
+    my $f_position_b  = $lynis::lynistest::f_position_b;
+    my $f_position_c  = $lynis::lynistest::f_position_c;
+
+    # Section name list
+    my @section_list_current  = ();
+    my @section_list_baseline = ();
+
+    select_console "root-console";
+
+    # Parse the "sections" in baseline file
+    upload_asset("$dir" . "$baseline_file");
+    @section_list_baseline = lynis::lynistest::parse_lynis_section_list("assets_private/$baseline_file");
+
+    # Parse the "sections" in new/current output files of "# lynis audit system"
+    upload_asset("$dir" . "$current_file");
+    @section_list_current = lynis::lynistest::parse_lynis_section_list("assets_private/$current_file");
+
+    if (@section_list_baseline != @section_list_current) {
+        record_soft_failure("poo#78224, Section quantity are not the same");
+    }
+
+    # Generate test cases/modules dynamically according to the sections,
+    # compare the results between "current" and "baseline",
+    # initiate files' pointer
+    $f_position_b = 0;
+    $f_position_c = 0;
+    lynis::lynistest::load_lynis_section_tests(@section_list_current);
+}
+
+1;

--- a/tests/security/lynis/lynis_harden_index.pm
+++ b/tests/security/lynis/lynis_harden_index.pm
@@ -1,0 +1,50 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Integrate the Lynis scanner into OpenQA: Checking the "Hardening
+#          index" numerical values should be the same
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#78224, poo#78230
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lynis::lynistest;
+
+sub run {
+    my $dir                 = $lynis::lynistest::testdir;
+    my $lynis_baseline_file = "$dir" . $lynis::lynistest::lynis_baseline_file;
+    my $lynis_current_file  = "$dir" . $lynis::lynistest::lynis_audit_system_current_file;
+    my $str                 = "Hardening index";
+
+    select_console "root-console";
+
+    # Parse the "Hardening index" of baseline and current files
+    my $out_b   = script_output("grep \"$str\" $lynis_baseline_file");
+    my $out_c   = script_output("grep \"$str\" $lynis_current_file");
+    my $index_b = script_output("echo $out_b | cut -d ':' -f2 | cut -d ' ' -f2");
+    my $index_c = script_output("echo $out_c | cut -d ':' -f2 | cut -d ' ' -f2");
+    if ("$index_b" eq "$index_c") {
+        record_info("Same", "\"Hardening index\" is the same.\n Baseline: $out_b\n Current: $out_c");
+    }
+    else {
+        record_info("NotSame", "\"Hardening index\" is NOT the same.\n Baseline: $out_b\n Current: $out_c");
+        record_soft_failure("poo#78224, \"Hardening index\" is NOT the same please check");
+    }
+}
+
+1;

--- a/tests/security/lynis/lynis_perform_system_audit.pm
+++ b/tests/security/lynis/lynis_perform_system_audit.pm
@@ -1,0 +1,53 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Integrate the Lynis scanner into OpenQA: Performs a system audit
+#          and upload related outputs
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#78224, poo#78230, poo#78330
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lynis::lynistest;
+
+sub run {
+    my $dir                             = $lynis::lynistest::testdir;
+    my $lynis_baseline_file             = "$dir" . $lynis::lynistest::lynis_baseline_file;
+    my $lynis_audit_system_current_file = "$dir" . $lynis::lynistest::lynis_audit_system_current_file;
+    my $lynis_audit_system_error_file   = "$dir" . $lynis::lynistest::lynis_audit_system_error_file;
+
+    select_console "root-console";
+
+    # Run "# lynis audit system" to "Performs a system audit" and save the outputs
+    assert_script_run("rm -rf $lynis_audit_system_current_file");
+    assert_script_run("rm -rf $lynis_audit_system_error_file");
+    assert_script_run("lynis audit system --nocolors > $lynis_audit_system_current_file 2> $lynis_audit_system_error_file", timeout => 600);
+
+    # Upload the outputs for reference: e.g.,
+    # file "$lynis_audit_system_current_file" can be used to be a new baseline
+    # file "$lynis_audit_system_error_file" can be used to check lynis warnings/errors
+    upload_logs("$lynis_audit_system_current_file");
+    upload_logs("/var/log/lynis.log");
+    upload_logs("$lynis_audit_system_error_file", failok => 1);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/security/lynis/lynis_setup.pm
+++ b/tests/security/lynis/lynis_setup.pm
@@ -1,0 +1,55 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Integrate the Lynis scanner into OpenQA: lynis env setup
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#78224, poo#88155
+
+use base 'consoletest';
+use version_utils qw(is_sle);
+use registration qw(add_suseconnect_product);
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lynis::lynistest;
+
+sub run {
+    my $lynis_baseline_file = $lynis::lynistest::lynis_baseline_file;
+    my $dir                 = $lynis::lynistest::testdir;
+
+    select_console "root-console";
+
+    if (is_sle) {
+        add_suseconnect_product("PackageHub", undef, undef, undef, 300, 1);
+        zypper_call("in lynis", timeout => 300);
+    }
+
+    # Record the pkgs' version for reference
+    my $results = script_output("rpm -qi lynis");
+    record_info("Pkg_ver", "Lynix packages' version is: $results");
+
+    # Download the $LYNIS_BASELINE_FILE ($lynis_baseline_file_bydefault) baseline
+    assert_script_run("wget --quiet " . data_url("lynis/$lynis_baseline_file") . " -O " . "$dir" . "$lynis_baseline_file");
+
+    # Install server software, e.g., apache
+    zypper_call("in apache2 apache2-utils");
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Integrate Lynis into OpenQA:
    Lynis - System and security auditing tool
    Lynis is a security auditing tool for Linux, macOS, and other systems based on UNIX.
    The tool checks the system and the software configuration, to see if there is
    any room for improvement the security defenses. All details are stored in a log file.
    This test case can build a "baseline" from the "log" file and compare
    "current/latest" "log" file with "baseline" file.
    We will support running for gnome images and other arches later.

- Related ticket:
  parent poo:    
      poo#78224 - [sle][security][sle15sp3] Integrate the Lynis scanner into OpenQA
  sub poo:
      poo#78330 - [sle][security][sle15sp3] Integrate Lynis into OpenQA - find a suitable output format for openQA automation
      poo#88155 - [sle][security][sle15sp3] Integrate Lynis into OpenQA - setup env
      poo#78230 - [sle][security][sle15sp3] Integrate Lynis into OpenQA - run lynis on Beta1 textmode image, analyse the report , create the Beta1 base line
- Needles: NA
- Verification run: https://openqa.suse.de/tests/5390756# on latest build 136.1 (all passed, soft failure can be tracked by poo#78224 atm)
