### PR TITLE
[virt_autotest] Collect and upload Guest wickded logs during virtual network test

### DIFF
--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -85,10 +85,17 @@ sub run_test {
         virt_autotest::utils::ssh_copy_id($guest);
         #Prepare the new guest network interface files for libvirt virtual network
         assert_script_run("ssh root\@$guest 'cd /etc/sysconfig/network/; cp ifcfg-eth0 ifcfg-eth1; cp ifcfg-eth0 ifcfg-eth2; cp ifcfg-eth0 ifcfg-eth3; cp ifcfg-eth0 ifcfg-eth4; cp ifcfg-eth0 ifcfg-eth5; cp ifcfg-eth0 ifcfg-eth6'");
+        #enable guest wickedd debugging
+        assert_script_run "ssh root\@$guest \"sed -i 's/^WICKED_DEBUG=.*/WICKED_DEBUG=\"all\"/g' /etc/sysconfig/network/config\"";
+        assert_script_run "ssh root\@$guest 'grep 'WICKED_DEBUG' /etc/sysconfig/network/config'";
+        assert_script_run "ssh root\@$guest \"sed -i 's/^WICKED_LOG_LEVEL=.*/WICKED_LOG_LEVEL=\"debug\"/g' /etc/sysconfig/network/config\"";
+        assert_script_run "ssh root\@$guest 'grep 'WICKED_LOG_LEVEL' /etc/sysconfig/network/config'";
         if ($guest =~ m/sles-?11/i) {
             assert_script_run("ssh root\@$guest service network restart", 90);
+            assert_script_run("ssh root\@$guest service wickedd restart", 90);
         } else {
             assert_script_run("time ssh -v root\@$guest systemctl restart network", 120);
+            assert_script_run("time ssh -v root\@$guest systemctl restart wickedd", 120);
         }
     }
 


### PR DESCRIPTION
- Background:
Refer to the https://bugzilla.suse.com/show_bug.cgi?id=1177879#c19, there was missed guest wicked configuration and status logs during post_fail_hook to call virt_utils::collect_host_and_guest_logs to collect and upload guest logs.
Required the guest wicked configuration and status logs as below: 
```
#enable wickedd debug logs
perl -i -lpe 's{WICKED_DEBUG=.}{$1=all};s{WICKED_LOG_LEVEL=.}{$1=debug}' /etc/sysconfig/network/config
before wickedd has been started, thus when you change it:
systemctl restart wickedd

# collect the configuration
tar -czf config-ifcfg.tgz /etc/sysconfig/network
wicked show-config > config-dump.log

# collect the status
wicked ifstatus --verbose all > status.log
journalctl -b -o short-precise > journal.log
ip addr show > ip_addr.log
ip route show table all > routes.log
rpm -qa | grep wicked > wicked-version.log
```
Refer to the above the guest wicked configuration and status logs required:
Should be
1. enable guest wicked debugging -> need to implement at libvirt_virtual_network_init step 
2. collect guest wicked configuration and status logs ->guest ssh(recommend)| guest console:: implemented at virt_logs_collector.sh script
3. upload guest wicked configuration and status logs-> guest ssh(recommend)| guest console:: implemented at virt_logs_collector.sh script

NOTE: 
1. confirm that "supportconfig" utility covered the guest (e.g SLE12+ and SLE15+)wicked configuration and status logs as required. So, use with the  "supportconfig" utility  to collect guest (e.g SLE12+ and SLE15+)wicked configuration and status logs. 
2. virt_logs_collector.sh script use with SSH (recommend) way to collect and upload required logs(supportconfig logs) from
guest system to vm host. if vm host found ssh do not work both vm host and guest system together, then used with guest console to collect and upload required logs from guest system to vm host 

So, create this PR to collect and upload guest wicked configuration and status logs during call virt_utils::collect_host_and_guest_logs to collect and upload guest logs. as the log enhancement

- Related ticket: https://progress.opensuse.org/issues/80970
- Verification run:
**OSD:**
[gi-guest_sles15sp3-on-host_sles15sp3-kvm](http://149.44.176.58/tests/5391130)
[gi-guest_sles15sp3-on-host_sles15sp2-kvm](http://149.44.176.58/tests/5393289)
[gi-guest_sles12sp5-on-host_sles15sp3-kvm](http://149.44.176.58/tests/5393301)
[gi-guest_sles15sp2-on-host_sles15sp3-kvm](http://149.44.176.58/tests/5393303)
[gi-guest_sles12sp5-on-host_sles15sp3-xen](http://149.44.176.58/tests/5393302)
[gi-guest_sles15sp3-on-host_sles15sp2-xen](http://149.44.176.58/tests/5404709)
**collect guest wicked log via guest ssh**
[gi-guest_sles15sp3-on-host_sles15sp3-xen](http://149.44.176.58/tests/5391134)
[gi-guest_sles15sp2-on-host_sles15sp3-xen](http://149.44.176.58/tests/5393304)
**collect guest wicked log via guest console**
[gi-guest_sles15sp3-on-host_sles15sp3-kvm](https://github.com/guoxuguang/os-autoinst-distri-opensuse/blob/cc74d84462b5c20137bacfa30e3a21c764b1ad92/virt_logs_collector.logs.guest_console)