### PR TITLE
Remove boot_to_desktop from containers' scheduling

### DIFF
--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -14,7 +14,6 @@ conditional_schedule:
                 - containers/container_diff
 schedule:
     - installation/bootloader_start
-    - boot/boot_to_desktop
     - containers/podman
     - '{{podman_image}}'
     - containers/docker

--- a/schedule/containers/sle_image_on_centos.yaml
+++ b/schedule/containers/sle_image_on_centos.yaml
@@ -3,7 +3,6 @@ description:  |
     Run sle container on Centos
 schedule:
     - installation/bootloader_start
-    - boot/boot_to_desktop
     - containers/host_configuration
     - containers/podman_image
     - containers/docker_image

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -4,7 +4,6 @@ description:    >
   Extra tests about software in containers module
 schedule:
   - installation/bootloader_start
-  - boot/boot_to_desktop
   - containers/host_configuration
   - containers/podman_image
   - containers/buildah_image

--- a/schedule/containers/sle_image_on_ubuntu.yaml
+++ b/schedule/containers/sle_image_on_ubuntu.yaml
@@ -3,7 +3,6 @@ description:  |
     Run sle container on Ubuntu
 schedule:
     - installation/bootloader_start
-    - boot/boot_to_desktop
     - containers/host_configuration
     - containers/podman_image
     - containers/docker_image


### PR DESCRIPTION
This is to remove the boot_to_desktop from the scheduling                                                                                                                                                                                    
as the bootloader_start can handle the boot process from                                                                                                                                                                                     
pre-installed qcows

- Related ticket: https://progress.opensuse.org/issues/88440
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%23fix_rm_bootloader_centos
