### PR TITLE
Set correct password for service check of users

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -113,7 +113,7 @@ sub switch_users {
     assert_screen "originUser-login-dm";
     #For poo#88247, we have to restore current user's password before migration,
     #so here need to use the original password.
-    type_password get_var('INCLUDE_SERVICES') ? "$password\n" : "$newpwd\n";
+    type_password(get_required_var('FLAVOR') =~ /Migration/ ? "$password\n" : "$newpwd\n");
     assert_screen "generic-desktop", 120;
 }
 


### PR DESCRIPTION
The condition of INCLUDE_SERVICES can't match all migration test, need change to match the flavor of migration.

- Related ticket: https://progress.opensuse.org/issues/88855
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/5497854
  to avoid regression run desktop change_password : 
    http://openqa.nue.suse.com/tests/5497912#
    http://openqa.nue.suse.com/tests/5497913#
