### PR TITLE
Increase more installation time for vmware

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -103,6 +103,10 @@ sub run {
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv') || (check_var('SCC_REGISTER', 'installation') && !get_var('SCC_URL'))) {
         $timeout = 5500;
     }
+    # VMware server is also a bit slow, needs to take more time
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+        $timeout = 3600;
+    }
     # aarch64 can be particularily slow depending on the hardware
     $timeout *= 2 if check_var('ARCH', 'aarch64') && get_var('MAX_JOB_TIME');
     # PPC HMC (Power9) performs very slow in general


### PR DESCRIPTION
To resolve the timeout failure during await_install tests, we have to increase more installation time for vmware for any low performance hardware.

- Related ticket: https://progress.opensuse.org/issues/81388
- Verification run: http://10.67.129.66/tests/37
