### PR TITLE
Fix rpcbind systemd unit failure

### DIFF
--- a/lib/services/rpcbind.pm
+++ b/lib/services/rpcbind.pm
@@ -52,6 +52,11 @@ sub stop_service {
     common_service_action($nfs_server, $service_type, 'stop');
 }
 
+sub check_enabled {
+    common_service_action('rpcbind',   $service_type, 'is-enabled');
+    common_service_action($nfs_server, $service_type, 'is-enabled');
+}
+
 sub check_service {
     common_service_action('rpcbind', $service_type, 'is-enabled');
     common_service_action('rpcbind', $service_type, 'is-active');
@@ -80,6 +85,7 @@ sub full_rpcbind_check {
         install_service();
         config_service();
         enable_service();
+        check_enabled();
         start_service();
     }
     check_service();

--- a/tests/console/rpcbind.pm
+++ b/tests/console/rpcbind.pm
@@ -30,6 +30,7 @@ sub run {
     services::rpcbind::check_install();
     services::rpcbind::config_service();
     services::rpcbind::enable_service();
+    services::rpcbind::check_enabled();
     services::rpcbind::start_service();
     services::rpcbind::check_service();
     services::rpcbind::check_function();


### PR DESCRIPTION
This is attempt to fix the `rpcbind` service.

- Related ticket: [poo#81132](https://progress.opensuse.org/issues/81132)
- Verification run: [SLE15-SP2@AZURE-BYOS](http://pdostal-server.suse.cz/tests/11043)
