### PR TITLE
HA offline migration tests fully migrated to YAML

### DIFF
--- a/schedule/ha/bv/ha_supportserver.yaml
+++ b/schedule/ha/bv/ha_supportserver.yaml
@@ -22,7 +22,6 @@ vars:
   DESKTOP: textmode
   QEMU_DISABLE_SNAPSHOTS: '1'
   SUPPORT_SERVER: '1'
-  SUPPORT_SERVER_ROLES: dhcp,dns,ntp,ssh,iscsi
   VIDEOMODE: text
   VIRTIO_CONSOLE: '0'
   # Below setting must be defined in the openQA UI because macros for %VERSION%,

--- a/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
@@ -1,0 +1,72 @@
+---
+name: migration_offline_sles_ha
+description: >
+  Offline migration from installed SLES with HA extension
+
+  This test does an offline migration using the *DVD* media, with or without SCC registration.
+vars:
+  BOOTFROM: 'd'
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: 'textmode'
+  FULL_UPDATE: '1'
+  HDDVERSION: '%ORIGIN_SYSTEM_VERSION%'
+  INSTALLONLY: '1'
+  MAX_JOB_TIME: '14400'
+  ORIGINAL_TARGET_VERSION: '%VERSION%'
+  PATCH: '1'
+  TERMINATE_AFTER_JOBS_DONE: '1'
+  TIMEOUT_SCALE: '2'
+  UEFI_PFLASH_VARS: '%DISTRI%-%HDDVERSION%-%ARCH%-ha-%CLUSTER_NAME%-%HOSTNAME%-uefi-vars.qcow2'
+  UPGRADE: '1'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - '{{bootloader_zkvm}}'
+  - boot/boot_to_desktop
+  - update/patch_sle
+  - migration/record_disk_info
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - '{{bootloader}}'
+  - installation/welcome
+  - installation/upgrade_select
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - migration/post_upgrade
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/zypper_lr
+  - console/system_prepare
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+  - '{{upload_zkvm}}'
+conditional_schedule:
+  bootloader:
+    ARCH:
+      aarch64:
+        - installation/bootloader_uefi
+      ppc64le:
+        - installation/bootloader
+      s390x:
+        - installation/bootloader_zkvm
+      x86_64:
+        - installation/bootloader
+  bootloader_zkvm:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
+  upload_zkvm:
+    ARCH:
+      s390x:
+        - shutdown/svirt_upload_assets

--- a/schedule/ha/bv/migration/migration_online_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_online_sles_ha.yaml
@@ -1,0 +1,57 @@
+---
+name: migration_online_sles_ha
+description: >
+  Online migration from installed SLES with HA extension
+
+  This test does an online migration using zypper
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: 'textmode'
+  FULL_UPDATE: '1'
+  HDDVERSION: '%ORIGIN_SYSTEM_VERSION%'
+  INSTALLONLY: '1'
+  MAX_JOB_TIME: '14400'
+  MIGRATION_METHOD: 'zypper'
+  ONLINE_MIGRATION: '1'
+  ORIGINAL_TARGET_VERSION: '%VERSION%'
+  SCC_REGISTER: 'installation'
+  TIMEOUT_SCALE: '2'
+  UEFI_PFLASH_VARS: '%DISTRI%-%HDDVERSION%-%ARCH%-ha-%CLUSTER_NAME%-%HOSTNAME%-uefi-vars.qcow2'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - '{{bootloader}}'
+  - migration/online_migration/online_migration_setup
+  - migration/online_migration/register_system
+  - migration/online_migration/zypper_patch
+  - '{{remove_ltss}}'
+  - migration/version_switch_upgrade_target
+  - migration/online_migration/pre_migration
+  - migration/online_migration/zypper_migration
+  - migration/online_migration/post_migration
+  - console/system_prepare
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+  - '{{upload_zkvm}}'
+conditional_schedule:
+  bootloader:
+    ARCH:
+      aarch64:
+        - installation/bootloader_uefi
+      ppc64le:
+        - installation/bootloader
+      s390x:
+        - installation/bootloader_zkvm
+      x86_64:
+        - installation/bootloader
+  upload_zkvm:
+    ARCH:
+      s390x:
+        - shutdown/svirt_upload_assets
+  remove_ltss:
+    LTSS:
+      1:
+        - migration/online_migration/register_without_ltss

--- a/schedule/ha/bv/migration/migration_verify_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_verify_sles_ha.yaml
@@ -1,0 +1,43 @@
+---
+name: migration_verify_sles_ha
+description: >
+  Offline migration from installed SLES with HA extension
+
+  This test does an offline migration using the *DVD* media, with or without SCC registration.
+vars:
+  BOOTFROM: 'c'
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: 'textmode'
+  HA_CLUSTER: '1'
+  QEMU_DISABLE_SNAPSHOTS: '1'
+  TIMEOUT_SCALE: '2'
+  UEFI_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-Build%BUILD%-HA-BV-uefi-vars.qcow2'
+schedule:
+  - '{{boot_zkvm}}'
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - '{{luns_zkvm}}'
+  - '{{additionals_sle12_sle11}}'
+  - ha/check_after_reboot
+  - ha/check_hawk
+conditional_schedule:
+  additionals_sle12_sle11:
+    ORIGIN_SYSTEM_VERSION:
+      11-SP4:
+        - ha/upgrade_from_sle11sp4_workarounds
+        - ha/migrate_clvmd_to_lvmlockd
+      12-SP3:
+        - ha/migrate_clvmd_to_lvmlockd
+      12-SP4:
+        - ha/migrate_clvmd_to_lvmlockd
+      12-SP5:
+        - ha/migrate_clvmd_to_lvmlockd
+  boot_zkvm:
+    ARCH:
+      s390x:
+        - ha/barrier_init
+        - installation/bootloader_zkvm
+  luns_zkvm:
+    ARCH:
+      s390x:
+        - ha/setup_hosts_and_luns


### PR DESCRIPTION
We are starting the process to convert all our test suites to YAML in order to no longer use the main_common "scheduler".
It will be done step by step due to the huge amount of tests, this PR covers all the migration types (offline_dvd, offline_scc, online).

- Related ticket: N/A
- Needles: N/A
- [Job group definition](https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/243)
- Verification run: 

1. Offline dvd migrations:
12-SP3 ltss: [migration_offline_dvd_node1](http://1b143.qa.suse.de/tests/6978), [migration_offline_dvd_node2](http://1b143.qa.suse.de/tests/6979), [migration_offline_dvd_verify_node1](http://1b143.qa.suse.de/tests/6981), [migration_offline_dvd_verify_node1](http://1b143.qa.suse.de/tests/6982), [migration_offline_dvd_supportserver](http://1b143.qa.suse.de/tests/6979)
15-SP1 ltss: [migration_offline_dvd_node1](http://1b143.qa.suse.de/tests/6761), [migration_offline_dvd_node2](http://1b143.qa.suse.de/tests/6762), [migration_offline_dvd_verify_node1](http://1b143.qa.suse.de/tests/6776), [migration_offline_dvd_verify_node1](http://1b143.qa.suse.de/tests/6777), [migration_offline_dvd_supportserver](http://1b143.qa.suse.de/tests/6775)
15-SP2: [migration_offline_dvd_node1](http://1b143.qa.suse.de/tests/6766), [migration_offline_dvd_node2](http://1b143.qa.suse.de/tests/6767), [migration_offline_dvd_verify_node1](http://1b143.qa.suse.de/tests/6768), [migration_offline_dvd_verify_node1](http://1b143.qa.suse.de/tests/6769), [migration_offline_dvd_supportserver](http://1b143.qa.suse.de/tests/6765)

2. Offline scc migrations:
12-SP3 ltss: [migration_offline_scc_node1](http://1b143.qa.suse.de/tests/6933), [migration_offline_scc_node2](http://1b143.qa.suse.de/tests/6934), [migration_offline_scc_verify_node1](http://1b143.qa.suse.de/tests/6935), [migration_offline_scc_verify_node1](http://1b143.qa.suse.de/tests/6936), [migration_offline_scc_supportserver](http://1b143.qa.suse.de/tests/6932)
15-SP1 ltss: [migration_offline_scc_node1](http://1b143.qa.suse.de/tests/6878), [migration_offline_scc_node2](http://1b143.qa.suse.de/tests/6879), [migration_offline_scc_verify_node1](http://1b143.qa.suse.de/tests/6880), [migration_offline_scc_verify_node1](http://1b143.qa.suse.de/tests/6881), [migration_offline_scc_supportserver](http://1b143.qa.suse.de/tests/6877)
15-SP2: [migration_offline_scc_node1](http://1b143.qa.suse.de/tests/6833), [migration_offline_scc_node2](http://1b143.qa.suse.de/tests/6834), [migration_offline_scc_verify_node1](http://1b143.qa.suse.de/tests/6835), [migration_offline_scc_verify_node1](http://1b143.qa.suse.de/tests/6836), [migration_offline_scc_supportserver](http://1b143.qa.suse.de/tests/6832)
3. Online migrations:
15: [migration_online_node1](http://1b143.qa.suse.de/tests/6551) [migration_online_node2](http://1b143.qa.suse.de/tests/6552) [migration_online_verify_node1](http://1b143.qa.suse.de/tests/6553) [migration_online_verify_node2](http://1b143.qa.suse.de/tests/6554) [migration_online_verify_supportserver](http://1b143.qa.suse.de/tests/6550) 
15-SP1: [migration_online_node1](http://1b143.qa.suse.de/tests/6528) [migration_online_node2](http://1b143.qa.suse.de/tests/6529) [migration_online_verify_node1](http://1b143.qa.suse.de/tests/6548) [migration_online_verify_node2](http://1b143.qa.suse.de/tests/6549) [migration_online_verify_supportserver](http://1b143.qa.suse.de/tests/6547) 
15-SP2: [migration_online_node1](http://1b143.qa.suse.de/tests/6579) [migration_online_node2](http://1b143.qa.suse.de/tests/6580) [migration_online_verify_node1](http://1b143.qa.suse.de/tests/6581) [migration_online_verify_node2](http://1b143.qa.suse.de/tests/6582) [migration_online_verify_supportserver](http://1b143.qa.suse.de/tests/6578) 