### PR TITLE
Package hostname is available on SLE 15+ and openSUSE

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -39,9 +39,10 @@ Possible values for C<$mode> are: SSL, NSS, NSSFIPS and PHP7
 
 =cut
 sub setup_apache2 {
-    my %args     = @_;
-    my $mode     = uc $args{mode} || "";
-    my @packages = qw(apache2 hostname);
+    my %args = @_;
+    my $mode = uc $args{mode} || "";
+    # package hostname is available on sle15+ and openSUSE, on <15 it's net-tools
+    my @packages = qw(apache2 /bin/hostname);
 
     if (($mode eq "NSS") && get_var("FIPS")) {
         $mode = "NSSFIPS";


### PR DESCRIPTION
- Related ticket:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11780
breaking SLE12 https://openqa.suse.de/tests/5307823#step/apache_ssl/19
- Verification run:
http://dzedro.suse.cz/tests/17286 12-SP4
https://openqa.opensuse.org/tests/1592575 TW JeOS
