### PR TITLE
Scope post_fail_hook for sssd test case

### DIFF
--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -94,4 +94,9 @@ sub run {
     }
 }
 
+sub post_fail_hook {
+    select_console 'log-console';
+    shift->export_logs_basic;
+}
+
 1;


### PR DESCRIPTION
_sssd.pm_ as phub dependent test case mostly fails in package
installation part when it comes to _sle_ testing.
IMHO it is enough to upload only basic logs.

- Related ticket: [[JeOS][VMWare] cifs fails after previously failed docker-compose test case](https://progress.opensuse.org/issues/87686)
- Verification run: [Build20.212-jeos-base+phub@svirt-vmware65](http://kepler.suse.cz/tests/3400#step/cifs/76)
