### PR TITLE
Backup the sshd_config and temporary fix test_cryptographic_policies

### DIFF
--- a/lib/ssh_crypto_policy.pm
+++ b/lib/ssh_crypto_policy.pm
@@ -1,0 +1,106 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+# Summary: Package for ssh cryptographic policy testing
+#
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+package ssh_crypto_policy;
+use base 'consoletest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+sub new() {
+    my ($class, %args) = @_;
+    my $self = $class->SUPER::new();
+    $self->{name}            = $args{name};
+    $self->{query}           = $args{query};
+    $self->{cmd_option}      = $args{cmd_option};
+    $self->{algorithm_array} = ();
+
+    # In the case of HostKeyAlgorithms, get only the ones provided by the server side
+    if ($self->{name} eq "HostKeyAlgorithms") {
+        $self->create_host_key_algorithm_array();
+    } else {
+        # Split the output of the ssh algorithm query to an array
+        $self->{algorithm_array} = [split(/\n/, script_output("ssh -Q $self->{query}"))];
+    }
+
+    return $self;
+}
+
+sub create_host_key_algorithm_array() {
+    my ($self) = @_;
+
+    # If nmap is not installed, install it
+    if (script_run("which nmap")) {
+        zypper_call("in nmap");
+    }
+
+    # Get all the algorithms supported by the server side
+    my $output       = script_output("nmap --script ssh2-enum-algos -sV -p 22 localhost");
+    my @output_lines = split('\|', $output);
+
+    my $parse_algorithms = 0;
+    foreach my $line (@output_lines) {
+        if ($parse_algorithms) {
+            # If line contains the string "encryption algorithms", you can finish parsing
+            last if (index($line, "encryption_algorithms") != -1);
+            # Get the host key algorithms
+            $line =~ s/^\s+|\s+$//g;
+            push(@{$self->{algorithm_array}}, $line);
+        } elsif (index($line, "server_host_key_algorithms") != -1) {
+            # If line contains the string server_host_key_algorithms, start parsing
+            $parse_algorithms = 1;
+        }
+    }
+}
+
+sub add_to_sshd_config() {
+    my ($self) = @_;
+
+    # Create the config line that allows all the available algorithms
+    # An example config can be "Ciphers aes128-ctr,aes192-ctr,aes256-ctr"
+    my $config_line = $self->{name} . " ";
+
+    for my $algorithm (@{$self->{algorithm_array}}) {
+        $config_line .= $algorithm . ",";
+    }
+
+    assert_script_run("(echo '$config_line' && cat /etc/ssh/sshd_config) > /etc/ssh/sshd_config_");
+    assert_script_run("mv /etc/ssh/sshd_config_ /etc/ssh/sshd_config");
+}
+
+sub test_algorithms() {
+    my ($self, %args) = @_;
+    my $remote_user = $args{remote_user};
+
+    my %failing_algorithms = (
+        "gss-gex-sha1-"     => 1,
+        "gss-group1-sha1-"  => 1,
+        "gss-group14-sha1-" => 1);
+
+    for my $algorithm (@{$self->{algorithm_array}}) {
+        if (exists $failing_algorithms{$algorithm}) {
+            record_soft_failure("$algorithm ($self->{name}) fails with unexpected internal error");
+            next;
+        }
+
+        if ($algorithm eq "ssh-dss") {
+            # In case that ssh-dss is available, make sure to explicitly add the dsa host key to known hosts
+            assert_script_run("ssh-keyscan -t dsa localhost >> ~/.ssh/known_hosts");
+        }
+
+        record_info($self->{name}, $algorithm);
+        assert_script_run("ssh $self->{cmd_option}$algorithm $remote_user\@localhost bash -c 'whoami| grep $remote_user'");
+    }
+}
+
+1;

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -29,12 +29,20 @@ use base "consoletest";
 use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
 use utils qw(systemctl exec_and_insert_password zypper_call random_string clear_console);
-use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap);
+use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap is_opensuse);
 use services::sshd;
+use ssh_crypto_policy;
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
+
+    # Backup/rename ~/.ssh , generated in consotest_setup, to ~/.ssh_bck
+    # poo#68200. Confirm the ~/.ssh directory is exist in advance, in order to avoid the null backup
+    assert_script_run 'if [ -d ~/.ssh ]; then mv ~/.ssh ~/.ssh_bck; fi';
+
+    # Backup the /etc/ssh/sshd_config
+    assert_script_run 'cp /etc/ssh/sshd_config{,_before}';
 
     # new user to test sshd
     my $ssh_testman        = "sshboy";
@@ -71,10 +79,6 @@ sub run {
     assert_script_run("useradd -m $ssh_testman");
     assert_script_run("echo $changepwd | chpasswd");
     assert_script_run("usermod -aG \$(stat -c %G /dev/$serialdev) $ssh_testman");
-
-    # Backup/rename ~/.ssh , generated in consotest_setup, to ~/.ssh_bck
-    # poo#68200. Confirm the ~/.ssh directory is exist in advance, in order to avoid the null backup
-    assert_script_run 'if [ -d ~/.ssh ]; then mv ~/.ssh ~/.ssh_bck; fi';
 
     # avoid harmless failures in virtio-console due to unexpected PS1
     assert_script_run("echo \"PS1='# '\" >> ~$ssh_testman/.bashrc") unless check_var('VIRTIO_CONSOLE', '0');
@@ -126,14 +130,57 @@ sub run {
     assert_script_run "scp -4v '$ssh_testman\@localhost:/etc/{group,passwd}' /tmp";
     assert_script_run "scp -4v '$ssh_testman\@localhost:/etc/ssh/*.pub' /tmp";
 
+    # poo#80716 Test all available ciphers, key exchange algorithms, host key algorithms and mac algorithms.
+    test_cryptographic_policies(remote_user => $ssh_testman);
+
+    assert_script_run "killall -u $ssh_testman || true";
+    wait_still_screen 3;
+
     # Restore ~/.ssh generated in consotest_setup
     # poo#68200. Confirm the ~/.ssh_bck directory is exist in advance and then restore, in order to avoid the null restore
     assert_script_run 'rm -rf ~/.ssh';
     assert_script_run 'if [ -d ~/.ssh_bck ]; then mv ~/.ssh_bck ~/.ssh; fi';
 
-    assert_script_run "killall -u $ssh_testman || true";
-    wait_still_screen 3;
+    # Restore the /etc/ssh/sshd_config
+    assert_script_run 'cp /etc/ssh/sshd_config{_before,}';
+
+    record_info("Restart sshd", "Restart sshd.service");
+    systemctl("restart sshd");
+
     clear_console if !is_serial_terminal;
+}
+
+sub test_cryptographic_policies() {
+    my %args        = @_;
+    my $remote_user = $args{remote_user};
+
+    # TODO: This does not work for Tumbleweed because of nmap
+    # See pull request #11930 for more details
+    my @crypto_params = (["Ciphers", "cipher", "-c "], ["KexAlgorithms", "kex", "-o kexalgorithms="], ["MACS", "mac", "-m "]);
+    push(@crypto_params, ["HostKeyAlgorithms", "key", "-o HostKeyAlgorithms="]) unless (is_opensuse);
+    my @policies;
+
+    # Create an array of the different cryptographic policies that will be tested
+    for my $i (0 .. $#crypto_params) {
+        my $obj = ssh_crypto_policy->new(name => $crypto_params[$i][0], query => $crypto_params[$i][1], cmd_option => $crypto_params[$i][2]);
+        push(@policies, $obj);
+    }
+
+    # Add all available algorithms to sshd_config
+    foreach my $policy (@policies) {
+        $policy->add_to_sshd_config();
+    }
+
+    record_info("Restart sshd", "Restart sshd.service");
+    systemctl("restart sshd");
+
+    # Add all the ssh public key hashes as known hosts
+    assert_script_run("ssh-keyscan -H localhost > ~/.ssh/known_hosts");
+
+    # Test all the policies
+    foreach my $policy (@policies) {
+        $policy->test_algorithms(remote_user => $remote_user);
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Hello,

this quick PR is solving two issues:
 * Reintroduce #11899 from @ggkioulis
 * It backups the `/etc/ssh/sshd_config` and restores at the end
 * It does not write under `Match` section (fix for related ticket)
 * Temporary exclude `HostKeyAlgorithms` for openSUSE

- Related ticket: [poo#88492](https://progress.opensuse.org/issues/88492)
- Verification run: [SLE15-SP2](http://pdostal-server.suse.cz/tests/11101) [Tumbleweed](http://pdostal-server.suse.cz/tests/11102)
