### PR TITLE
Initialize barriers earlier on HA tests without Support Server

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2928,14 +2928,14 @@ sub load_sles4sap_tests {
 sub load_ha_cluster_tests {
     return unless get_var('HA_CLUSTER');
 
+    # When not using a support server, node 1 setups barriers and mutex
+    loadtest 'ha/barrier_init' if (get_var('HOSTNAME') =~ /node01$/ and !get_var('USE_SUPPORT_SERVER'));
+
     # Standard boot
     boot_hdd_image;
 
     # Only SLE-15+ has support for lvmlockd
     set_var('USE_LVMLOCKD', 0) if (get_var('USE_LVMLOCKD') and is_sle('<15'));
-
-    # When not using a support server, node 1 setups barriers and mutex
-    loadtest 'ha/barrier_init' if (get_var('HOSTNAME') =~ /node01$/ and !get_var('USE_SUPPORT_SERVER'));
 
     # Wait for barriers to be initialized except when testing with a client
     # HAWK, Pacemaker CTS regression tests or CTDB


### PR DESCRIPTION
Initialize barriers earlier on HA tests without Support Server

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
