### PR TITLE
Schedule: run firewall_enabled test also in Stagings

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1187,7 +1187,7 @@ sub load_consoletests {
     }
     loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
 # textmode install comes without firewall by default atm on openSUSE. For virtualization server xen and kvm is disabled by default: https://fate.suse.com/324207
-    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_staging() && !is_krypton_argon && !is_virtualization_server) {
+    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server) {
         loadtest "console/firewall_enabled";
     }
     if (is_jeos) {


### PR DESCRIPTION
The staging project is supposedly close enough to the product and things
like firewall no longer auto-enabling is something we want to see early on.

This could avoid bugs like https://bugzilla.opensuse.org/show_bug.cgi?id=1182821
only being seen after merging into the product.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1182821
- Needles: N/A
- Verification run: 
  * broken yast stack: https://openqa.opensuse.org/tests/1649745 [running]
  * working yast stack: https://openqa.opensuse.org/tests/1649763 [running]
