### PR TITLE
containers: moving vars into Job Group settings

### DIFF
--- a/schedule/containers/create_hdd_autoyast.yaml
+++ b/schedule/containers/create_hdd_autoyast.yaml
@@ -3,9 +3,6 @@ name: create_hdd_autoyast
 description:    >
     Maintainer: qa-c@suse.de.
     HDD creation for container tests in product QA
-vars:
-    AUTOYAST: autoyast_sle15/autoyast_containers_%ARCH%.xml
-    HDDSIZEGB: 30
 conditional_schedule:
     grub_set_bootargs:
         ARCH:


### PR DESCRIPTION
almost all settings are in job group , let's move this two at same place