### PR TITLE
Adjust bootloader scheduling from schedule/containers/

### DIFF
--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -1,27 +1,31 @@
 name:           extra_tests_textmode_containers
 description:    >
-    Maintainer: jalausuch@suse.com, qa-c@suse.de.
-    Extra tests about software in containers module
+  Maintainer: qa-c@suse.de.
+  Extra tests about software in containers module
 conditional_schedule:
-    podman_image:
-        DISTRI:
-            'opensuse':
-                - containers/podman_image
-    docker_image:
-        DISTRI:
-            'opensuse':
-                - containers/docker_image
-                - containers/container_diff
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+  podman_image:
+    DISTRI:
+      'opensuse':
+        - containers/podman_image
+  docker_image:
+    DISTRI:
+      'opensuse':
+        - containers/docker_image
+        - containers/container_diff
 schedule:
-    - installation/bootloader_start
-    - boot/boot_to_desktop
-    - containers/podman
-    - '{{podman_image}}'
-    - containers/docker
-    - '{{docker_image}}'
-    - containers/docker_runc
-    - containers/docker_compose
-    - containers/zypper_docker
-    - containers/containers_3rd_party
-    - containers/registry
-    - console/coredump_collect
+  - '{{boot}}'
+  - boot/boot_to_desktop
+  - containers/podman
+  - '{{podman_image}}'
+  - containers/docker
+  - '{{docker_image}}'
+  - containers/docker_runc
+  - containers/docker_compose
+  - containers/zypper_docker
+  - containers/containers_3rd_party
+  - containers/registry
+  - console/coredump_collect

--- a/schedule/containers/sle_image_on_centos.yaml
+++ b/schedule/containers/sle_image_on_centos.yaml
@@ -1,9 +1,8 @@
 name:         sle_image_on_centos
 description:  |
-    Run sle container on Centos
+  Run sle container on Centos
 schedule:
-    - installation/bootloader_start
-    - boot/boot_to_desktop
-    - containers/host_configuration
-    - containers/podman_image
-    - containers/docker_image
+  - boot/boot_to_desktop
+  - containers/host_configuration
+  - containers/podman_image
+  - containers/docker_image

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -2,8 +2,17 @@ name:           sle_image_on_sle_host
 description:    >
   Maintainer: jalausuch@suse.com, qa-c@suse.de.
   Extra tests about software in containers module
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+  validate_btrfs:
+    ARCH:
+      x86_64:
+        - containers/validate_btrfs
 schedule:
-  - installation/bootloader_start
+  - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/podman_image
@@ -11,8 +20,3 @@ schedule:
   - containers/docker_image
   - containers/container_diff
   - '{{validate_btrfs}}'
-conditional_schedule:
-  validate_btrfs:
-    ARCH:
-      x86_64:
-        - containers/validate_btrfs

--- a/schedule/containers/sle_image_on_ubuntu.yaml
+++ b/schedule/containers/sle_image_on_ubuntu.yaml
@@ -1,9 +1,8 @@
 name:         sle_image_on_ubuntu
 description:  |
-    Run sle container on Ubuntu
+  Run sle container on Ubuntu
 schedule:
-    - installation/bootloader_start
-    - boot/boot_to_desktop
-    - containers/host_configuration
-    - containers/podman_image
-    - containers/docker_image
+  - boot/boot_to_desktop
+  - containers/host_configuration
+  - containers/podman_image
+  - containers/docker_image


### PR DESCRIPTION
Jobs seems can boot using only bootloader_start on OSD but not on O3.
As we boot from a pre-installed image we actually need only the boot_to_desktop.
Exception is s390x that needs bootloader_start wrapper to actual get to the bootloader.

- Related ticket: https://progress.opensuse.org/issues/88440
- [Verification run osd](https://openqa.suse.de/tests/overview?version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%23bootloader&distri=sle)
-  [Verification run o3 TW](https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=b10n1k%2Fos-autoinst-distri-opensuse%23bootloader)
- [Verification run o3 leap](https://openqa.opensuse.org/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%23bootloader&version=15.3&distri=opensuse)
