### PR TITLE
Add missing logs in ReaR tests

### DIFF
--- a/lib/rear.pm
+++ b/lib/rear.pm
@@ -1,0 +1,74 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Functions for ReaR tests
+
+package rear;
+use base "opensusebasetest";
+
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT = qw(
+  upload_rear_logs
+);
+
+=head1 SYNOPSIS
+
+Package with common methods and default values for testing ReaR on HA
+module.
+
+This package inherits from B<opensusebasetest> and should be used as
+a class.
+
+=cut
+
+=head2 upload_rear_logs
+
+ $self->upload_rear_logs();
+
+Upload needed logs for debugging purposes.
+=cut
+
+sub upload_rear_logs {
+    my ($self) = @_;
+
+    # Upload config file
+    upload_logs('/etc/rear/local.conf', failok => 1);
+
+    # List of block devices
+    $self->save_and_upload_log('lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,SIZE,MOUNTPOINT', '/tmp/lsblk.log');
+
+    # Create tarball with logfiles and upload it
+    my $logfile = '/tmp/rear-recover-logs.tar.bz2';
+    script_run("tar cjf $logfile /var/log/rear/rear-*.log /var/lib/rear/layout/* /var/lib/rear/recovery/*");
+    upload_logs("$logfile", failok => 1);
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    # We need to be sure that *ALL* consoles are closed, are SUPER:post_fail_hook
+    # does not support virtio/serial console yet
+    reset_consoles;
+    select_console('root-console');
+
+    # Upload the logs
+    $self->upload_rear_logs;
+
+    # Execute the common part
+    $self->SUPER::post_fail_hook unless check_var('LIVETEST', 1);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/ha/rear_backup.pm
+++ b/tests/ha/rear_backup.pm
@@ -10,7 +10,7 @@
 # Summary: Install ReaR packages and create a ReaR backup on an NFS server
 # Maintainer: Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'rear';
 use strict;
 use warnings;
 use testapi;
@@ -49,18 +49,16 @@ sub run {
         my $local_conf = '/etc/rear/local.conf';
         assert_script_run("curl -f -v " . data_url('ha/rear_local.conf') . " -o $local_conf");
         file_content_replace("$local_conf", q(%BACKUP_URL%) => $backup_url);
-        upload_logs("$local_conf", failok => 1);    # Upload the configuration file
         assert_script_run('rear -d -D mkbackup', timeout => $timeout);
     }
+
+    # Upload the logs
+    $self->upload_rear_logs;
 
     # Upload ISO image (as a public image)
     my $iso_image = "/var/lib/rear/output/rear-${hostname}";
     assert_script_run("mv ${iso_image}.iso ${iso_image}-${arch}.iso");
     upload_asset("${iso_image}-${arch}.iso", 1);
-}
-
-sub test_flags {
-    return {fatal => 1};
 }
 
 1;

--- a/tests/ha/rear_restore.pm
+++ b/tests/ha/rear_restore.pm
@@ -10,18 +10,11 @@
 # Summary: Restore a ReaR backup
 # Maintainer: Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'rear';
 use strict;
 use warnings;
 use testapi;
 use power_action_utils 'power_action';
-
-sub upload_rear_logs {
-    # Create tarball with logfiles and upload it
-    my $logfile = '/tmp/rear-recover-logs.tar.bz2';
-    script_run("tar cjf $logfile /var/log/rear/rear-*.log /var/lib/rear/layout/* /var/lib/rear/recovery/*");
-    upload_logs("$logfile", failok => 1);
-}
 
 sub run {
     my ($self) = @_;
@@ -34,10 +27,10 @@ sub run {
     $self->wait_boot_past_bootloader;
 
     # Restore the OS backup
-    set_var('LIVETEST', 1);                               # Because there is no password in Rear miniOS
+    set_var('LIVETEST', 1);                               # Because there is no password in ReaR miniOS
     select_console('root-console', skip_setterm => 1);    # Serial console is not configured in ReaR miniOS
     assert_script_run('export USER_INPUT_TIMEOUT=5; rear -d -D recover');
-    upload_rear_logs;
+    $self->upload_rear_logs;
     set_var('LIVETEST', 0);
 
     # Reboot into the restored OS
@@ -47,16 +40,6 @@ sub run {
     # Test login to ensure that the based OS configuration is correctly restored
     $self->select_serial_terminal;
     assert_script_run('cat /etc/os-release ; uname -a');
-}
-
-sub post_fail_hook {
-    my ($self) = shift;
-    upload_rear_logs;
-    $self->SUPER::post_fail_hook unless get_var('LIVETEST', 0);
-}
-
-sub test_flags {
-    return {fatal => 1};
 }
 
 1;


### PR DESCRIPTION
Add missing logs for ReaR and refactoring some code.

- Related ticket: N/A
- Needles: N/A
- Verification run: [rear_backup](http://1b210.qa.suse.de/tests/8253)

**Note:** rear_restore verification run can't be done because of a new bug in rear_backup