### PR TITLE
Expand timeout from 300 to 500 for system_prepare

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1329,7 +1329,7 @@ can be set to 1.
 =cut
 sub reconnect_mgmt_console {
     my (%args) = @_;
-    $args{timeout}             //= 300;
+    $args{timeout}             //= 500;
     $args{grub_expected_twice} //= 0;
 
     if (check_var('ARCH', 's390x')) {


### PR DESCRIPTION
System_prepare s running in a timeout on s390x at the moment: https://openqa.opensuse.org/tests/1615154#step/system_prepare/6

- Related ticket: https://progress.opensuse.org/issues/81682
- Verification run: https://openqa.opensuse.org/t1614995
