### PR TITLE
Add support switch 'enlarge swap' checkbox  in Filesystem Options page

### DIFF
--- a/lib/Installation/Partitioner/EnlargeToRAMSizeForSuspendCheckbox.pm
+++ b/lib/Installation/Partitioner/EnlargeToRAMSizeForSuspendCheckbox.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for 'Enlarge to RAM size'
+# checkbox'.
+# The checkbox is extracted to the separate package as several pages contain
+# it, but different shortcut is used for selecting.
+
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>, Dawei Pang <dawei.pang@suse.com>
+
+package Installation::Partitioner::EnlargeToRAMSizeForSuspendCheckbox;
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+use parent 'Element::Checkbox';
+
+use constant {
+    CHECKED_ENLARGE_TO_RAM_SIZE_FOR_SUSPEND_CHECKBOX   => 'enabledenlargeswap',
+    UNCHECKED_ENLARGE_TO_RAM_SIZE_FOR_SUSPEND_CHECKBOX => 'disabledenlargeswap'
+};
+
+sub set_state {
+    my ($self, $state) = @_;
+    $self->SUPER::set_state(
+        state            => $state,
+        shortcut         => 'alt-a',
+        checked_needle   => CHECKED_ENLARGE_TO_RAM_SIZE_FOR_SUSPEND_CHECKBOX,
+        unchecked_needle => UNCHECKED_ENLARGE_TO_RAM_SIZE_FOR_SUSPEND_CHECKBOX
+    );
+}
+
+1;

--- a/lib/Installation/Partitioner/LibstorageNG/FileSystemOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/FileSystemOptionsPage.pm
@@ -18,6 +18,7 @@ use warnings FATAL => 'all';
 use testapi;
 use parent 'Installation::WizardPage';
 use Installation::Partitioner::ProposeSeparateHomePartitionCheckbox;
+use Installation::Partitioner::EnlargeToRAMSizeForSuspendCheckbox;
 
 use constant {
     FILE_SYSTEM_OPTIONS_PAGE => 'inst-filesystem-options'
@@ -27,6 +28,7 @@ sub new {
     my ($class, %args) = @_;
     my $self = $class->SUPER::new(%args);
     $self->{propose_separate_home_partition_checkbox} = Installation::Partitioner::ProposeSeparateHomePartitionCheckbox->new();
+    $self->{enlarge_to_ram_size_for_suspend_checkbox} = Installation::Partitioner::EnlargeToRAMSizeForSuspendCheckbox->new();
     return $self;
 }
 
@@ -40,6 +42,20 @@ sub set_state_propose_separate_home_partition_checkbox {
     assert_screen(FILE_SYSTEM_OPTIONS_PAGE);
     $self->get_propose_separate_home_partition_checkbox()->set_state($state);
 }
+
+
+sub get_enlarge_to_ram_size_for_suspend_checkbox {
+    my ($self) = @_;
+    return $self->{enlarge_to_ram_size_for_suspend_checkbox};
+}
+
+
+sub set_state_enlarge_to_ram_size_for_suspend_checkbox {
+    my ($self, $state) = @_;
+    assert_screen(FILE_SYSTEM_OPTIONS_PAGE);
+    $self->get_enlarge_to_ram_size_for_suspend_checkbox()->set_state($state);
+}
+
 
 sub press_next {
     my ($self) = @_;

--- a/lib/Installation/Partitioner/LibstorageNG/GuidedSetupController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/GuidedSetupController.pm
@@ -91,6 +91,7 @@ sub _set_partitioning {
     my $is_lvm            = $args{is_lvm};
     my $is_encrypted      = $args{is_encrypted};
     my $has_separate_home = $args{has_separate_home};
+    my $has_enlarge_swap  = $args{has_enlarge_swap};
     if ($is_lvm) {
         $self->get_partitioning_scheme_page()->select_logical_volume_management_checkbox();
     }
@@ -107,6 +108,9 @@ sub _set_partitioning {
         else {
             $self->get_file_system_options_page()->set_state_propose_separate_home_partition_checkbox($has_separate_home);
         }
+    }
+    if (defined $has_enlarge_swap) {
+        $self->get_file_system_options_page()->set_state_enlarge_to_ram_size_for_suspend_checkbox($has_enlarge_swap);
     }
     $self->get_file_system_options_page()->press_next();
 }

--- a/schedule/sle-perf/hanaperf_installation.yaml
+++ b/schedule/sle-perf/hanaperf_installation.yaml
@@ -1,0 +1,52 @@
+---
+name: hanaperf_installation
+description: >
+  OS installation for HANA performance
+schedule:
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - '{{scc_registration}}'
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_smalldisk_storageng
+  - '{{separate_home}}'
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - support_server/login
+  - kernel_performance/install_qatestset
+  - boot/reconnect_mgmt_console
+  - support_server/login
+  - kernel_performance/full_run
+conditional_schedule:
+  scc_registration:
+    SCC_REGISTER:
+      none:
+        - '{{multipath}}'
+        - installation/scc_registration
+      installation:
+        - installation/scc_registration
+        - '{{multipath}}'
+  multipath:
+    MULTIPATH:
+      1:
+        - installation/multipath
+  separate_home:
+    SEPARATE_HOME:
+      1:
+        - installation/partitioning/no_separate_home
+        - '{{enlarge_swap}}'
+  enlarge_swap:
+    VERSION:
+      15-SP2:
+        - installation/partitioning/no_enlarge_swap

--- a/tests/installation/partitioning/no_enlarge_swap.pm
+++ b/tests/installation/partitioning/no_enlarge_swap.pm
@@ -1,15 +1,16 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-# Summary: The test module creates a partition with LVM and explicitly disables
-# separate /home partition.
-# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+# Summary: The test module goes through the Suggested Partitioning wizard,
+# keeping all the default values but explicitly disables enlarge swap checkbox.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>, Dawei Pang <dawei.pang@suse.com>
 
 use parent 'y2_installbase';
 use strict;
@@ -19,7 +20,7 @@ use testapi;
 sub run {
     my $partitioner    = $testapi::distri->get_partitioner();
     my $multiple_disks = get_var('NUMDISKS', 1) > 1 ? 1 : 0;
-    $partitioner->edit_proposal(is_lvm => 1, has_separate_home => 0, multiple_disks => $multiple_disks);
+    $partitioner->edit_proposal(has_enlarge_swap => 0, multiple_disks => $multiple_disks);
 }
 
 1;


### PR DESCRIPTION
In some conditions, installer suggests enable "Enlarge to RAM size", but actually
we need not it. Adding support switch 'enlarge swap' checkbox in openQA.
Other changes: 
1) Add update lvm_no_separate_home.pm like no_separate_home.pm
2) Add YAML file for verifying this change.
 
- Related ticket: https://progress.opensuse.org/issues/89785
- Verification run: http://10.67.19.72/tests/3206/modules/no_enlarge_swap/steps/1/src
