### PR TITLE
Adapt network setup for Xen domains

### DIFF
--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -150,7 +150,7 @@ sub genmac {
     my @mac = split(/:/, shift);
     my $len = scalar(@mac);
     for (my $i = 0; $i < (6 - $len); $i++) {
-        push @mac, (sprintf("%02X", int(rand(255))));
+        push @mac, (sprintf("%02X", int(rand(254))));
     }
     return lc(join(':', @mac));
 }

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -24,7 +24,7 @@ use warnings;
 use testapi;
 use mm_network;
 
-our @EXPORT = qw(setup_static_network recover_network can_upload_logs iface ifc_exists ifc_is_up);
+our @EXPORT = qw(setup_static_network recover_network can_upload_logs iface ifc_exists ifc_is_up genmac);
 
 =head2 setup_static_network
 
@@ -135,6 +135,24 @@ Return only if network status is UP.
 sub ifc_is_up {
     my ($ifc) = @_;
     return !script_run("ip link show dev $ifc | grep 'state UP'");
+}
+
+=head2 genmac
+
+Generate custom MAC address.
+Used for Xen domU testing, to define MAC address once for whole test suite lifecycle.
+
+ genmac(['aa:bb:cc'])
+
+=cut
+
+sub genmac {
+    my @mac = split(/:/, shift);
+    my $len = scalar(@mac);
+    for (my $i = 0; $i < (6 - $len); $i++) {
+        push @mac, (sprintf("%02X", int(rand(255))));
+    }
+    return lc(join(':', @mac));
 }
 
 1;


### PR DESCRIPTION
As our xen server runs on sle15sp2 and `linux bridge` has been replaced
by `openvswitch`, we need to specify `<virtualport type='openvswitch'/>`
in interface section for each domU.

- Related ticket: [[virtualization] Worker openqaw5-xen-1.qa.suse.de is not reachable (xen-hvm/xen-pv failing)](https://progress.opensuse.org/issues/88299)
- Verification run: 
   * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build24.8-jeos-main@svirt-xen-hvm](http://kepler.suse.cz/tests/3652)
   * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build24.8-jeos-main@svirt-xen-pv](http://kepler.suse.cz/tests/3651#step/glibc_locale/58)
