### PR TITLE
Fix a small error in Public Cloud library

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -224,7 +224,7 @@ sub wait_for_ssh
     }
 
     croak(sprintf("Unable to reach SSH port of instance %s with public IP:%s within %d seconds",
-            $self->{instance_id}, $self->{public_ip}, $self->{timeout}))
+            $self->{instance_id}, $self->{public_ip}, $args{timeout}))
       unless ($args{proceed_on_failure});
     return;
 }


### PR DESCRIPTION
A wrong timeout variable is used in wait_for_ssh.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/5584184#step/sles4sap/133
- Verification run: https://openqa.suse.de/t5591507