### PR TITLE
Add fix for rc-local systemd test

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -62,6 +62,13 @@ sub qaset_config {
     assert_script_run("mkdir -p /root/qaset");
     my $testsuites = "\n\t" . join("\n\t", @list) . "\n";
     assert_script_run("echo 'SQ_TEST_RUN_LIST=($testsuites)' > /root/qaset/config");
+
+    if (is_sle('>=15')) {
+        # poo88597 We need an executable boot.local to avoid failing rc-local service test for sle15+
+        my $boot_local = "/etc/init.d/boot.local";
+        assert_script_run("echo '#!/bin/sh' > $boot_local");
+        assert_script_run("chmod +x $boot_local");
+    }
 }
 
 # Add qa head repo for kernel testing. If QA_SERVER_REPO is set,


### PR DESCRIPTION
The executable `boot.local` does not exist by default in sle15, sle15sp1 and sle15sp2.
This results in qa_test_systemd failing the rc-local service test. 
A simple solution for the systemd to not fail in this test is to create the executable.

- Related ticket: https://progress.opensuse.org/issues/88597
- Needles: No needles
- Verification run: [before / failing](http://10.161.225.203/tests/1247#step/1_systemd/35) | [after / passing](http://10.161.225.203/tests/1259#step/1_systemd/35)
