### PR TITLE
Install python setuptools for robot framewok test

### DIFF
--- a/tests/sles4sap/robot_fw.pm
+++ b/tests/sles4sap/robot_fw.pm
@@ -16,7 +16,9 @@ use base "sles4sap";
 use testapi;
 use strict;
 use warnings;
-use version_utils 'is_sle';
+use version_utils qw(is_sle);
+use utils qw(zypper_call);
+use hacluster qw(is_package_installed);
 
 sub run {
     my ($self)           = @_;
@@ -32,6 +34,7 @@ sub run {
     # Install the robot framework
     assert_script_run "unzip /robot/bin/robotframework-$robot_fw_version.zip";
     assert_script_run "cd robotframework-$robot_fw_version";
+    zypper_call "in $python_bin-setuptools" unless is_package_installed("$python_bin-setuptools");
     assert_script_run "$python_bin setup.py install";
 
     # Disable extra tuning for testing "from scratch" system


### PR DESCRIPTION
Sometimes the python `setuptools` package is missing and it is needed for installing the robot framework. I've never faced it before but now we are using a qcow2 coming from SLE incident maintenance.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[15-SP2](http://1b143.qa.suse.de/tests/6316#step/robot_fw/9)
[12-SP5](http://1b143.qa.suse.de/tests/6317#step/robot_fw/9)

