### PR TITLE
Remove cluster_md debugging code (poo#80532)

### DIFF
--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -19,8 +19,7 @@ use lockapi;
 use hacluster;
 
 sub run {
-    my ($self) = @_;
-    my $mdadm_conf = '/etc/mdadm.conf';
+    my $mdadm_conf         = '/etc/mdadm.conf';
     my $clustermd_lun_01   = get_lun(use_once => 0);
     my $clustermd_lun_02   = get_lun(use_once => 0);
     my $clustermd_rsc      = 'cluster_md';
@@ -74,20 +73,6 @@ sub run {
 
     # Wait until cluster-md resource is created
     barrier_wait("CLUSTER_MD_RESOURCE_CREATED_$cluster_name");
-
-    # Currently we are seeing a sporadic issue in osd with nodes getting fenced during
-    # cluster_md setup right after the resource is created. So far this issue cannot be
-    # reproduced manually, and test passes with no issues in the development environment.
-    # Worse still, the nature of the failure prevents openQA from gathering logs. The
-    # following lines attempt to work around the issue
-    if (check_screen('grub2')) {
-        my $timeout = get_var('UEFI') ? 140 : 80;
-        record_soft_failure 'poo#80532 -- Unexpected node fence';
-        $self->wait_boot(bootloader_time => $timeout, nologin => 1);
-        reset_consoles;
-        select_console 'root-console';
-        ha_export_logs;
-    }
 
     # Wait for the resource to appear before testing the device
     # Otherwise sporadic failure can happen


### PR DESCRIPTION
As the cluster-md issue is fixed, we can remove the debugging code we added before [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11506/commits/46ee516384b0bcc36e538da14e87228f5012c961).

- Related ticket: https://progress.opensuse.org/issues/80532
- Needles: N/A
- Verification run: N/A
