### PR TITLE
Test glibc tunables: MTE on aarch64

### DIFF
--- a/data/console/mte_test.c
+++ b/data/console/mte_test.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+ 
+/* Generate an MTE fault for a UAF (Use-After-Free):
+ * - Use qemu with '-machine virt,mte=on -cpu max' _without_ kvm
+ * - export GLIBC_TUNABLES="glibc.mem.tagging=X"
+ *   where X has the following meanings:
+ *     0        Disabled (default)
+ *     1        asynchronous mode - useful to at least test and understand
+ *     3        synchronous mode - what we probably want for openSUSE
+ *   Details on: https://sourceware.org/pipermail/libc-alpha/attachments/20201218/cf93aeb4/attachment.bin
+ */
+ 
+int main(){
+        int* a;
+        a = malloc(sizeof(int));
+        *a = 42;
+        free(a);
+        *a = 24; /* Should fail here */
+        return 0;
+}

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1177,6 +1177,7 @@ sub load_consoletests {
     {
         loadtest "console/glibc_sanity";
     }
+    loadtest "console/glibc_tunables";
     load_system_update_tests(console_updates => 1);
     loadtest "console/console_reboot" if is_jeos;
     loadtest "console/zypper_in";

--- a/tests/console/glibc_tunables.pm
+++ b/tests/console/glibc_tunables.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 Guillaume GARDET
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: glibc
+# Summary: Check GLIBC_TUNABLES support
+# Maintainer: Guillaume GARDET <guillaume@opensuse.org>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use Utils::Architectures 'is_aarch64';
+
+sub run {
+    select_console 'root-console';
+
+    if (is_aarch64 && check_var('AARCH64_MTE_SUPPORTED', '1')) {
+        record_info('Testing MTE on aarch64');
+        zypper_call 'in gcc';
+
+        select_console 'user-console';
+        assert_script_run('curl ' . data_url("console/mte_test.c") . ' -o mte_test.c');
+
+        assert_script_run 'gcc -Wall mte_test.c -o mte_test';
+
+        record_info('Default', 'MTE should be disabled by default');
+        assert_script_run('./mte_test');
+
+        record_info('Async', 'MTE Async mode');
+        assert_script_run('export GLIBC_TUNABLES="glibc.mem.tagging=1"');
+        if (script_run('./mte_test') == 0) {
+            die("This run should SegFault, but it passed!");
+        }
+
+        record_info('Sync', 'MTE Sync mode');
+        assert_script_run('export GLIBC_TUNABLES="glibc.mem.tagging=3"');
+        if (script_run('./mte_test') == 0) {
+            die("This run should SegFault, but it passed!");
+        }
+
+        record_info('Disabled', 'MTE disabled');
+        assert_script_run('export GLIBC_TUNABLES="glibc.mem.tagging=0"');
+        assert_script_run('./mte_test');
+
+        assert_script_run('export GLIBC_TUNABLES=""');
+    }
+    else {
+        record_info('No GLIBC_TUNABLES', 'No GLIBC_TUNABLES available for testing on this worker');
+    }
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -8,6 +8,7 @@ NOTE: This list is not complete and may contain outdated info. If you face such 
 
 Variable        | Type      | Default value | Details
 ---             | ---       | ---           | ---
+AARCH64_MTE_SUPPORTED | boolean | false     | Set to 1 if your machine supports Memory Tagging Extension (MTE)
 ADDONS          | string    |               | Comma separated list of addons to be added using DVD. Also used to indicate addons in the SUT.
 ADDONURL        | string    |               | Comma separated list of addons. Includes addon names to get url defined in ADDONURL_*. For example: ADDONURL=sdk,we ADDONURL_SDK=https://url ADDONURL_WE=ftp://url
 ADDONURL_*      | string    |               | Define url for the addons list defined in ADDONURL


### PR DESCRIPTION
Glibc allows some tunables. 
This PR test MTE on aarch64.

- Verification run: 
  * With `AARCH64_MTE_SUPPORTED=1`: https://openqa.opensuse.org/t1668621