### PR TITLE
Implement liboauth test into FIPS test group

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2273,6 +2273,12 @@ sub load_security_tests_crypt_tool {
     loadtest "console/openvswitch_ssl";
 }
 
+sub load_security_tests_crypt_libtool {
+    load_security_console_prepare;
+
+    loadtest "fips/libtool/liboauth";
+}
+
 sub load_security_tests_crypt_krb5kdc {
 
     loadtest "console/consoletest_setup";
@@ -2572,7 +2578,7 @@ sub load_mitigation_tests {
 sub load_security_tests {
     my @security_tests = qw(
       fips_setup crypt_core crypt_web crypt_kernel crypt_x11 crypt_firefox crypt_tool
-      crypt_krb5kdc crypt_krb5server crypt_krb5client
+      crypt_libtool crypt_krb5kdc crypt_krb5server crypt_krb5client
       ipsec mmtest
       apparmor apparmor_profile yast2_apparmor yast2_users selinux
       openscap

--- a/tests/fips/libtool/liboauth.pm
+++ b/tests/fips/libtool/liboauth.pm
@@ -1,0 +1,100 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: liboauth test for FIPS integration test
+#
+# Description: liboauth is a collection of c functions implementing the
+#              http://oauth.net API. liboauth provides functions to escape
+#              and encode stings according to OAuth specifications  and
+#              offers high-level functionality built on top to sign requests
+#              or verify signatures using either NSS or OpenSSL for calculating
+#              the hash/signatures.
+#
+# Maintainer: Ben Chou <bchou@suse.com>
+# Tags: poo#81260, tc#1767540
+
+use base "consoletest";
+use testapi;
+use utils;
+use utils "zypper_call";
+use strict;
+use warnings;
+use registration qw(add_suseconnect_product cleanup_registration register_product);
+
+sub run {
+    select_console 'root-console';
+
+    zypper_output();
+
+    # Since we use the functional group qcow2 which is regitered to proxyscc
+    # The Source RPM packages are all located in SCC source pool repository
+    # Step 1. SUSEConnect -d deregister from proxyscc
+    # Step 2. SUSEConnect -r <CODE> to SCC
+    # Step 3. SUSEConnect -p module to add DEV tool and Desktop App modules
+
+    # De-register the system from proxyscc due to source RPM package does not mirror to proxyscc
+    cleanup_registration();
+    zypper_output();
+
+    # Register to official SCC(https://scc.suse.com) to get source RPM packages
+    register_product();
+    zypper_output();
+
+    # Add Desktop Applications Module
+    add_suseconnect_product("sle-module-desktop-applications");
+
+    # Add Devlopment Tool Modules
+    add_suseconnect_product("sle-module-development-tools");
+
+    zypper_output();
+
+    # enable source repositories to get latest source packages
+    assert_script_run('for r in `zypper lr|awk \'/Source-Pool/ {print $5}\'`; do zypper mr -e --refresh $r; done');
+    zypper_output();
+
+    # Install the liboauth source RPM package
+    zypper_call('in -t srcpackage liboauth');
+    assert_script_run('rpm -qi liboauth0');
+
+    # rpm-build is from Development Tools Module 15 SP3 repo
+    # Need to register and Install to Devleopment Tool module first
+    # libcurl-devel & libtool need to be installed due to liboauth dependancy
+    # libopenssl-devel is required to build liboauth
+    # zypper in libcurl-devel ( Development files for the curl library)
+    # zypper in libtool (A Tool to Build Shared Libraries)
+    zypper_call('in rpm-build libcurl-devel libopenssl-devel libtool');
+
+    # Use rpmbuild tool to Compile liboauth
+    assert_script_run('cd /usr/src/packages');
+    assert_script_run('rpmbuild -bc SPECS/liboauth.spec', 2000);
+
+    # Run liboauth self-tests
+    assert_script_run('cd /usr/src/packages/BUILD/liboauth-*/ && pwd');
+    # Execute 'make check' to do the self-tests check
+    validate_script_output "make check 2>&1 || true", sub { m/PASS:  3/ };
+
+}
+
+sub zypper_output {
+    zypper_call("ref", timeout => 1200);
+    zypper_call('lr');
+    zypper_call('lr -u');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
**Description:**
Add a new test case liboauth into FIPS test group.
1. liboauth is a collection of c functions implement http://oauth.net API.
2. The purpose is testing the liboauth complie and verify the result 
    liboauth provides functions to escape and encode strings according to OAuth specifications and offers high-level functionality built on top to sign requests or verify signatures using either NSS or OpenSSL for calculating the hash/signatures.

Related bug: bsc#[1170000](https://bugzilla.suse.com/show_bug.cgi?id=1170000) - [SLES15SP2] [Build 178.1][FIPS] liboauth0 and libqt5-qtbase source package cannot be retrieved from Source Pool."

- Related ticket: https://progress.opensuse.org/issues/81260
- Needles: NA
- Verification run: (Test passed in Dev job group)
   https://openqa.suse.de/tests/5254090 (non-FIPS Mode test)
   https://openqa.suse.de/tests/5254091 (FIPS Mode test)
   https://openqa.suse.de/tests/5254128 (Updated VR, load sub **load_security_console_prepare**)