### PR TITLE
Get YaST2 logs in case of failure in firstboot

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -160,4 +160,17 @@ sub run {
     type_string "exit\n" unless (get_var('BETA', 0) && is_sut_reg());
 }
 
+sub post_fail_hook {
+    assert_screen 'yast2-wsl-active';
+    # function keys are not encoded in consoles/VNC.pm
+    send_key 'alt-q';
+    wait_still_screen stilltime => 5, timeout => 35;
+    send_key 'alt-r';
+    assert_screen 'wsl-firsboot-exit-warning-pop-up';
+    send_key 'alt-a';
+    assert_screen 'wsl-installing-prompt';
+    wait_still_screen stilltime => 2, timeout => 11;
+    shift->opensusebasetest::save_and_upload_log('save_y2logs wsl-fb.tar.xz', '/tmp/wsl-fb.tar.xz', {screenshot => 1});
+}
+
 1;


### PR DESCRIPTION
Fetch for YaST2 logs while deploying a configuring WSL.

- Verification run: http://kepler.suse.cz/tests/3749#step/firstrun/27
