### PR TITLE
setup_zdup: add vendors config for 15.3 upgrading

### DIFF
--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_jeos is_desktop_installed);
+use version_utils qw(is_jeos is_desktop_installed is_leap);
 use Utils::Backends 'is_pvm';
 
 sub run {
@@ -60,6 +60,14 @@ sub run {
             select_console('root-console');
         }
 
+    }
+    # starting from 15.3, core binary RPMs was inherited from SLE build directly
+    # allowing the vendor change during migration is needed
+    # the change below also exists in openSUSE-release package
+    if (is_leap('>15.2')) {
+        assert_script_run "mkdir -p /etc/zypp/vendors.d";
+        assert_script_run "echo -e \"[main]\nvendors=openSUSE,SUSE,SUSE LLC\n\" > /etc/zypp/vendors.d/00-openSUSE.conf";
+        clear_console;
     }
 
 }


### PR DESCRIPTION
verification run: https://openqa.opensuse.org/tests/1613522

The proper solution is 1) releasing a openSUSE-release package update to the previous Leap version which contains that vendor config in this PR, and ask users update their system to the last before upgrade to 15.3, or 2) ask user to add vendor change config manually on their system.

This PR is doing 2) on openQA, I don't think we need to refresh all supported Leap pre-HDD images to the last, and 1) is not starting yet.