### PR TITLE
Fix test data for lvm_thin_provisioning

### DIFF
--- a/test_data/yast/lvm_thin_provisioning/lvm_thin_provisioning_s390x.yaml
+++ b/test_data/yast/lvm_thin_provisioning/lvm_thin_provisioning_s390x.yaml
@@ -33,4 +33,4 @@ lvm:
         type: thin_pool
       - name: lv-home
         type: thin_volume
-        id: data
+        role: data

--- a/test_data/yast/lvm_thin_provisioning/lvm_thin_provisioning_uefi.yaml
+++ b/test_data/yast/lvm_thin_provisioning/lvm_thin_provisioning_uefi.yaml
@@ -34,4 +34,4 @@ lvm:
         type: thin_pool
       - name: lv-home
         type: thin_volume
-        id: data
+        role: data


### PR DESCRIPTION
The commit fixes the test data for s390x and uefi.                                                                                                                                                        
Id key was used instead of role for lvm partition. 

- Verification run: https://openqa.suse.de/tests/5288331