### PR TITLE
Fix test data for lvm_thin_provisioning

### DIFF
--- a/test_data/yast/lvm_thin_provisioning/lvm_thin_provisioning.yaml
+++ b/test_data/yast/lvm_thin_provisioning/lvm_thin_provisioning.yaml
@@ -28,4 +28,4 @@ lvm:
         type: thin_pool
       - name: lv-home
         type: thin_volume
-        id: data
+        role: data


### PR DESCRIPTION
id key was used instead of role for lvm partition.

[Verification run](https://openqa.opensuse.org/tests/1585808#).

Fixes https://openqa.opensuse.org/tests/1585695#
