### PR TITLE
Decrease review time of xev by showing command output

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -138,7 +138,7 @@ sub run {
             assert_script_run '[ -s /tmp/xev_log ]';
         }
         else {
-            assert_script_run 'wc -l /tmp/xev_log | grep "^0 "';
+            validate_script_output('wc -l /tmp/xev_log"', qr/^0/);
         }
         assert_script_run 'rm /tmp/xev_log';
     }


### PR DESCRIPTION
- Failed job: https://openqa.suse.de/tests/5553225#step/vnc_two_passwords/34
- Verification run: (coming soon)
