### PR TITLE
yast2_apparmor: Use more reliable wait_still_screen

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -91,8 +91,10 @@ sub run {
     send_key(is_pre_15() ? 'alt-o' : 'alt-s');
     wait_still_screen(3);
     assert_screen 'yast2_apparmor_profile_mode_configuration_show_all';
-    wait_screen_change { send_key 'tab' };                              # focus on first element in the list
-    wait_screen_change { send_key(is_pre_15() ? 'alt-t' : 'alt-c') };
+    send_key 'tab';    # focus on first element in the list
+    wait_still_screen(3);
+    send_key(is_pre_15() ? 'alt-t' : 'alt-c');
+    wait_still_screen(3);
     assert_screen [qw(
           yast2_apparmor_profile_mode_configuration_toggle
           yast2_apparmor_profile_mode_configuration_show_all


### PR DESCRIPTION
wait_screen_change must not wait and then are keys pressed too soon

- Fail: https://openqa.suse.de/tests/5481773#step/yast2_apparmor/17
- Verification run: https://openqa.suse.de/tests/5488432#step/yast2_apparmor/13