### PR TITLE
Soften zfcp validation not to expect strict mapping

### DIFF
--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -50,13 +50,11 @@ test_data:
           port_type: 'NPIV VPORT'
         fcp_luns:
           - wwpn: '0x500507630718d3b3'
-            names: 'sda sg0'
             scsi:
               peripheral_type: disk
               vendor_model_revision: 'IBM'
               device_node_name: '/dev/sda'
           - wwpn: '0x500507630713d3b3'
-            names: 'sdb sg1'
             scsi:
               peripheral_type: disk
               vendor_model_revision: 'IBM'


### PR DESCRIPTION
We have assumed that we can rely which of zfcp devices will be mapped to
sda or sdb, even though it's not guaranteed and is not a requirement
either.
We do not reduce the coverage, as still expect 2 devices to be mapped
to /dev/sda and /dev/sdb, but we do not rely them to have same wwpn in
each run.

See [poo#81146](https://progress.opensuse.org/issues/81146).

* [Verification run](https://openqa.suse.de/tests/5382428#).
