### PR TITLE
Move multiline configs from apache.pm to data/

### DIFF
--- a/data/console/apache_.htaccess
+++ b/data/console/apache_.htaccess
@@ -1,0 +1,5 @@
+AuthType Basic
+AuthName "only joe must get in!"
+AuthUserFile /srv/www/vhosts/localhost/authtest/.htpasswd
+Require valid-user
+

--- a/data/console/apache_authtest.conf
+++ b/data/console/apache_authtest.conf
@@ -1,0 +1,4 @@
+<Directory "/srv/www/vhosts/localhost/authtest">
+AllowOverride AuthConfig
+</Directory>
+

--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -175,15 +175,10 @@ sub run {
     assert_script_run 'htpasswd -s -b /srv/www/vhosts/localhost/authtest/.htpasswd joe secret';
 
     # Paste the .htaccess file
-    assert_script_run "echo 'AuthType Basic
-    AuthName \"only joe must get in!\"
-    AuthUserFile /srv/www/vhosts/localhost/authtest/.htpasswd
-    Require valid-user' > /srv/www/vhosts/localhost/authtest/.htaccess";
+    assert_script_run('curl -o /srv/www/vhosts/localhost/authtest/.htaccess ' . data_url('console/apache_.htaccess'));
 
     # Paste the config file
-    assert_script_run "echo '<Directory \"/srv/www/vhosts/localhost/authtest\">
-    AllowOverride AuthConfig
-    </Directory>' > /etc/apache2/conf.d/authtest.conf";
+    assert_script_run('curl -o /etc/apache2/conf.d/authtest.conf ' . data_url('console/apache_authtest.conf'));
 
     # Start the webserver and test the password access
     systemctl 'start apache2';


### PR DESCRIPTION
As @mdoucha introduced #11625 we should get rid of multiline `assert_script_run()`.
Those multilines were used for echoing configs, so I moved those configs to `data/` instead.

- Verification run: [SLE15-SP2](http://pdostal-server.suse.cz/tests/10914)
