### PR TITLE
Use y2_module_basetest instead for the first boot

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -11,7 +11,7 @@
 # Doc: https://en.opensuse.org/YaST_Firstboot
 # Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
-use base 'y2_module_guitest';
+use base 'y2_module_basetest';
 use y2_logs_helper qw(accept_license verify_license_has_to_be_accepted);
 use strict;
 use warnings;


### PR DESCRIPTION
While fixing log collection for the yast2_firstboot module I've put
guitest as a base class, which has post_run_hook. There we assert
generic-desktop, which makes sense for gui tests, but in case of first
boot we finish at login screen.
So replacing base class not to have this behavior.

See [poo#87904](https://progress.opensuse.org/issues/87904).

#### Verification runs
* [yast2_firstboot](https://openqa.suse.de/tests/5327245)
* [autoyast2-yast2_firstboot](https://openqa.suse.de/tests/5327248)
