### PR TITLE
Move code into the cleanup subroutine to reduce duplication

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -462,7 +462,7 @@ sub terraform_destroy {
         assert_script_run('cd ' . TERRAFORM_DIR);
         $self->on_terraform_destroy_timeout();
     }
-    record_info('ERROR', 'Terraform exited with' . $ret, result => 'fail') if ($ret != 0);
+    record_info('ERROR', 'Terraform exited with ' . $ret, result => 'fail') if ($ret != 0);
 }
 
 =head2 __vault_login

--- a/lib/publiccloud/ssh_interactive_init.pm
+++ b/lib/publiccloud/ssh_interactive_init.pm
@@ -19,15 +19,13 @@
 
 package publiccloud::ssh_interactive_init;
 use base "consoletest";
-
+use publiccloud::utils;
 use strict;
 use warnings;
 use testapi;
 
 sub post_fail_hook {
-    select_console 'tunnel-console', await_console => 0;
-    send_key "ctrl-c";
-    send_key "ret";
+    select_host_console();
     assert_script_run('cd /root/terraform');
     script_run('terraform destroy -no-color -auto-approve', 240);
 }

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -31,6 +31,8 @@ sub select_host_console() {
     } else {
         select_console('root-console');
     }
+    send_key "ctrl-c";
+    send_key "ret";
 }
 
 sub is_publiccloud() {

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -70,9 +70,7 @@ sub post_fail_hook {
     my ($self) = @_;
     # Destroy the public cloud instance
     ssh_interactive_leave();
-    select_console('tunnel-console', await_console => 0);
-    send_key "ctrl-c";
-    send_key "ret";
+    select_host_console();
     $self->{provider}->cleanup();
 }
 

--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -13,6 +13,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use publiccloud::ssh_interactive;
+use publiccloud::utils;
 use testapi;
 use utils;
 
@@ -21,15 +22,7 @@ sub run {
     select_console 'root-console';
 
     ssh_interactive_leave();
-
-    # Find the PID of the SSH tunnel and kill it
-    #assert_script_run("ps --no-headers ao 'pid:1,cmd:1' | grep '[s]sh'");
-    #assert_script_run("kill -9 `ps --no-headers ao 'pid:1,cmd:1' | grep '[s]sh -t -R' | cut -d' ' -f1`");
-
-    # Destroy the public cloud instance
-    select_console 'tunnel-console', await_console => 0;
-    send_key "ctrl-c";
-    send_key "ret";
+    select_host_console();
     $args->{my_provider}->cleanup();
 }
 


### PR DESCRIPTION
Refactor recent code related to publiccloud clean subroutine.                                                                                                                                                                                
As for now we get a tunnel-console to the openqa instance                                                                                                                                                                                    
and exit the ssh terminal using manul calls before run the actual cleanup.                                                                                                                                                                   
The idea is that the cleanup can be reused and we dont need to                                                                                                                                                                               
repeat code.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                             
i found easier and cleaner to reuse the `select_host_console` than any other approach.

- Related ticket: https://progress.opensuse.org/issues/80922
- [Verification run sle15](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=b10n1k%2Fos-autoinst-distri-opensuse%2311711)
-  [Verification run sle12](https://openqa.suse.de/tests/overview?version=12-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2311711)