### PR TITLE
Add a softfail for bsc#1180618

### DIFF
--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -22,7 +22,9 @@ sub run {
     my $cluster_name = get_cluster_name;
 
     # Checking cluster state can take time, so default timeout is not enough
-    assert_script_run 'crm script run health', bmwqemu::scale_timeout(240);
+    if (script_run("crm script run health", bmwqemu::scale_timeout(240)) != 0) {
+        record_soft_failure("bsc#1180618, unexpected hostname in the output");
+    }
 
     barrier_wait("LOGS_CHECKED_$cluster_name");
 


### PR DESCRIPTION
This PR adds a softfail for managing a wrong hostname in `crm script run health` output.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
3 nodes cluster: [node1](http://1b143.qa.suse.de/tests/6156) [node2](http://1b143.qa.suse.de/tests/6157) [node3](http://1b143.qa.suse.de/tests/6158)
rgression test with 2 nodes cluster: [node1](http://1b143.qa.suse.de/tests/6160) [node2](http://1b143.qa.suse.de/tests/6161)

