### PR TITLE
Fix firewall enabled check after service check

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1164,7 +1164,7 @@ under test, the version and if the SUT is an upgrade.
 sub firewall {
     my $old_product_versions      = is_sle('<15') || is_leap('<15.0');
     my $upgrade_from_susefirewall = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
-    return (($old_product_versions || $upgrade_from_susefirewall) && !is_tumbleweed) ? 'SuSEfirewall2' : 'firewalld';
+    return (($old_product_versions || $upgrade_from_susefirewall) && !is_tumbleweed && !(check_var('SUSEFIREWALL2_SERVICE_CHECK', 1))) ? 'SuSEfirewall2' : 'firewalld';
 }
 
 =head2 remount_tmp_if_ro

--- a/lib/services/firewall.pm
+++ b/lib/services/firewall.pm
@@ -30,13 +30,14 @@ sub install_service {
 }
 
 sub susefirewall2_to_firewalld {
-    my $timeout = 180;
+    my $timeout = 360;
     assert_script_run('susefirewall2-to-firewalld -c',                                     timeout => $timeout);
     assert_script_run('firewall-cmd --permanent --zone=external --add-service=vnc-server', timeout => $timeout);
     # On some platforms such as Aarch64, the 'firewalld restart'
     # can't finish in the default timeout.
     systemctl 'restart firewalld', timeout => $timeout;
     script_run('iptables -S', timeout => $timeout);
+    set_var('SUSEFIREWALL2_SERVICE_CHECK', 1);
 }
 
 sub enable_service {


### PR DESCRIPTION
After we integrated the SuSEfirewall2 to firewalld service checking,
We need use firewalld to check in the firewall_enabled module.

- Related ticket: https://progress.opensuse.org/issues/87770
- Needles: N/A
- Verification run:  
  https://openqa.nue.suse.com/tests/5341421#step/firewall_enabled/1
  https://openqa.nue.suse.com/tests/5310162
  https://openqa.nue.suse.com/tests/5310214
  https://openqa.nue.suse.com/tests/5313802#step/firewall_enabled/1