### PR TITLE
ntp_client: Run chronyc activity with timeout command

### DIFF
--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -26,7 +26,7 @@ sub run {
         systemctl 'enable chronyd';
         systemctl 'start chronyd';
         # bsc#1179022 avoid '503 No such source' error while chrony does pick responding sources after start
-        assert_script_run 'until chronyc activity|grep "0 sources doing burst.*online"; do sleep 1; echo "waiting for ntp sources response"; done';
+        script_run qq(timeout 85 bash -c 'until chronyc activity|grep "0 sources doing burst.*online"; do sleep 1; echo "waiting for ntp sources response"; done' -k);
     }
 
     # ensure that ntpd is neither installed nor enabled nor active


### PR DESCRIPTION
Unfortunatelly sometimes ntp burst does need more time,
there is source or network slowness, assert_script_run timoeut
could be increased, but that would be unnecessary time spend.
Use script_run with timeout 85 -k

- Related ticket: https://progress.opensuse.org/issues/67324
- Verification run:
https://openqa.suse.de/tests/5407554
https://openqa.suse.de/tests/5407555
https://openqa.suse.de/tests/5407556
https://openqa.suse.de/tests/5407557
https://openqa.suse.de/tests/5407558
https://openqa.suse.de/tests/5407559
https://openqa.suse.de/tests/5407565#step/ntp_client/13 example of timeout