### PR TITLE
Softfail when a bug is opened - sles4sap robot tests

### DIFF
--- a/tests/sles4sap/robot_fw.pm
+++ b/tests/sles4sap/robot_fw.pm
@@ -20,6 +20,29 @@ use version_utils qw(is_sle);
 use utils qw(zypper_call);
 use hacluster qw(is_package_installed);
 
+sub remove_value {
+    my ($module, $parameter) = @_;
+    assert_script_run "perl -e 'while (<>) { /testcase.+name=\"([^\"]+)\"/; \$testcase = \$1; unless (\$testcase eq $parameter) { print; } }' < $module.xml > result.xml";
+    # As we just removed a failed value, we have to decrease the failure counter by 1.
+    assert_script_run 'awk -i inplace \'/failures=/ { new=substr($5,11,length($5)-11); new--; gsub($5, "failures=\""new"\"") } /./ { print }\' result.xml';
+    assert_script_run "mv result.xml $module.xml";
+}
+
+sub check_failure {
+    my ($module, $parameter) = @_;
+    return 1 if script_run("perl -e 'while (<>) { /testcase.+name=\"([^\"]+)\"/; \$testcase = \$1; exit 0 if (/\<failure/ && \$testcase eq \"$parameter\"); } exit 1' < $module.xml") == 0;
+}
+
+sub add_softfail {
+    my ($module, $os_version, $bsc_number, @parameters) = @_;
+    foreach my $parameter (@parameters) {
+        if (check_var("VERSION", $os_version) && check_failure($module, $parameter)) {
+            record_soft_failure "$bsc_number - Wrong value for $parameter";
+            remove_value($module, $parameter);
+        }
+    }
+}
+
 sub run {
     my ($self)           = @_;
     my $robot_fw_version = '3.2.2';
@@ -49,6 +72,19 @@ sub run {
     foreach my $robot_test (split /\n/, script_output "ls $test_repo") {
         record_info("$robot_test", "Starting $robot_test");
         script_run "robot --log $robot_test.html --xunit $robot_test.xml $robot_test";
+        # Soft fail section - How to add a new one
+        # add_softfail("TEST_NAME", "OS_VERSION", "BUG_NUMBER", "PARAMETERS") if ("TEST_NAME" eq "TEST_NAME");
+        # TEST_NAME  : In which test the bug was reported.
+        # OS_VERSION : In which OS version the bug was reported because this test is run over all the SLE versions.
+        # BUG_NUMBER : Bugzilla bug number for tracking the issue.
+        # PARAMETER  : What parameters have changed.
+        # TEST_NAME  : The function needs to be trigger only in the targeted test.
+        if ($robot_test eq "sysctl.robot") {
+            # bsc#1181925 - kernel.panic_on_oops is not consistent
+            add_softfail("sysctl.robot", "15-SP1", "bsc#1181925", qw(Sysctl_kernel_panic_on_oops));
+            # bsc#1181163 - unexpected values for net.ipv6.conf.lo.use_tempaddr and net.ipv6.conf.lo.accept_redirects
+            add_softfail("sysctl.robot", "15-SP1", "bsc#1181163", qw(Sysctl_net_ipv6_conf_lo_accept_redirects Sysctl_net_ipv6_conf_lo_use_tempaddr));
+        }
         parse_extra_log("XUnit", "$test_repo/$robot_test.xml");
         upload_logs("$test_repo/$robot_test.html", failok => 1);
     }


### PR DESCRIPTION
For readability and test review, we need to mark the test as a soft fail instead of failing when a bug is opened.
Requested by QEM.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[ 15-SP1](http://1b143.qa.suse.de/tests/6459)
- Regression tests:
[15-SP2](http://1b143.qa.suse.de/tests/6460)