### PR TITLE
Extract config files validation to the library function

### DIFF
--- a/lib/cfg_files_utils.pm
+++ b/lib/cfg_files_utils.pm
@@ -1,0 +1,75 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Shared library for validating and manipulating
+#          configuration files in the SUT.
+
+package cfg_files_utils;
+use Exporter 'import';
+use strict;
+use warnings;
+
+use testapi;
+
+our @EXPORT = qw(
+  validate_cfg_file
+);
+
+
+=head2 validate_cfg_file
+
+  validate_cfg_file($args)
+
+Method validates content of the config file. Method allows to validate
+file by the line content or by providing key-pair values for the
+configuration files which use "KEY=PAIR" syntax.
+
+Following structure is expected for the input:
+configuration_files:
+  - path: /etc/hosts
+    entries:
+      - '10.226.154.19\tnew.entry.de h999uz'
+      - '127.0.0.1\tlocalhost'
+  - path: /etc/sysconfig/kdump
+    settings:
+      KDUMP_DUMPLEVEL: 31
+      KDUMP_DUMPFORMAT: lzo
+=cut
+
+sub validate_cfg_file {
+    my ($args) = @_;
+    # Accumulate errors
+    my $errors = '';
+    foreach my $cfg_file (@{$args}) {
+        my $path        = $cfg_file->{path};
+        my $cfg_content = script_output("cat $path");
+
+        for my $setting (keys %{$cfg_file->{settings}}) {
+            my ($conf_line) = grep { /$setting=/ } split(/\n/, $cfg_content);
+            unless ($conf_line) {
+                $errors .= "Setting '$setting' not found in $path.\n";
+                next;
+            }
+            my $value = $cfg_file->{settings}->{$setting};
+            if ($conf_line !~ /^$setting=["]?$value["]?$/) {
+                $errors .= "Found unexpected setting value for '$setting' in $path.\n";
+            }
+        }
+
+        foreach my $entry (@{$cfg_file->{entries}}) {
+            if ($cfg_content !~ /$entry/) {
+                $errors .= "Entry '$entry' is not found in '$path'.\n";
+            }
+        }
+    }
+
+    die "Configuration files validation failed:\n$errors" if $errors;
+}
+
+1;

--- a/schedule/yast/yast2_ncurses/yast2_ncurses_textmode.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_textmode.yaml
@@ -7,6 +7,7 @@ schedule:
   - boot/boot_to_desktop
   - console/prepare_test_data
   - console/consoletest_setup
+  - console/scc_cleanup_reregister
   - console/yast2_lan
   - console/yast2_i
   - console/yast2_bootloader

--- a/test_data/yast/yast2_ncurses/textmode.yaml
+++ b/test_data/yast/yast2_ncurses/textmode.yaml
@@ -1,5 +1,5 @@
 ---
-kdump:
+configuration_files:
   - path: /etc/default/grub
     settings:
       GRUB_CMDLINE_LINUX_DEFAULT: '.*crashkernel=\d+M.*'

--- a/test_data/yast/yast2_ncurses/textmode_lzo.yaml
+++ b/test_data/yast/yast2_ncurses/textmode_lzo.yaml
@@ -1,5 +1,5 @@
 ---
-kdump:
+configuration_files:
   - path: /etc/default/grub
     settings:
       GRUB_CMDLINE_LINUX_DEFAULT: '.*crashkernel=\d+M.*'

--- a/test_data/yast/yast2_ncurses/textmode_lzo_fadump.yaml
+++ b/test_data/yast/yast2_ncurses/textmode_lzo_fadump.yaml
@@ -1,5 +1,5 @@
 ---
-kdump:
+configuration_files:
   - path: /etc/default/grub
     settings:
       GRUB_CMDLINE_LINUX_DEFAULT: '.*crashkernel=\d+M.*'

--- a/tests/console/verify_config_files.pm
+++ b/tests/console/verify_config_files.pm
@@ -16,32 +16,22 @@
 #    - path: /etc/chrony.conf
 #      entries:
 #        - pool ntp.suse.de iburst
-# NOTE: grep -P is used for validation, therefore perl regexp syntax can be
-#       used in the entries
+# See lib/cfg_files_utils.pm
 # Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 use base 'y2_module_consoletest';
 use strict;
 use warnings;
-use testapi;
+
+use cfg_files_utils 'validate_cfg_file';
 use scheduler;
+use testapi;
 use utils;
 
 sub run {
     select_console 'root-console';
 
-    my $test_data = get_test_suite_data();
-    # Accumulate errors for all checks
-    my $errors = '';
-    foreach my $file (@{$test_data->{configuration_files}}) {
-        foreach my $entry (@{$file->{entries}}) {
-            if (script_run("grep -P \"$entry\" $file->{path}") != 0) {
-                $errors .= "Entry '$entry' is not found in '$file->{path}'.\n";
-            }
-        }
-    }
-
-    die "Configuration files validation failed:\n$errors" if $errors;
+    validate_cfg_file(get_test_suite_data()->{configuration_files});
 }
 
 sub post_fail_hook {

--- a/tests/console/yast2_kdump.pm
+++ b/tests/console/yast2_kdump.pm
@@ -14,16 +14,16 @@
 use base "y2_module_consoletest";
 use strict;
 use warnings;
+
+use cfg_files_utils 'validate_cfg_file';
+use kdump_utils;
+use registration;
+use scheduler 'get_test_suite_data';
 use testapi;
 use utils;
-use registration;
-use kdump_utils;
-use scheduler 'get_test_suite_data';
-use Test::Assert ':all';
 
 sub run {
     select_console('root-console');
-    my @conf_files = @{get_test_suite_data()->{kdump}};
 
     # install kdump by adding additional modules
     add_suseconnect_product('sle-module-desktop-applications');
@@ -36,18 +36,7 @@ sub run {
     # check service (without restarting)
     systemctl('is-enabled kdump');
 
-    # check configuration files
-    for my $conf_file (@conf_files) {
-        my $path        = $conf_file->{path};
-        my $conf_output = script_output("cat $path");
-        for my $setting (keys %{$conf_file->{settings}}) {
-            my ($conf_line) = grep { /$setting=/ } split(/\n/, $conf_output);
-            die "Setting '$setting' not found in $path" unless $conf_line;
-            my $value = $conf_file->{settings}->{$setting};
-            assert_matches(qr/^$setting=["]?$value["]?$/, $conf_line,
-                "Found unexpected setting value in $path.");
-        }
-    }
+    validate_cfg_file(get_test_suite_data()->{configuration_files});
 
     # delete additional modules
     remove_suseconnect_product('sle-module-development-tools');


### PR DESCRIPTION
We have implemented 2 ways to validate configuration files, which we
decided to move to the library, as it's used in multiple scenarios.

Now configuration files can be validated both, by expected line, or by
KEY=VALUE pairs.

[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%23yast).

See [poo#88319](https://progress.opensuse.org/issues/88319).