### PR TITLE
Make openvswitch-ipsec test more stable

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -368,7 +368,9 @@ else {
                 barrier_create('traffic_check_done2', 2);
                 barrier_create('cert_done',           2);
                 barrier_create('host2_cert_ready',    2);
+                barrier_create('empty_directories',   2);
                 barrier_create('cacert_done',         2);
+                barrier_create('end_of_test',         2);
             }
             loadtest 'installation/bootloader_start';
             loadtest 'network/setup_multimachine';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1067,8 +1067,10 @@ else {
             barrier_create('ipsec2_done',         2);
             barrier_create('traffic_check_done2', 2);
             barrier_create('cert_done',           2);
+            barrier_create('empty_directories',   2);
             barrier_create('host2_cert_ready',    2);
             barrier_create('cacert_done',         2);
+            barrier_create('end_of_test',         2);
         }
         loadtest 'installation/bootloader_start';
         boot_hdd_image;

--- a/tests/console/ovs_client.pm
+++ b/tests/console/ovs_client.pm
@@ -95,6 +95,9 @@ sub run {
     barrier_wait 'traffic_check_done1';
 
     assert_script_run("rm -r $dir* $dir_certs* $dir_private*");
+
+    barrier_wait 'empty_directories';
+
     assert_script_run("ovs-vsctl del-br br-ipsec");
     add_bridge("$client_vpn");
 
@@ -123,6 +126,8 @@ sub run {
 
     assert_script_run("ovs-vsctl del-br br-ipsec");
     assert_script_run("rm -r $dir* $dir_certs* $dir_private*");
+
+    barrier_wait 'end_of_test';
 }
 
 1;

--- a/tests/console/ovs_server.pm
+++ b/tests/console/ovs_server.pm
@@ -97,9 +97,12 @@ sub run {
     barrier_wait 'traffic_check_done1';
 
     assert_script_run("rm -r $dir* $dir_certs* $dir_private*");
+    barrier_wait 'empty_directories';
 
     assert_script_run("ovs-vsctl del-br br-ipsec");
     add_bridge("$server_vpn");
+
+    barrier_wait 'host2_cert_ready';
 
     # Setup IPsec tunnel using CA-signed certificate
     assert_script_run("ovs-pki init");
@@ -110,7 +113,7 @@ sub run {
     assert_script_run("ovs-pki -b sign host_1 switch");
 
     # Wait for the client to send the certificate request and sign it with the CA key
-    barrier_wait 'host2_cert_ready';
+
     assert_script_run("ovs-pki -b sign host_2 switch");
 
     # Copy the client's certificate and CA certificate to client
@@ -136,6 +139,8 @@ sub run {
 
     assert_script_run("ovs-vsctl del-br br-ipsec");
     assert_script_run("rm -r $dir* $dir_certs* $dir_private* $dir_cacerts*");
+
+    barrier_wait 'end_of_test';
 
 }
 


### PR DESCRIPTION
Test `ovs-server` seems to fail sporadically. Two new barriers have been added in order to enforce the stability of the tests (`ovs-server` and `ovs-client`)

- One barrier is added after a directories' cleanup, as these directories are being used again within the next commands.
- One barrier is added in the end of the tests, to secure that both of the tests can finish in a parallel way.

- Related ticket: https://progress.opensuse.org/issues/88073
- Needles: N/A
- Verification run: 
Tumbleweed : [ovs-server](http://10.163.41.158/tests/237) | [ovs-client](http://10.163.41.158/tests/238)
SLE 15-SP2 : [ovs-server](http://10.163.41.158/tests/243) | [ovs-client](http://10.163.41.158/tests/244)
SLE 15-SP3 : [ovs-server](http://10.163.41.158/tests/255) | [ovs-client](http://10.163.41.158/tests/256)
