### PR TITLE
Add validation of the repos for offline installation

### DIFF
--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -29,9 +29,35 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/consoletest_setup
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks
+  - console/validate_repos
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+test_data:
+  repos:
+    - name: sle-module-basesystem
+      alias: Basesystem
+      uri: cd:/\?devices=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_cd0
+      enabled: No
+      filter: name
+    - name: sle-module-server-applications
+      alias: Server-Applications
+      uri: cd:/\?devices=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_cd0
+      enabled: No
+      filter: name
+    - name: sle-module-desktop-applications
+      alias: Desktop-Applications
+      uri: cd:/\?devices=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_cd0
+      enabled: No
+      filter: name
+    - name: SLES
+      nr: 3
+      alias: SLES
+      uri: cd:/\?devices=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_cd0
+      enabled: No
+      # As we cannot yet extrapolate vars.json variables, using nr to identify repo
+      filter: nr

--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -29,12 +29,18 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/system_prepare
   - console/consoletest_setup
   - console/hostname
-  - console/system_prepare
   - console/force_scheduled_tasks
+  - console/check_network
   - console/validate_repos
-  - shutdown/grub_set_bootargs
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/zypper_in
+  - console/orphaned_packages_check
+  - console/consoletest_finish
+  - x11/xterm
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
 test_data:

--- a/tests/console/validate_repos.pm
+++ b/tests/console/validate_repos.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate repos in the system using expectations from the test data.
+#
+# Maintainer: QE-YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "consoletest";
+use testapi;
+use repo_tools 'validate_repo_properties';
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my $test_data = get_test_suite_data();
+
+    select_console 'root-console';
+
+    foreach my $repo (@{$test_data->{repos}}) {
+        my $filter = $repo->{filter} ? $repo->{$repo->{filter}} : undef;
+        validate_repo_properties({
+                Filter      => $filter,
+                Alias       => $repo->{alias},
+                Name        => $repo->{name},
+                URI         => $repo->{uri},
+                Enabled     => $repo->{enabled},
+                Autorefresh => $repo->{autorefresh}
+        });
+    }
+}
+
+1;


### PR DESCRIPTION
Adding modules to validate offline installation, focusing on the repos in the installed system as it's main difference to unregistered installation with network.

See [poo#80786](https://progress.opensuse.org/issues/80786).

[Verification run](https://openqa.suse.de/tests/overview?version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23offline&distri=sle).