### PR TITLE
Add ha-cluster-preflight-check test for HA module

### DIFF
--- a/schedule/ha/bv/ha_cluster_node.yaml
+++ b/schedule/ha/bv/ha_cluster_node.yaml
@@ -1,0 +1,51 @@
+---
+name: ha_cluster_node
+description: >
+  HA Cluster Test. Schedule for all nodes.
+
+  Some settings are required in the job group or test suite for this schedule to work.
+
+  The other settings required in the job group are.
+
+  CLUSTER_NAME must be defined for all jobs as a string.
+  HA_CLUSTER_INIT must be defined to a non false value in the parent job
+  HA_CLUSTER_JOIN must be defined for the rest of the jobs, and it must contain the
+  hostname of the parent job (the job where HA_CLUSTER_SETUP is defined to init)
+  HOSTNAME must be defined to different hostnames for each node.
+  MAX_JOB_TIME is recommended to be defined as well to a high value (ex. 20000)
+  All jobs with the exception of the parent job must include a PARALLEL_WITH setting
+  referencing the parent job.
+  SLE_PRODUCT must be defined and set accordingly.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  BOOT_HDD_IMAGE: '1'
+  USE_SUPPORT_SERVER: '1'
+  HDD_SCC_REGISTERED: '1'
+  VIRTIO_CONSOLE: '0'
+  HA_CLUSTER: '1'
+  # Below setting must be defined in the openQA UI because macros for %VERSION%,
+  # %ARCH% and %BUILD% are usually not defined yet when this file is being loaded
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/iscsi_client
+  - ha/watchdog
+  - '{{cluster_setup}}'
+  - '{{ha_cluster_preflight_check}}'
+  - ha/check_logs
+conditional_schedule:
+  cluster_setup:
+    HA_CLUSTER_SETUP:
+      init:
+        - ha/ha_cluster_init
+      join:
+        - ha/ha_cluster_join
+  ha_cluster_preflight_check:
+    PREFLIGHT_CHECK:
+      1:
+        - ha/ha_cluster_preflight_check

--- a/schedule/ha/bv/ha_supportserver.yaml
+++ b/schedule/ha/bv/ha_supportserver.yaml
@@ -1,8 +1,34 @@
-name:           ha_supportserver
-description:    >
-    Create a supportserver for multi machines tests
+name: ha_supportserver
+description: >
+  SupportServer definition for HA tests.
+
+  Some settings are required in the job group or test suite for this schedule to work.
+
+  The other settings required in the job group are.
+
+  CLUSTER_INFOS must be defined in the parent job to the name of the cluster, number
+  of nodes and number of LUNs. Example 'hana:2:3'
+  NUMDISKS must be defined and set to the total number of disks, usually 2 for a
+  iSCSI server.
+  HDDSIZEGB_2 must be defined and set to the needed size of the 2nd disk.
+  NUMLUNS must be defined and set to the needed number of LUNs.
+  MAX_JOB_TIME is recommended to be defined as well to a high value (ex. 20000).
+  All jobs with the exception of the parent job must include a PARALLEL_WITH setting
+  referencing the parent job.
+  SLE_PRODUCT must be defined and set accordingly.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: textmode
+  SUPPORT_SERVER: '1'
+  SUPPORT_SERVER_ROLES: dhcp,dns,ntp,ssh,iscsi
+  VIDEOMODE: text
+  VIRTIO_CONSOLE: '0'
+  # Below setting must be defined in the openQA UI because macros for %VERSION%,
+  # %ARCH% and %BUILD% are usually not defined yet when this file is being loaded
+  # HDD_1: openqa_support_server_sles12sp3.%ARCH%.qcow2
 schedule:
-    - support_server/login
-    - support_server/setup
-    - ha/barrier_init
-    - support_server/wait_children
+  - support_server/login
+  - support_server/setup
+  - ha/barrier_init
+  - support_server/wait_children

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -25,9 +25,9 @@ sub is_not_supportserver_scenario {
 sub run {
     my $cluster_infos = get_required_var('CLUSTER_INFOS');
 
-    for my $cluster_info (split(/,/, $cluster_infos)) {
+    foreach (split(/,/, $cluster_infos)) {
         # The CLUSTER_INFOS variable for support_server also contains the number of node
-        my ($cluster_name, $num_nodes) = split(/:/, $cluster_info);
+        my ($cluster_name, $num_nodes) = split(/:/, $_);
 
         # Number of node is a mandatory variable!
         die 'A valid number of nodes is mandatory' if ($num_nodes lt '2');
@@ -70,7 +70,7 @@ sub run {
         barrier_create("LOCK_RESOURCE_CREATED_$cluster_name",   $num_nodes);
         barrier_create("LOGS_CHECKED_$cluster_name",            $num_nodes);
         # We have to create barriers for each nodes if we want to be able to fence *all* nodes
-        for (1 .. $num_nodes) {
+        foreach (1 .. $num_nodes) {
             barrier_create("CHECK_AFTER_REBOOT_BEGIN_${cluster_name}_NODE$_",   $num_nodes);
             barrier_create("CHECK_AFTER_REBOOT_END_${cluster_name}_NODE$_",     $num_nodes);
             barrier_create("CHECK_BEFORE_FENCING_BEGIN_${cluster_name}_NODE$_", $num_nodes);
@@ -123,11 +123,12 @@ sub run {
         barrier_create("SPLIT_BRAIN_TEST_READY_$cluster_name", $num_nodes + 1);
         barrier_create("SPLIT_BRAIN_TEST_DONE_$cluster_name",  $num_nodes + 1);
 
+        # Preflight-check barriers
+        barrier_create("PREFLIGHT_CHECK_INIT_${cluster_name}_NODE$_", $num_nodes) foreach (1 .. $num_nodes);
+
         # ROLLING UPGRADE / UPDATE barriers
         my $update_type = (get_var('UPDATE_TYPE') eq "update") ? "UPDATED" : "UPGRADED";
-        for (1 .. $num_nodes) {
-            barrier_create("NODE_${update_type}_${cluster_name}_NODE$_", $num_nodes);
-        }
+        barrier_create("NODE_${update_type}_${cluster_name}_NODE$_", $num_nodes) foreach (1 .. $num_nodes);
 
         # Create barriers for multiple tests
         foreach my $fs_tag ('LUN', 'CLUSTER_MD', 'DRBD_PASSIVE', 'DRBD_ACTIVE') {
@@ -160,7 +161,7 @@ sub run {
         barrier_create("HANA_CREATED_CONF_$cluster_name",    $num_nodes);
         barrier_create("HANA_LOADED_CONF_$cluster_name",     $num_nodes);
         # We have to create barriers for each nodes if we want to be able to fence *all* nodes
-        for (1 .. $num_nodes) {
+        foreach (1 .. $num_nodes) {
             barrier_create("HANA_RA_RESTART_${cluster_name}_NODE$_",      $num_nodes);
             barrier_create("HANA_REPLICATE_STATE_${cluster_name}_NODE$_", $num_nodes);
         }
@@ -179,16 +180,16 @@ sub run {
     my $dev_by_path    = '/dev/disk/by-path';
     my $index          = get_var('ISCSI_LUN_INDEX', 0);
 
-    for my $cluster_info (split(/,/, $cluster_infos)) {
+    foreach (split(/,/, $cluster_infos)) {
         # The CLUSTER_INFOS variable for support_server also contains the number of LUN
-        my ($cluster_name, $num_nodes, $num_luns) = split(/:/, $cluster_info);
+        my ($cluster_name, $num_nodes, $num_luns) = split(/:/, $_);
 
         # Export LUN name if needed
         if (defined $num_luns) {
             # Create a file that contains the list of LUN for each cluster
             my $lun_list_file = "/tmp/$cluster_name-lun.list";
-            foreach my $i (0 .. ($num_luns - 1)) {
-                my $lun_id = $i + $index;
+            foreach (0 .. ($num_luns - 1)) {
+                my $lun_id = $_ + $index;
                 script_run "echo '${dev_by_path}/ip-${target_ip_port}-iscsi-${target_iqn}-lun-${lun_id}' >> $lun_list_file";
             }
             $index += $num_luns;

--- a/tests/ha/ha_cluster_preflight_check.pm
+++ b/tests/ha/ha_cluster_preflight_check.pm
@@ -1,0 +1,132 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test HA cluster with cluster-preflight-check
+# Maintainer: Loic Devulder <ldevulder@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use hacluster qw(check_cluster_state get_cluster_name get_node_index get_node_number ha_export_logs);
+use utils qw(zypper_call);
+use Mojo::JSON qw(encode_json);
+
+our $dir_log = '/var/lib/ha-cluster-preflight-check/';
+
+sub upload_preflight_check_logs {
+    my @report_files = split(/\n/, script_output("ls $dir_log 2>/dev/null", proceed_on_failure => 1));
+    upload_logs("$dir_log/$_",                             failok => 1) foreach (@report_files);
+    upload_logs('/var/log/ha-cluster-preflight-check.log', failok => 1);
+}
+
+sub run {
+    my ($self) = @_;
+    my $cluster_name = get_cluster_name;
+
+    # Install needed package
+    $self->select_serial_terminal;
+    zypper_call 'in python3-cluster-preflight-check';
+
+    # Ensure that the cluster state is correct before executing the checks
+    check_cluster_state;
+
+    # We have to wait for previous nodes to finish the tests, as they can't be done in parallel without any damages!
+    barrier_wait("PREFLIGHT_CHECK_INIT_${cluster_name}_NODE$_") foreach (1 .. (get_node_index) - 1);
+
+    # List of things to check
+    my @checks    = qw(env-check cluster-check kill-sbd kill-corosync kill-pacemaker split-brain-iptables);
+    my @can_fence = qw(kill-sbd kill-corosync kill-pacemaker split-brain-iptables);
+
+    # Loop on each check
+    my $preflight_start_time = time;
+    foreach my $check (@checks) {
+        # Is the check can trigger a fencing?
+        my $trigger_fencing = grep { $_ eq $check } @can_fence;
+
+        # Execute the command
+        my $cmd = "ha-cluster-preflight-check --yes --${check}";
+        record_info("${check}", "Executing ${cmd}");
+        my $cmd_fails = script_run "${cmd}";
+        record_info('ERROR', "Failure while executing '$cmd'", result => 'fail') unless ((defined $cmd_fails and $cmd_fails == 0) or $trigger_fencing);
+        save_screenshot;
+
+        # Some commands may lead to a reboot of the node
+        if ($trigger_fencing) {
+            my $loop_count = bmwqemu::scale_timeout(15);    # Wait 1 minute (15*4) maximum, can be scaled with SCALE_TIMEOUT
+            while (1) {
+                last if ($loop_count-- <= 0);
+                if (check_screen('bootloader-grub2', 0, no_wait => 1)) {
+                    # Wait for boot and reconnect to root console
+                    $self->wait_boot;
+                    $self->select_serial_terminal;
+                    last;
+                }
+                sleep 4;
+            }
+        }
+    }
+    my $preflight_end_time = time;
+    upload_preflight_check_logs;
+
+    # Parse the logs to get a better overview in openQA
+    my $results_file = '/tmp/preflight_cluster.json';
+    my %results      = (
+        tests   => [],
+        info    => {timestamp => time, distro => "", results_file => ""},
+        summary => {num_tests => 0,    passed => 0,  duration     => $preflight_end_time - $preflight_start_time}
+    );
+
+    my $output = script_output("for FILE in $dir_log/*.report; do awk -F':' '/Testcase:|ERROR:/ { print }' ORS=' ' \$FILE 2>/dev/null && echo; done");
+    foreach my $line (split("\n", $output)) {
+        my @tab = split(/\s+/, $line);
+        my %aux = ();
+        $results{summary}->{num_tests}++;
+        $aux{name}       = lc(join('_', $tab[1], $tab[2], $tab[3]));
+        $aux{outcome}    = ($line =~ /ERROR:/) ? 'failed' : 'passed';
+        $aux{test_index} = 0;
+        push @{$results{tests}}, \%aux;
+        $results{summary}->{passed}++ if ($aux{outcome} eq 'passed');
+    }
+
+    my $json = encode_json \%results;
+    assert_script_run "echo '$json' > $results_file";
+
+    # Upload IPA log
+    parse_extra_log(IPA => $results_file);
+
+    # Sync *next* nodes
+    barrier_wait("PREFLIGHT_CHECK_INIT_${cluster_name}_NODE$_") foreach (get_node_index .. get_node_number);
+
+    # Check the whole cluster state at the end
+    check_cluster_state;
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    # We need to be sure that *ALL* consoles are closed, are SUPER:post_fail_hook
+    # does not support virtio/serial console yet
+    reset_consoles;
+    select_console('root-console');
+
+    # Upload the logs
+    $self->upload_preflight_check_logs;
+    ha_export_logs;
+
+    # Execute the common part
+    $self->post_fail_hook;
+}
+
+1;


### PR DESCRIPTION
ha-cluster-preflight-check is a tool used to validate an HA cluster stack after installation, to ensure that all prerequisites are done.
This commit adds a test for this tool.

I did some minor modifications in the barrier creation, let me know if you disagree on this.

- Scheduler Merge Request: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/236
- Related ticket: N/A
- Needles: N/A
- Verification run: [node01](http://1b210.qa.suse.de/tests/8484), [node02](http://1b210.qa.suse.de/tests/8485), [node03](http://1b210.qa.suse.de/tests/8483).
**Note:** the failures are because of a failing test during the preflight-check. I need to check if it's a false positive or not. Another PR to fix this if it's a test error will be done later.