### PR TITLE
MicroOS: add SLE base container tests

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -119,14 +119,13 @@ sub test_opensuse_based_image {
     $version = 'Tumbleweed' if ($version =~ /^Staging:/);
 
     if ($image_id =~ 'sles') {
-        my $pretty_version = $version =~ s/-SP/ SP/r;
-        my $betaversion    = get_var('BETA') ? '\s\([^)]+\)' : '';
-        record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
-        validate_script_output("$runtime container run --entrypoint '/bin/bash' --rm $image -c 'grep PRETTY_NAME /etc/os-release' | cut -d= -f2",
-            sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
-
-        # SUSEConnect zypper service is supported only on SLE based image on SLE host
         if ($host_id =~ 'sles') {
+            my $pretty_version = $version =~ s/-SP/ SP/r;
+            my $betaversion    = get_var('BETA') ? '\s\([^)]+\)' : '';
+            record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
+            validate_script_output("$runtime container run --entrypoint '/bin/bash' --rm $image -c 'grep PRETTY_NAME /etc/os-release' | cut -d= -f2",
+                sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
+            # SUSEConnect zypper service is supported only on SLE based image on SLE host
             my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
             assert_script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin -v'";
             script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lp'", 420;

--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -73,6 +73,13 @@ sub get_suse_container_urls {
         push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/totest/images/suse/sle15:${dotversion}";
         push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
     }
+    elsif (is_microos('suse')) {
+        push @image_names,
+          "registry.suse.com/suse/sle15:15.0",
+          "registry.suse.com/suse/sle15:15.1",
+          "registry.suse.com/suse/sle15:15.2",
+          "registry.suse.com/suse/sle15:15.3";
+    }
     elsif (is_tumbleweed || is_microos("Tumbleweed")) {
         push @image_names,  "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";
         push @stable_names, "registry.opensuse.org/opensuse/tumbleweed";

--- a/schedule/microos/suse_microos_containers.yaml
+++ b/schedule/microos/suse_microos_containers.yaml
@@ -7,3 +7,4 @@ schedule:
     - console/suseconnect_scc
     - containers/containers_3rd_party
     - containers/podman
+    - containers/podman_image


### PR DESCRIPTION
Enable SLE base container on MicroOS container tests.
This will pull the corresponding base container on corresponding the SUSE MicroOS version.
e.g.
5.0 -> SLE15-SP2
5.1 -> SLE15-SP3
and so on

- Related ticket: https://progress.opensuse.org/issues/76915

