### PR TITLE
container_diff: Use docker pull + daemon:// instead of remote://

### DIFF
--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -37,8 +37,9 @@ sub run {
     for my $i (@{$image_names}) {
         my $image_file             = $image_names->[$i] =~ s/\/|:/-/gr;
         my $container_diff_results = "/tmp/container-diff-$image_file.txt";
-        assert_script_run("docker pull $image_names->[$i]", 360);
-        assert_script_run("container-diff diff daemon://$image_names->[$i] remote://$stable_names->[$i] --type=rpm --type=file --type=size > $container_diff_results", 300);
+        assert_script_run("docker pull $image_names->[$i]",  360);
+        assert_script_run("docker pull $stable_names->[$i]", 360);
+        assert_script_run("container-diff diff daemon://$image_names->[$i] daemon://$stable_names->[$i] --type=rpm --type=file --type=size > $container_diff_results", 300);
         upload_logs("$container_diff_results");
         ensure_container_rpm_updates("$container_diff_results");
     }


### PR DESCRIPTION
The latter always selects an "linux/amd64" image instead of a suitable one for
the current platform.

Before: https://openqa.opensuse.org/tests/1582963#step/container_diff/46
After: https://openqa.opensuse.org/tests/1584004