### PR TITLE
Fix docker.io API issues in test_container_image subroutine

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -205,6 +205,10 @@ sub test_container_image {
     die 'Argument $image not provided!'   unless $image;
     die 'Argument $runtime not provided!' unless $runtime;
 
+    # Images from docker.io registry are listed without the 'docker.io/library/'
+    # Images from custom registry are listed with the '$registry/library/'
+    $image =~ s/^docker\.io\/library\///;
+
     my $smoketest = "/bin/uname -r; /bin/echo \"Heartbeat from $image\"";
 
     if ($runtime =~ /buildah/) {


### PR DESCRIPTION
This is a small follow-up to #12043

In [containers_3rd_party.pm](http://pdostal-server.suse.cz/tests/11175#step/containers_3rd_party/127) without `REGISTRY` variable, we were `grep`ing for `docker.io/library/alpine` but this image does not exists - we should just `grep` for `alpine`.


- Verification run: [without REGISTRY variable](http://pdostal-server.suse.cz/tests/11178), [with REGISTRY variable](http://pdostal-server.suse.cz/tests/11177)