### PR TITLE
Schedule add_update_test_repo only when MAINT_TEST_REPO is not empty

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -858,7 +858,7 @@ sub load_inst_tests {
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
-        if (get_var('MAINT_TEST_REPO') and !get_var("USER_SPACE_TESTSUITES")) {
+        if (get_var('MAINT_TEST_REPO') =~ /http/ and !get_var("USER_SPACE_TESTSUITES")) {
             loadtest 'installation/add_update_test_repo';
         }
         loadtest "installation/addon_products_sle";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/88235 
- Verification run: 