### PR TITLE
Ensure Expert Partitioner page is shown on cancel

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
@@ -78,6 +78,12 @@ sub get_add_volume_group_page {
     return $self->{AddVolumeGroupPage};
 }
 
+sub get_expert_partitioner_page {
+    my ($self) = @_;
+    $self->{ExpertPartitionerPage}->is_shown();
+    return $self->{ExpertPartitionerPage};
+}
+
 sub get_clone_partition_dialog {
     my ($self) = @_;
     return $self->{ClonePartitionsDialog};

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
@@ -45,6 +45,14 @@ sub init {
     return $self;
 }
 
+sub is_shown {
+    my ($self) = @_;
+    # Check for menu bar to be existing on Expert Partitioner Page.
+    # The menu bar is chosen as the element that allows to identify that Expert Partitioner Page is opened,
+    # as the page does not have any unique header.
+    $self->{menu_bar}->exist();
+}
+
 sub open_resize_device {
     my ($self) = @_;
     $self->{menu_bar}->select('&Device|&Resize...');


### PR DESCRIPTION
Wait for menu bar to be shown to ensure that Expert Partitioner Wizard
main page is opened.

As "Cancel" button exists on almost all the pages of the Wizard that
may cause failures on slow systems while "Cancel" is pressed on the
wrong page.

Fixes the failure: https://openqa.suse.de/tests/5246753#step/snapshots_small_root/15

- Verification runs: https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=120.1_uefi_oorlov&groupid=96
