### PR TITLE
HA barriers have to be load in only one s390x node

### DIFF
--- a/schedule/ha/bv/migration/migration_verify_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_verify_sles_ha.yaml
@@ -14,6 +14,7 @@ vars:
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1, UEFI_PFLASH_VARS
 schedule:
+  - '{{s390x_cluster_setup}}'
   - '{{boot_zkvm}}'
   - boot/boot_to_desktop
   - ha/wait_barriers
@@ -36,9 +37,12 @@ conditional_schedule:
   boot_zkvm:
     ARCH:
       s390x:
-        - ha/barrier_init
         - installation/bootloader_zkvm
   luns_zkvm:
     ARCH:
       s390x:
         - ha/setup_hosts_and_luns
+  s390x_cluster_setup:
+    HA_CLUSTER_SETUP:
+      1:
+        - ha/barrier_init


### PR DESCRIPTION
While a migration verify test, the module `ha/barrier_init` must be loaded in only one node on s390x

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
