### PR TITLE
Adjust test data for lvm+RAID1 scenario

### DIFF
--- a/test_data/yast/lvm_raid1/lvm+raid1_hyperv.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_hyperv.yaml
@@ -1,5 +1,5 @@
 ---
-mds: !include test_data/yast/lvm_raid1/lvm+raid1_mds.yaml
+mds: !include test_data/yast/lvm_raid1/lvm+raid1_mds_hyperv.yaml
 lvm: !include test_data/yast/lvm_raid1/lvm+raid1_lvm.yaml
 disks:
   - name: sda

--- a/test_data/yast/lvm_raid1/lvm+raid1_hyperv_uefi.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_hyperv_uefi.yaml
@@ -1,5 +1,5 @@
 ---
-mds: !include test_data/yast/lvm_raid1/lvm+raid1_mds.yaml
+mds: !include test_data/yast/lvm_raid1/lvm+raid1_mds_hyperv.yaml
 lvm: !include test_data/yast/lvm_raid1/lvm+raid1_lvm.yaml
 disks:
   - name: sda

--- a/test_data/yast/lvm_raid1/lvm+raid1_mds_hyperv.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_mds_hyperv.yaml
@@ -2,10 +2,10 @@
 - raid_level: 1
   chunk_size: '64 KiB'
   devices:
-    - vda2
-    - vdb2
-    - vdc2
-    - vdd2
+    - sda2
+    - sdb2
+    - sdc2
+    - sdd2
   partition:
     role: raw-volume
     formatting_options:
@@ -15,10 +15,10 @@
 - raid_level: 0
   chunk_size: '64 KiB'
   devices:
-    - vda3
-    - vdb3
-    - vdc3
-    - vdd3
+    - sda3
+    - sdb3
+    - sdc3
+    - sdd3
   partition:
     role: swap
     formatting_options:

--- a/test_data/yast/lvm_raid1/lvm+raid1_mds_xen.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_mds_xen.yaml
@@ -2,10 +2,10 @@
 - raid_level: 1
   chunk_size: '64 KiB'
   devices:
-    - vda2
-    - vdb2
-    - vdc2
-    - vdd2
+    - xvdb2
+    - xvdc2
+    - xvdd2
+    - xvde2
   partition:
     role: raw-volume
     formatting_options:
@@ -15,10 +15,10 @@
 - raid_level: 0
   chunk_size: '64 KiB'
   devices:
-    - vda3
-    - vdb3
-    - vdc3
-    - vdd3
+    - xvdb3
+    - xvdc3
+    - xvdd3
+    - xvde3
   partition:
     role: swap
     formatting_options:

--- a/test_data/yast/lvm_raid1/lvm+raid1_svirt-xen.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_svirt-xen.yaml
@@ -1,5 +1,5 @@
 ---
-mds: !include test_data/yast/lvm_raid1/lvm+raid1_mds.yaml
+mds: !include test_data/yast/lvm_raid1/lvm+raid1_mds_xen.yaml
 lvm: !include test_data/yast/lvm_raid1/lvm+raid1_lvm.yaml
 disks:
   - name: xvdb


### PR DESCRIPTION
After switching to REST API, we need to define exact devices to be
selected for the RAID. Initially I have missed lvm+RAID1 scenario, so
adding required changes here.

See [poo#88780](https://progress.opensuse.org/issues/88780).

#### Verification runs
* [SLES](https://openqa.suse.de/tests/overview?version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23restapi&distri=sle)
* [openSUSE](https://openqa.opensuse.org/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23restapi&distri=opensuse)  
