### PR TITLE
Replace drop by keep in cleanup of network persistent rules

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -209,7 +209,7 @@ sub is_svirt {
 
 =head2 is_image_backend
 
-Returns true if the current instance is running as qemu backend
+Returns true if the current instance is running on backend with image support
 
 =cut
 

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -42,6 +42,9 @@ use constant {
           is_pvm
           is_xen_pv
           is_ipmi
+          is_qemu
+          is_svirt
+          is_image_backend
           )
     ],
     CONSOLES => [
@@ -182,6 +185,36 @@ Returns true if the current instance is running as ipmi backend
 
 sub is_ipmi {
     return check_var('BACKEND', 'ipmi');
+}
+
+=head2 is_qemu
+
+Returns true if the current instance is running as qemu backend
+
+=cut
+
+sub is_qemu {
+    return check_var('BACKEND', 'qemu');
+}
+
+=head2 is_svirt
+
+Returns true if the current instance is running as svirt backend
+
+=cut
+
+sub is_svirt {
+    return check_var('BACKEND', 'svirt');
+}
+
+=head2 is_image_backend
+
+Returns true if the current instance is running as qemu backend
+
+=cut
+
+sub is_image_backend {
+    return (is_qemu || is_svirt);
 }
 
 #This subroutine takes absolute file path of sshd config file and desired ssh connection timeout as arguments

--- a/schedule/ha/rear/rear_backup.yaml
+++ b/schedule/ha/rear/rear_backup.yaml
@@ -2,8 +2,6 @@
 name: rear_backup
 description: >
   Generate backup files for ReaR tests.
-vars:
-  DROP_PERSISTENT_NET_RULES: '1'
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/schedule/sles4sap/installation/install_sles4sap.yaml
+++ b/schedule/sles4sap/installation/install_sles4sap.yaml
@@ -5,8 +5,6 @@ description: >
 
   Can be used to generate a qcow2 image, used to test SAP components like
   HANA, NetWeaver, WMP, etc.
-vars:
-  DROP_PERSISTENT_NET_RULES: '1'
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -12,7 +12,7 @@
 # itself and make the system ready for power off.
 # - if DEBUG_SHUTDOWN is set, then collect detailed logs to investigate shutdown issues
 #   and redirect them to serial console
-# - if DROP_PERSISTENT_NET_RULES is set, then remove 70-persistent-net.rules
+# - if KEEP_PERSISTENT_NET_RULES is set, 70-persistent-net.rules will not be deleted on backend with image support
 # - dhcp cleanup on qemu backend (stop network and wickedd, remove xml files from /var/lib/wicked)
 # - if DESKTOP is set, then set 'ForwardToConsole=yes', 'MaxLevelConsole=debug' and 'TTYPath=/dev/$serialdev'
 #   in /etc/systemd/journald.conf and restart systemd-journalctl
@@ -25,7 +25,7 @@ use testapi;
 use serial_terminal 'prepare_serial_console';
 use utils;
 use version_utils;
-use Utils::Backends 'is_qemu';
+use Utils::Backends qw(is_qemu is_image_backend);
 
 sub run {
     select_console('root-console');
@@ -43,8 +43,8 @@ END_SCRIPT
         assert_script_run $script;
         assert_script_run "chmod +x /usr/lib/systemd/system-shutdown/debug.sh";
     }
-    if (get_var('DROP_PERSISTENT_NET_RULES')) {
-        type_string "rm -f /etc/udev/rules.d/70-persistent-net.rules\n";
+    if (!get_var('KEEP_PERSISTENT_NET_RULES') && is_image_backend) {
+        script_run('rm -f /etc/udev/rules.d/70-persistent-net.rules');
     }
 
     prepare_serial_console;

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -25,6 +25,7 @@ use testapi;
 use serial_terminal 'prepare_serial_console';
 use utils;
 use version_utils;
+use Utils::Backends 'is_qemu';
 
 sub run {
     select_console('root-console');
@@ -51,7 +52,7 @@ END_SCRIPT
     # Proceed with dhcp cleanup on qemu backend only.
     # Cleanup is made, because if same hdd image used in multimachine scenario
     # on several nodes, the dhcp clients use same id and cause conflicts on dhcpd server.
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         my $network_status = script_output('systemctl status network');
         # Do dhcp cleanup for wicked
         if ($network_status =~ /wicked/) {

--- a/variables.md
+++ b/variables.md
@@ -77,6 +77,7 @@ ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
 KEEP_DISKS | boolean | false | Prevents disks wiping for remote backends without snaphots support, e.g. ipmi, powerVM, zVM
 KEEP_ONLINE_REPOS | boolean | false | openSUSE specific variable, not to replace original repos in the installed system with snapshot mirrors which are not yet published.
+KEEP_PERSISTENT_NET_RULES | boolean | false | Keep udev rules 70-persistent-net.rules, which are deleted on backends with image support (qemu, svirt) by default.
 LAPTOP |||
 LINUX_BOOT_IPV6_DISABLE | boolean | false | If set, boots linux kernel with option named "ipv6.disable=1" which disables IPv6 from startup.
 LINUXRC_KEXEC | integer | | linuxrc has the capability to download and run a new kernel and initrd pair from the repository.<br> There are four settings for the kexec option:<br> 0: feature disabled;<br> 1: always restart with kernel/initrd from repository (without bothering to check if it's necessary);<br>2: restart only if needed - that is, if linuxrc detects that the booted initrd is outdated (this is the default);<br>3: like kexec=2 but without user interaction.<br> *More details [here](https://en.opensuse.org/SDB:Linuxrc)*.


### PR DESCRIPTION
Fix poo#88423: Udev persistent network rules should be removed on
backends with image support by default. New variable
KEEP_PERSISTENT_NET_RULES replaced DROP_PERSISTENT_NET_RULES. Rules
will be cleaned on qemu and svirt backends. If we don't want to delete
rules file, we need to set variable KEEP_PERSISTENT_NET_RULES in the
installation job.

Original commit https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/3b5e534306ac4edc5d90a7e4bd8a15d0f21740dd was obviously for images only.

New `is_qemu, is_svirt, is_image_backend` functions were added.

Existing test suites should be cleaned from `DROP_PERSISTENT_NET_RULES`  after merge and few runs on osd. 

- Related ticket: https://progress.opensuse.org/issues/88423
- Needles: none
- Verification run: 
aarch64 qemu: https://openqa.suse.de/tests/5457242#step/cleanup_before_shutdown/2 cleaned = OK
aarch64 ipmi: https://openqa.suse.de/tests/5457046#step/cleanup_before_shutdown/1 not cleaned = OK
svirt s390:  https://openqa.suse.de/tests/5457243#step/shutdown/3 cleaned = OK
spvm: https://openqa.suse.de/tests/5457213#step/cleanup_before_shutdown/1 not cleaned = OK
sle4sap: https://openqa.suse.de/tests/5457256#step/cleanup_before_shutdown/2 cleaned = OK
ha: https://openqa.suse.de/tests/5457243#step/cleanup_before_shutdown/2 cleaned = OK
hpc: https://openqa.suse.de/tests/5457258#step/cleanup_before_shutdown/2 cleaned = OK
x86_64 with KEEP_PERSISTENT_NET_RULES:  https://openqa.suse.de/tests/5457244#step/cleanup_before_shutdown/8  not cleaned =OK
x86_64 without KEEP_PERSISTENT_NET_RULES: https://openqa.suse.de/tests/5457285#step/cleanup_before_shutdown/2 cleaned = OK
