### PR TITLE
Fix schedule for yast2 gui using libyui

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -38,7 +38,6 @@ conditional_schedule:
         - yast2_gui/yast2_lan_restart_bridge
         - yast2_gui/yast2_lan_restart_vlan
         - yast2_gui/yast2_lan_restart_bond
-
       aarch64:
         - yast2_gui/yast2_software_management
         - yast2_gui/yast2_security
@@ -52,6 +51,7 @@ conditional_schedule:
         - yast2_gui/yast2_lan_restart_vlan
         - yast2_gui/yast2_lan_restart_bond
       ppc64le:
+        - yast2_gui/yast2_expert_partitioner
         - yast2_gui/yast2_software_management
         - yast2_gui/yast2_security
         - x11/yast2_snapper
@@ -63,7 +63,6 @@ conditional_schedule:
         - yast2_gui/yast2_lan_restart_bridge
         - yast2_gui/yast2_lan_restart_vlan
         - yast2_gui/yast2_lan_restart_bond
-        - yast2_gui/yast2_expert_partitioner
       s390x:
         - yast2_gui/yast2_software_management
         - yast2_gui/yast2_security


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/80840
- Verification run: https://openqa.suse.de/tests/5295466#step/yast2_expert_partitioner/6

Note: current [failure](https://openqa.suse.de/tests/5286209#step/yast2_expert_partitioner/16) also happens in x86_64. Hypothesis is that after running scenarios where we change networking something goes wrong when accessing the module with libyui and timeout increase didn't help. We might want to deal with that when we are adding more scenarios with libyui.