### PR TITLE
Implement software TPM emulator tests for QEMU

### DIFF
--- a/data/swtpm/70-persistent-net.rules
+++ b/data/swtpm/70-persistent-net.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="52:54:00:95:27:53", ATTR{type}=="1",  NAME=""

--- a/data/swtpm/ssh_port_chk_script
+++ b/data/swtpm/ssh_port_chk_script
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+ip_addr=""
+for (( i = 0; i < 90; i++ )); do
+    ip_addr=`ip n | awk ' /192\\.168/ {print $1}'`
+    if [[ -n "$ip_addr" ]] && nc -zvw2 $ip_addr 22 2>/dev/null; then
+         echo "the vm's ssh port is online"
+         exit 0
+    else
+        echo "the vm's ssh service is offline, loop to check"
+        sleep 1
+    fi
+done
+echo "the ssh service is still offline after waiting 90s"
+exit 2

--- a/data/swtpm/ssh_script
+++ b/data/swtpm/ssh_script
@@ -1,0 +1,19 @@
+#!/usr/bin/expect
+ 
+# This script is used for access remote host via ssh and run some commands
+# without interactive operations
+# Usage: ssh_script [host] [user] [password]
+# Reference: https://www.journaldev.com/1405/expect-script-ssh-example-tutorial
+# Author: https://www.journaldev.com/author/pankaj
+
+set a_exp $::env(TPM_CHK_CMD)
+set timeout 60
+spawn ssh [lindex $argv 1]@[lindex $argv 0]
+expect "yes/no*" {
+    send "yes\r"
+    expect "*?assword" { send "[lindex $argv 2]\r" }
+    } "*?assword" { send "[lindex $argv 2]\r" }
+
+expect " #" { send "ls /dev/tpm*\r" }
+expect " #" { send "$a_exp\r" }
+expect " #" { send "exit\r" }

--- a/data/swtpm/swtpm_legacy.xml
+++ b/data/swtpm/swtpm_legacy.xml
@@ -1,0 +1,61 @@
+<domain type='kvm'>
+  <name>vm-swtpm-legacy</name>
+  <uuid>7b256a70-1525-4b57-bdcf-e9dc779c3e1d</uuid>
+  <metadata>
+  </metadata>
+  <memory unit='KiB'>1048576</memory>
+  <currentMemory unit='KiB'>1048576</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <boot dev='hd'/>
+    <bootmenu enable='yes'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <cpu mode='host-model' check='partial'/>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='none'/>
+      <source file='/var/lib/libvirt/images/swtpm_legacy@64bit.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
+    </disk>
+    <interface type='network'>
+      <mac address='52:54:00:95:27:53'/>
+      <source network='default'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <graphics type='vnc' port='-1' autoport='yes' listen='0.0.0.0'>
+      <listen type='address' address='0.0.0.0'/>
+    </graphics>
+    <video>
+      <model type='vga' vram='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
+    </video>
+  </devices>
+</domain>

--- a/data/swtpm/swtpm_uefi.xml
+++ b/data/swtpm/swtpm_uefi.xml
@@ -1,0 +1,66 @@
+<domain type='kvm'>
+  <name>vm-swtpm-uefi</name>
+  <uuid>b5049116-80e1-4c6a-9a68-d48e6528c687</uuid>
+  <metadata>
+  </metadata>
+  <memory unit='KiB'>1048576</memory>
+  <currentMemory unit='KiB'>1048576</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <loader readonly='yes' type='pflash'>/usr/share/qemu/ovmf-x86_64-code.bin</loader>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <cpu mode='host-model' check='partial'/>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/swtpm_uefi@64bit.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
+    </disk>
+    <interface type='network'>
+      <mac address='52:54:00:95:27:53'/>
+      <source network='default'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='0.0.0.0'>
+      <listen type='address' address='0.0.0.0'/>
+    </graphics>
+    <video>
+      <model type='vga' vram='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
+    </video>
+  </devices>
+</domain>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2480,6 +2480,19 @@ sub load_security_tests_pam {
     loadtest "security/pam/pam_mount";
 }
 
+sub load_security_tests_create_swtpm_hdd {
+    load_security_console_prepare;
+
+    loadtest "security/create_swtpm_hdd/build_hdd";
+}
+
+sub load_security_tests_swtpm {
+    load_security_console_prepare;
+
+    loadtest "security/swtpm/swtpm_env_setup";
+    loadtest "security/swtpm/swtpm_verify";
+}
+
 sub load_security_tests_grub_auth {
     load_security_console_prepare;
 
@@ -2603,6 +2616,8 @@ sub load_security_tests {
       check_kernel_config
       tpm2
       pam
+      create_swtpm_hdd
+      swtpm
       grub_auth
       lynis
     );

--- a/lib/swtpmtest.pm
+++ b/lib/swtpmtest.pm
@@ -1,0 +1,122 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Base module for swtpm test cases
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#81256, tc#1768671
+
+package swtpmtest;
+
+use base Exporter;
+use Exporter;
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+our @EXPORT = qw(
+  start_swtpm_vm
+  stop_swtpm_vm
+  swtpm_verify
+);
+
+my $image_path  = '/var/lib/libvirt/images';
+my $guestvm_cfg = {
+    swtpm_1 => {
+        xml_file   => {uefi => 'swtpm_uefi_1_2.xml', legacy => 'swtpm_legacy_1_2.xml'},
+        version    => '1.2',
+        expect_cmd => 'tpm_version',
+    },
+    swtpm_2 => {
+        xml_file   => {uefi => 'swtpm_uefi_2_0.xml', legacy => 'swtpm_legacy_2_0.xml'},
+        version    => '2.0',
+        expect_cmd => 'tpm2_pcrread sha1:0',
+    },
+};
+
+my $sample_cfg = {
+    uefi   => {vm_name => 'vm-swtpm-uefi',   sample_file => 'swtpm_uefi.xml'},
+    legacy => {vm_name => 'vm-swtpm-legacy', sample_file => 'swtpm_legacy.xml'},
+};
+
+# Function "start_swtpm_vm" starts a vm via libvirt "virsh" commands,
+# sample xml file and vm image file are pre-configured
+sub start_swtpm_vm {
+    my ($swtpm_ver, $swtpm_vm_type) = @_;
+    die "invalid swtpm type parameter $swtpm_ver"  unless ($guestvm_cfg->{$swtpm_ver});
+    die "invalid vm type parameter $swtpm_vm_type" unless ($sample_cfg->{$swtpm_vm_type});
+
+    # Copy the sample configuration file and modify it based on the test requirement
+    my $guest_swtpm_ver = $guestvm_cfg->{$swtpm_ver};
+    my $guest_mode      = $sample_cfg->{$swtpm_vm_type};
+    my $vm_name         = $guest_mode->{vm_name};
+    my $sample_xml      = $guest_mode->{sample_file};
+    my $guest_xml       = $guest_swtpm_ver->{xml_file};
+    my $swtpm_type      = $guest_swtpm_ver->{version};
+    assert_script_run("cd $image_path");
+    assert_script_run("cp $sample_xml $guest_xml->{$swtpm_vm_type}");
+    assert_script_run(
+"sed -i \"/<\\/devices>/i\\    <tpm model='tpm-tis'>\\n      <backend type='emulator' version='$swtpm_type'\\/>\\n    <\\/tpm>\" $guest_xml->{$swtpm_vm_type}"
+    );
+
+    # Define the guest vm and start it
+    assert_script_run("virsh define $guest_xml->{$swtpm_vm_type}");
+    assert_script_run("virsh start $vm_name");
+}
+
+# Function "stop_swtpm_vm" stops/destroys a running vm
+sub stop_swtpm_vm {
+    my $para = shift;
+    die "invalid vm type parameter $para" unless ($sample_cfg->{$para});
+
+    # For UEFI vm guest, we should add --nvram option
+    my $guest_mode   = $sample_cfg->{$para};
+    my $vm_name      = $guest_mode->{vm_name};
+    my $undef_vm_cmd = "virsh undefine $vm_name";
+    $undef_vm_cmd .= ' --nvram' if $para eq 'uefi';
+    assert_script_run("virsh destroy $vm_name");
+    assert_script_run("$undef_vm_cmd");
+}
+
+# Function "swtpm_verify" gets ip address of the vm, and ssh access
+# into it, then check the tpm parameters
+sub swtpm_verify {
+    my $para = shift;
+    die "invalid swtpm parameter $para" unless ($guestvm_cfg->{$para});
+
+    # Check the vm guest is up via listening to the port 22
+    assert_script_run("wget --quiet " . data_url("swtpm/ssh_port_chk_script") . " -P $image_path");
+    assert_script_run("bash $image_path/ssh_port_chk_script");
+
+    # Login to the vm and run the commands to check tpm device
+    my $user            = 'root';
+    my $passwd          = $testapi::password;
+    my $ip_addr         = script_output("ip n | awk '/192\\.168/ {print \$1}'");
+    my $guest_swtpm_ver = $guestvm_cfg->{$para};
+    my $result_file     = "/tmp/$para";
+    my $ssh_script      = "$image_path/ssh_script";
+    my $expect_cmd      = $guest_swtpm_ver->{expect_cmd};
+    assert_script_run("TPM_CHK_CMD=\"$expect_cmd\" $ssh_script $ip_addr $user $passwd > $result_file");
+    assert_script_run("grep tpm0 $result_file");
+    if ($para eq "swtpm_1") {
+        assert_script_run("grep 'TPM 1.2 Version' $result_file");
+    }
+    elsif ($para eq "swtpm_2") {
+        assert_script_run("grep tpmrm0 $result_file");
+        assert_script_run("grep '0 :' $result_file");    # The "tpm2_pcrread" command will show sha1:0 value
+    }
+}
+
+1;

--- a/tests/security/create_swtpm_hdd/build_hdd.pm
+++ b/tests/security/create_swtpm_hdd/build_hdd.pm
@@ -1,0 +1,56 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Ship the "swtpm" software TPM emulator for QEMU,
+#          prepare a test image with with grub timeout=1, and
+#          root access for ssh is enabled along with udev rules.
+#          at the same time, install some required packages.
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#81256, tc#1768671
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use power_action_utils 'power_action';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Install tpm and tpm2 related packages, then we can verify the swtpm function
+    zypper_call("in tpm-tools tpm-quote-tools tpm2-0-tss tpm2-tss-engine tpm2.0-abrmd tpm2.0-tools trousers");
+    assert_script_run("systemctl enable tcsd");
+
+    # Modify the grub setting with "grub timeout=1"
+    assert_script_run("sed -i 's/GRUB_TIMEOUT=.*\$/GRUB_TIMEOUT=1/' /etc/default/grub");
+    assert_script_run("grub2-mkconfig -o /boot/grub2/grub.cfg");
+
+    # Disable the firewalld so that we can access the vm via ssh for later tests
+    assert_script_run("systemctl disable firewalld");
+
+    # Define a new udev rule file to keep the NIC name persistent across OS rebooting
+    my $udev_rule_file = '/etc/udev/rules.d/70-persistent-net.rules';
+    my $nic_name       = script_output("ls /etc/sysconfig/network | grep ifcfg- | grep -v lo | awk -F '-' '{print \$2}'");
+    assert_script_run("wget --quiet " . data_url("swtpm/70-persistent-net.rules") . " -O $udev_rule_file");
+    assert_script_run("sed -i 's/NAME=\"\"/ NAME=\"$nic_name\"/' $udev_rule_file");
+
+    # Power down the vm
+    power_action('poweroff');
+}
+
+1;

--- a/tests/security/swtpm/swtpm_env_setup.pm
+++ b/tests/security/swtpm/swtpm_env_setup.pm
@@ -1,0 +1,71 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Ship the "swtpm" software TPM emulator for QEMU,
+#          install required packages and download the pre-installed
+#          OS images for later tests, prepare a script for remote
+#          ssh login and execution
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#81256, tc#1768671
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Install the required packages for libvirt environment setup,
+    # "expect" is used for later remote login test, so install here as well
+    zypper_call("in qemu libvirt swtpm expect virt-install virt-manager");
+
+    # Start libvirtd daemon and start the default libvirt network
+    assert_script_run("systemctl start libvirtd");
+    assert_script_run("virsh net-start default");
+    assert_script_run("systemctl is-active libvirtd");
+    assert_script_run("virsh net-list | grep default | grep active");
+
+    # Download the pre-installed guest images and sample xml files
+    my $image_path   = '/var/lib/libvirt/images';
+    my $legacy_image = 'swtpm_legacy@64bit.qcow2';
+    my $uefi_image   = 'swtpm_uefi@64bit.qcow2';
+    if (get_var('HDD_SWTPM_LEGACY')) {
+        my $hdd_swtpm_legacy = get_required_var('HDD_SWTPM_LEGACY');
+        assert_script_run("wget -c -P $image_path " . autoinst_url("/assets/hdd/$hdd_swtpm_legacy"), 900);
+        assert_script_run("mv $image_path/$hdd_swtpm_legacy $image_path/$legacy_image");
+        assert_script_run("wget --quiet " . data_url("swtpm/swtpm_legacy.xml") . " -P $image_path");
+    }
+    elsif (get_var('HDD_SWTPM_UEFI')) {
+        my $hdd_swtpm_uefi = get_required_var('HDD_SWTPM_UEFI');
+        assert_script_run("wget -c -P $image_path " . autoinst_url("/assets/hdd/$hdd_swtpm_uefi"), 900);
+        assert_script_run("mv $image_path/$hdd_swtpm_uefi $image_path/$uefi_image");
+        assert_script_run("wget --quiet " . data_url("swtpm/swtpm_uefi.xml") . " -P $image_path");
+    }
+
+    # Write expect script to implement ssh access into remote host and run some commands
+    assert_script_run("wget --quiet " . data_url("swtpm/ssh_script") . " -P $image_path");
+
+    # Change permission of the expect script
+    assert_script_run("chmod 755 $image_path/ssh_script");
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/security/swtpm/swtpm_verify.pm
+++ b/tests/security/swtpm/swtpm_verify.pm
@@ -1,0 +1,44 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Ship the "swtpm" software TPM emulator for QEMU,
+#          test Legacy guest OS under libvirt, cover both
+#          TPM 1.2 and TPM 2.0
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#81256, tc#1768671
+
+use base 'opensusebasetest';
+use swtpmtest;
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    my $vm_type = 'legacy';
+    $vm_type = 'uefi' if get_var('HDD_SWTPM_UEFI');
+    foreach my $i ("swtpm_1", "swtpm_2") {
+        start_swtpm_vm($i, "$vm_type");
+        swtpm_verify($i);
+        stop_swtpm_vm("$vm_type");
+    }
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
QEMU can support virtual TPMs these days, but needs the "swtpm" package to do so.

SWTPM background:
Trusted Platform Module (TPM) is a component to provide several security functions, e.g. encryption, random number generation, measurement, etc., and now widely deployed among the new machines due to the requirement of Windows 10 certification. For the developers who want to use TPM to develop the security features, a software TPM emulator is usually a good choice. Before 2.11, QEMU can only do TPM passthrough to access the TPM hardware on the host, and this limits the number of guests to access TPM. Besides, the developers are also limited by the hardware capabilities. It's impossible to develop the TPM 2.0 features with a TPM 1.2 chip. Fortunately, from 2.11, QEMU starts to support the TPM emulator. With TPM emulator, the guest can switch between TPM 1.2 and TPM 2.0 easily, and this makes the developer's life much easier.

- Related ticket: https://progress.opensuse.org/issues/81256
- Needles: n/a
- Verification run: https://openqa.nue.suse.com/tests/5404313#details
                            https://openqa.nue.suse.com/tests/5404316#details