### PR TITLE
Virtualization: Improve logging and make the SSH serial terminal work

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2664,8 +2664,9 @@ sub load_hypervisor_tests {
         load_inst_tests if check_var('VIRT_PART', 'install');
     }
 
+    loadtest "virt_autotest/login_console";
+
     if (check_var('VIRT_PART', 'install')) {
-        loadtest "virt_autotest/login_console";
         loadtest 'virtualization/universal/prepare_guests';         # Prepare libvirt and install guests
         loadtest 'virtualization/universal/ssh_hypervisor_init';    # Configure SSH for hypervisor
         loadtest 'virtualization/universal/waitfor_guests';         # Wait for guests to be installed
@@ -2677,14 +2678,15 @@ sub load_hypervisor_tests {
         loadtest 'virtualization/universal/patch_and_reboot';       # Apply updates and reboot
 
         loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";            # List all guests and ensure they are running
+    }
+
+    loadtest "virtualization/universal/list_guests";                # List all guests and ensure they are running
+
+    if (check_var('VIRT_PART', 'install')) {
         loadtest "virtualization/universal/kernel";                 # Virtualization kernel functions
     }
 
     if (check_var('VIRT_PART', 'virtmanager')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";            # List all guests and ensure they are running
-
         loadtest 'virtualization/universal/virtmanager_init';       # Connect to the Xen hypervisor using virt-manager
         loadtest 'virtualization/universal/virtmanager_offon';      # Turn all VMs off and then on again
 
@@ -2696,63 +2698,43 @@ sub load_hypervisor_tests {
 
 
     if (check_var('VIRT_PART', 'save_and_restore')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";         # List all guests and ensure they are running
-        loadtest 'virtualization/universal/save_and_restore';    # Try to save and restore the state of the guest
+        loadtest 'virtualization/universal/save_and_restore';               # Try to save and restore the state of the guest
     }
 
     if (check_var('VIRT_PART', 'guest_management')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";         # List all guests and ensure they are running
-        loadtest 'virtualization/universal/guest_management';    # Try to shutdown, start, suspend and resume the guest
+        loadtest 'virtualization/universal/guest_management';               # Try to shutdown, start, suspend and resume the guest
     }
 
     if (check_var('VIRT_PART', 'dom_metrics')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";         # List all guests and ensure they are running
-
-        loadtest 'virtualization/universal/virsh_stop';          # Stop libvirt guests
-        loadtest 'virtualization/universal/xl_create';           # Clone guests using the xl Xen tool
-        loadtest 'virtualization/universal/dom_install';         # Install vhostmd and vm-dump-metrics
-        loadtest 'virtualization/universal/dom_metrics';         # Collect some sample metrics
-        loadtest 'virtualization/universal/xl_stop';             # Stop guests created by the xl Xen tool
-        loadtest 'virtualization/universal/virsh_start';         # Start virsh guests again
+        loadtest 'virtualization/universal/virsh_stop';                     # Stop libvirt guests
+        loadtest 'virtualization/universal/xl_create';                      # Clone guests using the xl Xen tool
+        loadtest 'virtualization/universal/dom_install';                    # Install vhostmd and vm-dump-metrics
+        loadtest 'virtualization/universal/dom_metrics';                    # Collect some sample metrics
+        loadtest 'virtualization/universal/xl_stop';                        # Stop guests created by the xl Xen tool
+        loadtest 'virtualization/universal/virsh_start';                    # Start virsh guests again
     }
 
     if (check_var('VIRT_PART', 'hotplugging')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";         # List all guests and ensure they are running
-
-        loadtest 'virtualization/universal/hotplugging';         # Try to change properties of guests
+        loadtest 'virtualization/universal/hotplugging';                    # Try to change properties of guests
     }
 
     if (check_var('VIRT_PART', 'networking')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";
-
         loadtest "virt_autotest/libvirt_host_bridge_virtual_network";
         loadtest "virt_autotest/libvirt_nated_virtual_network";
         loadtest "virt_autotest/libvirt_isolated_virtual_network";
     }
 
     if (check_var('VIRT_PART', 'snapshots')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";
-
         loadtest "virt_autotest/virsh_internal_snapshot";
         loadtest "virt_autotest/virsh_external_snapshot";
+
     }
 
     if (check_var('VIRT_PART', 'storage')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";    # List all guests and ensure they are running
-
-        loadtest 'virtualization/universal/storage';        # Storage pool / volume test
+        loadtest 'virtualization/universal/storage';    # Storage pool / volume test
     }
 
     if (check_var('VIRT_PART', 'final')) {
-        loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/list_guests";          # List all guests and ensure they are running
         loadtest 'virtualization/universal/ssh_final';            # Check that every guest is reachable over SSH
         loadtest 'virtualization/universal/virtmanager_final';    # Check that every guest shows the login screen
         loadtest "virtualization/universal/smoketest";            # Virtualization smoke test for hypervisor
@@ -2762,10 +2744,11 @@ sub load_hypervisor_tests {
     }
 
     if (check_var('VIRT_PART', 'windows')) {
-        loadtest "virt_autotest/login_console";
         loadtest "virtualization/universal/download_image";       # Download Windows disk image(s)
         loadtest "virtualization/universal/windows";              # Import and test Windows
     }
+
+    loadtest "virtualization/universal/finish";                   # Collect logs
 }
 
 sub load_extra_tests_syscontainer {

--- a/tests/virtualization/universal/download_image.pm
+++ b/tests/virtualization/universal/download_image.pm
@@ -19,6 +19,7 @@ use utils;
 
 sub run {
     my $self = shift;
+    $self->select_serial_terminal;
 
     ensure_default_net_is_active();
 

--- a/tests/virtualization/universal/finish.pm
+++ b/tests/virtualization/universal/finish.pm
@@ -1,0 +1,36 @@
+# XEN regression tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Package: libvirt-client iputils nmap xen-tools
+# Summary: The last test of a typical virtualization run:
+#   It's purpose is to collect logs.
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base 'consoletest';
+use virt_autotest::common;
+use virt_autotest::utils;
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Show all guests
+    assert_script_run 'virsh list --all';
+    wait_still_screen 1;
+
+    script_run 'history -a';
+
+    collect_virt_system_logs();
+}
+
+1;

--- a/tests/virtualization/universal/list_guests.pm
+++ b/tests/virtualization/universal/list_guests.pm
@@ -9,7 +9,7 @@
 # Summary: List every guest and ensure they are online
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use virt_autotest::utils;
 use strict;
@@ -17,8 +17,9 @@ use warnings;
 use testapi;
 use utils;
 
-sub run {
+sub run_test {
     my $self = shift;
+    $self->select_serial_terminal;
 
     ensure_default_net_is_active();
 

--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -11,7 +11,7 @@
 # Summary: Apply patches to the all of our guests and reboot them
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-use base "consoletest";
+use base 'consoletest';
 use warnings;
 use strict;
 use testapi;
@@ -32,9 +32,10 @@ sub run {
     assert_script_run qq(echo -e "Guests before and after patching:" > $kernel_log);
     assert_script_run qq(echo -e "\\n\\nBefore:" >> $kernel_log);
     foreach my $guest (keys %virt_autotest::common::guests) {
-        ($guest_running_version, $guest_running_sp) = get_os_release("ssh root\@$guest");
+        record_info "$guest", "Probing the guest, adding test repositories and patching the system";
+        ensure_online $guest foreach (keys %virt_autotest::common::guests);
 
-        record_info "$guest", "Adding test repositories and patching the $guest system";
+        ($guest_running_version, $guest_running_sp) = get_os_release("ssh root\@$guest");
         if ($host_running_version == $guest_running_version && $host_running_sp == $guest_running_sp) {
             ssh_add_test_repositories "$guest";
 

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -22,6 +22,7 @@ use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
+    $self->select_serial_terminal;
 
     # Ensure additional package is installed
     zypper_call '-t in libvirt-client iputils nmap';
@@ -60,7 +61,15 @@ sub run {
 
     script_run 'history -a';
     script_run('cat ~/virt-install* | grep ERROR', 30);
-    script_run('xl dmesg |grep -i "fail\|error" |grep -vi Loglevel') if (get_var("REGRESSION", '') =~ /xen/);
+    script_run('xl dmesg |grep -i "fail\|error" |grep -vi Loglevel') if (is_xen_host());
+
+    collect_virt_system_logs();
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    collect_virt_system_logs();
+    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/virtualization/universal/register_guests.pm
+++ b/tests/virtualization/universal/register_guests.pm
@@ -17,7 +17,7 @@
 # Summary: Register all guests against local SMT server
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use strict;
 use warnings;
@@ -25,7 +25,7 @@ use testapi;
 use utils;
 use version_utils;
 
-sub run {
+sub run_test {
     my ($self) = @_;
 
     foreach my $guest (keys %virt_autotest::common::guests) {

--- a/tests/virtualization/universal/save_and_restore.pm
+++ b/tests/virtualization/universal/save_and_restore.pm
@@ -11,14 +11,14 @@
 # Summary: Test if the guests can be saved and restored
 # Maintainer: Jan Baier <jbaier@suse.cz>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use strict;
 use warnings;
 use testapi;
 use utils;
 
-sub run {
+sub run_test {
     assert_script_run "mkdir -p /var/lib/libvirt/images/saves/";
 
     record_info "Remove", "Remove previous saves (if there were any)";

--- a/tests/virtualization/universal/smoketest.pm
+++ b/tests/virtualization/universal/smoketest.pm
@@ -11,7 +11,7 @@
 # Summary: Tests, if the machine is up and running
 # Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use virt_autotest::utils;
 use strict;
@@ -37,7 +37,7 @@ my %cves = (
     "CVE-2018-12207" => "No eXcuses/iTLB Multihit",
 );
 
-sub run {
+sub run_test {
     my $self = shift;
     $self->select_serial_terminal;
 

--- a/tests/virtualization/universal/ssh_final.pm
+++ b/tests/virtualization/universal/ssh_final.pm
@@ -17,7 +17,7 @@
 # Summary: This checks all VMs over SSH
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use strict;
 use warnings;
 use virt_autotest::common;
@@ -25,7 +25,7 @@ use strict;
 use testapi;
 use utils;
 
-sub run {
+sub run_test {
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "Establishing SSH connection to $guest";
         assert_script_run "ping -c3 -W1 $guest";

--- a/tests/virtualization/universal/ssh_guests_init.pm
+++ b/tests/virtualization/universal/ssh_guests_init.pm
@@ -19,11 +19,11 @@
 
 use base "consoletest";
 use virt_autotest::common;
+use virt_autotest::utils;
 use strict;
 use warnings;
 use testapi;
 use utils;
-use virt_autotest::utils;
 
 sub run {
     foreach my $guest (keys %virt_autotest::common::guests) {

--- a/tests/virtualization/universal/stresstest.pm
+++ b/tests/virtualization/universal/stresstest.pm
@@ -11,7 +11,7 @@
 # Summary: Perform some stress tests on VM
 # Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use strict;
 use warnings;
@@ -19,7 +19,7 @@ use testapi;
 use utils;
 use version_utils;
 
-sub run {
+sub run_test {
     my $self = shift;
     $self->select_serial_terminal;
     # Fetch the test script to local host, before distributing it to the guests

--- a/tests/virtualization/universal/virtmanager_add_devices.pm
+++ b/tests/virtualization/universal/virtmanager_add_devices.pm
@@ -17,7 +17,7 @@
 # Summary: This test adds some devices to our VMs
 # Maintainer: Pavel Dostal <pdostal@suse.cz>, Felix Niederwanger <felix.niederwanger@suse.de>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use strict;
 use warnings;
@@ -26,7 +26,7 @@ use utils;
 use version_utils;
 use virtmanager;
 
-sub run {
+sub run_test {
     my ($self) = @_;
 
     #x11_start_program 'virt-manager';

--- a/tests/virtualization/universal/virtmanager_final.pm
+++ b/tests/virtualization/universal/virtmanager_final.pm
@@ -17,7 +17,7 @@
 # Summary: This test turns just check all VMs
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use strict;
 use warnings;
@@ -25,7 +25,8 @@ use testapi;
 use utils;
 use virtmanager;
 
-sub run {
+sub run_test {
+    select_console 'root-console';
     zypper_call '-t in virt-manager', exitcode => [0, 4, 102, 103, 106];
 
     #x11_start_program 'virt-manager';

--- a/tests/virtualization/universal/virtmanager_init.pm
+++ b/tests/virtualization/universal/virtmanager_init.pm
@@ -17,7 +17,7 @@
 # Summary: This test connects to hypervisor and check our VMs
 # Maintainer: Pavel Dostal <pdostal@suse.cz>, Felix Niederwanger <felix.niederwanger@suse.de>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use virt_autotest::utils;
 use strict;
@@ -26,8 +26,9 @@ use testapi;
 use utils;
 use virtmanager;
 
-sub run {
+sub run_test {
     my ($self) = @_;
+    select_console 'root-console';
 
     zypper_call '-t in virt-manager', exitcode => [0, 4, 102, 103, 106];
 

--- a/tests/virtualization/universal/virtmanager_offon.pm
+++ b/tests/virtualization/universal/virtmanager_offon.pm
@@ -17,7 +17,7 @@
 # Summary: This test turns all VMs off and then on again
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use strict;
 use warnings;
@@ -25,7 +25,7 @@ use testapi;
 use utils;
 use virtmanager;
 
-sub run {
+sub run_test {
     my ($self) = @_;
 
     #x11_start_program 'virt-manager';

--- a/tests/virtualization/universal/virtmanager_rm_devices.pm
+++ b/tests/virtualization/universal/virtmanager_rm_devices.pm
@@ -17,7 +17,7 @@
 # Summary: This test removed aditional HV from our VMs
 # Maintainer: Pavel Dostal <pdostal@suse.cz>, Felix Niederwanger <felix.niederwanger@suse.de>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use virt_autotest::common;
 use strict;
 use warnings;
@@ -25,7 +25,7 @@ use testapi;
 use utils;
 use virtmanager;
 
-sub run {
+sub run_test {
     my ($self) = @_;
 
     #x11_start_program 'virt-manager';

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -33,4 +33,10 @@ sub run {
     wait_still_screen 1;
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    collect_virt_system_logs();
+    $self->SUPER::post_fail_hook;
+}
+
 1;


### PR DESCRIPTION
Hello,

this PR has several purposes:
 * Modifying the `kernel.pm` smoke test output file to contain more information about the SUT.
 * Modify `virt_feature_test_base` so it can be used in maintenance and use it wherever possible.
 * Implement `collect_virt_system_logs` as `virt_utils::collect_host_and_guest_logs` cannot be used.
 * Add the `virtualization/universal/finish` test module which will collect logs at the end of every test run.
 * Modify `create_guest` to check if guest really started as serial terminal speeded the execution too much.

- Related ticket: [poo#75406](https://progress.opensuse.org/issues/75406) [poo#87758](https://progress.opensuse.org/issues/87758)
- Verification run: [KVM](http://pdostal-server.suse.cz/tests/11004) [XEN](http://pdostal-server.suse.cz/tests/11013)