### PR TITLE
Process registration screen for SLES distribution

### DIFF
--- a/data/autoyast_sle15/autoyast_firstboot.xml
+++ b/data/autoyast_sle15/autoyast_firstboot.xml
@@ -42,6 +42,7 @@
           <package>grub2</package>
           <package>sles-release</package>
           <package>yast2-firstboot</package>
+          <package>yast2-registration</package>
         </packages>
         <patterns config:type="list">
           <pattern>apparmor</pattern>

--- a/test_data/yast/firstboot/yast2_firstboot_sle.yaml
+++ b/test_data/yast/firstboot/yast2_firstboot_sle.yaml
@@ -1,0 +1,8 @@
+clients:
+  - firstboot_language_keyboard
+  - firstboot_welcome
+  - firstboot_licenses
+  - firstboot_timezone
+  - firstboot_user
+  - firstboot_root
+  - firstboot_registration

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -77,6 +77,11 @@ sub firstboot_hostname {
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
 }
 
+sub firstboot_registration {
+    assert_screen 'system_registered';
+    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+}
+
 sub run {
     my $self      = shift;
     my $test_data = get_test_suite_data();


### PR DESCRIPTION
We now have registration module being added by default to the first boot
profile. System is already registered, as we use Online medium for the
installation. Instead of de-registering it, we would prefer to assert
that registered system is recognized as such, as registration code is
tested in other installations.

See [poo#87904](https://progress.opensuse.org/issues/87904).

* [Related job group settings](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/337).

* [Verification runs](https://openqa.suse.de/tests/overview?version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23autoyast&distri=sle).