### PR TITLE
Remove if statement with workaround for bsc#1156047

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -82,9 +82,6 @@ sub prepare_parmfile {
     my $params = '';
     $params .= " " . get_var('S390_NETWORK_PARAMS');
     $params .= " " . get_var('EXTRABOOTPARAMS');
-    if ((is_sle('>=15-SP2') || is_tumbleweed()) && get_var('WORKAROUND_BUGS') =~ 'bsc1156047') {
-        $params .= ' hvc_iucv=8';
-    }
 
     $params .= remote_install_bootmenu_params;
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/87788
- Verification run: https://openqa.opensuse.org/t1589414#

The SoftFailed is required code. So the record_soft_fail has to be brought back.
