### PR TITLE
Test yast2 kdump in unsupported environment 

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -40,6 +40,7 @@ use constant {
           is_hyperv_in_gui
           is_svirt_except_s390x
           is_pvm
+          is_xen_pv
           )
     ],
     CONSOLES => [
@@ -140,6 +141,16 @@ Returns true if the current instance is running as hyperv gui backend
 
 sub is_hyperv_in_gui {
     return is_hyperv && !check_var('VIDEOMODE', 'text');
+}
+
+=head2 is_xen_pv
+
+Returns true if the current VM runs in Xen host in paravirtual mode 
+
+=cut
+
+sub is_xen_pv {
+    return check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux');
 }
 
 =head2 is_svirt_except_s390x

--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -20,7 +20,10 @@ use kdump_utils;
 
 sub run {
     select_console('root-console');
-    kdump_utils::configure_service('function');
+    if (kdump_utils::configure_service('function') == 16) {
+        record_info 'Not supported', 'Kdump is not supported in a PV DomU';
+        return;
+    }
     kdump_utils::check_function('function');
 }
 


### PR DESCRIPTION
YaST2 currently detects the environment and alerts the user in case there is an attempt to configure
kdump in Xen DomU system which is not supported.

- Related ticket: [Handle unsupported warning in kdump_and_crash](https://progress.opensuse.org/issues/80888)
- Needles: [Handle unsupported environment alerts in YaST2 kdump](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1475)
- Verification runs:
  * [sle-15-SP2-Build15.61-jeos-extratest@uefi-virtio-vga](http://kepler.suse.cz/tests/3348#step/kdump_and_crash/71)
  * [sle-15-SP2-Build15.61-jeos-extratest@svirt-xen-hvm](http://kepler.suse.cz/tests/3370#step/kdump_and_crash/86)
  * [sle-15-SP2-Build15.61-jeos-extratest@svirt-xen-pv](http://kepler.suse.cz/tests/3357#step/kdump_and_crash/34)
  * [sle-15-SP3-Build20.195-jeos-extratest@svirt-hyperv-uefi](http://kepler.suse.cz/tests/3349#step/kdump_and_crash/37)
  * [sle-15-SP3-Build20.195-jeos-extratest@svirt-xen-pv](http://kepler.suse.cz/tests/3358#step/kdump_and_crash/35)
  * [sle-15-SP3-Build20.195-jeos-extratest@svirt-xen-hvm](http://kepler.suse.cz/tests/3369#step/kdump_and_crash/86)
 