### PR TITLE
Enlarge wait time for text-logged-in-root on aarch64

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -749,7 +749,9 @@ sub activate_console {
                 return;
             }
         }
-        assert_screen "text-logged-in-$user", 60;
+        # For poo#81016, need enlarge wait time for aarch64.
+        my $waittime = check_var('ARCH', 'aarch64') ? 120 : 60;
+        assert_screen "text-logged-in-$user", $waittime;
         unless ($args{skip_set_standard_prompt}) {
             $self->set_standard_prompt($user, skip_set_standard_prompt => $args{skip_set_standard_prompt});
             assert_screen $console;


### PR DESCRIPTION
We need wait more time for tag text-logged-in-root cause ARM's poor performance, I enlarge it from 60s to 120s. 

- Related ticket: https://progress.opensuse.org/issues/81016
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/5230917
