### PR TITLE
Modify the scheduling of extra_tests_transactional_server

### DIFF
--- a/schedule/functional/extra_tests_transactional_server.yaml
+++ b/schedule/functional/extra_tests_transactional_server.yaml
@@ -2,12 +2,10 @@
 name: extra_tests_transactional_server
 description: >
     Maintainer: zluo
-    transactional server for Tumbleweed
+    transactional server for SLES 15-SP3
     boot transactional server as serverrole and run some transactional tests
 schedule:
     - boot/boot_to_desktop
-    - update/zypper_clear_repos
-    - console/zypper_ar
     - console/zypper_ref
     - console/update_alternatives
     - console/java


### PR DESCRIPTION
As the yaml file was overtaken from the Tumbleweed runs, it has to be
adapted accordingly.

- Related ticket: N/A
- Needles: N/A
- Verification run: [SLE 15-SP3](http://10.161.229.247/tests/1616)
