### PR TITLE
Exclude rootless_podman module from sle12

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1723,7 +1723,7 @@ sub load_extra_tests_docker {
     loadtest "containers/docker_compose" unless (is_sle('<15') || is_sle('>=15-sp2'));
     loadtest 'containers/registry';
     loadtest "containers/zypper_docker";
-    loadtest "containers/rootless_podman";
+    loadtest "containers/rootless_podman" unless is_sle('<=12-SP5');
 }
 
 sub load_extra_tests_prepare {


### PR DESCRIPTION
podman is not available on sle12 https://openqa.suse.de/tests/5495799#step/rootless_podman/30
So it will not be scheduled for smaller or equal to sle12sp5


- Related ticket: https://progress.opensuse.org/issues/87976
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=b10n1k%2Fos-autoinst-distri-opensuse%2312012
https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2312012&version=15-SP2&distri=sle