### PR TITLE
Add a test suite using encrypted disk in autoyast

### DIFF
--- a/data/autoyast_sle15/autoyast_reuse-encrypted.xml
+++ b/data/autoyast_sle15/autoyast_reuse-encrypted.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">true</confirm>
+    </mode>
+  </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+    </bootloader>
+    <suse_register>
+      <do_registration config:type="boolean">true</do_registration>
+      <email/>
+      <reg_code>{{SCC_REGCODE}}</reg_code>
+      <install_updates config:type="boolean">true</install_updates>
+      <reg_server>{{SCC_URL}}</reg_server>
+      <addons config:type="list">
+        <addon>
+          <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        </addon>
+        <addon>
+          <name>sle-we</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+          <reg_code>{{SCC_REGCODE_WE}}</reg_code>
+        </addon>
+      </addons>
+    </suse_register>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+    <networking>
+      <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+  <partitioning t="list">
+    <drive t="map">
+      <device>/dev/system</device>
+      <enable_snapshots t="boolean">true</enable_snapshots>
+      <partitions t="list">
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">xfs</filesystem>
+          <format t="boolean">false</format>
+          <lv_name>home</lv_name>
+          <mount>/home</mount>
+          <mountby t="symbol">device</mountby>
+          <pool t="boolean">false</pool>
+          <resize t="boolean">false</resize>
+          <size>7314866176</size>
+          <stripes t="integer">1</stripes>
+          <stripesize t="integer">0</stripesize>
+        </partition>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <create_subvolumes t="boolean">true</create_subvolumes>
+          <filesystem t="symbol">btrfs</filesystem>
+          <format t="boolean">false</format>
+          <lv_name>root</lv_name>
+          <mount>/</mount>
+          <mountby t="symbol">device</mountby>
+          <pool t="boolean">false</pool>
+          <quotas t="boolean">true</quotas>
+          <resize t="boolean">false</resize>
+          <size>15804137472</size>
+          <stripes t="integer">1</stripes>
+          <stripesize t="integer">0</stripesize>
+          <subvolumes t="list">
+            <subvolume t="map">
+              <copy_on_write t="boolean">false</copy_on_write>
+              <path>var</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>usr/local</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>tmp</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>srv</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>root</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>opt</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>boot/grub2/x86_64-efi</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>boot/grub2/i386-pc</path>
+            </subvolume>
+          </subvolumes>
+          <subvolumes_prefix>@</subvolumes_prefix>
+        </partition>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">swap</filesystem>
+          <format t="boolean">false</format>
+          <lv_name>swap</lv_name>
+          <mount>swap</mount>
+          <mountby t="symbol">device</mountby>
+          <pool t="boolean">false</pool>
+          <resize t="boolean">false</resize>
+          <size>1560281088</size>
+          <stripes t="integer">1</stripes>
+          <stripesize t="integer">0</stripesize>
+        </partition>
+      </partitions>
+      <pesize>4194304</pesize>
+      <type t="symbol">CT_LVM</type>
+    </drive>
+    <drive t="map">
+      <device>/dev/vda</device>
+      <disklabel>gpt</disklabel>
+      <partitions t="list">
+        <partition t="map">
+          <create t="boolean">true</create>
+          <format t="boolean">false</format>
+          <partition_id t="integer">263</partition_id>
+          <partition_nr t="integer">1</partition_nr>
+          <resize t="boolean">false</resize>
+          <size>8388608</size>
+        </partition>
+        <partition t="map">
+          <create t="boolean">false</create>
+          <crypt_key>nots3cr3t</crypt_key>
+          <crypt_method t="symbol">luks1</crypt_method>
+          <format t="boolean">false</format>
+          <loop_fs t="boolean">true</loop_fs>
+          <lvm_group>system</lvm_group>
+          <partition_id t="integer">142</partition_id>
+          <partition_nr t="integer">2</partition_nr>
+          <resize t="boolean">false</resize>
+          <size>24686607872</size>
+        </partition>
+      </partitions>
+      <type t="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+    <users config:type="list">
+      <user>
+        <fullname>Bernhard M. Wiedemann</fullname>
+        <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+      </user>
+      <user>
+        <encrypted config:type="boolean">false</encrypted>
+        <user_password>nots3cr3t</user_password>
+        <username>root</username>
+      </user>
+    </users>
+    <software>
+      <products config:type="list">
+        <product>SLES</product>
+        <product>sle-we</product>
+      </products>
+      <patterns config:type="list">
+        <pattern>base</pattern>
+        <pattern>enhanced_base</pattern>
+        <pattern>yast2_basis</pattern>
+        </patterns>
+    </software>
+</profile>

--- a/lib/validate_encrypt_utils.pm
+++ b/lib/validate_encrypt_utils.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   verify_cryptsetup_properties
   verify_restoring_luks_backups
   verify_locked_encrypted_partition
+  validate_activation_encrypted_partition
 );
 
 =head2 parse_devices_in_crypttab
@@ -228,6 +229,15 @@ sub verify_locked_encrypted_partition {
         die "partition '/dev/$enc_disk_part' is already unlocked";
     }
     record_info('lock OK', "Encrypted partition '/dev/$enc_disk_part' still locked");
+}
+
+sub validate_activation_encrypted_partition {
+    my ($args) = @_;
+    select_console 'install-shell';
+    my $status = parse_cryptsetup_status($args->{mapped_device});
+    verify_cryptsetup_message($args->{message}, $status->{message});
+    verify_cryptsetup_properties($args->{properties}, $status->{properties});
+    select_console 'installation';
 }
 
 1;

--- a/schedule/yast/autoyast/autoyast_cryptlvm+activate_existing.yaml
+++ b/schedule/yast/autoyast/autoyast_cryptlvm+activate_existing.yaml
@@ -1,0 +1,18 @@
+---
+name: autoyast_cryptlvm+activate_existing
+description: >
+    Conduct autoyast installation activating encrypted partitions
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_reuse-encrypted.xml
+  ENCRYPT_ACTIVATE_EXISTING: '1'
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/validate_encrypt
+  - autoyast/clone
+  - autoyast/verify_cloned_profile
+  - autoyast/logs

--- a/test_data/yast/encryption/autoyast_cryptlvm+activate_existing.yaml
+++ b/test_data/yast/encryption/autoyast_cryptlvm+activate_existing.yaml
@@ -1,0 +1,42 @@
+mapped_device: '/dev/mapper/cr-auto-1'
+profile:
+  partitioning:
+    - drive:
+        unique_key: device
+        device: /dev/system0
+    - drive:
+        unique_key: device
+        device: /dev/vda
+        disklabel: gpt
+        partitions:
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 1
+          - partition:
+              unique_key: partition_nr
+              partition_nr: 2
+              crypt_method: luks1
+              loop_fs: 'true'
+disks:
+  - name: vda
+    partitions:
+      - size: 2MiB
+        role: raw-volume
+        id: bios-boot
+      - role: raw-volume
+        id: linux-lvm
+        encrypt_device: 1
+lvm:
+  volume_groups:
+  - name: vg-system
+    devices:
+      - /dev/vda2
+    logical_volumes:
+      - name: lv-swap
+        size: 2000MiB
+        role: swap
+      - name: lv-root
+        role: operating-system
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/yast/encryption/default_enc.yaml

--- a/tests/console/validate_activation_encrypted_partition.pm
+++ b/tests/console/validate_activation_encrypted_partition.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -24,11 +24,11 @@ use validate_encrypt_utils;
 
 sub run {
     my $test_data = get_test_suite_data();
-    select_console 'install-shell';
-    my $status = parse_cryptsetup_status($test_data->{mapped_device});
-    verify_cryptsetup_message($test_data->{device_status}->{message}, $status->{message});
-    verify_cryptsetup_properties($test_data->{device_status}->{properties}, $status->{properties});
-    select_console 'installation';
+    validate_activation_encrypted_partition({
+            mapped_device => $test_data->{mapped_device},
+            device_status => $test_data->{device_status}->{message},
+            properties    => $test_data->{device_status}->{properties}
+    });
 }
 
 1;


### PR DESCRIPTION
Test covers installation activating existing encrypted partitions.

Progress ticket: https://progress.opensuse.org/issues/33364

- Verification runs: 
[autoyast_cryptlvm+activate_existing@64bit](http://waaa-amazing.suse.cz/tests/13885#)
[cryptlvm+activate_existing@64bit](http://waaa-amazing.suse.cz/tests/13884)
