### PR TITLE
Include python-scientific in opensuse tests

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -65,6 +65,7 @@ conditional_schedule:
                 - console/nano
                 - '{{steamcmd}}'
                 - console/libqca2
+                - console/python_scientific
                 - console/kdump_and_crash
     validate_packages_and_patterns:
         DISTRI:


### PR DESCRIPTION
Add python_scientific test run to YAML schedule.

- Verification run: [http://duck-norris.qam.suse.de/tests/4506](http://duck-norris.qam.suse.de/tests/4506#step/python_scientific/29) - `python_scientific` appears in schedule and is OK
