### PR TITLE
Fix registration for publiccloud-ec2-aarch64 runs

### DIFF
--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -33,15 +33,16 @@ sub run {
 
         # note: ssh_script_retry dies on failure
         $args->{my_instance}->retry_ssh_command("sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'), timeout => 420, retry => 3);
-
+        my $arch = get_var('PUBLIC_CLOUD_ARCH') // "x86_64";
+        $arch = "aarch64" if ($arch eq "arm64");
         for my $addon (@addons) {
             next if ($addon =~ /^\s+$/);
             if (is_sle('<15') && $addon =~ /tcm|wsm|contm|asmm|pcm/) {
-                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '`echo ${VERSION} | cut -d- -f1`');
+                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '`echo ${VERSION} | cut -d- -f1`', $arch);
             } elsif (is_sle('<15') && $addon =~ /sdk|we/) {
-                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '${VERSION_ID}');
+                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '${VERSION_ID}', $arch);
             } else {
-                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon));
+                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), undef, $arch);
             }
         }
     }


### PR DESCRIPTION
Fixes the wrong CPU architecture issue on ec2-aarch64 test runs.
The issue is, that the CPU architecture of the openQA host is used 
when registering the system, when instead the architecture of the 
publiccloud instance should be taken.

- Related ticket: https://progress.opensuse.org/issues/81861
- Needles: -
- Verification runs: [SLE 15-SP2 ec2-aarch64](http://duck-norris.qam.suse.de/tests/4498#step/register_system/59) | [SLE 15-SP2 EC2-BYOS](http://duck-norris.qam.suse.de/tests/4499#step/register_system/59) | [SLE 12-SP5 GCE-BYOS](http://duck-norris.qam.suse.de/tests/4496#step/register_system/53)

