### PR TITLE
Modify kernel performance test codes for HANA

### DIFF
--- a/tests/kernel_performance/full_run.pm
+++ b/tests/kernel_performance/full_run.pm
@@ -33,7 +33,8 @@ sub full_run {
     assert_script_run("/usr/share/qa/qaset/qaset reset");
     assert_script_run("/usr/share/qa/qaset/run/performance-run.upload_Beijing");
     while (1) {
-        if (script_run("cat /var/log/qaset/control/NEXT_RUN | grep '_'") == 0) {
+        if ((script_run("cat /var/log/qaset/control/NEXT_RUN | grep '_'") == 0) ||
+            (script_run("ps ax | grep [r]untest") == 0)) {
             last;
         }
         if ($time_out == 0) {

--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -31,10 +31,23 @@ sub setup_environment {
     my $ver_path          = "/root";
 
     assert_script_run("wget -N -P $ver_path $ver_cfg 2>&1");
-    assert_script_run(
-        "/usr/share/qa/qaset/bin/deploy_performance.sh $runid $mitigation_switch"
-    );
-    assert_script_run("cat /root/qaset/qaset-setup.log");
+    if (get_var("HANA_PERF")) {
+        assert_script_run("/usr/share/qa/qaset/bin/deploy_hana_perf.sh $runid $mitigation_switch");
+        assert_script_run("ls /root/qaset/deploy_hana_perf_env.done");
+        if (my $qaset_config = get_var("QASET_CONFIG")) {
+            my @fields = split(/;/, $qaset_config);
+            if (scalar @fields > 0) {
+                foreach my $qaset_config (@fields) {
+                    assert_script_run("echo ${qaset_config} >> /root/qaset/config");
+                }
+            }
+        }
+    } else {
+        assert_script_run(
+            "/usr/share/qa/qaset/bin/deploy_performance.sh $runid $mitigation_switch"
+        );
+        assert_script_run("cat /root/qaset/qaset-setup.log");
+    }
 }
 
 sub run {


### PR DESCRIPTION
Improve current kernel performance test codes for HANA performance testing.
1)  Add HANA_PERF switch for detecting HANA performance code path
2) Add QASET_CONFIG switch for appending options to "/root/qaset/config" file
3) Detect [r]untest proccess to check if full run is launched.

- Verification run: http://10.67.19.72/tests/overview?distri=sle&version=15-SP2&build=GM&groupid=4
