### PR TITLE
Split AY profiles for Leap due to product section

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot_leap.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot_leap.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- no confirmation asked but firstboot wizard requested -->
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+    </general>
+    <login_settings>
+      <autologin_user>bernhard</autologin_user>
+    </login_settings>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+      <install_recommended config:type="boolean">true</install_recommended>
+      <packages config:type="list">
+        <package>yast2-firstboot</package>
+      </packages>
+      <patterns config:type="list">
+        <pattern>apparmor</pattern>
+        <pattern>base</pattern>
+        <pattern>gnome</pattern>
+      </patterns>
+      <products config:type="list">
+        <product>Leap</product>
+      </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <firstboot>
+        <firstboot_enabled config:type="boolean">true</firstboot_enabled>
+    </firstboot>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+</profile>

--- a/data/autoyast_opensuse/opensuse_leap_gnome.xml
+++ b/data/autoyast_opensuse/opensuse_leap_gnome.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <login_settings>
+    <autologin_user>bernhard</autologin_user>
+  </login_settings>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <products config:type="list">
+      <product>Leap</product>
+    </products>
+    <patterns config:type="list">
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>gnome</pattern>
+    </patterns>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_opensuse/opensuse_leap_minimal.xml
+++ b/data/autoyast_opensuse/opensuse_leap_minimal.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">true</confirm>
+    </mode>
+  </general>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <software>
+    <packages config:type="list">
+      <package>zypper</package>
+    </packages>
+    <products config:type="list">
+      <product>Leap</product>
+    </products>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
@@ -7,7 +7,6 @@ description:    >
   configure root and user accounts. SUT should end up in GDM screen after exiting YaST2
   Firstboot.
 vars:
-  AUTOYAST: autoyast_opensuse/autoyast_firstboot.xml
   DESKTOP: gnome
   YAST2_FIRSTBOOT_USERNAME: firstbootuser
 schedule:


### PR DESCRIPTION
I've checked and there are 2 points. First, TW works well without
product being defined, which is not the case for leap. Also, there is a
bug https://bugzilla.opensuse.org/show_bug.cgi?id=1181790 on leap when
product is defined.
Considering these points, and the fact that we only run 3 AY profiles, I
believe that having a separate profiles is a good solution, which will
also give us further flexibility in case there are more differences to
TW.

We will have to override `AUTOYAST` setting in the job group setting
accordingly.

See [poo#88355](https://progress.opensuse.org/issues/88355).

[Verification runs](https://openqa.opensuse.org/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23ay&distri=opensuse&version=15.3). NOTE: All VRs are currently failing with https://bugzilla.opensuse.org/show_bug.cgi?id=1181790

I've already adjusted autoyast_firstboot test suite, so PR can be safely merged.