### PR TITLE
Address an ambiguity in autoyast_activate_encrypted_volume

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -164,6 +164,8 @@ sub run {
 
     # Push needle 'inst-bootmenu' to ensure boot from hard disk on aarch64
     push(@needles, 'inst-bootmenu') if (check_var('ARCH', 'aarch64') && get_var('UPGRADE'));
+    # If we have an encrypted root or boot volume, we reboot to a grub password prompt.
+    push(@needles, 'encrypted-disk-password-prompt') if get_var("ENCRYPT_ACTIVATE_EXISTING");
     # Kill ssh proactively before reboot to avoid half-open issue on zVM, do not need this on zKVM
     prepare_system_shutdown if check_var('BACKEND', 's390x');
     my $postpartscript = 0;
@@ -179,7 +181,8 @@ sub run {
           || match_has_tag('bios-boot')
           || match_has_tag('autoyast-stage1-reboot-upcoming')
           || match_has_tag('inst-bootmenu')
-          || match_has_tag('lang_and_keyboard'))
+          || match_has_tag('lang_and_keyboard')
+          || match_has_tag('encrypted-disk-password-prompt'))
     {
         #Verify timeout and continue if there was a match
         next unless verify_timeout_and_check_screen(($timer += $check_time), \@needles);


### PR DESCRIPTION
If we have an encrypted root volume, we reboot to a grub password prompt
that may either match "bios-boot" or "encrypted-disk-password-prompt",
we need to cover both possibilities. Initially only bios-boot was supposed to match, but sometimes does not work https://openqa.suse.de/tests/5282295#step/installation/56 because the "Seabios" part does not appear.

ticket https://progress.opensuse.org/issues/33364
VRs:
build 120.1, matching bios-boot: http://waaa-amazing.suse.cz/tests/13888#step/installation/22
build 123.3, matching encrypted-disk-password-prompt: http://waaa-amazing.suse.cz/tests/13918#step/installation/23
