### PR TITLE
Ensure to query for static hostname only

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -84,7 +84,7 @@ sub run {
     check_etc_hosts_update() if get_var('VALIDATE_ETC_HOSTS');
 
     $self->clear_and_verify_console;
-    assert_script_run "hostname|grep $hostname";
+    assert_script_run "hostnamectl --static |grep $hostname";
 
     clear_console;
     script_run('ip -o a s');


### PR DESCRIPTION
Mostly non QEMU hypervisors have been affected.

* Issue: [test fails in yast2_lan](https://progress.opensuse.org/issues/89287)
* VRs:
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build24.25-jeos-main@svirt-xen-hvm](http://kepler.suse.cz/tests/3735#step/yast2_lan/17)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build24.25-jeos-main@svirt-xen-hvm](http://kepler.suse.cz/tests/3734#step/yast2_lan/138)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build24.25-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/3732#step/yast2_lan/138)
  * [sle-15-SP3-JeOS-for-VMware-x86_64-Build24.25-jeos-main@svirt-vmware65](http://kepler.suse.cz/tests/3737#)
  * [sle-15-SP3-JeOS-for-MS-HyperV-x86_64-Build24.25-jeos-main@svirt-hyperv](http://kepler.suse.cz/tests/3736))]
