### PR TITLE
Exclude rootless_podman from sle versions that do not have podman pgk

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1723,7 +1723,7 @@ sub load_extra_tests_docker {
     loadtest "containers/docker_compose" unless (is_sle('<15') || is_sle('>=15-sp2'));
     loadtest 'containers/registry';
     loadtest "containers/zypper_docker";
-    loadtest "containers/rootless_podman" unless is_sle('<=12-SP5');
+    loadtest "containers/rootless_podman" unless is_sle('<15-SP2');
 }
 
 sub load_extra_tests_prepare {


### PR DESCRIPTION
We missed that the podman is not available in some versions or it doesnt support rootless

- [sle 15 GA](https://openqa.suse.de/tests/5548118)
- [sle 15 SP1](https://openqa.suse.de/tests/5548134)
- [sle 15 SP2](https://openqa.suse.de/tests/5548133)
