### PR TITLE
Reconnect on console when hostname is changed

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -35,6 +35,13 @@ sub run {
     file_content_replace('/etc/sysconfig/network/dhcp', 'DHCLIENT_SET_HOSTNAME="yes"' => 'DHCLIENT_SET_HOSTNAME="no"');
 
     set_hostname(get_var('HOSTNAME', 'susetest'));
+
+    # We have to reconnect to be sure that the new hostname is used
+    unless (get_var('SET_CUSTOM_PROMPT')) {
+        send_key 'ctrl-d';
+        reset_consoles;
+        select_console 'root-console';
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
We have to reconnect on the console to be sure that the new hostname is used.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://1b210.qa.suse.de/tests/8204#step/hostname/23 (I canceled the test after after `hostname` module, as the other parts are not needed).