### PR TITLE
Use serial console on php and apache tests

### DIFF
--- a/tests/console/apache_nss.pm
+++ b/tests/console/apache_nss.pm
@@ -18,7 +18,8 @@ use testapi;
 use apachetest;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     setup_apache2(mode => 'NSS');
 }
 

--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -21,7 +21,8 @@ use apachetest;
 use utils 'clear_console';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     clear_console;
     setup_apache2(mode => 'SSL');
 }

--- a/tests/console/php7.pm
+++ b/tests/console/php7.pm
@@ -23,7 +23,8 @@ use testapi;
 use apachetest;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     setup_apache2(mode => 'PHP7');
     assert_script_run('curl http://localhost/index.php | tee /tmp/tests-console-php7.txt');
     assert_script_run('grep "PHP Version 7" /tmp/tests-console-php7.txt');

--- a/tests/console/php7_mysql.pm
+++ b/tests/console/php7_mysql.pm
@@ -35,7 +35,8 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 use apachetest;
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
     setup_apache2(mode => 'PHP7');
     # install requirements
     zypper_call "in php7-mysql mysql sudo";

--- a/tests/console/php7_postgresql.pm
+++ b/tests/console/php7_postgresql.pm
@@ -42,8 +42,8 @@ use apachetest qw(setup_apache2 setup_pgsqldb test_pgsql destroy_pgsqldb postgre
 use Utils::Systemd 'systemctl';
 
 sub run {
-    select_console 'root-console';
-
+    my $self = shift;
+    $self->select_serial_terminal;
     # ensure apache2 + php7 installed and running
     setup_apache2(mode => 'PHP7');
 


### PR DESCRIPTION
try to improve performance of these tests by using serial console

- Related ticket: no ticket
- Needles: no needles
- Verification run: 
  - 15-sp2 https://openqa.suse.de/tests/5267204 
