### PR TITLE
Partially revert " QEM: Handle released maintenance repositories"

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -5,7 +5,7 @@ Provide translations for autoyast XML file
 =cut
 # SUSE's openQA tests
 #
-# Copyright © 2018-2020 SUSE LLC
+# Copyright © 2018-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -28,7 +28,6 @@ use registration qw(scc_version get_addon_fullname);
 use File::Copy 'copy';
 use File::Path 'make_path';
 use LWP::Simple 'head';
-use maintenance_smelt qw(repo_is_not_active);
 
 use xml_utils;
 
@@ -174,7 +173,7 @@ sub expand_template {
     my $template  = Mojo::Template->new(vars => 1);
     my $vars      = {
         addons   => expand_addons,
-        repos    => [grep { !repo_is_not_active($_) } split(/,/, get_var('MAINT_TEST_REPO', ''))],
+        repos    => [split(/,/, get_var('MAINT_TEST_REPO', ''))],
         patterns => expand_patterns,
         # pass reference to get_required_var function to be able to fetch other variables
         get_var => \&get_required_var,

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -19,7 +19,6 @@ use Utils::Architectures qw(is_ppc64le is_aarch64);
 use power_action_utils 'power_action';
 use version_utils qw(is_sle is_jeos is_leap is_tumbleweed is_opensuse);
 use utils 'ensure_serialdev_permissions';
-use maintenance_smelt qw(repo_is_not_active);
 
 
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump
@@ -62,7 +61,6 @@ sub prepare_for_kdump_sle {
         # append _debug to the incident repo
         for my $i (split(/,/, get_var('MAINT_TEST_REPO'))) {
             next unless $i;
-            next if repo_is_not_active($i);
             $i =~ s,/$,_debug/,;
             $counter++;
             zypper_call("--no-gpg-checks ar -f $i 'DEBUG_$counter'");

--- a/lib/maintenance_smelt.pm
+++ b/lib/maintenance_smelt.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use base "Exporter";
 use Exporter;
 
 
-our @EXPORT = qw(query_smelt get_incident_packages get_packagebins_in_modules repo_is_not_active);
+our @EXPORT = qw(query_smelt get_incident_packages get_packagebins_in_modules);
 
 sub query_smelt {
     my $graphql = $_[0];
@@ -56,14 +56,6 @@ sub get_packagebins_in_modules {
     # Return a hash of hashes, hashed by name. The values are hashes with the keys 'name', 'supportstatus' and
     # 'package'.
     return map { $_->{name} => $_ } @arr;
-}
-
-sub repo_is_not_active {
-    my $repo = $_[0];
-    $repo =~ m".+Maintenance\:\/(\d+)";
-    my $id     = $1;
-    my $status = query_smelt("{incidents(incidentId: $id){edges{node{status {name}}}}}");
-    record_info("$id", "$id have been released") && return $id if $status =~ /\Qstatus":{"name":"done"\E/;
 }
 
 1;

--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2020 SUSE LLC
+# Copyright © 2016-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,6 @@ use utils qw(zypper_call);
 use JSON;
 use List::Util qw(max);
 use version_utils 'is_sle';
-use maintenance_smelt qw(repo_is_not_active);
 
 our @EXPORT
   = qw(capture_state check_automounter is_patch_needed add_test_repositories ssh_add_test_repositories remove_test_repositories advance_installer_window get_patches check_patch_variables);
@@ -89,7 +88,6 @@ sub add_test_repositories {
     @repos = split(',', $oldrepo) if ($oldrepo);
 
     for my $var (@repos) {
-        next if repo_is_not_active($var);
         zypper_call("--no-gpg-checks ar -f -n 'TEST_$counter' $var 'TEST_$counter'");
         $counter++;
     }

--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -15,7 +15,6 @@ use warnings;
 use base 'y2_installbase';
 use testapi;
 use qam 'advance_installer_window';
-use maintenance_smelt qw(repo_is_not_active);
 
 sub run() {
 
@@ -31,7 +30,6 @@ sub run() {
 
     while (defined(my $maintrepo = shift @repos)) {
         next if $maintrepo =~ /^\s*$/;
-        next if repo_is_not_active($maintrepo);
         assert_screen('addon-menu-active', 60);
         send_key 'alt-u';    # specify url
         wait_still_screen(1);
@@ -43,18 +41,6 @@ sub run() {
         advance_installer_window('addon-products');
         # if more repos to come, add more
         send_key_until_needlematch('addon-menu-active', 'alt-a', 10, 2) if @repos;
-    }
-
-    # when last maintrepo was released thus not added, previous loop will end in addon-menu-active
-    # expecting another entry and fail as there is no next repo to add
-    if (get_var('FLAVOR', '') =~ /-Updates/) {
-        wait_still_screen(2);
-        if (check_screen('addon-menu-active')) {
-            # go back to registration and forward to addons
-            send_key 'alt-b';
-            wait_still_screen(3);
-            send_key_until_needlematch([qw(inst-addon addon-products)], 'alt-n', 3, 2);
-        }
     }
 }
 


### PR DESCRIPTION
Workaround in not need as repo of released update is kept.
https://jira.suse.com/browse/OBS-84
This reverts commit 7f2c8e3e423fd78f2121ec3dd07a0ee479f57630.
Keep split of smelt functions in lib/maintenance_smelt.pm

- Related ticket:
https://jira.suse.com/browse/OBS-84
https://progress.opensuse.org/issues/72121
#11153
- Verification run:
https://openqa.suse.de/tests/5327604 HA x86_64
https://openqa.suse.de/tests/5327641 x86_64
https://openqa.suse.de/tests/5327642 s390x
https://openqa.suse.de/tests/5327643 aarch64
released repo: 
https://openqa.suse.de/tests/5327644 x86_64
https://openqa.suse.de/tests/5327645 s390x
https://openqa.suse.de/tests/5327646 ppc64le
https://openqa.suse.de/tests/5327647 aarch64
https://openqa.suse.de/tests/5327648 create_hdd_xfstests