### PR TITLE
Fix yast2_lan_restart for xen machines

### DIFF
--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -28,6 +28,8 @@ use y2lan_restart_common;
 use y2_module_basetest 'is_network_manager_default';
 use version_utils ':VERSION';
 
+my $backend = get_required_var('BACKEND');
+
 sub check_network_settings_tabs {
     send_key 'alt-g';    # Global options tab
     assert_screen 'yast2_lan_global_options_tab';
@@ -87,12 +89,17 @@ sub change_hw_device_name {
 sub run {
     initialize_y2lan;
     verify_network_configuration;               # check simple access to Overview tab
-    verify_network_configuration(\&check_network_settings_tabs);
+    my $service_status_after_conf = (is_sle('<=15')) ? 'no_restart_or_reload' : 'reload';
+    if ($backend eq "svirt") {
+        verify_network_configuration(\&check_network_settings_tabs, $service_status_after_conf);
+    }
+    else {
+        verify_network_configuration(\&check_network_settings_tabs);
+    }
     unless (is_network_manager_default) {
         # Run detailed check only if explicitly configured in the test suite
         check_etc_hosts_update() if get_var('VALIDATE_ETC_HOSTS');
         record_info "check_network_card_setup_tabs";
-        my $service_status_after_conf = (is_sle('<=15')) ? 'no_restart_or_reload' : 'reload';
         verify_network_configuration(\&check_network_card_setup_tabs, $service_status_after_conf);
         record_info "check_default_gateway";
         verify_network_configuration(\&check_default_gateway);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/87943
- Needles: N/A
- Verification run: SLES-15-SP3 [extra_tests_gnome@64bit](http://10.161.229.247/tests/1687#step/yast2_lan_restart/128) | [extra_tests_gnome@svirt-xen-pv](https://openqa.suse.de/tests/5401774#step/yast2_lan_restart/128) | [extra_tests_gnome@svirt-xen-hvm](https://openqa.suse.de/tests/5404987#step/yast2_lan_restart/128) 
Tumbleweed [extra_tests_gnome@64bit](http://10.161.229.247/tests/1688#step/yast2_lan_restart/51) 
