### PR TITLE
Fix MicroOS image flavor detection

### DIFF
--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -24,7 +24,7 @@ sub is_regproxy_required {
 }
 
 sub is_image_flavor {
-    return get_required_var('FLAVOR') =~ /-Image$/;
+    return get_required_var('FLAVOR') =~ /-Image/;
 }
 
 sub load_boot_from_dvd_tests {


### PR DESCRIPTION
Neither MicroOS-Image-ContainerHost nor MicroOS-Image-Kubic-kubeadm end in
-Image, so fix the check.

Verification runs:
* https://openqa.opensuse.org/t1643820
* https://openqa.opensuse.org/t1643821
* https://openqa.opensuse.org/t1643822
* https://openqa.opensuse.org/t1643823

Failures in two tests due to boo#1182544 are expected.