### PR TITLE
Enable reboots in vmware without changing GRUB2 terminal settings

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 use utils;
 use testapi;
-use version_utils qw(is_sle is_opensuse is_tumbleweed is_vmware);
+use version_utils qw(is_sle is_opensuse is_tumbleweed is_vmware is_jeos);
 use Carp 'croak';
 
 our @EXPORT = qw(
@@ -332,8 +332,9 @@ sub power_action {
             console('svirt')->start_serial_grab;
         }
         # When 'sut' is ready, select it
+        # GRUB's serial terminal configuration relies on installation/add_serial_console.pm
         if (is_vmware && $action eq 'reboot') {
-            wait_serial('GNU GRUB', 180) || die 'GRUB not found on serial console';
+            die 'GRUB not found on serial console' unless (is_jeos || wait_serial('GNU GRUB', 180));
             select_console('sut');
         }
     }


### PR DESCRIPTION
SLE installations on VMWare host set serial terminal in grub before
firstboot in _installation/add_serial_console.pm_.

- [Adapt test cases to run on vmware](https://progress.opensuse.org/issues/77275)
- VRs:
    * [sle-15-SP3-Online-x86_64-Build118.3-default_install_svirt@svirt-vmware65](http://kepler.suse.cz/tests/2958#step/console_reboot/12)
    * [sle-15-SP3-JeOS-for-VMware-x86_64-Build20.195-jeos-extratest@svirt-vmware65](http://kepler.suse.cz/tests/2996#step/console_reboot/9)
