### PR TITLE
Add check for @/home subvolume

### DIFF
--- a/lib/partitions_validator_utils.pm
+++ b/lib/partitions_validator_utils.pm
@@ -20,7 +20,8 @@ our @EXPORT = qw(
   validate_partition_creation
   validate_filesystem
   validate_read_write
-  validate_unpartitioned_space);
+  validate_unpartitioned_space
+  validate_subvolume);
 
 sub validate_partition_table {
     my $args = shift;
@@ -71,6 +72,14 @@ sub validate_unpartitioned_space {
             die "There is $+{unpartitioned} unpartitioned disk space." if ($+{unpartitioned} gt $args->{allowed_unpartitioned});
         }
     }
+}
+
+sub validate_subvolume {
+    my $args = shift;
+    record_info("Check $args->{subvolume}",
+        "Check if $args->{subvolume} subvolume exists in $args->{mount_point} partition");
+    assert_script_run("btrfs subvolume list $args->{mount_point} | grep $args->{subvolume}",
+        fail_message => "Subvolume $args->{subvolume} does not exist in $args->{mount_point} partition");
 }
 
 1;

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -32,6 +32,8 @@ schedule:
   - console/consoletest_setup
   - console/validate_installed_software
   - console/yast2_i
+  - console/verify_no_separate_home
+  - console/validate_subvolumes
 conditional_schedule:
   boot_handler:
     BACKEND:

--- a/test_data/yast/select_modules_and_patterns.yaml
+++ b/test_data/yast/select_modules_and_patterns.yaml
@@ -12,3 +12,6 @@ software:
       installed: 1
     devel_yast:
       installed: 1
+validate_subvolumes:
+  - subvolume: home
+    mount_point: /

--- a/tests/console/validate_subvolumes.pm
+++ b/tests/console/validate_subvolumes.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate that the subvolumes, specified in the test data,
+# exist in the given partition (described by mount point).
+# example of expected test data syntax:
+# test_data:
+#   validate_subvolumes:
+#     - subvolume: subvolume1
+#       mount_point: /
+#     - subvolume: subvolume2
+#       mount_point: /home
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use partitions_validator_utils 'validate_subvolume';
+
+sub run {
+    my $test_data = get_test_suite_data;
+    select_console 'root-console';
+
+    foreach my $subvolume (@{$test_data->{validate_subvolumes}}) {
+        validate_subvolume({
+                subvolume   => $subvolume->{subvolume},
+                mount_point => $subvolume->{mount_point}
+        });
+    }
+}
+
+1;


### PR DESCRIPTION
Add extra check for test scenario select_modules_and_patterns, for the architectures that test explicitly sets no separate home partition.

- Related ticket: https://progress.opensuse.org/issues/88480
- Verification runs:
64bit -> https://openqa.suse.de/t5472305
s390x-kvm-sle12 -> https://openqa.suse.de/t5472306
ppc64le -> https://openqa.suse.de/t5472307
aarch64 -> https://openqa.suse.de/t5472308
