### PR TITLE
ipxe_install: Disable problematic disks before installation

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -20,6 +20,7 @@ use bmwqemu;
 use ipmi_backend_utils;
 use version_utils 'is_upgrade';
 use bootloader_setup 'prepare_disks';
+use Utils::Architectures qw(is_aarch64);
 
 use HTTP::Tiny;
 use IPC::Run;
@@ -159,6 +160,11 @@ sub run {
             prepare_disks if (!is_upgrade && !get_var('KEEP_DISKS'));
         }
         save_screenshot;
+        # Disable SATA disks on arm server as workaround for poo#88403
+        if (is_aarch64) {
+            script_run('for disk in $(lsscsi | awk \'/ST9500325AS/ {split ($6, dev, "/"); print dev[3] }\'); do echo 1> /sys/block/$disk/device/delete; done');
+            save_screenshot;
+        }
 
         set_bootscript_hdd if get_var('IPXE_UEFI');
 


### PR DESCRIPTION
Workaround poo#88403: Disable problematic disks, which cause boot
failure after installation.


- Related ticket: https://progress.opensuse.org/issues/88403
- Needles: none
- Verification run: https://openqa.suse.de/tests/5394531#step/first_boot/1
