### PR TITLE
Install missing yast2 modules for control center test on TW

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -327,6 +327,10 @@ sub run {
         # see bsc#1062331, sound is not added to the yast2 pattern
         ensure_installed 'yast2-boot-server yast2-sound';
     }
+    elsif (is_tumbleweed) {
+        record_soft_failure('bsc#1182125', "yast2-online-update-frontend is not pre-installed on TW");
+        ensure_installed 'yast2-online-update-frontend';
+    }
     $self->launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
 
     start_addon_products;

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -329,7 +329,9 @@ sub run {
     }
     elsif (is_tumbleweed) {
         record_soft_failure('bsc#1182125', "yast2-online-update-frontend is not pre-installed on TW");
-        ensure_installed 'yast2-online-update-frontend';
+        ensure_installed('yast2-online-update-frontend');
+        record_soft_failure('bsc#1182241', "yast2-vpn is not pre-installed on TW");
+        ensure_installed('yast2-vpn yast2-sudo yast2-tune yast2-kdump');
     }
     $self->launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
 


### PR DESCRIPTION
We miss multiple yast2 package to be pre-installed on TW, so not to fail the test
due to known issue, adding the workaround along with the soft failure.

This change should be reverted once [bsc#1182241](https://bugzilla.suse.com/show_bug.cgi?id=1182241) is fixed.

[Verification run](https://openqa.opensuse.org/tests/1630026).
