### PR TITLE
Fix failure of test_nodedesc in infiniband tests

### DIFF
--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -15,7 +15,7 @@ vars:
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_CONSOLE: ttyS1,115200
-    PACKAGES: rdma-core
+    PACKAGES: rdma-core,rdma-ndd
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
 schedule:

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -15,7 +15,7 @@ vars:
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_CONSOLE: ttyS1,115200
-    PACKAGES: rdma-core
+    PACKAGES: rdma-core,rdma-ndd
     PARALLEL_WITH: ibtest-master
     PATTERNS: base,minimal
     SCC_ADDONS: sdk


### PR DESCRIPTION
For the same reason we had to install rdma-core during system
installation, we need to install rdma-ndd at the same time.
This prevents the calls to smpquery from failing, due to starting them
too soon.

- Related ticket: https://progress.opensuse.org/issues/88539
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1488
- Verification run: http://baremetal-support.qa.suse.de/tests/774 and http://baremetal-support.qa.suse.de/tests/775