### PR TITLE
Move valgrind before orphan check for publiccloud

### DIFF
--- a/schedule/publiccloud/mau-extratests-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-publiccloud.yml
@@ -55,6 +55,6 @@ schedule:
   - console/aaa_base
   - console/osinfo_db
   - console/libgcrypt
-  - console/orphaned_packages_check
   - console/valgrind
+  - console/orphaned_packages_check
   - publiccloud/ssh_interactive_end


### PR DESCRIPTION
Moves the valgrind test before the orphaned_packages_check in all publiccloud test runs

- Related ticket: -
- Verification run: http://duck-norris.qam.suse.de/t5137