### PR TITLE
xfstests: Distinguish generic or non-generic test when include/exclude tests

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -180,14 +180,14 @@ sub tests_from_category {
 # Return matched exclude tests from groups in @GROUPLIST
 # return structure - hash
 # Group name start with ! will exclude in test, and expected to use to update blacklist
+# If TEST_RANGES contain generic tests, then exclude tests from generic folder, else will exclude tests from filesystem type folder
 sub exclude_grouplist {
-    my %tests_list = ();
+    my %tests_list  = ();
+    my $test_folder = $TEST_RANGES =~ /generic/ ? "generic" : $FSTYPE;
     foreach my $group_name (@GROUPLIST) {
         next if ($group_name !~ /^\!/);
         $group_name = substr($group_name, 1);
-        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$FSTYPE/group | awk '{printf \"$FSTYPE/\"}{printf \$1}{printf \",\"}' > tmp.group";
-        script_run($cmd);
-        $cmd = "awk '/$group_name/' $INST_DIR/tests/generic/group | awk '{printf \"generic/\"}{printf \$1}{printf \",\"}' >> tmp.group";
+        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$test_folder/group | awk '{printf \"$test_folder/\"}{printf \$1}{printf \",\"}' > tmp.group";
         script_run($cmd);
         $cmd = "cat tmp.group";
         my %tmp_list = map { $_ => 1 } split(/,/, substr(script_output($cmd), 0, -1));
@@ -199,13 +199,13 @@ sub exclude_grouplist {
 # Return matched include tests from groups in @GROUPLIST
 # return structure - array
 # Group name start without ! will include in test, and expected to use to update test ranges
+# If TEST_RANGES contain generic tests, then include tests from generic folder, else will include tests from filesystem type folder
 sub include_grouplist {
     my @tests_list;
+    my $test_folder = $TEST_RANGES =~ /generic/ ? "generic" : $FSTYPE;
     foreach my $group_name (@GROUPLIST) {
         next if ($group_name =~ /^\!/);
-        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$FSTYPE/group | awk '{printf \"$FSTYPE/\"}{printf \$1}{printf \",\"}' > tmp.group";
-        script_run($cmd);
-        $cmd = "awk '/$group_name/' $INST_DIR/tests/generic/group | awk '{printf \"generic/\"}{printf \$1}{printf \",\"}' >> tmp.group";
+        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$test_folder/group | awk '{printf \"$test_folder/\"}{printf \$1}{printf \",\"}' > tmp.group";
         script_run($cmd);
         $cmd = "cat tmp.group";
         my $tests = substr(script_output($cmd), 0, -1);


### PR DESCRIPTION
During include or exclude tests by group, we will need to go through two
test folder the first is the filesystem type folder the other is generic
folder. In case we include tests from those two folder will cause test
timeout sometimes. Add this commit to include/exclude tests more
flexable. To distinguish generic or non-generic test by consider parameter
XFSTESTS_RANGES contain generic test or not.

- Related ticket: https://progress.opensuse.org/issues/81496
- Verification run: 
Before PR, it will run xfs and generic tests, and cause timeout: http://10.67.133.133/tests/10 
After PR, it will only run xfs tests: http://10.67.133.133/tests/14
And this only run generic tests: http://10.67.133.133/tests/15
Test btrfs-generic: http://10.67.133.133/tests/17
Test btrfs: http://10.67.133.133/tests/18
