### PR TITLE
WIP Bypass keyring lock at seahorse startup for ppc64le

### DIFF
--- a/tests/x11/seahorse.pm
+++ b/tests/x11/seahorse.pm
@@ -23,6 +23,11 @@ use testapi;
 
 sub run {
     x11_start_program('seahorse');
+    if (check_screen "seahorse-keyring-locked") {
+        assert_and_click "unlock";
+        type_password;
+        send_key "ret";
+    }
     send_key "ctrl-n";                                # New keyring
     assert_screen "seahorse-keyring-selector";        # Dialog "Select type to create"
     wait_still_screen(3);


### PR DESCRIPTION
Bypass keyring lock at seahorse startup for ppc64le

- Related ticket: https://progress.opensuse.org/issues/89422
- Needles:  https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/29e19893e8da7dd137a9cdf78fc7bc9ec6c0b2eb
- Verification run:
   TW ppc64le:  https://openqa.opensuse.org/tests/1653616#step/seahorse/3
   will do a run with x86_64
  will replace workaround needle by ref to issue#89422

