### PR TITLE
xfstests: To support kernel live patching

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -725,6 +725,9 @@ elsif (get_var('XFSTESTS')) {
             unless (get_var('NO_KDUMP')) {
                 loadtest 'xfstests/enable_kdump';
             }
+            if (get_var('XFSTEST_KLP')) {
+                loadtest 'kernel/install_klp_product';
+            }
             loadtest 'shutdown/shutdown';
         }
         else {


### PR DESCRIPTION
Add kernel live patching in installation part, and use "XFSTEST_KLP" to open it.

- Verification run: http://10.67.133.133/tests/6
