### PR TITLE
Fix typo in the conditional_schedule

### DIFF
--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -11,7 +11,7 @@ schedule:
   - containers/container_diff
   - '{{validate_btrfs}}'
 conditional_schedule:
-  validate_btrf:
+  validate_btrfs:
     ARCH:
       x86_64:
         - containers/validate_btrfs


### PR DESCRIPTION
This was the reason of not scheduled validate_btrfs module

