### PR TITLE
Implement 389ds and sssd tests into OpenQA

### DIFF
--- a/data/389ds/.dsrc
+++ b/data/389ds/.dsrc
@@ -1,0 +1,5 @@
+[localhost]
+# Note that '/' is replaced with '%%2f'.
+uri = ldapi://%%2fvar%%2frun%%2fslapd-localhost.socket 
+basedn = dc=example,dc=com
+binddn = cn=Directory Manager

--- a/data/389ds/instance.inf
+++ b/data/389ds/instance.inf
@@ -1,0 +1,11 @@
+[general]
+config_version = 2
+strict_host_checking = True
+ 
+[slapd]
+root_password = nots3cr3t
+instance_name = localhost
+ 
+[backend-userroot]
+sample_entries = yes
+suffix = dc=example,dc=com

--- a/lib/opensslca.pm
+++ b/lib/opensslca.pm
@@ -1,0 +1,55 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Base module for OpenSSL Certificate Authority
+#          The corresponding key pairs can be use in
+#          a number of situations, such as issuing server
+#          certificates to secure an intranet website, or
+#          for issuing certificates to clients to allow them
+#          to authenticate to a server
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#88513, tc#1768672
+
+package opensslca;
+
+use base Exporter;
+use Exporter;
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+our @EXPORT = qw(self_sign_ca);
+
+# Function "self_sign_ca" is used for generating self-signed CA and server key pair
+# At the same time, it should verify the certification before using it
+sub self_sign_ca {
+    my ($ca_dir, $cn_name) = @_;
+
+    assert_script_run("rm -rf $ca_dir");
+    assert_script_run("mkdir -p $ca_dir");
+    assert_script_run("cd $ca_dir");
+    assert_script_run(
+        "openssl req -new -x509 -newkey rsa:2048 -keyout myca.key -days 3560 -out myca.pem -nodes -subj \"/C=CN/ST=Beijing/L=Beij
+ing/O=QA/OU=security/CN=$cn_name.example.com\""
+    );
+    assert_script_run("openssl genrsa -out server.key 2048");
+    assert_script_run("openssl req -new -key server.key -out server.csr -subj \"/C=CN/ST=Beijing/L=Beijing/O=QA/OU=security/CN=$cn_name.example.com\"");
+    assert_script_run("openssl x509 -req -days 3560 -CA myca.pem -CAkey myca.key -CAcreateserial -in server.csr -out server.pem");
+    assert_script_run("openssl pkcs12 -export -inkey server.key -in server.pem -out crt.p12 -nodes -name Server-Cert -password pass:\"\"");
+    assert_script_run("openssl verify -verbose -CAfile myca.pem server.pem");
+}
+
+1;

--- a/schedule/security/389ds_sssd.yaml
+++ b/schedule/security/389ds_sssd.yaml
@@ -1,0 +1,14 @@
+description:    >
+    This is for 389ds and sssd authentication
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - network/setup_multimachine
+    - '{{tls_389ds}}'
+conditional_schedule:
+    tls_389ds:
+        HOSTNAME:
+            server:
+                - security/389ds/tls_389ds_server
+            client:
+                - security/389ds/tls_389ds_sssd_client

--- a/tests/security/389ds/tls_389ds_server.pm
+++ b/tests/security/389ds/tls_389ds_server.pm
@@ -1,0 +1,115 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Implement & Integrate 389ds + sssd test case into openQA,
+#          This test module covers the server setup processes
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#88513, tc#1768672
+
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use lockapi;
+use mmapi 'wait_for_children';
+use opensslca;
+
+sub run {
+    select_console("root-console");
+
+    my $local_ip    = '10.0.2.101';
+    my $remote_ip   = '10.0.2.102';
+    my $local_name  = '389ds';
+    my $remote_name = 'sssdclient';
+    my $ca_dir      = '/etc/openldap/ssl';
+    my $inst_ca_dir = '/etc/dirsrv/slapd-localhost';
+
+    # Install 389-ds and create an server instance
+    zypper_call("in 389-ds");
+    assert_script_run("wget --quiet " . data_url("389ds/instance.inf") . " -O /tmp/instance.inf");
+    assert_script_run("dscreate from-file /tmp/instance.inf");
+    validate_script_output("dsctl localhost status", sub { m/Instance.*is running/ });
+
+    # Configure CA Certificates for TLS
+    assert_script_run("wget --quiet " . data_url("389ds/.dsrc") . " -O /root/.dsrc");
+    self_sign_ca("$ca_dir", "$local_name");
+
+    # Deleted the default CA files since it can only resolve "localhost",
+    # Please refer to bug 1180628 for more detail information
+    assert_script_run("certutil -D -d $inst_ca_dir -n Server-Cert");
+    assert_script_run("certutil -D -d $inst_ca_dir -n Self-Signed-CA");
+
+    # Import new CA files and resart the instance
+    assert_script_run("dsctl localhost tls import-server-key-cert $ca_dir/server.pem $ca_dir/server.key");
+    assert_script_run("dsctl localhost tls import-ca $ca_dir/myca.pem myca");
+    assert_script_run("cp $ca_dir/myca.pem $inst_ca_dir/ca.crt");
+    systemctl("restart dirsrv\@localhost.service");
+
+    # Configure host names for C/S communication
+    assert_script_run("sed -i -e 's/master/$local_name.example.com/' -e 's/minion/$remote_name.example.com/' /etc/hosts");
+
+    # Create ldap user and group
+    my $ldap_user    = $testapi::username;
+    my $ldap_passwd  = $testapi::password;
+    my $ldap_group   = 'server_admins';
+    my $uid          = '1003';
+    my $gid          = '1003';
+    my $display_name = 'Domain User';
+    assert_script_run(
+"dsidm localhost user create --uid $ldap_user --cn $ldap_user --displayName '$display_name' --uidNumber $uid --gidNumber $gid --homeDirectory /home/$ldap_user"
+    );
+    script_run_interactive(
+        "dsidm localhost account reset_password uid=$ldap_user,ou=people,dc=example,dc=com",
+        [
+            {
+                prompt => qr/Enter new password.*/m,
+                string => "$ldap_passwd\n",
+            },
+            {
+                prompt => qr/CONFIRM.*/m,
+                string => "$ldap_passwd\n",
+            },
+        ],
+        60
+    );
+    script_run_interactive(
+        "dsidm localhost group create",
+        [
+            {
+                prompt => qr/Enter value.*/m,
+                string => "$ldap_group\n",
+            },
+        ],
+        60
+    );
+    assert_script_run("dsidm localhost group add_member $ldap_group uid=$ldap_user,ou=people,dc=example,dc=com");
+
+    # Generate the sample sssd configuration file
+    assert_script_run("dsidm localhost client_config sssd.conf $ldap_group > /tmp/sssd.conf");
+
+    # Delete the first 2 lines for the sample sssd.conf due to invalid messages there
+    assert_script_run("sed -i '1,2d' /tmp/sssd.conf");
+
+    # Set the ldap_uri with LDAP over SSL (LDAPS) Certificate
+    assert_script_run("sed -i 's/^ldap_uri =.*\$/ldap_uri = ldaps:\\/\\/$local_name.example.com/' /tmp/sssd.conf");
+    mutex_create("389DS_READY");
+
+    # Finish job
+    wait_for_children;
+}
+
+1;

--- a/tests/security/389ds/tls_389ds_sssd_client.pm
+++ b/tests/security/389ds/tls_389ds_sssd_client.pm
@@ -1,0 +1,75 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Implement & Integrate 389ds + sssd test case into openQA,
+#          This test module covers the sssd client tests
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#88513, tc#1768672
+
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use lockapi;
+use Utils::Systemd qw(systemctl disable_and_stop_service);
+
+sub run {
+    select_console("root-console");
+
+    my $remote_ip   = '10.0.2.101';
+    my $remote_name = '389ds';
+    my $inst_ca_dir = '/etc/dirsrv/slapd-localhost';
+    my $tls_dir     = '/etc/openldap/certs';
+    my $ldap_user   = $testapi::username;
+    my $uid         = '1003';
+
+    # Install 389-ds and sssd on client
+    zypper_call("in 389-ds sssd");
+
+    # Disable and stop the nscd daemon because it conflicts with sssd
+    disable_and_stop_service("nscd", ignore_failure => 1);
+
+    # Copy the /etc/hosts, sample sssd.conf and CA files from server
+    # Configure tls CA key on client
+    mutex_wait("389DS_READY");
+    assert_script_run("mkdir -p $tls_dir");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:/etc/hosts /etc/hosts");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:/tmp/sssd.conf /tmp");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:$inst_ca_dir/ca.crt $tls_dir");
+    assert_script_run("/usr/bin/openssl rehash $tls_dir");
+
+    # On newer environments, nsswitch.conf is located in /usr/etc
+    # Copy it to /etc directory
+    script_run("f=/etc/nsswitch.conf; [ ! -f \$f ] && cp /usr\$f \$f");
+    assert_script_run("sed -i -e '/^passwd.*/ s/\$/ sss/' -e '/^group.*/ s/\$/ sss/' -e '/^shadow.*/ s/\$/ sss/' /etc/nsswitch.conf");
+
+    # Configure pam to enable sssd
+    assert_script_run("pam-config -a --sss");
+    assert_script_run("pam-config -q --sss");
+
+    # Now, we can start the sssd service
+    assert_script_run("cat /tmp/sssd.conf > /etc/sssd/sssd.conf");
+    systemctl("enable sssd");
+    systemctl("start sssd");
+
+    # Verify the sssd client can communicate with server in secure mode
+    # Make sure ldap user can login from client as well
+    assert_script_run("LDAPTLS_REQCERT=never ldapwhoami -H ldaps://$remote_name.example.com:636 -x");
+    assert_script_run("id $ldap_user | grep $uid");
+}
+
+1;


### PR DESCRIPTION
The Lightweight Directory Access Protocol (LDAP) is a protocol
designed to access and maintain information directories.
SUSE uses 389-ds as the supported LDAP server of the platform.

- Related ticket: https://progress.opensuse.org/issues/88513
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/5519185 (SLE)
                            https://openqa.suse.de/tests/5519186 (SLE)
                            https://openqa.opensuse.org/tests/1643612 (TW)
                            https://openqa.opensuse.org/tests/1643613 (TW)