### PR TITLE
Use supportserver for VMware&HyperV virtualization smoketests

### DIFF
--- a/schedule/virtualization/vmware_hyperv.yaml
+++ b/schedule/virtualization/vmware_hyperv.yaml
@@ -3,7 +3,8 @@ description:    >
     Maintainer: pdostal@suse.cz
     Testing Kernel on VMware / Hyper-V SLE hosts
 schedule:
-    - boot/boot_to_desktop
+    - support_server/login
+    - support_server/setup
     - virtualization/external/prepare
     - virtualization/universal/ssh_hypervisor_init
     - virtualization/universal/ssh_guests_init

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -46,6 +46,7 @@ use opensusebasetest 'firewall';
 use registration 'scc_version';
 use iscsi;
 use version_utils 'is_opensuse';
+use virt_autotest::utils qw(is_vmware_virtualization is_hyperv_virtualization);
 
 my $pxe_server_set       = 0;
 my $http_server_set      = 0;
@@ -566,7 +567,10 @@ sub setup_nfs_server {
 }
 
 sub run {
-    configure_static_network('10.0.2.1/24');
+    # Persist DHCP configuration for VMware & HyperV virtualization smoketests
+    unless (is_vmware_virtualization || is_hyperv_virtualization) {
+        configure_static_network('10.0.2.1/24');
+    }
 
     my @server_roles = split(',|;', lc(get_var("SUPPORT_SERVER_ROLES")));
     my %server_roles = map { $_ => 1 } @server_roles;

--- a/tests/virtualization/external/prepare.pm
+++ b/tests/virtualization/external/prepare.pm
@@ -29,6 +29,8 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
+    script_run("SUSEConnect -r " . get_var('SCC_REGCODE'), timeout => 420);
+
     assert_script_run "rm /etc/zypp/repos.d/SUSE_Maintenance* || true";
     assert_script_run "rm /etc/zypp/repos.d/TEST* || true";
     zypper_call '-t in nmap iputils bind-utils', exitcode => [0, 102, 103, 106];


### PR DESCRIPTION
On OSD, we have smoke tests for VMware & Hyper-V **guests**.
This implements the [Support Server](http://open.qa/docs/#_support_server_based_tests) as the `HDD_1` from where those guests are accessed.

- Related ticket: [poo#87677](https://progress.opensuse.org/issues/87677)
- Verification run: [VMware](http://pdostal-server.suse.cz/tests/10982) [Hyper-V](http://pdostal-server.suse.cz/tests/10983)
