### PR TITLE
Revert "workaround: Uninstall btrfsmaintenance bsc#1174436"

### DIFF
--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2020 SUSE LLC
+# Copyright (C) 2015-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,14 +24,8 @@ use warnings;
 use base 'basetest';
 use testapi;
 use power_action_utils 'power_action';
-use version_utils 'is_sle';
-use utils qw(zypper_call);
 
 sub run {
-    if (is_sle('=15-sp2')) {
-        record_soft_failure('bsc#1174436');
-        zypper_call('rm btrfsmaintenance');
-    }
     # We are already in console, so reboot from it and do not switch to x11 or root console
     # Note, on s390x with SLE15 VNC is not running even if enabled in the profile
     power_action('reboot', textmode => 1, keepconsole => 1);


### PR DESCRIPTION
This reverts commit 5ba4f9c26f03ba594f87d93244c432c17d8d5219.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1174436
- Verification run: https://openqa.suse.de/tests/5505655#step/autoyast_reboot/1