### PR TITLE
Adopt openscap tests for qam testing

### DIFF
--- a/schedule/qam/common/security/openscap.yml
+++ b/schedule/qam/common/security/openscap.yml
@@ -1,0 +1,16 @@
+---
+name: Openscap
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/openscap/oscap_setup
+    - security/openscap/oscap_info
+    - security/openscap/oscap_oval_scanning
+    - security/openscap/oscap_xccdf_scanning
+    - security/openscap/oscap_source_datastream
+    - security/openscap/oscap_result_datastream
+    - security/openscap/oscap_remediating_online
+    - security/openscap/oscap_remediating_offline
+    - security/openscap/oscap_generating_report
+    - security/openscap/oscap_generating_fix
+    - security/openscap/oscap_validating


### PR DESCRIPTION
Adopt openscap tests to QAM test repo tests.

- Related ticket: https://progress.opensuse.org/issues/58844
- Needles: no
- Verification run: 
- sles12sp4: http://10.67.17.201/tests/1252
- sles12sp5: http://10.67.17.201/tests/1246
- sles15: http://10.67.17.201/tests/1250
- sles15sp1: http://10.67.17.201/tests/1249
- sles15sp2: http://10.67.17.201/tests/1245