### PR TITLE
Remove UEFI_PFLASH_VARS from HA YAML scheduling

### DIFF
--- a/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
@@ -16,9 +16,10 @@ vars:
   PATCH: '1'
   TERMINATE_AFTER_JOBS_DONE: '1'
   TIMEOUT_SCALE: '2'
-  UEFI_PFLASH_VARS: '%DISTRI%-%HDDVERSION%-%ARCH%-ha-%CLUSTER_NAME%-%HOSTNAME%-uefi-vars.qcow2'
   UPGRADE: '1'
   UPGRADE_TARGET_VERSION: '%VERSION%'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1, UEFI_PFLASH_VARS
 schedule:
   - migration/version_switch_origin_system
   - '{{bootloader_zkvm}}'

--- a/schedule/ha/bv/migration/migration_online_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_online_sles_ha.yaml
@@ -16,8 +16,9 @@ vars:
   ORIGINAL_TARGET_VERSION: '%VERSION%'
   SCC_REGISTER: 'installation'
   TIMEOUT_SCALE: '2'
-  UEFI_PFLASH_VARS: '%DISTRI%-%HDDVERSION%-%ARCH%-ha-%CLUSTER_NAME%-%HOSTNAME%-uefi-vars.qcow2'
   UPGRADE_TARGET_VERSION: '%VERSION%'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1, UEFI_PFLASH_VARS
 schedule:
   - migration/version_switch_origin_system
   - '{{bootloader}}'

--- a/schedule/ha/bv/migration/migration_verify_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_verify_sles_ha.yaml
@@ -11,7 +11,8 @@ vars:
   HA_CLUSTER: '1'
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '2'
-  UEFI_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-Build%BUILD%-HA-BV-uefi-vars.qcow2'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1, UEFI_PFLASH_VARS
 schedule:
   - '{{boot_zkvm}}'
   - boot/boot_to_desktop


### PR DESCRIPTION
This variable is not read in the YAML scheduling files, it must be configured in the YAML job
  group.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
