### PR TITLE
Test for pre-installed rsyslog package

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -128,7 +128,9 @@ sub run {
         script_run("journalctl --boot=-1 | grep 'no persistent journal was found'") or die "Persistent journal should not be enabled by default on SLE!\n";
         assert_script_run "mkdir ${\ PERSISTENT_LOG_DIR }";
         assert_script_run "systemd-tmpfiles --create --prefix ${\ PERSISTENT_LOG_DIR }";
-        # test for imuxsock
+        # test for installed rsyslog and for imuxsock existance
+        # rsyslog must be there by design
+        assert_script_run 'rpm -q rsyslog';
         assert_script_run 'test -S /run/systemd/journal/syslog';
         upload_logs('/var/log/messages');
         systemctl 'restart systemd-journald';


### PR DESCRIPTION
Seems like JeOS images based on sle15sp1 are missing `rsyslog` package.

* ticket: [[sle15sp1] test fails in journalctl because of missing rsyslog](https://progress.opensuse.org/issues/89515)
* VR: [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build37.8.31-jeos-extratest@64bit-virtio-vga](http://kepler.suse.cz/tests/3770#)