### PR TITLE
Change wipefs to dd in prepare_disks

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1347,7 +1347,7 @@ sub prepare_disks {
 
     my $disks = script_output('lsblk -n -l -o NAME -d -e 7,11');
     for my $d (split('\n', $disks)) {
-        script_run "wipefs -a /dev/$d";
+        script_run "wipefs -af /dev/$d";
         if (get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_CANCEL_EXISTING'))
         {
             create_encrypted_part(disk => $d);


### PR DESCRIPTION
`wipefs` sometimes didn't clean the disk labels properly (See [poo#89074](https://progress.opensuse.org/issues/89074)).
This commit replaces `wipefs` with `dd` to ensure there is nothing left from the partition table.

- Related ticket: https://progress.opensuse.org/issues/89074
- Verification run: http://duck-norris.qam.suse.de/tests/5138

This PR is related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11325