### PR TITLE
Run ibtests against linux-rdma's for-next branch

### DIFF
--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -1,0 +1,46 @@
+name:           ibtest-master
+description:    >
+    The master node for the infiniband testsuite (hpc-testing)
+vars:
+    DESKTOP: textmode
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
+    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
+    GRUB_TIMEOUT: 300
+    IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
+    IBTEST_IP1: 10.162.2.93
+    IBTEST_IP2: 10.162.2.94
+    IBTEST_ROLE: IBTEST_MASTER
+    IPXE: 1
+    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+    IPXE_CONSOLE: ttyS1,115200
+    KERNEL_GIT_TREE: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
+    KERNEL_GIT_BRANCH: for-next
+    PACKAGES: rdma-core,rdma-ndd
+    PATTERNS: base,minimal
+    SCC_ADDONS: sdk
+schedule:
+    - kernel/ibtests_barriers
+    - installation/ipxe_install
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/select_packages
+    - installation/installation_overview
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - boot/reconnect_mgmt_console
+    - installation/first_boot
+    - kernel/build_git_kernel
+    - kernel/ibtests

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -1,0 +1,46 @@
+name:           ibtest-slave
+description:    >
+    The slave node for the infiniband testsuite (hpc-testing)
+vars:
+    DESKTOP: textmode
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
+    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
+    GRUB_TIMEOUT: 300
+    IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
+    IBTEST_IP1: 10.162.2.93
+    IBTEST_IP2: 10.162.2.94
+    IBTEST_ROLE: IBTEST_SLAVE
+    IPXE: 1
+    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+    IPXE_CONSOLE: ttyS1,115200
+    KERNEL_GIT_TREE: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
+    KERNEL_GIT_BRANCH: for-next
+    PACKAGES: rdma-core,rdma-ndd
+    PARALLEL_WITH: ibtest-master
+    PATTERNS: base,minimal
+    SCC_ADDONS: sdk
+schedule:
+    - installation/ipxe_install
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/select_packages
+    - installation/installation_overview
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - boot/reconnect_mgmt_console
+    - installation/first_boot
+    - kernel/build_git_kernel
+    - kernel/ibtests

--- a/tests/kernel/build_git_kernel.pm
+++ b/tests/kernel/build_git_kernel.pm
@@ -36,10 +36,7 @@ sub run {
     assert_script_run('cd linux');
     assert_script_run('zcat /proc/config.gz > .config');
     assert_script_run('make olddefconfig');
-    assert_script_run('yes | make localmodconfig');
 
-    # building a kernel takes a while, give it a long timeout in case we run
-    # this on a slower machine
     assert_script_run('make -j `nproc` | tee /tmp/kernelbuild.log', 3600);
     assert_script_run("sed -i 's/allow_unsupported_modules 0/allow_unsupported_modules 1/g' /etc/modprobe.d/10-unsupported-modules.conf");
     assert_script_run('make install modules_install');

--- a/tests/kernel/build_git_kernel.pm
+++ b/tests/kernel/build_git_kernel.pm
@@ -29,7 +29,7 @@ sub run {
     $self->select_serial_terminal;
 
     # download, compile and install a kernel tree from git
-    zypper_call('in git-core ncurses-devel gcc flex bison libelf-devel libopenssl-devel');
+    zypper_call('in bc git-core ncurses-devel gcc flex bison libelf-devel libopenssl-devel');
     # git clone takes a long time due to slow network connection
     assert_script_run("git clone --depth 1 --single-branch --branch $git_branch $git_tree linux", 7200);
 


### PR DESCRIPTION
Run the InfiniBand-testsuite also using the linux-rdma upstream development tree

- Related ticket: https://progress.opensuse.org/issues/89413
- Needles: -
- Verification run: http://baremetal-support.qa.suse.de/tests/838 and http://baremetal-support.qa.suse.de/tests/839
