### PR TITLE
Parameterize --rm option in runtime module

### DIFF
--- a/lib/containers/runtime.pm
+++ b/lib/containers/runtime.pm
@@ -55,15 +55,18 @@ If C<daemon> is enabled then container will run in the detached mode. Otherwise 
 interactive mode.
 if C<cmd> found then it will execute the given command into the container.
 The container is always removed after exit.
+if C<keep_container> is 1 the container is not removed after creation. Default to get removed
+when it exits or when the daemon exits
 
 =cut
 sub up {
     my ($self, $image_name, %args) = @_;
     die 'image name or id is required' unless $image_name;
-    my $mode   = $args{daemon} ? '-d'    : '-it';
-    my $remote = $args{cmd}    ? 'sh -c' : '';
-    my $ret    = $self->_rt_script_run(sprintf qq(run --rm %s %s %s '%s'), $mode, $image_name, $remote, $args{cmd});
-    record_info "Remote run on $image_name", $args{cmd};
+    my $mode           = $args{daemon}         ? '-d'    : '-it';
+    my $remote         = $args{cmd}            ? 'sh -c' : '';
+    my $keep_container = $args{keep_container} ? ''      : '--rm';
+    my $ret            = $self->_rt_script_run(sprintf qq(run %s %s %s %s '%s'), $keep_container, $mode, $image_name, $remote, $args{cmd});
+    record_info "Remote run on $image_name", "options $keep_container $mode $image_name $remote $args{cmd}";
     return $ret;
 }
 

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -30,19 +30,13 @@ sub _sanity_test_btrfs {
     assert_script_run "btrfs fi df $dev_path/btrfs/";
     assert_script_run "ls -td $dev_path/btrfs/subvolumes/* | head -n 1 > $btrfs_head";
     validate_script_output "df -h |grep var", sub { m/\/dev\/vda.+[1-6]\d?%/ };
-    # /var is using its own partition which is size of 10G. Create file in the container
-    # enough to fill up the partition up to ~99%
-    $rt->up('huge_image', cmd => 'fallocate -l 9152000KiB bigfile.stty');
-    # partition should be full
-    validate_script_output "df -h |grep var",       sub { m/\/dev\/vda.+\s+(9[7-9]|100)%/ };
-    validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=8.*GiB, used=8.*GiB/ };
 }
 
 sub _test_btrfs_balancing {
     my ($dev_path) = shift;
     assert_script_run qq(btrfs balance start --full-balance $dev_path), timeout => 600;
     assert_script_run "btrfs fi show $dev_path/btrfs";
-    validate_script_output "btrfs fi show $dev_path/btrfs", sub { m/devid\s+2.+20.00G.+9.\d+G.+\/dev\/vdb/ };
+    validate_script_output "btrfs fi show $dev_path/btrfs", sub { m/devid\s+2.+20.00G.+10.\d+G.+\/dev\/vdb/ };
 }
 
 sub _test_btrfs_thin_partitioning {
@@ -52,15 +46,21 @@ sub _test_btrfs_thin_partitioning {
     $rt->build($dockerfile_path, 'thin_image');
     # validate that new subvolume has been created. This should be improved.
     assert_script_run qq{test \$(ls -td $dev_path/btrfs/subvolumes/* | head -n 1) == \$(cat $btrfs_head)};
-    validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=8.*GiB, used=8.*GiB/ };
+    validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=1.*GiB, used=\d+.+[KM]iB/ };
 }
 
 sub _test_btrfs_device_mgmt {
     my ($rt, $dev_path) = @_;
     my $container  = 'registry.opensuse.org/cloud/platform/stack/rootfs/images/sle15';
     my $btrfs_head = '/tmp/subvolumes_saved';
+    record_info "test btrfs";
+    # /var is using its own partition which is size of 10G. Create file in the container
+    # enough to fill up the partition up to ~99%
+    $rt->up('huge_image', keep_container => 1, cmd => 'fallocate -l 9152000KiB bigfile.txt');
+    validate_script_output "df -h --sync|grep var", sub { m/\/dev\/vda.+\s+(9[7-9]|100)%/ };
+    # partition should be full
+    validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=8.*GiB, used=8.*GiB/ };
     # Due to disk space this should fail
-    record_info "test";
     die("pull still works") if ($rt->pull("$container") == 0);
     assert_script_run "btrfs device add /dev/vdb $dev_path";
     validate_script_output "lsblk | grep vdb",              sub { m/vdb.+20G/ };


### PR DESCRIPTION
Make the --rm parametirized as there are cases that we do not want
to have the image removed after exit.
This provides a solution on the validate_btrfs fail.

- Verification run: http://aquarius.suse.cz/tests/4397
https://openqa.suse.de/tests/5269147