### PR TITLE
Add noverifycert option to verify host certficate in x3270_ssl

### DIFF
--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -12,7 +12,7 @@
 # Summary: x3270 for SSL support testing, with openssl s_server running on local system
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#65570, poo#65615
+# Tags: poo#65570, poo#65615, poo#89005
 
 use base "x11test";
 use strict;
@@ -42,6 +42,13 @@ sub run {
     # Install x3270
     zypper_call "install x3270";
 
+    # SLE-16633: [post GA] Update x3270 package for SLES 15 SP1 to support noverifycert option
+    # Check x3270 version
+    # x3270 3.6ga version has been submitted to SLE15 SP1, SP2, and SP3
+    zypper_call('info x3270');
+    my $current_ver = script_output("rpm -q --qf '%{version}\n' x3270");
+    record_info("x3270_ver", "Current x3270 package version: $current_ver");
+
     #Generate self-signed x509 certificate
     type_string
 "openssl req -new -x509 -newkey rsa:2048 -keyout $key_file -days 3560 -out $cert_file -nodes -subj \"/C=CN/ST=BJ/L=BJ/O=SUSE/OU=QA/CN=suse/emailAddress=test\@suse.com\" 2>&1 | tee /dev/$serialdev\n";
@@ -63,8 +70,11 @@ sub run {
     x11_start_program('xterm');
     mouse_hide(1);
 
-    #Launch x3270
-    type_string "x3270 -trace -tracefile $tracelog_file L:localhost:8443\n";
+    # Launch x3270
+    # Add noverifycert option if x3270 is or greater than v3.6ga
+    my $noverifycert = ($current_ver < 3.6 ? '' : '-noverifycert');
+    type_string "x3270 -trace $noverifycert -tracefile $tracelog_file L:localhost:8443\n";
+
     assert_screen 'x3270_fips_launched_with_TLS_SSL';
 
     # Exit and back to generic desktop


### PR DESCRIPTION
Description:

x3270 has been upgraded to v3.6 with many bug fixes and patches. It introduces the patch about potentially incompatible changes, it causes the original self-signed host certificates to become unsupported.

1. Workaround the patch: potentially incompatible changes
2. Add noverifycert option to verify host certificate by default

Bug reference:
bsc#[1182390](https://bugzilla.suse.com/show_bug.cgi?id=1182390) - [SLES15SP3][150.1][x3270_ssl] x3270 error: SSL Host certificate verification failed: self signed certificate

- Related ticket: https://progress.opensuse.org/issues/89005
- Needles: x3270_ssl-x3270_fips_launched_with_TLS_SSL-20210223
- Verification run: 
   https://openqa.suse.de/tests/5546744 (SLE15 SP3 Build 154.1 with x3270 v3.6)
   https://openqa.suse.de/tests/5546798 (SLE15 SP3 Build 148.1 with x3270 v3.5)
