### PR TITLE
migration: Disable local repo once and don't enable it

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -137,6 +137,7 @@ sub remove_espos {
 # Disable installation repos before online migration
 # s390x: use ftp remote repos as installation repos
 # Other archs: use local DVDs as installation repos
+# https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-online.html#sec-upgrade-online-zypper
 sub disable_installation_repos {
     if (check_var('ARCH', 's390x')) {
         zypper_call "mr -d `zypper lr -u | awk '/ftp:.*?openqa.suse.de/ {print \$1}'`";
@@ -184,8 +185,6 @@ sub check_rollback_system {
     }
     systemctl('is-active rollback');
 
-    # Disable the obsolete cd and dvd repos to avoid zypper error
-    zypper_call("mr -d -m cd -m dvd");
     # Verify registration status matches current system version
     # system is un-registered during media based upgrade
     unless (get_var('MEDIA_UPGRADE')) {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -650,9 +650,9 @@ sub fill_in_registration_data {
                 send_key 'alt-y';
                 next;
             }
-            elsif (match_has_tag("license-agreement") || match_has_tag("license-agreement-accepted")) {
-                send_key 'alt-a' unless match_has_tag("license-agreement-accepted");
-                record_soft_failure 'bsc#1080450: license agreement is shown twice' if match_has_tag("license-agreement-accepted");
+            elsif (match_has_tag("license-agreement")) {
+                send_key 'alt-a';
+                assert_screen('license-agreement-accepted');
                 send_key $cmd{next};
                 assert_screen "remove-repository";
                 send_key $cmd{next};

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -44,9 +44,9 @@ sub run {
     # The SLE15-SP2 license page moved after registration.
     if (get_var('MEDIA_UPGRADE') || is_sle('<15-SP2') || is_opensuse) {
         assert_screen [qw(remove-repository license-agreement license-agreement-accepted)], 240;
-        if (match_has_tag("license-agreement") || match_has_tag("license-agreement-accepted")) {
-            send_key 'alt-a' unless match_has_tag("license-agreement-accepted");
-            record_soft_failure 'bsc#1080450: license agreement is shown twice' if match_has_tag("license-agreement-accepted");
+        if (match_has_tag("license-agreement")) {
+            send_key 'alt-a';
+            assert_screen('license-agreement-accepted');
             send_key $cmd{next};
             assert_screen "remove-repository";
         }

--- a/tests/migration/online_migration/minimal_patch.pm
+++ b/tests/migration/online_migration/minimal_patch.pm
@@ -19,6 +19,7 @@ use migration;
 
 sub run {
     select_console 'root-console';
+    disable_installation_repos;
     minimal_patch_system(version_variable => 'HDDVERSION');
     remove_ltss;
 }

--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -54,8 +54,6 @@ sub run {
     # set scc proxy url here to perform online migration via scc proxy
     set_scc_proxy_url;
 
-    disable_installation_repos;
-
     # according to comment 19 of bsc#985647, uninstall all kgraft-patch* packages prior to migration as a workaround to
     # solve conflict during online migration with live patching addon
     remove_kgraft_patch if is_sle('<15');

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -25,6 +25,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
 
+    disable_installation_repos;
     add_test_repositories;
     fully_patch_system;
     install_patterns() if (get_var('PATTERNS'));

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -42,10 +42,7 @@ sub patching_sle {
         if (is_sle('12-SP2+')) {
             set_var('HDD_SP2ORLATER', 1);
         }
-        # disable existing repos temporary
-        zypper_call "lr";
-        zypper_call "mr --disable --all";
-        save_screenshot;
+        disable_installation_repos;
         # Set SCC_PROXY_URL if needed
         set_scc_proxy_url if ((check_var('HDDVERSION', get_var('ORIGINAL_TARGET_VERSION')) && is_upgrade()));
         sle_register("register");
@@ -106,16 +103,6 @@ sub patching_sle {
     }
     else {
         sle_register("unregister");
-    }
-
-    # RMT didn't mirror all repos, cannot use enable all
-    if (!get_var("SMT_URL")) {
-        zypper_call("mr --enable --all");
-    }
-
-    # Disable old repositories during AutoYaST driven upgrade
-    if (get_var('AUTOUPGRADE')) {
-        disable_installation_repos;
     }
 
     # Restore the old value of VIDEOMODE and SCC_REGISTER


### PR DESCRIPTION
[If Zypper finds obsolete repositories coming from DVD or a local server, it is highly recommended to disable them. Old SUSE Customer Center or RMT repositories are removed automatically.](https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-online.html#sec-upgrade-online-zypper)

- Related ticket: https://progress.opensuse.org/issues/88269
- Verification run:
https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&groupid=265&build=133.1 Migration-from-SLE15-SPx
https://openqa.suse.de/tests/5357805
https://openqa.suse.de/tests/5357788
https://openqa.suse.de/tests/5357789
https://openqa.suse.de/tests/5357824
https://openqa.suse.de/tests/5358045