### PR TITLE
Fix fail in xrdp_server: login sequence

### DIFF
--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -86,7 +86,6 @@ sub run {
 
     if (is_sles4sap || is_tumbleweed) {
         # We don't have to test the reconnection and reboot part in SLES4SAP and TW
-        send_key "tab" if is_tumbleweed;
         handle_login;
     }
 


### PR DESCRIPTION
Remove the condition `send_key "tab" if is_tumbleweed;` ,as it selects the not listed choice, instead of the username choice that already exists.

- Related ticket: https://progress.opensuse.org/issues/66784
- Needles: N/A
- Verification run: [remote-desktop-supportserver4](http://10.163.41.158/tests/95) | [remote-desktop-client4](http://10.163.41.158/tests/96)
