### PR TITLE
Add autoyast iscsi test

### DIFF
--- a/data/autoyast_sle15/autoyast_iscsi_ibft.xml
+++ b/data/autoyast_sle15/autoyast_iscsi_ibft.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <general t="map">
+        <mode t="map">
+            <confirm t="boolean">false</confirm>
+        </mode>
+    </general>
+    <iscsi-client t="map">
+        <initiatorname>iqn.2010-04.org.ipxe:00000000-0000-0000-0000-000000000000</initiatorname>
+        <targets t="list">
+            <listentry t="map">
+                <authmethod>None</authmethod>
+                <iface>default</iface>
+                <portal>{{WORKER_HOSTNAME}}:3260</portal>
+                <startup>onboot</startup>
+                <target>{{NBF}}</target>
+            </listentry>
+        </targets>
+        <version>1.0</version>
+    </iscsi-client>
+    <partitioning t="list">
+        <drive t="map">
+            <device>/dev/sda</device>
+            <disklabel>gpt</disklabel>
+            <enable_snapshots t="boolean">true</enable_snapshots>
+            <partitions t="list">
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <format t="boolean">false</format>
+                    <partition_id t="integer">263</partition_id>
+                    <partition_nr t="integer">1</partition_nr>
+                    <resize t="boolean">false</resize>
+                    <size>8MiB</size>
+                </partition>
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <create_subvolumes t="boolean">true</create_subvolumes>
+                    <filesystem t="symbol">btrfs</filesystem>
+                    <format t="boolean">true</format>
+                    <mount>/</mount>
+                    <mountby t="symbol">uuid</mountby>
+                    <partition_id t="integer">131</partition_id>
+                    <partition_nr t="integer">2</partition_nr>
+                    <quotas t="boolean">true</quotas>
+                    <resize t="boolean">false</resize>
+                    <size>12GiB</size>
+                    <subvolumes t="list">
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">false</copy_on_write>
+                            <path>var</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>usr/local</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>tmp</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>srv</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>root</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>opt</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>boot/grub2/x86_64-efi</path>
+                        </subvolume>
+                        <subvolume t="map">
+                            <copy_on_write t="boolean">true</copy_on_write>
+                            <path>boot/grub2/i386-pc</path>
+                        </subvolume>
+                    </subvolumes>
+                    <subvolumes_prefix>@</subvolumes_prefix>
+                </partition>
+                <partition t="map">
+                    <create t="boolean">true</create>
+                    <filesystem t="symbol">xfs</filesystem>
+                    <format t="boolean">true</format>
+                    <fstopt>_netdev</fstopt>
+                    <mount>/home</mount>
+                    <mountby t="symbol">uuid</mountby>
+                    <partition_id t="integer">131</partition_id>
+                    <partition_nr t="integer">3</partition_nr>
+                    <resize t="boolean">false</resize>
+                    <size>6GiB</size>
+                </partition>
+            </partitions>
+            <type t="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+    </partitioning>
+    <software t="map">
+        <products t="list">
+            <product>SLES</product>
+        </products>
+        <packages config:type="list">
+          <package>hdparm</package>
+          <package>sg3_utils</package>
+          <package>smartmontools</package>
+        </packages>
+    </software>
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons config:type="list">
+            <addon>
+                <name>sle-module-basesystem</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">-1</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">-1</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">-1</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">-1</timeout>
+        </yesno_messages>
+    </report>
+</profile>

--- a/schedule/yast/autoyast/autoyast_iscsi_ibft.yaml
+++ b/schedule/yast/autoyast/autoyast_iscsi_ibft.yaml
@@ -1,0 +1,42 @@
+---
+name: autoyast_iscsi_ibft
+description: >
+  AutoYaST ibft installation on iSCSI disk. iSCSI configuration is validated
+  in the installed system, as well as cloned profile is verified to check
+  relevant sections.
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_iscsi_ibft.xml
+  # Using it for specifying iscsi portal
+  AY_EXPAND_VARS: WORKER_HOSTNAME,NBF
+  DESKTOP: textmode
+  IBFT: '1'
+  NBF: iqn.2016-02.openqa.de:for.openqa
+  NICTYPE: user
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - installation/validation/ibft
+  - autoyast/verify_cloned_profile
+test_data:
+  profile:
+    iscsi-client:
+      initiatorname: iqn.2010-04.org.ipxe:00000000-0000-0000-0000-000000000000
+      targets:
+        listentry:
+          authmethod: None
+          iface: default
+          portal: '%WORKER_HOSTNAME%:3260'
+          startup: onboot
+          target: '%NBF%'


### PR DESCRIPTION
Adding new test suite to test installation on iSCSI disk. Test suite validates installation, as well as cloned profile to have relevant sections.

o3 workers miss iSCSI configuration, so that has to be addressed first.

See [poo#32143](https://progress.opensuse.org/issues/32143).

[Job group changes](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/344).

[Verification run](https://openqa.suse.de/tests/5640893).