### PR TITLE
kdump_and_crash: Suspend failed process to get logs

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -30,6 +30,7 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
 
+    send_key 'ctrl-z';
     script_run 'ls -lah /boot/';
     script_run 'tar -cvJf /tmp/crash_saved.tar.xz -C /var/crash .';
     upload_logs '/tmp/crash_saved.tar.xz';


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/5341533#step/kdump_and_crash/51
- Verification run: http://dzedro.suse.cz/tests/17308#step/kdump_and_crash/52