### PR TITLE
Move lib/suse_container_urls.pm to lib/containers/urls.pm

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -10,7 +10,7 @@
 # Summary: Database for URLs of container images to be tested
 # Maintainer: Fabian Vogt <fvogt@suse.com>
 
-package suse_container_urls;
+package containers::urls;
 
 use base Exporter;
 use Exporter;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -16,7 +16,7 @@ use File::Basename;
 use File::Find;
 use Exporter;
 use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
-use suse_container_urls 'get_suse_container_urls';
+use containers::urls 'get_suse_container_urls';
 use autotest;
 use utils;
 use wicked::TestContext;

--- a/tests/console/regproxy.pm
+++ b/tests/console/regproxy.pm
@@ -15,7 +15,7 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use suse_container_urls 'get_opensuse_registry_prefix';
+use containers::urls 'get_opensuse_registry_prefix';
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
 sub run {

--- a/tests/containers/buildah_image.pm
+++ b/tests/containers/buildah_image.pm
@@ -20,7 +20,7 @@ use testapi;
 use utils;
 use containers::common;
 use containers::container_images;
-use suse_container_urls 'get_suse_container_urls';
+use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
 
 sub run {

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 use containers::common;
 use containers::container_images;
-use suse_container_urls 'get_suse_container_urls';
+use containers::urls 'get_suse_container_urls';
 use version_utils qw(is_sle get_os_release);
 
 sub run {

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 use containers::common;
 use containers::container_images;
-use suse_container_urls 'get_suse_container_urls';
+use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
 
 sub run {

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -17,7 +17,7 @@ use testapi;
 use utils;
 use containers::common;
 use containers::container_images;
-use suse_container_urls 'get_suse_container_urls';
+use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
 
 sub run {

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 use containers::common;
 use containers::container_images;
-use suse_container_urls 'get_suse_container_urls';
+use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release);
 use version_utils 'is_sle';
 


### PR DESCRIPTION
Hello,

as we have `tests/containers/` as well as `lib/containers/` it makes no sense to keep `lib/suse_container_urls.pm` file out of `lib/containers/` so I decided to move it into `lib/containers/urls.pm` but as this requires a lot of file to be changed I decided to create a separate pull request for that.

- Verification run: [Tumbleweed](http://pdostal-server.suse.cz/tests/11128) [SLE15-SP2](http://pdostal-server.suse.cz/tests/11127)