### PR TITLE
Fix for validate built against new page layout

### DIFF
--- a/data/qam/validate_kiwi.sh
+++ b/data/qam/validate_kiwi.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Dump kiwi obs page, dump build status and check for failures
+curl -k https://build.suse.de/project/monitor/QA:Maintenance:Images:$1:$2 | grep tbody | sed 's/&quot//g' | tr -d \'\; | sed -n 's/\(data-statushash={.*}\)/@\1@/p' | cut -d "@" -f 2 | tr { '\n' | grep package: | sed 's/package:\(test-image.*\),code:\(.*\)}.*/\1 \2/' | tr -d } > $3
+if grep -q failed $3; then
+    echo "KIWI build failed, check $3"
+    exit 1
+fi
+echo "KIWI build successfully finished"
+exit 0
+
+

--- a/tests/kiwi_images_test/validate_build.pm
+++ b/tests/kiwi_images_test/validate_build.pm
@@ -42,20 +42,10 @@ sub run {
     if ($install_type == 0) {
         $kiwi_version = $kiwi_version . "-ng";
     }
-
-    script_run("curl -k https://build.suse.de/project/monitor/QA:Maintenance:Images:$sle_version:$kiwi_version-testing | sed -n \"s/.*\\(test-image-[[:alpha:]]\\+\\).*>\\(.*\\)<\\/a><\\/td>/\\1 \\2/p\" > $logfile");
-    #script_run("echo -e \"test-image-iso succeeded\\ntest-image-pxe succeeded\\ntest-image-vmx succeeded\\n\" > $logfile");
-    my $check_log = script_output("cat $logfile");
-    foreach my $line (split(/\n/, $check_log)) {
-        if ($line !~ /succeeded/) {
-            print $line;
-            die "Kiwi build failure";
-        }
-        else {
-            print $line;
-        }
-    }
-
+    # new page layout contains a hash inside tbody, became too complex to run using assert_script
+    assert_script_run("curl -v -o /tmp/validate_kiwi.sh" . data_url("qam/validate_kiwi.sh"));
+    assert_script_run("chmod +x /tmp/validate_kiwi.sh");
+    assert_script_run("/tmp/validate_kiwi.sh $sle_version $kiwi_version-testing $logfile");
     # upload logs anyway
     upload_logs $logfile;
 }


### PR DESCRIPTION
Page for build.suse.de where the isos are generated had a layout change,
thus breaking the parser script that checks build status.

Changing to a shell script, since it is easier to run than a command
inside assert_script_run.

Fix poo#89407 [qem] kiwi build validation fails due to page layout
change

Test runs:
SLE12SP3:http://10.161.229.209/tests/209
SLE12SP4: http://10.161.229.209/tests/208
SLE12SP5: http://10.161.229.209/tests/212
SLE15SP0: http://10.161.229.209/tests/213
SLE15SP1: http://10.161.229.209/tests/214
SLE15SP2: http://10.161.229.209/tests/215

- Related ticket: https://progress.opensuse.org/issues/89407
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
