### PR TITLE
Refactor call of SAPHanaSR-showAttr

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -761,7 +761,7 @@ sub do_hana_takeover {
         wait_until_resources_started(timeout => 900);
         save_state;
         $self->check_replication_state;
-        script_run 'SAPHanaSR-showAttr';
+        $self->check_hanasr_attr;
         script_run 'egrep "expected_votes|two_node" /etc/corosync/corosync.conf';
         $self->do_hana_sr_register(node => $args{node});
     }


### PR DESCRIPTION
#11929 introduced a method in `lib/sles4sap` to execute `SAPHanaSR-showAttr`. This PR refactor the remaining calls to the command with `sles4sap::check_hanasr_attr()`.

- Related ticket: N/A
- Needles: N/A
- Verification run: x86_64 (http://mango.qa.suse.de/tests/3447 & 
http://mango.qa.suse.de/tests/3448), ppc64le (http://mango.qa.suse.de/tests/3449 & http://mango.qa.suse.de/tests/3450)