### PR TITLE
Fix patch_sle yast scc registration timeout on Aarch64

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -739,9 +739,11 @@ sub yast_scc_registration {
         $client_module = 'registration';
     }
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module, yast2_opts => $args{yast2_opts});
+    # For Aarch64 if the worker run with heavy loads, it will
+    # timeout in nearly 120 seconds. So we set it to 150.
     assert_screen_with_soft_timeout(
         'scc-registration',
-        timeout      => 90,
+        timeout      => (check_var('ARCH', 'aarch64')) ? 150 : 90,
         soft_timeout => 30,
         bugref       => 'wait longer time to start yast2 scc in case of multiple jobs start to execute it in parallel on a same worker'
     );


### PR DESCRIPTION
When run patch_sle on Aarch64, if there are lots of workloads on
one worker the yast scc registration will need more time to bring
up the registration screen. We need wait more time at this scenario.


- Related ticket: https://progress.opensuse.org/issues/81350
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/5230999
  https://openqa.nue.suse.com/tests/5231000
  https://openqa.nue.suse.com/tests/5231001
  
  https://openqa.nue.suse.com/t5232827
  https://openqa.nue.suse.com/t5232828