### PR TITLE
Fix loadtest python_scientific in main_common.pm

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1695,7 +1695,7 @@ sub load_extra_tests_console {
     loadtest 'console/valgrind'          unless is_sle('<=12-SP3');
     loadtest 'console/sssd_samba'        unless (is_sle("<15") || is_sle(">=15-sp2") || is_leap('>=15.2') || is_tumbleweed);
     loadtest 'console/wpa_supplicant'    unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1') || is_jeos || is_public_cloud);
-    loadtest 'console/python-scientific' unless (is_sle("<15"));
+    loadtest 'console/python_scientific' unless (is_sle("<15"));
     loadtest "console/parsec" if is_tumbleweed;
 }
 


### PR DESCRIPTION
Fixed "Invalid version format (negative version number)".

Broke everything: https://openqa.opensuse.org/tests/1579079

Verification run: http://10.160.67.86/tests/849