### PR TITLE
Fix issues with InfiniBand testing

### DIFF
--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -15,6 +15,7 @@ vars:
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_CONSOLE: ttyS1,115200
+    PACKAGES: rdma-core
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
 schedule:
@@ -31,6 +32,7 @@ schedule:
     - installation/user_settings
     - installation/user_settings_root
     - installation/resolve_dependency_issues
+    - installation/select_packages
     - installation/installation_overview
     - installation/start_install
     - installation/await_install

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -15,6 +15,7 @@ vars:
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_CONSOLE: ttyS1,115200
+    PACKAGES: rdma-core
     PARALLEL_WITH: ibtest-master
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
@@ -31,6 +32,7 @@ schedule:
     - installation/user_settings
     - installation/user_settings_root
     - installation/resolve_dependency_issues
+    - installation/select_packages
     - installation/installation_overview
     - installation/start_install
     - installation/await_install

--- a/tests/installation/select_packages.pm
+++ b/tests/installation/select_packages.pm
@@ -65,23 +65,25 @@ sub run {
         assert_screen('installation-settings-overview-loaded');
     }
 
-    # Check that installation is blocked (expected behavior)
-    assert_screen 'inst-overview-blocked';
-    send_key 'alt-i';
-    assert_screen 'startinstall-blocked';
-    send_key 'alt-o';
-    assert_screen 'inst-overview-blocked';
+    if ($blocker_packages) {
+        # Check that installation is blocked (expected behavior)
+        assert_screen 'inst-overview-blocked';
+        send_key 'alt-i';
+        assert_screen 'startinstall-blocked';
+        send_key 'alt-o';
+        assert_screen 'inst-overview-blocked';
 
-    $self->go_to_patterns();
-    $self->go_to_search_packages();
-    for my $package_name (split(/,/, $blocker_packages)) {
-        $self->search_package($package_name);
-        $self->toogle_package($package_name, '+');
-    }
-    $self->back_to_overview_from_packages();
+        $self->go_to_patterns();
+        $self->go_to_search_packages();
+        for my $package_name (split(/,/, $blocker_packages)) {
+            $self->search_package($package_name);
+            $self->toogle_package($package_name, '+');
+        }
+        $self->back_to_overview_from_packages();
 
-    if (check_screen('inst-overview-blocked', 0)) {
-        die('Installation looks blocked. Is some blocker package not included in INSTALLATION_BLOCKED?');
+        if (check_screen('inst-overview-blocked', 0)) {
+            die('Installation looks blocked. Is some blocker package not included in INSTALLATION_BLOCKED?');
+        }
     }
 }
 

--- a/tests/kernel/ibtests.pm
+++ b/tests/kernel/ibtests.pm
@@ -24,7 +24,7 @@ use mmapi;
 our $master;
 our $slave;
 
-sub upload_logs {
+sub upload_ibtest_logs {
     my $self = shift;
 
     $self->save_and_upload_log('dmesg',                   '/tmp/dmesg.log',         {screenshot => 0});
@@ -47,7 +47,7 @@ sub ibtest_slave {
     zypper_call('in iputils python');
     barrier_wait('IBTEST_BEGIN');
     barrier_wait('IBTEST_DONE');
-    $self->upload_logs;
+    $self->upload_ibtest_logs;
 }
 
 sub ibtest_master {
@@ -97,7 +97,7 @@ sub ibtest_master {
     script_run('tr -cd \'\11\12\15\40-\176\' < results/TEST-ib-test.xml > /tmp/results.xml');
     parse_extra_log('XUnit', '/tmp/results.xml');
 
-    $self->upload_logs;
+    $self->upload_ibtest_logs;
 
     barrier_wait('IBTEST_DONE');
     barrier_destroy('IBTEST_SETUP');
@@ -149,7 +149,7 @@ sub post_fail_hook {
         parse_extra_log('XUnit', '/tmp/results.xml');
     }
 
-    $self->upload_logs;
+    $self->upload_ibtest_logs;
 
     barrier_wait('IBTEST_DONE');
     wait_for_children;
@@ -178,7 +178,7 @@ we assume it is "64bit-mlx_con5". See the schedule/kernel/ibtest-master.yaml and
 schedule/kernel/ibtest-slave.yaml for more details.
 
 =head2 openQA test suites
-As the test is executed on two hosts, two test suites should be created. Please note: 
+As the test is executed on two hosts, two test suites should be created. Please note:
 most settings are now defined in the YAML schedule.
 
 =head3 ibtest-master
@@ -189,26 +189,26 @@ PARALLEL_WITH=ibtest-master
 YAML_SCHEDULE=schedule/kernel/ibtest-slave.yaml
 
 =head3 additional configuration variables
-These are only effective, when defined for the master job. Leave them at their 
+These are only effective, when defined for the master job. Leave them at their
 defaults unless you know what you are doing.
 
 IBTEST_TIMEOUT
- Test timeout in seconds. 
+ Test timeout in seconds.
  Default: 3600 (1 hour)
 IBTEST_ONLY_PHASE
- integer value. Only run the defined phase. 
+ integer value. Only run the defined phase.
  Not set by default.
 IBTEST_START_PHASE
- integer value. Start with specified phase. 
+ integer value. Start with specified phase.
  Default: 0
 IBTEST_END_PHASE
- integer value. End with specified phase. 
+ integer value. End with specified phase.
  Default: 999
 IBTEST_MPI_FLAVOURS
- Comma separated list of MPI flavours to test. 
+ Comma separated list of MPI flavours to test.
  Default: mvapich2,mpich,openmpi,openmpi2,openmpi3
 IBTEST_IPOIB_MODES
- Comma separated list of IPoIB modes to test 
+ Comma separated list of IPoIB modes to test
  Default: connected,datagram
 IBTEST_VERBOSE
  Set this variable to enable verbose mode


### PR DESCRIPTION
This PR contains two fixes for the InfiniBand testsuite. 
First, we need to install rdma-core package earlier to avoid race conditions after package installation. This allows the testsuite to run and find an active port.
Second, improve logfiles created for both nodes, so we have dmesg and systemd logs for both master and slave, whis is sometimes needed for error diagnosis and bug reporting

See the verification run, which gets past phase 1 now and can execute the entire testsuite.

- Related ticket: https://progress.opensuse.org/issues/88539
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1487
- Verification run: http://baremetal-support.qa.suse.de/tests/768 and http://baremetal-support.qa.suse.de/tests/769