### PR TITLE
[WIP] Add users check before and after migration

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -33,6 +33,7 @@ use services::hpcpackage_remain;
 use services::ntpd;
 use services::cups;
 use services::rpcbind;
+use services::users;
 use autofs_utils;
 use services::postfix;
 use services::firewall;
@@ -59,6 +60,12 @@ our %srv_check_results = (
 );
 
 our $default_services = {
+    users => {
+        srv_pkg_name       => 'users',
+        srv_proc_name      => 'users',
+        support_ver        => $support_ver_ge12,
+        service_check_func => \&services::users::full_users_check
+    },
     hpcpackage_remain => {
         srv_pkg_name       => 'hpcpackage_remain',
         srv_proc_name      => 'hpcpackage_remain',

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -1,0 +1,173 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Package for users service test
+# Test steps:
+#   1.Change current user's password and verify new one works.
+#   2.Add new user and set password.
+#   3.Restore Bernhard's password to ensure won't be block by later test.
+#   4.Switch Bernhard and new user.
+#   5.Restore current user's password.
+# Maintainer: Lemon Li <leli@suse.com>
+
+package services::users;
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use power_action_utils 'reboot_x11';
+use version_utils;
+use x11utils;
+use main_common 'opensuse_welcome_applicable';
+
+my $newpwd      = "suseTEST-987";
+my $newUser     = "test";
+my $pwd4newUser = "helloWORLD-0";
+
+sub lock_screen {
+    assert_and_click "system-indicator";
+    assert_and_click "lock-system";
+    send_key_until_needlematch 'gnome-screenlock-password', 'esc', 5, 10;
+    type_password "$newpwd\n";
+    assert_screen "generic-desktop";
+}
+
+sub logout_and_login {
+    handle_logout;
+    send_key_until_needlematch 'displaymanager', 'esc', 9, 10;
+    mouse_hide();
+    wait_still_screen;
+    assert_and_click "displaymanager-$username";
+    assert_screen 'displaymanager-password-prompt', no_wait => 1;
+    type_password "$newpwd\n";
+    assert_screen 'generic-desktop', 120;
+}
+
+sub switch_user {
+    assert_and_click "system-indicator";
+    assert_and_click "user-logout-sector";
+    assert_and_click "switch-user";
+}
+
+sub change_pwd {
+    send_key "alt-p";
+    wait_still_screen;
+    send_key "ret";
+    wait_still_screen;
+    send_key "alt-p";
+    wait_still_screen;
+    type_password;
+    wait_still_screen;
+    send_key "alt-n";
+    wait_still_screen;
+    type_string $newpwd;
+    wait_still_screen;
+    send_key 'tab';
+    wait_still_screen;
+    type_string $newpwd;
+    assert_screen "actived-change-password";
+    wait_still_screen;
+    send_key "alt-a";
+    assert_screen "users-settings", 60;
+}
+
+sub add_user {
+    assert_and_click "add-user";
+    type_string $newUser;
+    assert_screen("input-username-test");
+    assert_and_click "set-password-option";
+    send_key "alt-p";
+    type_string $pwd4newUser;
+    send_key 'tab';
+    type_string $pwd4newUser;
+    assert_screen "actived-add-user";
+    send_key "alt-a";
+    assert_screen "users-settings", 60;
+    send_key "alt-f4";
+}
+
+sub auto_login_alter {
+    my ($self) = @_;
+    $self->unlock_user_settings;
+    send_key "alt-u";
+    send_key "alt-f4";
+}
+
+#swtich to new added user then switch back
+sub switch_users {
+    switch_user;
+    wait_still_screen 5;
+    send_key "esc";
+    assert_and_click 'displaymanager-test';
+    assert_screen "testUser-login-dm";
+    type_password "$pwd4newUser\n";
+    # Handle welcome screen, when needed
+    handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
+    assert_screen "generic-desktop", 120;
+    switch_user;
+    send_key "esc";
+    assert_and_click "displaymanager-$username";
+    assert_screen "originUser-login-dm";
+    #For poo#88247, we have to restore current user's password before migration,
+    #so here need to use the original password.
+    type_password get_var('INCLUDE_SERVICES') ? "$password\n" : "$newpwd\n";
+    assert_screen "generic-desktop", 120;
+}
+
+#restore password to original value
+sub restore_passwd {
+    x11_start_program('gnome-terminal');
+    type_string "su\n";
+    assert_screen "pwd4root-terminal";
+    type_password "$password\n";
+    assert_screen "root-gnome-terminal";
+    type_string "passwd $username\n";
+    assert_screen "pwd4user-terminal";
+    type_password "$password\n";
+    assert_screen "pwd4user-confirm-terminal";
+    type_password "$password\n";
+    assert_screen "password-changed-terminal";
+}
+
+# check users before and after migration
+# stage is 'before' or 'after' system migration.
+sub full_users_check {
+    my ($stage) = @_;
+    $stage //= '';
+
+    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
+    select_console 'x11', await_console => 0;
+    wait_still_screen 5;
+    ensure_unlocked_desktop;
+    assert_screen "generic-desktop";
+    if ($stage eq 'before') {
+        #change pwd for current user and add new user for switch scenario
+        x11test::unlock_user_settings;
+        change_pwd;
+        add_user;
+        #verify changed password work well in the following scenario:
+        lock_screen;
+        turn_off_gnome_screensaver;
+        logout_and_login;
+        #For poo#88247, it is hard to deal with the authorization of bernhard in
+        #following migration process, we have to restore current user's password.
+        record_soft_failure("poo#88247, it is hard to deal with the authorization of bernhard in following migration process, we have to restore current users password");
+        restore_passwd;
+    }
+    else {
+        #swtich to new added user then switch back
+        switch_users;
+        send_key "alt-f4";
+        send_key "ret";
+        select_console 'root-console';
+    }
+}
+
+1;

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -63,7 +63,16 @@ sub run {
         type_password;
         send_key 'ret';
     }
-    wait_serial("ha-cluster-join-finished-0", $join_timeout);
+    my $join_success = wait_serial("ha-cluster-join-finished-0", $join_timeout);
+    unless ($join_success) {
+        record_info "Join Failed", "HA cluster join failed. Waiting 3 seconds and re-trying";
+        sleep bmwqemu::scale_timeout(3);
+        # Attempt to start pacemaker in case this was what failed during join
+        # This is needed so ha-cluster-remove works
+        assert_script_run 'systemctl start pacemaker';
+        assert_script_run 'ha-cluster-remove -F -y -c $(hostname)';
+        assert_script_run "ha-cluster-join -yc $node_to_join", $join_timeout;
+    }
 
     # Indicate that the other nodes have joined the cluster
     barrier_wait("NODE_JOINED_$cluster_name");

--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2020 SUSE LLC
+# Copyright © 2016-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -29,31 +29,9 @@ use power_action_utils 'reboot_x11';
 use version_utils;
 use x11utils;
 use main_common 'opensuse_welcome_applicable';
+use services::users;
 
 #testcase 5255-1503803: Gnome:Change Password
-
-my $newpwd      = "suseTEST-987";
-my $newUser     = "test";
-my $pwd4newUser = "helloWORLD-0";
-
-sub lock_screen {
-    assert_and_click "system-indicator";
-    assert_and_click "lock-system";
-    send_key_until_needlematch 'gnome-screenlock-password', 'esc', 5, 10;
-    type_password "$newpwd\n";
-    assert_screen "generic-desktop";
-}
-
-sub logout_and_login {
-    handle_logout;
-    send_key_until_needlematch 'displaymanager', 'esc', 9, 10;
-    mouse_hide();
-    wait_still_screen;
-    assert_and_click "displaymanager-$username";
-    assert_screen 'displaymanager-password-prompt', no_wait => 1;
-    type_password "$newpwd\n";
-    assert_screen 'generic-desktop', 120;
-}
 
 sub reboot_system {
     my ($self) = @_;
@@ -72,66 +50,17 @@ sub reboot_system {
     assert_screen "generic-desktop";
 }
 
-sub switch_user {
-    assert_and_click "system-indicator";
-    assert_and_click "user-logout-sector";
-    assert_and_click "switch-user";
-}
-
-sub change_pwd {
-    send_key "alt-p";
-    wait_still_screen;
-    send_key "ret";
-    wait_still_screen;
-    send_key "alt-p";
-    wait_still_screen;
-    type_password;
-    wait_still_screen;
-    send_key "alt-n";
-    wait_still_screen;
-    type_string $newpwd;
-    wait_still_screen;
-    send_key 'tab';
-    wait_still_screen;
-    type_string $newpwd;
-    assert_screen "actived-change-password";
-    send_key "alt-a";
-    assert_screen "users-settings", 60;
-}
-
-sub add_user {
-    assert_and_click "add-user";
-    type_string $newUser;
-    assert_screen("input-username-test");
-    assert_and_click "set-password-option";
-    send_key "alt-p";
-    type_string $pwd4newUser;
-    send_key 'tab';
-    type_string $pwd4newUser;
-    assert_screen "actived-add-user";
-    send_key "alt-a";
-    assert_screen "users-settings", 60;
-    send_key "alt-f4";
-}
-
-sub auto_login_alter {
-    my ($self) = @_;
-    $self->unlock_user_settings;
-    send_key "alt-u";
-    send_key "alt-f4";
-}
-
 sub run {
     my ($self) = @_;
 
     #change pwd for current user and add new user for switch scenario
     assert_screen "generic-desktop";
     $self->unlock_user_settings;
-    change_pwd;
-    add_user;
+    services::users::change_pwd();
+    services::users::add_user();
     #verify changed password work well in the following scenario:
-    lock_screen;
-    logout_and_login;
+    services::users::lock_screen();
+    services::users::logout_and_login();
     $self->reboot_system;
     if (is_tumbleweed && !get_var('NOAUTOLOGIN')) {
         set_var('NOAUTOLOGIN', 1);
@@ -139,34 +68,10 @@ sub run {
     }
 
     #swtich to new added user then switch back
-    switch_user;
-    wait_still_screen 5;
-    send_key "esc";
-    assert_and_click 'displaymanager-test';
-    assert_screen "testUser-login-dm";
-    type_string "$pwd4newUser\n";
-    # Handle welcome screen, when needed
-    handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
-    assert_screen "generic-desktop", 120;
-    switch_user;
-    send_key "esc";
-    assert_and_click "displaymanager-$username";
-    assert_screen "originUser-login-dm";
-    type_string "$newpwd\n";
-    assert_screen "generic-desktop", 120;
+    services::users::switch_users();
 
     #restore password to original value
-    x11_start_program('gnome-terminal');
-    type_string "su\n";
-    assert_screen "pwd4root-terminal";
-    type_password "$password\n";
-    assert_screen "root-gnome-terminal";
-    type_string "passwd $username\n";
-    assert_screen "pwd4user-terminal";
-    type_password "$password\n";
-    assert_screen "pwd4user-confirm-terminal";
-    type_password "$password\n";
-    assert_screen "password-changed-terminal";
+    services::users::restore_passwd();
 
     send_key "alt-f4";
     send_key "ret";


### PR DESCRIPTION
Add the change password and add new user test before migration, switch users and restore passwords after migration.

- Related ticket: https://progress.opensuse.org/issues/70342
- Needles: added in OSD.
- Verification run: http://openqa.nue.suse.com/tests/5416809#