### PR TITLE
Revert "php7: be specific to install php7-* packages"

### DIFF
--- a/tests/console/php7.pm
+++ b/tests/console/php7.pm
@@ -30,7 +30,7 @@ sub run {
     assert_script_run('grep "PHP Version 7" /tmp/tests-console-php7.txt');
 
     # test function provided by external module (php7-json RPM)
-    zypper_call 'in php7-json php7-cli';
+    zypper_call 'in php-json';
     assert_script_run('php -r \'echo json_encode(array("foo" => true))."\n";\' | grep :true');
 
     # test reading file


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#11869

This breaks on leap - as it's not mandatory on TW neither (it's a nice to have and generally seen, the right thing) this needs more thought to get it right