### PR TITLE
Fix login wait string for TW on zVM

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1333,8 +1333,7 @@ sub reconnect_mgmt_console {
     $args{grub_expected_twice} //= 0;
 
     if (check_var('ARCH', 's390x')) {
-        my $login_ready = qr/Welcome to /;
-        $login_ready .= is_sle() ? qr/SUSE Linux Enterprise Server.*\(s390x\)/ : qr/openSUSE Tumbleweed/;
+        my $login_ready = serial_terminal::get_login_message();
         console('installation')->disable_vnc_stalls;
 
         # different behaviour for z/VM and z/KVM


### PR DESCRIPTION
We have failures, as we match `Welcome to openSUSE Tumbleweed
dracut-051+suse.84.gc6bd70b8-1.15 (Initramfs)!` while reconnecting the
management console, which is too early and the machine is not fully
booted.

We still have an issue, as similar functionality is implemented in
`reconnect_s390` method and some parts of code is duplicated, including
hard-coded value for the welcome message.

See [poo#81682](https://progress.opensuse.org/issues/81682).

#### Verification runs
* [TW](https://openqa.opensuse.org/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23zvm&distri=opensuse&version=Tumbleweed) (Note, runs are cancelled after successful boot and couple of modules in the SUT)
* [SLES](https://openqa.suse.de/t5407356)