### PR TITLE
check_network: also display dns info from /etc/resolv.conf

### DIFF
--- a/tests/console/check_network.pm
+++ b/tests/console/check_network.pm
@@ -31,6 +31,7 @@ sub run {
     }
     # check the network configuration
     script_run "ip addr show";
+    script_run "cat /etc/resolv.conf";
 }
 
 1;


### PR DESCRIPTION
This will allow to check DNS config and this could be compared to the value found later when a test failed with https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11772

Related to https://progress.opensuse.org/issues/87797

- Verification run: https://openqa.opensuse.org/t1590007
