### PR TITLE
Fix return key not received issue for hyperv-uefi guest

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1002,6 +1002,8 @@ sub wait_boot_past_bootloader {
         select_console('x11');
     }
     elsif ($textmode || check_var('DESKTOP', 'textmode')) {
+        # Avoid return key not received occasionally for hyperv guest with uefi at first boot
+        send_key_until_needlematch('linux-login', 'ret') if (check_var('VIRSH_VMM_FAMILY', 'hyperv') && get_var('UEFI'));
         return $self->wait_boot_textmode(ready_time => $ready_time);
     }
 


### PR DESCRIPTION
During guest installation on Hyper-V 2012r2, return key was not received occasionally at first boot. So adding the times of key trigger to avoid the issue.

- Related ticket: https://progress.opensuse.org/issues/89452
- Verification run: http://10.67.129.83/tests/114
