### PR TITLE
Remove SCC_ADDONS from transactional_server schedule

### DIFF
--- a/schedule/yast/transactional_server/create_hdd_transactional_server_opensuse.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server_opensuse.yaml
@@ -5,7 +5,6 @@ description: >
   root filesystem to provide atomic, automatic updates of a
   system without interfering with the running system.
 vars:
-  SCC_ADDONS: tsm
   HDDSIZEGB: 40
 schedule:
   - installation/bootloader_start


### PR DESCRIPTION
The commit removes the var from the schedule for opensuse as it is not
needed on opensuse.
