### PR TITLE
Fix CI check for renamed/deleted files

### DIFF
--- a/tools/test_deleted_renamed_referenced_files
+++ b/tools/test_deleted_renamed_referenced_files
@@ -17,13 +17,12 @@ for FILE in $FILES; do
     elif [ -n "$(echo $FILE | grep '\.ya\?ml$')" ] 
     then
         file_to_verify="$FILE" 
-        target_paths='schedule/'
+        target_paths='schedule/ test_data/'
     fi
-    if [[ -n $file_to_verify ]] && [[ MATCHED_SCHEDULE_FILES="$(grep --recursive --ignore-case \
-       --files-with-matches "${file_to_verify}\b" $target_paths)" ]]
+    MATCHED_REFERENCE_FILES="$(grep --recursive --ignore-case --files-with-matches "${file_to_verify}\b" $target_paths)"
+    if [[ -n $file_to_verify ]] && [ -n "$(echo $MATCHED_REFERENCE_FILES | grep '\(\.ya\?ml$\|\.pm\)')" ]
     then
-        echo "\"$file_to_verify\" was removed or renamed, but it is still used in: \
-              \n$MATCHED_SCHEDULE_FILES\n"
+        echo -e "\"$file_to_verify\" was removed or renamed, but it is still used in:\n$MATCHED_REFERENCE_FILES" 
         success=0
     fi
 done


### PR DESCRIPTION
In case of too many files renamed, git diff --name-only --exit-code --diff-filter=DR origin/master | grep '^test*' 
will give warnings like:
warning: inexact rename detection was skipped due to too many files.
warning: you may want to set your diff.renameLimit variable to at least 2770 and retry the command.
 and the $MATCHED_REFERENCE_FILES takes null value and the check wrongly fails. Failure example here:
https://github.com/okurz/os-autoinst-distri-opensuse/runs/1726012747?check_suite_focus=true#step:6:1254
Adding check for $MATCHED_REFERENCE_FILES to include in naming ".pm" or ".yaml" (also ".yml").

Additionally, some test_data files can be included in other test_data files, so the check is enhanced to cover this part as well.

test: https://github.com/os-autoinst/os-autoinst-distri-opensuse/runs/1728184942?check_suite_focus=true