### PR TITLE
sles4sap/saptune/mr_test: Skip nr_requests on VM's to fix bsc#1177888

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -55,6 +55,8 @@ sub setup {
     if (check_var('BACKEND', 'qemu')) {
         # Ignore disk_elevator on VM's
         assert_script_run "sed -ri '/:scripts\\/disk_elevator/s/^/#/' \$(fgrep -rl :scripts/disk_elevator Pattern/)";
+        # Skip nr_requests on VM's. Fix bsc#1177888
+        assert_script_run 'sed -i "/:scripts\/nr_requests/s/^/#/" Pattern/SLE15/testpattern_note_1680803_*';
     }
     $self->reboot_wait;
 }


### PR DESCRIPTION
Fix bsc#1177888 by ignoring nr_requests on virtual machines.  saptune ignores vda and so must mr_test

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1177888
- Verification run: http://ix64hae1001.qa.suse.de/tests/2188#live