### PR TITLE
Schedule check_resume test for all architectures

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -35,7 +35,7 @@ schedule:
   # Called on BACKEND: qemu
   - '{{grub_test}}'
   - installation/first_boot
-  - '{{check_resume}}'
+  - console/check_resume
   - console/validate_no_cow_attribute
   # On all the backends except s390x, /home is located on a separate partition
   - '{{validate_home_partition}}'
@@ -54,10 +54,6 @@ conditional_schedule:
         - boot/reconnect_mgmt_console
       svirt:
         - boot/reconnect_mgmt_console
-  check_resume:
-    ARCH:
-      s390x:
-        - console/check_resume
   grub_test:
     BACKEND:
       qemu:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -26,6 +26,7 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/check_resume
   - console/validate_no_cow_attribute
   - console/verify_separate_home
 test_data:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -30,6 +30,7 @@ schedule:
   - boot/reconnect_mgmt_console
   - installation/grub_test
   - installation/first_boot
+  - console/check_resume
   - console/verify_separate_home
   - console/validate_file_system
 test_data:

--- a/tests/console/check_resume.pm
+++ b/tests/console/check_resume.pm
@@ -8,8 +8,6 @@
 # without any warranty.
 
 # Summary: Verify that "resume=" kernel parameter is absent in the list of default parameters on Sle15-SP2
-# for s390 see https://jira.suse.com/browse/SLE-6926
-# Only for s390.
 
 # Maintainer: Jonathan Rivrain <jrivrain@suse.com>
 


### PR DESCRIPTION
By default on all SLES installations, resume= kernel option is not
added.

Previously that check was made for s390x only, now it is added for all
the architectures.

- Related task: https://progress.opensuse.org/issues/87841
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=145.1_btrfs_libstorage-ng&groupid=96
