### PR TITLE
Add scale_timeout in ReaR restore test

### DIFF
--- a/tests/ha/rear_restore.pm
+++ b/tests/ha/rear_restore.pm
@@ -17,8 +17,9 @@ use testapi;
 use power_action_utils 'power_action';
 
 sub run {
-    my ($self) = @_;
+    my ($self)   = @_;
     my $hostname = get_var('HOSTNAME', 'susetest');
+    my $timeout  = bmwqemu::scale_timeout(600);
 
     # Select recovering entry and wait for OS boot
     assert_screen('rear-boot-screen');
@@ -29,7 +30,7 @@ sub run {
     # Restore the OS backup
     set_var('LIVETEST', 1);                               # Because there is no password in ReaR miniOS
     select_console('root-console', skip_setterm => 1);    # Serial console is not configured in ReaR miniOS
-    assert_script_run('export USER_INPUT_TIMEOUT=5; rear -d -D recover', timeout => 300);
+    assert_script_run('export USER_INPUT_TIMEOUT=5; rear -d -D recover', timeout => $timeout);
     $self->upload_rear_logs;
     set_var('LIVETEST', 0);
 


### PR DESCRIPTION
ReaR restore test is lacking the `scale_timeout` use which could be useful on slow workers.
This commit also increase the default timeout to 600s, to be aligned to the backup test and also because some workers are slower than the one in our lab.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A