### PR TITLE
[virt_autotest] fix up ssh connection refused problem after attached virt network interface to guest system

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -112,7 +112,7 @@ sub test_network_interface {
     #flag SRIOV test as it need not restart network service
     my $is_sriov_test = "false";
     $is_sriov_test = "true" if caller 0 eq 'sriov_network_card_pci_passthrough';
-    script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 180) if (is_sle('=11-sp4') || ($routed == 1) || ($isolated == 1));
+    script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 180);
     my $nic = script_output "ssh root\@$guest \"grep '$mac' /sys/class/net/*/address | cut -d'/' -f5 | head -n1\"";
     if (check_var('TEST', 'qam-xen-networking') || check_var('TEST', 'qam-kvm-networking') || $is_sriov_test eq "true") {
         assert_script_run("ssh root\@$guest \"echo BOOTPROTO=\\'dhcp\\' > /etc/sysconfig/network/ifcfg-$nic\"");


### PR DESCRIPTION
Refer to the new failure about virt network test,
[sle-15-SP3-Online-x86_64-Build127.1-gi-guest_developing-on-host_developing-kvm](https://149.44.176.58/tests/5305018)
Fail to connect guest system via ssh after attached nat virtual network interface
[sle-15-SP3-Online-x86_64-Build124.5-gi-guest_developing-on-host_sles15sp2-kvm](https://149.44.176.58/tests/5303319)
Fail to connect guest system via ssh after attached host bridge virtual network interface

After attached virtual network interface to guest system, then try to connect guest system via ssh, figure out ssh connection refused problem.

- Related ticket: https://progress.opensuse.org/issues/87937
- Verification run:
[gi-guest_developing-on-host_developing-kvm](http://149.44.176.58/t5319388)
[gi-guest_developing-on-host_developing-xen](http://149.44.176.58/t5319389)
[gi-guest_developing-on-host_sles12sp5-kvm](http://149.44.176.58/tests/5319659)
[gi-guest_sles12sp5-on-host_developing-kvm](http://149.44.176.58/tests/5319698)
[gi-guest_sles12sp5-on-host_developing-xen](http://149.44.176.58/t5319803)
[gi-guest_sles15sp2-on-host_developing-kvm](http://149.44.176.58/t5319783)
[gi-guest_sles15sp2-on-host_developing-xen](http://149.44.176.58/t5319802)
[gi-guest_developing-on-host_sles12sp5-xen](http://149.44.176.58/t5322413)




