### PR TITLE
Wait for boot reset in case of hyperv gen2

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1109,9 +1109,14 @@ sub wait_boot {
     }
     else {
         $self->handle_grub(bootloader_time => $bootloader_time, in_grub => $in_grub);
-        if (get_var('UEFI') && is_hyperv && check_screen('grub2', 10)) {
-            record_soft_failure 'bsc#1118456 - Booting reset on Hyper-V (UEFI)';
-            send_key 'ret';
+        # part of soft failure bsc#1118456
+        if (get_var('UEFI') && is_hyperv) {
+            wait_still_screen stilltime => 5, timeout => 26;
+            save_screenshot;
+            if (check_screen('grub2', 20)) {
+                record_soft_failure 'bsc#1118456 - Booting reset on Hyper-V (UEFI)';
+                send_key 'ret';
+            }
         }
     }
     reconnect_xen if check_var('VIRSH_VMM_FAMILY', 'xen');


### PR DESCRIPTION
Hyperv 2016 suffers from boot reset in case of VM is configured as gen2 and uses UEFI. The previously introduced softfailure could match grub2 early and resulting to [test case failure](https://openqa.suse.de/tests/5590453#step/glibc_locale/54)

* VRs:
  * [reset in glibc_locale](http://kepler.suse.cz/tests/3758#step/glibc_locale/105)
  * [no reset](http://kepler.suse.cz/tests/3759#step/snapper_jeos_cli/104)
  * [no reset])http://kepler.suse.cz/tests/3760)
  * [reset in snapper testcase](http://kepler.suse.cz/tests/3762#step/snapper_jeos_cli/63)