### PR TITLE
Change service check function call with 'string' and 'hash'

### DIFF
--- a/lib/autofs_utils.pm
+++ b/lib/autofs_utils.pm
@@ -196,8 +196,8 @@ Run checks of autofs by call following functions:
 
 =cut
 sub full_autofs_check {
-    my ($stage, $type) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my ($stage, $type) = ($hash{stage}, $hash{service_type});
     $service_type = $type;
 
     select_console 'root-console';

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -353,13 +353,13 @@ sub check_function {
 # parameter $stage is 'before' or 'after' of a system migration stage.
 #
 sub full_kdump_check {
-    my ($stage) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my $stage = $hash{stage};
 
     select_console 'root-console';
 
     if ($stage eq 'before') {
-        configure_service('before');
+        configure_service($stage);
     }
     check_function();
 

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -263,8 +263,8 @@ sub check_service {
 }
 
 sub check_y2_nfs_func {
-    my ($stage) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my $stage = $hash{stage};
     if ($stage eq 'before') {
         install_service();
         config_service($rw, $ro);

--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -247,7 +247,7 @@ sub install_services {
                     $service_type = 'Systemd';
                 }
                 if (exists $service->{$s}->{service_check_func}) {
-                    $service->{$s}->{service_check_func}->('before', $service_type);
+                    $service->{$s}->{service_check_func}->(%{$service->{$s}}, service_type => $service_type, stage => 'before');
                     next;
                 }
                 zypper_call "in $srv_pkg_name";
@@ -285,7 +285,7 @@ sub check_services {
                 # service check after migration. if we've set up service check
                 # function, we don't need following actions to check the service.
                 if (exists $service->{$s}->{service_check_func}) {
-                    $service->{$s}->{service_check_func}->('after', 'Systemd');
+                    $service->{$s}->{service_check_func}->(%{$service->{$s}}, service_type => $service_type, stage => 'after');
                     next;
                 }
                 common_service_action($srv_proc_name, $service_type, 'is-active');

--- a/lib/services/apache.pm
+++ b/lib/services/apache.pm
@@ -50,15 +50,17 @@ sub check_function {
 # check apache service before and after migration
 # stage is 'before' or 'after' system migration.
 sub full_apache_check {
-    my ($stage, $type) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my $stage  = $hash{stage};
+    my $type   = $hash{service_type};
+    my $pkg    = $hash{srv_pkg_name};
     if ($stage eq 'before') {
         install_service();
-        common_service_action('apache2', $type, 'enable');
-        common_service_action('apache2', $type, 'start');
+        common_service_action($pkg, $type, 'enable');
+        common_service_action($pkg, $type, 'start');
     }
-    common_service_action('apache2', $type, 'is-enabled');
-    common_service_action('apache2', $type, 'is-active');
+    common_service_action($pkg, $type, 'is-enabled');
+    common_service_action($pkg, $type, 'is-active');
     check_function();
 }
 

--- a/lib/services/apparmor.pm
+++ b/lib/services/apparmor.pm
@@ -142,8 +142,8 @@ sub check_function {
 # check apparmor service before and after migration
 # stage is 'before' or 'after' system migration.
 sub full_apparmor_check {
-    my ($stage) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my $stage = $hash{stage};
     if ($stage eq 'before') {
         install_service();
         enable_service();

--- a/lib/services/cups.pm
+++ b/lib/services/cups.pm
@@ -116,7 +116,8 @@ sub check_function {
 # check apache service before and after migration
 # stage is 'before' or 'after' system migration.
 sub full_cups_check {
-    my ($stage, $type) = @_;
+    my (%hash) = @_;
+    my ($stage, $type) = ($hash{stage}, $hash{service_type});
     $service_type = $type;
     if ($stage eq 'before') {
         install_service();

--- a/lib/services/dhcpd.pm
+++ b/lib/services/dhcpd.pm
@@ -78,8 +78,8 @@ sub check_service {
 # Check dhcp service before and after migration.
 # Stage is 'before' or 'after' system migration.
 sub full_dhcpd_check {
-    my ($stage, $type) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my ($stage, $type) = ($hash{stage}, $hash{service_type});
     $service_type = $type;
     if ($stage eq 'before') {
         install_service();

--- a/lib/services/firewall.pm
+++ b/lib/services/firewall.pm
@@ -59,7 +59,8 @@ sub check_service {
 #           'before' for SuSEfirewall2 or
 #           'after' for firewalld after system migration.
 sub full_firewall_check {
-    my ($stage) = @_;
+    my (%hash) = @_;
+    my $stage = $hash{stage};
 
     # we just support SLE12 to SLES15 SuSEfirewall2 to firewalld check
     return if (get_var('ORIGIN_SYSTEM_VERSION') eq '11-SP4');

--- a/lib/services/hpcpackage_remain.pm
+++ b/lib/services/hpcpackage_remain.pm
@@ -86,8 +86,9 @@ sub check_pkg {
 }
 
 sub full_pkgcompare_check {
-    my ($stage) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my $stage = $hash{stage};
+
     if ($stage eq 'before') {
         list_pkg("orignalq1w2.txt");
         install_pkg();

--- a/lib/services/ntpd.pm
+++ b/lib/services/ntpd.pm
@@ -69,10 +69,10 @@ sub check_function {
 # Check ntp service before and after migration.
 # Stage is 'before' or 'after' system migration.
 sub full_ntpd_check {
-    my ($stage, $type) = @_;
+    my (%hash) = @_;
+    my ($stage, $type) = ($hash{stage}, $hash{service_type});
     $service_type = $type;
     $service_name = ($service_type eq 'SystemV') ? 'ntp' : 'ntpd';
-    $stage //= '';
     if ((get_var('ORIGIN_SYSTEM_VERSION') eq '11-SP4') || $stage eq 'before') {
         install_service();
         config_service();

--- a/lib/services/postfix.pm
+++ b/lib/services/postfix.pm
@@ -52,8 +52,8 @@ sub check_function {
 # check postfix service before and after migration
 # stage is 'before' or 'after' system migration.
 sub full_postfix_check {
-    my ($stage) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my $stage = $hash{stage};
     if ($stage eq 'before') {
         install_service();
         enable_service();

--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -95,8 +95,8 @@ sub check_suseconnect_cmd {
 }
 
 sub full_registered_check {
-    my ($stage) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my $stage = $hash{stage};
     check_suseconnect();
     check_suseconnect_cmd();
     if ($stage eq 'before') {

--- a/lib/services/rpcbind.pm
+++ b/lib/services/rpcbind.pm
@@ -77,8 +77,8 @@ sub check_function {
 # Check rpcbind service before and after migration.
 # Stage is 'before' or 'after' system migration.
 sub full_rpcbind_check {
-    my ($stage, $type) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my ($stage, $type) = ($hash{stage}, $hash{service_type});
     $service_type = $type;
     $nfs_server   = 'nfsserver' if ($type eq 'SystemV');
     if ($stage eq 'before') {

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -135,8 +135,8 @@ sub restore_passwd {
 # check users before and after migration
 # stage is 'before' or 'after' system migration.
 sub full_users_check {
-    my ($stage) = @_;
-    $stage //= '';
+    my (%hash) = @_;
+    my $stage = $hash{stage};
 
     turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     select_console 'x11', await_console => 0;


### PR DESCRIPTION
When call function_call in service_check.pm, we need to extend existing test with new functionality. 
We need to pass more arguments to function. Now we can call with ($string, %hash) for the function check.

- Related ticket: https://progress.opensuse.org/issues/89533 
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/5627153
   https://openqa.nue.suse.com/tests/5627154
   https://openqa.nue.suse.com/tests/5637062