### PR TITLE
Fix ncurses command mistype issue

### DIFF
--- a/tests/console/ncurses.pm
+++ b/tests/console/ncurses.pm
@@ -24,6 +24,8 @@ use utils qw(clear_console zypper_call);
 sub run {
     select_console 'root-console';
     zypper_call 'in dialog';
+    #poo 88033, we need to clean up console before issue command.
+    clear_console;
     script_run 'dialog --yesno "test for boo#1054448" 3 20';
     assert_screen 'ncurses-simple-dialog';
     send_key 'ret';


### PR DESCRIPTION
We need to clean up the console before issue the dialog command.
In some cases the output will mixed with the command, this can cause
the command not found error.

- Related ticket: https://progress.opensuse.org/issues/88033
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t5310507 
  https://openqa.nue.suse.com/t5310509
  https://openqa.nue.suse.com/t5313827
  https://openqa.nue.suse.com/t5313828