### PR TITLE
Add workaround to select Format Device on aarch

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/FormatMountOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/FormatMountOptionsPage.pm
@@ -14,6 +14,7 @@
 package Installation::Partitioner::LibstorageNG::v4_3::FormatMountOptionsPage;
 use strict;
 use warnings;
+use YuiRestClient::Wait;
 
 sub new {
     my ($class, $args) = @_;
@@ -50,7 +51,12 @@ sub enter_formatting_options {
 
 sub select_format {
     my ($self) = @_;
-    return $self->{rb_format_device}->select();
+    # Workaround with selecting 'Format Device' radio button until 'Filesystem' combobox is enabled.
+    # Needed to resolve sporadic issue on aarch64, that most likely happens due to workers slowness: poo#88524
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->{rb_format_device}->select();
+            return $self->{cb_filesystem}->is_enabled();
+    });
 }
 
 sub select_not_format {

--- a/lib/YuiRestClient/Widget/ComboBox.pm
+++ b/lib/YuiRestClient/Widget/ComboBox.pm
@@ -39,4 +39,12 @@ sub value {
     return $self->property('value');
 }
 
+# When combobox is enabled it does not have 'enabled' property. Only in case it is disabled, the property appears
+# and equals to 'false'.
+sub is_enabled {
+    my ($self) = @_;
+    my $is_enabled = $self->property('enabled');
+    return !defined $is_enabled || $is_enabled;
+}
+
 1;


### PR DESCRIPTION
The test failed sporadically. I've started 20 runs, 10 of them were failed. 

I cannot reproduce the issue manually though. So this looks like libyui-rest-api selects 'Format Device' radio button too quick for slow aarch64 workers and event to enable "Formatting Options" is not fired.

So, I see two possible solutions here:

1. Not so right, but quick and possible to implement: select Format device radiobutton until Filesystem combobox is enabled;
2. Most proper, but I'm not sure yet if it is possible to implement: update libyui-rest-api to allow checking if an element is loaded and visible on screen. That will allow to not manipulate with the items once they loaded but not shown on UI.

This PR introduces the 1st solution.

I do not pretend that this is a perfect one, but it will allow test to work. I think we can apply it, at least temporarily, until we figure out whether it can be fixed in libyui-rest-api.

For more details about the issue please see the discussion in https://progress.opensuse.org/issues/88524

- Related ticket: https://progress.opensuse.org/issues/88524
- Verification runs: https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=148.1_oorlov&groupid=96
