### PR TITLE
Fix xterm startup failure under X11 for hyper-v

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -665,7 +665,12 @@ sub hyperv_console_switch {
     # If we are in VT, 'Alt-Fx' switch already worked
     return if check_screen('any-console', 10);
     # We are in X11 and wan't to switch to VT
-    testapi::x11_start_program('xterm');
+    if (check_var('DESKTOP', 'textmode') && check_var('VIDEOMODE', 'text')) {
+        testapi::assert_still_screen { type_string "xinit /usr/bin/xterm -- :1 &\n" };
+        testapi::mouse_set(10, 10);
+    } else {
+        testapi::x11_start_program('xterm');
+    }
     self->distribution::script_sudo("exec chvt $nr; exit", 0);
 }
 


### PR DESCRIPTION
The function of x11_start_program is based on a desktop environment such as gnome or kde. But with a desktop environment in textmode installation, the needle matching will be failed at first_boot. So we have to start up xterm by xinit against X server instead of using Alt+F2 to run the X window program.

- Related ticket: https://progress.opensuse.org/issues/81388
- Verification run for hyper-v 2016: http://10.67.129.83/tests/65# , http://10.67.129.83/tests/71# 

@alice-suse @guoxuguang @Julie-CAO @waynechen55 please help to review this PR. Thanks