### PR TITLE
wicked-wlan: Increase timeout for freerad bootstrap

### DIFF
--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -128,7 +128,7 @@ sub prepare_freeradius_server {
     # we can authenticate with PEAP+MSCHAPv2, TLS and TTLS/PAP
     assert_script_run(sprintf(q(echo '%s ClearText-Password := "%s"' >> /etc/raddb/users),
             $self->eap_user, $self->eap_password));
-    assert_script_run('(cd /etc/raddb/certs && ./bootstrap)', timeout => 300);
+    assert_script_run('time (cd /etc/raddb/certs && ./bootstrap)', timeout => 600);
     assert_script_run(q(openssl rsa -in /etc/raddb/certs/client.key -out /etc/raddb/certs/client_no_pass.key -passin pass:'whatever'));
 }
 


### PR DESCRIPTION
From time to time I see such errors: http://openqa.wicked.suse.de/tests/6641#step/before_test/21

- Verification run: https://openqa.suse.de/tests/5641089
