### PR TITLE
Fix user unlock issue in consoletest_finish on s390x

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -36,7 +36,10 @@ sub run {
     save_screenshot();
 
     systemctl 'unmask packagekit.service';
-
+    # On s390x sometimes the vnc will still be there and the next select_console
+    # will create another vnc. This will make the OpenQA have 2 vnc sessions at
+    # the same time. We'd cleanup the previous one and setup the new one.
+    assert_script_run 'pkill Xvnc ||:' if !check_var('DESKTOP', 'textmode') && check_var('ARCH', 's390x');
     # logout root (and later user) so they don't block logout
     # in KDE
     type_string "exit\n";


### PR DESCRIPTION
On s390x test, We'll sometime have 2 vnc connection at a time. The first one was orphaned but in  consoletest_finish
we called select_console to create another new connection. We need make sure that we have only 1 for the OpenQA.

- Related ticket: https://progress.opensuse.org/issues/89377
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/5572644
  https://openqa.nue.suse.com/tests/5572645
  https://openqa.nue.suse.com/tests/5581042
  https://openqa.nue.suse.com/tests/5581043
  https://openqa.nue.suse.com/tests/5581045