### PR TITLE
Add registration cleanup in yast2_gui schedule

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -21,6 +21,7 @@ conditional_schedule:
   yast2_modules:
     ARCH:
       x86_64:
+        - console/scc_cleanup_reregister
         - console/setup_libyui_running_system
         - yast2_gui/yast2_control_center
         - yast2_gui/yast2_expert_partitioner
@@ -52,6 +53,7 @@ conditional_schedule:
         - yast2_gui/yast2_lan_restart_vlan
         - yast2_gui/yast2_lan_restart_bond
       ppc64le:
+        - console/scc_cleanup_reregister
         - console/setup_libyui_running_system
         - yast2_gui/yast2_expert_partitioner
         - yast2_gui/yast2_software_management

--- a/tests/console/scc_cleanup_reregister.pm
+++ b/tests/console/scc_cleanup_reregister.pm
@@ -8,6 +8,13 @@
 # without any warranty.
 
 # Summary: Cleanup scc registration and reregister system and addon products.
+# The addons can be defined either by SCC_ADDONS variable or in test data:
+#
+# test_data:
+#   addons: dev,phub
+#
+# Test data would override SCC_ADDONS.
+#
 # Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use strict;
@@ -15,12 +22,14 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 use registration qw(cleanup_registration register_product register_addons_cmd);
+use scheduler 'get_test_suite_data';
 
 sub run {
     select_console 'root-console';
     cleanup_registration;
     register_product;
-    register_addons_cmd;
+    my $addons = get_test_suite_data()->{addons};
+    register_addons_cmd($addons);
 }
 
 1;


### PR DESCRIPTION
Schedule registration cleanup module before the setup_libyui_running_system, to avoid failures due to product modification on the image.

Also added the option for addons definition via test data for scc_cleanup_reregister module.

- Related ticket: https://progress.opensuse.org/issues/87973
- Verification runs:
ppc - > https://openqa.suse.de/tests/5382436
64bit ->https://openqa.suse.de/tests/5382435

vr for addons via test_data: http://falafel.suse.cz/tests/1182