### PR TITLE
Add cluster after slurmdb did start and open socket

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -71,7 +71,9 @@ EOF
     record_info("slurmdbd conf", script_output("cat /etc/slurm/slurmdbd.conf"));
     $self->enable_and_start("slurmdbd");
     systemctl('is-active slurmdbd');
-    script_run('sacctmgr -i add cluster linux');
+    # wait for slurmdbd sockets to avoid 'Connection refused'
+    assert_script_run('until ss -apn|grep pid=$(pidof slurmdbd)|grep LIST; do echo "waiting for slurmdb daemon"; done');
+    assert_script_run('sacctmgr -i add cluster linux');
     barrier_wait('SLURM_SETUP_DBD');
     barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/80292
- Verification run:
https://openqa.suse.de/tests/5472883#step/slurm_db/113
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP1&build=%3A18272%3Abind&groupid=237