### PR TITLE
Reduce needle list for aarch64 JeOS testing

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -41,6 +41,7 @@ use constant {
           is_svirt_except_s390x
           is_pvm
           is_xen_pv
+          is_xen_hvm
           is_ipmi
           is_qemu
           is_svirt
@@ -149,12 +150,22 @@ sub is_hyperv_in_gui {
 
 =head2 is_xen_pv
 
-Returns true if the current VM runs in Xen host in paravirtual mode 
+Returns true if the current VM runs in Xen host in paravirtualization (PV) mode 
 
 =cut
 
 sub is_xen_pv {
     return check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux');
+}
+
+=head2 is_xen_hvm
+
+Returns true if the current VM runs in Xen host in full virtualization (HVM) mode 
+
+=cut
+
+sub is_xen_hvm {
+    return check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'hvm');
 }
 
 =head2 is_svirt_except_s390x

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -334,9 +334,7 @@ sub get_bootmenu_console_params {
 sub uefi_bootmenu_params {
     # assume bios+grub+anim already waited in start.sh
     # in grub2 it's tricky to set the screen resolution
-    #send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5);
-    (is_jeos) ? send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5)
-      :         send_key 'e';
+    send_key_until_needlematch('grub2-enter-edit-mode', 'e', 10, 0.1);
     # Kiwi in TW uses grub2-mkconfig instead of the custom kiwi config
     # Locate gfxpayload parameter and update it
     if (is_jeos && (is_tumbleweed || is_sle('>=15-sp1') || is_leap('>=15.1'))) {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -34,6 +34,7 @@ use constant {
           is_sle_micro
           is_gnome_next
           is_jeos
+          is_community_jeos
           is_krypton_argon
           is_leap
           is_opensuse
@@ -113,6 +114,13 @@ sub is_jeos {
     return get_var('FLAVOR', '') =~ /^JeOS/;
 }
 
+=head2 is_community_jeos
+
+Returns true if called on community jeos images, which don't use jeos-firstboot by default
+=cut
+sub is_community_jeos {
+    return (check_var('FLAVOR', 'JeOS-for-AArch64') || check_var('FLAVOR', 'JeOS-for-RPi'));
+}
 =head2 is_vmware
 
 Returns true if called on vmware

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -107,6 +107,14 @@ sub cleanup_needles {
         unregister_needle_tags('ENV-JEOS-1');
     }
 
+    if (is_jeos) {
+        unregister_needle_tags('inst-bootmenu');
+        unregister_needle_tags('ENV-PXEBOOT-0');
+        unregister_needle_tags('ENV-PXEBOOT-1');
+        unregister_needle_tags('ENV-OFW-0');
+        unregister_needle_tags('ENV-OFW-1');
+    }
+
     if (get_var('OFW')) {
         unregister_needle_tags('ENV-OFW-0');
     }

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -88,6 +88,7 @@ sub run {
         tianocore_http_boot;
     }
     assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2)], $bootloader_timeout);
+    stop_grub_timeout;
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";
         send_key "ret";


### PR DESCRIPTION
Although that we do not necessary need to include bootloader handler module in all tests (reasoning below), it is still valuable to have it at least in _filesystems_ test suite for now.
To make it work on slower aarch64 machines in O.S.D we need to make sure that grub2 needles will match within 10s timeout, meaning that we need to reduce the set of possible matches to bare minimum.
Unfortunately I was able to make it work only on *WORKER_CLASS=qemu_aarch64_slow_worker* for now.

We configure screen resolution at firstboot, however it is not always necessary. For _HyperV_ (gen1 and gen2), QEMU with _VGA=virtio_ or
_aarch64_ is not really needed and GRUB2 sets the screen resolution by default.
For instance bootloader handler is already skipped in several test suites.

* [hyperv - gen2](https://openqa.suse.de/tests/5573716#step/firstrun/1)
* [rpi sle image](https://openqa.suse.de/tests/5552113#step/firstrun/1)
* [vga driver in qemu backend](https://openqa.suse.de/tests/5555726#step/firstrun/1)

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1522
- Verification runs:

    * **sles** :
      * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build15.77-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/4093#step/bootloader_uefi/1)
      * [kvm-and-xen-x86_64-Build1.5-jeos-filesystem@svirt-xen-hvm](http://kepler.suse.cz/tests/4092#step/bootloader_uefi/1)
      * [kvm-and-xen-x86_64-Build1.5-jeos-filesystem@svirt-xen-pv](http://kepler.suse.cz/tests/4090#step/firstrun/1)
      * [sle-15-SP3-Full-x86_64-Build163.1-skip_registration+workaround_modules@uefi](http://kepler.suse.cz/tests/4106#step/bootloader_uefi/1)
      * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build15.77-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/4093#step/bootloader_uefi/1)
      * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build1.5-jeos-filesystem@uefi-virtio-vga](http://kepler.suse.cz/tests/4101#step/bootloader_uefi/1)
      * [sle-15-SP3-JeOS-for-MS-HyperV-x86_64-Build1.5-jeos-filesystem@svirt-hyperv-uefi](http://kepler.suse.cz/tests/4087#step/bootloader_uefi/1)
      * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build37.8.34-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/4094#step/bootloader_uefi/1)
      * [sle-15-SP3-JeOS-for-VMware-x86_64-Build1.5-jeos-filesystem@svirt-vmware65](http://kepler.suse.cz/tests/4103#step/bootloader_uefi/1)
      * [sle-15-SP2-JeOS-for-VMware-x86_64-Build15.77-jeos-filesystem@svirt-vmware65](http://kepler.suse.cz/tests/4099#step/bootloader_uefi/1)
      * [sle-15-SP1-JeOS-for-VMware-x86_64-Build37.8.34-jeos-filesystem@svirt-vmware65](http://kepler.suse.cz/tests/4105#step/bootloader_uefi/1)
      * [sle-15-SP1-JeOS-for-MS-HyperV-x86_64-Build37.8.34-jeos-filesystem@svirt-hyperv-uefi](http://kepler.suse.cz/tests/4095#step/bootloader_uefi/1)
      * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build37.8.34-jeos-filesystem@svirt-xen-hvm ](http://kepler.suse.cz/tests/4097#step/bootloader_uefi/1)
      * [sle-15-SP2-JeOS-for-MS-HyperV-x86_64-Build15.77-jeos-filesystem@svirt-hyperv-uefi](http://kepler.suse.cz/tests/4098)
      * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build15.77-jeos-filesystem@svirt-xen-hvm](http://kepler.suse.cz/tests/4100)
      * [sle-15-SP3-Online-x86_64-Build163.1-default@svirt-hyperv-uefi](http://kepler.suse.cz/tests/4107)
      * [sle-15-SP3-JeOS-for-kvm-and-xen-aarch64@aarch64](https://openqa.suse.de/tests/5746755#step/bootloader_uefi/1)
     
   * **oS**:
     * [Tumbleweed-DVD-s390x@s390x-zVM-vswitch-l2](https://openqa.opensuse.org/tests/1686800#step/welcome/1)
     * [Tumbleweed-NET-ppc64le@ppc64le](https://openqa.opensuse.org/tests/1686801#step/welcome/1)
     * [opensuse-Tumbleweed-DVD-aarch64@aarch64](https://openqa.opensuse.org/tests/1686802)
     * [opensuse-Tumbleweed-JeOS-for-AArch64@aarch64-HD24G](https://openqa.opensuse.org/tests/1686803)
