### PR TITLE
Fix zfcp device mappings validation

### DIFF
--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -53,12 +53,10 @@ test_data:
             scsi:
               peripheral_type: disk
               vendor_model_revision: 'IBM'
-              device_node_name: '/dev/sda'
           - wwpn: '0x500507630713d3b3'
             scsi:
               peripheral_type: disk
               vendor_model_revision: 'IBM'
-              device_node_name: '/dev/sdb'
       - fcp_channel: '0.0.fc00'
         attributes:
           online: 0

--- a/tests/console/validate_zfcp.pm
+++ b/tests/console/validate_zfcp.pm
@@ -115,23 +115,24 @@ sub verify_scsi_devices {
             # Validate scsi devices with specific scsi command
             my $peripheral_type       = $lun->{scsi}->{peripheral_type};
             my $vendor_model_revision = $lun->{scsi}->{vendor_model_revision};
-            my $device_node_name      = $lun->{scsi}->{device_node_name};
-            my $iscsi_output          = script_output("lsscsi | grep '$device_node_name'");
-
-            unless ($iscsi_output =~ /^\[(?<hctl>.*)\]\s*$peripheral_type\s+$vendor_model_revision/)
-            {
-                die "SCSI device $device_node_name was not found with peripheral type '$peripheral_type' and " .
-                  "vendor/model/revision '$vendor_model_revision'";
-            }
-
-            # Save H:C:T:L
-            my $hctl = $+{hctl};
 
             # Validate scsi devices with specific command for zfcp: lszfcp
-            my $fcp_channel = $fcp_device->{fcp_channel};
-            my $wwpn        = $lun->{wwpn};
-            my $bus_wwpn    = "$fcp_channel/$wwpn";
-            validate_script_output("lszfcp -D -b $fcp_channel | grep '$bus_wwpn'", qr/$hctl/);
+            my $fcp_channel  = $fcp_device->{fcp_channel};
+            my $wwpn         = $lun->{wwpn};
+            my $bus_wwpn     = "$fcp_channel/$wwpn";
+            my $iscsi_output = script_output("lszfcp -D -b $fcp_channel | grep '$bus_wwpn'");
+
+            # Store SCSI target id H:C:T:L
+            my $hctl;
+            if ($iscsi_output =~ /(?<hctl>(\d+:){3}\d+)/)
+            {
+                $hctl = $+{hctl};
+            } else {
+                die "Could not parse SCSI target ID for the device with wwpn: '$bus_wwpn'";
+            }
+
+            assert_script_run("lsscsi | grep '$hctl.*/dev/'",
+                fail_message => "Device with wwpn: '$bus_wwpn' is not mapped to any device node");
 
             # Validate scsi devices with specific command for zfcp: lszdev
             $bus_wwpn = "$fcp_channel:$wwpn";


### PR DESCRIPTION
We have a problem that we cannot guarantee which device name which zfcp
device will get, so we should receive those expectations from the static
information which are luns wwpn and the channel id.

After first attempt we still had dependency on the device node name,
which is now removed, whereas we still validate that lsscsi output shows
that devices are properly mapped.

See [poo#81146](https://progress.opensuse.org/issues/81146).
[Verification run](https://openqa.suse.de/tests/5472253#).