### PR TITLE
[WIP] Rancher UI selenium test

### DIFF
--- a/data/rancher/ui_test.py
+++ b/data/rancher/ui_test.py
@@ -1,0 +1,45 @@
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+import time
+
+if __name__ == '__main__' :
+  driver = webdriver.Firefox()
+  wait=WebDriverWait(driver, 5)
+
+  driver.get("https://localhost:10443")
+  time.sleep(2)
+
+  # Check page started
+  assert "Rancher" in driver.title
+
+  # Initial page: Change password page
+  wait.until(EC.visibility_of_element_located((By.XPATH, "//input[@type='password']")))
+  inputs = driver.find_elements_by_xpath("//input[@type='password']")
+
+  for input in inputs:
+    input.send_keys("123456asdfgh")
+
+  checkboxes = driver.find_elements_by_xpath("//input[@type='checkbox']")
+  checkboxes[1].click()
+
+  driver.find_element_by_xpath("//button[@type='submit']").click()
+
+  # Initial page: set the URL
+  time.sleep(2)
+  wait.until(EC.visibility_of_element_located((By.XPATH, "//button[@type='submit']")))
+  driver.find_element_by_xpath("//button[@type='submit']").click()
+
+  # Welcome page
+  #driver.get("https://localhost:10443/c/local")
+  time.sleep(2)
+  wait.until(EC.visibility_of_element_located((By.XPATH, "//div[@class='welcome-copy']")))
+
+  # Cluster explorer
+  driver.get("https://localhost:10443/dashboard/c/local")
+  time.sleep(2)
+  wait.until(EC.visibility_of_element_located((By.XPATH, "//*[contains(text(),'Cluster Explorer')]")))
+
+  driver.close()

--- a/schedule/rancher/rancher.yaml
+++ b/schedule/rancher/rancher.yaml
@@ -13,3 +13,4 @@ schedule:
     - boot/boot_to_desktop
     - '{{runtime_test}}'
     - rancher/rancher_ui
+    - rancher/rancher_ui_selenium

--- a/tests/rancher/rancher_ui_selenium.pm
+++ b/tests/rancher/rancher_ui_selenium.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Web browser UI test for rancher container
+# Maintainer: Ivan Lausuch <ilausuch@suse.com>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use x11utils 'ensure_unlocked_desktop';
+
+sub run {
+    my ($self) = @_;
+
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    assert_script_run("pip3 install selenium");
+    assert_script_run('curl -O ' . data_url("rancher/ui_test.py"), timeout => 300);    
+    assert_script_run('mv ui_test.py /home/bernhard');
+    
+    select_console('x11', await_console => 0);    
+    x11_start_program('xterm');
+    
+    type_string "python3 ui_test.py && touch /tmp/ok\n";
+    assert_script_run("[ -f /tmp/ok ]");
+}
+
+1;
+


### PR DESCRIPTION
This test checks some initial pages of the rancher UI. 
This differs from #11807 because uses Selenium instead of traditional openQA click commands. This difference allows to check the individual pages using the DOM instead of using needles. There are several benefits in this way:
- Not adding more needles to the needles repository in this case is not necessary. 
- In case some page text changes, for instance in the main page, where a "What's new" dialog appears, we don't need to redo a new needle every time this dialog changes.
- Using DOM we could accelerate the test, because we can check if one element is visible or not, preventing long sleeps.


Test: https://openqa.opensuse.org/tests/1607472#

See: https://progress.opensuse.org/issues/88183