### PR TITLE
Enable yast2_firstboot in textmode

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -30,6 +30,7 @@ sub firstboot_language_keyboard {
     mouse_hide(1);
     foreach (sort keys %${shortcuts}) {
         send_key 'alt-' . $_;
+        send_key 'ret' if check_var('DESKTOP', 'textmode');
         assert_screen $shortcuts->{$_} . '_selected';
     }
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
@@ -92,6 +93,10 @@ sub run {
         die "Client '$client' is not defined in the module, please check test_data" unless defined(&{"$client"});
         my $client_method = \&{"$client"};
         $client_method->($self);
+    }
+    if (check_var('DESKTOP', 'textmode') && check_screen("linux-login", 10)) {
+        record_soft_failure "bsc#1180840 - the client inst_congratulate is missing";
+        return;
     }
     assert_screen 'installation_completed';
     send_key $cmd{finish};

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -74,12 +74,6 @@ sub firstboot_root {
 }
 
 sub firstboot_hostname {
-    if (check_screen('bsc1173298', 30)) {
-        record_soft_failure "bsc#1173298";
-        send_key $cmd{ok};
-        wait_screen_change(sub { send_key $cmd{next}; }, 7);
-        return;
-    }
     assert_screen 'hostname';
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
 }


### PR DESCRIPTION
In case we don't have an X server available, firstboot uses ncurses, this new test will cover it.
Also deleting a soft-failure for a closed bug bsc#1173298

- Related ticket: https://progress.opensuse.org/issues/73471
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1476
- Verification run: http://waaa-amazing.suse.cz/tests/13911#