### PR TITLE
Rework journald testing

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -23,45 +23,45 @@
 #             Sergio Lindo Mansilla <slindomansilla@suse.com>
 # Tags: bsc#1063066 bsc#1171858
 
-use base "consoletest";
-use strict;
-use warnings;
-use Date::Parse;
+use Mojo::Base qw(consoletest);
+use Date::Parse qw(str2time);
 use testapi;
-use utils;
-use version_utils;
-use power_action_utils 'power_action';
+use utils qw(zypper_call script_retry systemctl);
+use version_utils qw(is_opensuse is_tumbleweed is_sle is_public_cloud);
+use Utils::Backends qw(is_hyperv);
+use power_action_utils qw(power_action);
+use constant {
+    PERSISTENT_LOG_DIR => '/var/log/journal',
+    DROPIN_DIR         => '/etc/systemd/journald.conf.d/',
+    SYSLOG             => '/var/log/messages'
+};
 
-sub check_journal {
+sub is_journal_empty {
     my ($args, $filename) = @_;
     assert_script_run("journalctl -q $args > $filename");
-    return script_run("if [ -s $filename ]; then true; else false; fi");
-}
-
-sub skip_fss_check {
-    # FSS check is not supported by SLE. Disable this check for SLES
-    return is_sle;
-}
-
-sub check_syslog {
-    # rsyslog is not installed on tumbleweed anymore
-    return !is_tumbleweed && !is_jeos;
+    return (script_run("[ -s $filename ]") != 0);
 }
 
 sub verify_journal {
+    my $fss_key = shift;
     # Run journalctl --verify and on failure check for 'File corruption detected'
     # if that happens, run it again after waiting some time and softfailure to https://bugzilla.suse.com/show_bug.cgi?id=1178193
-    my $cmd = "journalctl --verify";
-    $cmd = 'journalctl --verify --verify-key=`cat /var/tmp/journalctl-setup-keys.txt`' unless skip_fss_check;
+    my $cmd = 'journalctl --verify';
+    $cmd .= " --verify-key=$fss_key" if defined($fss_key);
+
+    #No sealing yet
 
     return if (script_run("$cmd 2>&1 | tee errs") == 0);
     # Check for https://bugzilla.suse.com/show_bug.cgi?id=1171858, corruption bug when FSS is enabled
-    if (!skip_fss_check && script_run("grep 'tag/entry realtime timestamp out of synchronization' errs") == 0) {
-        record_soft_failure "bsc#1171858";
+    if (defined($fss_key) && (script_run("grep 'tag/entry realtime timestamp out of synchronization' errs") == 0)) {
+        # upstream issue
+        # https://github.com/systemd/systemd/issues/17833
+        record_soft_failure 'bsc#1171858 - journal corruption: "tag/entry realtime timestamp out of synchronization"';
+    } elsif (defined($fss_key) && (script_run("egrep 'No sealing yet,.*of entries not sealed.' errs") == 0)) {
+        die "Sealing is not working!\n";
         # Check for https://bugzilla.suse.com/show_bug.cgi?id=1178193, a race condition for `journalctl --verify`
-    } elsif (script_run("grep 'File corruption detected' errs") == 0) {
+    } elsif ((script_run("grep 'File corruption detected' errs") == 0) && script_run("$cmd")) {
         record_soft_failure("bsc#1178193 - Journal corruption race condition");
-        record_soft_failure("bsc#1178193") if (script_retry("$cmd", retry => 6, delay => 10, timeout => 10, die => 0) != 0);
     } else {
         assert_script_run("mv errs journalctl-verify-err.txt");
         upload_logs('journalctl-verify-err.txt');
@@ -73,95 +73,168 @@ sub reboot {
     my ($self) = @_;
     power_action('reboot', textmode => 1);
     $self->wait_boot(bootloader_time => 300);
-    select_console 'root-console';
+    $self->select_serial_terminal;
+}
+
+sub get_current_boot_id {
+    my $boot_list = shift;
+    push @{$boot_list}, script_output('sed "s/-//g" /proc/sys/kernel/random/boot_id');
+}
+
+sub write_test_log_entries {
+    my $entries = shift;
+    foreach (keys(%{$entries})) {
+        assert_script_run("systemd-cat --priority=$_ --identifier=batman echo $entries->{$_}");
+    }
+}
+
+sub assert_test_log_entries {
+    my ($entries, $boots) = @_;
+    foreach my $bootid (@{$boots}) {
+        foreach (keys(%{$entries})) {
+            assert_script_run("journalctl --boot=$bootid --identifier=batman --priority=$_ --output=short | grep $entries->{$_}");
+            assert_script_run("grep $entries->{$_} ${\ SYSLOG }") if is_sle;
+        }
+    }
 }
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
-    zypper_call 'in socat';
-    # Test for bsc#1063066
-    if (script_run('command -v man') == 0) {
-        my $output = script_output('man -P cat journalctl');
-        record_soft_failure('bsc#1063066 - broken manpage') if ($output =~ m/\s+\.SH /);
+    my %log_entries = (
+        info  => q{'We need to call batman'},
+        err   => q{'We NEED to call the batman NOW'},
+        emerg => q{'CALL THE BATMAN NOW!1!! AARRGGH!!'}
+    );
+    my @boots;
+
+    # create dropin directory for further journal.conf updates
+    assert_script_run "mkdir -p ${\ DROPIN_DIR }/";
+    # Test for possible resurrection of bsc#1063066
+    die "Systemd: broken manpage!\n"
+      if ((script_run('command -v man') == 0) && (script_output('man -P cat journalctl') =~ m/\s+\.SH /));
+
+    # Enable persistent journal or check if it is enabled by default in opensuse
+    # journald.conf is almost identical for opensuse and sle
+    # default settings Storage=Auto behaves like "persistent" if the */var/log/journal* directory exists,
+    # and "volatile" otherwise (the existence of the directory controls the storage mode).
+    # Other configuration changes should be overridden using _drop-in_ file
+    # To enable persistent logging in opensuse, we use systemd-logger.rpm that creates */var/log/journal/* directory
+    get_current_boot_id \@boots;
+    if (is_opensuse) {
+        assert_script_run 'rpm -q systemd-logger';
+        assert_script_run "rpm -q --conflicts systemd-logger | tee -a /dev/$serialdev | grep syslog";
+    } else {
+        script_run("journalctl --boot=-1 | grep 'no persistent journal was found'") or die "Persistent journal should not be enabled by default on SLE!\n";
+        assert_script_run "mkdir ${\ PERSISTENT_LOG_DIR }";
+        assert_script_run "systemd-tmpfiles --create --prefix ${\ PERSISTENT_LOG_DIR }";
+        # test for imuxsock
+        assert_script_run 'test -S /run/systemd/journal/syslog';
+        upload_logs('/var/log/messages');
+        systemctl 'restart systemd-journald';
     }
-    # Enable persistent journal
-    assert_script_run("sed -i 's/.*Storage=.*/Storage=persistent/' /etc/systemd/journald.conf");
-    assert_script_run("sed -i 's/.*Seal=.*/Seal=yes/' /etc/systemd/journald.conf") unless skip_fss_check;
-    assert_script_run("systemctl restart systemd-journald");
-    assert_script_run("journalctl -e | grep -i 'Flush Journal to Persistent Storage'");
-    # Setup FSS keys before reboot
-    assert_script_run('journalctl --interval=10s --setup-keys | tee /var/tmp/journalctl-setup-keys.txt && journalctl --rotate') unless skip_fss_check;
+
+    # Write first series of messages with different log priority
+    write_test_log_entries \%log_entries;
+    assert_test_log_entries(\%log_entries, \@boots);
+
     assert_script_run("date '+%F %T' | tee /var/tmp/reboottime");
-    assert_script_run("echo 'The batman is going to sleep' | systemd-cat -p info -t batman");
     # Reboot system - public cloud does not handle reboot well atm
     if (!is_public_cloud) {
+        assert_script_run("echo 'The batman is going to sleep' | systemd-cat -p info -t batman");
         reboot($self);
+        get_current_boot_id \@boots;
+        my @listed_boots = split('\n', script_output 'journalctl --list-boots');
+        die "journal lists less than 2 boots" if (scalar(@listed_boots) < 2);
+        is_journal_empty('--boot=-1', "journalctl-1.txt");
+        assert_script_run('journalctl --identifier=batman --boot=-1| grep "The batman is going to sleep"', fail_message => "Error getting beacon from previous boot");
     } else {
         # TODO: Handle reboots on public cloud
         record_info("publiccloud", "Public cloud omits rebooting (temporary workaround)");
     }
-    # Check journal state after reboot to trigger bsc#1171858
-    record_soft_failure "bsc#1171858" if (!skip_fss_check && script_run('journalctl --verify --verify-key=`cat /var/tmp/journalctl-setup-keys.txt`') != 0);
-    # Basic journalctl tests: Export journalctl with various arguments and ensure they are not empty
     script_run('echo -e "Reboot time:  `cat /var/tmp/reboottime`\nCurrent time: `date -u \'+%F %T\'`"');
-    die "journalctl empty" if check_journal('', "journalctl.txt");
-    die "journalctl of previous boot empty" if !is_public_cloud && check_journal('--boot=-1', "journalctl-1.txt");
-    # Note: Detailled error message is "Specifying boot ID or boot offset has no effect, no persistent journal was found."
-    die "no persistent journal was found" if script_run("journalctl --boot=-1 | grep 'no persistent journal was found'") == 0;
-    die "journalctl after reboot empty"   if check_journal('-S "`cat /var/tmp/reboottime`"', "journalctl-after.txt");
-    if (check_journal('-U "`cat /var/tmp/reboottime`"', "journalctl-before.txt")) {
+    # Basic journalctl tests: Export journalctl with various arguments and ensure they are not empty
+    die "journalctl output is empty!"   if is_journal_empty('',                               "journalctl.txt");
+    die "journalctl after reboot empty" if is_journal_empty('-S "`cat /var/tmp/reboottime`"', "journalctl-after.txt");
+    die "journalctl dmesg empty"        if is_journal_empty("-k",                             "journalctl-dmesg.txt");
+
+    # Check boot times from journal
+    unless (is_journal_empty('-U "`cat /var/tmp/reboottime`"', "journalctl-before.txt")) {
         # Check for bsc1173856, i.e. the first date in the journal is newer than the last date
         my $awk    = '{print($1 " " $2 " " $3);}';
         my $f_time = script_output("journalctl -q | head -n 1 | awk '$awk'", proceed_on_failure => 1);
         my $l_time = script_output("journalctl -q | tail -n 1 | awk '$awk'", proceed_on_failure => 1);
-        if (str2time($f_time) > str2time($l_time)) {
-            record_soft_failure "bsc#1173856";
-        } else {
-            die "journalctl before reboot empty";
+        record_info 'head time', "$f_time -> " . str2time($f_time);
+        record_info 'tail time', "$l_time -> " . str2time($l_time);
+        if (str2time($f_time) >= str2time($l_time)) {
+            record_soft_failure "bsc#1173856 - journalctl until breaks when time is set back";
+            die "journalctl before reboot is empty" unless is_hyperv;
         }
     }
-    die "journalctl dmesg empty" if check_journal("-k", "journalctl-dmesg.txt");
-    assert_script_run('journalctl --identifier=batman --boot=-1| grep "The batman is going to sleep"', fail_message => "Error getting beacon from previous boot") unless is_public_cloud;
-    # Create virtual serial console for journal redirecting
-    script_run('socat pty,raw,echo=0,link=/dev/ttyS100 pty,raw,echo=0,link=/dev/ttyS101 & true');
-    assert_script_run('jobs | grep socat', fail_message => "socat is not running");
-    # Redirect journal to virtual serial console and syslog
-    assert_script_run('mkdir -p /etc/systemd/journald.conf.d/');
-    assert_script_run('echo -e "[Journal]\nForwardToConsole=yes\nTTYPath=/dev/ttyS100\nMaxLevelConsole=info" > /etc/systemd/journald.conf.d/fw-ttyS100.conf');
-    assert_script_run('echo -e "ForwardToSyslog=yes" >> /etc/systemd/journald.conf.d/fw-ttyS100.conf') if check_syslog;
-    assert_script_run('systemctl restart systemd-journald.service');
-    script_run('cat /dev/ttyS101 > /var/tmp/journal_serial.out & true');
-    assert_script_run('echo "journal redirect output started (grep for: aeru4Poh eiDeik5l)" | systemd-cat -p info -t redirect');
-    # Write messages and check for them
-    assert_script_run('echo "We need to call batman" | systemd-cat -p info -t batman');
-    assert_script_run('echo "We NEED to call the batman NOW" | systemd-cat -p err -t batman');
-    assert_script_run("echo 'CALL THE BATMAN NOW!1!! AARRGGH!!' | systemd-cat -p emerg -t batman");
     assert_script_run('journalctl --sync');
     assert_script_run('journalctl --flush');
-    assert_script_run('journalctl --identifier=batman | grep "We need to call batman"');
-    assert_script_run('journalctl --identifier=batman | grep "We NEED to call the batman NOW"');
-    assert_script_run('journalctl -p 3 --identifier=batman | grep "We NEED to call the batman NOW"');
-    die "journalctl -p 3 selection criterion failed" if (script_run('journalctl -p 3 --identifier=batman | grep "We need to call batman"') == 0);
-    die "journalctl -p 0 selection criterion failed (non emerg entries shown)" if (script_run('journalctl -p 0 --identifier=batman | grep -v "CALL THE BATMAN NOW" | grep "batman"') == 0);
-    assert_script_run('journalctl -p 0 --identifier=batman | grep "CALL THE BATMAN NOW"', fail_message => "journalctl -p 0 selection criterion failed (emerg entry not shown)");
-    # Stop redirecting to serial console and syslog
-    assert_script_run('rm /etc/systemd/journald.conf.d/fw-ttyS100.conf');
-    assert_script_run('systemctl restart systemd-journald.service');
-    # Terminate background jobs (for serial console)
-    script_run("kill %2");
-    script_run("kill %1");
-    assert_script_run('cat /var/tmp/journal_serial.out | grep "aeru4Poh eiDeik5l"', fail_message => "Forward to serial failed");
-    assert_script_run('cat /var/log/messages | grep "aeru4Poh eiDeik5l"',           fail_message => "Forward to syslog failed") if check_syslog;
-    script_run('journalctl -q > /var/tmp/journalctl.txt');
-    upload_logs('/var/tmp/journalctl.txt');
+    # Write second series of messages with different log priority
+    # and grep with according to bootID
+    write_test_log_entries \%log_entries;
+    assert_test_log_entries(\%log_entries, \@boots);
+
+    # Check journal state after reboot to trigger bsc#1171858
+    verify_journal();
+    # Note: Detailled error message is "Specifying boot ID or boot offset has no effect, no persistent journal was found."
+    # Create virtual serial console for journal redirecting
+    if (is_opensuse) {
+        zypper_call 'in socat';
+        script_run('socat pty,raw,echo=0,link=/dev/ttyS100 pty,raw,echo=0,link=/dev/ttyS101 & true');
+        assert_script_run('jobs | grep socat', fail_message => "socat is not running");
+        # Redirect journal to virtual serial console and syslog
+        assert_script_run "echo -e '[Journal]\nForwardToConsole=yes\nTTYPath=/dev/ttyS100\nMaxLevelConsole=info' > ${\ DROPIN_DIR }/fw-ttyS100.conf";
+        systemctl 'restart systemd-journald.service';
+        script_run('cat /dev/ttyS101 > /var/tmp/journal_serial.out & true');
+        assert_script_run('echo "journal redirect output started (grep for: aeru4Poh eiDeik5l)" | systemd-cat -p info -t redirect');
+        assert_script_run('grep "aeru4Poh eiDeik5l" /var/tmp/journal_serial.out', fail_message => "Forward to syslog failed");
+        # Stop redirecting to serial console and syslog
+        assert_script_run('rm /etc/systemd/journald.conf.d/fw-ttyS100.conf');
+        systemctl 'restart systemd-journald.service';
+        # Terminate background jobs (for serial console)
+        script_run("kill %2");
+        script_run("kill %1");
+    }
+    # Sync and Verify journal before FSS
+    assert_script_run 'journalctl --disk-usage';
+    assert_script_run 'journalctl --sync';
+    assert_script_run 'journalctl --flush';
+    verify_journal();
+    # Write second series of messages with different log priority
+    die("System is not using persistent logging\n")
+      if (script_output('journalctl --interval=10s --setup-keys 2>&1 | tee /var/tmp/journalctl-setup-keys.txt') =~
+        '/var/log/journal is not a directory, must be using persistent logging for FSS.');
+    my $key_regex = qr|(\b([a-f0-9]{6}-){3}[a-f0-9]{6}\/[a-f0-9]{7}-[a-f0-9]{6}\b)|;
+    my $keyid;
+    if (script_output('cat /var/tmp/journalctl-setup-keys.txt') =~ $key_regex) {
+        $keyid = $1;
+    } else {
+        die "FSS key regex does not match\n";
+    }
+
+    # Set new log entries for FSS checks
+    %log_entries = (
+        info  => q{'We need to call batman-after sealing'},
+        err   => q{'We NEED to call the batman NOW-after sealing'},
+        emerg => q{'CALL THE BATMAN NOW!1!! AARRGGH!!-after sealing'}
+    );
+    assert_script_run('journalctl --rotate');
+    # remove first bootid
+    shift @boots;
+    write_test_log_entries \%log_entries;
+    assert_test_log_entries(\%log_entries, \@boots);
+    # verify sealing
+    verify_journal($keyid);
+    # Rotate once more and verify the journal afterwards
+    assert_script_run('journalctl --rotate');
     # Additional journalctl commands/use cases
     assert_script_run('journalctl --vacuum-size=100M');
     assert_script_run('journalctl --vacuum-time=1years');
-    # Rotate once more and verify the journal afterwards
-    verify_journal();
-    assert_script_run('journalctl --rotate');
-    verify_journal();
+    assert_script_run 'journalctl --disk-usage';
 }
 
 sub cleanup {
@@ -169,6 +242,7 @@ sub cleanup {
     script_run('rm -f /var/tmp/journalctl-setup-keys.txt');
     script_run('rm -f /var/tmp/journal_serial.out');
     script_run('rm -f /var/tmp/reboottime');
+    script_run("rm -rf ${\ DROPIN_DIR }");
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
[journalctl@vmware](https://openqa.suse.de/tests/5287717#step/journalctl/34) or [journalctl@hyperv](https://openqa.suse.de/tests/5315914#step/journalctl/53) has been failing for a while.

Logging settings among opensuse and sle distros are different and not really unified at the moment.
Although all of them rely on almost identical default journald-systemd settings shipped in */etc/systemd/journald.conf*. There are few differences that should be mentioned.
1) openSUSE relies on persistent journald settings
    - */var/log/journald/* is provided by *systemd-logger* package (not present in sle) and it is in conflict with *rsyslog* package
2) sle based distros keep persistent logging using rsyslog features

- [[VMWare] journactl missing boot ID](https://progress.opensuse.org/issues/87749)
- VRs:
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build24.21-jeos-extratest@uefi-virtio-vga](http://kepler.suse.cz/tests/3701#step/journalctl/1)
  * [Build24.21-jeos-extratest@svirt-vmware65 FULL TS](http://kepler.suse.cz/tests/3700#step/journalctl/62) && [Build24.8-jeos-extratest@svirt-vmware65 REDUCED TS](http://kepler.suse.cz/tests/3695#step/journalctl/1)
  * [Build24.21-jeos-extratest@svirt-hyperv FULL TS](http://kepler.suse.cz/tests/3699#step/journalctl/1) && [Build24.8-jeos-extratest@svirt-hyperv REDUCED TS](http://kepler.suse.cz/tests/3694#step/journalctl/63)
  * [Build24.21-jeos-extratest@svirt-xen-hvm](http://kepler.suse.cz/tests/3703#)
  * [Build24.21-jeos-extratest@svirt-xen-pv](http://kepler.suse.cz/tests/3704)
  * [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build6.2-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/3711#live)
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20210222-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/3710#step/journalctl/1)