### PR TITLE
Simplify scheduling for reboot handling

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -1,0 +1,93 @@
+package grub_utils;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use opensusebasetest qw(handle_uefi_boot_disk_workaround);
+use testapi;
+use utils;
+use version_utils qw(is_sle is_livecd);
+use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
+
+our @EXPORT = qw(
+  grub_test
+);
+
+=head2
+
+  grub_test();
+
+Handle grub menu after reboot
+    - Handle grub2 to boot from hard disk (opposed to installation)
+    - Handle passphrase for encrypted disks
+    - Handle booting of snapshot or XEN, acconding to BOOT_TO_SNAPSHOT or XEN
+    - Enable plymouth debug if product if GRUB_KERNEL_OPTION_APPEND is set,
+      or product is sle, aarch64 and PLYMOUTH_DEBUG is set
+=cut
+sub grub_test {
+    my $timeout = get_var('GRUB_TIMEOUT', 90);
+
+    handle_installer_medium_bootup();
+    workaround_type_encrypted_passphrase;
+    # 60 due to rare slowness e.g. multipath poo#11908
+    # 90 as a workaround due to the qemu backend fallout
+    assert_screen_with_soft_timeout('grub2', timeout => 2 * $timeout, soft_timeout => $timeout, bugref => 'boo#1120256');
+    stop_grub_timeout;
+    boot_into_snapshot                                               if get_var("BOOT_TO_SNAPSHOT");
+    send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');
+    if ((check_var('ARCH', 'aarch64') && is_sle && get_var('PLYMOUTH_DEBUG'))
+        || get_var('GRUB_KERNEL_OPTION_APPEND'))
+    {
+        bug_workaround_bsc1005313() unless get_var("BOOT_TO_SNAPSHOT");
+    }
+    else {
+        # avoid timeout for booting to HDD
+        send_key 'ret';
+    }
+    # Avoid return key not received occasionally for hyperv-uefi guest at first boot
+    send_key 'ret' if (check_var('VIRSH_VMM_FAMILY', 'hyperv') && get_var('UEFI'));
+}
+
+=head2 handle_installer_medium_bootup
+
+Due to pre-installation setup, qemu boot order is always booting from CD-ROM.
+=cut
+sub handle_installer_medium_bootup {
+    return unless (check_var("BOOTFROM", "d") || (get_var('UEFI') && get_var('USBBOOT')));
+    assert_screen 'inst-bootmenu', 180;
+
+    if (check_var("BOOTFROM", "d") && check_var("AUTOUPGRADE") && check_var("PATCH")) {
+        assert_screen 'grub2';
+    }
+
+    # Layout of live is different from installation media
+    my $key = is_livecd() ? 'down' : 'up';
+    send_key_until_needlematch 'inst-bootmenu-boot-harddisk', $key;
+    send_key 'ret';
+
+    # use firmware boot manager of aarch64 to boot upgraded system
+    handle_uefi_boot_disk_workaround() if (check_var('ARCH', 'aarch64'));
+}
+
+sub bug_workaround_bsc1005313 {
+    record_soft_failure "Running with plymouth:debug to catch bsc#1005313" if get_var('PLYMOUTH_DEBUG');
+    send_key 'e';
+    # Move to end of kernel boot parameters line
+    send_key_until_needlematch "linux-line-selected", "down";
+    send_key "end";
+
+    assert_screen "linux-line-matched";
+    if (get_var('PLYMOUTH_DEBUG')) {
+        # remove "splash=silent quiet showopts"
+        for (1 .. 28) { send_key "backspace" }
+        type_string 'plymouth:debug';
+    }
+    type_string " " . get_var('GRUB_KERNEL_OPTION_APPEND') if get_var('GRUB_KERNEL_OPTION_APPEND');
+
+    save_screenshot;
+    send_key 'ctrl-x';
+}
+
+1;

--- a/schedule/functional/allpatterns.yaml
+++ b/schedule/functional/allpatterns.yaml
@@ -14,16 +14,6 @@ conditional_schedule:
         BACKEND:
             's390x':
                 - installation/disk_activation
-    grub_or_reconnect:
-        ARCH:
-            'x86_64':
-                - installation/grub_test
-            'ppc64le':
-                - installation/grub_test
-            'aarch64':
-                - installation/grub_test
-            's390x':
-                - boot/reconnect_mgmt_console
 schedule:
     - installation/bootloader_start
     - installation/welcome
@@ -45,5 +35,5 @@ schedule:
     - installation/await_install
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
-    - '{{grub_or_reconnect}}'
+    - installation/handle_reboot
     - installation/first_boot

--- a/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
@@ -39,7 +39,7 @@ schedule:
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation
-  - '{{after_reboot}}'
+  - installation/handle_reboot
   - installation/first_boot
   - migration/post_upgrade
   - console/system_prepare
@@ -67,16 +67,6 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/bootloader_zkvm
-  after_reboot:
-    ARCH:
-      aarch64:
-        - installation/grub_test
-      ppc64le:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
   upload_zkvm:
     ARCH:
       s390x:

--- a/schedule/ha/bv/sles_ha_installation.yaml
+++ b/schedule/ha/bv/sles_ha_installation.yaml
@@ -52,7 +52,7 @@ schedule:
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation
-  - '{{after_reboot}}'
+  - installation/handle_reboot
   - installation/first_boot
   - '{{create_hdd_tests}}'
 conditional_schedule:
@@ -64,16 +64,6 @@ conditional_schedule:
     CHECK_RELEASENOTES:
       1:
         - installation/releasenotes
-  after_reboot:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      aarch64:
-        - installation/grub_test
-      x86_64:
-        - installation/grub_test
-      ppc64le:
-        - installation/grub_test
   svirt_upload_assets:
     BACKEND:
       svirt:

--- a/schedule/install/offline_spvm_install.yaml
+++ b/schedule/install/offline_spvm_install.yaml
@@ -23,8 +23,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/hostname

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -40,7 +40,7 @@ schedule:
     - installation/await_install
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
-    - boot/reconnect_mgmt_console
+    - installation/handle_reboot
     - installation/first_boot
     - kernel/build_git_kernel
     - kernel/ibtests

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -38,6 +38,6 @@ schedule:
     - installation/await_install
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
-    - boot/reconnect_mgmt_console
+    - installation/handle_reboot
     - installation/first_boot
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -40,7 +40,7 @@ schedule:
     - installation/await_install
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
-    - boot/reconnect_mgmt_console
+    - installation/handle_reboot
     - installation/first_boot
     - kernel/build_git_kernel
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -38,6 +38,6 @@ schedule:
     - installation/await_install
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
-    - boot/reconnect_mgmt_console
+    - installation/handle_reboot
     - installation/first_boot
     - kernel/ibtests

--- a/schedule/kernel/install_ltp_uefi_baremetal.yaml
+++ b/schedule/kernel/install_ltp_uefi_baremetal.yaml
@@ -28,7 +28,7 @@ schedule:
     - installation/await_install
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
-    - boot/reconnect_mgmt_console
+    - installation/handle_reboot
     - installation/first_boot
     - kernel/install_ltp
     - kernel/shutdown_ltp

--- a/schedule/kernel/prepare_baremetal.yaml
+++ b/schedule/kernel/prepare_baremetal.yaml
@@ -25,7 +25,7 @@ schedule:
     - installation/await_install
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
-    - boot/reconnect_mgmt_console
+    - installation/handle_reboot
     - installation/first_boot
     - console/hostname
     - console/system_prepare

--- a/schedule/kernel/prepare_pvm_lvm_encrypt.yaml
+++ b/schedule/kernel/prepare_pvm_lvm_encrypt.yaml
@@ -33,8 +33,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/hostname

--- a/schedule/migration/offline_spvm_Upgrade.yaml
+++ b/schedule/migration/offline_spvm_Upgrade.yaml
@@ -14,8 +14,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - migration/post_upgrade
   - console/system_prepare

--- a/schedule/migration/s390x-zVM-Upgrade.yaml
+++ b/schedule/migration/s390x-zVM-Upgrade.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - migration/post_upgrade
   - console/system_prepare
   - console/consoletest_setup

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - migration/post_upgrade
   - console/system_prepare

--- a/schedule/qam/12-SP1/qam-minimal.yaml
+++ b/schedule/qam/12-SP1/qam-minimal.yaml
@@ -20,7 +20,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{reboot}}'
+- installation/handle_reboot
 - installation/first_boot
 - qam-minimal/install_update
 - qam-minimal/update_minimal
@@ -31,16 +31,6 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/disk_activation
-  reboot:
-    ARCH:
-      x86_64:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      ppc64le:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   publish:
     ARCH:
       x86_64:

--- a/schedule/qam/12-SP2/qam-minimal.yaml
+++ b/schedule/qam/12-SP2/qam-minimal.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{reboot}}'
+- installation/handle_reboot
 - installation/first_boot
 - qam-minimal/install_update
 - qam-minimal/update_minimal
@@ -37,16 +37,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - installation/system_role
-  reboot:
-    ARCH:
-      x86_64:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      ppc64le:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   s390tools:
     ARCH:
       s390x:

--- a/schedule/qam/12-SP3/qam-minimal.yaml
+++ b/schedule/qam/12-SP3/qam-minimal.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{reboot}}'
+- installation/handle_reboot
 - installation/first_boot
 - qam-minimal/install_update
 - qam-minimal/update_minimal
@@ -37,16 +37,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - installation/system_role
-  reboot:
-    ARCH:
-      x86_64:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      ppc64le:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   s390tools:
     ARCH:
       s390x:

--- a/schedule/qam/12-SP4/qam-gnome.yaml
+++ b/schedule/qam/12-SP4/qam-gnome.yaml
@@ -11,7 +11,7 @@ schedule:
 - autoyast/clone
 - autoyast/logs
 - autoyast/autoyast_reboot
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/system_prepare
@@ -60,14 +60,6 @@ schedule:
 - shutdown/cleanup_before_shutdown
 - shutdown/shutdown
 conditional_schedule:
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   x86_64_tests:
     ARCH:
       x86_64:

--- a/schedule/qam/12-SP4/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP4/qam-minimal-base.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/dracut
@@ -66,14 +66,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - installation/system_role
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   glibc_sanity:
     ARCH:
       x86_64:

--- a/schedule/qam/12-SP4/qam-minimal.yaml
+++ b/schedule/qam/12-SP4/qam-minimal.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{reboot}}'
+- installation/handle_reboot
 - installation/first_boot
 - qam-minimal/install_update
 - qam-minimal/update_minimal
@@ -37,16 +37,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - installation/system_role
-  reboot:
-    ARCH:
-      x86_64:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      ppc64le:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   s390tools:
     ARCH:
       s390x:

--- a/schedule/qam/12-SP5/qam-gnome.yaml
+++ b/schedule/qam/12-SP5/qam-gnome.yaml
@@ -11,7 +11,7 @@ schedule:
 - autoyast/clone
 - autoyast/logs
 - autoyast/autoyast_reboot
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/system_prepare
@@ -67,14 +67,6 @@ conditional_schedule:
       x86_64:
         - installation/isosize
         - installation/bootloader
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   x86_64_tests:
     ARCH:
       x86_64:

--- a/schedule/qam/12-SP5/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-base.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/dracut
@@ -62,14 +62,6 @@ schedule:
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   glibc_sanity:
     ARCH:
       x86_64:

--- a/schedule/qam/12-SP5/qam-minimal.yaml
+++ b/schedule/qam/12-SP5/qam-minimal.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{reboot}}'
+- installation/handle_reboot
 - installation/first_boot
 - qam-minimal/install_update
 - qam-minimal/update_minimal
@@ -33,16 +33,6 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/disk_activation
-  reboot:
-    ARCH:
-      x86_64:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      ppc64le:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   s390tools:
     ARCH:
       s390x:

--- a/schedule/qam/15-SP1/qam-gnome.yaml
+++ b/schedule/qam/15-SP1/qam-gnome.yaml
@@ -12,7 +12,7 @@ schedule:
 - autoyast/logs
 - console/force_scheduled_tasks
 - autoyast/autoyast_reboot
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/system_prepare
@@ -68,14 +68,6 @@ conditional_schedule:
       x86_64:
         - installation/isosize
         - installation/bootloader
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   x86_64_tests:
     ARCH:
       x86_64:

--- a/schedule/qam/15-SP1/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP1/qam-minimal-base.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/dracut
@@ -70,14 +70,6 @@ conditional_schedule:
       x86_64:
         - installation/isosize
         - installation/bootloader
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   glibc_sanity:
     ARCH:
       x86_64:

--- a/schedule/qam/15-SP1/qam-minimal.yaml
+++ b/schedule/qam/15-SP1/qam-minimal.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{reboot}}'
+- installation/handle_reboot
 - installation/first_boot
 - qam-minimal/install_update
 - qam-minimal/update_minimal
@@ -33,16 +33,6 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/disk_activation
-  reboot:
-    ARCH:
-      x86_64:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      ppc64le:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   s390tools:
     ARCH:
       s390x:

--- a/schedule/qam/15-SP2/qam-gnome.yaml
+++ b/schedule/qam/15-SP2/qam-gnome.yaml
@@ -12,7 +12,7 @@ schedule:
 - autoyast/logs
 - console/force_scheduled_tasks
 - autoyast/autoyast_reboot
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/system_prepare
@@ -61,12 +61,6 @@ schedule:
 - shutdown/cleanup_before_shutdown
 - shutdown/shutdown
 conditional_schedule:
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
   x86_64_tests:
     ARCH:
       x86_64:

--- a/schedule/qam/15-SP2/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP2/qam-minimal-base.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/dracut
@@ -63,14 +63,6 @@ schedule:
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   glibc_sanity:
     ARCH:
       x86_64:

--- a/schedule/qam/15-SP2/qam-minimal.yaml
+++ b/schedule/qam/15-SP2/qam-minimal.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{reboot}}'
+- installation/handle_reboot
 - installation/first_boot
 - qam-minimal/install_update
 - qam-minimal/update_minimal
@@ -33,16 +33,6 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/disk_activation
-  reboot:
-    ARCH:
-      x86_64:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      ppc64le:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   s390tools:
     ARCH:
       s390x:

--- a/schedule/qam/15/qam-gnome.yaml
+++ b/schedule/qam/15/qam-gnome.yaml
@@ -12,7 +12,7 @@ schedule:
 - autoyast/logs
 - console/force_scheduled_tasks
 - autoyast/autoyast_reboot
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/system_prepare
@@ -61,14 +61,6 @@ schedule:
 - shutdown/cleanup_before_shutdown
 - shutdown/shutdown
 conditional_schedule:
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   x86_64_tests:
     ARCH:
       x86_64:

--- a/schedule/qam/15/qam-minimal-base.yaml
+++ b/schedule/qam/15/qam-minimal-base.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{grub}}'
+- installation/handle_reboot
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - console/dracut
@@ -63,14 +63,6 @@ schedule:
 - console/orphaned_packages_check
 - console/coredump_collect
 conditional_schedule:
-  grub:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-      x86_64:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   glibc_sanity:
     ARCH:
       x86_64:

--- a/schedule/qam/15/qam-minimal.yaml
+++ b/schedule/qam/15/qam-minimal.yaml
@@ -21,7 +21,7 @@ schedule:
 - installation/await_install
 - installation/logs_from_installation_system
 - installation/reboot_after_installation
-- '{{reboot}}'
+- installation/handle_reboot
 - installation/first_boot
 - qam-minimal/install_update
 - qam-minimal/update_minimal
@@ -33,16 +33,6 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/disk_activation
-  reboot:
-    ARCH:
-      x86_64:
-        - installation/grub_test
-      s390x:
-        - boot/reconnect_mgmt_console
-      ppc64le:
-        - installation/grub_test
-      aarch64:
-        - installation/grub_test
   s390tools:
     ARCH:
       s390x:

--- a/schedule/qam/QR/15-SP1/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/qam/QR/15-SP1/btrfs_sle_libstorage-ng.yaml
@@ -30,10 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on BACKEND: s390x, svirt
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - '{{check_resume}}'
   - console/validate_no_cow_attribute
@@ -48,16 +45,6 @@ conditional_schedule:
     BACKEND:
       s390x:
         - installation/disk_activation
-  reconnect_mgmt_console:
-    BACKEND:
-      s390x:
-        - boot/reconnect_mgmt_console
-      svirt:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
   hostname_inst:
     BACKEND:
       qemu:

--- a/schedule/qam/QR/15-SP1/zfcp.yaml
+++ b/schedule/qam/QR/15-SP1/zfcp.yaml
@@ -26,5 +26,5 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot

--- a/schedule/qam/QR/15-SP2/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/qam/QR/15-SP2/btrfs_sle_libstorage-ng.yaml
@@ -30,10 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on BACKEND: s390x, svirt
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - '{{check_resume}}'
   - console/validate_no_cow_attribute
@@ -48,16 +45,6 @@ conditional_schedule:
     BACKEND:
       s390x:
         - installation/disk_activation
-  reconnect_mgmt_console:
-    BACKEND:
-      s390x:
-        - boot/reconnect_mgmt_console
-      svirt:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
   hostname_inst:
     BACKEND:
       qemu:

--- a/schedule/qam/QR/15-SP2/zfcp.yaml
+++ b/schedule/qam/QR/15-SP2/zfcp.yaml
@@ -26,5 +26,5 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot

--- a/schedule/qam/QR/lvm_encrypt_separate_boot.yaml
+++ b/schedule/qam/QR/lvm_encrypt_separate_boot.yaml
@@ -12,11 +12,11 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/boot_encrypt
-        - boot/reconnect_mgmt_console
+        - installation/handle_reboot
   grub_test_boot_encrypt:
     BACKEND:
       qemu:
-        - installation/grub_test
+        - installation/handle_reboot
         - installation/boot_encrypt
 schedule:
   - installation/bootloader_start

--- a/schedule/qam/common/create_hdd_transactional_server.yaml
+++ b/schedule/qam/common/create_hdd_transactional_server.yaml
@@ -12,19 +12,6 @@ conditional_schedule:
         BACKEND:
             pvm_hmc:
             - installation/edit_optional_kernel_cmd_parameters
-    reconnect_mgmt_console:
-        ARCH:
-            s390x:
-            - boot/reconnect_mgmt_console
-        BACKEND:
-            pvm_hmc:
-            - boot/reconnect_mgmt_console
-    grub_test:
-        BACKEND:
-            qemu:
-            - installation/grub_test
-            pvm_hmc:
-            - installation/grub_test
     shutdown_svirt:
         BACKEND:
             svirt:
@@ -49,8 +36,7 @@ schedule:
     - installation/await_install
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
-    - "{{reconnect_mgmt_console}}"
-    - "{{grub_test}}"
+    - installation/handle_reboot
     - installation/first_boot
     - console/hostname
     - console/system_prepare

--- a/schedule/sles4sap/hana/pvm_hana.yaml
+++ b/schedule/sles4sap/hana/pvm_hana.yaml
@@ -31,8 +31,7 @@ schedule:
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - sles4sap/patterns

--- a/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
@@ -59,8 +59,7 @@ schedule:
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - ha/wait_barriers
   - console/system_prepare
@@ -106,14 +105,12 @@ conditional_schedule:
   boot_to_desktop:
     HA_CLUSTER_SETUP:
       init:
-        - boot/reconnect_mgmt_console
-        - installation/grub_test
+        - installation/handle_reboot
         - installation/first_boot
   boot_to_desktop_non_init:
     HA_CLUSTER_SETUP:
       join:
-        - boot/reconnect_mgmt_console
-        - installation/grub_test
+        - installation/handle_reboot
         - installation/first_boot
   sles4sap12_product:
     VERSION:

--- a/schedule/sles4sap/installation/sles4sap_gnome_saptune_v2_baremetal.yaml
+++ b/schedule/sles4sap/installation/sles4sap_gnome_saptune_v2_baremetal.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - sles4sap/saptune/mr_test

--- a/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
+++ b/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_hana.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - sles4sap/patterns

--- a/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_wizard.yaml
+++ b/schedule/sles4sap/installation/sles4sap_online_dvd_gnome_wizard.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - sles4sap/patterns

--- a/schedule/yast/addon-module-ftp.yaml
+++ b/schedule/yast/addon-module-ftp.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - '{{grub}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup
@@ -41,15 +41,6 @@ conditional_schedule:
         - installation/hostname_inst
       svirt:
         - installation/hostname_inst
-  grub:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      svirt:
-        - boot/reconnect_mgmt_console
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
-        - installation/grub_test
 test_data:
   system_role:
     default: 'HA node'

--- a/schedule/yast/addon-module-http.yaml
+++ b/schedule/yast/addon-module-http.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - '{{grub}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup
@@ -38,12 +38,3 @@ conditional_schedule:
         - installation/hostname_inst
       svirt:
         - installation/hostname_inst
-  grub:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      svirt:
-        - boot/reconnect_mgmt_console
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
-        - installation/grub_test

--- a/schedule/yast/autoyast/autoyast_mini_spvm.yaml
+++ b/schedule/yast/autoyast/autoyast_mini_spvm.yaml
@@ -18,8 +18,7 @@ schedule:
   - autoyast/clone
   - autoyast/logs
   - autoyast/autoyast_reboot
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_file_system
   - console/zypper_lr

--- a/schedule/yast/autoyast/autoyast_zvm_sles_product_reg.yaml
+++ b/schedule/yast/autoyast/autoyast_zvm_sles_product_reg.yaml
@@ -19,5 +19,5 @@ schedule:
   - autoyast/clone
   - autoyast/logs
   - autoyast/autoyast_reboot
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/autoyast_reinstall.yaml
+++ b/schedule/yast/autoyast_reinstall.yaml
@@ -17,10 +17,7 @@ schedule:
   - autoyast/verify_cloned_profile
   - autoyast/logs
   - autoyast/autoyast_reboot
-  # Called on ARCH: s390x and on powerVM
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu and on powerVM
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_file_system
   - console/zypper_lr
@@ -31,19 +28,6 @@ schedule:
   - console/zypper_log
   - console/orphaned_packages_check
 conditional_schedule:
-  reconnect_mgmt_console:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-    BACKEND:
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      pvm_hmc:
-        - installation/grub_test
   opensuse_welcome:
     VERSION:
       Tumbleweed:

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -41,10 +41,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  # Called on BACKEND: svirt
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
 conditional_schedule:
   hostname_inst:
@@ -53,15 +50,3 @@ conditional_schedule:
         - installation/hostname_inst
       svirt:
         - installation/hostname_inst
-  reconnect_mgmt_console:
-    BACKEND:
-      svirt:
-        - boot/reconnect_mgmt_console
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      pvm_hmc:
-        - installation/grub_test

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -33,10 +33,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  # Called on BACKEND: s390x, svirt
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks
@@ -53,16 +50,6 @@ conditional_schedule:
     BACKEND:
       s390x:
         - installation/disk_activation
-  reconnect_mgmt_console:
-    BACKEND:
-      s390x:
-        - boot/reconnect_mgmt_console
-      svirt:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
   hostname_inst:
     BACKEND:
       qemu:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks

--- a/schedule/yast/btrfs/btrfs_sle_libstorage.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage.yaml
@@ -30,10 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on ARCH: s390x
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks
@@ -53,14 +50,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - installation/system_role
-  reconnect_mgmt_console:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
   hostname_inst:
     BACKEND:
       qemu:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -29,6 +29,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/handle_reboot
   - installation/teardown_libyui
   - boot/reconnect_mgmt_console
   - installation/grub_test

--- a/schedule/yast/clone_system/clone_system_pvm.yaml
+++ b/schedule/yast/clone_system/clone_system_pvm.yaml
@@ -23,8 +23,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
@@ -33,8 +33,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/validate_lvm

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -30,7 +30,6 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_user_login_textmode

--- a/schedule/yast/encryption/activate_encrypted_volume_dasd.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_dasd.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
 test_data:
   <<: !include test_data/yast/encryption/activate_encrypted_volume.yaml

--- a/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
@@ -32,8 +32,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
 test_data:
   mapped_device: '/dev/mapper/cr-auto-1'

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -34,8 +34,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -30,8 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
 test_data:

--- a/schedule/yast/encryption/cryptlvm_sle_12_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_12_spvm.yaml
@@ -30,8 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/validate_lvm

--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -31,8 +31,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/validate_lvm

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -13,11 +13,11 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/boot_encrypt
-        - boot/reconnect_mgmt_console
+        - installation/handle_reboot
   grub_test_boot_encrypt:
     BACKEND:
       qemu:
-        - installation/grub_test
+        - installation/handle_reboot
         - installation/boot_encrypt
 schedule:
   - installation/bootloader_start

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
@@ -32,8 +32,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -15,11 +15,11 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/boot_encrypt
-        - boot/reconnect_mgmt_console
+        - installation/handle_reboot
   grub_test_boot_encrypt:
     BACKEND:
       qemu:
-        - installation/grub_test
+        - installation/handle_reboot
         - installation/boot_encrypt
 schedule:
   - installation/bootloader_start

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -32,8 +32,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/validate_lvm

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_ext4_fs
 test_data:

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -29,6 +29,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/handle_reboot
   - installation/teardown_libyui
   - boot/reconnect_mgmt_console
   - installation/first_boot

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -31,8 +31,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_ext4_fs
 test_data:

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -28,8 +28,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -28,8 +28,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/validate_lvm

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -30,8 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
   - console/validate_lvm

--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -29,26 +29,14 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on BACKEND: svirt
-  - '{{reconnect_mgmt_console}}'
   - installation/teardown_libyui
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - console/lvm_thin_check
-conditional_schedule:
-  reconnect_mgmt_console:
-    BACKEND:
-      svirt:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
 test_data:
   system_role:
     default: 'SLES with GNOME'

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/installation_snapshots

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/installation_snapshots

--- a/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/installation_snapshots

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -27,8 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - '{{reconnect_mgmt_console}}'
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/installation_snapshots
@@ -40,11 +39,6 @@ schedule:
   - console/orphaned_packages_check
   - console/validate_installed_patterns
   - console/consoletest_finish
-conditional_schedule:
-  reconnect_mgmt_console:
-    BACKEND:
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
 test_data:
   software:
     patterns:

--- a/schedule/yast/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal.yaml
@@ -29,10 +29,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on BACKEND: svirt, pvm_hmc
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu, pvm_hmc
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup
@@ -55,15 +52,3 @@ conditional_schedule:
         - installation/hostname_inst
       svirt:
         - installation/hostname_inst
-  reconnect_mgmt_console:
-    BACKEND:
-      svirt:
-        - boot/reconnect_mgmt_console
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      pvm_hmc:
-        - installation/grub_test

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -27,18 +27,8 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - '{{reconnect_mgmt_console}}'
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_modify_existing_partition
 test_data:
   <<: !include test_data/yast/modify_existing_partition/modify_existing_partition.yaml
-conditional_schedule:
-  reconnect_mgmt_console:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test

--- a/schedule/yast/msdos.yaml
+++ b/schedule/yast/msdos.yaml
@@ -24,7 +24,7 @@ schedule:
   - '{{logs_from_installation_system}}'
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - '{{reconnect_mgmt_console}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_fs_table
 conditional_schedule:
@@ -49,16 +49,6 @@ conditional_schedule:
         - installation/logs_from_installation_system
       pvm_hmc:
         - installation/logs_from_installation_system
-  reconnect_mgmt_console:
-    ARCH:
-      s390x:
-        - boot/reconnect_mgmt_console
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
-        - installation/grub_test
     VIRSH_VMM_TYPE:
       hvm:
         - installation/grub_test

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -31,8 +31,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_raid
 test_data:

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -31,8 +31,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_raid
 test_data:

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -31,8 +31,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_raid
 test_data:

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -31,8 +31,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_raid
 test_data:

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -31,8 +31,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/teardown_libyui
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_raid
 test_data:

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -29,8 +29,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - "{{reconnect_mgmt_console}}"
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_first_disk_selection
 conditional_schedule:
@@ -38,10 +37,6 @@ conditional_schedule:
     BACKEND:
       pvm_hmc:
         - installation/edit_optional_kernel_cmd_parameters
-  reconnect_mgmt_console:
-    BACKEND:
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
 test_data:
   guided_partitioning:
     disks:

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
@@ -36,8 +36,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -34,7 +34,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/check_resume
   - console/hostname

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -34,7 +34,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/check_resume
   - console/hostname

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - "{{boot_handler}}"
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup
@@ -35,10 +35,3 @@ schedule:
   - console/yast2_i
   - console/verify_no_separate_home
   - console/validate_subvolumes
-conditional_schedule:
-  boot_handler:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      svirt:
-        - boot/reconnect_mgmt_console

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -29,8 +29,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup

--- a/schedule/yast/skip_registration/skip_registration_pvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration_pvm.yaml
@@ -27,8 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/installation_snapshots

--- a/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
+++ b/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - installation/addon_products_via_SCC_yast2_ncurses

--- a/schedule/yast/ssh-x.yaml
+++ b/schedule/yast/ssh-x.yaml
@@ -27,9 +27,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  # Called on powerVM BACKEND
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - installation/validation/validate_sshd_reachable
   - console/sshd
@@ -38,7 +36,3 @@ conditional_schedule:
     BACKEND:
       s390x:
         - installation/disk_activation
-  grub_test:
-    BACKEND:
-      pvm_hmc:
-        - installation/grub_test

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -27,8 +27,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  - '{{reconnect_mgmt_console}}'
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/prepare_test_data
@@ -45,24 +44,6 @@ conditional_schedule:
     BACKEND:
       s390x:
         - installation/disk_activation
-  reconnect_mgmt_console:
-    BACKEND:
-      s390x:
-        - boot/reconnect_mgmt_console
-      svirt:
-        - boot/reconnect_mgmt_console
-      spvm:
-        - boot/reconnect_mgmt_console
-      pvm_hmc:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
-      spvm:
-        - installation/grub_test
-      pvm_hmc:
-        - installation/grub_test
 test_data:
   system_role:
     default: 'Text Mode'

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/installation_snapshots

--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -13,19 +13,6 @@ conditional_schedule:
         BACKEND:
             pvm_hmc:
             - installation/edit_optional_kernel_cmd_parameters
-    reconnect_mgmt_console:
-        ARCH:
-            s390x:
-            - boot/reconnect_mgmt_console
-        BACKEND:
-            pvm_hmc:
-            - boot/reconnect_mgmt_console
-    grub_test:
-        BACKEND:
-            qemu:
-            - installation/grub_test
-            pvm_hmc:
-            - installation/grub_test
     shutdown_svirt:
         BACKEND:
             svirt:
@@ -53,8 +40,7 @@ schedule:
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
     - installation/teardown_libyui
-    - "{{reconnect_mgmt_console}}"
-    - "{{grub_test}}"
+    - installation/handle_reboot
     - installation/first_boot
     - console/hostname
     - console/system_prepare

--- a/schedule/yast/xfs/xfs.yaml
+++ b/schedule/yast/xfs/xfs.yaml
@@ -34,10 +34,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/teardown_libyui
-  # Called on BACKEND: s390x, svirt
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_fs_table
 conditional_schedule:
@@ -45,23 +42,9 @@ conditional_schedule:
     BACKEND:
       s390x:
         - installation/disk_activation
-  reconnect_mgmt_console:
-    BACKEND:
-      s390x:
-        - boot/reconnect_mgmt_console
-      svirt:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test
   hostname_inst:
     BACKEND:
       qemu:
         - installation/hostname_inst
       svirt:
         - installation/hostname_inst
-test_data:
-  guided_partitioning:
-    filesystem_options:
-      root_filesystem_type: xfs

--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -29,8 +29,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_fs_table
 test_data:

--- a/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
@@ -28,17 +28,5 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on BACKEND: svirt
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
-conditional_schedule:
-  reconnect_mgmt_console:
-    BACKEND:
-      svirt:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
@@ -26,6 +26,5 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -28,17 +28,5 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  # Called on BACKEND: svirt
-  - '{{reconnect_mgmt_console}}'
-  # Called on BACKEND: qemu
-  - '{{grub_test}}'
+  - installation/handle_reboot
   - installation/first_boot
-conditional_schedule:
-  reconnect_mgmt_console:
-    BACKEND:
-      svirt:
-        - boot/reconnect_mgmt_console
-  grub_test:
-    BACKEND:
-      qemu:
-        - installation/grub_test

--- a/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
@@ -26,6 +26,5 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - boot/reconnect_mgmt_console
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_zfcp
   - console/validate_multipath

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -21,75 +21,10 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use utils;
-use version_utils qw(is_sle is_livecd);
-use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
-
-=head2 handle_installer_medium_bootup
-
-Due to pre-installation setup, qemu boot order is always booting from CD-ROM.
-=cut
-sub handle_installer_medium_bootup {
-    my ($self) = @_;
-
-    return unless (check_var("BOOTFROM", "d") || (get_var('UEFI') && get_var('USBBOOT')));
-    assert_screen 'inst-bootmenu', 180;
-
-    if (check_var("BOOTFROM", "d") && check_var("AUTOUPGRADE") && check_var("PATCH")) {
-        assert_screen 'grub2';
-    }
-
-    # Layout of live is different from installation media
-    my $key = is_livecd() ? 'down' : 'up';
-    send_key_until_needlematch 'inst-bootmenu-boot-harddisk', $key;
-    send_key 'ret';
-
-    # use firmware boot manager of aarch64 to boot upgraded system
-    $self->handle_uefi_boot_disk_workaround if (check_var('ARCH', 'aarch64'));
-}
-
-sub bug_workaround_bsc1005313 {
-    record_soft_failure "Running with plymouth:debug to catch bsc#1005313" if get_var('PLYMOUTH_DEBUG');
-    send_key 'e';
-    # Move to end of kernel boot parameters line
-    send_key_until_needlematch "linux-line-selected", "down";
-    send_key "end";
-
-    assert_screen "linux-line-matched";
-    if (get_var('PLYMOUTH_DEBUG')) {
-        # remove "splash=silent quiet showopts"
-        for (1 .. 28) { send_key "backspace" }
-        type_string 'plymouth:debug';
-    }
-    type_string " " . get_var('GRUB_KERNEL_OPTION_APPEND') if get_var('GRUB_KERNEL_OPTION_APPEND');
-
-    save_screenshot;
-    send_key 'ctrl-x';
-}
+use grub_utils qw(grub_test);
 
 sub run {
-    my ($self) = @_;
-    my $timeout = get_var('GRUB_TIMEOUT', 90);
-
-    $self->handle_installer_medium_bootup;
-    workaround_type_encrypted_passphrase;
-    # 60 due to rare slowness e.g. multipath poo#11908
-    # 90 as a workaround due to the qemu backend fallout
-    assert_screen_with_soft_timeout('grub2', timeout => 2 * $timeout, soft_timeout => $timeout, bugref => 'boo#1120256');
-    stop_grub_timeout;
-    boot_into_snapshot                                               if get_var("BOOT_TO_SNAPSHOT");
-    send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');
-    if ((check_var('ARCH', 'aarch64') && is_sle && get_var('PLYMOUTH_DEBUG'))
-        || get_var('GRUB_KERNEL_OPTION_APPEND'))
-    {
-        $self->bug_workaround_bsc1005313 unless get_var("BOOT_TO_SNAPSHOT");
-    }
-    else {
-        # avoid timeout for booting to HDD
-        send_key 'ret';
-    }
-    # Avoid return key not received occasionally for hyperv-uefi guest at first boot
-    send_key 'ret' if (check_var('VIRSH_VMM_FAMILY', 'hyperv') && get_var('UEFI'));
+    grub_test();
 }
 
 sub test_flags {

--- a/tests/installation/handle_reboot.pm
+++ b/tests/installation/handle_reboot.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Combine modules with the actions that are required after reboot.
+# Reconnect management-consoles on remote backends and then process GRUB.
+# The solution is implemented to use in declarative scheduling to reduce
+# usage of complex conditions.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use grub_utils qw(grub_test);
+use testapi;
+use Utils::Backends 'is_remote_backend';
+use utils qw(reconnect_mgmt_console);
+
+sub run {
+    if (is_remote_backend) {
+        record_info 'Reconnect mgmt console';
+        reconnect_mgmt_console();
+    }
+
+    unless (check_var('ARCH', 's390x') || check_var('BACKEND', 'ipmi')) {
+        record_info 'Handle GRUB';
+        grub_test();
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
We have many differences in the schedules only because of the way reboot
is handled after installation.

The PR combines `reconnect_mgmt_console` and `grub_test` modules with the actions required after reboot
into single module.

- Related ticket: https://progress.opensuse.org/issues/88786
- Verification runs: https://openqa.suse.de/tests/overview.html?groupid=96&distri=sle&build=172.3_handle_reboot&version=15-SP3
