### PR TITLE
Add support for kernel-default-base testing

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -258,7 +258,11 @@ sub setup_network {
     # echo/echoes, getaddrinfo_01
     assert_script_run('f=/etc/nsswitch.conf; [ ! -f $f ] && f=/usr$f; sed -i \'s/^\(hosts:\s+files\s\+dns$\)/\1 myhostname/\' $f');
 
-    foreach my $service (qw(auditd dnsmasq nfs-server rpcbind vsftpd)) {
+    my @services = qw(auditd dnsmasq rpcbind vsftpd);
+    # nfsd module is not included in kernel-default-base package
+    push @services, 'nfs-server' unless get_var('KERNEL_BASE');
+
+    foreach my $service (@services) {
         if (!is_jeos && is_sle('12+') || is_opensuse) {
             systemctl("reenable $service");
             assert_script_run("systemctl start $service || { systemctl status --no-pager $service; journalctl -xe --no-pager; false; }");

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -54,6 +54,15 @@ sub prepare_azure {
     boot_to_console($self);
 }
 
+sub prepare_kernel_base {
+    my $self = shift;
+
+    remove_kernel_packages();
+    zypper_call("in -l kernel-default-base", exitcode => [0, 100, 101, 102, 103], timeout => 700);
+    power_action('reboot', textmode => 1);
+    boot_to_console($self);
+}
+
 sub update_kernel {
     my ($repo, $incident_id) = @_;
 
@@ -389,6 +398,10 @@ sub run {
             update_kernel($repo, $incident_id);
         }
     }
+    elsif (get_var('KERNEL_BASE')) {
+        $self->prepare_kernel_base;
+        update_kernel($repo, $incident_id);
+    }
     elsif (get_var('KOTD_REPO')) {
         install_kotd($repo);
     }
@@ -432,6 +445,12 @@ kernel as in the default case.
 When AZURE_FIRST_RELEASE evaluates to true, install kernel-azure directly
 from incident repository and update system. This is a chicken&egg workaround
 because there is never any kernel-azure package in the pool repository.
+
+=head2 KERNEL_BASE
+
+When KERNEL_BASE variable evaluates to true, the job should test the
+alternative minimal kernel. Uninstall kernel-default and install
+kernel-default-base instead. Then update kernel as in the default case.
 
 =head2 KOTD_REPO
 


### PR DESCRIPTION
Add support for installing LTP test images with `kernel-default-base` instead of `kernel-default`.

- Related ticket: https://progress.opensuse.org/issues/89203
- Needles: N/A
- Verification run:
  - aarch64: https://openqa.suse.de/tests/5551436
  - ppc64le: https://openqa.suse.de/tests/5552082
  - s390x: https://openqa.suse.de/tests/5551438
  - x86_64: https://openqa.suse.de/tests/5551435