### PR TITLE
Add script_run timeout for dialog command in ncurses.pm

### DIFF
--- a/tests/console/ncurses.pm
+++ b/tests/console/ncurses.pm
@@ -24,7 +24,7 @@ use utils qw(clear_console zypper_call);
 sub run {
     select_console 'root-console';
     zypper_call 'in dialog';
-    script_run 'dialog --yesno "test for boo#1054448" 3 20', 0;
+    script_run 'dialog --yesno "test for boo#1054448" 3 20';
     assert_screen 'ncurses-simple-dialog';
     send_key 'ret';
     clear_console;


### PR DESCRIPTION
add timeout for script_run function, try to fix random issue in migration regression job group

- Related ticket: https://progress.opensuse.org/issues/81826
- Needles: na
- Verification run: http://openqa.suse.de/t5270865
