### PR TITLE
Fix "yast2 apparmor" performance issue

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2020 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -646,7 +646,7 @@ sub yast2_apparmor_setup {
 # Yast2 Apparmor: check apparmor is enabled
 sub yast2_apparmor_is_enabled {
     type_string("yast2 apparmor &\n");
-    assert_screen("AppArmor-Configuration-Settings");
+    assert_screen("AppArmor-Configuration-Settings", timeout => 180);
     send_key "alt-l";
     assert_screen("AppArmor-Settings-Enable-Apparmor");
 }

--- a/tests/security/yast2_apparmor/manually_add_profile.pm
+++ b/tests/security/yast2_apparmor/manually_add_profile.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -50,9 +50,9 @@ sub run {
     # Enter "Manually Add Profile" to generate a profile for a program
     # "marked as a program that should not have its own profile",
     # it should be failed
-    assert_and_click("AppArmor-Manually-Add-Profile");
+    assert_and_click("AppArmor-Manually-Add-Profile", timeout => 60);
     send_key "alt-l";
-    assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
+    assert_screen("AppArmor-Chose-a-program-to-generate-a-profile", timeout => 90);
     type_string("$test_file");
     send_key "alt-o";
     assert_screen("AppArmor-generate-a-profile-Error");
@@ -65,7 +65,7 @@ sub run {
     # Enter "Manually Add Profile" to generate a profile for a program
     # *NOT* "marked as a program that should not have its own profile",
     # it should be succeeded
-    assert_and_click("AppArmor-Manually-Add-Profile");
+    assert_and_click("AppArmor-Manually-Add-Profile", timeout => 60);
     send_key "alt-l";
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_bk");
@@ -83,7 +83,7 @@ sub run {
     # Verify bsc#1172040
     # Enter "yast2 apparmor" again
     type_string("yast2 apparmor &\n");
-    assert_and_click("AppArmor-Manually-Add-Profile");
+    assert_and_click("AppArmor-Manually-Add-Profile", timeout => 60);
     send_key "alt-l";
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_vsftpd");

--- a/tests/security/yast2_apparmor/scan_audit_logs.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -43,7 +43,7 @@ sub run {
     # Enter "yast2 apparmor"
     type_string("yast2 apparmor &\n");
     # Enter "Scan Audit logs" and check there should no records
-    assert_and_click("AppArmor-Scan-Audit-logs");
+    assert_and_click("AppArmor-Scan-Audit-logs", timeout => 60);
     send_key "alt-l";
     assert_screen("AppArmor-Scan-Audit-logs-no-records");
     # Exit "yast2 apparmor"
@@ -71,7 +71,7 @@ sub run {
     # Enter "yast2 apparmor" and verify apparmor can revise the profile based on former violation
     type_string("yast2 apparmor &\n");
     # Enter "Scan Audit logs" and check there should have records
-    assert_and_click("AppArmor-Scan-Audit-logs");
+    assert_and_click("AppArmor-Scan-Audit-logs", timeout => 60);
     send_key "alt-l";
     assert_screen("AppArmor-Scan-Audit-logs-scan-records");
 

--- a/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
+++ b/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ sub run {
 
     # Enable apparmor service and check
     type_string("yast2 apparmor &\n");
-    assert_screen("AppArmor-Configuration-Settings");
+    assert_screen("AppArmor-Configuration-Settings", timeout => 60);
     send_key "alt-l";
     assert_screen("AppArmor-Settings-Disable-Apparmor");
     send_key "alt-e";


### PR DESCRIPTION
Fix "yast2 apparmor" performance issue:
There are some performance issues on all architectures, such as "yast2 apparmor" loading is very slow.
 "yast2" UI loads the "chose a program to generate a profile for" window is very slowly also.
Then increasing the time out value instead of default value (30). 

- Related ticket: 
  poo#81811 - [sle][security][sle15sp3] test fails in manually_add_profile about type_string missing and Needles mismatch
  poo#88145 - [sle][security][sle15sp3] test fails in settings_disable_enable_apparmor (needle mismach due to new desktop background?)
- Needles: invalid needle "manually_add_profile-AppArmor-Chose-a-program-to-generate-a-profile-20201124.json" was deleted via openQA.
- Verification run: passed on build 130.3
  https://openqa.suse.de/tests/5335877#step/manually_add_profile/28
  https://openqa.suse.de/tests/5341465#details
  https://openqa.suse.de/tests/5341356
