### PR TITLE
[virt_autotest] Fix up reset_partition problem

### DIFF
--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -171,4 +171,13 @@ sub post_fail_hook {
     save_screenshot;
 }
 
+sub get_virt_disk_and_available_space {
+    # ensure the available disk space size for virt disk - /var/lib/libvirt
+    my $virt_disk_name      = script_output 'lsblk -rnoPKNAME $(findmnt -nrvoSOURCE /var/lib/libvirt)';
+    my $virt_available_size = script_output("df -k | grep libvirt | awk '{print \$4}'");
+    # default available virt disk unit as GiB
+    $virt_available_size = int($virt_available_size / 1048576);
+    return ($virt_disk_name, $virt_available_size);
+}
+
 1;


### PR DESCRIPTION
Refer to the new failure about reset_partition, 
[gi-guest_developing-on-host_developing-kvm](https://149.44.176.58/tests/5317499)
[gi-guest_developing-on-host_developing-xen](https://149.44.176.58/tests/5317501)

there was missed `get_virt_disk_and_available_space() `under` lib/virt_feature_test_base.pm`.
Now, add missed get_virt_disk_and_available_space() under lib/virt_feature_test_base.pm to fix up this reset_partition problem. 

- Verification run: 
[gi-guest_developing-on-host_developing-kvm](http://149.44.176.58/tests/5318963)
[gi-guest_developing-on-host_developing-xen](http://149.44.176.58/tests/5318615)
[gi-guest_sles12sp5-on-host_developing-kvm](http://149.44.176.58/tests/5318617)
[gi-guest_developing-on-host_sles12sp5-kvm](http://149.44.176.58/tests/5318616)