### PR TITLE
Use integration_services as soon as the ssh connection is available

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -579,6 +579,7 @@ sub load_jeos_tests {
             loadtest "jeos/grub2_gfxmode";
             loadtest "jeos/diskusage";
             loadtest "jeos/build_key";
+            loadtest "console/integration_services" if is_hyperv || is_vmware;
         }
         if (is_sle) {
             loadtest "console/suseconnect_scc";
@@ -1080,7 +1081,6 @@ sub load_consoletests {
     loadtest "console/system_state";
     loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
-    loadtest 'console/integration_services' if is_hyperv || is_vmware;
 
     if (get_var('IBM_TESTS')) {
         # prepare tarballs for the testcase

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -224,9 +224,6 @@ Die, if this is not the case.
 
 =cut
 sub integration_services_check_ip {
-    # Workaround for poo#44771 "Can't call method "exec" on an undefined value"
-    select_console('svirt');
-    select_console('sut');
     # Host-side of Integration Services
     my $vmname = console('svirt')->name;
     my $ips_host_pov;
@@ -259,8 +256,8 @@ are present and in working condition.
 
 =cut
 sub integration_services_check {
+    integration_services_check_ip;
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        integration_services_check_ip;
         # Guest-side of Integration Services
         assert_script_run('rpmquery hyper-v');
         assert_script_run('rpmverify hyper-v');
@@ -278,7 +275,6 @@ sub integration_services_check {
         assert_script_run('systemctl list-unit-files | grep hv_fcopy_daemon.service');
     }
     elsif (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
-        integration_services_check_ip;
         assert_script_run('rpmquery open-vm-tools');
         assert_script_run('rpmquery open-vm-tools-desktop') unless check_var('DESKTOP', 'textmode');
         assert_script_run('modinfo vmw_vmci');


### PR DESCRIPTION
Moving the integration_services module early in the scheduling seems to
fix the problem as a workaround.
The modules tries to use the existing ssh connection but it cant create
a new channel.

- Related ticket: https://progress.opensuse.org/issues/81878
- Verification run: http://aquarius.suse.cz/tests/4981
