### PR TITLE
Temporary disable kdump testing on xen HVM

### DIFF
--- a/schedule/jeos/sle/jeos-extratest.yaml
+++ b/schedule/jeos/sle/jeos-extratest.yaml
@@ -17,6 +17,20 @@ conditional_schedule:
             'svirt-vmware65':
                 - installation/bootloader_svirt
                 - installation/bootloader_uefi
+    kdump:
+        MACHINE:
+            '64bit-virtio-vga':
+                - console/kdump_and_crash
+            'uefi-virtio-vga':
+                - console/kdump_and_crash
+            'svirt-hyperv-uefi':
+                - console/kdump_and_crash
+            'svirt-hyperv':
+                - console/kdump_and_crash
+            'svirt-vmware65':
+                - console/kdump_and_crash
+            'svirt-xen-pv':
+                - console/kdump_and_crash
 schedule:
     - '{{bootloader}}'
     - jeos/firstrun
@@ -54,4 +68,4 @@ schedule:
     - console/dstat
     - console/journalctl
     - console/procps
-    - console/kdump_and_crash
+    - '{{kdump}}'


### PR DESCRIPTION
Due to [openQA job causes libvirtd to dump core when running kdump inside domain](https://bugzilla.suse.com/show_bug.cgi?id=1181989) we should skip kdump test case.

- Verification runs: 
   * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build24.8-jeos-extratest@svirt-xen-hvm](http://kepler.suse.cz/tests/3655#)
   * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build24.8-jeos-extratest@uefi-virtio-vga](http://kepler.suse.cz/tests/3654#)
