### PR TITLE
Stabizile  bootloader parameter comparison

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1246,7 +1246,7 @@ Returns the array of the boot parameters.
 =cut
 
 sub parse_bootparams_in_serial {
-    my $parsed_string = wait_serial(qr/command line:.*/msi);
+    my $parsed_string = wait_serial(qr/command line:.*\[/msi);
     $parsed_string =~ m/.*command line:(?<boot>.*)/i;
     return split ' ', $+{boot};
 }
@@ -1268,7 +1268,7 @@ sub compare_bootparams {
     if (scalar @difference > 0) {
         record_info("params mismatch", "Actual bootloader params do not correspond to the expected ones. Mismatched params: @difference", result => 'fail');
     } else {
-        record_info("params ok", "Bootloader parameters are typed correctly.\nVerified parameters: @{$expected_boot_params}");
+        record_info("params ok", "Bootloader parameters are typed correctly.\nVerified parameters:\n" . join("\n", @{$expected_boot_params}));
     }
 }
 


### PR DESCRIPTION
There have been some sporadic failures , because function parse_bootparams_in_serial doesn't always wait for the serial output to be complete. 

Plus, modifying the record info when we have successfully matched parameters for better readability.

- Related ticket: https://progress.opensuse.org/issues/88283
- Verification run: 
 svirt-hyperv : https://openqa.suse.de/tests/5452347
svirt-xen-hvm : https://openqa.suse.de/tests/5452331
ppc64le : https://openqa.suse.de/tests/5452332
ppc64le-no-tmpfs : https://openqa.suse.de/tests/5452346
64bit : https://openqa.suse.de/tests/5452345

