### PR TITLE
Modify yast_dns_server test domain

### DIFF
--- a/tests/yast2_cmd/yast_dns_server.pm
+++ b/tests/yast2_cmd/yast_dns_server.pm
@@ -75,13 +75,13 @@ sub run {
     assert_script_run(qq(sed -i 's/NETCONFIG_FORCE_REPLACE="no"/NETCONFIG_FORCE_REPLACE="yes"/' /etc/sysconfig/network/config));
 
     #Forward server and test lookup
-    my $suseip = script_output("dig www.suse.com +short");
-    $suseip =~ s/.*(\d+\.\d+\.\d+\.\d+).*/$1/s;
+    my $opensuseip = script_output("dig www.opensuse.org +short");
+    $opensuseip =~ s/.*^(\d+\.\d+\.\d+\.\d+).*/$1/ms;
     $self->cmd_handle("forwarders", "add", ip => "10.0.2.3");
     #disable dnssec validation
     assert_script_run("sed -i 's/#dnssec-validation auto/dnssec-validation no/' /etc/named.conf");
     systemctl("start named.service");
-    validate_script_output('dig @localhost www.suse.com +short', sub { /\Q$suseip\E/ });
+    validate_script_output('dig @localhost www.opensuse.org +short', sub { /\Q$opensuseip\E/ });
 
     assert_script_run("sed -i 's/dnssec-validation no/#dnssec-validation auto/' /etc/named.conf");
     $self->cmd_handle("forwarders", "remove", ip => "10.0.2.3");


### PR DESCRIPTION
After recent changes for www.suse.com DNS round robin, it is not a
suitable domain for testing the dns server set-up of test scenario
yas2_cmd.

- Related ticket: https://progress.opensuse.org/issues/88621
- Verification runs:
     * 64bit -> https://openqa.suse.de/t5499748
     * aarch64 -> https://openqa.suse.de/t5499750
     * ppc64le -> https://openqa.suse.de/t5499751
