### PR TITLE
Add regression test for php and timezone

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1064,6 +1064,7 @@ sub load_console_server_tests {
         loadtest "console/php7";
         loadtest "console/php7_mysql";
         loadtest "console/php7_postgresql";
+        loadtest "console/php7_timezone";
     }
     # TODO test on openSUSE https://progress.opensuse.org/issues/31972
     loadtest "console/apache_ssl" if is_sle;

--- a/tests/console/php7_timezone.pm
+++ b/tests/console/php7_timezone.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: php7 timezone 
+# Summary: Basic timezone and php extra test, to make sure php timezone is consistent with the system one.
+# Maintainer: Michael Grifalconi <mgrifalconi@suse.com>
+
+
+use base "consoletest";
+use strict;
+use warnings;
+use utils;
+use testapi;
+use apachetest;
+
+my $date_time = "a";
+my $php_time = "b";
+
+sub compare_time{
+    $date_time = script_output 'date +"%H:%M"';
+    $php_time = script_output "php -r 'date_default_timezone_set(\"Europe/Berlin\");echo date(\"H:i\"), \"\n\";'";
+    return ($date_time eq $php_time)
+}
+
+sub run {
+    #Preparation
+    my $self = shift;
+    $self->select_serial_terminal;
+    setup_apache2(mode => 'PHP7');
+    
+    #Save current timezone
+    my $current_timezone = script_output 'timedatectl | grep "Time zone" | awk \'{print $3}\' ';
+
+    #Set timezone
+    assert_script_run 'timedatectl set-timezone Europe/Berlin';
+
+    #Compare times (if first fails, try again to cover a possible minute change)
+    if (compare_time() == 0){
+     if (compare_time() == 0){
+       #Cleanup and fail
+       script_run "timedatectl set-timezone $current_timezone";
+       die sprintf("Time from `date`: %s and `php date`: %s do not match", $date_time, $php_time);
+     } 
+    }
+
+    #Cleanup
+    assert_script_run "timedatectl set-timezone $current_timezone";
+}
+1;

--- a/tests/console/php7_timezone.pm
+++ b/tests/console/php7_timezone.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Package: php7 timezone 
+# Package: php7 timezone
 # Summary: Basic timezone and php extra test, to make sure php timezone is consistent with the system one.
 # Maintainer: Michael Grifalconi <mgrifalconi@suse.com>
 
@@ -20,12 +20,12 @@ use testapi;
 use apachetest;
 
 my $date_time = "a";
-my $php_time = "b";
+my $php_time  = "b";
 
-sub compare_time{
+sub compare_time {
     $date_time = script_output 'date +"%H:%M"';
-    $php_time = script_output "php -r 'date_default_timezone_set(\"Europe/Berlin\");echo date(\"H:i\"), \"\n\";'";
-    return ($date_time eq $php_time)
+    $php_time  = script_output "php -r 'date_default_timezone_set(\"Europe/Berlin\");echo date(\"H:i\"), \"\n\";'";
+    return ($date_time eq $php_time);
 }
 
 sub run {
@@ -33,7 +33,7 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
     setup_apache2(mode => 'PHP7');
-    
+
     #Save current timezone
     my $current_timezone = script_output 'timedatectl | grep "Time zone" | awk \'{print $3}\' ';
 
@@ -41,12 +41,12 @@ sub run {
     assert_script_run 'timedatectl set-timezone Europe/Berlin';
 
     #Compare times (if first fails, try again to cover a possible minute change)
-    if (compare_time() == 0){
-     if (compare_time() == 0){
-       #Cleanup and fail
-       script_run "timedatectl set-timezone $current_timezone";
-       die sprintf("Time from `date`: %s and `php date`: %s do not match", $date_time, $php_time);
-     } 
+    if (compare_time() == 0) {
+        if (compare_time() == 0) {
+            #Cleanup and fail
+            script_run "timedatectl set-timezone $current_timezone";
+            die sprintf("Time from `date`: %s and `php date`: %s do not match", $date_time, $php_time);
+        }
     }
 
     #Cleanup


### PR DESCRIPTION
make sure that timezone on php and date command are consistent

- Related ticket: https://progress.opensuse.org/issues/76954
- Needles: no needles
- Verification run:
- 15-sp2 --> https://openqa.suse.de/tests/5255893
- 15-sp1 --> https://openqa.suse.de/tests/5259744
- 15--ga --> https://openqa.suse.de/tests/5259745
- 12-sp5 --> https://openqa.suse.de/tests/5259224
- 12-sp4 --> https://openqa.suse.de/tests/5259225
- 12-sp3 --> https://openqa.suse.de/tests/5259226
- 12-sp2 --> https://openqa.suse.de/tests/5259731
- Tumbleweed --> https://openqa.opensuse.org/tests/1579590
