### PR TITLE
Fix undefined behavior in check_console_font

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -395,7 +395,7 @@ sub check_console_font {
     # we do not await the console here, as we have to expect the font to be broken
     # for the needle to match, for migration, need wait root console
     my $flavor = get_var('FLAVOR');
-    select_console('root-console', await_console => ($flavor =~ /Migration/));
+    select_console('root-console', await_console => ($flavor =~ /Migration/) ? 1 : 0);
 
     # if this command failed, we're not in a console (e.g. in a svirt
     # ssh connection) and don't see the console font but the local


### PR DESCRIPTION
Some jobs were dying in [consoletest_setup](https://openqa.suse.de/tests/5422850#step/consoletest_setup/46) because #11678 introduced a behavior that could end up in some strange
state. 

VR (HyperV): https://openqa.suse.de/tests/5435614 (Failure is unrelated)
VR (aarch64 migration): https://openqa.suse.de/tests/5439244#step/consoletest_setup/59