### PR TITLE
Increase ReaR backup test timeout

### DIFF
--- a/tests/ha/rear_backup.pm
+++ b/tests/ha/rear_backup.pm
@@ -21,7 +21,7 @@ sub run {
     my $hostname   = get_var('HOSTNAME', 'susetest');
     my $arch       = get_required_var('ARCH');
     my $backup_url = get_required_var('BACKUP_URL');
-    my $timeout    = bmwqemu::scale_timeout(300);
+    my $timeout    = bmwqemu::scale_timeout(600);
 
     # Disable packagekit and install ReaR
     get_var('USE_YAST_REAR') ? select_console 'root-console' : $self->select_serial_terminal;


### PR DESCRIPTION
Increase the ReaR backup test timeout to 10 minutes as some workers can be very slow.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/5430158 (tested by setting `TIMEOUT_SCALE=2`).