### PR TITLE
php7: be specific to install php7-* packages

### DIFF
--- a/tests/console/php7.pm
+++ b/tests/console/php7.pm
@@ -30,7 +30,7 @@ sub run {
     assert_script_run('grep "PHP Version 7" /tmp/tests-console-php7.txt');
 
     # test function provided by external module (php7-json RPM)
-    zypper_call 'in php-json';
+    zypper_call 'in php7-json php7-cli';
     assert_script_run('php -r \'echo json_encode(array("foo" => true))."\n";\' | grep :true');
 
     # test reading file


### PR DESCRIPTION
The test module is called php7 - so explicitly requesting php7 packages sounds actually sensible

- Related ticket: https://progress.opensuse.org/issues/88107
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1609451
