### PR TITLE
desktop_mainmenu: Xfce on 15.3 also needs the super key now

### DIFF
--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -27,7 +27,7 @@ sub run {
         # or Super_L or Windows key
         x11_start_program('lxpanelctl menu', target_match => 'test-desktop_mainmenu-1');
     }
-    elsif (check_var("DESKTOP", "xfce") && !is_leap("<16.0")) {
+    elsif (check_var("DESKTOP", "xfce") && !is_leap("<15.3")) {
         send_key "super";
     }
     elsif (check_var("DESKTOP", "xfce")) {


### PR DESCRIPTION
Verification run: https://openqa.opensuse.org/tests/1632829
