### PR TITLE
Add SuSEfirewall2 to firewalld service check

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -6,7 +6,7 @@ check service status or service function before and after migration
 
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -35,6 +35,7 @@ use services::cups;
 use services::rpcbind;
 use autofs_utils;
 use services::postfix;
+use services::firewall;
 use kdump_utils;
 use version_utils 'is_sle';
 
@@ -71,9 +72,10 @@ our $default_services = {
         service_check_func => \&services::registered_addons::full_registered_check
     },
     susefirewall => {
-        srv_pkg_name  => 'SuSEfirewall2',
-        srv_proc_name => 'SuSEfirewall2',
-        support_ver   => $support_ver_12
+        srv_pkg_name       => 'SuSEfirewall2',
+        srv_proc_name      => 'SuSEfirewall2',
+        support_ver        => $support_ver_lt15,
+        service_check_func => \&services::firewall::full_firewall_check
     },
     firewall => {
         srv_pkg_name  => 'firewalld',

--- a/lib/services/firewall.pm
+++ b/lib/services/firewall.pm
@@ -1,0 +1,78 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Package for firewall service tests
+#
+# On s390x regression test, the reboot_gnome module will fail for firewall
+# with this service change, we can make it work.
+#
+# Maintainer: Huajian Luo <hluo@suse.com>
+
+package services::firewall;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+my $service      = 'firewalld';
+my $service_type = 'Systemd';
+my $pkg          = 'SuSEfirewall2';
+
+sub install_service {
+    zypper_call('in ' . $pkg);
+}
+
+sub susefirewall2_to_firewalld {
+    my $timeout = 180;
+    script_run('susefirewall2-to-firewalld -c',                                     timeout => $timeout);
+    script_run('firewall-cmd --permanent --zone=external --add-service=vnc-server', timeout => $timeout);
+    systemctl 'restart firewalld';
+    script_run('iptables -S', timeout => $timeout);
+}
+
+sub enable_service {
+    common_service_action $service, $service_type, 'enable';
+}
+
+sub start_service {
+    common_service_action $service, $service_type, 'start';
+}
+
+# check service is running and enabled
+sub check_service {
+    common_service_action $service, $service_type, 'is-enabled';
+    common_service_action $service, $service_type, 'is-active';
+}
+
+# check firewall service before and after migration
+# stage is :
+#           'before' for SuSEfirewall2 or
+#           'after' for firewalld after system migration.
+sub full_firewall_check {
+    my ($stage) = @_;
+
+    # we just support SLE12 to SLES15 SuSEfirewall2 to firewalld check
+    return if (get_var('ORIGIN_SYSTEM_VERSION') eq '11-SP4');
+    if ($stage eq 'before') {
+        $service = 'SuSEfirewall2';
+        install_service();
+        enable_service();
+        start_service();
+    } else {
+        $service = 'firewalld';
+        $pkg     = 'susefirewall2-to-firewalld';
+        install_service();
+        susefirewall2_to_firewalld();
+    }
+    check_service();
+}
+
+1;
+


### PR DESCRIPTION
When upgrading from SLE12.X to SLES15SP3, SuSEfirewall2 was not changed
and remains active. Firewalld have firewall2-tofirewalld script to automatically change 
SuSEfirewall2 to firewalld and make it active and enabled.


- Related ticket: https://progress.opensuse.org/issues/68564
- Needles: N/A
- Verification run: 
 S390x
  https://openqa.nue.suse.com/tests/5270845
  https://openqa.nue.suse.com/tests/5270846
 ppc64
 https://openqa.nue.suse.com/t5271969
 https://openqa.nue.suse.com/t5271970

 x86
 https://openqa.nue.suse.com/tests/5271971

 Aarch64
 https://openqa.nue.suse.com/tests/5271972


