### PR TITLE
ibtests: Call upload_ibtest_logs() as OOP method

### DIFF
--- a/tests/kernel/ibtests.pm
+++ b/tests/kernel/ibtests.pm
@@ -130,10 +130,10 @@ sub run {
 
 
     if ($role eq 'IBTEST_MASTER') {
-        ibtest_master;
+        $self->ibtest_master;
     }
     elsif ($role eq 'IBTEST_SLAVE') {
-        ibtest_slave;
+        $self->ibtest_slave;
     }
 
     power_action('poweroff');


### PR DESCRIPTION
Fixes  Can't call method "upload_ibtest_logs" on an undefined value at
tests/kernel/ibtests.pm line 50.

Verification run:
- http://openqa.suse.de/t5473106
- http://openqa.suse.de/t5473107