### PR TITLE
[qam][maint] Replace SOFTFAIL_TESTCASES with TESTCASES_BLACKLIST

### DIFF
--- a/schedule/qam/common/mau-qa_userspace.yaml
+++ b/schedule/qam/common/mau-qa_userspace.yaml
@@ -3,7 +3,7 @@ name: Userspace_test
 vars:
     DISABLE_SUBMIT_QADB: 1
     USER_SPACE_TESTSUITES: bash
-    SOFTFAIL_TESTCASES: >
+    TESTCASES_BLACKLIST: >
       bash.run-appendop.sh bash.run-array.sh bash.run-errors.sh bash.run-execscript.sh bash.run-herestr.sh
       bash.run-jobs.sh bash.run-new-exp.sh bash.run-posix2.sh bash.run-read.sh bash.run-shopt.sh
       bash.run-trap.sh bash.run-nquote4.sh


### PR DESCRIPTION
SOFTFAIL_TESTCASES is misleading so replace SOFTFAIL_TESTCASES with TESTCASES_BLACKLIST in schedule/qam/common/mau-qa_userspace.yaml

- Related ticket: https://progress.opensuse.org/issues/88434
- Needles: no
- Verification run: 
- sles15sp2: http://10.67.17.201/tests/1240
- sles12sp5: http://10.67.17.201/tests/1239