### PR TITLE
install_qatestset using reboot for ppc64le instead of poweroff for x86_64

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -66,7 +66,11 @@ sub run {
     }
     install_pkg;
     setup_environment;
-    power_action('poweroff', keepconsole => 1, textmode => 1);
+    if (check_var('ARCH', 'ppc64le')) {
+        power_action('reboot', keepconsole => 1, textmode => 1);
+    } else {
+        power_action('poweroff', keepconsole => 1, textmode => 1);
+    }
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Because the power behavior is different between ppc64le and x86_64 on openqa, add detection for ppc64le to use reboot instead of poweroff.

Verification URL: http://10.67.19.72/tests/3207
