### PR TITLE
Add the reconnect_mgmt_console module to s390x HA

### DIFF
--- a/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
@@ -39,7 +39,7 @@ schedule:
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation
-  - installation/grub_test
+  - '{{after_reboot}}'
   - installation/first_boot
   - migration/post_upgrade
   - console/system_prepare
@@ -67,6 +67,16 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/bootloader_zkvm
+  after_reboot:
+    ARCH:
+      aarch64:
+        - installation/grub_test
+      ppc64le:
+        - installation/grub_test
+      s390x:
+        - boot/reconnect_mgmt_console
+      x86_64:
+        - installation/grub_test
   upload_zkvm:
     ARCH:
       s390x:


### PR DESCRIPTION
I forgot to add the `boot/reconnect_mgmt_console` module in the s390x migration tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
