### PR TITLE
Fix failing HanaSR tests on 12-SP2

### DIFF
--- a/tests/sles4sap/sap_suse_cluster_connector.pm
+++ b/tests/sles4sap/sap_suse_cluster_connector.pm
@@ -78,7 +78,7 @@ sub run {
     # Test Stop/Start of SAP resource
     my $rsc = get_var('NW') ? "rsc_sap_${instance_sid}_${instance_type}${instance_id}" : "rsc_SAPHana_${instance_sid}_${instance_type}${instance_id}";
     exec_conn_cmd(binary => $binary, cmd => "$_ --res $rsc --act stop", timeout => 120) foreach qw(fra cpa);
-    sleep 10;      # wait to let enough time for the HA stack to stop the resource
+    wait_until_resources_stopped(timeout => 1200);
     save_state;    # do a check of the cluster with a screenshot
     exec_conn_cmd(binary => $binary, cmd => "$_ --res $rsc --act start", timeout => 120) foreach qw(fra cpa);
 


### PR DESCRIPTION
HanaSR tests on 12-SP2 are currently failing due to 2 related issues:

1. The method `wait_until_resources_started` on `lib/hacluster` is checking that HA resources are started only on SLES versions after 12-SP3. This causes the modules `sles4sap/sap_suse_cluster_connector` and `ha/check_after_reboot` to continue testing even when all the resources have not finished starting, which can lead to having an incorrect or invalid cluster state in subsequent tests: [cluster resources still starting at the end of sap_suse_cluster_connector](https://openqa.suse.de/tests/5290768#step/sap_suse_cluster_connector/60) -> [cluster resources still starting at the start of fencing module](https://openqa.suse.de/tests/5290768#step/fencing/2) -> [HANA demoted in both nodes in the fencing module just before fence operation](https://openqa.suse.de/tests/5290768#step/fencing/15) -> [HANA fails to correctly start after fence](https://openqa.suse.de/tests/5290768#step/check_after_reboot/25)
2. The test module `sles4sap/sap_suse_cluster_connector` performs a stop and start operation in the cluster, and checks for the cluster resources to finish starting after the start operation, but only sleeps for 10 seconds after the stop operation. This can cause that if the stopping of the resources is taking longer than the 10 seconds, the start command is sent on a process that's stopping but still active, and thus the start operation is ignored.

This pull request adds a method to check when HA resources are finished stopping, includes its call in
`sles4sap/sap_suse_cluster_connector.pm` after this module stops cluster resources, and changes `wait_until_resources_started` so it checks for Starting resources in older versions of SLES.

- Failed job: https://openqa.suse.de/tests/5290768
- Related ticket: N/A
- Needles: N/A
- Verification run: [node 1](http://mango.qa.suse.de/tests/3370) & [node 2](http://mango.qa.suse.de/tests/3371)
