### PR TITLE
Enable container tests for openSUSE Maintenance

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -49,6 +49,7 @@ sub build_container_image {
 
     # Build the image
     assert_script_run("$runtime build -t dockerfile_derived .");
+    assert_script_run("cd");
 
     assert_script_run("$runtime run --entrypoint 'printenv' dockerfile_derived WORLD_VAR | grep Arda");
     assert_script_run("$runtime images");

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -193,6 +193,7 @@ sub build_img {
     else {
         die "Unsupported runtime: $runtime";
     }
+    assert_script_run("cd");
     assert_script_run("$runtime images| grep myapp");
 }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1211,6 +1211,7 @@ sub load_consoletests {
         loadtest "console/mysql_srv";
         # disable these tests of server packages for SLED (poo#36436)
         load_console_server_tests() unless is_desktop;
+        load_extra_tests_docker()   unless (is_desktop || !is_released);
     }
     if (check_var("DESKTOP", "xfce")) {
         loadtest "console/xfce_gnome_deps";


### PR DESCRIPTION
Good evening,

the aim of this pull request is to enable regular container testing on openSUSE Leap 15.1 and 15.2.
There are two ways suggested: Either creating new test suite, or including containers in `textmode`.

This is not final propise, but request for your suggestions.

- Related ticket: [poo#88588](https://progress.opensuse.org/issues/88588)
- Known issues: [boo#1182507](https://bugzilla.opensuse.org/show_bug.cgi?id=1182507)
- Verification runs:
   * [openSUSE Leap 15.2 Images) > textmode@64bit](http://pdostal-server.suse.cz/tests/11621)
