### PR TITLE
Use "super" key to open the Xfce main menu on Tumbleweed

### DIFF
--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -17,6 +17,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use version_utils qw(is_leap);
 
 
 sub run {
@@ -25,6 +26,9 @@ sub run {
     if (check_var("DESKTOP", "lxde")) {
         # or Super_L or Windows key
         x11_start_program('lxpanelctl menu', target_match => 'test-desktop_mainmenu-1');
+    }
+    elsif (check_var("DESKTOP", "xfce") && !is_leap("<16.0")) {
+        send_key "super";
     }
     elsif (check_var("DESKTOP", "xfce")) {
         mouse_set(0, 0);


### PR DESCRIPTION
Alt-F1 now opens the desktop context menu.

Verification runs:
* http://10.160.67.86/tests/854 (Tumbleweed)
* http://10.160.67.86/tests/856 (Leap 15.2)
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/710
Ticket: https://progress.opensuse.org/issues/87692