### PR TITLE
Use of select_host_console in place of select_console with tunnel

### DIFF
--- a/lib/publiccloud/ssh_interactive_init.pm
+++ b/lib/publiccloud/ssh_interactive_init.pm
@@ -19,15 +19,13 @@
 
 package publiccloud::ssh_interactive_init;
 use base "consoletest";
-
+use publiccloud::utils;
 use strict;
 use warnings;
 use testapi;
 
 sub post_fail_hook {
-    select_console 'tunnel-console', await_console => 0;
-    send_key "ctrl-c";
-    send_key "ret";
+    select_host_console(await_console => 0);
     assert_script_run('cd /root/terraform');
     script_run('terraform destroy -no-color -auto-approve', 240);
 }

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -24,12 +24,15 @@ use version_utils;
 our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand is_ec2 is_azure is_gce);
 
 # Select console on the test host, regardless of the TUNNELED variable.
-sub select_host_console() {
+sub select_host_console {
+    my (@args) = @_;
     if (check_var('TUNNELED', '1')) {
-        select_console('tunnel-console');
+        select_console('tunnel-console', @args);
     } else {
-        select_console('root-console');
+        select_console('root-console', @args);
     }
+    send_key "ctrl-c";
+    send_key "ret";
 }
 
 sub is_publiccloud() {

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -70,11 +70,8 @@ sub post_fail_hook {
     my ($self) = @_;
     # Destroy the public cloud instance
     ssh_interactive_leave();
-    select_console('tunnel-console', await_console => 0);
-    send_key "ctrl-c";
-    send_key "ret";
+    select_host_console(await_console => 0);
     $self->{provider}->cleanup();
 }
 
 1;
-

--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -13,6 +13,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use publiccloud::ssh_interactive;
+use publiccloud::utils;
 use testapi;
 use utils;
 
@@ -21,15 +22,7 @@ sub run {
     select_console 'root-console';
 
     ssh_interactive_leave();
-
-    # Find the PID of the SSH tunnel and kill it
-    #assert_script_run("ps --no-headers ao 'pid:1,cmd:1' | grep '[s]sh'");
-    #assert_script_run("kill -9 `ps --no-headers ao 'pid:1,cmd:1' | grep '[s]sh -t -R' | cut -d' ' -f1`");
-
-    # Destroy the public cloud instance
-    select_console 'tunnel-console', await_console => 0;
-    send_key "ctrl-c";
-    send_key "ret";
+    select_host_console(await_console => 0);
     $args->{my_provider}->cleanup();
 }
 


### PR DESCRIPTION
As for now we get a tunnel-console to the openqa instance
and exit the ssh terminal using manul calls before run the actual cleanup.
The idea is that the cleanup can be reused and we dont need to
repeat code.

We have a function to reuse instead right those line again and again.
await_console by default is enable and performs checks for the console.
We need to skip those check in cases like ssh_interactive_end as it causes
https://openqa.suse.de/tests/5272317#step/ssh_interactive_end/3

- Related ticket: https://progress.opensuse.org/issues/80922
- Verification run:
- https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2311749&version=12-SP5&distri=sle
- https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=b10n1k%2Fos-autoinst-distri-opensuse%2311749