### PR TITLE
Add repository validation for repo_inst test suite

### DIFF
--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -4,12 +4,15 @@ description: >
   Install system from remote repository as long as the repo is type of repomd or
   susetags. Installer is loaded from local DVD and installation packages are
   downloaded from repo during installation. Test covers linuxrc features.
+  Validation of installation repository parameters before and after installation.
 vars:
   DESKTOP: gnome
   VALIDATE_INST_SRC: '1'
+  EXTRABOOTPARAMS: startshell=1
 schedule:
   - installation/isosize
   - installation/bootloader
+  - installation/validation/repo_inst
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -28,5 +31,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/exit_startshell
   - installation/grub_test
   - installation/first_boot
+  - console/validate_mirror_repos

--- a/tests/installation/exit_startshell.pm
+++ b/tests/installation/exit_startshell.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Exit startshell.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+
+
+sub run {
+    assert_screen 'startshell', 90;
+    type_string "exit\n";
+}
+
+1;

--- a/tests/installation/validation/repo_inst.pm
+++ b/tests/installation/validation/repo_inst.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate that instsys and install urls match the boot parameters.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use utils 'get_netboot_mirror';
+use testapi;
+
+
+sub run {
+    assert_screen 'startshell', 90;
+    my $arch = get_var('ARCH');
+    assert_script_run("grep -Pzo \"instsys url:(.|\\n)*disk:/boot/$arch/root\" /var/log/linuxrc.log");
+    my $mirror = get_netboot_mirror;
+    assert_script_run("grep -Pzo \"install url:(.|\\n)*$mirror\" /var/log/linuxrc.log");
+    type_string "exit\n";
+}
+
+1;


### PR DESCRIPTION
Validation through linuxrc.log prior the installation begins and validation of the mirror repository after first boot.

- Related ticket: https://progress.opensuse.org/issues/80784
- Verification run: http://falafel.suse.cz/tests/1046

Test plan update: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/330