### PR TITLE
Add test for flatpak

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1994,6 +1994,7 @@ sub load_x11_other {
             loadtest "x11/gnome_tweak_tool";
             loadtest "x11/seahorse";
         }
+        loadtest 'x11/flatpak' if (is_opensuse);
     }
     # shotwell was replaced by gnome-photos in SLE15 & yast_virtualization isn't in SLE15
     if (is_sle('>=12-sp2') && is_sle('<15')) {

--- a/tests/x11/flatpak.pm
+++ b/tests/x11/flatpak.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test flatpak
+#   * Install flatpak
+#   * Run smoke test (flatpak --version)
+#   * Search for gimp and steam
+#   * Install gimp
+#   * Run gimp
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils;
+use x11utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    # Install flatpak and run basic tests
+    zypper_call('in flatpak');
+    assert_script_run('flatpak --version | grep -i Flatpak');
+    die "flatpak list is not empty" if script_output("flatpak list") != "";
+    assert_script_run('flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo');
+    assert_script_run('flatpak search gimp | grep -i "org.gimp.GIMP"');
+    assert_script_run('flatpak search steam | grep -i "com.valvesoftware.Steam"');
+    assert_script_run('flatpak install -y org.gimp.GIMP');
+    assert_script_run('flatpak list | grep -i gimp');
+    # Run flatpak gimp and check if GUI is appearing
+    select_console 'x11';
+    ensure_unlocked_desktop;
+    x11_start_program('flatpak run org.gimp.GIMP', target_match => 'flatpak-gimp');
+    wait_still_screen(3);
+    assert_and_click('flatpak-gimp');
+    wait_still_screen(3);
+}
+
+1;


### PR DESCRIPTION
Adds flatpak openQA test for Tumbleweed.
We run some basic flatpak commands, install and run gimp to ensure flatpak is working properly.

- Related ticket: https://progress.opensuse.org/issues/68636
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/713
- Verification run: http://duck-norris.qam.suse.de/t5084
