### PR TITLE
Add autoyast test with btrfs quota limit

### DIFF
--- a/data/autoyast_opensuse/autoyast_btrfs_quota.xml
+++ b/data/autoyast_opensuse/autoyast_btrfs_quota.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+    </general>
+    <login_settings>
+        <autologin_user>bernhard</autologin_user>
+    </login_settings>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">true</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <partitioning t="list">
+        <drive t="map">
+            <device>/dev/vda</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots t="boolean">true</enable_snapshots>
+            <partitions t="list">
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <format t="boolean">false</format>
+                    <partition_id t="integer">263</partition_id>
+                    <partition_nr t="integer">1</partition_nr>
+                    <resize t="boolean">false</resize>
+                    <size>8MiB</size>
+                </partition>
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <create_subvolumes t="boolean">true</create_subvolumes>
+                    <filesystem t="symbol">btrfs</filesystem>
+                    <format t="boolean">true</format>
+                    <mount>/</mount>
+                    <mountby t="symbol">uuid</mountby>
+                    <partition_id t="integer">131</partition_id>
+                    <partition_nr t="integer">2</partition_nr>
+                    <quotas t="boolean">true</quotas>
+                    <resize t="boolean">false</resize>
+                    <size>18.5GiB</size>
+                    <subvolumes t="list">
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">false</copy_on_write>
+                            <path>var</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>srv</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>root</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>opt</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>boot/grub2/x86_64-efi</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>boot/grub2/i386-pc</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix>@</subvolumes_prefix>
+                </partition>
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <filesystem t="symbol">swap</filesystem>
+                    <format t="boolean">true</format>
+                    <mount>swap</mount>
+                    <mountby t="symbol">uuid</mountby>
+                    <partition_id t="integer">130</partition_id>
+                    <partition_nr t="integer">3</partition_nr>
+                    <resize t="boolean">false</resize>
+                    <size>1.4GiB</size>
+                </partition>
+            </partitions>
+            <type t="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+    </partitioning>
+</profile>

--- a/data/autoyast_sle15/autoyast_btrfs_quota.xml
+++ b/data/autoyast_sle15/autoyast_btrfs_quota.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons t="list">
+            <addon t="map">
+                <name>sle-module-server-applications</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+            <addon t="map">
+                <name>sle-module-basesystem</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+    <partitioning t="list">
+        <drive t="map">
+            <device>/dev/vda</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots t="boolean">true</enable_snapshots>
+            <partitions t="list">
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <format t="boolean">false</format>
+                    <partition_id t="integer">263</partition_id>
+                    <partition_nr t="integer">1</partition_nr>
+                    <resize t="boolean">false</resize>
+                    <size>8MiB</size>
+                </partition>
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <create_subvolumes t="boolean">true</create_subvolumes>
+                    <filesystem t="symbol">btrfs</filesystem>
+                    <format t="boolean">true</format>
+                    <mount>/</mount>
+                    <mountby t="symbol">uuid</mountby>
+                    <partition_id t="integer">131</partition_id>
+                    <partition_nr t="integer">2</partition_nr>
+                    <quotas t="boolean">true</quotas>
+                    <resize t="boolean">false</resize>
+                    <size>18.6GiB</size>
+                    <subvolumes t="list">
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">false</copy_on_write>
+                            <path>var</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>srv</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>root</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>opt</path>
+                            <referenced_limit>1 GiB</referenced_limit>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>boot/grub2/x86_64-efi</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>boot/grub2/i386-pc</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix>@</subvolumes_prefix>
+                </partition>
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <filesystem t="symbol">swap</filesystem>
+                    <format t="boolean">true</format>
+                    <mount>swap</mount>
+                    <mountby t="symbol">uuid</mountby>
+                    <partition_id t="integer">130</partition_id>
+                    <partition_nr t="integer">4</partition_nr>
+                    <resize t="boolean">false</resize>
+                    <size>1.4GiB</size>
+                </partition>
+            </partitions>
+            <type t="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+    </partitioning>
+</profile>

--- a/schedule/yast/autoyast/autoyast_btrfs_quota.yaml
+++ b/schedule/yast/autoyast/autoyast_btrfs_quota.yaml
@@ -1,0 +1,89 @@
+---
+name: autoyast_btrfs_quota
+description: >
+  AutoYaST installation with BTRFS subvolume quotas. Verifies quota limit on the installed system
+  and if its size corresponds to the configured quota limit during installation.
+vars:
+  AUTOYAST_PREPARE_PROFILE: 1
+  DESKTOP: textmode
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/verify_btrfs_quota
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/verify_cloned_profile
+test_data:
+  disks:
+    - partitions:
+      - mounting_options:
+          mount_point: '/'
+        subvolumes:
+          - subvolume:
+              path: var
+              quota: 1.00GiB
+          - subvolume:
+              path: usr/local
+              quota: 1.00GiB
+          - subvolume:
+              path: tmp
+              quota: 1.00GiB
+          - subvolume:
+              path: root
+              quota: 1.00GiB
+          - subvolume:
+              path: srv
+              quota: 1.00GiB
+          - subvolume:
+              path: opt
+              quota: 1.00GiB
+  profile:
+    partitioning:
+      - drive:
+          unique_key: device
+          device: /dev/vda
+          partitions:
+            - partition:
+                unique_key: mount
+                mount: swap
+            - partition:
+                unique_key: mount
+                mount: /
+                quotas: 'true'
+                subvolumes:
+                  - subvolume:
+                      unique_key: path
+                      path: var
+                      referenced_limit: '1 GiB'
+                  - subvolume:
+                      unique_key: path
+                      path: usr/local
+                      referenced_limit: '1 GiB'
+                  - subvolume:
+                      unique_key: path
+                      path: tmp
+                      referenced_limit: '1 GiB'
+                  - subvolume:
+                      unique_key: path
+                      path: root
+                      referenced_limit: '1 GiB'
+                  - subvolume:
+                      unique_key: path
+                      path: srv
+                      referenced_limit: '1 GiB'
+                  - subvolume:
+                      unique_key: path
+                      path: opt
+                      referenced_limit: '1 GiB'
+                  - subvolume:
+                      unique_key: path
+                      path: boot/grub2/i386-pc
+                  - subvolume:
+                      unique_key: path
+                      path: boot/grub2/x86_64-efi
+            - partition:
+                unique_key: partition_nr
+                partition_nr: 1

--- a/tests/autoyast/verify_btrfs_quota.pm
+++ b/tests/autoyast/verify_btrfs_quota.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# Summary: Verify that quota is set and corresponds to the expected limit for the required subvolumes.
+# The list of subvolumes and expected quota limit are stored in 'test_data'.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'basetest';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use Test::Assert 'assert_equals';
+
+sub run {
+    my $test_data = get_test_suite_data();
+    foreach my $disk (@{$test_data->{disks}}) {
+        foreach my $partition (@{$disk->{partitions}}) {
+            my $mount_point             = $partition->{mounting_options}->{mount_point};
+            my $output_btrfs_subvolumes = assert_script_run("btrfs subvolume list $mount_point");
+            # Get 'qgroupid' and 'max_rfer' columns from the output. Other columns are not needed for this test.
+            my $output_btrfs_qgroups = assert_script_run("btrfs qgroup show -r $mount_point | awk '{print \$1,\$4}'");
+            foreach my $subvolume (@{$partition->{subvolumes}}) {
+                # Parse id for the subvolume path
+                (my $subvolume_id) = ($output_btrfs_subvolumes =~ /ID\s*([0-9]*).*?$subvolume->{path}/);
+                # Parse quota size using subvolume id
+                (my $quota_size) = ($output_btrfs_qgroups =~ /0\/$subvolume_id\s*(\d+.\d+\w+)/);
+                assert_equals($subvolume->{quota_size}, $quota_size,
+                    "Quota size for $subvolume->{path} does not match the expected.");
+            }
+        }
+    }
+}
+
+1;


### PR DESCRIPTION
The test validates that limit is set after installation and the limit
corresponds to the expected value.

**For reviewers:** The MR in Job Group Settings should be merged with this PR to add the test suite on OSD: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/341
For o3, the following should be added to Job Group settings:

```yaml
- autoyast_btrfs_quota:
    settings:
      AUTOYAST: autoyast_opensuse/autoyast_btrfs_quota.xml
```

Related task: https://progress.opensuse.org/issues/87646

- Related ticket: https://progress.opensuse.org/issues/87646
- Verification runs:
    - SLE: https://openqa.suse.de/tests/5457401
    - TW: https://openqa.opensuse.org/tests/1630050