### PR TITLE
Soft fail with bsc#1181052 if iscsiadm segfaults are detected

### DIFF
--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -32,7 +32,14 @@ sub run {
     ha_export_logs;
 
     # Looking for segfault during the test
-    record_soft_failure "bsc#1132123" if (script_run '(( $(grep -sR segfault /var/log | wc -l) == 0 ))');
+    if (script_run '(( $(grep -sR segfault /var/log | wc -l) == 0 ))') {
+        if (script_run '(( $(egrep -sR iscsiadm.+segfault /var/log | wc -l) == 0 ))') {
+            record_soft_failure "bsc#1181052 - segfault on iscsiadm";
+        }
+        else {
+            die "segfault detected in the system! Aborting";
+        }
+    }
 }
 
 # Specific test_flags for this test module


### PR DESCRIPTION
1. Soft fail with bsc#1181052 if iscsiadm segfaults are detected
2. Remove soft fail to bsc#1132123 as this bug has been resolved
3. Include a hard failure when unexpected segfaults are detected

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1181052
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/3358 & http://mango.qa.suse.de/tests/3359
