### PR TITLE
Add 10.160.0.100 into local repo regex on s390x

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -140,7 +140,7 @@ sub remove_espos {
 # https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-online.html#sec-upgrade-online-zypper
 sub disable_installation_repos {
     if (check_var('ARCH', 's390x')) {
-        zypper_call "mr -d `zypper lr -u | awk '/ftp:.*?openqa.suse.de/ {print \$1}'`";
+        zypper_call "mr -d `zypper lr -u | awk '/ftp:.*?openqa.suse.de|10.160.0.100/ {print \$1}'`";
     }
     else {
         zypper_call "mr -d -l";


### PR DESCRIPTION
Old images e.g. SLE11 migrations use REPO_HOST=10.160.0.100 as installation repo

- Related ticket: #11853 
- Fail: https://openqa.suse.de/tests/5366144#step/patch_sle/19
- Verification run: https://openqa.suse.de/tests/5366195