### PR TITLE
Stabilize yast2_firstboot for ncurses

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -30,7 +30,7 @@ sub firstboot_language_keyboard {
     mouse_hide(1);
     foreach (sort keys %${shortcuts}) {
         send_key 'alt-' . $_;
-        send_key 'ret' if check_var('DESKTOP', 'textmode');
+        wait_screen_change(sub { send_key 'ret' }) if check_var('DESKTOP', 'textmode');
         assert_screen $shortcuts->{$_} . '_selected';
     }
     wait_screen_change(sub { send_key $cmd{next}; }, 7);


### PR DESCRIPTION
In rare occasions, it seems like the key "ret" is sent before the key
alt-k is received by the SUT. This change seems to correct this problem,
Tried in 60 VRs such as http://waaa-amazing.suse.cz/tests/13991
