### PR TITLE
ncurses: stop the test if the console is misconfigured in openQA - boo#1183234

### DIFF
--- a/tests/console/ncurses.pm
+++ b/tests/console/ncurses.pm
@@ -25,7 +25,10 @@ sub run {
     select_console 'root-console';
     zypper_call 'in dialog';
     script_run 'dialog --yesno "test for boo#1054448" 3 20';
-    assert_screen 'ncurses-simple-dialog';
+    assert_screen([qw(ncurses-simple-dialog ncurses-simple-dialog-broken-boo1183234)]);
+    if (match_has_tag 'ncurses-simple-dialog-broken-boo1183234') {
+        die "boo#1183234: Console misconfigured, ncurses UI broken!\n";
+    }
     send_key 'ret';
     clear_console;
     if (match_has_tag 'boo#1054448') {


### PR DESCRIPTION
This is a follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11516

- Related ticket: https://progress.opensuse.org/issues/63026
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/714
- Verification run: 
