### PR TITLE
Increase timeout when opening yast2 lan with NM

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -331,7 +331,7 @@ Confirm if a warning popup for Networkmanager controls networking.
 
 =cut
 sub handle_Networkmanager_controlled {
-    assert_screen "Networkmanager_controlled";
+    assert_screen 'Networkmanager_controlled', 60;
     send_key "ret";    # confirm networkmanager popup
     assert_screen "Networkmanager_controlled-approved";
     send_key "alt-c";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/80622
- Verification run: [gnome staging x10](https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Staging%3AA&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_yast2_lan_staging)
