### PR TITLE
sles4sap/saptune/mr_test: Skip nr_requests on VM's to fix bsc#1177888

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -56,7 +56,7 @@ sub setup {
         # Ignore disk_elevator on VM's
         assert_script_run "sed -ri '/:scripts\\/disk_elevator/s/^/#/' \$(fgrep -rl :scripts/disk_elevator Pattern/)";
         # Skip nr_requests on VM's. Fix bsc#1177888
-        assert_script_run 'sed -i "/:scripts\/nr_requests/s/^/#/" Pattern/SLE15/testpattern_note_1680803_*';
+        assert_script_run 'sed -i "/:scripts\/nr_requests/s/^/#/" Pattern/SLE15/testpattern_note_*';
     }
     $self->reboot_wait;
 }


### PR DESCRIPTION
Fix bsc#1177888 by ignoring nr_requests on virtual machines. saptune ignores vda and so must mr_test

This complements the previous PR with a missing testpattern for the `overrides` test. 

- Verification run: http://ix64hae1001.qa.suse.de/tests/2191