### PR TITLE
Attempt exiting install shell even if polluted

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -95,8 +95,9 @@ sub teardown_libyui {
         save_svirt_pty;
         type_line_svirt "exit";
     } else {
-        assert_screen('startshell', timeout => 100);
-        type_string_slow "exit\n";
+        check_screen('startshell', timeout => 100);
+        # Putting new line to avoid issues if anything was put there (see poo#81034)
+        type_string_slow "\nexit\n";
     }
 }
 


### PR DESCRIPTION
In order to make teardown more tolerant to errors, we replace
assert_screen with check_screen and try to type `exit`, as will solve
issue with sporadic failures we face on powerVM.

On top of that, shell might get polluted, additional new line symbol
will solve the issue of polluted shell, as we also saw some characters
being added to the shell.

See [poo#81034](https://progress.opensuse.org/issues/81034).

Triggered 20 runs:
[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23libyui2) 