### PR TITLE
Fix fail in nautilus_permission

### DIFF
--- a/tests/x11/gnomecase/nautilus_permission.pm
+++ b/tests/x11/gnomecase/nautilus_permission.pm
@@ -42,6 +42,9 @@ sub run {
     send_key "r";        #choose properties
     assert_screen 'nautilus-properties';
     send_key "up";       #move focus onto tab
+                         # For Tumbleweed it is needed one more hit to reach the tab
+                         # In case that the problem appears again, switch to an assert and click strategy for reaching the tab
+    send_key "up";
     send_key "right";    #move to tab Permissions
     for (1 .. 4) { send_key "tab" }
     send_key "ret";
@@ -65,6 +68,9 @@ sub run {
     send_key "r";        #choose properties
     assert_screen 'nautilus-properties';
     send_key "up";       #move focus onto tab
+                         # For Tumbleweed it is needed one more hit to reach the tab
+                         # In case that the problem appears again, switch to an assert and click strategy for reaching the tab
+    send_key "up";
     send_key "right";    #move to tab Permissions
     assert_screen 'nautilus-permissions-changed';
     send_key "esc";      #close the dialog


### PR DESCRIPTION
- Added one more key to reach the permissions' tab

- Related ticket: https://progress.opensuse.org/issues/78536
- Needles: N/A
- Verification run: 
Tumbleweed [desktopapps-gnome](http://10.161.229.247/tests/1716#step/nautilus_permission/27) | [desktopapps-gnome-x11](http://10.161.229.247/tests/1717#step/nautilus_permission/27)
SLES 15-SP3 [wayland-desktopapps-gnome](http://10.161.229.247/tests/1719#step/nautilus_permission/26) | [desktopapps-gnome-x11](http://10.161.229.247/tests/1718#step/nautilus_permission/28)
