### PR TITLE
GRUB2 sets higher screen resultion automatically

### DIFF
--- a/schedule/jeos/sle/jeos-base+phub.yaml
+++ b/schedule/jeos/sle/jeos-base+phub.yaml
@@ -11,7 +11,6 @@ conditional_schedule:
                 - installation/bootloader_uefi
             svirt-hyperv-uefi:
                 - installation/bootloader_hyperv
-                - installation/bootloader_uefi
             svirt-hyperv:
                 - installation/bootloader_hyperv
                 - installation/bootloader_uefi

--- a/schedule/jeos/sle/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/jeos-base+sdk+desktop.yaml
@@ -10,7 +10,6 @@ conditional_schedule:
                 - installation/bootloader_uefi
             'svirt-hyperv-uefi':
                 - installation/bootloader_hyperv
-                - installation/bootloader_uefi
             'svirt-hyperv':
                 - installation/bootloader_hyperv
                 - installation/bootloader_uefi

--- a/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
+++ b/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
@@ -11,7 +11,6 @@ conditional_schedule:
                 - installation/bootloader_uefi
             'svirt-hyperv-uefi':
                 - installation/bootloader_hyperv
-                - installation/bootloader_uefi
             'svirt-hyperv':
                 - installation/bootloader_hyperv
                 - installation/bootloader_uefi

--- a/schedule/jeos/sle/jeos-extratest.yaml
+++ b/schedule/jeos/sle/jeos-extratest.yaml
@@ -11,7 +11,6 @@ conditional_schedule:
                 - installation/bootloader_uefi
             'svirt-hyperv-uefi':
                 - installation/bootloader_hyperv
-                - installation/bootloader_uefi
             'svirt-hyperv':
                 - installation/bootloader_hyperv
                 - installation/bootloader_uefi

--- a/schedule/jeos/sle/jeos-fs_stress.yaml
+++ b/schedule/jeos/sle/jeos-fs_stress.yaml
@@ -11,7 +11,6 @@ conditional_schedule:
                 - installation/bootloader_uefi
             'svirt-hyperv-uefi':
                 - installation/bootloader_hyperv
-                - installation/bootloader_uefi
             'svirt-hyperv':
                 - installation/bootloader_hyperv
                 - installation/bootloader_uefi

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -11,7 +11,6 @@ conditional_schedule:
                 - installation/bootloader_uefi
             'svirt-hyperv-uefi':
                 - installation/bootloader_hyperv
-                - installation/bootloader_uefi
             'svirt-hyperv':
                 - installation/bootloader_hyperv
                 - installation/bootloader_uefi


### PR DESCRIPTION
When JeOS images are booted as Gen2 VMs in Hyperv, GRUB2 prefers higher video
resolution by default.

- Verification runs: 
   * [jeos-extratest@svirt-hyperv-uefi](http://kepler.suse.cz/tests/3581#step/firstrun/1)  
   * [jeos-base+phub@svirt-hyperv-uefi](http://kepler.suse.cz/tests/3575#step/firstrun/1)  
   * [jeos-container-engines_and_tools@svirt-hyperv-uefi](http://kepler.suse.cz/tests/3567#step/firstrun/1)  
   * [jeos-base+sdk+desktop@svirt-hyperv-uefi](http://kepler.suse.cz/tests/3583#step/firstrun/1)  
   * [jeos-main@svirt-hyperv-uefi](http://kepler.suse.cz/tests/3584#step/firstrun/1)  
