### PR TITLE
[WIP] Enable ssh service for gpt test suite (poo#88491) - s390x 

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -42,9 +42,9 @@ sub ensure_ssh_unblocked {
                 send_key_until_needlematch 'ssh-blocked-selected', 'tab', 25;
                 send_key 'ret';
                 send_key_until_needlematch 'ssh-open', 'tab';
-                send_key_until_needlematch 'ssh-service-disabled', 'tab', 25;
-                send_key 'ret';
 		send_key_until_needlematch 'ssh-service-enabled', 'tab';
+		send_key_until_needlematch 'confirm-installation', 'tab';
+		send_key 'ret';
             }
         }
         #performance ci need disable firewall

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -47,9 +47,6 @@ sub ensure_ssh_unblocked {
 		send_key_until_needlematch 'ssh-service-enabled', 'tab';
             }
         }
-	#confirm installation after ssh enabled
-	send_key_until_needlematch 'confirm-installation', 'tab';
-        send_key 'ret';
 
         #performance ci need disable firewall
         if (get_var('DISABLE_FIREWALL')) {
@@ -67,6 +64,12 @@ sub ensure_ssh_unblocked {
             }
         }
     }
+}
+
+sub confirm_installation {
+    #confirm installation after ssh enabled
+    send_key_until_needlematch 'confirm-installation', 'tab';
+    send_key 'ret';
 }
 
 sub check_default_target {
@@ -111,6 +114,7 @@ sub run {
             }
         }
         ensure_ssh_unblocked;
+	confirm_installation;
         check_default_target;
     }
 }

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -41,9 +41,9 @@ sub ensure_ssh_unblocked {
             else {
                 send_key_until_needlematch 'ssh-blocked-selected', 'tab', 25;
                 send_key 'ret';
+                send_key_until_needlematch 'ssh-open', 'tab';
                 send_key_until_needlematch 'ssh-service-disabled', 'tab', 25;
                 send_key 'ret';
-                send_key_until_needlematch 'ssh-open', 'tab';
             }
         }
         #performance ci need disable firewall

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -44,7 +44,7 @@ sub ensure_ssh_unblocked {
                 send_key_until_needlematch 'ssh-open', 'tab';
                 send_key_until_needlematch 'ssh-service-disabled', 'tab', 28;
                 send_key 'ret';
-		send_key_until_needlematch 'ssh-service-enabled', 'tab';
+	        send_key_until_needlematch 'ssh-service-enabled', 'tab';
             }
         }
 
@@ -114,7 +114,7 @@ sub run {
             }
         }
         ensure_ssh_unblocked;
-	confirm_installation;
+        confirm_installation;
         check_default_target;
     }
 }

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -41,6 +41,8 @@ sub ensure_ssh_unblocked {
             else {
                 send_key_until_needlematch 'ssh-blocked-selected', 'tab', 25;
                 send_key 'ret';
+                send_key_until_needlematch 'ssh-service-disabled', 'tab', 25;
+                send_key 'ret';
                 send_key_until_needlematch 'ssh-open', 'tab';
             }
         }

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -44,6 +44,7 @@ sub ensure_ssh_unblocked {
                 send_key_until_needlematch 'ssh-open', 'tab';
                 send_key_until_needlematch 'ssh-service-disabled', 'tab', 25;
                 send_key 'ret';
+		send_key_until_needlematch 'ssh-service-enabled', 'tab';
             }
         }
         #performance ci need disable firewall

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -42,6 +42,8 @@ sub ensure_ssh_unblocked {
                 send_key_until_needlematch 'ssh-blocked-selected', 'tab', 25;
                 send_key 'ret';
                 send_key_until_needlematch 'ssh-open', 'tab';
+                send_key_until_needlematch 'ssh-service-disabled', 'tab', 28;
+                send_key 'ret';
 		send_key_until_needlematch 'ssh-service-enabled', 'tab';
 		send_key_until_needlematch 'confirm-installation', 'tab';
 		send_key 'ret';

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -45,10 +45,12 @@ sub ensure_ssh_unblocked {
                 send_key_until_needlematch 'ssh-service-disabled', 'tab', 28;
                 send_key 'ret';
 		send_key_until_needlematch 'ssh-service-enabled', 'tab';
-		send_key_until_needlematch 'confirm-installation', 'tab';
-		send_key 'ret';
             }
         }
+	#confirm installation after ssh enabled
+	send_key_until_needlematch 'confirm-installation', 'tab';
+        send_key 'ret';
+
         #performance ci need disable firewall
         if (get_var('DISABLE_FIREWALL')) {
             send_key_until_needlematch [qw(firewall-enable firewall-disable)], 'tab';


### PR DESCRIPTION
The gpt test suite is failing at reconnect_mgmt_console because of a disabled ssh service. The ssh port has been opened in installation_overview. But the service is disabled. I have created a new needle for ssh-service-disabled.
The service should be enabled with the selected "enable" button and "return".

- Related ticket: https://progress.opensuse.org/issues/88491
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/1b5b9b551ebf3e8701f32a7efe9be8e892bab85d
- Verification run: https://openqa.opensuse.org/t1641576
