### PR TITLE
Remove softfail bsc#1180605 for SLE15-SP3

### DIFF
--- a/tests/console/python_scientific.pm
+++ b/tests/console/python_scientific.pm
@@ -27,8 +27,9 @@ sub run_python_script {
     assert_script_run("chmod a+rx '$script'");
     assert_script_run("./$script 2>&1 | tee $logfile");
     if (script_run("grep 'Softfail' $logfile") == 0) {
-        # bsc#1180605 is only relevant for SLE > 15-SP2.
-        if (script_run("grep 'Softfail' $logfile | grep 'bsc#1180605'") == 0 && is_sle("<=15-SP2")) {
+        # bsc#1180605 is only relevant for SLE >= 15-SP2 but not yet available for 15-SP3
+        # Note: Remote 'is_sle(">15-SP2")' when available in PackageHub
+        if (script_run("grep 'Softfail' $logfile | grep 'bsc#1180605'") == 0 && (is_sle("<15-SP2") || is_sle(">15-SP2"))) {
             record_info("scipy-fft", "scipy-fft module not available for SLE <= 15-SP2");
         } else {
             my $failmsg = script_output("grep 'Softfail' '$logfile'");


### PR DESCRIPTION
On request, disable the softfailure for [bsc#1180605](https://bugzilla.suse.com/show_bug.cgi?id=1180605) for SLE>15-SP3 until `scipy.fft` will be packaged.

- Related ticket: -
- Needles: -
- Verification run: [SLES15-SP3](http://duck-norris.qam.suse.de/t5153) | [SLES15-SP2](http://duck-norris.qam.suse.de/tests/5154) | [SLES15-SP1](http://duck-norris.qam.suse.de/t5155) | [Tumbleweed](http://duck-norris.qam.suse.de/t5157)