### PR TITLE
Handle serial terminal on HA bootstrap tests

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -40,13 +40,15 @@ sub cluster_init {
 
     # Clear the console to correctly catch the password needle if needed
     clear_console if !is_serial_terminal();
+    # No need to send status to serial terminal if running on serial terminal
+    my $redirection = is_serial_terminal() ? '' : "> /dev/$serialdev";
 
     if ($init_method eq 'ha-cluster-init') {
-        type_string "ha-cluster-init -y $fencing_opt $unicast_opt $qdevice_opt ; echo ha-cluster-init-finished-\$? > /dev/$serialdev\n";
+        type_string "ha-cluster-init -y $fencing_opt $unicast_opt $qdevice_opt ; echo ha-cluster-init-finished-\$? $redirection\n";
         type_qnetd_pwd if get_var('QDEVICE');
     }
     elsif ($init_method eq 'crm-debug-mode') {
-        type_string "crm -dR cluster init -y $fencing_opt $unicast_opt $qdevice_opt ; echo ha-cluster-init-finished-\$? > /dev/$serialdev\n";
+        type_string "crm -dR cluster init -y $fencing_opt $unicast_opt $qdevice_opt ; echo ha-cluster-init-finished-\$? $redirection\n";
         type_qnetd_pwd                      if get_var('QDEVICE');
         die "Cluster initialization failed" if (!wait_serial("ha-cluster-init-finished-0", $join_timeout));
     }


### PR DESCRIPTION
HA bootstrap tests (`ha/ha_cluster_init` and `ha/ha_cluster_join`) historically relied on `assert_screen()` calls to detect the password prompt printed by the bootstrap processes, however since the introduction of a SSH serial terminal for the `pvm_hmc` backend (#11625), this approach causes tests run on this backend using the serial console to fail. This commit changes both HA bootstrap test modules so they are able to detect whether they are running on a serial terminal so they can send commands and status redirection accordingly, and so they check with `wait_serial()`, `assert_screen()` or `check_screen()` for the password prompt depending on the type of terminal in use.

- Related ticket: N/A
- Failing test: http://mango.qa.suse.de/tests/3301#step/ha_cluster_init/23
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/3325 & http://mango.qa.suse.de/tests/3326
- Regression tests: HA Alpha node on QEMU x86_64: [node 1](http://mango.qa.suse.de/tests/3321), [node 2](http://mango.qa.suse.de/tests/3322) & [support server](http://mango.qa.suse.de/tests/3320); HanaSR Cluster on QEMU x86_64: [node 1](http://mango.qa.suse.de/tests/3343), [node 2](http://mango.qa.suse.de/tests/3344) & [support server](http://mango.qa.suse.de/tests/3342)
