### PR TITLE
qa_test_klp: Allow to clone https with unknown certificate

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -42,6 +42,7 @@ sub run {
     add_suseconnect_product("sle-sdk") if (is_sle('<12-SP5'));
     zypper_call('in -l autoconf automake gcc git make');
 
+    assert_script_run('git config --global http.sslVerify false');
     assert_script_run('git clone ' . $git_repo);
     assert_script_run("cd $dir && ./run.sh", 2760);
 }


### PR DESCRIPTION
Fixes:

```
fatal: unable to access 'http://gitlab.suse.de/nstange/qa_test_klp.git/': 
SSL certificate problem: unable to get local issuer certificate
```

- Verification run: http://quasar.suse.cz/tests/6095
