### PR TITLE
Fix user_defined_snapshot

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -68,7 +68,7 @@ sub run {
     wait_serial("$module_name-0", 200) || die "'yast2 $module_name' didn't finish";
     $self->{in_wait_boot} = 1;
     record_info 'Snapshot created', 'booting the system into created snapshot';
-    power_action('reboot', keepconsole => 1, observe => is_remote_backend);
+    power_action('reboot', keepconsole => 1);
     $self->wait_grub(bootloader_time => 250);
     send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
     send_key 'ret';
@@ -88,7 +88,7 @@ sub run {
     $self->wait_boot(textmode => $is_textmode, in_grub => 1);
     # request reboot again to ensure we will end up in the original system
     record_info 'Desktop reached', 'Now return system to original state with a reboot';
-    power_action('reboot', keepconsole => 1, observe => is_remote_backend);
+    power_action('reboot', keepconsole => 1);
     $self->wait_boot(textmode => $is_textmode, in_grub => 1, bootloader_time => 250);
 }
 


### PR DESCRIPTION
Fix user_defined_snapshot

- Related ticket: https://progress.opensuse.org/issues/65058
- Needles: N/A
- Verification run: [SLE 15-SP3](https://openqa.suse.de/tests/5289769#step/user_defined_snapshot/80) | [SLE 15-SP2](https://openqa.suse.de/tests/5290329#step/user_defined_snapshot/50)