### PR TITLE
Fix firewalld restart timeout

### DIFF
--- a/lib/services/firewall.pm
+++ b/lib/services/firewall.pm
@@ -31,9 +31,11 @@ sub install_service {
 
 sub susefirewall2_to_firewalld {
     my $timeout = 180;
-    script_run('susefirewall2-to-firewalld -c',                                     timeout => $timeout);
-    script_run('firewall-cmd --permanent --zone=external --add-service=vnc-server', timeout => $timeout);
-    systemctl 'restart firewalld';
+    assert_script_run('susefirewall2-to-firewalld -c',                                     timeout => $timeout);
+    assert_script_run('firewall-cmd --permanent --zone=external --add-service=vnc-server', timeout => $timeout);
+    # On some platforms such as Aarch64, the 'firewalld restart'
+    # can't finish in the default timeout.
+    systemctl 'restart firewalld', timeout => $timeout;
     script_run('iptables -S', timeout => $timeout);
 }
 


### PR DESCRIPTION
On some platforms such as Aarch64, the sytemctl restart firewall
can't finished in the default timeout. We need to enlarge it to
make the restart finish.

- Related ticket: https://progress.opensuse.org/issues/87784
- Needles: N/A
- Verification run: 
 https://openqa.nue.suse.com/tests/5302861  
 https://openqa.nue.suse.com/tests/5303509  