### PR TITLE
Split regression test to reduce running time

### DIFF
--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -1,0 +1,109 @@
+name:           aarch64_regression_test_offline.yaml
+description:    |
+  This is for aarch64 offline regression test.
+  #REGRESSION_SERVICE: '1' means support service check test. '0' means doesn't
+  #support service check test, normally set '0' for package media test.
+  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
+  #means regression test part2 include x11 test and some performance related test.
+vars:
+  DESKTOP: 'gnome'
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+  BOOTFROM: 'd'
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - update/patch_sle
+  - migration/record_disk_info
+  - '{{install_service}}'
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - '{{isosize_test}}'
+  - installation/bootloader_uefi
+  - installation/welcome
+  - installation/upgrade_select
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - installation/system_workarounds
+  - migration/post_upgrade
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - '{{check_upgraded_service}}'
+  - '{{regression_tests}}'
+  - boot/grub_test_snapshot
+  - migration/version_switch_origin_system
+  - boot/snapper_rollback
+conditional_schedule:
+  check_upgraded_service:
+    REGRESSION_SERVICE:
+      1:
+        - console/check_upgraded_service
+  isosize_test:
+    REGRESSION_SERVICE:
+      1:
+        - installation/isosize
+  install_service:
+    REGRESSION_SERVICE:
+      1:
+        - installation/install_service
+  regression_tests:
+    REGRESSION_TEST:
+      1:
+        - locale/keymap_or_locale
+        - console/supportutils
+        - console/check_package_version
+        - console/force_scheduled_tasks
+        - console/textinfo
+        - console/hostname
+        - console/upgrade_snapshots
+        - console/x_vt
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/zypper_in
+        - console/zypper_log
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/zypper_lifecycle
+        - console/orphaned_packages_check
+        - console/consoletest_finish
+      2:
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/upgrade_snapshots
+        - console/zypper_lifecycle
+        - console/consoletest_finish
+        - x11/desktop_runner
+        - x11/xterm
+        - locale/keymap_or_locale_x11
+        - x11/sshxterm
+        - x11/gnome_control_center
+        - x11/gnome_terminal
+        - x11/gedit
+        - x11/firefox
+        - x11/yast2_snapper
+        - x11/glxgears
+        - x11/nautilus
+        - x11/desktop_mainmenu
+        - x11/reboot_gnome

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -1,0 +1,93 @@
+name:           aarch64_regression_test_online.yaml
+description:    |
+  This is for aarch64 online regression test.
+  #REGRESSION_LTSS: '1' means base system supports ltss test.
+  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
+  # means regression test part2 include x11 test and some performance related test.
+vars:
+  DESKTOP: 'gnome'
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - '{{online_migration_test}}'
+  - '{{remove_ltss}}'
+  - migration/version_switch_upgrade_target
+  - migration/online_migration/pre_migration
+  - '{{migration_method}}'
+  - migration/online_migration/post_migration
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/check_upgraded_service
+  - '{{regression_tests}}'
+  - boot/grub_test_snapshot
+  - migration/version_switch_origin_system
+  - boot/snapper_rollback
+conditional_schedule:
+  remove_ltss:
+    REGRESSION_LTSS:
+      1:
+        - migration/online_migration/register_without_ltss
+  migration_method:
+    MIGRATION_METHOD:
+      yast:
+        - migration/online_migration/yast2_migration
+      zypper:
+        - migration/online_migration/zypper_migration
+  online_migration_test:
+    ONLINE_MIGRATION:
+      1:
+        - installation/isosize
+        - installation/bootloader_uefi
+        - migration/online_migration/online_migration_setup
+        - migration/online_migration/register_system
+        - migration/online_migration/zypper_patch
+        - installation/install_service
+  regression_tests:
+    REGRESSION_TEST:
+      1:
+        - locale/keymap_or_locale
+        - console/check_package_version
+        - console/textinfo
+        - console/hostname
+        - console/x_vt
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/zypper_in
+        - console/zypper_log
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/orphaned_packages_check
+        - console/consoletest_finish
+      2:
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/upgrade_snapshots
+        - console/zypper_lifecycle
+        - console/consoletest_finish
+        - x11/desktop_runner
+        - x11/xterm
+        - locale/keymap_or_locale_x11
+        - x11/sshxterm
+        - x11/gnome_control_center
+        - x11/gnome_terminal
+        - x11/gedit
+        - x11/firefox
+        - x11/yast2_snapper
+        - x11/glxgears
+        - x11/nautilus
+        - x11/desktop_mainmenu
+        - x11/reboot_gnome

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -1,0 +1,107 @@
+name:           ppc64le_regression_test_offline.yaml
+description:    |
+  This is for ppc64le offline regression test.
+  #REGRESSION_SERVICE: '1' means support service check test. '0' means doesn't
+  #support service check test, normally set '0' for package media test.
+  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
+  #means regression test part2 include x11 test and some performance related test.
+vars:
+  DESKTOP: 'gnome'
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+  BOOTFROM: 'd'
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - update/patch_sle
+  - migration/record_disk_info
+  - '{{install_service}}'
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - '{{isosize_test}}'
+  - installation/bootloader
+  - installation/welcome
+  - installation/upgrade_select
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - migration/post_upgrade
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - '{{check_upgraded_service}}'
+  - '{{regression_tests}}'
+  - boot/grub_test_snapshot
+  - migration/version_switch_origin_system
+  - boot/snapper_rollback
+conditional_schedule:
+  check_upgraded_service:
+    REGRESSION_SERVICE:
+      1:
+        - console/check_upgraded_service
+  isosize_test:
+    REGRESSION_SERVICE:
+      1:
+        - installation/isosize
+  install_service:
+    REGRESSION_SERVICE:
+      1:
+        - installation/install_service
+  regression_tests:
+    REGRESSION_TEST:
+      1:
+        - locale/keymap_or_locale
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/textinfo
+        - console/hostname
+        - console/upgrade_snapshots
+        - console/x_vt
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/zypper_in
+        - console/zypper_log
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/zypper_lifecycle
+        - console/orphaned_packages_check
+        - console/consoletest_finish
+      2:
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/upgrade_snapshots
+        - console/zypper_lifecycle
+        - console/consoletest_finish
+        - x11/desktop_runner
+        - x11/xterm
+        - locale/keymap_or_locale_x11
+        - x11/sshxterm
+        - x11/gnome_control_center
+        - x11/gnome_terminal
+        - x11/gedit
+        - x11/firefox
+        - x11/yast2_snapper
+        - x11/glxgears
+        - x11/nautilus
+        - x11/desktop_mainmenu
+        - x11/reboot_gnome

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -1,0 +1,99 @@
+name:           ppc64le_regression_test_online.yaml
+description:    |
+  This is for ppc64le online regression test.
+  #REGRESSION_LTSS: '1' means base system supports ltss test.
+  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
+  # means regression test part2 include x11 test and some performance related test.
+vars:
+  DESKTOP: 'gnome'
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - '{{online_migration_test}}'
+  - '{{remove_ltss}}'
+  - migration/version_switch_upgrade_target
+  - migration/online_migration/pre_migration
+  - '{{migration_method}}'
+  - migration/online_migration/post_migration
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/check_upgraded_service
+  - '{{regression_tests}}'
+  - boot/grub_test_snapshot
+  - migration/version_switch_origin_system
+  - boot/snapper_rollback
+conditional_schedule:
+  remove_ltss:
+    REGRESSION_LTSS:
+      1:
+        - migration/online_migration/register_without_ltss
+  migration_method:
+    MIGRATION_METHOD:
+      yast:
+        - migration/online_migration/yast2_migration
+      zypper:
+        - migration/online_migration/zypper_migration
+  online_migration_test:
+    ONLINE_MIGRATION:
+      1:
+        - installation/isosize
+        - installation/bootloader
+        - migration/online_migration/online_migration_setup
+        - migration/online_migration/register_system
+        - migration/online_migration/zypper_patch
+        - installation/install_service
+  regression_tests:
+    REGRESSION_TEST:
+      1:
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - locale/keymap_or_locale
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/textinfo
+        - console/hostname
+        - console/upgrade_snapshots
+        - console/x_vt
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/zypper_in
+        - console/zypper_log
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/zypper_lifecycle
+        - console/orphaned_packages_check
+        - console/consoletest_finish
+      2:
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/upgrade_snapshots
+        - console/zypper_lifecycle
+        - console/consoletest_finish
+        - x11/desktop_runner
+        - x11/xterm
+        - locale/keymap_or_locale_x11
+        - x11/sshxterm
+        - x11/gnome_control_center
+        - x11/gnome_terminal
+        - x11/gedit
+        - x11/firefox
+        - x11/yast2_snapper
+        - x11/glxgears
+        - x11/nautilus
+        - x11/desktop_mainmenu
+        - x11/reboot_gnome

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -1,0 +1,94 @@
+name:           s390x_regression_test_offline.yaml
+description:    |
+  This is for s390x zkvm upgrade regression test.
+  #REGRESSION_SERVICE: '1' means support service check test. '0' means doesn't
+  #support service check test, normally set '0' for package media test.
+  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
+  #means regression test part2 include x11 test and some performance related test.
+vars:
+  DESKTOP: 'gnome'
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - installation/bootloader_zkvm
+  - boot/boot_to_desktop
+  - update/patch_sle
+  - migration/record_disk_info
+  - '{{install_service}}'
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - installation/bootloader_zkvm
+  - installation/welcome
+  - installation/upgrade_select
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - migration/post_upgrade
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - '{{check_upgraded_service}}'
+  - '{{regression_tests}}'
+conditional_schedule:
+  check_upgraded_service:
+    REGRESSION_SERVICE:
+      1:
+        - console/check_upgraded_service
+  install_service:
+    REGRESSION_SERVICE:
+      1:
+        - installation/install_service
+  regression_tests:
+    REGRESSION_TEST:
+      1:
+        - locale/keymap_or_locale
+        - console/textinfo
+        - console/hostname
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/zypper_in
+        - console/zypper_log
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/orphaned_packages_check
+        - console/consoletest_finish
+      2:
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/upgrade_snapshots
+        - console/zypper_lifecycle
+        - console/consoletest_finish
+        - x11/desktop_runner
+        - x11/xterm
+        - locale/keymap_or_locale_x11
+        - x11/sshxterm
+        - x11/gnome_control_center
+        - x11/gnome_terminal
+        - x11/gedit
+        - x11/firefox
+        - x11/yast2_snapper
+        - x11/glxgears
+        - x11/nautilus
+        - x11/desktop_mainmenu
+        - x11/reboot_gnome

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -1,0 +1,87 @@
+name:           s390x_regression_test_online.yaml
+description:    |
+  This is for s390x online regression test.
+  #REGRESSION_LTSS: '1' means base system supports ltss test.
+  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
+  # means regression test part2 include x11 test and some performance related test.
+vars:
+  DESKTOP: 'gnome'
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - '{{online_migration_test}}'
+  - '{{remove_ltss}}'
+  - migration/version_switch_upgrade_target
+  - migration/online_migration/pre_migration
+  - '{{migration_method}}'
+  - migration/online_migration/post_migration
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - '{{regression_tests}}'
+conditional_schedule:
+  remove_ltss:
+    REGRESSION_LTSS:
+      1:
+        - migration/online_migration/register_without_ltss
+  migration_method:
+    MIGRATION_METHOD:
+      yast:
+        - migration/online_migration/yast2_migration
+      zypper:
+        - migration/online_migration/zypper_migration
+  online_migration_test:
+    ONLINE_MIGRATION:
+      1:
+        - installation/bootloader_zkvm
+        - migration/online_migration/online_migration_setup
+        - migration/online_migration/register_system
+        - migration/online_migration/zypper_patch
+  regression_tests:
+    REGRESSION_TEST:
+      1:
+        - locale/keymap_or_locale
+        - console/check_upgraded_service
+        - console/textinfo
+        - console/hostname
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/zypper_in
+        - console/zypper_log
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/orphaned_packages_check
+        - console/consoletest_finish
+      2:
+        - console/check_upgraded_service
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/upgrade_snapshots
+        - console/zypper_lifecycle
+        - console/consoletest_finish
+        - x11/desktop_runner
+        - x11/xterm
+        - locale/keymap_or_locale_x11
+        - x11/sshxterm
+        - x11/gnome_control_center
+        - x11/gnome_terminal
+        - x11/gedit
+        - x11/firefox
+        - x11/yast2_snapper
+        - x11/glxgears
+        - x11/nautilus
+        - x11/desktop_mainmenu
+        - x11/reboot_gnome

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -1,0 +1,119 @@
+name:           x86_regression_test_offline.yaml
+description:    |
+  This is for x86 offline regression test.
+  #REGRESSION_SERVICE: '1' means support service check test. '0' means doesn't
+  #support service check test, normally set '0' for package media test.
+  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
+  #means regression test part2 include x11 test and some performance related test.
+vars:
+  DESKTOP: 'gnome'
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+  BOOTFROM: 'd'
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - update/patch_sle
+  - migration/record_disk_info
+  - '{{install_service}}'
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - '{{isosize_test}}'
+  - installation/bootloader
+  - installation/welcome
+  - installation/upgrade_select
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - migration/post_upgrade
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - '{{check_upgraded_service}}'
+  - '{{regression_tests}}'
+  - boot/grub_test_snapshot
+  - migration/version_switch_origin_system
+  - boot/snapper_rollback
+conditional_schedule:
+  check_upgraded_service:
+    REGRESSION_SERVICE:
+      1:
+        - console/check_upgraded_service
+  isosize_test:
+    REGRESSION_SERVICE:
+      1:
+        - installation/isosize
+  install_service:
+    REGRESSION_SERVICE:
+      1:
+        - installation/install_service
+  regression_tests:
+    REGRESSION_TEST:
+      1:
+        - locale/keymap_or_locale
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/textinfo
+        - console/hostname
+        - console/upgrade_snapshots
+        - console/x_vt
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/glibc_sanity
+        - console/zypper_in
+        - console/zypper_log
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/vim
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/zypper_lifecycle
+        - console/orphaned_packages_check
+        - console/consoletest_finish
+
+      2:
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/upgrade_snapshots
+        - console/zypper_lifecycle
+        - console/consoletest_finish
+        - x11/desktop_runner
+        - x11/xterm
+        - locale/keymap_or_locale_x11
+        - x11/sshxterm
+        - x11/gnome_control_center
+        - x11/gnome_terminal
+        - x11/gedit
+        - x11/firefox
+        - x11/eog
+        - x11/gnome_music
+        - x11/wireshark
+        - x11/ImageMagick
+        - x11/ghostscript
+        - x11/ooffice
+        - x11/oomath
+        - x11/oocalc
+        - x11/yast2_snapper
+        - x11/glxgears
+        - x11/nautilus
+        - x11/evolution
+        - x11/desktop_mainmenu
+        - x11/reboot_gnome

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -1,0 +1,109 @@
+name:           x86_regression_test_online.yaml
+description:    |
+  This is for x86_64 online regression test.
+  #REGRESSION_LTSS: '1' means base system supports ltss test.
+  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
+  # means regression test part2 include x11 test and some performance related test.
+vars:
+  DESKTOP: gnome
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - '{{online_migration_test}}'
+  - '{{remove_ltss}}'
+  - installation/install_service
+  - migration/version_switch_upgrade_target
+  - migration/online_migration/pre_migration
+  - '{{migration_method}}'
+  - migration/online_migration/post_migration
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - '{{regression_tests}}'
+  - boot/grub_test_snapshot
+  - migration/version_switch_origin_system
+  - boot/snapper_rollback
+conditional_schedule:
+  remove_ltss:
+    REGRESSION_LTSS:
+      1:
+        - migration/online_migration/register_without_ltss
+  migration_method:
+    MIGRATION_METHOD:
+      yast:
+        - migration/online_migration/yast2_migration
+      zypper:
+        - migration/online_migration/zypper_migration
+  online_migration_test:
+    ONLINE_MIGRATION:
+      1:
+        - installation/isosize
+        - installation/bootloader
+        - migration/online_migration/online_migration_setup
+        - migration/online_migration/register_system
+        - migration/online_migration/zypper_patch
+  regression_tests:
+    REGRESSION_TEST:
+      1:
+        - locale/keymap_or_locale
+        - console/check_upgraded_service
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/textinfo
+        - console/hostname
+        - console/upgrade_snapshots
+        - console/x_vt
+        - console/zypper_lr
+        - console/check_system_info
+        - console/zypper_ref
+        - console/ncurses
+        - console/yast2_lan
+        - console/curl_https
+        - console/salt
+        - console/glibc_sanity
+        - console/zypper_in
+        - console/zypper_log
+        - console/yast2_i
+        - console/yast2_bootloader
+        - console/vim
+        - console/firewall_enabled
+        - console/sshd
+        - console/ssh_cleanup
+        - console/mtab
+        - console/zypper_lifecycle
+        - console/orphaned_packages_check
+        - console/consoletest_finish
+
+      2:
+        - console/check_upgraded_service
+        - console/supportutils
+        - console/force_scheduled_tasks
+        - console/upgrade_snapshots
+        - console/zypper_lifecycle
+        - console/consoletest_finish
+        - x11/desktop_runner
+        - x11/xterm
+        - locale/keymap_or_locale_x11
+        - x11/sshxterm
+        - x11/gnome_control_center
+        - x11/gnome_terminal
+        - x11/gedit
+        - x11/firefox
+        - x11/eog
+        - x11/gnome_music
+        - x11/wireshark
+        - x11/ImageMagick
+        - x11/ghostscript
+        - x11/ooffice
+        - x11/oomath
+        - x11/oocalc
+        - x11/yast2_snapper
+        - x11/glxgears
+        - x11/nautilus
+        - x11/evolution
+        - x11/desktop_mainmenu
+        - x11/reboot_gnome


### PR DESCRIPTION
To reduce the running time of regression, we try to divide the regression test to two part, part1 mainly contains console test, part2 contains x11 test and some console test performance related.

Some new setting needed for the yaml:
REGRESSION_SERVICE: '1' means support service check test, currently for not via package media, include online migration and offline migration via pscc, only needed for offline migration test.  '0' means doesn't support service check test, normally set '0' for offline package media test.
REGRESSION_TEST: '1' means regression test part1 include console test. '2' means regression test part2 include x11 test and some performance related test.
REGRESSION_LTSS: '1' means base system supports ltss test, only needed for online migration test.

- Related ticket: https://progress.opensuse.org/issues/67744
- Needles: N/A
- Verification run:
x86_64:
http://openqa.nue.suse.com/tests/5254072#   - offline package media
https://openqa.nue.suse.com/tests/5253993#   - offline poxySCC
http://openqa.nue.suse.com/tests/5254073#      -online

 s390x:
https://openqa.nue.suse.com/tests/5254123#       - offline package media
http://openqa.nue.suse.com/tests/5254075#       - offline poxySCC
https://openqa.nue.suse.com/tests/5254732       - online

ppc64le:
https://openqa.nue.suse.com/tests/5254639#details  - offline package media
http://openqa.nue.suse.com/tests/5254638#  - offline poxySCC
http://openqa.nue.suse.com/tests/5254082#  -online

aarch64:
http://openqa.nue.suse.com/tests/5254084#  - offline package media
http://openqa.nue.suse.com/tests/5254085#    - offline poxySCC
http://openqa.nue.suse.com/tests/5254087#    - online