### PR TITLE
Stabilize boot_encrypt for wrong password

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -327,7 +327,14 @@ sub unlock_if_encrypted {
         assert_screen("encrypted-disk-password-prompt", 200);
         type_password;    # enter PW at boot
         save_screenshot;
-        assert_screen 'encrypted_disk-typed_password' if $args{check_typed_password};
+        if ($args{check_typed_password}) {
+            unless (check_screen "encrypted_disk-typed_password", 30) {
+                record_info("Invalid password", "Not all password characters were typed successfully, retyping");
+                send_key "backspace" for (0 .. 9);
+                type_password;
+                assert_screen "encrypted_disk-typed_password";
+            }
+        }
         send_key "ret";
     }
 }


### PR DESCRIPTION
For ppc, the worker often misses to type one character.
The commit enchances the password check, so we don't get failures
 due to backend sending keys issues.

- Related ticket: https://progress.opensuse.org/issues/88480
- Verification runs: 
    * wrong password: https://openqa.suse.de/tests/5491892#step/boot_encrypt/5
    * correct password: https://openqa.suse.de/tests/5491887#step/boot_encrypt/3

