### PR TITLE
Add support of ppc64le in ReaR tests

### DIFF
--- a/schedule/ha/rear/rear_backup.yaml
+++ b/schedule/ha/rear/rear_backup.yaml
@@ -31,3 +31,4 @@ schedule:
   - console/hostname
   - console/consoletest_setup
   - ha/rear_backup
+  - console/scc_deregistration

--- a/schedule/ha/rear/rear_restore.yaml
+++ b/schedule/ha/rear/rear_restore.yaml
@@ -2,16 +2,5 @@
 name: rear_restore
 description: >
   Restore ReaR backup files.
-vars:
-  BOOTFROM: c
-  BOOT_HDD_IMAGE: '1'
-  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
-  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-%DESKTOP%.qcow2
 schedule:
   - ha/rear_restore
-  - '{{scc_deregister}}'
-conditional_schedule:
-  scc_deregister:
-    SCC_DEREGISTER:
-      1:
-        - console/scc_deregistration

--- a/tests/ha/rear_backup.pm
+++ b/tests/ha/rear_backup.pm
@@ -19,6 +19,7 @@ use utils qw(file_content_replace quit_packagekit zypper_call);
 sub run {
     my ($self)     = @_;
     my $hostname   = get_var('HOSTNAME', 'susetest');
+    my $arch       = get_required_var('ARCH');
     my $backup_url = get_required_var('BACKUP_URL');
     my $timeout    = bmwqemu::scale_timeout(300);
 
@@ -52,8 +53,10 @@ sub run {
         assert_script_run('rear -d -D mkbackup', timeout => $timeout);
     }
 
-    # Upload ISO image
-    upload_asset("/var/lib/rear/output/rear-$hostname.iso", 1);
+    # Upload ISO image (as a public image)
+    my $iso_image = "/var/lib/rear/output/rear-${hostname}";
+    assert_script_run("mv ${iso_image}.iso ${iso_image}-${arch}.iso");
+    upload_asset("${iso_image}-${arch}.iso", 1);
 }
 
 sub test_flags {


### PR DESCRIPTION
Add support for ppc64le and s390x in ReaR tests.
ReaR does not exist on aarch64 and s390x architectures (at least on SLE).

- Related ticket: N/A
- Needles: N/A (in fact already created on o.s.d., were needed for the verification runs).
- YAML for scheduling: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/226
- Verification runs: [rear_backup-ppc64le](https://openqa.suse.de/t5283339) and [rear_restore-ppc64le](https://openqa.suse.de/t5283599)
- Regression tests: [rear_backup-x86_64](http://1b210.qa.suse.de/tests/8249) and [rear_restore-x86_64](http://1b210.qa.suse.de/tests/8250)