### PR TITLE
Fix autoyast installation on SLES4SAP

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -343,7 +343,7 @@ sub run {
     $self->wait_boot if check_var('BACKEND', 'ipmi') and not get_var('VIRT_AUTOTEST') and not $pxe_boot_done;
 
     # Second stage starts here
-    $maxtime = 1000;
+    $maxtime = 1000 * get_var('TIMEOUT_SCALE', 1);    # Max waiting time for stage 2
     $timer   = 0;
     $stage   = 'stage2';
 


### PR DESCRIPTION
HANA installation with autoyast on SLES4SAP is failing because stage2 `maxtime` doesn't handle TIMEOUT_SCALE variable.

Note: default value will still be the same after this change, so this shouldn't break current tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: [x86_64](https://openqa.suse.de/t5469788), [ppc64le](https://openqa.suse.de/t5470433)
- Regression test: [autoyast_eula_full_medium](https://openqa.suse.de/t5469910)