### PR TITLE
xfstests: Fix loop device number and increase HB timeout

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -379,11 +379,11 @@ END_CMD
 
 sub reload_loop_device {
     my $self = shift;
-    assert_script_run("losetup -fP test_dev");
-    my $scratch_amount = script_output("ls scratch_dev* | wc -l");
-    my $scratch_num    = 0;
+    assert_script_run("losetup -fP $INST_DIR/test_dev");
+    my $scratch_amount = script_output("ls $INST_DIR/scratch_dev* | wc -l");
+    my $scratch_num    = 1;
     while ($scratch_amount >= $scratch_num) {
-        assert_script_run("losetup -fP scratch_dev$scratch_num", 300);
+        assert_script_run("losetup -fP $INST_DIR/scratch_dev$scratch_num", 300);
         $scratch_num += 1;
     }
     script_run('losetup -a');

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -29,6 +29,7 @@ use testapi;
 use utils;
 use Utils::Backends 'is_pvm';
 use power_action_utils 'power_action';
+use filesystem_utils qw(format_partition);
 
 # Heartbeat variables
 my $HB_INTVL     = get_var('XFSTESTS_HEARTBEAT_INTERVAL') || 30;
@@ -387,6 +388,7 @@ sub reload_loop_device {
         $scratch_num += 1;
     }
     script_run('losetup -a');
+    format_partition("$INST_DIR/test_dev", $FSTYPE);
 }
 
 # Umount TEST_DEV and SCRATCH_DEV

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -32,7 +32,7 @@ use power_action_utils 'power_action';
 
 # Heartbeat variables
 my $HB_INTVL     = get_var('XFSTESTS_HEARTBEAT_INTERVAL') || 30;
-my $HB_TIMEOUT   = get_var('XFSTESTS_HEARTBEAT_TIMEOUT')  || 40;
+my $HB_TIMEOUT   = get_var('XFSTESTS_HEARTBEAT_TIMEOUT')  || 200;
 my $HB_PATN      = '<heartbeat>';
 my $HB_DONE      = '<done>';
 my $HB_DONE_FILE = '/opt/test.done';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/81790
- Fail: https://openqa.suse.de/tests/5266872#step/run/404 inconsistent FS on test_dev after failed test
- Verification run:
http://dzedro.suse.cz/tests/17200
https://openqa.suse.de/tests/5270957 15
https://openqa.suse.de/tests/5271027 15
https://openqa.suse.de/tests/5261557 15-sp1 
https://openqa.suse.de/tests/5260952 15-sp1
https://openqa.suse.de/tests/5260953 15-sp2
https://openqa.suse.de/tests/5270917 15-sp2
https://openqa.suse.de/tests/5260954 12-sp5
https://openqa.suse.de/tests/5271052 12-sp5
https://openqa.suse.de/tests/5260955 15-sp3 x86_64
https://openqa.suse.de/tests/5260956 15-sp3 s390x
https://openqa.suse.de/tests/5260957 15-sp3 ppc64le
https://openqa.suse.de/tests/5260959 15-sp3 aarch64

