### PR TITLE
Implement test module for buildah container engine

### DIFF
--- a/data/containers/Dockerfile.python
+++ b/data/containers/Dockerfile.python
@@ -1,0 +1,18 @@
+FROM registry.suse.de/suse/sle-15-sp3/update/cr/totest/images/suse/sle15:15.3
+
+RUN zypper -n in python3 python3-pip curl
+
+# set a directory for the app
+WORKDIR /usr/src/app
+
+# copy all the files to the container
+COPY . .
+
+# install dependencies
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# tell the port number the container should expose
+EXPOSE 5000
+
+# run the command
+ENTRYPOINT ["python3", "./app.py"]

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -7,6 +7,7 @@ schedule:
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/podman_image
+  - containers/buildah_image
   - containers/docker_image
   - containers/container_diff
   - '{{validate_btrfs}}'

--- a/tests/containers/buildah_image.pm
+++ b/tests/containers/buildah_image.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: buildah
+# Summary: building OCI-compatible sle base images with buildah.
+# - install buildah
+# - create and run container
+# - build image with service and test connectivity
+# - cleanup system (images, containers)
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use utils;
+use containers::common;
+use containers::container_images;
+use suse_container_urls 'get_suse_container_urls';
+use version_utils qw(get_os_release check_os_release);
+
+sub run {
+    my ($image_names, $stable_names) = get_suse_container_urls();
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    my $runtime = "buildah";
+
+    install_buildah_when_needed($host_distri);
+    allow_selected_insecure_registries(runtime => $runtime);
+    scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
+
+    for my $iname (@{$image_names}) {
+        test_container_image(image => $iname, runtime => $runtime);
+        if (check_os_release('suse', 'PRETTY_NAME')) {
+            # sle15-working-container is the default name given to a container. it is created in test_container_image
+            test_opensuse_based_image(image => 'sle15-working-container', runtime => $runtime);
+            allow_selected_insecure_registries(runtime => 'podman');
+            test_containered_app('podman', $iname);
+        }
+    }
+    scc_restore_docker_image_credentials();
+    clean_container_host(runtime => 'podman');
+}
+
+1;

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -46,7 +46,7 @@ sub _test_btrfs_thin_partitioning {
     $rt->build($dockerfile_path, 'thin_image');
     # validate that new subvolume has been created. This should be improved.
     assert_script_run qq{test \$(ls -td $dev_path/btrfs/subvolumes/* | head -n 1) == \$(cat $btrfs_head)};
-    validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=1.*GiB, used=\d+.+[KM]iB/ };
+    validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=[12].*GiB, used=\d+.+[KM]iB/ };
 }
 
 sub _test_btrfs_device_mgmt {
@@ -54,9 +54,10 @@ sub _test_btrfs_device_mgmt {
     my $container  = 'registry.opensuse.org/cloud/platform/stack/rootfs/images/sle15';
     my $btrfs_head = '/tmp/subvolumes_saved';
     record_info "test btrfs";
+    script_run("df -h");
     # /var is using its own partition which is size of 10G. Create file in the container
     # enough to fill up the partition up to ~99%
-    $rt->up('huge_image', keep_container => 1, cmd => 'fallocate -l 9152000KiB bigfile.txt');
+    $rt->up('huge_image', keep_container => 1, cmd => 'fallocate -l 9149000KiB bigfile.txt');
     validate_script_output "df -h --sync|grep var", sub { m/\/dev\/vda.+\s+(9[7-9]|100)%/ };
     # partition should be full
     validate_script_output "btrfs fi df $dev_path", sub { m/^Data.+total=8.*GiB, used=8.*GiB/ };


### PR DESCRIPTION
Module tries to build and run Container Images using Buildah.
Scenario provide a networking test of a server built in the sle base image
I encounter issues with zypper-docker thus i have not covered this test case
in this PR.


- Related ticket: https://progress.opensuse.org/issues/87800
- Verification run: 
- https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2311828&version=15-SP3
- https://openqa.opensuse.org/tests/overview?version=Tumbleweed&build=b10n1k%2Fos-autoinst-distri-opensuse%2311828&distri=microos
- https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2311828&version=Tumbleweed