### PR TITLE
Workaround for bsc#1180350 and updated get_os_release

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -580,6 +580,7 @@ sub get_os_release {
     $os_release_file //= '/etc/os-release';
     my %os_release = script_output("$go_to_target cat $os_release_file") =~ /^([^#]\S+)="?([^"\r\n]+)"?$/gm;
     %os_release = map { uc($_) => $os_release{$_} } keys %os_release;
+    ($os_release{VERSION}) = $os_release{VERSION} =~ /(^\d+\S*\d*)/im;
     my ($os_version, $os_service_pack) = split(/\.|-sp/i, $os_release{VERSION});
     $os_service_pack //= 0;
     return $os_version, $os_service_pack, $os_release{ID};


### PR DESCRIPTION
* **Skip** live vcpus testing for fv guest on 15-SP3 host due to bsc#1180350
* **This** [github commit](https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/c3d275160032634f22c5b2f750b1ceb05b8c4a31) tried to improve get_os_release subroutine. But there is one more step needs to be done before doing detailed sles os version extraction. That is: "($os_release{VERSION}) = $os_release{VERSION} =~ /(^\d+\S*\d*)/im;" which carves out version information snippet only and gets rid of anything appended to ensure we really gets what we need. For example, VERSION="15-SP3 Snapshot6" needs to become stripped-down VERSION="15-SP3", otherwise we will get service pack information like "3 Snapshot6". And this addition also works with VERSION="15-SP2" or "11.4" if this is its original form, so compatible with all versions.
* **Related ticket:** 
  * [15-SP3 guest on 15-SP3 Xen host hotplugging](https://openqa.suse.de/tests/5253164#step/1_hotplugging/1)
  * [15-SP2 guest on 15-SP3 Xen host hotplugging](https://openqa.suse.de/tests/5247860#step/1_hotplugging/1)
  * [12-SP5 guest on 15-SP3 Xen host hotplugging](https://openqa.suse.de/tests/5247858#step/1_hotplugging/1)
* **Needles:** n/a
* **Verification run:**
  * [15-SP3 guest on 15-SP3 Xen host](http://10.67.129.106/tests/558)
  * [15-SP2 guest on 15-SP3 Xen host](http://10.67.129.106/tests/559)
  * [12-SP5 guest on 15-SP3 Xen host](http://10.67.129.106/tests/560)
  * [Also confirmed new get_os_release works on 12-SP5 host](http://10.67.129.106/tests/562)
  * Also confirmed new get_os_release also works with 11-SP4 /etc/os-release file manually by using online perl compiler
