### PR TITLE
Update migration test autoyast profile for ppc64le

### DIFF
--- a/data/autoyast_sle15/autoyast_scc_up_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_scc_up_ppc64le.xml
@@ -1,6 +1,7 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <!--  very minimal autoyast profile-->
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
     <reg_server>{{SCC_URL}}</reg_server>
@@ -40,32 +41,11 @@
     <language>en_US</language>
     <languages>en_US</languages>
   </language>
-  <report>
-    <errors>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
-    </errors>
-    <messages>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
-    </messages>
-    <warnings>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
-    </warnings>
-    <yesno_messages>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
-    </yesno_messages>
-  </report>
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>
       <disklabel>gpt</disklabel>
+      <initialize config:type="boolean">true</initialize>
       <enable_snapshots config:type="boolean">true</enable_snapshots>
       <partitions config:type="list">
         <partition>
@@ -87,7 +67,7 @@
           <partition_nr config:type="integer">2</partition_nr>
           <partition_type>primary</partition_type>
           <resize config:type="boolean">false</resize>
-          <size>30054285312</size>
+          <size>35G</size>
           <subvolumes config:type="list">
             <listentry>
               <copy_on_write config:type="boolean">true</copy_on_write>
@@ -130,20 +110,33 @@
           <partition_nr config:type="integer">3</partition_nr>
           <partition_type>primary</partition_type>
           <resize config:type="boolean">false</resize>
-          <size>2148515328</size>
+          <size>2G</size>
         </partition>
       </partitions>
       <type config:type="symbol">CT_DISK</type>
       <use>all</use>
     </drive>
   </partitioning>
+  <report>
+    <errors>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <software>
     <products config:type="list">
-      <listentry>SLES</listentry>
+      <product>SLES</product>
     </products>
   </software>
   <upgrade>
-    <only_installed_packages config:type="boolean">false</only_installed_packages>
     <stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>
   </upgrade>
 </profile>


### PR DESCRIPTION
The old autoyast profile cannot be used. updated migration autoyast
profile

- Related ticket: https://progress.opensuse.org/issues/88103
- Verification run: https://openqa.suse.de/tests/5322337#
