### PR TITLE
Add a module to check if yast2-lan handles typos

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -39,6 +39,7 @@ our @EXPORT = qw(
   turn_off_gnome_screensaver
   turn_off_gnome_suspend
   untick_welcome_on_next_startup
+  start_root_shell_in_xterm
   workaround_boo1170586
 );
 
@@ -389,6 +390,19 @@ sub handle_welcome_screen {
     assert_screen([qw(opensuse-welcome opensuse-welcome-boo1169203)], $args{timeout});
     workaround_broken_opensuse_welcome_window() if match_has_tag("opensuse-welcome-boo1169203");
     untick_welcome_on_next_startup;
+}
+
+=head2 start_root_shell_in_xterm
+
+    start_root_shell_in_xterm()
+    
+Start a root shell in xterm.
+
+=cut
+sub start_root_shell_in_xterm {
+    select_console 'x11';
+    x11_start_program("xterm -geometry 155x50+5+5", target_match => 'xterm');
+    become_root;
 }
 
 1;

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -27,6 +27,7 @@ use version_utils qw(is_sle is_leap);
 use y2_module_basetest qw(accept_warning_network_manager_default is_network_manager_default);
 use y2_module_consoletest;
 use Test::Assert ':all';
+use x11utils "start_root_shell_in_xterm";
 
 our @EXPORT = qw(
   check_etc_hosts_update
@@ -59,9 +60,7 @@ Initialize yast2 lan. Stop firewalld. Ensure firewalld is stopped. Enable DEBUG.
 =cut
 sub initialize_y2lan
 {
-    select_console 'x11';
-    x11_start_program("xterm -geometry 155x50+5+5", target_match => 'xterm');
-    become_root;
+    start_root_shell_in_xterm();
     # make sure that firewalld is stopped, or we have later pops for firewall activation warning
     # or timeout for command 'ip a' later
     if ((is_sle('15+') or is_leap('15.0+')) and script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=inactive")) {

--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -34,6 +34,7 @@ conditional_schedule:
         - yast2_gui/yast2_datetime
         - yast2_gui/yast2_hostnames
         - yast2_gui/yast2_network_settings
+        - yast2_gui/yast2_lan_ifcfg_errors
         - x11/yast2_lan_restart
         - yast2_gui/yast2_lan_restart_bridge
         - yast2_gui/yast2_lan_restart_vlan
@@ -73,6 +74,12 @@ conditional_schedule:
         - yast2_gui/yast2_datetime
         - yast2_gui/yast2_hostnames
 test_data:
+  net_device: eth0
+  errors_in_ifcfg_file:            # Each command is followed by ifcfg file name.
+#   - "sed -i 's/dhcp/dgcp/'"      # Typo in value. To be enabled once bsc#1181296 is fixed.
+    - "echo ETHERDEVICE='eth0' >>" # Wrong device for VLAN (should be same as current).
+    - "echo BOOTPROTO='dhcp' >>"   # Duplicate entry, same data.
+    - "echo BOOTPROTO='none' >>"   # Duplicate entry, different data.
   disks:
     - name: vdb
       partitions:

--- a/tests/yast2_gui/yast2_lan_ifcfg_errors.pm
+++ b/tests/yast2_gui/yast2_lan_ifcfg_errors.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that yast2-lan does not crash if there are errors
+# (like typos or duplicates) in one of the ifcfg files.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base 'y2_module_guitest';
+use strict;
+use warnings;
+use testapi;
+use y2lan_restart_common qw(open_network_settings wait_for_xterm_to_be_visible close_xterm close_network_settings);
+use x11utils 'start_root_shell_in_xterm';
+use scheduler 'get_test_suite_data';
+
+sub check_errors_in_ifcfg {
+    my ($error_in_ifcfg, $ifcfg_file) = @_;
+    assert_script_run("$error_in_ifcfg $ifcfg_file");    # Insert an error in ifcfg file
+    open_network_settings;
+    close_network_settings;
+    wait_for_xterm_to_be_visible();
+}
+
+sub run {
+    my $test_data  = get_test_suite_data();
+    my $ifcfg_file = '/etc/sysconfig/network/ifcfg-' . $test_data->{net_device};
+    record_info('IFCFG', 'Verify that putting wrong settings in ifcfg files do not provoke a crash');
+    start_root_shell_in_xterm();
+    assert_script_run("cat $ifcfg_file > backup");
+    foreach my $error_in_ifcfg (@{$test_data->{errors_in_ifcfg_file}}) {
+        check_errors_in_ifcfg($error_in_ifcfg, $ifcfg_file);    # See descriptions of errors in test_data
+        assert_script_run("cat backup > $ifcfg_file");
+    }
+    assert_script_run("rm backup");
+    close_xterm();
+}
+
+1;


### PR DESCRIPTION
YaST must not break if it finds something unexpected in network configuration files (ifcfg).

- Related ticket: https://progress.opensuse.org/issues/28639
- Verification run: http://waaa-amazing.suse.cz/tests/14213