### PR TITLE
Fix GNOME issue on IPMI server

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -76,7 +76,7 @@ sub ensure_unlocked_desktop {
     while ($counter--) {
         my @tags = qw(displaymanager displaymanager-password-prompt generic-desktop screenlock screenlock-password authentication-required-user-settings authentication-required-modify-system guest-disabled-display oh-no-something-has-gone-wrong);
         push(@tags, 'blackscreen') if get_var("DESKTOP") =~ /minimalx|xfce/;    # Only xscreensaver and xfce have a blackscreen as screenlock
-        assert_screen \@tags, no_wait => 1;
+        check_screen \@tags, no_wait => 1;
         if (match_has_tag 'oh-no-something-has-gone-wrong') {
             # bsc#1159950 - gnome-session-failed is detected
             # Note: usually happens on *big* hardware with lot of cpus/memory


### PR DESCRIPTION
Fix an issue when `gnome-session-failed` is detected on GDM login on IPMI server. Sometimes the issue appears but is not detected by the `assert_screen` function.

`check_screen` seems to  do the job, as it checks more quickly the needle. I don't think that there will be negative impact but I need to do more regression tests to be sure.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/5247785
- Verification run: https://openqa.suse.de/tests/5268203 (**Note:** the failure is because of [bsc#1178715](https://bugzilla.suse.com/show_bug.cgi?id=1178715))
- Regression tests: [sle-15-SP3-Online-x86_64-Build120.1-x11-desktopapps-gnome](https://openqa.suse.de/tests/5268214)