### PR TITLE
apparmor: aa_notify no longer returns with an empty string on a clean log

### DIFF
--- a/tests/security/apparmor/aa_notify.pm
+++ b/tests/security/apparmor/aa_notify.pm
@@ -50,7 +50,7 @@ sub run {
 
     assert_script_run "echo > $audit_log";
 
-    validate_script_output "aa-notify -l", sub { m/^$/ };
+    validate_script_output "aa-notify -l", sub { m/^(AppArmor\sdenials:\s+0\s+\(since.*)?$/ };
 
     # Make it failed intentionally to get some audit messages
     assert_script_run "sed -i '/\\/etc\\/nscd.conf/d' $tmp_prof/usr.sbin.nscd";


### PR DESCRIPTION
AppArmor < 3.0 made no output if audit.log was empty when aa-notify -l was started.
With apparmor 3.0, this has changed and the output is something along the lines of:
  AppArmor denials: 0 (since Sat Nov 7 00:15:58 2020)

Accept empty result or "AppArmore denials: 0"

- Related ticket: https://progress.opensuse.org/issues/77095
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1542650 (aa_notify passed; success)
