### PR TITLE
Remove old travis badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-os-autoinst/openQA tests for openSUSE and SUSE Linux Enterprise [![Build Status](https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse.svg?branch=master)](https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse?branch=master)
+os-autoinst/openQA tests for openSUSE and SUSE Linux Enterprise
 =================================================================================================================================================================================================================================
 os-autoinst-distri-opensuse is repo which contains tests, which are executed
 by openQA for openSUSE and SLE distributions.


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/80394

There  is still an old travis badge in the readme, but we replaced travis with github actions.
Github actions provides badges as well, but we only run the deploy hook on master - not the static code checks aka "PR Checks".
I would actually prefer to enable them for the master branch to ensure, that multiple PRs that would be fine on their own don't bring conflicting changes that break on master.
With the current configuration this wouldn't be detected. I will create a separate PR about this.

![](https://github.com/os-autoinst/os-autoinst-distri-opensuse/workflows/Deploy/badge.svg)
![](https://github.com/os-autoinst/os-autoinst-distri-opensuse/workflows/PR%20Checks/badge.svg)
