### PR TITLE
Replace minimal_base with Enhanced_base on autoyast for containers

### DIFF
--- a/data/autoyast_sle15/autoyast_containers_aarch64.xml
+++ b/data/autoyast_sle15/autoyast_containers_aarch64.xml
@@ -94,7 +94,7 @@
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
-      <pattern>minimal_base</pattern>
+      <pattern>enhanced_base</pattern>
     </patterns>
   </software>
   <users config:type="list">

--- a/data/autoyast_sle15/autoyast_containers_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_containers_ppc64le.xml
@@ -107,7 +107,7 @@
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
-      <pattern>minimal_base</pattern>
+      <pattern>enhanced_base</pattern>
     </patterns>
   </software>
   <users config:type="list">

--- a/data/autoyast_sle15/autoyast_containers_s390x.xml
+++ b/data/autoyast_sle15/autoyast_containers_s390x.xml
@@ -120,7 +120,7 @@
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
-      <pattern>minimal_base</pattern>
+      <pattern>enhanced_base</pattern>
     </patterns>
   </software>
   <users config:type="list">

--- a/data/autoyast_sle15/autoyast_containers_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_containers_x86_64.xml
@@ -122,7 +122,7 @@
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
-      <pattern>minimal_base</pattern>
+      <pattern>enhanced_base</pattern>
     </patterns>
   </software>
   <users config:type="list">


### PR DESCRIPTION
To remove the workaround on rootless_podman regarding the read permissions
on /etc/zypp/credentials.d/* I replace the minimal_base with enhanched_base
which installs acl tool.
i have applied the change to all the architectures and i have updated the
test module.


- Related ticket: https://progress.opensuse.org/issues/88843
- Verification run: http://aquarius.suse.cz/tests/4950#
https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2311999&distri=sle&version=15-SP3