### PR TITLE
Add check for existing subuid before assign a new range

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -187,9 +187,9 @@ sub test_opensuse_based_image {
 }
 
 sub verify_userid_on_container {
-    my ($runtime, $image) = @_;
-    record_info "host uid", script_output "echo \$UID";
-
+    my ($runtime, $image, $start_id) = @_;
+    my $huser_id = script_output "echo \$UID";
+    record_info "host uid",          "$huser_id";
     record_info "root default user", "rootless mode process runs with the default container user(root)";
     my $cid = script_output "$runtime run -d --rm --name test1 $image sleep infinity";
     validate_script_output "$runtime top $cid user huser", sub { /root\s+1000/ };
@@ -197,7 +197,8 @@ sub verify_userid_on_container {
 
     record_info "non-root user", "process runs under the range of subuids assigned for regular user";
     $cid = script_output "$runtime run -d --rm --name test2 --user 1000 $image sleep infinity";
-    validate_script_output "$runtime top $cid user huser", sub { /1000\s+200999/ };
+    my $id = $start_id + $huser_id - 1;
+    validate_script_output "$runtime top $cid user huser", sub { /1000\s+${id}/ };
     validate_script_output "$runtime top $cid capeff",     sub { /none/ };
 
     record_info "root with keep-id", "the default user(root) starts process with the same uid as host user";


### PR DESCRIPTION
This intends to fix the rootless_podman on jeos where
the user already exists in the /etc/subuid.

Fixing this include that the test will should get the number
where has been assigned to the user from the file or if he is not found
a given number is assigned. Then the test validates against this
number plus the host $UID-1.


- Verification run: 
[sle](https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2312093)
[tw](https://openqa.opensuse.org/tests/overview?version=Tumbleweed&build=b10n1k%2Fos-autoinst-distri-opensuse%2312093&distri=opensuse)