### PR TITLE
Fix can_build_sle_base

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -213,7 +213,8 @@ The call should return false if the test is run on a non-sle host.
 
 =cut
 sub can_build_sle_base {
-    my $has_sle_registration = script_run("test -e /etc/zypp/credentials.d/SCCcredentials");
+    # script_run returns 0 if true, but true is 1 on perl
+    my $has_sle_registration = !script_run("test -e /etc/zypp/credentials.d/SCCcredentials");
     return check_os_release('sles', 'ID') && $has_sle_registration;
 }
 


### PR DESCRIPTION
Fixing the `can_build_sle_base` subroutine where the return value from `script_run` got mixed with perl logic.
This subroutine is used in `install_docker_when_needed` to check if the system is capable of adding the Containers module.

- Verification run: [Tumbleweed](http://pdostal-server.suse.cz/tests/11152) [Leap15-SP3](http://pdostal-server.suse.cz/tests/11153) [SLE15-SP2](http://pdostal-server.suse.cz/tests/11150) [JeOS15-SP3](http://pdostal-server.suse.cz/tests/11149) [SLE15](http://pdostal-server.suse.cz/tests/11148#details) [SLES12-SP3](http://pdostal-server.suse.cz/tests/11157#live)