### PR TITLE
Add sles4sap::do_hana_sr_register and workarounds for transient failures during HA cluster initialization and HanaSR configuration

### DIFF
--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -63,7 +63,16 @@ sub run {
         type_password;
         send_key 'ret';
     }
-    wait_serial("ha-cluster-join-finished-0", $join_timeout);
+    my $join_success = wait_serial("ha-cluster-join-finished-0", $join_timeout);
+    unless ($join_success) {
+        record_info "Join Failed", "HA cluster join failed. Waiting 3 seconds and re-trying";
+        sleep bmwqemu::scale_timeout(3);
+        # Attempt to start pacemaker in case this was what failed during join
+        # This is needed so ha-cluster-remove works
+        assert_script_run 'systemctl start pacemaker';
+        assert_script_run 'ha-cluster-remove -F -y -c $(hostname)';
+        assert_script_run "ha-cluster-join -yc $node_to_join", $join_timeout;
+    }
 
     # Indicate that the other nodes have joined the cluster
     barrier_wait("NODE_JOINED_$cluster_name");


### PR DESCRIPTION
Changes introduced in PR #11230, replaced the call to `hdbnsutil -sr_register` in the test module `sles4sap/hana_cluster` with a call to the method `sles4sap::do_hana_takeover()` which does a call to sr_register internally. This only works when the setting **AUTOMATED_REGISTER** is set to false, as `sles4sap::do_hana_takeover()` will be skipped when the setting is set to true. Additionally, semantically it does not make much sense to do a takeover while the HanaSR resources are being configured
in the cluster, which is what the `sles4sap/hana_cluster` test module does. At this time there is no actual takeover action being performed, only the registration of one HANA node to another in a system replication configuration.

This PR adds the `sles4sap::do_hana_sr_register()` method, which is called from `sles4sap/hana_cluster` instead of `sles4sap::do_hana_takeover()`, and also changes the calls to sr_register within `sles4sap::do_hana_takeover()` to use `sles4sap::do_hana_sr_register()` instead.

Other workarounds are also included in case that transient failures or race conditions caused by poor performance of the infrastructure during the test, impact the tests and cause a false negative abort. These are:

1. In case the call to sr_register fails in `sles4sap::do_hana_takeover()`, test will wait for cluster resources to finish starting, print out some configuration information, and then attempt the sr_register call again. If the second call after all cluster resources have started fails, then test is aborted.

2. In case the verification for an online status in sr_state fails for 90 seconds, instead of aborting the test, new code will issue the command to start the system again, and then check for an online status in sr_state a second time. If the second verification also fails, the test is aborted.

3. During cluster init, if the call to ha-cluster-init failed, sleep for some seconds and then attempt starting pacemaker in
case this is what failed during HA bootstrap due to a transient failure.

4. During cluster join, the test module `ha/ha_cluster_join` currently has no code detecting when the call to ha-cluster-join fails. This PR adds code so this is detected, and a second call to join is attempted after a small wait time in case this failed due to a transient failure. Before the second call to join, current node is removed from the cluster to ensure second HA bootstrap process starts from a clean configuration.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/3390 & http://mango.qa.suse.de/tests/3391
