### PR TITLE
Do not start cluster md manually

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -78,7 +78,6 @@ sub run {
         }
         barrier_create("CLUSTER_MD_INIT_$cluster_name",             $num_nodes);
         barrier_create("CLUSTER_MD_CREATED_$cluster_name",          $num_nodes);
-        barrier_create("CLUSTER_MD_STARTED_$cluster_name",          $num_nodes);
         barrier_create("CLUSTER_MD_RESOURCE_CREATED_$cluster_name", $num_nodes);
         barrier_create("CLUSTER_MD_CHECKED_$cluster_name",          $num_nodes);
         barrier_create("HAWK_INIT_$cluster_name",                   $num_nodes);

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -62,14 +62,6 @@ sub run {
     # Wait until cluster-md device is created
     barrier_wait("CLUSTER_MD_CREATED_$cluster_name");
 
-    # We need to start the cluster-md device on all nodes but node01, as it still has the device started
-    if (!is_node(1)) {
-        assert_script_run "mdadm -A $clustermd_device \"$clustermd_lun_01\" \"$clustermd_lun_02\"", $default_timeout;
-    }
-
-    # Wait until cluster-md device is started
-    barrier_wait("CLUSTER_MD_STARTED_$cluster_name");
-
     if (is_node(1)) {
         # Create cluster-md resource
         assert_script_run


### PR DESCRIPTION
We don't need to start the `cluster md` stack manually in other nodes than the node1, the cluster will do it itself.

Our cluster md test is failing for 2 months with this error message:
`Dec 30 11:10:30 delta-node01 pacemaker-schedulerd[7192] (native_create_actions) error: Resource cluster_md is active on 3 nodes (attempting recovery)`

In our test, we start the cluster md manually on each nodes before configuring the Raid1 resource agent.
It worked before but we are now facing sporadic conflicts with 15-SP3.
Moreover, the [official documentation](https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/cha-ha-cluster-md.html#sec-ha-cluster-md-ra) does not ask to start cluster md manually.

- Related ticket: https://jira.suse.com/browse/TEAM-2612
- Needles: N/A
- Verification run: 
**3 nodes cluster:** [node1](http://1b143.qa.suse.de/tests/6115) [node2](http://1b143.qa.suse.de/tests/6116) [node3](http://1b143.qa.suse.de/tests/6117)
**2 nodes cluster:** [node1](http://1b143.qa.suse.de/tests/6125) [node2](http://1b143.qa.suse.de/tests/6126)
The tests failed but this is not related to this PR, the cluster md step passed.