### PR TITLE
Add basic rancher container test

### DIFF
--- a/lib/rancher/utils.pm
+++ b/lib/rancher/utils.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Basic functionality for testing rancher container
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+package rancher::utils;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils;
+
+our @EXPORT = qw(setup_rancher_container);
+
+sub setup_rancher_container {
+    my %args    = @_;
+    my $runtime = $args{runtime};
+    die "You must define the runtime!" unless $runtime;
+
+    assert_script_run("$runtime pull rancher/rancher", timeout => 600);
+    assert_script_run("$runtime run --name rancher_webui --privileged -d --restart=unless-stopped -p 80:80 -p 443:443 rancher/rancher");
+
+    # Check every 30 seconds that the cluster is setup. Times out after 20 minutes
+    script_retry("$runtime logs rancher_webui 2>&1 |grep 'Starting networking.k8s.io'", delay => 30, retry => 40);
+
+    assert_script_run("curl -k https://localhost");
+    record_info("Rancher UI ready");
+}
+
+1;

--- a/schedule/rancher/rancher.yaml
+++ b/schedule/rancher/rancher.yaml
@@ -1,0 +1,15 @@
+---
+name: rancher
+description:    >
+    Tests for Rancher in openSUSE
+conditional_schedule:
+    runtime_test:
+        RUNTIME:
+            docker:
+            - rancher/docker_rancher
+            podman:
+            - rancher/podman_rancher
+schedule:
+    - boot/boot_to_desktop
+    - '{{runtime_test}}'
+    - rancher/rancher_ui

--- a/tests/rancher/docker_rancher.pm
+++ b/tests/rancher/docker_rancher.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Rancher container test using docker
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use containers::common;
+use version_utils "get_os_release";
+use containers::utils;
+use rancher::utils;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    install_docker_when_needed($host_distri);
+
+    setup_rancher_container(runtime => "docker");
+}
+
+1;

--- a/tests/rancher/podman_rancher.pm
+++ b/tests/rancher/podman_rancher.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Rancher container test using podman
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use containers::common;
+use containers::utils;
+use version_utils "get_os_release";
+use rancher::utils;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    install_podman_when_needed($host_distri);
+
+    setup_rancher_container(runtime => "podman");
+}
+
+1;

--- a/tests/rancher/rancher_ui.pm
+++ b/tests/rancher/rancher_ui.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Web browser UI test for rancher container
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use x11utils 'ensure_unlocked_desktop';
+
+sub run {
+    my ($self) = @_;
+
+    select_console('x11', await_console => 0);
+    ensure_unlocked_desktop();
+
+    # start firefox
+    $self->start_firefox_with_profile();
+    $self->firefox_open_url('https://localhost');
+    assert_and_click('security_risk_advanced');
+    send_key('pgdn');
+    assert_and_click('security_risk_continue');
+    assert_screen('welcome_to_rancher');
+
+    $self->exit_firefox();
+}
+
+1;
+


### PR DESCRIPTION
A basic test for the rancher container using docker and podman.

- Related ticket: No related ticket, purely experimental
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/707
- Verification run: [docker](http://angmar.suse.de/tests/2875) | [podman](http://angmar.suse.de/tests/2876)
