### PR TITLE
Revert "sles4sap/robot_fw: Create test_repo dir"

### DIFF
--- a/tests/sles4sap/robot_fw.pm
+++ b/tests/sles4sap/robot_fw.pm
@@ -40,7 +40,6 @@ sub run {
     select_console 'root-console';
 
     # Execute each test and upload its results
-    assert_script_run "mkdir -p $test_repo";
     assert_script_run "cd $test_repo";
     foreach my $robot_test (split /\n/, script_output "ls $test_repo") {
         record_info("$robot_test", "Starting $robot_test");


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#11765

Actually, the real fix is this one https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/60
The variable `SLE_PRODUCT` has to be `sles4sap`, then the correct folder can be loaded:
`my $test_repo        = "/robot/tests/" . get_var('SLE_PRODUCT') . "-" . get_var('VERSION');`

Your [VR](http://dzedro.suse.cz/tests/17261) is green but the robot framework is not executed.