### PR TITLE
Fixes for virtualization runs

### DIFF
--- a/data/autoyast_kvm/sles15sp2_PRG.xml
+++ b/data/autoyast_kvm/sles15sp2_PRG.xml
@@ -5,12 +5,12 @@
     <add_on_others config:type="list"/>
     <add_on_products config:type="list">
       <listentry>
-        <media_url><![CDATA[http://mirror.suse.cz/install/SLP/SLE-15-SP2-Full-LATEST/x86_64/DVD1/]]></media_url>
+        <media_url><![CDATA[http://mirror.suse.cz/install/SLP/SLE-15-SP2-Full-GM/x86_64/DVD1/]]></media_url>
         <product>Basesystem-Module 15.2-0</product>
         <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
-        <media_url><![CDATA[http://mirror.suse.cz/install/SLP/SLE-15-SP2-Full-LATEST/x86_64/DVD1/]]></media_url>
+        <media_url><![CDATA[http://mirror.suse.cz/install/SLP/SLE-15-SP2-Full-GM/x86_64/DVD1/]]></media_url>
         <product>Server-Applications-Module 15.2-0</product>
         <product_dir>/Module-Server-Applications</product_dir>
       </listentry>

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -360,7 +360,7 @@ sub wait_guests_shutdown {
 
 # Start all guests and wait until they are online
 sub start_guests {
-    assert_script_run "virsh start $_" foreach (keys %virt_autotest::common::guests);
+    script_run "virsh start $_" foreach (keys %virt_autotest::common::guests);
     # Wait for guests to show up as running
     script_retry("virsh list | grep $_ | grep running", delay => 5, retry => 10) foreach (keys %virt_autotest::common::guests);
     wait_guest_online($_) foreach (keys %virt_autotest::common::guests);

--- a/tests/virtualization/universal/patch_and_reboot.pm
+++ b/tests/virtualization/universal/patch_and_reboot.pm
@@ -26,6 +26,8 @@ use qam;
 sub run {
     my $self       = shift;
     my $kernel_log = shift // '/tmp/virt_kernel.txt';
+    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
+    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
 
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));
 

--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -24,6 +24,9 @@ use virt_autotest::utils;
 
 sub run {
     my ($self) = @_;
+    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
+    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
+
     my $kernel_log = '/tmp/guests_kernel_results.txt';
     my ($host_running_version, $host_running_sp) = get_os_release();
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));

--- a/tests/virtualization/universal/register_guests.pm
+++ b/tests/virtualization/universal/register_guests.pm
@@ -27,6 +27,8 @@ use version_utils;
 
 sub run_test {
     my ($self) = @_;
+    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
+    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
 
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "Registrating $guest against SMT";

--- a/tests/virtualization/universal/ssh_guests_init.pm
+++ b/tests/virtualization/universal/ssh_guests_init.pm
@@ -26,6 +26,10 @@ use testapi;
 use utils;
 
 sub run {
+    my $self = shift;
+    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
+    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
+
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "Establishing SSH connection to $guest";
 

--- a/tests/virtualization/universal/ssh_hypervisor_init.pm
+++ b/tests/virtualization/universal/ssh_hypervisor_init.pm
@@ -28,7 +28,8 @@ use virt_autotest::utils;
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
+    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
+    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
     my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     # Remove old files

--- a/tests/virtualization/universal/stresstest.pm
+++ b/tests/virtualization/universal/stresstest.pm
@@ -21,7 +21,8 @@ use version_utils;
 
 sub run_test {
     my $self = shift;
-    $self->select_serial_terminal;
+    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
+    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
     # Fetch the test script to local host, before distributing it to the guests
     script_run('curl -v -o /var/tmp/stresstest.sh ' . data_url('virtualization/stresstest.sh'));
     script_run('chmod 0755 /var/tmp/stresstest.sh');

--- a/tests/virtualization/universal/upgrade_guests.pm
+++ b/tests/virtualization/universal/upgrade_guests.pm
@@ -21,6 +21,8 @@ use virt_autotest::common;
 
 sub run {
     my ($self) = @_;
+    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
+    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
 
     script_run("mkdir /root/update_guests");
     foreach my $guest (keys %virt_autotest::common::guests) {

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -93,16 +93,21 @@ sub upload_machine_definitions {
 }
 
 sub run {
+    my $self = shift;
+    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
+    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
+
     # Fill the current pairs of hostname & address into /etc/hosts file
     assert_script_run 'virsh list --all';
     add_guest_to_hosts $_, $virt_autotest::common::guests{$_}->{ip} foreach (keys %virt_autotest::common::guests);
     assert_script_run "cat /etc/hosts";
 
     # Wait for guests to finish installation
-    assert_script_run("wait", timeout => 1200);
+    script_run("wait", timeout => 1200);
     #script_retry("! ps x | grep -v 'grep' | grep 'virt-install'", retry => 120, delay => 10);
     # Unfortunately this doesn't cover the second step of the installation, where ssh is available
-    script_run("sleep 300", timeout => 360);    # XXX No idea yet how to prevent this sleep :-(
+    script_run("sleep 600", timeout => 660);    # XXX No idea yet how to prevent this sleep :-(
+    start_guests();
     record_info("guests installed", "Guest installation completed");
     wait_guest_online($_, 120) foreach (keys %virt_autotest::common::guests);
 

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -77,6 +77,9 @@ sub add_pci_bridge {
         # Apply xml settings to VM. Note: They will be applied after reboot.
         assert_script_run("virt-xml-validate $xml");
         assert_script_run("virsh define $xml");
+
+    } elsif (is_xen_host() && is_pv_guest($guest)) {
+        # We're skipping to add an additional bridge on xen
     } else {
         my $msg = "Unknown machine type";
         record_soft_failure($msg);


### PR DESCRIPTION
This PR contains three commits which should fix the recent issues in our virtualization runs

- Related ticket: [poo#89500](https://progress.opensuse.org/issues/89500), [poo#89026](https://progress.opensuse.org/issues/89026)
- Verification run: http://duck-norris.qam.suse.de/tests/5425

`VIRTINSTALL_EXTRA_ARGS_SLES15SP2` is set to `selfupdate=0` because of [bsc#1183042](https://bugzilla.suse.com/show_bug.cgi?id=1183042)

