### PR TITLE
Test warnings in Expert Partitioner when too small root, /boot/zipl and PReP are used

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/partitioning/warning/uefi_small
   - installation/partitioning/warning/prep_small
   - installation/partitioning/warning/zipl_small
+  - installation/partitioning/warning/rootfs_small
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -25,6 +25,7 @@ schedule:
   - installation/partitioning/warning/boot_small_for_kernel
   - installation/partitioning/warning/bios_boot_small_for_bootloader
   - installation/partitioning/warning/uefi_small
+  - installation/partitioning/warning/prep_small
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -26,6 +26,7 @@ schedule:
   - installation/partitioning/warning/bios_boot_small_for_bootloader
   - installation/partitioning/warning/uefi_small
   - installation/partitioning/warning/prep_small
+  - installation/partitioning/warning/zipl_small
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -65,9 +65,5 @@ test_data:
     <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
   warnings:
     <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
-    no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
-    bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader
-    uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader
-    prep_small: A partition of type BIOS Boot Partition is needed to install the bootloader
-    zipl_small: A partition of type BIOS Boot Partition is needed to install the bootloader
+    missing_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
     rootfs_small: Missing device for / with size equal or bigger than 5 GiB and filesystem ext2, ext3, ext4, btrfs, xfs

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -26,6 +26,7 @@ schedule:
   - installation/partitioning/warning/bios_boot_small_for_bootloader
   - installation/partitioning/warning/uefi_small
   - installation/partitioning/warning/prep_small
+  - installation/partitioning/warning/zipl_small
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
@@ -53,8 +54,6 @@ test_data:
     <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
     no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
     bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader
-<<<<<<< HEAD
     uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader
-=======
     prep_small: A partition of type BIOS Boot Partition is needed to install the bootloader
->>>>>>> 15942c42f (Test warning when PReP boot is too small)
+    zipl_small: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -25,6 +25,7 @@ schedule:
   - installation/partitioning/warning/boot_small_for_kernel
   - installation/partitioning/warning/bios_boot_small_for_bootloader
   - installation/partitioning/warning/uefi_small
+  - installation/partitioning/warning/prep_small
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
@@ -52,4 +53,8 @@ test_data:
     <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
     no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
     bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader
+<<<<<<< HEAD
     uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader
+=======
+    prep_small: A partition of type BIOS Boot Partition is needed to install the bootloader
+>>>>>>> 15942c42f (Test warning when PReP boot is too small)

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/partitioning/warning/uefi_small
   - installation/partitioning/warning/prep_small
   - installation/partitioning/warning/zipl_small
+  - installation/partitioning/warning/rootfs_small
   - installation/partitioning_filesystem
   - installation/partitioning_finish
   - installation/installer_timezone
@@ -48,6 +49,18 @@ test_data:
     - name: vda
       partitions:
         <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+        rootfs_small:
+          - role: raw-volume
+            size: 2mb
+            id: bios-boot
+          - role: operating-system
+            size: 4GiB
+            formatting_options:
+              should_format: 1
+              filesystem: xfs
+            mounting_options:
+              should_mount: 1
+              mount_point: /
   errors:
     <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
   warnings:
@@ -57,3 +70,4 @@ test_data:
     uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader
     prep_small: A partition of type BIOS Boot Partition is needed to install the bootloader
     zipl_small: A partition of type BIOS Boot Partition is needed to install the bootloader
+    rootfs_small: Missing device for / with size equal or bigger than 5 GiB and filesystem ext2, ext3, ext4, btrfs, xfs

--- a/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
@@ -2,6 +2,22 @@ disks:
   - name: vda
     partitions:
       <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+      rootfs_small:
+        - role: efi
+          size: 128mb
+          formatting_options:
+            should_format: 1
+          mounting_options:
+            should_mount: 1
+            mount_point: /boot/efi
+        - role: operating-system
+          size: 2GiB
+          formatting_options:
+            should_format: 1
+            filesystem: xfs
+          mounting_options:
+            should_mount: 1
+            mount_point: /
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:

--- a/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
@@ -9,3 +9,4 @@ warnings:
   no_boot: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
   bios_boot_small_for_bootloader: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
   uefi_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
+  prep_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat

--- a/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
@@ -10,3 +10,4 @@ warnings:
   bios_boot_small_for_bootloader: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
   uefi_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
   prep_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
+  zipl_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat

--- a/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_aarch64.yaml
@@ -22,8 +22,4 @@ errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
-  no_boot: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
-  bios_boot_small_for_bootloader: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
-  uefi_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
-  prep_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
-  zipl_small: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
+  missing_boot: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -18,7 +18,4 @@ errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
-  no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
-  bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep
-  prep_small: Missing device with size equal or bigger than 2 MiB and partition id prep
-  zipl_small: Missing device with size equal or bigger than 2 MiB and partition id prep
+  missing_boot: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -2,6 +2,18 @@ disks:
   - name: sda
     partitions:
       <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+      rootfs_small:
+        - role: raw-volume
+          size: 8mb
+          id: prep-boot
+        - role: operating-system
+          size: 2GiB
+          formatting_options:
+            should_format: 1
+            filesystem: xfs
+          mounting_options:
+            should_mount: 1
+            mount_point: /
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -8,4 +8,4 @@ warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
   bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep
-  uefi_small: Missing device with size equal or bigger than 2 MiB and partition id prep
+  prep_small: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_hmc.yaml
@@ -9,3 +9,4 @@ warnings:
   no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
   bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep
   prep_small: Missing device with size equal or bigger than 2 MiB and partition id prep
+  zipl_small: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
@@ -18,8 +18,4 @@ errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
-  no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
-  bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep
-  uefi_small: Missing device with size equal or bigger than 2 MiB and partition id prep
-  prep_small: Missing device with size equal or bigger than 2 MiB and partition id prep
-  zipl_small: Missing device with size equal or bigger than 2 MiB and partition id prep
+  missing_boot: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
@@ -2,6 +2,18 @@ disks:
   - name: vda
     partitions:
       <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+      rootfs_small:
+        - role: raw-volume
+          size: 8mb
+          id: prep-boot
+        - role: operating-system
+          size: 2GiB
+          formatting_options:
+            should_format: 1
+            filesystem: xfs
+          mounting_options:
+            should_mount: 1
+            mount_point: /
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:

--- a/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
@@ -10,3 +10,4 @@ warnings:
   bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep
   uefi_small: Missing device with size equal or bigger than 2 MiB and partition id prep
   prep_small: Missing device with size equal or bigger than 2 MiB and partition id prep
+  zipl_small: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_ppc64le.yaml
@@ -9,3 +9,4 @@ warnings:
   no_boot: Missing device with size equal or bigger than 2 MiB and partition id prep
   bios_boot_small_for_bootloader: Missing device with size equal or bigger than 2 MiB and partition id prep
   uefi_small: Missing device with size equal or bigger than 2 MiB and partition id prep
+  prep_small: Missing device with size equal or bigger than 2 MiB and partition id prep

--- a/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
@@ -10,3 +10,4 @@ warnings:
   bios_boot_small_for_bootloader: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
   uefi_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
   prep_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
+  zipl_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs

--- a/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
@@ -2,6 +2,23 @@ disks:
   - name: vda
     partitions:
       <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+      rootfs_small:
+        - role: operating-system
+          size: 500mb
+          formatting_options:
+            should_format: 1
+            filesystem: ext2
+          mounting_options:
+            should_mount: 1
+            mount_point: /boot/zipl
+        - role: operating-system
+          size: 2GiB
+          formatting_options:
+            should_format: 1
+            filesystem: xfs
+          mounting_options:
+            should_mount: 1
+            mount_point: /
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:

--- a/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
@@ -9,3 +9,4 @@ warnings:
   no_boot: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
   bios_boot_small_for_bootloader: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
   uefi_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
+  prep_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs

--- a/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_s390x.yaml
@@ -23,8 +23,4 @@ errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
-  no_boot: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
-  bios_boot_small_for_bootloader: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
-  uefi_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
-  prep_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
-  zipl_small: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs
+  missing_boot: Missing device for /boot/zipl with size equal or bigger than 100 MiB and filesystem ext2, ext3, ext4, xfs

--- a/test_data/yast/btrfs/btrfs+warnings_x64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_x64.yaml
@@ -2,6 +2,18 @@ disks:
   - name: vda
     partitions:
       <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+      rootfs_small:
+        - role: raw-volume
+          size: 2mb
+          id: bios-boot
+        - role: operating-system
+          size: 2GiB
+          formatting_options:
+            should_format: 1
+            filesystem: xfs
+          mounting_options:
+            should_mount: 1
+            mount_point: /
 errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:

--- a/test_data/yast/btrfs/btrfs+warnings_x64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_x64.yaml
@@ -9,3 +9,4 @@ warnings:
   no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
   bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader
   uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader
+  prep_small: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/test_data/yast/btrfs/btrfs+warnings_x64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_x64.yaml
@@ -18,8 +18,4 @@ errors:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
-  no_boot: A partition of type BIOS Boot Partition is needed to install the bootloader
-  bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader
-  uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader
-  prep_small: A partition of type BIOS Boot Partition is needed to install the bootloader
-  zipl_small: A partition of type BIOS Boot Partition is needed to install the bootloader
+  missing_boot: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/test_data/yast/btrfs/btrfs+warnings_x64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_x64.yaml
@@ -10,3 +10,4 @@ warnings:
   bios_boot_small_for_bootloader: A partition of type BIOS Boot Partition is needed to install the bootloader
   uefi_small: A partition of type BIOS Boot Partition is needed to install the bootloader
   prep_small: A partition of type BIOS Boot Partition is needed to install the bootloader
+  zipl_small: A partition of type BIOS Boot Partition is needed to install the bootloader

--- a/test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+++ b/test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
@@ -56,3 +56,14 @@ uefi_small:
     mounting_options:
       should_mount: 1
       mount_point: /boot/efi
+prep_small:
+  - role: operating-system
+    size: 11GiB
+    formatting_options:
+      should_format: 1
+    mounting_options:
+      should_mount: 1
+      mount_point: /
+  - role: raw-volume
+    size: 1mb
+    id: prep-boot

--- a/test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+++ b/test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
@@ -67,3 +67,19 @@ prep_small:
   - role: raw-volume
     size: 1mb
     id: prep-boot
+zipl_small:
+  - role: operating-system
+    size: 11GiB
+    formatting_options:
+      should_format: 1
+    mounting_options:
+      should_mount: 1
+      mount_point: /
+  - role: operating-system
+    size: 50mb
+    formatting_options:
+      should_format: 1
+      filesystem: ext2
+    mounting_options:
+      should_mount: 1
+      mount_point: /boot/zipl

--- a/test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
+++ b/test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
@@ -1,1 +1,2 @@
 snapshots_small_root: Your root device is very small for snapshots
+rootfs_small: Missing device for / with size equal or bigger than 3 GiB and filesystem ext2, ext3, ext4, btrfs, xfs

--- a/tests/installation/partitioning/warning/bios_boot_small_for_bootloader.pm
+++ b/tests/installation/partitioning/warning/bios_boot_small_for_bootloader.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -34,7 +34,7 @@ sub run {
     }
     $partitioner->accept_changes();
 
-    assert_matches(qr/$test_data->{warnings}->{bios_boot_small_for_bootloader}/, $partitioner->get_warning_rich_text(),
+    assert_matches(qr/$test_data->{warnings}->{missing_boot}/, $partitioner->get_warning_rich_text(),
         "Warning Dialog for 'BIOS boot partition has too small size to install bootloader' did not appear, while it is expected.");
 }
 

--- a/tests/installation/partitioning/warning/no_boot.pm
+++ b/tests/installation/partitioning/warning/no_boot.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -32,7 +32,7 @@ sub run {
     });
     $partitioner->accept_changes();
 
-    assert_matches(qr/$test_data->{warnings}->{no_boot}/, $partitioner->get_warning_rich_text(),
+    assert_matches(qr/$test_data->{warnings}->{missing_boot}/, $partitioner->get_warning_rich_text(),
         "Warning Dialog for missed boot partition did not appear, while it is expected.");
 }
 

--- a/tests/installation/partitioning/warning/prep_small.pm
+++ b/tests/installation/partitioning/warning/prep_small.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify Warning Dialog when PReP boot partition has too small
+# size.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+my $partitioner;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    my $disk      = $test_data->{disks}[0];
+    $partitioner = $testapi::distri->get_expert_partitioner();
+
+    $partitioner->run_expert_partitioner();
+    foreach my $partition (@{$disk->{partitions}->{prep_small}}) {
+        $partitioner->add_partition_on_gpt_disk({
+                disk      => $disk->{name},
+                partition => $partition
+        });
+    }
+    $partitioner->accept_changes();
+
+    assert_matches(qr/$test_data->{warnings}->{prep_small}/, $partitioner->get_warning_rich_text(),
+        "Warning Dialog for missing boot partition did not appear, while it is expected.");
+}
+
+sub post_run_hook {
+    save_screenshot;
+    $partitioner->decline_warning();
+    $partitioner->cancel_changes({accept_modified_devices_warning => 1});
+}
+
+1;

--- a/tests/installation/partitioning/warning/prep_small.pm
+++ b/tests/installation/partitioning/warning/prep_small.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -34,8 +34,8 @@ sub run {
     }
     $partitioner->accept_changes();
 
-    assert_matches(qr/$test_data->{warnings}->{prep_small}/, $partitioner->get_warning_rich_text(),
-        "Warning Dialog for missing boot partition did not appear, while it is expected.");
+    assert_matches(qr/$test_data->{warnings}->{missing_boot}/, $partitioner->get_warning_rich_text(),
+        "Warning Dialog for small boot partition did not appear, while it is expected.");
 }
 
 sub post_run_hook {

--- a/tests/installation/partitioning/warning/rootfs_small.pm
+++ b/tests/installation/partitioning/warning/rootfs_small.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/installation/partitioning/warning/rootfs_small.pm
+++ b/tests/installation/partitioning/warning/rootfs_small.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify Warning Dialog when root partition has too small
+# size.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+my $partitioner;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    my $disk      = $test_data->{disks}[0];
+    $partitioner = $testapi::distri->get_expert_partitioner();
+
+    $partitioner->run_expert_partitioner();
+    foreach my $partition (@{$disk->{partitions}->{rootfs_small}}) {
+        $partitioner->add_partition_on_gpt_disk({
+                disk      => $disk->{name},
+                partition => $partition
+        });
+    }
+    $partitioner->accept_changes();
+
+    assert_matches(qr/$test_data->{warnings}->{rootfs_small}/, $partitioner->get_warning_rich_text(),
+        "Warning Dialog for too small root partition did not appear, while it is expected.");
+}
+
+sub post_run_hook {
+    save_screenshot;
+    $partitioner->decline_warning();
+    $partitioner->cancel_changes({accept_modified_devices_warning => 1});
+}
+
+1;

--- a/tests/installation/partitioning/warning/uefi_small.pm
+++ b/tests/installation/partitioning/warning/uefi_small.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -34,7 +34,7 @@ sub run {
     }
     $partitioner->accept_changes();
 
-    assert_matches(qr/$test_data->{warnings}->{uefi_small}/, $partitioner->get_warning_rich_text(),
+    assert_matches(qr/$test_data->{warnings}->{missing_boot}/, $partitioner->get_warning_rich_text(),
         "Warning Dialog for missing boot partition did not appear, while it is expected.");
 }
 

--- a/tests/installation/partitioning/warning/zipl_small.pm
+++ b/tests/installation/partitioning/warning/zipl_small.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -34,8 +34,8 @@ sub run {
     }
     $partitioner->accept_changes();
 
-    assert_matches(qr/$test_data->{warnings}->{zipl_small}/, $partitioner->get_warning_rich_text(),
-        "Warning Dialog for missing boot partition did not appear, while it is expected.");
+    assert_matches(qr/$test_data->{warnings}->{missing_boot}/, $partitioner->get_warning_rich_text(),
+        "Warning Dialog for missing boot partition did not appear.");
 }
 
 sub post_run_hook {

--- a/tests/installation/partitioning/warning/zipl_small.pm
+++ b/tests/installation/partitioning/warning/zipl_small.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify Warning Dialog when /boot/zipl partition has too small
+# size.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert ':all';
+
+my $partitioner;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    my $disk      = $test_data->{disks}[0];
+    $partitioner = $testapi::distri->get_expert_partitioner();
+
+    $partitioner->run_expert_partitioner();
+    foreach my $partition (@{$disk->{partitions}->{zipl_small}}) {
+        $partitioner->add_partition_on_gpt_disk({
+                disk      => $disk->{name},
+                partition => $partition
+        });
+    }
+    $partitioner->accept_changes();
+
+    assert_matches(qr/$test_data->{warnings}->{zipl_small}/, $partitioner->get_warning_rich_text(),
+        "Warning Dialog for missing boot partition did not appear, while it is expected.");
+}
+
+sub post_run_hook {
+    save_screenshot;
+    $partitioner->decline_warning();
+    $partitioner->cancel_changes({accept_modified_devices_warning => 1});
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/80840
- Verification runs:
   - SLE: https://openqa.suse.de/tests/overview?build=124.5_oorlov&groupid=96&distri=sle&version=15-SP3
   - opensuse: https://openqa.opensuse.org/tests/1588622
