### PR TITLE
Add workaround for qaperf.service fail in systemd

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -69,6 +69,11 @@ sub qaset_config {
         assert_script_run("echo '#!/bin/sh' > $boot_local");
         assert_script_run("chmod +x $boot_local");
     }
+
+    if (is_sle('=15') or is_sle('=15-SP1')) {
+        record_soft_failure("qaperf.service fails to start bsc#1182914");
+        assert_script_run("systemctl reset-failed qaperf.service");
+    }
 }
 
 # Add qa head repo for kernel testing. If QA_SERVER_REPO is set,


### PR DESCRIPTION
`qa_test_systemd` fails in the `check-unit` testcase because `qaperf.service` fails to start for SLE 15 and SLE 15-SP1.
Until this issue is fixed in `qa_testset_automation`, a workaround is to reset the recorded failed state of `qaperf.service`.

- Related ticket: https://progress.opensuse.org/issues/89335
- Needles: No Needles
- Verification run:  [before](http://angmar.suse.de/tests/3077#step/1_systemd/63) | [after](http://angmar.suse.de/tests/3079#step/qa_run/47)
