### PR TITLE
Openldap to 389ds migration tools test case

### DIFF
--- a/data/openldap_to_389ds/aci.ldif
+++ b/data/openldap_to_389ds/aci.ldif
@@ -1,0 +1,5 @@
+dn: dc=ldapdom,dc=net
+changetype: modify
+add: aci
+aci: (targetattr = "*") (version 3.0;acl "myaci";allow (all) (userdn = "ldap:///anyone");)
+

--- a/data/openldap_to_389ds/db.ldif
+++ b/data/openldap_to_389ds/db.ldif
@@ -1,0 +1,73 @@
+# base
+dn: dc=ldapdom,dc=net
+dc: ldapdom
+objectClass: top
+objectClass: domain
+
+dn: ou=UnixUser,dc=ldapdom,dc=net
+ou: People
+objectClass: top
+objectClass: organizationalUnit
+
+dn: ou=UnixGroup,dc=ldapdom,dc=net
+ou: Group
+objectClass: top
+objectClass: organizationalUnit
+
+# users
+dn: uid=testuser1,ou=UnixUser,dc=ldapdom,dc=net
+objectClass: account
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+uid: testuser1
+cn: testuser1
+userPassword: {crypt}$6$7syqq.EQ$68iOWF0BTWC24aKE0rJ8cUtPd2Cs7HkruwjEikcJAD5dNNEgMMJ5Jk7w2sC2hYUwN2s65srTQTU83ADt2.t4l0
+loginShell: /bin/bash
+uidNumber: 9000
+gidNumber: 8000
+homeDirectory: /tmp
+
+dn: uid=testuser2,ou=UnixUser,dc=ldapdom,dc=net
+objectClass: account
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+uid: testuser2
+cn: testuser2
+userPassword: {crypt}$6$7syqq.EQ$68iOWF0BTWC24aKE0rJ8cUtPd2Cs7HkruwjEikcJAD5dNNEgMMJ5Jk7w2sC2hYUwN2s65srTQTU83ADt2.t4l0
+loginShell: /bin/bash
+uidNumber: 9001
+gidNumber: 8000
+homeDirectory: /tmp
+
+# groups
+dn: cn=group1,ou=UnixGroup,dc=ldapdom,dc=net
+objectClass: groupOfNames
+objectClass: posixGroup
+objectClass: top
+cn: group1
+gidNumber: 8000
+member: uid=testuser1,ou=UnixUser,dc=ldapdom,dc=net
+memberUid: 9000
+member: uid=testuser2,ou=UnixUser,dc=ldapdom,dc=net
+memberUid: 9001
+
+dn: cn=group2,ou=UnixGroup,dc=ldapdom,dc=net
+objectClass: groupOfNames
+objectClass: posixGroup
+objectClass: top
+cn: group2
+gidNumber: 8001
+member: uid=testuser1,ou=UnixUser,dc=ldapdom,dc=net
+memberUid: 9000
+
+dn: cn=group3,ou=UnixGroup,dc=ldapdom,dc=net
+objectClass: groupOfNames
+objectClass: posixGroup
+objectClass: top
+cn: group3
+gidNumber: 8002
+member: uid=testuser2,ou=UnixUser,dc=ldapdom,dc=net
+memberUid: 9001
+

--- a/data/openldap_to_389ds/instance.inf
+++ b/data/openldap_to_389ds/instance.inf
@@ -1,0 +1,9 @@
+[general]
+config_version = 2
+
+[slapd]
+root_password = YOUR_ADMIN_PASSWORD_HERE
+
+[backend-userroot]
+sample_entries = yes
+suffix = dc=example,dc=com

--- a/data/openldap_to_389ds/slapd.conf
+++ b/data/openldap_to_389ds/slapd.conf
@@ -1,0 +1,36 @@
+include		/etc/openldap/schema/core.schema
+include		/etc/openldap/schema/cosine.schema
+include		/etc/openldap/schema/inetorgperson.schema
+include		/etc/openldap/schema/rfc2307bis.schema
+include		/etc/openldap/schema/yast.schema
+
+access to dn.base=""
+        by * read
+
+access to dn.base="cn=Subschema"
+        by * read
+
+access to attrs=userPassword,userPKCS12
+        by self write
+        by * auth
+
+access to attrs=shadowLastChange
+        by self write
+        by * read
+
+access to *
+        by * read
+
+moduleload  back_hdb.la
+moduleload  memberof.la
+
+database	hdb
+suffix		"dc=ldapdom,dc=net"
+checkpoint      1024    5
+cachesize       10000
+rootdn		"cn=root,dc=ldapdom,dc=net"
+rootpw		pass
+directory	/tmp/ldap-sssdtest
+index	objectClass	eq
+
+overlay memberof

--- a/data/openldap_to_389ds/sssd.conf
+++ b/data/openldap_to_389ds/sssd.conf
@@ -1,0 +1,24 @@
+[sssd]
+config_file_version = 2
+domains = ldapdom
+services = nss, pam
+debug = 9
+
+[nss]
+filter_groups = root
+filter_users = root
+debug = 9
+
+[domain/ldapdom]
+debug = 9
+id_provider = ldap
+auth_provider = none
+
+ldap_schema = rfc2307bis
+ldap_uri = ldap://127.0.0.1
+ldap_tls_reqcert = never
+
+ldap_search_base = dc=ldapdom,dc=net
+ldap_user_search_base = dc=ldapdom,dc=net
+ldap_group_search_base = dc=ldapdom,dc=net
+ldap_group_object_class = groupOfNames

--- a/schedule/migration/openldap_to_389ds.yaml
+++ b/schedule/migration/openldap_to_389ds.yaml
@@ -1,0 +1,7 @@
+name:   openldap_to_389ds
+description:    >
+    This yaml file is used for call module openldap_to_389ds.pm(check function of openldap_to_ds tools)
+schedule:
+  - boot/boot_to_desktop
+  - console/consoletest_setup
+  - migration/openldap_to_389ds

--- a/tests/migration/openldap_to_389ds.pm
+++ b/tests/migration/openldap_to_389ds.pm
@@ -1,0 +1,106 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: The openldap_to_ds tool will attempt to automatically migrate
+# custom schema, backens, some overlays from openldap to 389ds.
+#
+# Maintainer: wegao <wegao@suse.com>
+
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use lockapi;
+use Utils::Systemd qw(systemctl disable_and_stop_service);
+use registration qw(add_suseconnect_product);
+use version_utils;
+
+sub run {
+    my ($self) = @_;
+    my $password = $testapi::password;
+    $self->select_serial_terminal;
+
+    # Install 389-ds and sssd on client
+    zypper_call("in 389-ds sssd sssd-tools");
+    zypper_call('info 389-ds');
+    # Install openldap since we need use slaptest tools
+    add_suseconnect_product('sle-module-legacy') if is_sle;
+    zypper_call("in openldap2 sssd-ldap openldap2-client");
+
+    # Disable and stop the nscd daemon because it conflicts with sssd
+    disable_and_stop_service("nscd");
+
+    # On newer environments, nsswitch.conf is located in /usr/etc
+    # Copy it to /etc directory
+    script_run 'f=/etc/nsswitch.conf; [ ! -f $f ] && cp /usr$f $f';
+    # Configure nsswitch with sssd
+    assert_script_run "sed -i 's/^passwd:.*/passwd: compat sss/' /etc/nsswitch.conf";
+    assert_script_run "sed -i 's/^group:.*/group: compat sss/' /etc/nsswitch.conf";
+    assert_script_run "cat /etc/nsswitch.conf";
+
+    # Prepare test env
+    assert_script_run "cd; curl -L -v " . autoinst_url . "/data/openldap_to_389ds > openldap_to_389ds.data && cpio -id < openldap_to_389ds.data && mv data test && ls test";
+    assert_script_run("cd test");
+
+    # We need start openldap to kick out date base file which stored in directory
+    assert_script_run "mkdir /tmp/ldap-sssdtest";
+    assert_script_run "slapd -h 'ldap:///' -f slapd.conf";
+    assert_script_run "ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif";
+    assert_script_run "killall slapd";
+    assert_script_run "ps -aux | grep slapd";
+
+    # setup sssd
+    assert_script_run "cp ./sssd.conf /etc/sssd/sssd.conf";
+    systemctl("stop sssd");
+    assert_script_run "rm -rf /var/lib/sss/db/*";
+    systemctl("restart sssd");
+    systemctl("status sssd");
+
+    # Prepare data file for migration
+    assert_script_run "sed -i 's/^root_password.*/root_password = $password/' ./instance.inf";
+    assert_script_run "mkdir slapd.d";
+    assert_script_run("dscreate from-file ./instance.inf", timeout => 60);
+    assert_script_run "dsctl localhost status";
+    assert_script_run "slaptest -f slapd.conf -F ./slapd.d";
+
+    # Check migration tools
+    assert_script_run "openldap_to_ds --confirm localhost ./slapd.d ./db.ldif";
+    assert_script_run "ldapmodify -H ldap://localhost -x -D 'cn=Directory Manager' -w $password -f aci.ldif";
+
+    # Manual fix memberof plugin
+    assert_script_run "dsconf localhost plugin memberof show";
+    assert_script_run "systemctl restart dirsrv\@localhost";
+    assert_script_run "dsconf localhost plugin memberof fixup dc=ldapdom,dc=net -f '(objectClass=*)'";
+
+    # Restart sssd make sure re-detect backend
+    systemctl("restart sssd");
+    systemctl("status sssd");
+
+    # check memeberof plugin
+    validate_script_output("ldapsearch -H ldap://localhost -b 'dc=ldapdom,dc=net' -s sub -x -D 'cn=Directory Manager' -w $password memberof", sub { m/memberof:.*group1/ });
+    validate_script_output('getent passwd testuser1\@ldapdom', sub { m/testuser1.*testuser1/ });
+
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    select_console 'log-console';
+    $self->tar_and_upload_log('/var/log/dirsrv', '/tmp/ds389.tar.bz2');
+    $self->tar_and_upload_log('/var/log/sssd',   '/tmp/sssd.tar.bz2');
+    $self->SUPER::post_fail_hook;
+}
+
+1;


### PR DESCRIPTION
This test case include basic check on openldap to 389 migration tools.

- Related ticket: https://progress.opensuse.org/issues/81352
- Needles: na
- Verification run: https://openqa.suse.de/tests/5607399#step/openldap_to_389ds/72
New run after update, for failed part will submit an issue:
https://openqa.suse.de/tests/5620935#step/openldap_to_389ds/112
