### PR TITLE
Update details of enabling remote connections on Windows

### DIFF
--- a/tests/x11/remote_desktop/windows_network_setup.pm
+++ b/tests/x11/remote_desktop/windows_network_setup.pm
@@ -24,6 +24,7 @@ sub run {
     assert_and_click "windows-powershell-admin";
     assert_and_click "windows-powershell-yes";
 
+    assert_and_click "powershell-started";
     type_string "netsh interface ip set address name=Ethernet static 10.0.2.18 255.255.255.0 10.0.2.2";
     send_key "ret";
 

--- a/tests/x11/remote_desktop/windows_server_setup.pm
+++ b/tests/x11/remote_desktop/windows_server_setup.pm
@@ -22,10 +22,11 @@ sub run {
     my $self = shift;
 
     assert_and_click "start";
-    type_string "remote access";
+    type_string "allow remote connections";
     assert_screen "start_menu-remote_access-controlpanel";
     send_key "ret";
 
+    assert_and_click "show-settings";
     assert_and_click "allow-remote-connections";
     assert_screen "allow-connections-with-nla-enabled";
 
@@ -35,6 +36,7 @@ sub run {
     }
 
     assert_and_click "system-properties-ok";
+    assert_and_click "close-settings";
 
     mutex_create 'win_server_ready';
     wait_for_children;


### PR DESCRIPTION
- Update details of enabling remote connections on Windows
- Update windows qcow to fix the desktopapps-remote-desktop-xrdp-client/server failures on both SLE and TW
- Update details of enabling remote connections to make it work with newer window qcow

- Related tickets:
https://progress.opensuse.org/issues/70942
https://progress.opensuse.org/issues/87680

- Needles: 
  SLE: Already added when debugging online on o.s.d
  TW: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/708

- Verification test run:
SLE15SP3:
[desktopapps-remote-desktop-xrdp-client1](http://10.163.42.54/tests/1697) 
[desktopapps-remote-desktop-xrdp-server1](http://10.163.42.54/tests/1696)
[desktopapps-remote-desktop-xrdp-client2](http://10.163.42.54/tests/1701)
[desktopapps-remote-desktop-xrdp-server2](http://10.163.42.54/tests/1700)

TW:
[desktopapps-remote-desktop-xrdp-client2](http://10.163.42.54/tests/1707)
[desktopapps-remote-desktop-xrdp-server2](http://10.163.42.54/tests/1706)
