### PR TITLE
Add method to check for sync_state in SAPHanaSR-showAttr

### DIFF
--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -97,6 +97,12 @@ sub run {
     # And check for the state of the whole cluster
     check_cluster_state;
 
+    if (check_var('CLUSTER_NAME', 'hana')) {
+        'sles4sap'->check_replication_state;
+        'sles4sap'->check_hanasr_attr;
+        save_screenshot;
+    }
+
     # Synchronize all nodes
     barrier_wait("CHECK_AFTER_REBOOT_END_${cluster_name}_NODE${node_index}");
     # Note: the following barriers aren't supposed to be used in multiple fencing tests

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -30,7 +30,7 @@ sub run {
     # Give time for HANA to replicate the database
     if (check_var('CLUSTER_NAME', 'hana')) {
         'sles4sap'->check_replication_state;
-        assert_script_run 'SAPHanaSR-showAttr';
+        'sles4sap'->check_hanasr_attr;
         save_screenshot;
         barrier_wait("HANA_REPLICATE_STATE_${cluster_name}_NODE${node_index}");
     }


### PR DESCRIPTION
This PR introduces the `sles4sap::check_hanasr_attr()` method which runs `SAPHanaSR-showAttr` up to a timeout while waiting for the sync_state of the HANA nodes to change from **SFAIL** to **SOK**.

Also refactor the call to `SAPHanaSR-showAttr` in the `ha/fencing` test module and add a call to the new method and to `sles4sap::check_replication_status` in the `ha/check_after_reboot` test module so more information is supplied in the test results.

Also included is an minor fix in `sles4sap::check_replication_status()` to properly detect when `systemReplicationStatus.py` is called on the primary node. It seems the output of this command has changed and now the information of the primary node is presented in a single line instead of two lines.

These changes are intended as fixes to a race condition that can be seen in slower workers, where the current code could attempt to fence one node when the HANA system replication is not fully ready for the fence operation, such as in http://mango.qa.suse.de/tests/3408#step/fencing/25. As can be seen there, `systemReplicationStatus.py` is run once, and even though it was run in the primary node, and the retval was 13, current code did not detect that it was running in the primary node (see `lib/sles4sap` L634) and test module went ahead with the fence. Then in http://mango.qa.suse.de/tests/3408#step/fencing/28 it can be seen that node 2 has a sync_state of **SFAIL** just before the fence. As a result, primary node gets fenced while secondary node is not ready to get promoted, and then HA stack does not move the HANA resources to the secondary node. Test eventually fails when test code attempts to register node 1 as a secondary, but it is still configured as the primary node as node 2 was never promoted: http://mango.qa.suse.de/tests/3408#step/check_after_reboot/51 & http://mango.qa.suse.de/tests/3408#step/check_after_reboot/60

- Related ticket: N/A
- Needles: N/A
- Verification run: [node 1 x86_64 qemu](http://mango.qa.suse.de/tests/3431) & [node 2 x86_64 qemu](http://mango.qa.suse.de/tests/3432); [node 1 pvm_hmc](http://mango.qa.suse.de/tests/3435) & [node 2 pvm_hmc](http://mango.qa.suse.de/tests/3436)
