### PR TITLE
Increase bootloader time for ipmi backend

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1075,7 +1075,7 @@ the env var NOAUTOLOGIN was set.
 =cut
 sub wait_boot {
     my ($self, %args) = @_;
-    my $bootloader_time = $args{bootloader_time} // ((is_pvm) ? 200 : 100);
+    my $bootloader_time = $args{bootloader_time} // ((is_pvm || check_var('BACKEND', 'ipmi')) ? 300 : 100);
     my $textmode        = $args{textmode};
     my $ready_time      = $args{ready_time} // ((check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 500 : 300);
     my $in_grub         = $args{in_grub}    // 0;


### PR DESCRIPTION
Fix poo#88419: It sometimes tak more time to get to grub menu on bare
metal ipmi backend, time was increased to 300s.

- Related ticket: https://progress.opensuse.org/issues/88419
- Needles:
- Verification run:  https://openqa.suse.de/tests/5397168#step/install_ltp/1  

Grub matched  after 190s  and booted to console.
