### PR TITLE
Fix missing function in containers test for microos

### DIFF
--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -18,7 +18,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_sle_micro);
+use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_microos is_sle_micro);
 
 our @EXPORT = qw(
   get_opensuse_registry_prefix


### PR DESCRIPTION
It fixes bug introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/d3b83743772a9562a39440ef860c1ff82c69d3c5
https://openqa.opensuse.org/tests/1593455#step/podman_image/2

VR: http://fromm.arch.suse.de/tests/112