### PR TITLE
Remove a superfluous keystroke in firstboot

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -70,7 +70,6 @@ sub firstboot_user {
 sub firstboot_root {
     assert_screen 'root_user', 60;
     enter_rootinfo;
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
 }
 
 sub firstboot_hostname {
@@ -87,10 +86,6 @@ sub run {
         die "Client '$client' is not defined in the module, please check test_data" unless defined(&{"$client"});
         my $client_method = \&{"$client"};
         $client_method->($self);
-    }
-    if (check_var('DESKTOP', 'textmode') && check_screen("linux-login", 10)) {
-        record_soft_failure "bsc#1180840 - the client inst_congratulate is missing";
-        return;
     }
     assert_screen 'installation_completed';
     send_key $cmd{finish};


### PR DESCRIPTION
We don't need to type alt-n at the end of the "root-user" client. This
causes a strange failure with ncurses: the last module is
skipped, as if "send_key 'ret'" was typed twice or as if alt-f was sent.
Confusing as that extra key that key to be alt-n, not ret or alt-f. However, removing
that extra "send_key alt-n" works, tested 20 times on both qt and ncurses,
maybe some race condition is causing this.

Also in this test run: https://openqa.suse.de/tests/5290579#step/yast2_firstboot/17 we see that the extra "alt-n" actually hides a bug by closing the pop-up (bug reported)

Vrs:
yast2_fistboot: 
TW http://waaa-amazing.suse.cz/tests/13979
SLE http://waaa-amazing.suse.cz/tests/13971
 
autoyast_y2_firstboot:
TW http://waaa-amazing.suse.cz/tests/13976
SLE http://waaa-amazing.suse.cz/tests/13971
yast_firstboot_custom http://waaa-amazing.suse.cz/tests/13975
yast_firstboot_textmode http://waaa-amazing.suse.cz/tests/13973