### PR TITLE
Test warning when /boot/efi is too small

### DIFF
--- a/lib/Installation/Partitioner/RolePage.pm
+++ b/lib/Installation/Partitioner/RolePage.pm
@@ -44,6 +44,9 @@ sub select_role_radiobutton {
     if ($role eq 'data') {
         send_key('alt-d');
     }
+    if ($role eq 'efi') {
+        send_key('alt-e');
+    }
 }
 
 sub press_next {

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -24,6 +24,7 @@ schedule:
   - installation/partitioning/warning/no_boot
   - installation/partitioning/warning/boot_small_for_kernel
   - installation/partitioning/warning/bios_boot_small_for_bootloader
+  - installation/partitioning/warning/uefi_small
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -24,6 +24,7 @@ schedule:
   - installation/partitioning/warning/no_boot
   - installation/partitioning/warning/boot_small_for_kernel
   - installation/partitioning/warning/bios_boot_small_for_bootloader
+  - installation/partitioning/warning/uefi_small
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
@@ -46,9 +47,9 @@ test_data:
       partitions:
         <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
   errors:
-    no_root: There is no device mounted at '/'
-    boot_small_for_kernel: The device mounted at '/boot' does not have enough space to contain a kernel
+    <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
   warnings:
-    snapshots_small_root: Your root device is very small for snapshots
+    <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
     no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
     bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader
+    uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
@@ -6,5 +6,6 @@ errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
-  no_boot: Missing device for /boot/efi with size equal or bigger than 256 MiB and filesystem vfat
-  bios_boot_small_for_bootloader: Missing device for /boot/efi with size equal or bigger than 256 MiB and filesystem vfat
+  no_boot: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
+  bios_boot_small_for_bootloader: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
+  uefi_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -8,3 +8,4 @@ warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
   bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep
+  uefi_small: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
@@ -8,3 +8,4 @@ warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
   bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep
+  uefi_small: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
@@ -8,3 +8,4 @@ warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
   bios_boot_small_for_bootloader: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
+  uefi_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs

--- a/test_data/yast/btrfs/btrfs+warnings_x64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_x64.yaml
@@ -8,3 +8,4 @@ warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
   bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader
+  uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+++ b/test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
@@ -41,3 +41,18 @@ bios_boot_small_for_bootloader:
   - role: raw-volume
     size: 1mb
     id: bios-boot
+uefi_small:
+  - role: operating-system
+    size: 11GiB
+    formatting_options:
+      should_format: 1
+    mounting_options:
+      should_mount: 1
+      mount_point: /
+  - role: efi
+    size: 100mb
+    formatting_options:
+      should_format: 1
+    mounting_options:
+      should_mount: 1
+      mount_point: /boot/efi

--- a/tests/installation/partitioning/warning/uefi_small.pm
+++ b/tests/installation/partitioning/warning/uefi_small.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify Warning Dialog when /boot/efi partition has too small
+# size.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+my $partitioner;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    my $disk      = $test_data->{disks}[0];
+    $partitioner = $testapi::distri->get_expert_partitioner();
+
+    $partitioner->run_expert_partitioner();
+    foreach my $partition (@{$disk->{partitions}->{uefi_small}}) {
+        $partitioner->add_partition_on_gpt_disk({
+                disk      => $disk->{name},
+                partition => $partition
+        });
+    }
+    $partitioner->accept_changes();
+
+    assert_matches(qr/$test_data->{warnings}->{uefi_small}/, $partitioner->get_warning_rich_text(),
+        "Warning Dialog for missing boot partition did not appear, while it is expected.");
+}
+
+sub post_run_hook {
+    save_screenshot;
+    $partitioner->decline_warning();
+    $partitioner->cancel_changes({accept_modified_devices_warning => 1});
+}
+
+1;


### PR DESCRIPTION
The PR adds test module to check that the appropriate warning message
appears when /boot/efi is too small on aarch64.

The test is also scheduled for other architectures to verify that adding
/boot/efi partition processes correctly even if the system does not
require it.

- Related ticket: https://progress.opensuse.org/issues/78007
- Verification runs: https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&groupid=96&build=120.1_uefi_oorlov
(aarch64 fails here, but #11728 should fix that)
