### PR TITLE
Adjust test data to btrfs warnings on openSUSE arm

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -41,8 +41,14 @@ schedule:
   - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
-  - installation/opensuse_welcome
+  # On Tumbleweed process Welcome pop-up screen
+  - '{{opensuse_welcome}}'
   - console/system_prepare
+conditional_schedule:
+  opensuse_welcome:
+    VERSION:
+      Tumbleweed:
+        - installation/opensuse_welcome
 test_data:
   disks:
     - name: vda

--- a/test_data/yast/btrfs/btrfs+warnings_opensuse_aarch64.yaml
+++ b/test_data/yast/btrfs/btrfs+warnings_opensuse_aarch64.yaml
@@ -1,0 +1,28 @@
+# Leap and TW require at least 5GiB of disk space for the root partition as on 64 bit
+# SLES requires only 3GiB for the same scenario
+disks:
+  - name: vda
+    partitions:
+      <<: !include test_data/yast/btrfs/common/btrfs+warnings_partitions.yaml
+      rootfs_small:
+        - role: efi-boot
+          size: 128mb
+          formatting_options:
+            should_format: 1
+          mounting_options:
+            should_mount: 1
+            mount_point: /boot/efi
+        - role: operating-system
+          size: 4GiB
+          formatting_options:
+            should_format: 1
+            filesystem: xfs
+          mounting_options:
+            should_mount: 1
+            mount_point: /
+errors:
+  <<: !include test_data/yast/btrfs/common/btrfs+warnings_errors.yaml
+warnings:
+  <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
+  rootfs_small: Missing device for / with size equal or bigger than 5 GiB and filesystem ext2, ext3, ext4, btrfs, xfs
+  missing_boot: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat


### PR DESCRIPTION
For leap and TW we require 5GiB of disk space for the `/` partition and
not 3GiB as it's for SLES on arm.
Creating separate test data in order to express this difference. Even
though some data is duplicated, this solution is easier to grasp as test
data is already split in to 4 files and some parts being defined in the
schedule itself.

Requires following settings for the test suite (just `YAML_SCHEDULE` for 64 bit):
```
YAML_SCHEDULE=schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
YAML_TEST_DATA=test_data/yast/btrfs/btrfs+warnings_opensuse_aarch64.yaml
```

See [poo#88357](https://progress.opensuse.org/issues/88357).

#### Verification runs
* [TW arm](https://openqa.opensuse.org/t1614762)
* [Leap arm](https://openqa.opensuse.org/tests/1614847)
* [Leap 64 bit](https://openqa.opensuse.org/t1614796).