### PR TITLE
AppArmor: copy /etc/apparmor.d/abi in case of apparmor >= 3.0

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -82,7 +82,10 @@ sub aa_tmp_prof_prepare {
     if ($type == 0) {
         assert_script_run "mkdir $prof_dir_tmp";
         assert_script_run "cp -r $prof_dir/{tunables,abstractions} $prof_dir_tmp/";
-        if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
+        if (!(is_sle('<16') or is_leap('<16.0'))) {    # apparmor >= 3.0
+            assert_script_run "cp -r $prof_dir/abi $prof_dir/disable $prof_dir_tmp/";
+        }
+        if (is_sle('<15') or is_leap('<15.0')) {       # apparmor < 2.8.95
             assert_script_run "cp -r $prof_dir/program-chunks $prof_dir/disable $prof_dir_tmp/";
         }
     }


### PR DESCRIPTION
AappArmor 3.0 can presumably be found in SLE/Leap 16 (and Tumblweed, since 20201105)

- Related ticket: https://bugzilla.opensuse.org/1178527#c9
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1613931
