### PR TITLE
Rework rolling upgrade between two LTSS versions

### DIFF
--- a/lib/zypper.pm
+++ b/lib/zypper.pm
@@ -41,7 +41,7 @@ lock so that we can run a new zypper for our test.
 
 =cut
 sub wait_quit_zypper {
-    assert_script_run 'until ! pgrep zypper; do sleep 1; done';
+    assert_script_run('until ! pgrep \'zypper|purge-kernels|rpm\' > /dev/null; do sleep 10; done', 600);
 }
 
 1;

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01.yaml
@@ -8,7 +8,7 @@ schedule:
   - console/suseconnect_scc
   - update/zypper_up
   - console/console_reboot
-  - '{{register_without_ltss}}'
+  - migration/online_migration/register_without_ltss
   - ha/wait_barriers
   - console/system_prepare
   - console/consoletest_setup
@@ -34,6 +34,7 @@ schedule:
   - '{{cluster_boot_mgmt}}'
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_migration
+  - '{{register_ltss}}'
   - migration/online_migration/post_migration
   - '{{cluster_boot_mgmt}}'
   - '{{console_reboot}}'
@@ -50,7 +51,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/console_reboot
-  register_without_ltss:
-    ORIGIN_SYSTEM_VERSION:
-      15:
-        - migration/online_migration/register_without_ltss
+  register_ltss:
+    LTSS_TO_LTSS:
+      1:
+        - migration/online_migration/register_ltss

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
@@ -34,7 +34,7 @@ schedule:
   - '{{cluster_boot_mgmt}}'
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_migration
-  - '{{register_system}}'
+  - '{{register_ltss}}'
   - migration/online_migration/post_migration
   - '{{cluster_boot_mgmt}}'
   - '{{console_reboot}}'
@@ -51,7 +51,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/console_reboot
-  register_system:
+  register_ltss:
     LTSS_TO_LTSS:
       1:
-        - migration/online_migration/register_system
+        - migration/online_migration/register_ltss

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02.yaml
@@ -8,7 +8,7 @@ schedule:
   - console/suseconnect_scc
   - update/zypper_up
   - console/console_reboot
-  - '{{register_without_ltss}}'
+  - migration/online_migration/register_without_ltss
   - ha/wait_barriers
   - console/system_prepare
   - console/consoletest_setup
@@ -34,6 +34,7 @@ schedule:
   - '{{cluster_boot_mgmt}}'
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_migration
+  - '{{register_ltss}}'
   - migration/online_migration/post_migration
   - '{{cluster_boot_mgmt}}'
   - '{{console_reboot}}'
@@ -50,7 +51,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/console_reboot
-  register_without_ltss:
-    ORIGIN_SYSTEM_VERSION:
-      15:
-        - migration/online_migration/register_without_ltss
+  register_ltss:
+    LTSS_TO_LTSS:
+      1:
+        - migration/online_migration/register_ltss

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
@@ -34,7 +34,7 @@ schedule:
   - '{{cluster_boot_mgmt}}'
   - ha/cluster_state_mgmt
   - migration/online_migration/zypper_migration
-  - '{{register_system}}'
+  - '{{register_ltss}}'
   - migration/online_migration/post_migration
   - '{{cluster_boot_mgmt}}'
   - '{{console_reboot}}'
@@ -51,7 +51,7 @@ conditional_schedule:
     QAM_INCI:
       1:
         - console/console_reboot
-  register_system:
+  register_ltss:
     LTSS_TO_LTSS:
       1:
-        - migration/online_migration/register_system
+        - migration/online_migration/register_ltss

--- a/tests/migration/online_migration/register_ltss.pm
+++ b/tests/migration/online_migration/register_ltss.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Register the LTSS extension
+# Used when we migrate from LTSS to another LTSS version
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use registration qw(add_suseconnect_product);
+use zypper qw(wait_quit_zypper);
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    # Make sure that nothing is using rpm for avoiding lock conflict
+    wait_quit_zypper;
+
+    my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
+    if (grep $_ eq 'ltss', @scc_addons) {
+        my $os_sp_version = get_var("HDDVERSION");
+        $os_sp_version =~ s/-/_/g;
+        add_suseconnect_product("SLES-LTSS", undef, undef, "-r " . get_var("SCC_REGCODE_LTSS_$os_sp_version", 300, 0));
+    }
+}
+
+1;

--- a/tests/migration/online_migration/register_system.pm
+++ b/tests/migration/online_migration/register_system.pm
@@ -15,17 +15,9 @@ use strict;
 use warnings;
 use testapi;
 use migration;
-use registration "scc_deregistration";
 
 sub run {
     select_console 'root-console';
-
-    # Sometimes in HA scenario, we need to test rolling upgrade migration from
-    # a LTSS version to another one LTSS version.
-    # In this case, we need to deregister the system and register it again for adding the
-    # LTSS of the targeted OS version.
-    scc_deregistration if get_var('LTSS_TO_LTSS');
-
     register_system_in_textmode;
 }
 


### PR DESCRIPTION
This PR brings three things:

1. Change the rolling upgrade scheduling file for SLE15 for managing 15SP1-LTSS
2. Simplify how to deal with rolling upgrades between two LTSS migrations. 
Previously, we basically unregistered the system and registered it again with the LTSS instead of simply add the LTSS extension.
3. Modify the `wait_quit_zypper` function, that's not sufficient to only catch a `zypper` process, I've added `purge-kernels` and `rpm`. One reason is that purge-kernels uses `rpm` on 15-SP1 and `zypper` on 15-SP2+.

- Related ticket: https://progress.opensuse.org/issues/88942
- Needles: N/A
- Verification run: 
15 LTSS to 15SP1 LTSS: [node1](http://1b143.qa.suse.de/tests/7095) [node2](http://1b143.qa.suse.de/tests/7096)
15SP1 LTSS to 15SP2: [node1](http://1b143.qa.suse.de/tests/7107) [node2](http://1b143.qa.suse.de/tests/7108)
12SP3 LTSS to 12SP4 LTSS: [node1](http://1b143.qa.suse.de/tests/7104) [node2](http://1b143.qa.suse.de/tests/7105)
12SP4 LTSS to 12SP5: [node1](http://1b143.qa.suse.de/tests/7101) [node2](http://1b143.qa.suse.de/tests/7102)