### PR TITLE
Set correct base class in yast2_firstboot test module

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -11,7 +11,7 @@
 # Doc: https://en.opensuse.org/YaST_Firstboot
 # Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
-use base 'y2_installbase';
+use base 'y2_module_guitest';
 use y2_logs_helper qw(accept_license verify_license_has_to_be_accepted);
 use strict;
 use warnings;
@@ -96,6 +96,10 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
     # upload YaST2 Firstboot configuration file
     upload_logs('/etc/YaST2/firstboot.xml', log_name => "firstboot.xml.conf");
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;


### PR DESCRIPTION
First boot is actually running in the installed system, therefore we
should use post_fail_hook which is suitable.
Other point is too still keep this module `fatal`, as if there is a
failure, we won't be able to run any further tests and it would not make
sense anyway.

See [poo#87907](https://progress.opensuse.org/issues/87907).

* [Verification run](https://openqa.suse.de/tests/5323441). Failure is triggered, logs are collected, which failed here: https://openqa.suse.de/tests/5305137