### PR TITLE
Enable lvm multipath tests for YaST job group

### DIFF
--- a/schedule/yast/lvm_multipath.yaml
+++ b/schedule/yast/lvm_multipath.yaml
@@ -1,0 +1,44 @@
+---
+name:           lvm_multipath
+description:    >
+  Textmode installation test for lvm partitioning with no spearate home, on multipath with lvm validation.
+vars:
+  DESKTOP: textmode
+  MULTIPATH: 1
+  LVM: 1
+  SEPARATE_HOME: 0
+  HDDMODEL: scsi-hd
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/multipath
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/lvm_no_separate_home
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_multipath
+  - console/validate_lvm
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+test_data:
+  <<: !include test_data/yast/multipath.yaml

--- a/schedule/yast/lvm_multipath_encrypted.yaml
+++ b/schedule/yast/lvm_multipath_encrypted.yaml
@@ -1,0 +1,61 @@
+---
+name:           lvm_multipath_encrypted
+description:    >
+  Textmode installation test for encrypted lvm partitioning on multipath with lvm and encryption validation.
+vars:
+  DESKTOP: textmode
+  MULTIPATH: 1
+  LVM: 1
+  ENCRYPT: 1
+  SEPARATE_HOME: 0
+  HDDMODEL: scsi-hd
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/multipath
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/validate_multipath
+  - console/validate_lvm
+  - console/validate_encrypt
+  - console/consoletest_finish
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  cryptsetup:
+    device_status:
+      message: is active and is in use.
+      properties:
+        type: LUKS1
+        cipher: aes-xts-plain64
+        device: /dev/mapper/0QEMU_QEMU_HARDDISK_hd0-part2
+        key_location: dm-crypt
+        mode: read/write
+  backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
+  backup_path: '/root/bkp_luks_header_cr_home'
+  <<: !include test_data/yast/multipath.yaml

--- a/tests/console/validate_lvm.pm
+++ b/tests/console/validate_lvm.pm
@@ -88,15 +88,17 @@ sub run {
         die "LVM usage stats do not differ!";
     }
 
-    record_info('parted align', 'Verify if partition satisfies the alignment constraint of optimal type');
-    my $lsblk_output_json = script_output qq[lsblk -p -o NAME,TYPE,MOUNTPOINT -J -e 11];
-    my $drives            = extract_drives_from_json($lsblk_output_json);
-    my $i;
-    foreach my $dev (@{$drives}) {
-        $i = 1;
-        foreach my $child (@{get_children($dev)}) {
-            assert_script_run("parted $dev->{name} align-check optimal $i");
-            $i++;
+    unless (get_var('MULTIPATH')) {
+        record_info('parted align', 'Verify if partition satisfies the alignment constraint of optimal type');
+        my $lsblk_output_json = script_output qq[lsblk -p -o NAME,TYPE,MOUNTPOINT -J -e 11];
+        my $drives            = extract_drives_from_json($lsblk_output_json);
+        my $i;
+        foreach my $dev (@{$drives}) {
+            $i = 1;
+            foreach my $child (@{get_children($dev)}) {
+                assert_script_run("parted $dev->{name} align-check optimal $i");
+                $i++;
+            }
         }
     }
 }


### PR DESCRIPTION
Slight modification of kernel tests:
create_hdd_multipath_lvm_encrypt_textmode
and
create_hdd_multipath_lvm_textmode
so that there is lvm and encryption validation.

The goal is to enable the test suites for YaST job group

- Related ticket: https://progress.opensuse.org/issues/81108
- Verification runs: https://openqa.suse.de/tests/overview?build=dev_test_ssyrianidou&groupid=96&distri=sle&version=15-SP3
- Job groups: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/331/diffs 