### PR TITLE
Use REST API to test SLES license screen

### DIFF
--- a/lib/Distribution/Sle/15_current.pm
+++ b/lib/Distribution/Sle/15_current.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,11 +13,24 @@
 # Tumbleweed distribution, and only if it behaves different in Sle15 then it
 # should be overriden here.
 
-# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package Distribution::Sle::15_current;
 use strict;
 use warnings FATAL => 'all';
 use parent 'Distribution::Opensuse::Tumbleweed';
+
+use Installation::License::SLE::LicenseAgreementController;
+
+=head2 get_eula_controller
+
+Returns controller for the EULA page. This page significantly differs
+from the openSUSE distributions, therefore has its own controller.
+
+=cut
+
+sub get_eula_controller() {
+    return Installation::License::SLE::LicenseAgreementController->new();
+}
 
 1;

--- a/lib/Installation/License/SLE/AcceptLicensePopup.pm
+++ b/lib/Installation/License/SLE/AcceptLicensePopup.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The module provides interface to act on pop-up when license is not
+#          accepted.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::License::SLE::AcceptLicensePopup;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_ok}   = $self->{app}->button({id => 'ok'});
+    $self->{lbl_text} = $self->{app}->checkbox({label => 'You must accept the license to install this product'});
+
+    return $self;
+}
+
+sub press_ok {
+    my ($self) = @_;
+    return $self->{btn_ok}->click();
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{lbl_text}->exist();
+}
+
+1;

--- a/lib/Installation/License/SLE/LicenseAgreementController.pm
+++ b/lib/Installation/License/SLE/LicenseAgreementController.pm
@@ -60,7 +60,7 @@ sub proceed_to_next_page {
 sub process_accept_license_pop_up {
     my ($self) = @_;
     $self->get_accept_license_popup()->press_ok();
-    return $self->get_license_agreement_page()->exist();
+    return $self->get_license_agreement_page()->is_shown();
 }
 
 1;

--- a/lib/Installation/License/SLE/LicenseAgreementController.pm
+++ b/lib/Installation/License/SLE/LicenseAgreementController.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for License Agreement Page
+#          of the installer.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::License::SLE::LicenseAgreementController;
+use strict;
+use warnings;
+use Installation::License::SLE::LicenseAgreementPage;
+
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{LicenseAgreementPage} = Installation::License::SLE::LicenseAgreementPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_license_agreement_page {
+    my ($self) = @_;
+    die "License Agreement Page is not displayed" unless $self->{LicenseAgreementPage}->is_shown();
+    return $self->{LicenseAgreementPage};
+}
+
+1;

--- a/lib/Installation/License/SLE/LicenseAgreementController.pm
+++ b/lib/Installation/License/SLE/LicenseAgreementController.pm
@@ -15,8 +15,8 @@
 package Installation::License::SLE::LicenseAgreementController;
 use strict;
 use warnings;
+use Installation::License::SLE::AcceptLicensePopup;
 use Installation::License::SLE::LicenseAgreementPage;
-
 use YuiRestClient;
 
 sub new {
@@ -27,7 +27,16 @@ sub new {
 
 sub init {
     my ($self, $args) = @_;
+    $self->{AcceptLicensePopup}   = Installation::License::SLE::AcceptLicensePopup->new({app => YuiRestClient::get_app()});
     $self->{LicenseAgreementPage} = Installation::License::SLE::LicenseAgreementPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub accept_license {
+    my ($self) = @_;
+    $self->get_license_agreement_page()->check_accept_license();
+    $self->proceed_to_next_page();
+
     return $self;
 }
 
@@ -35,6 +44,23 @@ sub get_license_agreement_page {
     my ($self) = @_;
     die "License Agreement Page is not displayed" unless $self->{LicenseAgreementPage}->is_shown();
     return $self->{LicenseAgreementPage};
+}
+
+sub get_accept_license_popup {
+    my ($self) = @_;
+    die "Accept License Agreement popup is not displayed" unless $self->{AcceptLicensePopup}->is_shown();
+    return $self->{AcceptLicensePopup};
+}
+
+sub proceed_to_next_page {
+    my ($self) = @_;
+    $self->get_license_agreement_page()->press_next();
+}
+
+sub process_accept_license_pop_up {
+    my ($self) = @_;
+    $self->get_accept_license_popup()->press_ok();
+    return $self->get_license_agreement_page()->exist();
 }
 
 1;

--- a/lib/Installation/License/SLE/LicenseAgreementPage.pm
+++ b/lib/Installation/License/SLE/LicenseAgreementPage.pm
@@ -36,6 +36,11 @@ sub get_available_languages {
     return $self->{cb_eula_language}->items();
 }
 
+sub get_eula_content {
+    my ($self) = @_;
+    return $self->{txt_eula}->text();
+}
+
 sub get_selected_language {
     my ($self) = @_;
     return $self->{cb_eula_language}->value();

--- a/lib/Installation/License/SLE/LicenseAgreementPage.pm
+++ b/lib/Installation/License/SLE/LicenseAgreementPage.pm
@@ -7,7 +7,8 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-# Summary: The module provides interface to act on
+# Summary: The module provides interface to act on license agreement page of
+#          the installer for SLE products
 # Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package Installation::License::SLE::LicenseAgreementPage;
@@ -24,11 +25,17 @@ sub new {
 
 sub init {
     my $self = shift;
-    $self->{btn_next}         = $self->{app}->button({id => 'next'});
-    $self->{cb_eula_language} = $self->{app}->combobox({id => '"simple_language_selection"'});
-    $self->{txt_eula}         = $self->{app}->richtext({id => '"CWM::RichText"'});
+    $self->{btn_next}          = $self->{app}->button({id => 'next'});
+    $self->{cb_accept_license} = $self->{app}->checkbox({id => '"Y2Packager::Widgets::ProductLicenseConfirmation"'});
+    $self->{cb_eula_language}  = $self->{app}->combobox({id => '"simple_language_selection"'});
+    $self->{txt_eula}          = $self->{app}->richtext({id => '"CWM::RichText"'});
 
     return $self;
+}
+
+sub check_accept_license {
+    my ($self) = @_;
+    return $self->{cb_accept_license}->check();
 }
 
 sub get_available_languages {
@@ -51,7 +58,7 @@ sub is_shown {
     return $self->{txt_eula}->exist();
 }
 
-sub press_next_button {
+sub press_next {
     my ($self) = @_;
     return $self->{btn_next}->click();
 }

--- a/lib/Installation/License/SLE/LicenseAgreementPage.pm
+++ b/lib/Installation/License/SLE/LicenseAgreementPage.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The module provides interface to act on
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::License::SLE::LicenseAgreementPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_next}         = $self->{app}->button({id => 'next'});
+    $self->{cb_eula_language} = $self->{app}->combobox({id => '"simple_language_selection"'});
+    $self->{txt_eula}         = $self->{app}->richtext({id => '"CWM::RichText"'});
+
+    return $self;
+}
+
+sub get_available_languages {
+    my ($self) = @_;
+    return $self->{cb_eula_language}->items();
+}
+
+sub get_selected_language {
+    my ($self) = @_;
+    return $self->{cb_eula_language}->value();
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{txt_eula}->exist();
+}
+
+sub press_next_button {
+    my ($self) = @_;
+    return $self->{btn_next}->click();
+}
+
+sub select_language {
+    my ($self, $item) = @_;
+    return $self->{cb_eula_language}->select($item);
+}
+
+1;

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -630,6 +630,13 @@ sub save_strace_gdb_output {
     }
 }
 
+sub post_run_hook {
+    my $self = shift;
+
+    $self->SUPER::post_run_hook;
+    save_screenshot;
+}
+
 sub post_fail_hook {
     my $self = shift;
 

--- a/schedule/yast/installer_extended.yaml
+++ b/schedule/yast/installer_extended.yaml
@@ -8,11 +8,8 @@ description: >
 vars:
   CHECK_PRESELECTED_MODULES: '1'
   CHECK_RELEASENOTES: '1'
-  EULA_LANGUAGES: korean
   EXIT_AFTER_START_INSTALL: '1'
   EXTRABOOTPARAMS: Y2STRICTTEXTDOMAIN=1
-  INSTALLER_EXTENDED_TEST: '1'
-  VALIDATE_CHECKSUM: '1'
   YUI_REST_API: 1
 schedule:
   # Called on BACKEND: qemu
@@ -22,7 +19,7 @@ schedule:
   - installation/welcome
   - installation/licensing/verify_license_translations
   - installation/licensing/verify_license_has_to_be_accepted
-  - installation/accept_license
+  - installation/licensing/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/installer_extended.yaml
+++ b/schedule/yast/installer_extended.yaml
@@ -21,6 +21,7 @@ schedule:
   - installation/setup_libyui
   - installation/welcome
   - installation/licensing/verify_license_translations
+  - installation/licensing/verify_license_has_to_be_accepted
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle

--- a/schedule/yast/installer_extended.yaml
+++ b/schedule/yast/installer_extended.yaml
@@ -45,15 +45,27 @@ test_data:
   license:
     default: English (US)
     translations:
-      - Czech
-      - English (US)
-      - French
-      - German
-      - Italian
-      - Japanese
-      - Korean
-      - Portuguese (Brazilian)
-      - Russian
-      - Simplified Chinese
-      - Spanish
-      - Traditional Chinese
+      - language: Czech
+        text: Licenční smlouva společnosti
+      - language: English (US)
+        text: End User License Agreement
+      - language: French
+        text: Contrat de licence utilisateur final
+      - language: German
+        text: Endbenutzer-Lizenzvereinbarung
+      - language: Italian
+        text: Contratto di licenza
+      - language: Japanese
+        text: 版ソフトウェア
+      - language: Korean
+        text: 소프트웨어
+      - language: Portuguese (Brazilian)
+        text: Contrato de Licença para Usuário Final
+      - language: Russian
+        text: Лицензионное соглашение
+      - language: Simplified Chinese
+        text: 软件的
+      - language: Spanish
+        text: Acuerdo de licencia de usuario final
+      - language: Traditional Chinese
+        text: 版軟體的

--- a/schedule/yast/installer_extended.yaml
+++ b/schedule/yast/installer_extended.yaml
@@ -13,11 +13,14 @@ vars:
   EXTRABOOTPARAMS: Y2STRICTTEXTDOMAIN=1
   INSTALLER_EXTENDED_TEST: '1'
   VALIDATE_CHECKSUM: '1'
+  YUI_REST_API: 1
 schedule:
   # Called on BACKEND: qemu
   - '{{compare_checksums}}'
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
+  - installation/licensing/verify_license_translations
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
@@ -38,3 +41,19 @@ conditional_schedule:
       qemu:
         - installation/isosize
         - installation/data_integrity
+test_data:
+  license:
+    default: English (US)
+    translations:
+      - Czech
+      - English (US)
+      - French
+      - German
+      - Italian
+      - Japanese
+      - Korean
+      - Portuguese (Brazilian)
+      - Russian
+      - Simplified Chinese
+      - Spanish
+      - Traditional Chinese

--- a/tests/installation/licensing/accept_license.pm
+++ b/tests/installation/licensing/accept_license.pm
@@ -1,0 +1,30 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test module to accept license agreement and proceed to the next
+#          installer page.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+
+sub run {
+    $testapi::distri->get_eula_controller()->accept_license();
+}
+
+1;

--- a/tests/installation/licensing/verify_license_has_to_be_accepted.pm
+++ b/tests/installation/licensing/verify_license_has_to_be_accepted.pm
@@ -1,0 +1,40 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test module is used to validate that installation cannot be
+#          continued without accepted license and appropriate message is shown.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+use Test::Assert 'assert_true';
+
+sub run {
+    my ($self) = @_;
+
+    my $eula_controller = $testapi::distri->get_eula_controller();
+
+    $eula_controller->proceed_to_next_page();
+
+    my $accept_license_popup = $eula_controller->get_accept_license_popup();
+    assert_true($accept_license_popup->is_shown(), "Accept License popup is not shown when license is not accepted.");
+
+    $eula_controller->process_accept_license_pop_up();
+}
+
+1;

--- a/tests/installation/licensing/verify_license_translations.pm
+++ b/tests/installation/licensing/verify_license_translations.pm
@@ -76,7 +76,6 @@ sub run {
     assert_true(!$errors, $errors);
     # Set language back to default
     $eula_page->select_language($default_language);
-    save_screenshot;
 }
 
 1;

--- a/tests/installation/licensing/verify_license_translations.pm
+++ b/tests/installation/licensing/verify_license_translations.pm
@@ -1,0 +1,61 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test module is used to validate available EULA translations as well
+#          as a translation selected by default. Test module is test data driven
+#          and following structure should be used:
+# license:
+#   default: English (US)
+#   translations:
+#     - Greek
+#     - French
+#     - Russian
+#     - Spanish
+#     - Ukranian
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use scheduler 'get_test_suite_data';
+use testapi;
+use List::Util 'first';
+use Test::Assert ':all';
+
+sub run {
+    my ($self) = @_;
+
+    my $test_data = get_test_suite_data();
+
+    my $eula_controller = $testapi::distri->get_eula_controller();
+    my $eula_page       = $eula_controller->get_license_agreement_page();
+
+    assert_str_equals($test_data->{license}->{default}, $eula_page->get_selected_language(),
+        "Wrong EULA language is pre-selected");
+    my @available_translations = $eula_page->get_available_languages();
+    # Accumulate errors
+    my $errors = '';
+    foreach my $language (@{$test_data->{license}->{translations}}) {
+        unless (first { /$language/ } @available_translations)
+        {
+            $errors += "Language: $language cannot be found in the list of available EULA translations\n";
+        }
+    }
+
+    die "$errors" if $errors;
+}
+
+1;


### PR DESCRIPTION
Now we can easily assert available translations and also validate the content. We decided not to go to deep into text validation, as it changes and should be validated on rpm level from the content perspective. Our part is to test that language is available.

As page was defined, it was decided to rewrite accept_license module functionality to use REST API. We can apply this in all tests, where libyui REST API is configured.

[Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23eula&distri=sle&version=15-SP3).

See [poo#81902](https://progress.opensuse.org/issues/81902).
