### PR TITLE
Fix podman_rancher timeout

### DIFF
--- a/lib/rancher/utils.pm
+++ b/lib/rancher/utils.pm
@@ -28,7 +28,7 @@ sub setup_rancher_container {
     my $runtime = $args{runtime};
     die "You must define the runtime!" unless $runtime;
 
-    assert_script_run("$runtime pull rancher/rancher", timeout => 600);
+    assert_script_run("$runtime pull docker.io/rancher/rancher:latest", timeout => 600);
     assert_script_run("$runtime run --name rancher_webui --privileged -d --restart=unless-stopped -p 80:80 -p 443:443 rancher/rancher");
 
     # Check every 30 seconds that the cluster is setup. Times out after 20 minutes


### PR DESCRIPTION
When pulling the rancher/rancher image, podman expects user input to
select registry.
Because of the failure getting registry.opensuse.org/rancher/rancher
the solution is to explicitly pull the docker.io image.

- Related ticket: but related to https://confluence.suse.com/display/~geor/Rancher+QE+testing+project
- Needles: No needles
- Verification run: [podman_rancher](http://angmar.suse.de/tests/3124) | [docker_rancher](http://angmar.suse.de/tests/3129)
