### PR TITLE
Setup libyui only for x86_64 and ppc64le

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -16,12 +16,12 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/hostname
-  - console/setup_libyui_running_system
   - "{{yast2_modules}}"
 conditional_schedule:
   yast2_modules:
     ARCH:
       x86_64:
+        - console/setup_libyui_running_system
         - yast2_gui/yast2_control_center
         - yast2_gui/yast2_expert_partitioner
         - yast2_gui/yast2_software_management
@@ -51,6 +51,7 @@ conditional_schedule:
         - yast2_gui/yast2_lan_restart_vlan
         - yast2_gui/yast2_lan_restart_bond
       ppc64le:
+        - console/setup_libyui_running_system
         - yast2_gui/yast2_expert_partitioner
         - yast2_gui/yast2_software_management
         - yast2_gui/yast2_security


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/80840
- Verification run: https://openqa.suse.de/tests/5310729
