### PR TITLE
Fix manually_add_profile needle mismatich failure

### DIFF
--- a/tests/security/yast2_apparmor/manually_add_profile.pm
+++ b/tests/security/yast2_apparmor/manually_add_profile.pm
@@ -52,7 +52,7 @@ sub run {
     # it should be failed
     assert_and_click("AppArmor-Manually-Add-Profile", timeout => 60);
     send_key "alt-l";
-    assert_screen("AppArmor-Chose-a-program-to-generate-a-profile", timeout => 90);
+    send_key_until_needlematch("AppArmor-Chose-a-program-to-generate-a-profile", "alt-n", 30, 3);
     type_string("$test_file");
     send_key "alt-o";
     assert_screen("AppArmor-generate-a-profile-Error");


### PR DESCRIPTION
It is a random failure on aarch64, enhance test code to handle this failure.

- Related ticket: https://progress.opensuse.org/issues/80234
- Needles: added to github already
- Verification run: https://openqa.suse.de/tests/5481632
