### PR TITLE
Update suseRegister.conf before call to suse_register -E

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -167,6 +167,7 @@ sub sle_register {
         }
         else {
             # Erase all local files created from a previous executed registration
+            assert_script_run("sed -i '/^url[[:space:]]*/s|.*|url = https://scc.suse.com/ncc/center/regsvc|' /etc/suseRegister.conf") if (get_var('SLE11_USE_SCC'));
             assert_script_run('suse_register -E');
             # Register SLE 11 to SMT server
             my $smt_url = get_var('SMT_URL', '');
@@ -182,7 +183,6 @@ sub sle_register {
             elsif (get_var('SLE11_USE_SCC')) {
                 my $reg_code = get_required_var('NCC_REGCODE');
                 my $reg_mail = get_var('NCC_MAIL');               # email address is not mandatory for SCC
-                assert_script_run("sed -i '/^url[[:space:]]*/s|.*|url = https://scc.suse.com/ncc/center/regsvc|' /etc/suseRegister.conf");
                 if (get_var('NCC_REGCODE_SDK')) {
                     my $reg_code_sdk = get_required_var('NCC_REGCODE_SDK');
                     zypper_call("ar http://schnell.suse.de/SLE11/SLE-11-SP4-SDK-GM/s390x/DVD1/ sdk");


### PR DESCRIPTION
Even though `suse_register -E` only removes local registration data, currently command also attempts a connection to whatever is configured in `/etc/suseRegister.conf`. In the case that NCC is still configured there, command will fail as NCC is no longer available for SLES 11. More information in https://www.suse.com/support/kb/doc/?id=000019508

- Failing test: https://openqa.suse.de/tests/5400983#step/patch_sle/20
- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/3397
