### PR TITLE
apachetest: Install php7-cli on Tumbleweed + Fix CI

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -22,7 +22,7 @@ use warnings;
 
 use testapi;
 use utils;
-use version_utils qw(is_sle check_version);
+use version_utils qw(is_sle is_leap check_version);
 
 our @EXPORT = qw(setup_apache2 setup_pgsqldb destroy_pgsqldb test_pgsql test_mysql postgresql_cleanup);
 # Setup apache2 service in different mode: SSL, NSS, NSSFIPS, PHP7
@@ -52,6 +52,7 @@ sub setup_apache2 {
 
     if ($mode eq "PHP7") {
         push @packages, qw(apache2-mod_php7 php7);
+        push @packages, qw(php7-cli) unless (is_sle || is_leap);
         zypper_call("rm -u apache2-mod_php5 php5", exitcode => [0, 104]);
     }
 

--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -41,7 +41,7 @@ Possible values for C<$mode> are: SSL, NSS, NSSFIPS and PHP7
 sub setup_apache2 {
     my %args     = @_;
     my $mode     = uc $args{mode} || "";
-    my @packages = qw(apache2);
+    my @packages = qw(apache2 hostname);
 
     if (($mode eq "NSS") && get_var("FIPS")) {
         $mode = "NSSFIPS";

--- a/tools/test_deleted_renamed_referenced_files
+++ b/tools/test_deleted_renamed_referenced_files
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 FILES="${@}"
 success=1
@@ -19,7 +19,7 @@ for FILE in $FILES; do
         file_to_verify="$FILE" 
         target_paths='schedule/'
     fi
-    if [[ -n  $file_to_verify ]] && [[ MATCHED_SCHEDULE_FILES="$(grep --recursive --ignore-case \
+    if [[ -n $file_to_verify ]] && [[ MATCHED_SCHEDULE_FILES="$(grep --recursive --ignore-case \
        --files-with-matches "${file_to_verify}\b" $target_paths)" ]]
     then
         echo "\"$file_to_verify\" was removed or renamed, but it is still used in: \


### PR DESCRIPTION
While on first glance this seems like the wrong place to add this, php tests
use this function to install php, even if they don't use apache at all.

Once this change lands in Leap/SLE, the condition can be changed accordingly.

Fixes https://progress.opensuse.org/issues/87844

Verification run: http://10.160.67.86/tests/853