### PR TITLE
Fix no_separate_home issue on multi-disks scenario

### DIFF
--- a/tests/installation/partitioning/no_separate_home.pm
+++ b/tests/installation/partitioning/no_separate_home.pm
@@ -15,10 +15,12 @@
 use parent 'y2_installbase';
 use strict;
 use warnings FATAL => 'all';
+use testapi;
 
 sub run {
-    my $partitioner = $testapi::distri->get_partitioner();
-    $partitioner->edit_proposal(has_separate_home => 0);
+    my $partitioner    = $testapi::distri->get_partitioner();
+    my $multiple_disks = get_var('NUMDISKS', 1) > 1 ? 1 : 0;
+    $partitioner->edit_proposal(has_separate_home => 0, multiple_disks => $multiple_disks);
 }
 
 1;


### PR DESCRIPTION
The workflow should handle multi-disks on text mode with the
followed parameters:
NUMDISKS=4
SEPARATE_HOME=0

- Related ticket: https://progress.opensuse.org/issues/88129
- Verification run: http://10.67.19.72/tests/3033#step/no_separate_home/2
