### PR TITLE
Modify detect_yast2_failures to use HDD_1

### DIFF
--- a/schedule/yast/detect_yast2_failures.yaml
+++ b/schedule/yast/detect_yast2_failures.yaml
@@ -1,55 +1,13 @@
 ---
 name: detect_yast2_failures
+vars:
+  ASSERT_Y2LOGS: 1
 description: >
    Specific test displaying as much dialogs as possible to increase test coverage,
    which would fail hard in case any yast2 failure is found in logs.
-vars:
-  ASSERT_Y2LOGS:  '1'
-  RAIDLEVEL:  '0'
-  YUI_REST_API: '1'
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/welcome
-  - installation/accept_license
-  - installation/scc_registration
-  - installation/addon_products_sle
-  - installation/system_role
-  - installation/partitioning
-  - installation/partitioning/raid_gpt
-  - installation/installer_timezone
-  - installation/hostname_inst
-  - installation/user_settings
-  - installation/user_settings_root
-  - installation/resolve_dependency_issues
-  - installation/installation_overview
-  - installation/disable_grub_timeout
-  - installation/start_install
-  - installation/await_install
-  - installation/logs_from_installation_system
-  - installation/reboot_after_installation
-  - installation/teardown_libyui
-  - installation/grub_test
-  - installation/first_boot
+  - boot/boot_to_desktop
+  - console/download_asset
+  - console/detect_yast2_failures
 test_data:
-  <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
-  mds:
-    - raid_level: 0
-      chunk_size: 64
-      device_selection_step: 2
-      partition:
-        role: operating-system
-        formatting_options:
-          should_format: 1
-        mounting_options:
-          should_mount: 1
-    - raid_level: 0
-      chunk_size: 64
-      device_selection_step: 1
-      partition:
-        role: operating-system
-        formatting_options:
-          should_format: 1
-          filesystem: swap
-        mounting_options:
-          should_mount: 1
+  file_location: "/tmp/compressed_y2log.tar"

--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -1,11 +1,12 @@
-name:           RAID0_gpt
-description:    >
-  Configure RAID 0 on the disks with GPT partition tables using Expert Partitioner.
-  Creates BIOS boot, root and swap partitions on each of the 4 disks and then uses
-  them for RAID 0.
+---
+name: detect_yast2_failures
+description: >
+   Specific test displaying as much dialogs as possible to increase test coverage,
+   which would fail hard in case any yast2 failure is found in logs.
 vars:
-  RAIDLEVEL: 0
-  YUI_REST_API: 1
+  ASSERT_Y2LOGS:  '1'
+  RAIDLEVEL:  '0'
+  YUI_REST_API: '1'
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
@@ -26,19 +27,12 @@ schedule:
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system
-  - console/upload_asset
   - installation/reboot_after_installation
   - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
-  asset_files: "/var/log/YaST2/y2log*"
   mds:
     - raid_level: 0
       chunk_size: 64

--- a/tests/console/detect_yast2_failures.pm
+++ b/tests/console/detect_yast2_failures.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Decompress y2log files, as given in test data and parse for failures.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler "get_test_suite_data";
+use File::Basename;
+
+sub run {
+    my $self = shift;
+    select_console 'root-console';
+    my $file_location = get_test_suite_data()->{file_location};
+    assert_script_run("tar -xvf $file_location -C " . dirname($file_location));
+    $self->investigate_yast2_failure(logs_path => dirname($file_location));
+    record_info(dirname($file_location));
+}
+
+1;
+

--- a/tests/console/download_asset.pm
+++ b/tests/console/download_asset.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Downloads ASSET_1 file to, specified by test_data, file location.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler "get_test_suite_data";
+use File::Basename;
+
+sub run {
+    select_console 'root-console';
+    my $file_location    = get_test_suite_data()->{file_location};
+    my $file_to_download = autoinst_url("/assets/other/" . basename(get_required_var("ASSET_1")));
+    assert_script_run("wget " . $file_to_download . " -O  " . $file_location);
+}
+1;

--- a/tests/console/upload_asset.pm
+++ b/tests/console/upload_asset.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Compresses files, as given in test data and upload the compressed file as asset.
+# test data example:
+# test_data:
+#   asset_files: "/dir1/file1 /dir2/file2"
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler "get_test_suite_data";
+
+sub run {
+    select_console 'root-console';
+    my $files_to_upload = get_test_suite_data()->{asset_files};
+    assert_script_run("tar -cvf asset_files.tar $files_to_upload", fail_message => "Failed to compress file(s)");
+    upload_asset("asset_files.tar");
+}
+
+1;
+


### PR DESCRIPTION
Instead of installing new system and then analyzing logs, the test suite will boot to textmode image and get logs from RAID0 test suite

- Related ticket: https://progress.opensuse.org/issues/48707
- Verification runs: RAID0: https://openqa.suse.de/tests/5427455
                  detect_yast2_failures : https://openqa.suse.de/tests/5429748

Combined with gitlab PR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/340