### PR TITLE
Make sure zypper process exit to avoid conflict

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@ use warnings;
 
 use testapi;
 use utils;
+use zypper;
 use registration;
 use qam 'remove_test_repositories';
 use version_utils qw(is_sle is_sles4sap);
@@ -51,6 +52,8 @@ sub setup_sle {
         assert_script_run "chmod 444 /usr/sbin/packagekitd";
     }
 
+    # poo#87850 wait the zypper processes in background to finish and release the lock.
+    wait_quit_zypper;
     # Change serial dev permissions
     ensure_serialdev_permissions;
 

--- a/lib/zypper.pm
+++ b/lib/zypper.pm
@@ -1,0 +1,47 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package zypper;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi qw(is_serial_terminal :DEFAULT);
+use version_utils qw(is_microos is_leap is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos);
+use Mojo::UserAgent;
+
+our @EXPORT = qw(
+  wait_quit_zypper
+);
+
+=head2 wait_quit_zypper
+
+    wait_quit_zypper();
+
+This function waits for any zypper processes in background to finish.
+
+Some zypper processes (such as purge-kernels) in background hold the lock,
+usually it's not intended or common that run 2 zypper tasks at the same time,
+so we need wait the zypper processes in background to finish and release the
+lock so that we can run a new zypper for our test.
+
+=cut
+sub wait_quit_zypper {
+    assert_script_run 'until ! pgrep zypper; do sleep 1; done';
+}
+
+1;

--- a/tests/autoyast/repos.pm
+++ b/tests/autoyast/repos.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 SUSE LLC
+# Copyright (C) 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,11 +26,16 @@ use warnings;
 use base 'y2_module_consoletest';
 use testapi;
 use utils;
+use zypper;
 
 sub run {
     # sles12_minimal.xml profile does not install "ip"
     assert_script_run 'ip a || ifstatus all';
-    quit_packagekit;
+    if (!check_var('DESKTOP', 'textmode')) {
+        quit_packagekit;
+        # poo#87850 wait the zypper processes in background to finish and release the lock.
+        wait_quit_zypper;
+    }
     zypper_enable_install_dvd;
     # make sure that save_y2logs from yast2 package, tar and bzip2 are installed
     # even on minimal system

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,6 +19,7 @@
 use base 'consoletest';
 use testapi;
 use utils;
+use zypper;
 use version_utils 'is_sle';
 use serial_terminal 'prepare_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
@@ -38,8 +39,8 @@ sub run {
     if (!check_var('DESKTOP', 'textmode')) {
         # Make sure packagekit is not running, or it will conflict with SUSEConnect.
         quit_packagekit;
-        # poo#77134 wait for packagekit related zypper process to exit
-        assert_script_run 'until ! pgrep zypper; do sleep 1; done';
+        # poo#87850 wait the zypper processes in background to finish and release the lock.
+        wait_quit_zypper;
     }
 
     # Register the modules after media migration, so it can do regession


### PR DESCRIPTION
We need wait zypper process exit to avoid conflict, now we found the blocked zypper process is 'zypper -n purge-kernels'. This zypper process is called by init on reboot after migration and used to clean the old kernels.

- Related ticket: https://progress.opensuse.org/issues/87850
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/5309886#