### PR TITLE
HA: add ReaR tests

### DIFF
--- a/data/ha/rear_local.conf
+++ b/data/ha/rear_local.conf
@@ -1,0 +1,20 @@
+# Default is to create Relax-and-Recover rescue media as ISO image
+# set OUTPUT to change that
+# set BACKUP to activate an automated (backup and) restore of your data
+# Possible configuration values can be found in /usr/share/rear/conf/default.conf
+#
+# This file (local.conf) is intended for manual configuration. For configuration
+# through packages and other automated means we recommend creating a new
+# file named site.conf next to this file and to leave the local.conf as it is.
+# Our packages will never ship with a site.conf.
+BACKUP=NETFS
+OUTPUT=ISO
+BACKUP_URL=%BACKUP_URL%
+BACKUP_OPTIONS=nolock
+NETFS_KEEP_OLD_BACKUP_COPY=
+USE_DHCLIENT=
+MODULES_LOAD=( )
+BACKUP_PROG_INCLUDE=(/boot/grub2/i386-pc/* /boot/grub2/x86_64-efi/* /opt/* /root/* /srv/* /tmp/* /usr/local/* /var/*)
+POST_RECOVERY_SCRIPT=(if\ snapper\ --no-dbus\ -r\ $TARGET_FS_ROOT\ get-config\ |\ grep\ -q\ "^QGROUP.*[0-9]/[0-9]"\ ;\ then\ snapper\ --no-dbus\ -r\ $TARGET_FS_ROOT\ set-config\ QGROUP=\ ;\ snapper\ --no-dbus\ -r\ $TARGET_FS_ROOT\ setup-quota\ &&\ echo\ snapper\ setup-quota\ done\ ||\ echo\ snapper\ setup-quota\ failed\ ;\ else\ echo\ snapper\ setup-quota\ not\ used\ ;\ fi)
+REQUIRED_PROGS=(snapper chattr lsattr ${REQUIRED_PROGS[@]})
+COPY_AS_IS=(/usr/lib/snapper/installation-helper /etc/snapper/config-templates/default ${COPY_AS_IS[@]})

--- a/schedule/ha/rear/rear_backup.yaml
+++ b/schedule/ha/rear/rear_backup.yaml
@@ -1,0 +1,33 @@
+---
+name: rear_backup
+description: >
+  Generate backup files for ReaR tests.
+vars:
+  DROP_PERSISTENT_NET_RULES: '1'
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/releasenotes
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/hostname
+  - console/consoletest_setup
+  - ha/rear_backup

--- a/schedule/ha/rear/rear_restore.yaml
+++ b/schedule/ha/rear/rear_restore.yaml
@@ -1,0 +1,17 @@
+---
+name: rear_restore
+description: >
+  Restore ReaR backup files.
+vars:
+  BOOTFROM: c
+  BOOT_HDD_IMAGE: '1'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-%DESKTOP%.qcow2
+schedule:
+  - ha/rear_restore
+  - '{{scc_deregister}}'
+conditional_schedule:
+  scc_deregister:
+    SCC_DEREGISTER:
+      1:
+        - console/scc_deregistration

--- a/tests/ha/rear_backup.pm
+++ b/tests/ha/rear_backup.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Install ReaR packages and create a ReaR backup on an NFS server
+# Maintainer: Loic Devulder <ldevulder@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils qw(file_content_replace quit_packagekit zypper_call);
+
+sub run {
+    my ($self)     = @_;
+    my $hostname   = get_var('HOSTNAME', 'susetest');
+    my $backup_url = get_required_var('BACKUP_URL');
+    my $timeout    = bmwqemu::scale_timeout(300);
+
+    # Disable packagekit and install ReaR
+    get_var('USE_YAST_REAR') ? select_console 'root-console' : $self->select_serial_terminal;
+    quit_packagekit;
+    zypper_call 'in yast2-rear';
+
+    # Configure ReaR by using YaST module
+    if (get_var('USE_YAST_REAR')) {
+        my $backup_options = get_var('BACKUP_OPTIONS', 'nolock');
+        script_run("yast2 rear; echo yast2-rear-status-\$? > /dev/$serialdev", 0);
+        assert_screen('yast-rear-modify-config');
+        send_key('alt-o');    # Validate the default configuration
+        assert_screen('yast-rear-initial-config');
+        send_key('alt-l');    # Set location
+        type_string($backup_url);
+        send_key('alt-p');    # Modify backup options
+        send_key_until_needlematch('yast-rear-backup-options-empty', 'backspace');
+        type_string($backup_options);
+        send_key('alt-s');    # Save configuration and run ReaR backup
+        assert_screen('yast-rear-backup-finished', $timeout);
+        send_key('alt-l');    # Close the status window
+        send_key('alt-o');    # Exit YaST
+        wait_serial('yast2-rear-status-0') || die "'yast2 rear' didn't finish";
+    } else {
+        my $local_conf = '/etc/rear/local.conf';
+        assert_script_run("curl -f -v " . data_url('ha/rear_local.conf') . " -o $local_conf");
+        file_content_replace("$local_conf", q(%BACKUP_URL%) => $backup_url);
+        upload_logs("$local_conf", failok => 1);    # Upload the configuration file
+        assert_script_run('rear -d -D mkbackup', timeout => $timeout);
+    }
+
+    # Upload ISO image
+    upload_asset("/var/lib/rear/output/rear-$hostname.iso", 1);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/ha/rear_restore.pm
+++ b/tests/ha/rear_restore.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Restore a ReaR backup
+# Maintainer: Loic Devulder <ldevulder@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use power_action_utils 'power_action';
+
+sub upload_rear_logs {
+    # Create tarball with logfiles and upload it
+    my $logfile = '/tmp/rear-recover-logs.tar.bz2';
+    script_run("tar cjf $logfile /var/log/rear/rear-*.log /var/lib/rear/layout/* /var/lib/rear/recovery/*");
+    upload_logs("$logfile", failok => 1);
+}
+
+sub run {
+    my ($self) = @_;
+    my $hostname = get_var('HOSTNAME', 'susetest');
+
+    # Select recovering entry and wait for OS boot
+    assert_screen('rear-boot-screen');
+    send_key_until_needlematch('rear-recover-selected', 'up');
+    send_key 'ret';
+    $self->wait_boot_past_bootloader;
+
+    # Restore the OS backup
+    set_var('LIVETEST', 1);                               # Because there is no password in Rear miniOS
+    select_console('root-console', skip_setterm => 1);    # Serial console is not configured in ReaR miniOS
+    assert_script_run('export USER_INPUT_TIMEOUT=5; rear -d -D recover');
+    upload_rear_logs;
+    set_var('LIVETEST', 0);
+
+    # Reboot into the restored OS
+    power_action('reboot', keepconsole => 1);
+    $self->wait_boot;
+
+    # Test login to ensure that the based OS configuration is correctly restored
+    $self->select_serial_terminal;
+    assert_script_run('cat /etc/os-release ; uname -a');
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    upload_rear_logs;
+    $self->SUPER::post_fail_hook unless get_var('LIVETEST', 0);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
ReaR is a tool used to backup/restore OS image. It is part of the HA module but not specific to HA.

This commit adds the first version of automated tests.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1470
- Scheduling: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/225
- Verification run: [rear_backup_virtio](http://1b210.qa.suse.de/tests/8178), [rear_restore_virtio](http://1b210.qa.suse.de/tests/8184), [rear_backup_scsi](http://1b210.qa.suse.de/tests/8180), [rear_restore_scsi](http://1b210.qa.suse.de/tests/8183)

**Note:** the SCSI test is failing because of [bsc#1180295](https://bugzilla.suse.com/show_bug.cgi?id=1180295).
**Note 2:** the ppc64le version will come later (as well as the aarch64 and s390x versions if applicable).