### PR TITLE
Fix openssl_nodejs test

### DIFF
--- a/data/console/test_openssl_nodejs.sh
+++ b/data/console/test_openssl_nodejs.sh
@@ -77,7 +77,7 @@ main(){
   # Install dependencies to apply source patches and run tests
   zypper -n in quilt rpm-build
 
-  if [ "$OS_VERSION" = "SLE_12_SP5"]; then
+  if [ "$OS_VERSION" = "SLE_12_SP5" ]; then
     zypper -n in openssl-1_1
   fi
 


### PR DESCRIPTION
Missing space in 'if'



- Related ticket: fixes https://openqa.suse.de/tests/5269519#next_previous
- Needles: no needles
- Verification run: http://10.161.229.176/tests/450