### PR TITLE
Disable SSH serial terminal on Svirt

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1224,7 +1224,7 @@ sub select_serial_terminal {
         } else {
             $console = $root ? 'root-virtio-terminal' : 'virtio-terminal';
         }
-    } elsif (get_var('SUT_IP') || get_var('VIRSH_GUEST')) {
+    } elsif (get_var('SUT_IP')) {
         $console = $root ? 'root-serial-ssh' : 'user-serial-ssh';
     } elsif ($backend eq 'svirt') {
         if (check_var('SERIAL_CONSOLE', 0)) {


### PR DESCRIPTION
This is a temporary fix for XEN/HyperV issues with the new SSH serial terminal.

`VIRSH_GUEST` sometimes appears to point to the hypervisor instead of the SUT. In that case, the SSH serial terminal will connect to the wrong machine.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/5250385