### PR TITLE
Add support for livepatch uninstallation tests

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -176,8 +176,6 @@ sub schedule_tests {
         format      => 'result_array:v2',
         environment => {},
         results     => []};
-    my $cmd_pattern = get_var('LTP_COMMAND_PATTERN') || '.*';
-    my $cmd_exclude = get_var('LTP_COMMAND_EXCLUDE') || '$^';
     my $environment = {
         product     => get_var('DISTRI') . ':' . get_var('VERSION'),
         revision    => get_var('BUILD'),
@@ -211,18 +209,7 @@ sub schedule_tests {
         loadtest_kernel 'ltp_init_lvm';
     }
 
-    for my $name (split(/,/, $cmd_file)) {
-        if ($name eq 'openposix') {
-            parse_openposix_runfile($name,
-                read_runfile('/root/openposix-test-list'),
-                $cmd_pattern, $cmd_exclude, $test_result_export);
-        }
-        else {
-            parse_runtest_file($name, read_runfile("/opt/ltp/runtest/$name"),
-                $cmd_pattern, $cmd_exclude, $test_result_export);
-        }
-    }
-
+    parse_runfiles($cmd_file, $test_result_export);
     shutdown_ltp(run_args => testinfo($test_result_export));
 }
 
@@ -253,6 +240,25 @@ sub parse_runtest_file {
             if ($test->{name} =~ m/$cmd_pattern/ && !($test->{name} =~ m/$cmd_exclude/)) {
                 loadtest_kernel('run_ltp', name => $test->{name}, run_args => $tinfo);
             }
+        }
+    }
+}
+
+sub parse_runfiles {
+    my ($cmd_file, $test_result_export) = @_;
+
+    my $cmd_pattern = get_var('LTP_COMMAND_PATTERN') || '.*';
+    my $cmd_exclude = get_var('LTP_COMMAND_EXCLUDE') || '$^';
+
+    for my $name (split(/,/, $cmd_file)) {
+        if ($name eq 'openposix') {
+            parse_openposix_runfile($name,
+                read_runfile('/root/openposix-test-list'),
+                $cmd_pattern, $cmd_exclude, $test_result_export);
+        }
+        else {
+            parse_runtest_file($name, read_runfile("/opt/ltp/runtest/$name"),
+                $cmd_pattern, $cmd_exclude, $test_result_export);
         }
     }
 }

--- a/tests/kernel/uninstall_incident.pm
+++ b/tests/kernel/uninstall_incident.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Disable kernel incident repositories and force package downgrade.
+#          Used mainly for livepatch uninstallation testing.
+# Maintainer: Martin Doucha <mdoucha@suse.cz>
+
+use 5.018;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    my $repo = get_required_var('INCIDENT_REPO');
+
+    for my $uri (split(",", $repo)) {
+        zypper_call("mr -d $uri");
+    }
+
+    zypper_call('--no-refresh dup --allow-downgrade');
+
+    for my $uri (split(",", $repo)) {
+        zypper_call("mr -e $uri");
+    }
+
+}
+
+sub test_flags {
+    return {
+        fatal     => 1,
+        milestone => 1,
+    };
+}
+
+=head1 Configuration
+
+This test module is activated when KGRAFT=1 and UNINSTALL_INCIDENT=1.
+
+=cut
+
+1;


### PR DESCRIPTION
Labs have requested some basic livepatch uninstallation tests. This patchset implements the basic uninstallation test schedule:
1. Boot test system
2. Run LTP tests as usual
3. Uninstall livepatch
4. Run the same LTP tests again

- Related ticket: https://progress.opensuse.org/issues/80788
- Needles: N/A
- Verification runs:
  - 12-SP2 PPC64LE: https://openqa.suse.de/tests/5430397
  - 12-SP2 x86_64: https://openqa.suse.de/tests/5430398
  - 12-SP5 PPC64LE: https://openqa.suse.de/tests/5430403
  - 12-SP5 s390x: https://openqa.suse.de/tests/5430583
  - 12-SP5 x86_64: https://openqa.suse.de/tests/5430405
  - 15-SP2 PPC64LE: https://openqa.suse.de/tests/5430407
  - 15-SP2 s390x: https://openqa.suse.de/tests/5430408
  - 15-SP2 x86_64: https://openqa.suse.de/tests/5430409