### PR TITLE
module_build: Fix missing module license

### DIFF
--- a/data/kernel/module/hello.c
+++ b/data/kernel/module/hello.c
@@ -1,13 +1,23 @@
-/* Example from http://www.tldp.org/LDP/lkmpg/2.6/html/x121.html */
+/*
+ * Example from http://www.tldp.org/LDP/lkmpg/2.6/html/x121.html
+ * Updated to the current standard
+ */
 
 #include <linux/module.h>
 #include <linux/kernel.h>
-int init_module(void)
+
+static int __init hello_init_module(void)
 {
- printk(KERN_INFO "Hello world.\n");
- return 0;
+	printk(KERN_INFO "Hello world.\n");
+
+	return 0;
 }
-void cleanup_module(void)
+
+static void __exit hello_cleanup_module(void)
 {
- printk(KERN_INFO "Goodbye world.\n");
+	printk(KERN_INFO "Goodbye world.\n");
 }
+
+module_init(hello_init_module)
+module_exit(hello_cleanup_module)
+MODULE_LICENSE("GPL");

--- a/tests/kernel/tuned.pm
+++ b/tests/kernel/tuned.pm
@@ -33,7 +33,7 @@ sub run {
     $known_errors{bsc_1148789} = 'Executing cpupower error: Error setting perf-bias value on CPU' if is_sle '<15';
     $known_errors{bsc_1148789} = 'Failed to set energy_perf_bias on cpu'                          if (is_sle('>=15') || is_tumbleweed);
 
-    select_console 'root-console';
+    $self->select_serial_terminal;
     # Install tuned package
     zypper_call 'in tuned';
     # Start daemon


### PR DESCRIPTION
\+ tuned: Use serial console when possible

Verification run:
- http://quasar.suse.cz/tests/6124 (Tumbleweed, note tuned failure not related to this, it's been failing for 
 few months: https://bugzilla.opensuse.org/show_bug.cgi?id=1175932, https://openqa.opensuse.org/tests/1659129#next_previous)
- http://quasar.suse.cz/tests/6125 (SLE15-SP3 just in case)
