### PR TITLE
Adapt yast2_lan_restart_vlan

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -11,7 +11,7 @@
 # YaST2 lan module dialog, when VLAN is selected to be configured. The Tab
 # contains all the same elements as the common Address Tab, but with some
 # additional elements that are specific for VLAN.
-# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 package YaST::NetworkSettings::NetworkCardSetup::VLANAddressTab;
 use strict;
@@ -20,7 +20,8 @@ use testapi;
 use parent 'YaST::NetworkSettings::NetworkCardSetup::AddressTab';
 
 use constant {
-    ADDRESS_TAB => 'yast2_lan_address_tab_selected'
+    ADDRESS_TAB     => 'yast2_lan_address_tab_selected',
+    VLAN_ID_WARNING => 'yast2_lan_vlan_id_warning'
 };
 
 sub fill_in_vlan_id {
@@ -29,6 +30,11 @@ sub fill_in_vlan_id {
     send_key 'alt-v';
     send_key 'tab';
     wait_screen_change { type_string($vlan_id) };
+}
+
+sub decline_vlan_id_warning {
+    assert_screen(VLAN_ID_WARNING);
+    send_key 'alt-n';
 }
 
 1;

--- a/lib/YaST/NetworkSettings/v4/NetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/v4/NetworkSettingsController.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,7 +9,7 @@
 
 # Summary: The class introduces business actions for Network Settings Dialog
 # (yast2 lan module), version 4.
-# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 package YaST::NetworkSettings::v4::NetworkSettingsController;
 use parent 'YaST::NetworkSettings::AbstractNetworkSettingsController';
@@ -87,6 +87,7 @@ sub add_vlan_device {
     $self->get_vlan_address_tab()->select_dynamic_address();
     $self->get_vlan_address_tab()->fill_in_vlan_id('12');
     $self->get_vlan_address_tab()->press_next();
+    $self->get_vlan_address_tab()->decline_vlan_id_warning();
 }
 
 sub view_bridged_device_without_editing {


### PR DESCRIPTION
See [poo#88387](https://progress.opensuse.org/issues/88387)
Verification run: [yast2_gui](https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_yast2_lan_restart_vlan)
