### PR TITLE
Ignore bsc#1180605 on SLE < 15-SP2

### DIFF
--- a/tests/console/python_scientific.pm
+++ b/tests/console/python_scientific.pm
@@ -28,8 +28,13 @@ sub run_python_script {
     assert_script_run("chmod a+rx '$script'");
     assert_script_run("./$script 2>&1 | tee $logfile");
     if (script_run("grep 'Softfail' $logfile") == 0) {
-        my $failmsg = script_output("grep 'Softfail' '$logfile'");
-        record_soft_failure("$failmsg");
+        # bsc#1180605 is only relevant for SLE > 15-SP2.
+        if (script_run("grep 'Softfail' $logfile | grep 'bsc#1180605'") == 0 && is_sle("<=15-SP2")) {
+            record_info("scipy-fft", "scipy-fft module not available for SLE <= 15-SP2");
+        } else {
+            my $failmsg = script_output("grep 'Softfail' '$logfile'");
+            record_soft_failure("$failmsg");
+        }
     }
 }
 


### PR DESCRIPTION
The package `scipy-fft` is not available in the version provided in
SLE 15-SP2. This commit removes the softfailure for this package.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1180605
- Verification run: http://duck-norris.qam.suse.de/tests/4548 | http://duck-norris.qam.suse.de/tests/4549
