### PR TITLE
wicked: Add `--debug all` and timestamp to wicked call

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -40,8 +40,8 @@ This function saves the command and the stdout and stderr to a file to be upload
 =cut
 sub wicked_command {
     my ($self, $action, $iface) = @_;
-    my $cmd = '/usr/sbin/wicked --log-target syslog ' . $action . ' ' . $iface;
-    assert_script_run(q(echo -e "\n# ") . $cmd . ' >> /tmp/wicked_serial.log');
+    my $cmd = '/usr/sbin/wicked --log-target syslog --debug all ' . $action . ' ' . $iface;
+    assert_script_run('echo -e "\n# $(date -Isecond)\n# "' . $cmd . ' >> /tmp/wicked_serial.log');
     record_info('wicked cmd', $cmd);
     assert_script_run($cmd . ' 2>&1 | tee -a /tmp/wicked_serial.log');
     assert_script_run(q(echo -e "\n# ip addr" >> /tmp/wicked_serial.log));


### PR DESCRIPTION
`WICKED_DEBUG="all"` doesn't apply to the `wicked` client, thus we need to set `debugging all` differently.
    
There are two possibilities:
1) Create a `/etc/wicked/client-local.xml` file with the following content:
 ```
    <config>
        <debug>all</debug>
    </config>
```
2) Attach `--debug all` to the `wicked` call.
    
I choose the second approach. So we get the `debug all` on all programmatically calls, but if we need to manual debug, we don't get spamd with things we didn't want.
    
Also adding a timestamp in wicked_serial.log, so we can make correlations with other log files.


- Verification run: https://openqa.suse.de/tests/5348443
