### PR TITLE
Fix docker.io API issues and SUSEConnect timeout

### DIFF
--- a/data/containers/docker-compose.yml
+++ b/data/containers/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3.3"
 services:
 
   nginx:
-    image: nginx
+    # The REGISTRY is variable and will be replaced
+    image: REGISTRY/library/nginx
     networks:
       - backend
     volumes:
@@ -10,7 +11,8 @@ services:
     restart: on-failure
 
   haproxy:
-    image: haproxy
+    # The REGISTRY is variable and will be replaced
+    image: REGISTRY/library/haproxy
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     ports:

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -75,7 +75,7 @@ sub install_docker_when_needed {
                 assert_script_run "apt-get -y install docker-ce", timeout => 260;
             } else {
                 # We may run openSUSE with DISTRI=sle and openSUSE does not have SUSEConnect
-                if (can_build_sle_base && script_run("SUSEConnect --status-text | grep Containers") != 0) {
+                if (can_build_sle_base && script_run("SUSEConnect --status-text | grep Containers", timeout => 240) != 0) {
                     is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
                 }
 

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -45,10 +45,16 @@ sub basic_container_tests {
     my %args    = @_;
     my $runtime = $args{runtime};
     die "You must define the runtime!" unless $runtime;
-    my $registry             = get_var('REGISTRY', 'docker.io');
+
+    my $registry = get_var('REGISTRY', 'docker.io');
+    # Images from docker.io registry are listed without the 'docker.io/library/'
+    # Images from custom registry are listed with the 'server/library/'
+    # We also filter images the same way they are listed.
+    my $prefix = ($registry =~ /docker\.io/) ? "" : "$registry/library/";
+
     my $alpine_image_version = '3.6';
-    my $alpine               = "$registry/library/alpine:$alpine_image_version";
-    my $hello_world          = "$registry/library/hello-world";
+    my $alpine               = "${prefix}alpine:$alpine_image_version";
+    my $hello_world          = "${prefix}hello-world";
     my $leap                 = "registry.opensuse.org/opensuse/leap";
     my $tumbleweed           = "registry.opensuse.org/opensuse/tumbleweed";
 
@@ -70,6 +76,8 @@ sub basic_container_tests {
     #   - pull image of openSUSE Tumbleweed
     assert_script_run("$runtime image pull $tumbleweed", timeout => 600);
 
+    # All images can be listed
+    assert_script_run("$runtime image ls");
     # Local images can be listed
     assert_script_run("$runtime image ls none");
     #   - filter with tag

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -52,7 +52,7 @@ sub run {
 
     allow_selected_insecure_registries(runtime => 'docker');
     my $registry = get_var('REGISTRY', 'docker.io');
-    assert_script_run("docker image pull $registry/library/nginx", timeout => 300);
+    assert_script_run("sed -i 's/REGISTRY/$registry/' docker-compose.yml");
     assert_script_run 'docker-compose pull', 600;
 
     # Start all containers in background


### PR DESCRIPTION
Hello,

 * docker_compose:
  before, we were pulling `library/nginx` image manually before running `docker-compose pull` but in our `docker-compose.yml` we use also `library/haproxy` image.
  Instead of pulling those images manually, I would rather just use `sed` here to replace the `REGISTRY` keyword with either the content of `REGISTRY` variable or `docker.io` default string.
 * docker:
  We pull `$registry/library/alpine:3.6` when the `$reigstry` is custom address, we see it correctly in `docker image ls` but when `$registry` is the default `docker.io` we don't see the address, nor the `library/` part in `image ls`.
  * SUSEConnect
  This is just a timeout increase for slower s390x workers.

- Issue: [docker image ls](http://pdostal-server.suse.cz/tests/11161#step/docker/119), [docker-compose pull](https://openqa.suse.de/tests/5568153) and [SUSEConnect --status-text](https://openqa.suse.de/tests/5544940#step/docker/25) [poo#89284](https://progress.opensuse.org/issues/89284)
- Verification run: [With REGISTRY](http://pdostal-server.suse.cz/tests/11168), [Without REGISTRY](http://pdostal-server.suse.cz/tests/11166)
