### PR TITLE
Selecting a dedicated console to avoid problems

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -61,6 +61,7 @@ sub os_update {
 
 
 sub run {
+    select_console 'root-console';
     if (my $hana_perf_os_update = get_var("HANA_PERF_OS_UPDATE")) {
         os_update($hana_perf_os_update);
     }


### PR DESCRIPTION
Without selecting a console specifically we cannnot be sure where the
code is run.
By selecting the root console we avoid an undefined state

Please see http://dub-8-192.qa.prv.suse.net/tests/54#step/install_qatestset/1 as reference

- Related ticket: none
- Needles: none
- Verification run: http://dub-8-192.qa.prv.suse.net/tests/56

@JoyceNa @Dawei-Pang 