### PR TITLE
Fix test data for btrfs+warnings on opensuse

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -43,7 +43,8 @@ schedule:
 test_data:
   disks:
     - name: vda
-      <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+      partitions:
+        <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
   errors:
     no_root: There is no device mounted at '/'
     boot_small_for_kernel: The device mounted at '/boot' does not have enough space to contain a kernel


### PR DESCRIPTION
'partitions' key was missed in the scheduling file for btrfs+warnings on
opensuse. The test failed due to that.

The commit fixes the issue by adding the missed key.

- Related failures: https://openqa.opensuse.org/tests/1544907
- Verification run: https://openqa.opensuse.org/tests/1578265
