### PR TITLE
Adjust the windows server slightly because of its recent upgrade

### DIFF
--- a/tests/x11/remote_desktop/windows_network_setup.pm
+++ b/tests/x11/remote_desktop/windows_network_setup.pm
@@ -31,6 +31,7 @@ sub run {
     assert_screen "network-allow-discovered";
     assert_and_click "network-discovered-yes";
 
+    sleep 5;
     type_string "netsh interface ip set dns Ethernet static 10.67.0.2";
     send_key "ret";
 

--- a/tests/x11/remote_desktop/windows_server_setup.pm
+++ b/tests/x11/remote_desktop/windows_server_setup.pm
@@ -22,9 +22,9 @@ sub run {
     my $self = shift;
 
     assert_and_click "start";
+    sleep 5;
     type_string "allow remote connections";
-    assert_screen "start_menu-remote_access-controlpanel";
-    send_key "ret";
+    assert_and_click "start_menu-remote_access-controlpanel";
 
     assert_and_click "show-settings";
     assert_and_click "allow-remote-connections";


### PR DESCRIPTION
Some changes are needed for our recently updated windows qcow2 image.

Note that this allows the Tumbleweed test cases to pass. As for SLE testcases, it will now pass the windows server setup, and fail at client side (parallel job) later due to another bug.

@GraceWang571 , can you review this, please!

- Related ticket: https://progress.opensuse.org/issues/88436
- Needles: None
- Verification run: https://openqa.opensuse.org/tests/1661387 https://openqa.opensuse.org/tests/1661450
