### PR TITLE
Properly handle reboots in update_kernel on IPMI

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -22,7 +22,6 @@ use utils;
 use bootloader_setup qw(add_custom_grub_entries add_grub_cmdline_settings);
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
-use serial_terminal 'prepare_serial_console';
 use upload_system_log;
 use version_utils qw(is_jeos is_opensuse is_released is_sle);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x is_x86_64);
@@ -292,8 +291,6 @@ sub run {
     if (!get_var('KGRAFT') && !get_var('LTP_BAREMETAL') && !is_jeos) {
         $self->wait_boot;
     }
-
-    prepare_serial_console;
 
     $self->select_serial_terminal;
 

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -89,17 +89,15 @@ sub kgraft_state {
     script_run("ls -lt /boot >/tmp/lsboot");
     upload_logs("/tmp/lsboot");
     script_run("cat /tmp/lsboot");
-    save_screenshot;
 
-    script_run("basename /boot/initrd-\$(uname -r) | sed s_initrd-__g > /dev/$serialdev", 0);
-    my ($kver) = wait_serial(qr/(^[\d.-]+)-.+\s/) =~ /(^[\d.-]+)-.+\s/;
+    die "Invalid kernel version string" if script_output("uname -r") !~ m/(^[\d.-]+)-.+/;
+    my $kver = $1;
     my $module;
 
     # xen kernel exists only on SLE12 and SLE12SP1
     if (is_sle('<=12-SP1')) {
         script_run("lsinitrd /boot/initrd-$kver-xen | grep patch");
-        save_screenshot;
-        $module = script_output("lsinitrd /boot/initrd-$kver-xen | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}' > /dev/$serialdev");
+        $module = script_output("lsinitrd /boot/initrd-$kver-xen | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}'");
 
         if (check_var('REMOVE_KGRAFT', '1')) {
             die 'Kgraft module exists when it should have been removed' if $module;
@@ -110,8 +108,7 @@ sub kgraft_state {
     }
 
     script_run("lsinitrd /boot/initrd-$kver-default | grep patch");
-    save_screenshot;
-    $module = script_output("lsinitrd /boot/initrd-$kver-default | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}' > /dev/$serialdev");
+    $module = script_output("lsinitrd /boot/initrd-$kver-default | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}'");
 
     if (check_var('REMOVE_KGRAFT', '1')) {
         die 'Kgraft module exists when it should have been removed' if $module;
@@ -121,7 +118,6 @@ sub kgraft_state {
     }
 
     script_run("uname -a");
-    save_screenshot;
 }
 
 sub override_shim {
@@ -292,7 +288,7 @@ sub update_kgraft {
         die "Patch isn't needed";
     }
     else {
-        script_run(qq{rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE} (%{INSTALLTIME:date})\n" | sort -t '-' > /tmp/rpmlist.before});
+        script_run(qq{rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE} (%{INSTALLTIME:date})\\n" | sort -t '-' > /tmp/rpmlist.before});
         upload_logs('/tmp/rpmlist.before');
 
         # Download HEAVY LOAD script
@@ -313,7 +309,7 @@ sub update_kgraft {
         script_run("screen -S newburn_KCOMPILE -X quit");
         script_run("rm -Rf /var/log/qa");
 
-        script_run(qq{rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE} (%{INSTALLTIME:date})\n" | sort -t '-' > /tmp/rpmlist.after});
+        script_run(qq{rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE} (%{INSTALLTIME:date})\\n" | sort -t '-' > /tmp/rpmlist.after});
         upload_logs('/tmp/rpmlist.after');
 
         my $installed_klp_pkg =

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -337,13 +337,21 @@ sub install_kotd {
 
 sub boot_to_console {
     my ($self) = @_;
-    $self->wait_boot unless check_var('BACKEND', 'ipmi') && get_var('LTP_BAREMETAL');
+
+    select_console('sol', await_console => 0) if check_var('BACKEND', 'ipmi');
+    $self->wait_boot;
     $self->select_serial_terminal;
 }
 
 sub run {
     my $self = shift;
-    boot_to_console($self);
+
+    if (check_var('BACKEND', 'ipmi') && get_var('LTP_BAREMETAL')) {
+        # System is already booted after installation, just switch terminal
+        $self->select_serial_terminal;
+    } else {
+        boot_to_console($self);
+    }
 
     my $repo        = get_var('KOTD_REPO');
     my $incident_id = undef;

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -338,12 +338,7 @@ sub install_kotd {
 sub boot_to_console {
     my ($self) = @_;
     $self->wait_boot unless check_var('BACKEND', 'ipmi') && get_var('LTP_BAREMETAL');
-    if (check_var('BACKEND', 'ipmi')) {
-        use_ssh_serial_console;
-    }
-    else {
-        select_console('root-console');
-    }
+    $self->select_serial_terminal;
 }
 
 sub run {


### PR DESCRIPTION
The `update_kernel` test module currently skips `wait_boot()` on IPMI because it starts on a fully booted system and nobody thought about the need to reboot in some cases. Enable `wait_boot()` in `boot_to_console()` again and add exception only for the first call. This fix will be needed to support livepatch testing on baremetal.

Also use the best available serial terminal in `update_kernel`.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - x86_64 QEMU: https://openqa.suse.de/tests/5394648
  - ppc64le QEMU: https://openqa.suse.de/tests/5394650
  - s390x SVIRT: https://openqa.suse.de/tests/5394649
  - x86_64 IPMI: http://openqa.qam.suse.cz/tests/16612