### PR TITLE
Adapt the code for new passwordless settings

### DIFF
--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -41,6 +41,10 @@ sub run {
     assert_screen 'ha-cluster-join-password', $join_timeout;
     type_password;
     send_key 'ret';
+    if (check_var('TWO_NODES', 'no') && check_screen('ha-cluster-join-3nodes-password', 60)) {
+        type_password;
+        send_key 'ret';
+    }
     wait_serial("ha-cluster-join-finished-0", $join_timeout);
 
     # Indicate that the other nodes have joined the cluster


### PR DESCRIPTION
The ssh key is now shared during the join process between all nodes and a new locking mechanism has been introduced via bsc# 1175976.

- Related ticket: N/A
- Needles:  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1472
- Verification run: 
3 nodes cluster: http://1b143.qa.suse.de/tests/6133#step/ha_cluster_join/11
2 nodes cluster: http://1b143.qa.suse.de/tests/6126
