### PR TITLE
Fix the typo in qam mau yaml schedule

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-extratests1
-descrition: First set of CLI extratests
+description: First set of CLI extratests
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -1,6 +1,6 @@
 ---
 name: mau-extratests2
-descrition: Second set of CLI extratests
+description: Second set of CLI extratests
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop


### PR DESCRIPTION
Profiles do not validate against schema due to the typo.
Fixing it, as it breaks CI for other PRs.

