### PR TITLE
Fix repos downgrade in transactional_server test

### DIFF
--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -29,33 +29,18 @@ conditional_schedule:
         BACKEND:
             svirt:
             - shutdown/svirt_upload_assets
-    license_reg_scc_addon:
-        DISTRI:
-            sle:
-            - installation/accept_license
-            - installation/scc_registration
-            - installation/addon_products_sle
-    online_repos_inst_mode_logpackes:
-        DISTRI:
-            opensuse:
-            - installation/online_repos
-            - installation/installation_mode
-            - installation/logpackages
-    user_settings_root:
-        DISTRI:
-            sle:
-            - installation/user_settings_root
 schedule:
     - installation/bootloader_start
     - installation/welcome
-    - "{{license_reg_scc_addon}}"
-    - "{{online_repos_inst_mode_logpackes}}"
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
     - installation/system_role
     - installation/partitioning
     - installation/partitioning_finish
     - installation/installer_timezone
     - installation/user_settings
-    - "{{user_settings_root}}"
+    - installation/user_settings_root
     - installation/resolve_dependency_issues
     - installation/installation_overview
     - "{{kernel_cmd_parameters}}"

--- a/schedule/yast/transactional_server/create_hdd_transactional_server_opensuse.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server_opensuse.yaml
@@ -1,0 +1,38 @@
+---
+name: create_hdd_transactional_server_opensuse
+description: >
+  Installation of a Transactional Server which uses a read-only
+  root filesystem to provide atomic, automatic updates of a
+  system without interfering with the running system.
+vars:
+  SCC_ADDONS: tsm
+  HDDSIZEGB: 40
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - update/zypper_clear_repos
+  - console/zypper_ar
+  - console/zypper_ref
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
There was a revert to the previous snapshot between installation and
shutdown.

That happened in 'force_scheduled_tasks', that triggers all system
timers - in case of MicroOS that implies the transactional-update.timer,
which in turn runs `zypper dup`. At this time though, the repositories
have NOT been switched to the snapshot to be tested, but still point to
download.o.o (aka the last published snapshot) - we thus DOWNGRADE the
system to a previous snapshot and then pass THIS on to the child test.

The commit puts correct repos for the create hdd job.

**The fix suggested in the poo#86078 has fixed the issue: Proper snapshot version is used now: https://openqa.opensuse.org/tests/1607576#step/boot_to_desktop/2**

- Related ticket: https://progress.opensuse.org/issues/86078
- Verification runs: 
   - create_hdd_transactional_server: https://openqa.opensuse.org/tests/1607471
   - extra_tests_transactional_server: https://openqa.opensuse.org/tests/1607576
