### PR TITLE
Create test to run podman in rootless mode

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -135,8 +135,8 @@ sub clean_container_host {
         assert_script_run("$runtime rm --all");
         assert_script_run("$runtime rmi --all --force");
     } else {
-        assert_script_run("$runtime stop \$($runtime ps -q)", 180) if script_output("$runtime ps -q | wc -l") != '0';
-        assert_script_run("$runtime system prune -a -f",      180);
+        assert_script_run("$runtime ps -q | xargs -r $runtime stop", 180);
+        assert_script_run("$runtime system prune -a -f",             180);
     }
 }
 
@@ -234,6 +234,7 @@ sub test_container_image {
             upload_logs("$logfile");
             die "Heartbeat test failed for $image";
         }
+        assert_script_run "rm $logfile";
     }
 }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1722,6 +1722,7 @@ sub load_extra_tests_docker {
     loadtest "containers/docker_compose" unless (is_sle('<15') || is_sle('>=15-sp2'));
     loadtest 'containers/registry';
     loadtest "containers/zypper_docker";
+    loadtest "containers/rootless_podman";
 }
 
 sub load_extra_tests_prepare {

--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -29,3 +29,4 @@ schedule:
   - containers/containers_3rd_party
   - containers/registry
   - console/coredump_collect
+  - containers/rootless_podman

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -20,3 +20,4 @@ schedule:
   - containers/docker_image
   - containers/container_diff
   - '{{validate_btrfs}}'
+  - containers/rootless_podman

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -1,0 +1,66 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test rootless mode on podman.
+# - add a user on the /etc/subuid and /etc/subgid to allow automatically allocation subuid and subgid ranges.
+# - check uids allocated to user (inside the container are mapped on the host)
+# - give read access to the SUSE Customer Center credentials to call zypper from in the container
+#   proper way to add Access Control List is via `setfacl` which is not available so we just do
+#   `chmod` instead!! This grants the current user the required access rights
+# - Test rootless container:
+#   * container is launched with default root user
+#   * container is launched with existing user id
+#   * container is launched with keep-id of the user who run the container
+# - Restore /etc/zypp/credentials.d/ credentials
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use utils;
+use containers::common;
+use containers::container_images;
+use suse_container_urls 'get_suse_container_urls';
+use version_utils qw(get_os_release);
+use version_utils 'is_sle';
+
+sub run {
+    my ($self) = @_;
+    my ($image_names, $stable_names) = get_suse_container_urls();
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    my $runtime = "podman";
+
+    install_podman_when_needed($host_distri);
+    allow_selected_insecure_registries(runtime => $runtime);
+    my $user      = $testapi::username;
+    my $check_msg = 'Checking allocation range of user';
+    script_run "grep $user /etc/subuid || echo /etc/subuid has no uid range for $user", output => $check_msg;
+    script_run "grep $user /etc/subgid || echo /etc/subgid has no gid range for $user", output => $check_msg;
+    assert_script_run "usermod --add-subuids 200000-201000 --add-subgids 200000-201000 $user";
+    assert_script_run "grep $user /etc/subuid", fail_message => "subuid range not assigned for $user";
+    assert_script_run "grep $user /etc/subgid", fail_message => "subgid range not assigned for $user";
+    # Workaround instead of
+    # "setfacl -m u:$user:r /etc/zypp/credentials.d/*"
+    assert_script_run "chmod -R 666 /etc/zypp/credentials.d/*" if is_sle;
+    ensure_serialdev_permissions;
+    select_console "user-console";
+
+    # smoke test
+    assert_script_run "$runtime images -a";
+    for my $iname (@{$image_names}) {
+        test_container_image(image => $iname, runtime => $runtime);
+        build_container_image(image => $iname, runtime => $runtime);
+        test_zypper_on_container($runtime, $iname);
+        verify_userid_on_container($runtime, $iname);
+    }
+    clean_container_host(runtime => $runtime);
+    $self->select_serial_terminal();
+    assert_script_run "chmod -R 600 /etc/zypp/credentials.d/*" if is_sle;
+}
+
+1;


### PR DESCRIPTION
Run containers based on the base image as regular user and check                                                                                                                                                                             
automatically allocated uids given for container user.                                                                                                                                                                                       
The test defines a range that the user can get to run in the container                                                                                                                                                                       
and grant the current user the required access rights (read access)                                                                                                                                                                          
to the SUSE Customer Center credentials file. This allows the user to run                                                                                                                                                                    
zypper. in additional i add a minimal validation of the capabilities. More that                                                                                                                                                              
something is there or not.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                             
I could build a custom image which run with non-root user. Instead I                                                                                                                                                                         
use the `--user` option to manipulate the running user on the container.                                                                                                                                                                     
The verification checks only uid. no check if a group member can run rootless containers.

Update: I had to modify the clenup subroutine and particular the part that it calls the script_output.                                                                                                                                               
Inside the script_output there are actions that occur based on the console type. As the console is                                                                                                                                           
not serial when it runs from the rootless_podman, it will run and exit, which ends up in a                                                                                                                                                   
timeout.                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                             
Restore terminal and revert credentials on /etc/zypp/credentials.d 

- Related ticket: https://progress.opensuse.org/issues/87976
- [Verification run](https://openqa.suse.de/tests/overview?version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2311878&distri=sle)
[TW](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2311878&version=Tumbleweed)