### PR TITLE
.github: Don't run git checkout cpanfile before make test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
       run: apt-get -y install yamllint libdbus-1-dev libssh2-1-dev parallel
     - name: Setup perl
       run: |
-        echo "requires 'Code::DRY';" >> cpanfile
-        echo "requires 'Date::Parse';" >> cpanfile
-        echo "requires 'Regexp::Common';" >> cpanfile
-        echo "requires 'Perl::Tidy', '== 20210111';" >> cpanfile
+        # Prefix with space to bypass ./tools/update_spec
+        echo " requires 'Code::DRY';" >> cpanfile
+        echo " requires 'Date::Parse';" >> cpanfile
+        echo " requires 'Regexp::Common';" >> cpanfile
+        echo " requires 'Perl::Tidy', '== 20210111';" >> cpanfile
         make prepare
     - name: Run ${{ matrix.test }} tests
       env:
         TESTS: ${{ matrix.test }}
       run: |
         git fetch origin master
-        git checkout cpanfile
         make test


### PR DESCRIPTION
The changes done before make prepare need to be kept.

With this, the version of perltidy specified in the workflow file is used successfully: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11793