### PR TITLE
prepare_firstboot: Adjust path after jeos-firstboot refactoring

### DIFF
--- a/tests/jeos/prepare_firstboot.pm
+++ b/tests/jeos/prepare_firstboot.pm
@@ -25,7 +25,6 @@ sub run {
     my $reboot_for_jeos_firstboot = 1;
 
     my $is_generalhw_via_ssh = check_var('BACKEND', 'generalhw') && !defined(get_var('GENERAL_HW_VNC_IP'));
-    my $jeos_firstboot_cmd   = (is_leap) ? '/usr/lib/jeos-firstboot' : '/usr/sbin/jeos-firstboot';
 
     if ($is_generalhw_via_ssh) {
         # Run jeos-firstboot manually and do not reboot as we use SSH
@@ -48,7 +47,9 @@ sub run {
 
     if ($is_generalhw_via_ssh) {
         # Do not set network down as we are connected through ssh!
-        assert_script_run("sed -i 's/ip link set down /# ip link set down/g' $jeos_firstboot_cmd");
+        my $filetoedit = is_leap('<=15.2') ? '/usr/lib/jeos-firstboot' : '/usr/share/jeos-firstboot/jeos-firstboot-dialogs';
+        $filetoedit = '/usr/sbin/jeos-firstboot' unless is_leap;    # Change is not in TW just yet
+        assert_script_run("sed -i 's/ip link set down /# ip link set down/g' $filetoedit");
     }
     # Remove current root password
     assert_script_run("sed -i 's/^root:[^:]*:/root:*:/' /etc/shadow", 600);
@@ -69,9 +70,8 @@ sub run {
         type_string("reboot\n");
     }
     else {
-        type_string("$jeos_firstboot_cmd\n");
+        type_string(is_leap('<=15.2') ? "/usr/lib/jeos-firstboot\n" : "jeos-firstboot\n");
     }
-
 }
 
 1;


### PR DESCRIPTION
The refactor landed in Leap 15.3, but not in TW yet:

Leap <= 15.2: /usr/lib/jeos-firstboot
Leap >= 15.3: /usr/share/jeos-firstboot/jeos-firstboot-dialogs
Tumbleweed:   /usr/sbin/jeos-firstboot

Verification run: https://openqa.opensuse.org/tests/1657371
