### PR TITLE
Increase timeout opening yast2 lan with NM (2nd try)

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -331,7 +331,7 @@ Confirm if a warning popup for Networkmanager controls networking.
 
 =cut
 sub handle_Networkmanager_controlled {
-    assert_screen 'Networkmanager_controlled', 60;
+    assert_screen 'Networkmanager_controlled', 90;
     send_key "ret";    # confirm networkmanager popup
     assert_screen "Networkmanager_controlled-approved";
     send_key "alt-c";


### PR DESCRIPTION
Let's see if with 1 min and half which seems still reasonable works more stable.

- Related ticket: https://progress.opensuse.org/issues/80622
- Verification run: https://openqa.opensuse.org/tests/1589714
