### PR TITLE
QEM adopt bash into aggregate test and  improve qaset_pre_patch_run. 

### DIFF
--- a/schedule/qam/common/mau-qa_userspace.yaml
+++ b/schedule/qam/common/mau-qa_userspace.yaml
@@ -1,0 +1,10 @@
+---
+name: Userspace_test
+vars:
+    DISABLE_SUBMIT_QADB: 1
+    USER_SPACE_TESTSUITES: bash
+    SOFTFAIL_TESTCASES: bash.run-appendop.sh bash.run-array.sh bash.run-errors.sh bash.run-execscript.sh bash.run-herestr.sh bash.run-jobs.sh bash.run-new-exp.sh bash.run-posix2.sh bash.run-read.sh bash.run-shopt.sh bash.run-trap.sh bash.run-nquote4.sh
+    INDEPENDENT_RUN: 1
+schedule:
+    - boot/boot_to_desktop
+    - qa_automation/qaset_pre_patch_run

--- a/tests/qa_automation/qaset_pre_patch_run.pm
+++ b/tests/qa_automation/qaset_pre_patch_run.pm
@@ -11,16 +11,26 @@ package qaset_pre_patch_run;
 # Summary: Simplify test reporting for qa_automation tests
 #
 # This execution is entirely based on qa_automation/qa_run. The test result is simplfied to only show failed testcases
-# triggered by regression bug. That will satisfy the need for maintenance update test
+# triggered by regression in product if it is running with qaset_post_patch_run. It also can be run without qaset_post_patch_run if
+# INDEPENDENT_RUN is set to 1;
 # Using YAML_SCHEDULE to schedule is recommanded to keep flexibility.
+# INDEPENDENT_RUN schedule as follows:
+#name: bash
+#vars:
+#    DISABLE_SUBMIT_QADB: 1
+#    USER_SPACE_TEST-SUITES: bash openssl
+#    SOFTFAIL_TESTCASES: bash.run-appendop.sh bash.run-array.sh
+#    INDEPENDENT_RUN: 1
+#schedule:
+#    - boot/boot_to_desktop
+#    - qa_automation/qaset_pre_patch_run
 # qaset_pre_patch_run, patch_and_reboot and qaset_post_patch_run should schedule in order.
 #
 # features added:
 # 1. Only failed test case names triggered by regression are show on result page.
 # 2. QADB url of comparison of before update and after is posted under testcase name.
-# 3. Added var SOFTFAIL_TESTCASES which make a failed testcase softfailed to avoid triggering
-#    entire test failed until the corresponding bug is fixed.
-# 4. Auto define test in qaset if it's no defined.
+# 3. Added var SOFTFAIL_TESTCASES which can mask some test cases.
+# 4. Run multiple testsuites.
 # 5. disble/enable QADB submission with var DISABLE_SUBMIT_QADB.
 #
 # Maintainer: Tony Yuan <tyuan@suse.com>
@@ -55,7 +65,52 @@ sub qaset_config {
     $cmd .= q( do grep test_$n-run /usr/share/qa/qaset/set/* >/dev/null || echo "def_simple_run $n '/usr/share/qa/tools/test_${n}-run' qa_test_$n" >> /usr/share/qa/qaset/set/regression.set; done);
     assert_script_run($cmd);
 }
+sub upload_parse {
+    if (my $soft_tc = get_var("SOFTFAIL_TESTCASES")) {
+        record_info("$soft_tc");
+        my $xslt = <<'EOT';
+<?xml version="1.0"?>
+ <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+     <xsl:param name="masked_tc"></xsl:param>
+     <xsl:template match="@*|node()">
+         <xsl:copy>
+             <xsl:apply-templates select="@*|node()" />
+         </xsl:copy>
+     </xsl:template>
+     <xsl:template match="testcase">
+           <xsl:if test="not(contains($masked_tc, @classname))">
+        <xsl:copy>
+             <xsl:apply-templates select="@*|node()" />
+         </xsl:copy>
+           </xsl:if>
+         
+     </xsl:template>
+     
+<xsl:template match="testsuite/@failures[. > 0]">
+	<xsl:variable name="c" select="count(../testcase[contains($masked_tc, @classname) and @status='failure'])" />
+	   <xsl:attribute name="{name()}">
+		<xsl:value-of select=".-$c" />
+	   </xsl:attribute>
+</xsl:template>
+<xsl:template match="testsuite/@skipped[. > 0]">
+	<xsl:variable name="c" select="count(../testcase[contains($masked_tc, @classname) and @status='skipped'])" />
+	   <xsl:attribute name="{name()}">
+		<xsl:value-of select=".-$c" />
+	   </xsl:attribute>
+</xsl:template>
+ </xsl:stylesheet>
+EOT
+        assert_script_run("cat > /tmp/trans_junit.xsl <<'END'\n$xslt\nEND\n( exit \$?)");
 
+        assert_script_run("xml tr /tmp/trans_junit.xsl -s masked_tc=\"$soft_tc\"  /tmp/junit.xml > /tmp/junit_trans.xml");
+
+        parse_junit_log("/tmp/junit_trans.xml");
+
+    } else {
+
+        parse_junit_log("/tmp/junit.xml");
+    }
+}
 # qa_testset_automation validation test
 sub run {
     my $self = shift;
@@ -76,16 +131,26 @@ sub run {
     assert_script_run("/usr/share/qa/qaset/bin/junit_xml_gen.py -n 'regression' -d -o /tmp/junit.xml /var/log/qaset");
     upload_logs('/tmp/junit.xml', timeout => 600);
 
-    # Collect all testcases with status="failure"
-    assert_script_run(q(xml sel -t -v '//testcase[@status="failure"]/@classname' /tmp/junit.xml |sed '/\.dummy/d' | tr '\n' ' ' > /tmp/broken_tclist));
-    upload_logs('/tmp/broken_tclist', timeout => 100);
+    if (get_var("INDEPENDENT_RUN")) {
 
-    #Save submission ids of all tests to a file.
-    my $ts_list = join(" ", @{get_var_array('USER_SPACE_TESTSUITES')});
-    my $cmd = "for i in $ts_list; " . 'do xml sel -t -v "/testsuites/testsuite[@name=\"$i\"]/testcase[1]/system-err" /tmp/junit.xml|sed -n "s/.*id=\(.*\)/$i \1/p"; done > /tmp/submission_ids_before';
-    assert_script_run("$cmd");
-    die "Test run didn't finish within time limit" unless ($testrun_finished);
 
+        $self->upload_parse();
+
+
+    } else {
+
+
+
+        # Collect all testcases with status="failure"
+        assert_script_run(q(xml sel -t -v '//testcase[@status="failure"]/@classname' /tmp/junit.xml |sed '/\.dummy/d' | tr '\n' ' ' > /tmp/broken_tclist));
+        upload_logs('/tmp/broken_tclist', timeout => 100);
+
+        #Save submission ids of all tests to a file.
+        my $ts_list = join(" ", @{get_var_array('USER_SPACE_TESTSUITES')});
+        my $cmd = "for i in $ts_list; " . 'do xml sel -t -v "/testsuites/testsuite[@name=\"$i\"]/testcase[1]/system-err" /tmp/junit.xml|sed -n "s/.*id=\(.*\)/$i \1/p"; done > /tmp/submission_ids_before';
+        assert_script_run("$cmd");
+        die "Test run didn't finish within time limit" unless ($testrun_finished);
+    }
     # clean up qaset
     assert_script_run('rm -rf /tmp/junit.xml /var/log/qaset/submission/* /var/log/qaset/log/* /tmp/qaset.tar.bz2');
     select_console('root-console');


### PR DESCRIPTION
 Added three new features in qaset_pre_patch_run
1. Enable running multiple userspace testsuites in a job
2. testcase Softfail
3. Create yaml schedule file

- Related ticket: https://progress.opensuse.org/issues/50747
- Needles: no
- Verification run: 
- sle15sp2: http://10.67.17.201/tests/1220
- sle15sp1: http://10.67.17.201/tests/1228
- sle15: http://10.67.17.201/tests/1235
- sle12sp4: http://10.67.17.201/tests/1222