### PR TITLE
Fix HA preflight-check test

### DIFF
--- a/tests/ha/ha_cluster_preflight_check.pm
+++ b/tests/ha/ha_cluster_preflight_check.pm
@@ -63,7 +63,7 @@ sub run {
             my $loop_count = bmwqemu::scale_timeout(15);    # Wait 1 minute (15*4) maximum, can be scaled with SCALE_TIMEOUT
             while (1) {
                 last if ($loop_count-- <= 0);
-                if (check_screen('bootloader-grub2', 0, no_wait => 1)) {
+                if (check_screen('grub2', 0, no_wait => 1)) {
                     # Wait for boot and reconnect to root console
                     $self->wait_boot;
                     $self->select_serial_terminal;


### PR DESCRIPTION
We have to use `grub2` needle instead of `bootloader-grub2` to ensure that the test works on all architecture.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/5469802
- Verification run: [ppc64le-node01](https://openqa.suse.de/tests/5471919), [ppc64le-node02](https://openqa.suse.de/tests/5471918), [ppc64le-node03](https://openqa.suse.de/tests/5471917)
- Regression tests: [aarch64-node01](http://1b210.qa.suse.de/tests/8500), [aarch64-node02](http://1b210.qa.suse.de/tests/8501), [aarch64-node03](http://1b210.qa.suse.de/tests/8502), [x86_64-node01](http://1b210.qa.suse.de/tests/8505), [x86_64-node02](http://1b210.qa.suse.de/tests/8506), [x86_64-node03](http://1b210.qa.suse.de/tests/8504)