### PR TITLE
btrfs-progs: Add KEEP_DEFAULT_BTRFS_BINARY parameter

### DIFF
--- a/data/btrfs-progs/install.sh
+++ b/data/btrfs-progs/install.sh
@@ -2,6 +2,7 @@
 
 # The first parameter is the git url
 # The second parameter is the install folder
+# The third parameter keep default btrfs binary
 btrfs_bin='
 btrfs
 btrfs-convert
@@ -21,4 +22,6 @@ make
 make testsuite
 mkdir -p $2
 tar zxf tests/btrfs-progs-tests.tar.gz -C $2
-cp -r $btrfs_bin /sbin/
+if [ "$3" = 0 ]; then
+    cp -r $btrfs_bin /sbin/
+fi

--- a/tests/btrfs-progs/install.pm
+++ b/tests/btrfs-progs/install.pm
@@ -35,6 +35,7 @@ sub install_dependencies {
       zlib-devel
       libext2fs-devel
       libmount-devel
+      libuuid-devel
     );
     if (get_var('BTRFS_PROGS_DEPS')) {
         @deps = split(/,/, get_var('BTRFS_PROGS_DEPS'));
@@ -49,10 +50,17 @@ sub run {
     # Install btrfs-progs
     if (get_var('BTRFS_PROGS_REPO')) {
         # Add filesystems repository and install btrfs-progs package
-        zypper_call 'rm btrfsprogs';
+        my $btrfs_package_name;
+        if (get_var('KEEP_DEFAULT_BTRFS_BINARY')) {
+            $btrfs_package_name = get_var('BTRFS_PACKAGE_NAME', 'btrfs-progs-tests');
+        }
+        else {
+            $btrfs_package_name = get_var('BTRFS_PACKAGE_NAME', 'btrfs-progs');
+            zypper_call 'rm btrfsprogs';
+        }
         zypper_call '--no-gpg-checks ar -f ' . get_var('BTRFS_PROGS_REPO') . ' filesystems';
         zypper_call '--gpg-auto-import-keys ref';
-        zypper_call 'in -r filesystems btrfs-progs';
+        zypper_call "in -r filesystems $btrfs_package_name";
         zypper_call 'rr filesystems';
         set_var('WORK_DIR', '/opt/btrfs-progs-tests');
     }
@@ -60,10 +68,17 @@ sub run {
         # Build test suite of btrfs-progs from git
         use constant INST_DIR => '/opt/btrfs-progs-tests';
         use constant GIT_URL  => get_var('BTRFS_PROGS_GIT_URL', 'https://github.com/kdave/btrfs-progs.git');
+        my $keep_default_btrfs_binary;
+        if (get_var('KEEP_DEFAULT_BTRFS_BINARY')) {
+            $keep_default_btrfs_binary = 1;
+        }
+        else {
+            $keep_default_btrfs_binary = 0;
+        }
         install_dependencies;
         assert_script_run 'wget ' . autoinst_url('/data/btrfs-progs/install.sh');
         assert_script_run 'chmod a+x install.sh';
-        assert_script_run './install.sh ' . GIT_URL . " " . INST_DIR, timeout => 1200;
+        assert_script_run './install.sh ' . GIT_URL . " " . INST_DIR . " " . $keep_default_btrfs_binary, timeout => 1200;
         set_var('WORK_DIR', INST_DIR);
     }
 

--- a/tests/btrfs-progs/run.pm
+++ b/tests/btrfs-progs/run.pm
@@ -98,6 +98,7 @@ sub run {
     select_console('root-console');
 
     assert_script_run('cd ' . get_var('WORK_DIR'));
+    assert_script_run('btrfs version | tee ' . STATUS_LOG);
     for my $category (@category) {
         assert_script_run('mkdir -p ' . LOG_DIR . $category);
 


### PR DESCRIPTION
The btrfs-progs test will install the latest btrfs binarys to replace the default. But sometimes we need to keep the default for debugging or other reasons.

- Related ticket: https://progress.opensuse.org/issues/88954
- Needles: N/A
- Verification run: 
http://10.67.134.217/tests/11956 (git install)
http://10.67.134.217/tests/11957 (git install and keep default)
http://10.67.134.217/tests/11958 (IBS install)
http://10.67.134.217/tests/11959 (IBS install and keep default)