### PR TITLE
Remove unnecessary modules from container group

### DIFF
--- a/schedule/containers/sle_image_on_centos.yaml
+++ b/schedule/containers/sle_image_on_centos.yaml
@@ -3,7 +3,6 @@ description:  |
     Run sle container on Centos
 schedule:
     - installation/bootloader_start
-    - boot/boot_to_desktop
     - containers/host_configuration
     - containers/podman_image
     - containers/docker_image

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -4,7 +4,6 @@ description:    >
   Extra tests about software in containers module
 schedule:
   - installation/bootloader_start
-  - boot/boot_to_desktop
   - containers/host_configuration
   - containers/podman_image
   - containers/buildah_image

--- a/schedule/containers/sle_image_on_ubuntu.yaml
+++ b/schedule/containers/sle_image_on_ubuntu.yaml
@@ -3,7 +3,6 @@ description:  |
     Run sle container on Ubuntu
 schedule:
     - installation/bootloader_start
-    - boot/boot_to_desktop
     - containers/host_configuration
     - containers/podman_image
     - containers/docker_image

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -84,7 +84,6 @@ conditional_schedule:
                 - console/systemd_rpm_macros
 schedule:
     - installation/bootloader_start
-    - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup
     - '{{update_repos}}'


### PR DESCRIPTION
This is to remove the boot_to_desktop from the scheduling
as the bootloader_start can handle the boot process from
pre-installed qcows.
Second attempt after f24164a was reverted. This time
schedule/containers/extra_tests_textmode_containers.yaml was
excluded because it is shared with o3 and need special care.