### PR TITLE
Kdump on bare metal

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -41,6 +41,7 @@ use constant {
           is_svirt_except_s390x
           is_pvm
           is_xen_pv
+          is_ipmi
           )
     ],
     CONSOLES => [
@@ -171,6 +172,16 @@ Returns true if the current instance is running as PowerVM backend 'spvm' or 'hm
 
 sub is_pvm {
     return check_var('BACKEND', 'spvm') || check_var('BACKEND', 'pvm_hmc');
+}
+
+=head2 is_ipmi
+
+Returns true if the current instance is running as ipmi backend
+
+=cut
+
+sub is_ipmi {
+    return check_var('BACKEND', 'ipmi');
 }
 
 #This subroutine takes absolute file path of sshd config file and desired ssh connection timeout as arguments

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -14,7 +14,7 @@ use warnings;
 use testapi;
 use utils;
 use registration;
-use Utils::Backends qw(is_pvm is_xen_pv);
+use Utils::Backends qw(is_pvm is_xen_pv is_ipmi);
 use Utils::Architectures qw(is_ppc64le is_aarch64);
 use power_action_utils 'power_action';
 use version_utils qw(is_sle is_jeos is_leap is_tumbleweed is_opensuse);
@@ -283,7 +283,7 @@ sub check_function {
         assert_screen 'grub2', 180;
         wait_screen_change { send_key 'ret' };
     }
-    elsif (is_pvm) {
+    elsif (is_pvm || is_ipmi) {
         reconnect_mgmt_console;
     }
     else {

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -18,7 +18,7 @@ use base 'bootbasetest';
 use strict;
 use warnings;
 use testapi;
-use Utils::Backends 'is_pvm';
+use Utils::Backends qw(is_pvm is_ipmi);
 use version_utils qw(is_upgrade is_sles4sap is_sle);
 
 sub run {
@@ -27,6 +27,9 @@ sub run {
     # We have tests that boot from HDD and wait for DVD boot menu's timeout, so
     # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
     my $timeout = get_var('UEFI') ? 140 : 80;
+    # Increase timeout on ipmi bare metal backend, firmware initialization takes
+    # a lot of time
+    $timeout += 300 if is_ipmi;
     # Add additional 60 seconds if the test suite is migration as reboot from
     # pre-migration system may take an additional time. Booting of encrypted disk
     # needs additional time too.


### PR DESCRIPTION
We don't run openQA kdump scenario on bare metal yet. 

- Related ticket: https://progress.opensuse.org/issues/88458
- Needles: none
- Verification run: 
ipmi x86_64:  http://baremetal-support.qa.suse.de/tests/702
ipmi aarch64: http://baremetal-support.qa.suse.de/tests/703  - expected fail, most important part is working boot_to_desktop 
qemu x86_64: https://openqa.suse.de/t5417232


