### PR TITLE
Add bootloader to kernel kdump schedule for spvm

### DIFF
--- a/schedule/kernel/kdump.yaml
+++ b/schedule/kernel/kdump.yaml
@@ -3,6 +3,7 @@ description:    >
     Kdump kernel testing for various architectures with possibility to change crash
     memory using CRASH_MEMORY variable.
 schedule:
+    - installation/bootloader_start
     - boot/boot_to_desktop
     - kernel/kdump
     - shutdown/shutdown


### PR DESCRIPTION
Extend kernel kdump schedule by `bootloader` for spvm.

- Related ticket: https://progress.opensuse.org/issues/73510
- Needles: none
- Verification run: 
spvm: https://openqa.suse.de/tests/5469561
ipxe: https://openqa.suse.de/tests/5471668 (fail is related to something else)

Workaround for IPXE: https://gitlab.suse.de/kernel-qa/kernelqa-openqa-yaml/-/merge_requests/150