### PR TITLE
Enhance container_diff with rpm packages' comparison

### DIFF
--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -34,12 +34,13 @@ sub run {
     my ($image_names, $stable_names) = get_suse_container_urls();
 
     # container-diff
-    for my $i (0 .. $#$image_names) {
-        my $image_file = $image_names->[$i] =~ s/\/|:/-/gr;
-        assert_script_run("docker pull $image_names->[$i]",  360);
-        assert_script_run("docker pull $stable_names->[$i]", 360);
-        assert_script_run("container-diff diff daemon://$image_names->[$i] daemon://$stable_names->[$i] --type=rpm --type=file --type=size > /tmp/container-diff-$image_file.txt", 300);
-        upload_logs("/tmp/container-diff-$image_file.txt");
+    for my $i (@{$image_names}) {
+        my $image_file             = $image_names->[$i] =~ s/\/|:/-/gr;
+        my $container_diff_results = "/tmp/container-diff-$image_file.txt";
+        assert_script_run("docker pull $image_names->[$i]", 360);
+        assert_script_run("container-diff diff daemon://$image_names->[$i] remote://$stable_names->[$i] --type=rpm --type=file --type=size > $container_diff_results", 300);
+        upload_logs("$container_diff_results");
+        ensure_container_rpm_updates("$container_diff_results");
     }
 
     # Clean container


### PR DESCRIPTION
Add function to compare the rpm's version from the output of the
container-diff tool.
For convenience i picked the cpan::version tool to make the comparison.
Documentation https://metacpan.org/pod/distribution/version/lib/version.pm
Note the conversion as it might end to unexpected results in first glance.
For instance `version->parse('1.2')` returns `1.200` which will make a
comparison with 1.19 for example to evaluate the first bigger than the later.
To solve this and for more other reasons the v-string is required.

- Related ticket: https://progress.opensuse.org/issues/71050
- Verification run: http://aquarius.suse.cz/tests/4336
