### PR TITLE
sles4sap: Disable all nr_requests tests on every test pattern file

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -56,7 +56,7 @@ sub setup {
         # Ignore disk_elevator on VM's
         assert_script_run "sed -ri '/:scripts\\/disk_elevator/s/^/#/' \$(fgrep -rl :scripts/disk_elevator Pattern/)";
         # Skip nr_requests on VM's. Fix bsc#1177888
-        assert_script_run 'sed -i "/:scripts\/nr_requests/s/^/#/" Pattern/SLE15/testpattern_note_*';
+        assert_script_run 'sed -i "/:scripts\/nr_requests/s/^/#/" Pattern/SLE15/testpattern_*';
     }
     $self->reboot_wait;
 }


### PR DESCRIPTION
Disable all nr_requests test on all patterns.

Verification runs:
- http://ix64hae1001.qa.suse.de/tests/2193
- http://ix64hae1001.qa.suse.de/tests/2192