### PR TITLE
Fix 1st ssh connection on generalhw by using 'root-ssh' 

### DIFF
--- a/tests/jeos/prepare_firstboot.pm
+++ b/tests/jeos/prepare_firstboot.pm
@@ -33,7 +33,8 @@ sub run {
 
         # Handle default credentials for ssh login
         $testapi::password = $default_password;
-        $self->select_serial_terminal;
+        # 'root-ssh' console will wait for SUT to be reachable from ssh
+        select_console('root-ssh');
     }
     else {
         # Login with default credentials (root:linux)


### PR DESCRIPTION
since the new default 'root-serial-ssh' expect the SUT to be up and running

- Related ticket: https://progress.opensuse.org/issues/81835
- Verification run: https://openqa.opensuse.org/t1579685
