### PR TITLE
Add skip_ping in ensure_online subroutine

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -211,6 +211,7 @@ sub ensure_online {
     my $dns_host     = $args{DNS_TEST_HOST} // "suse.de";
     my $skip_ssh     = $args{skip_ssh}      // 0;
     my $skip_network = $args{skip_network}  // 0;
+    my $skip_ping    = $args{skip_ping}     // 0;
     my $ping_delay   = $args{ping_delay}    // 15;
     my $ping_retry   = $args{ping_retry}    // 60;
 
@@ -223,7 +224,10 @@ sub ensure_online {
         }
     }
     unless ($skip_network == 1) {
-        die "$guest does not respond to ICMP" if (script_retry("ping -c 1 '$guest'", delay => $ping_delay, retry => $ping_retry) != 0);
+        # Check if we can ping guest
+        unless ($skip_ping == 1) {
+            die "$guest does not respond to ICMP" if (script_retry("ping -c 1 '$guest'", delay => $ping_delay, retry => $ping_retry) != 0);
+        }
         unless ($skip_ssh == 1) {
             # Wait for ssh to come up
             die "$guest does not start ssh" if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12) != 0);
@@ -232,10 +236,13 @@ sub ensure_online {
             if (script_run("ssh $guest ip r s | grep default") != 0) {
                 assert_script_run("ssh $guest ip r a default via $hypervisor");
             }
-            die "Pinging hypervisor failed for $guest" if (script_retry("ssh $guest ping -c 3 $hypervisor", delay => 1, retry => 10, timeout => 90) != 0);
+            # Check if we can ping hypervizor from the guest
+            unless ($skip_ping == 1) {
+                die "Pinging hypervisor failed for $guest" if (script_retry("ssh $guest ping -c 3 $hypervisor", delay => 1, retry => 10, timeout => 90) != 0);
+            }
             # Check also if name resolution works - restart libvirtd if not
             if (script_run("ssh $guest ping -c 3 -w 120 $dns_host", timeout => 180) != 0) {
-                restart_libvirtd;
+                restart_libvirtd                        if (is_xen_host || is_kvm_host);
                 die "name resolution failed for $guest" if (script_retry("ssh $guest ping -c 3 -w 120 $dns_host", delay => 1, retry => 10, timeout => 180) != 0);
             }
         }

--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -33,7 +33,8 @@ sub run {
     assert_script_run qq(echo -e "\\n\\nBefore:" >> $kernel_log);
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "Probing the guest, adding test repositories and patching the system";
-        ensure_online $guest foreach (keys %virt_autotest::common::guests);
+        ensure_online($guest, skip_ping => (is_hyperv_virtualization || is_vmware_virtualization))
+          foreach (keys %virt_autotest::common::guests);
 
         ($guest_running_version, $guest_running_sp) = get_os_release("ssh root\@$guest");
         if ($host_running_version == $guest_running_version && $host_running_sp == $guest_running_sp) {


### PR DESCRIPTION
There is an error that we cannot ping the external virtual machine from the openQA support server.
As everything else works, the easiest solution is to disable the `ping` check in `ensure_online` routine.

- This is a hotfix for [openqa.suse.de](https://openqa.suse.de/tests/5435933)
- Verification run: [SLE15-SP2 VMware](http://pdostal-server.suse.cz/tests/11095)
