### PR TITLE
kernel/install_klp_product: Remove s390 console workaround

### DIFF
--- a/tests/kernel/install_klp_product.pm
+++ b/tests/kernel/install_klp_product.pm
@@ -20,7 +20,6 @@ use testapi;
 use utils;
 use klp;
 use power_action_utils 'power_action';
-use serial_terminal 'prepare_serial_console';
 use Utils::Architectures qw(is_s390x);
 use Utils::Backends qw(is_pvm);
 
@@ -30,13 +29,7 @@ sub do_reboot {
     power_action('reboot', textmode => 1, keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
     $self->wait_boot;
-
-    if (is_s390x) {
-        select_console('root-console');
-    } else {
-        prepare_serial_console;
-        $self->select_serial_terminal;
-    }
+    $self->select_serial_terminal;
 }
 
 sub run {


### PR DESCRIPTION
Reconnecting serial terminal works now even on s390 so the workaround in install_klp_product is no longer needed.

- Related ticket: https://progress.opensuse.org/issues/80996
- Needles: N/A
- Verification run:
  - x86_64: https://openqa.suse.de/tests/5430362
  - s390x: https://openqa.suse.de/tests/5430363
  - ppc64le: https://openqa.suse.de/tests/5430364
