### PR TITLE
registration: Add nvidia to addons with license

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -124,7 +124,7 @@ sub accept_addons_license {
     #   isc co SUSE:SLE-15:GA 000product
     #   grep -l EULA SUSE:SLE-15:GA/000product/*.product | sed 's/.product//'
     # All shown products have a license that should be checked.
-    my @addons_with_license = qw(geo rt idu);
+    my @addons_with_license = qw(geo rt idu nvidia);
     # For the legacy module we do not need any additional subscription,
     # like all modules, it is included in the SLES subscription.
     push @addons_with_license, 'lgm' unless is_sle('15+');


### PR DESCRIPTION
We need to add nvidia to `addons_with_license` to properly register NVIDIA Compute Module during installation.

- Related ticket: https://jira.suse.com/browse/SLE-16787
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1482
- Verification run: 
15-SP2 HPC with SCC_ADDONS=nvidia: http://black-bit.suse.cz/tests/10#step/scc_registration/20
15-SP2 HPC: http://black-bit.suse.cz/tests/12