### PR TITLE
Automate new feature SLE-15464 - Update Apparmor

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -41,6 +41,9 @@ our @EXPORT = qw(
   $prof_dir
   $adminer_file
   $adminer_dir
+  create_a_test_profile_name_is_special
+  create_log_content_is_special
+  test_profile_content_is_special
 );
 
 our $prof_dir      = "/etc/apparmor.d";
@@ -665,6 +668,74 @@ sub yast2_apparmor_cleanup {
 
     # Upload logs for reference
     upload_logs("$audit_log");
+}
+
+# Create a test profile with name contains '('
+sub create_a_test_profile_name_is_special {
+    my ($testfile, $str) = @_;
+
+    my $testfile2 = "$testfile" . "$str";
+    assert_script_run("cp $testfile $testfile2");
+    assert_script_run("aa-autodep $testfile2");
+    assert_script_run("ll /etc/apparmor.d/ | grep $str");
+}
+
+# Refer to "https://bugs.launchpad.net/apparmor/+bug/1848227"
+# to create a test profile with content "local include above the '}'",
+# then run "aa-complain, aa-disable, aa-enforce, aa-logprof"
+# to verify all the commands should be succeeded
+sub test_profile_content_is_special {
+    my ($self, $cmd, $msg) = @_;
+    my $test          = "test_profile";
+    my $test_profile  = "/etc/apparmor.d/usr.sbin." . "$test";
+    my $local_profile = "/etc/apparmor.d/local/usr.sbin.cupsd";
+
+    # Create an empty local profile under "/etc/apparmor.d/local/"
+    assert_script_run("rm -rf $local_profile");
+    assert_script_run("touch $local_profile");
+
+    # Create a test profile under "/etc/apparmor.d/"
+    assert_script_run("echo '/usr/sbin/cupsd {' > $test_profile");
+    assert_script_run("echo '}' >> $test_profile");
+    assert_script_run("echo '#include <local/usr.sbin.cupsd>' >> $test_profile");
+
+    # Run aa-* commands and check the output
+    my $cmd1 = $cmd eq "aa-logprof" ? $cmd : "$cmd $test_profile";
+    validate_script_output($cmd1, sub { m/$msg/ });
+    if ("$cmd" eq "aa-disable") {
+        # The profile will not be listed out if disabled
+        my $ret = script_run("aa-status | grep $test");
+        if ($ret == 0) {
+            $self->result("fail");
+        }
+    }
+
+    # Clean up
+    assert_script_run("rm -rf $test_profile");
+    assert_script_run("rm -rf $local_profile");
+}
+
+# Refer to "https://apparmor.net/news/release-2.13.4/" setup env to verify the fix:
+# "Fix crash when log message contains a filename with unbalanced parenthesis".
+# Create a test profile with content "local include above the '}'" in order
+# to run "aa-logprof" to verify the commands should be succeeded
+sub create_log_content_is_special {
+    my ($self, $testfile, $test_special) = @_;
+
+    # Enable & Start auditd service
+    systemctl("enable auditd");
+    systemctl("start auditd");
+
+    # Clean up audit log
+    assert_script_run("echo '' > $audit_log");
+
+    # Generate an audit record which "contains a filename with unbalanced parenthesis"
+    assert_script_run("cp $testfile $test_special");
+    assert_script_run("aa-autodep $test_special");
+    assert_script_run("$test_special ./");
+
+    # Check the record which "contains a filename with unbalanced parenthesis"
+    validate_script_output("cat $audit_log", sub { m/.*type=AVC.*profile=.*$test_special.*/sx });
 }
 
 =head2 upload_logs_mail

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2343,6 +2343,7 @@ sub load_security_tests_apparmor {
     loadtest "security/apparmor/aa_logprof";
     loadtest "security/apparmor/aa_easyprof";
     loadtest "security/apparmor/aa_notify";
+    loadtest "security/apparmor/aa_disable";
 }
 
 sub load_security_tests_apparmor_profile {

--- a/tests/security/apparmor/aa_disable.pm
+++ b/tests/security/apparmor/aa_disable.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# Copyright (C) 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,32 +12,23 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
-
-# Package: apparmor-utils apparmor-parser
-# Summary: Test AppArmor complain mode.
-# - Creates a temporary profile dir in /tmp
-# - Sets usr.bin.nscd in complain mode using command
-# "aa-complain usr.sbin.nscd" and "aa-complain -d $aa_tmp_prof usr.sbin.nscd",
-# validates output of command and take a screenshot of each command
-# - Put nscd back in enforce mode
-# - Cleanup temporary directories
+#
+# Summary: Test AppArmor aa-disable - disable an AppArmor security profile.
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#36880, tc#1621142, poo#81730, tc#1767574
+# Tags: poo#81730, tc#1767574
 
 use strict;
 use warnings;
 use base "apparmortest";
 use testapi;
 use utils;
-use services::apparmor;
 
 sub run {
     my ($self) = @_;
     select_console 'root-console';
-    services::apparmor::check_aa_complain();
 
     # Verify "https://bugs.launchpad.net/apparmor/+bug/1848227"
-    $self->test_profile_content_is_special("aa-complain", "Setting.*to complain mode");
+    $self->test_profile_content_is_special("aa-disable", "Disabling.*");
 }
 
 1;

--- a/tests/security/apparmor/aa_enforce.pm
+++ b/tests/security/apparmor/aa_enforce.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 # - runs aa-enforce on /usr/bin/nscd to enforce mode and check output
 # - runs aa-status and check if nscd is on enforce mode.
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#36877, tc#1621145
+# Tags: poo#36877, tc#1621145, poo#81730, tc#1767574
 
 use strict;
 use warnings;
@@ -34,6 +34,9 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
     services::apparmor::check_aa_enforce($self);
+
+    # Verify "https://bugs.launchpad.net/apparmor/+bug/1848227"
+    $self->test_profile_content_is_special("aa-enforce", "Setting.*to enforce mode");
 }
 
 1;

--- a/tests/security/apparmor/aa_logprof.pm
+++ b/tests/security/apparmor/aa_logprof.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2019 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@
 # - Check if nscd could start with the temporary apparmor profiles
 # - Cleanup temporary directory
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#36892, poo#45803
+# Tags: poo#36892, poo#45803, poo#81730, tc#1767574
 
 use base "apparmortest";
 use strict;
@@ -39,8 +39,19 @@ sub run {
     my ($self) = @_;
     my $log_file = $apparmortest::audit_log;
     my $output;
-    my $aa_tmp_prof = "/tmp/apparmor.d";
+    my $aa_tmp_prof     = "/tmp/apparmor.d";
+    my $interactive_str = [
+        {
+            prompt => qr/\(A\)llow/m,
+            key    => 'a',
+        },
+        {
+            prompt => qr/\(S\)ave Changes/m,
+            key    => 's',
+        },
+    ];
 
+    # Stop nscd and restart auditd before generate needed audit logs
     systemctl('stop nscd');
     systemctl('restart auditd');
 
@@ -66,20 +77,7 @@ sub run {
     # Upload audit.log for reference
     upload_logs "$log_file";
 
-    script_run_interactive(
-        "aa-logprof -d $aa_tmp_prof",
-        [
-            {
-                prompt => qr/\(A\)llow/m,
-                key    => 'a',
-            },
-            {
-                prompt => qr/\(S\)ave Changes/m,
-                key    => 's',
-            },
-        ],
-        30
-    );
+    script_run_interactive("aa-logprof -d $aa_tmp_prof", $interactive_str, 30);
 
     foreach my $item (@aa_logprof_items) {
         validate_script_output "cat $aa_tmp_prof/usr.sbin.nscd", sub { m/$item/ };
@@ -87,6 +85,16 @@ sub run {
 
     $self->aa_tmp_prof_verify("$aa_tmp_prof", 'nscd');
     $self->aa_tmp_prof_clean("$aa_tmp_prof");
+    $self->test_profile_content_is_special("aa-logprof -f", "Reading log entries.*");
+
+    # Verify "aa-logprof" can work with "log message contains a filename with unbalanced parenthesis"
+    my $testfile     = "/usr/bin/ls";
+    my $test_special = '/usr/bin/l\(s';
+    $self->create_log_content_is_special("$testfile", "$test_special");
+    script_run_interactive("aa-logprof -f $log_file", $interactive_str, 30);
+
+    # Verify "https://bugs.launchpad.net/apparmor/+bug/1848227"
+    $self->test_profile_content_is_special("aa-logprof", "Reading log entries from.*");
 }
 
 1;

--- a/tests/security/apparmor/aa_status.pm
+++ b/tests/security/apparmor/aa_status.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,9 +17,10 @@
 # aa-status.
 # - Check if apparmor is active
 # - Run aa-status, check the output for strings about modules/profiles/processes
+#   and verify "aa-status" can "handle profile with name contains '('".
 # and strings enforced, complain, unconfined and loaded.
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#36874, poo#44912
+# Tags: tc#1767574, poo#81727, poo#36874, poo#44912
 
 use base "consoletest";
 use strict;
@@ -27,11 +28,25 @@ use warnings;
 use testapi;
 use utils;
 use services::apparmor;
+use apparmortest qw(create_a_test_profile aa_status_stdout_check);
 
 sub run {
+    my ($self) = @_;
+
     select_console 'root-console';
     services::apparmor::check_service();
     services::apparmor::check_aa_status();
+
+    # Verify "aa-status" can "handle profile with name contains '('"
+    my $testfile    = "/usr/bin/ls";
+    my $str_special = '\(test\)';
+
+    apparmortest::create_a_test_profile_name_is_special($testfile, $str_special);
+    systemctl("restart apparmor");
+    services::apparmor::check_aa_status();
+    validate_script_output 'aa-status', sub { m/.*$str_special.*/ };
+    apparmortest::aa_tmp_prof_clean($self, "$testfile" . "$str_special");
+    apparmortest::aa_tmp_prof_clean($self, "/etc/apparmor.d/.*$str_special.*");
 }
 
 1;


### PR DESCRIPTION
Automate SLE-15464 into openQA:
  Feature: SLE-15464 - QA: Update Apparmor to 2.13.4
  parent poo#80200 - [sle][security][sle15sp3][feature][automation] SLE-15464: QA: Update Apparmor to 2.13.4
  sub:
        poo#81727 - [sle][security][sle15sp3][feature][automation] AppArmor SLE-15464: verify "aa-status" can " handle profile names containing ‘(’ " '
         poo#81730 - [sle][security][sle15sp3][feature][automation] AppArmor SLE-15464: verify bug 1848227
         poo#81732 - [sle][security][sle15sp3][feature][automation] AppArmor SLE-15464: verify " Fix crash when log message contains a filename with unbalanced parenthesis"

- Related ticket: 
  https://progress.opensuse.org/issues/81727
  https://progress.opensuse.org/issues/81730
  https://progress.opensuse.org/issues/81732
- Needles: NA
- Verification run: 
  https://openqa.suse.de/tests/5506798
  https://openqa.opensuse.org/tests/1643615
  
