### PR TITLE
Cleanup and reregister system for clone_system test

### DIFF
--- a/schedule/yast/clone_system/clone_system.yaml
+++ b/schedule/yast/clone_system/clone_system.yaml
@@ -8,11 +8,10 @@ vars:
 schedule:
   # Called on ARCH: s390x
   - '{{bootloader_zkvm}}'
-  # Called on ARCH: aarch64
-  - '{{uefi_bootmenu}}'
   - boot/boot_to_desktop
   - console/system_prepare
   - console/consoletest_setup
+  - console/scc_cleanup_reregister
   - console/yast2_clone_system
   - console/consoletest_finish
 conditional_schedule:
@@ -20,6 +19,3 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/bootloader_zkvm
-  uefi_bootmenu:
-    ARCH:
-      aarch64:

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_64bit.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_64bit.yaml
@@ -21,9 +21,6 @@ profile:
       - addon:
           unique_key: name
           name: sle-module-basesystem
-      - addon:
-          unique_key: name
-          name: sle-module-development-tools
     do_registration: 'true'
     install_updates: 'false'
     slp_discovery: 'false'

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_aarch64.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_aarch64.yaml
@@ -21,9 +21,6 @@ profile:
       - addon:
           unique_key: name
           name: sle-module-basesystem
-      - addon:
-          unique_key: name
-          name: sle-module-development-tools
     do_registration: 'true'
     install_updates: 'false'
     slp_discovery: 'false'

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le-hmc.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le-hmc.yaml
@@ -17,13 +17,7 @@ profile:
           name: sle-module-server-applications
       - addon:
           unique_key: name
-          name: sle-module-desktop-applications
-      - addon:
-          unique_key: name
           name: sle-module-basesystem
-      - addon:
-          unique_key: name
-          name: sle-module-development-tools
     do_registration: 'true'
     install_updates: 'false'
     slp_discovery: 'false'

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le.yaml
@@ -21,9 +21,6 @@ profile:
       - addon:
           unique_key: name
           name: sle-module-basesystem
-      - addon:
-          unique_key: name
-          name: sle-module-development-tools
     do_registration: 'true'
     install_updates: 'false'
     slp_discovery: 'false'

--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_s390x.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_s390x.yaml
@@ -21,9 +21,6 @@ profile:
       - addon:
           unique_key: name
           name: sle-module-basesystem
-      - addon:
-          unique_key: name
-          name: sle-module-web-scripting
     do_registration: 'true'
     install_updates: 'false'
     slp_discovery: 'false'

--- a/tests/console/scc_cleanup_reregister.pm
+++ b/tests/console/scc_cleanup_reregister.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Cleanup scc registration and reregister system and addon products.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use registration qw(cleanup_registration register_product register_addons_cmd);
+
+sub run {
+    select_console 'root-console';
+    cleanup_registration;
+    register_product;
+    register_addons_cmd;
+}
+
+1;


### PR DESCRIPTION
In some cases, the products of create_hdd_gnome image are modified, resulting in clone_system test to clone a profile with unpredictable products. The module scc_cleanup_reregister will fix this issue by cleaning up the scc regitsration of the system and reregister the system and addons.

- Related ticket: https://progress.opensuse.org/issues/69256
- Verification runs:
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=_ssyrianidou_2&groupid=96 
