### PR TITLE
Enable POM structure and libyui for firstboot

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot.xml
@@ -67,4 +67,34 @@
         <timeout config:type="integer">0</timeout>
       </yesno_messages>
     </report>
+    <scripts>
+        <chroot-scripts config:type="list">
+            <script>
+            <chrooted config:type="boolean">true</chrooted>
+                <source>
+                    <![CDATA[#!/bin/bash
+                    for i in YUI_HTTP_PORT={{YUI_PORT}} YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1 Y2DEBUG=1; do
+                    echo "export $i" >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    done
+                    chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    ]]>
+                </source>
+            </script>
+        </chroot-scripts>
+        <post-scripts config:type="list">
+            <script>
+            <filename>install_libyui.sh</filename>
+            <interpreter>shell</interpreter>
+            <location/>
+            <feedback config:type="boolean">false</feedback>
+            <source><![CDATA[#!/bin/sh
+                mv /var/run/zypp.pid /var/run/zypp.sav
+                zypper ar https://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-i586-x86_64-Snapshot{{BUILD}} tumb
+                zypper -n in libyui-rest-api
+                mv /var/run/zypp.sav /var/run/zypp.pid
+                systemctl disable firewalld
+                ]]></source>
+            </script>
+        </post-scripts>
+    </scripts>
 </profile>

--- a/data/autoyast_opensuse/autoyast_firstboot_leap.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot_leap.xml
@@ -70,4 +70,34 @@
         <timeout config:type="integer">0</timeout>
       </yesno_messages>
     </report>
+        <scripts>
+        <chroot-scripts config:type="list">
+            <script>
+            <chrooted config:type="boolean">true</chrooted>
+                <source>
+                    <![CDATA[#!/bin/bash
+                    for i in YUI_HTTP_PORT={{YUI_PORT}} YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1 Y2DEBUG=1; do
+                    echo "export $i" >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    done
+                    chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    ]]>
+                </source>
+            </script>
+        </chroot-scripts>
+        <post-scripts config:type="list">
+            <script>
+            <filename>install_libyui.sh</filename>
+            <interpreter>shell</interpreter>
+            <location/>
+            <feedback config:type="boolean">false</feedback>
+            <source><![CDATA[#!/bin/sh
+                mv /var/run/zypp.pid /var/run/zypp.sav
+                zypper ar http://openqa.opensuse.org/assets/repo/openSUSE-Leap-{{VERSION}}-oss-Build{{BUILD}} leap
+                zypper -n in libyui-rest-api
+                mv /var/run/zypp.sav /var/run/zypp.pid
+                systemctl disable firewalld
+                ]]></source>
+            </script>
+        </post-scripts>
+    </scripts>
 </profile>

--- a/data/autoyast_sle15/autoyast_firstboot.xml
+++ b/data/autoyast_sle15/autoyast_firstboot.xml
@@ -20,6 +20,11 @@
           <arch>{{ARCH}}</arch>
         </addon>
         <addon>
+          <name>sle-module-development-tools</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+        <addon>
           <name>sle-module-desktop-applications</name>
           <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
@@ -34,6 +39,23 @@
     <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>
+      <firewall>
+        <zones config:type="list">
+            <zone>
+                <name>external</name>
+                <services config:type="list">
+                    <service>http</service>
+                    <service>https</service>
+                </services>
+                <ports config:type="list">
+                    <port>{{YUI_PORT}}/tcp</port>
+                </ports>
+            </zone>
+        </zones>
+        <log_denied_packets>off</log_denied_packets>
+        <enable_firewall config:type="boolean">false</enable_firewall>
+        <start_firewall config:type="boolean">false</start_firewall>
+    </firewall>
     <software>
         <products config:type="list">
             <product>SLES</product>
@@ -43,6 +65,7 @@
           <package>sles-release</package>
           <package>yast2-firstboot</package>
           <package>yast2-registration</package>
+          <!--<package>libyui-rest-api15</package>-->
         </packages>
         <patterns config:type="list">
           <pattern>apparmor</pattern>
@@ -55,7 +78,7 @@
           <pattern>minimal_base</pattern>
           <pattern>x11</pattern>
           <pattern>x11_enhanced</pattern>
-        </patterns>
+	</patterns>
     </software>
     <users config:type="list">
         <user>
@@ -95,4 +118,32 @@
         <timeout config:type="integer">0</timeout>
       </yesno_messages>
     </report>
+    <scripts>
+        <chroot-scripts config:type="list">
+            <script>
+            <chrooted config:type="boolean">true</chrooted>
+                <source>
+                    <![CDATA[#!/bin/bash
+                    for i in YUI_HTTP_PORT={{YUI_PORT}} YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1 Y2DEBUG=1; do
+                    echo "export $i" >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    done
+                    chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    ]]>
+                </source>
+            </script>
+        </chroot-scripts>
+        <post-scripts config:type="list">
+            <script>
+            <filename>install_libyui.sh</filename>
+            <interpreter>shell</interpreter>
+            <location/>
+            <feedback config:type="boolean">false</feedback>
+            <source><![CDATA[#!/bin/sh
+                mv /var/run/zypp.pid /var/run/zypp.sav
+                zypper -n in libyui-rest-api
+                mv /var/run/zypp.sav /var/run/zypp.pid
+                ]]></source>
+            </script>
+        </post-scripts>
+    </scripts>
 </profile>

--- a/data/yast2/firstboot/firstboot_custom-opensuse.xml
+++ b/data/yast2/firstboot/firstboot_custom-opensuse.xml
@@ -88,7 +88,7 @@
                 </module>
                 <module>
                     <label>Keyboard Layout</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_keyboard</name>
                 </module>
                 <module>
@@ -132,7 +132,7 @@
                 </module>
                 <module>
                     <label>NTP Client</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_ntp</name>
                 </module>
                 <module>

--- a/data/yast2/firstboot/firstboot_custom-sle.xml
+++ b/data/yast2/firstboot/firstboot_custom-sle.xml
@@ -80,7 +80,7 @@
                 </module>
                 <module>
                     <label>Keyboard Layout</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_keyboard</name>
                 </module>
                 <module>
@@ -110,7 +110,10 @@
                 <module>
                     <label>Network</label>
                     <name>inst_lan</name>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
+                    <arguments>
+                        <skip_detection config:type="boolean">true</skip_detection>
+                    </arguments>
                 </module>
                  <module>
                     <label>Automatic Configuration</label>
@@ -124,7 +127,7 @@
                 </module>
                 <module>
                     <label>NTP Client</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_ntp</name>
                 </module>
                 <module>

--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -23,6 +23,7 @@ use Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerController;
 use YaST::NetworkSettings::v4_3::NetworkSettingsController;
 use Installation::SystemRole::SystemRoleController;
 use YaST::SystemSettings::SystemSettingsController;
+use YaST::Installer::InstallerController;
 
 sub get_partitioner {
     return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
@@ -50,6 +51,10 @@ sub get_system_settings {
 
 sub get_suggested_partitioning() {
     return Installation::Partitioner::LibstorageNG::v4_3::SuggestedPartitioningController->new();
+}
+
+sub get_firstboot {
+    return YaST::Installer::InstallerController->new();
 }
 
 1;

--- a/lib/YaST/Installer/GenericPage.pm
+++ b/lib/YaST/Installer/GenericPage.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+package YaST::Installer::GenericPage;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->{btn_next}           = $self->{app}->button({id => 'next'});
+    # $self->{debug_label} = $self->{app}->debug_label({debug_label => $debug_label}); # to be implemented as part of poo#89866
+    return $self;
+}
+
+sub assert_page {
+  return; # to be implemented as part of poo#89866
+}
+
+sub press_next {
+    my ($self) = @_;
+    return $self->{btn_next}->click();
+}
+
+1;

--- a/lib/YaST/Installer/InstallerController.pm
+++ b/lib/YaST/Installer/InstallerController.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Controller for firstboot page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Installer::InstallerController;
+use strict;
+use warnings;
+use YuiRestClient;
+use YaST::Installer::GenericPage;
+# use YaST::Installer::Firstboot::LanPage;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{GenericPage} = YaST::Installer::GenericPage->new({app => YuiRestClient::get_app()});
+#    $self->{LanPage} = YaST::Firstboot::LanPage->new({app => YuiRestPage::get_app()});
+    return $self;
+} 
+
+sub get_generic_page {
+    my ($self) = @_;
+    $self->{GenericPage};
+}
+
+sub get_lan_page {
+    my ($self) = @_;
+    $self->{LanPage};
+}
+    
+# sub inst_lan {
+#     my ($self) = @_;
+#     $self->{GenericPage}->assert_page('Network_settings');
+#     $self->get_lan_page->is_shown();
+#     $self->{GenericPage}->press_next();
+# }
+
+sub check_and_skip_page {
+    my ($self, $debug_label) = @_;
+    $self->get_generic_page->assert_page($debug_label);
+    $self->get_generic_page->press_next();
+}
+
+1;

--- a/lib/YaST/Installer/InstallerController.pm
+++ b/lib/YaST/Installer/InstallerController.pm
@@ -15,7 +15,9 @@ use strict;
 use warnings;
 use YuiRestClient;
 use YaST::Installer::GenericPage;
-# use YaST::Installer::Firstboot::LanPage;
+use YaST::Installer::LanPage;
+use YaST::Installer::KeyboardPage;
+use YaST::Installer::NTPPage;
 use testapi;
 
 sub new {
@@ -26,10 +28,12 @@ sub new {
 
 sub init {
     my ($self, $args) = @_;
-    $self->{GenericPage} = YaST::Installer::GenericPage->new({app => YuiRestClient::get_app()});
-#    $self->{LanPage} = YaST::Firstboot::LanPage->new({app => YuiRestPage::get_app()});
+    $self->{GenericPage}  = YaST::Installer::GenericPage->new({app => YuiRestClient::get_app()});
+    $self->{LanPage}      = YaST::Firstboot::LanPage->new({app => YuiRestClient::get_app()});
+    $self->{KeyboardPage} = YaST::Firstboot::KeyboardPage->new({app => YuiRestClient::get_app()});
+    $self->{NTPPage}      = YaST::Firstboot::NTPPage->new({app => YuiRestClient::get_app()});
     return $self;
-} 
+}
 
 sub get_generic_page {
     my ($self) = @_;
@@ -40,13 +44,34 @@ sub get_lan_page {
     my ($self) = @_;
     $self->{LanPage};
 }
-    
-# sub inst_lan {
-#     my ($self) = @_;
-#     $self->{GenericPage}->assert_page('Network_settings');
-#     $self->get_lan_page->is_shown();
-#     $self->{GenericPage}->press_next();
-# }
+
+sub get_NTP_page {
+    my ($self) = @_;
+    $self->{NTPPage};
+}
+
+sub get_keyboard_page {
+    my ($self) = @_;
+    $self->{KeyboardPage};
+}
+
+sub inst_lan {
+    my ($self) = @_;
+    $self->get_lan_page->is_shown();
+    $self->get_generic_page->press_next();
+}
+
+sub NTP_page {
+    my ($self) = @_;
+    $self->get_NTP_page->is_shown();
+    $self->get_generic_page->press_next();
+}
+
+sub keyboard_page {
+    my ($self) = @_;
+    $self->get_keyboard_page->is_shown();
+    $self->get_generic_page->press_next();
+}
 
 sub check_and_skip_page {
     my ($self, $debug_label) = @_;

--- a/lib/YaST/Installer/KeyboardPage.pm
+++ b/lib/YaST/Installer/KeyboardPage.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-package YaST::Installer::GenericPage;
+package YaST::Firstboot::KeyboardPage;
 use strict;
 use warnings;
 use testapi;
@@ -22,18 +22,15 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{btn_next} = $self->{app}->button({id => 'next'});
-    # $self->{debug_label} = $self->{app}->debug_label({debug_label => $debug_label}); # to be implemented as part of poo#89866
+    $self->{selectionbox} = $self->{app}->selectionbox({id => 'layout_list'});
     return $self;
 }
 
-sub assert_page {
-    return;    # to be implemented as part of poo#89866
-}
-
-sub press_next {
+sub is_shown {
     my ($self) = @_;
-    return $self->{btn_next}->click();
+    # Just check if we can select the first listed interface.
+    $self->{selectionbox}->exist();
+    save_screenshot;
 }
 
 1;

--- a/lib/YaST/Installer/LanPage.pm
+++ b/lib/YaST/Installer/LanPage.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-package YaST::Installer::GenericPage;
+package YaST::Firstboot::LanPage;
 use strict;
 use warnings;
 use testapi;
@@ -22,18 +22,15 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{btn_next} = $self->{app}->button({id => 'next'});
-    # $self->{debug_label} = $self->{app}->debug_label({debug_label => $debug_label}); # to be implemented as part of poo#89866
+    $self->{tbl_devices} = $self->{app}->table({id => '"Y2Network::Widgets::InterfacesTable"'});
     return $self;
 }
 
-sub assert_page {
-    return;    # to be implemented as part of poo#89866
-}
-
-sub press_next {
+sub is_shown {
     my ($self) = @_;
-    return $self->{btn_next}->click();
+    # Just check if we can select the first listed interface.
+    $self->{tbl_devices}->exist();
+    save_screenshot;
 }
 
 1;

--- a/lib/YaST/Installer/NTPPage.pm
+++ b/lib/YaST/Installer/NTPPage.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-package YaST::Installer::GenericPage;
+package YaST::Firstboot::NTPPage;
 use strict;
 use warnings;
 use testapi;
@@ -22,18 +22,14 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{btn_next} = $self->{app}->button({id => 'next'});
-    # $self->{debug_label} = $self->{app}->debug_label({debug_label => $debug_label}); # to be implemented as part of poo#89866
+    $self->{radiobutton_sync} = $self->{app}->radiobutton({id => 'sync'});
     return $self;
 }
 
-sub assert_page {
-    return;    # to be implemented as part of poo#89866
-}
-
-sub press_next {
+sub is_shown {
     my ($self) = @_;
-    return $self->{btn_next}->click();
+    $self->{radiobutton_sync}->exist();
+    save_screenshot;
 }
 
 1;

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -135,4 +135,14 @@ sub set_libyui_backend_vars {
     set_var('YUI_SERVER', $server);
 }
 
+sub setup_libyui_firstboot {
+    my $port = get_var('YUI_PORT');
+    zypper_call('in libyui-rest-api');
+    assert_script_run "firewall-cmd --zone=public --add-port=$port/tcp --permanent";
+    foreach my $export ("YUI_HTTP_PORT=$port", "YUI_HTTP_REMOTE=1", "YUI_REUSE_PORT=1", "Y2DEBUG=1") {
+        assert_script_run "echo export $export >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api";
+    }
+    assert_script_run "chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api";
+}
+
 1;

--- a/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
@@ -15,6 +15,7 @@ schedule:
   - autoyast/prepare_profile
   - installation/isosize
   - installation/bootloader_start
+  - installation/setup_libyui
   - autoyast/installation
   - installation/yast2_firstboot
   - installation/first_boot

--- a/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
@@ -13,6 +13,7 @@ schedule:
   - autoyast/prepare_profile
   - installation/isosize
   - installation/bootloader_start
+  - installation/setup_libyui
   - autoyast/installation
   - installation/yast2_firstboot
   - installation/first_boot

--- a/schedule/yast/firstboot/yast2_firstboot.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot.yaml
@@ -10,8 +10,10 @@ schedule:
     - console/consoletest_setup
     - console/hostname
     - installation/enable_y2_firstboot
+    - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
+    - boot/check_libyui_firstboot
     - installation/yast2_firstboot
     - installation/first_boot
     - console/validate_yast2_firstboot_configuration

--- a/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
@@ -22,10 +22,12 @@ schedule:
 test_data:
     clients:
         - firstboot_language_keyboard
+        - firstboot_keyboard
         - firstboot_welcome
         - firstboot_licenses
         - firstboot_hostname
         - firstboot_timezone
+        - firstboot_NTP
         - firstboot_user
         - firstboot_finish
     custom_control_file: "firstboot_custom-opensuse.xml"

--- a/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
@@ -12,8 +12,10 @@ schedule:
     - console/consoletest_setup
     - console/hostname
     - installation/enable_y2_firstboot
+    - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
+    - boot/check_libyui_firstboot
     - installation/yast2_firstboot
     - installation/first_boot
     - console/validate_yast2_firstboot_configuration
@@ -25,5 +27,6 @@ test_data:
         - firstboot_hostname
         - firstboot_timezone
         - firstboot_user
+        - firstboot_finish
     custom_control_file: "firstboot_custom-opensuse.xml"
     sysconfig_firstboot: "sysconfig_firstboot"

--- a/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
@@ -22,10 +22,13 @@ schedule:
 test_data:
     clients:
         - firstboot_language_keyboard
+        - firstboot_keyboard
         - firstboot_welcome
         - firstboot_licenses
         - firstboot_hostname
+        - firstboot_inst_lan
         - firstboot_timezone
+        - firstboot_NTP
         - firstboot_user
         - firstboot_finish
     custom_control_file: "firstboot_custom-sle.xml"

--- a/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
@@ -12,8 +12,10 @@ schedule:
     - console/consoletest_setup
     - console/hostname
     - installation/enable_y2_firstboot
+    - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
+    - boot/check_libyui_firstboot
     - installation/yast2_firstboot
     - installation/first_boot
     - console/validate_yast2_firstboot_configuration
@@ -25,5 +27,6 @@ test_data:
         - firstboot_hostname
         - firstboot_timezone
         - firstboot_user
+        - firstboot_finish
     custom_control_file: "firstboot_custom-sle.xml"
     sysconfig_firstboot: "sysconfig_firstboot"

--- a/test_data/yast/firstboot/yast2_firstboot.yaml
+++ b/test_data/yast/firstboot/yast2_firstboot.yaml
@@ -5,3 +5,4 @@ clients:
   - firstboot_timezone
   - firstboot_user
   - firstboot_root
+  - firstboot_finish

--- a/test_data/yast/firstboot/yast2_firstboot_sle.yaml
+++ b/test_data/yast/firstboot/yast2_firstboot_sle.yaml
@@ -6,3 +6,4 @@ clients:
   - firstboot_user
   - firstboot_root
   - firstboot_registration
+  - firstboot_finish

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -190,6 +190,9 @@ sub run {
             send_key 'ret';    # press enter if grub timeout is disabled, like we have in reinstall scenarios
             last;              # if see grub, we get to the second stage, as it appears after bios-boot which we may miss
         }
+        elsif (match_has_tag('linuxrc-start-shell-after-installation')) {
+            type_string_slow "exit\n";
+        }
         elsif (match_has_tag('import-untrusted-gpg-key')) {
             handle_untrusted_gpg_key;
             @needles = grep { $_ ne 'import-untrusted-gpg-key' } @needles;

--- a/tests/boot/check_libyui_firstboot.pm
+++ b/tests/boot/check_libyui_firstboot.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Check that libyui is available before firstboot
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base 'bootbasetest';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    YuiRestClient::connect_to_app();
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/tests/installation/enable_y2_firstboot.pm
+++ b/tests/installation/enable_y2_firstboot.pm
@@ -18,6 +18,7 @@ use testapi;
 use utils qw(zypper_call clear_console);
 use scheduler 'get_test_suite_data';
 
+
 sub run {
     my $test_data = get_test_suite_data();
     my $base_path = "yast2/firstboot/";

--- a/tests/installation/setup_libyui_firstboot.pm
+++ b/tests/installation/setup_libyui_firstboot.pm
@@ -1,0 +1,35 @@
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Enable libyui for firstboot. Temporary module until 
+# https://progress.opensuse.org/issues/90368 is done.
+
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "installbasetest";
+use testapi;
+
+use testapi;
+use registration "add_suseconnect_product";
+use version_utils "is_sle";
+
+sub run {
+    add_suseconnect_product('sle-module-development-tools') if is_sle;
+    YuiRestClient::setup_libyui_firstboot();
+}
+
+1;

--- a/tests/installation/setup_libyui_firstboot.pm
+++ b/tests/installation/setup_libyui_firstboot.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# Summary: Enable libyui for firstboot. Temporary module until 
+# Summary: Enable libyui for firstboot. Temporary module until
 # https://progress.opensuse.org/issues/90368 is done.
 
 # Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -50,13 +50,20 @@ sub firstboot_licenses {
 
 sub firstboot_welcome {
     my ($self, $custom_needle) = @_;
+    my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'welcome' . $custom_needle;
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    $firstboot->check_and_skip_page('Welcome');
 }
 
 sub firstboot_timezone {
+    my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'inst-timezone';
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    $firstboot->check_and_skip_page('Clock and Time Zone');
+}
+
+sub firstboot_inst_lan {
+    my $firstboot = $testapi::distri->get_firstboot();
+    $firstboot->inst_lan();
 }
 
 sub firstboot_user {
@@ -74,13 +81,21 @@ sub firstboot_root {
 }
 
 sub firstboot_hostname {
+    my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'hostname';
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    $firstboot->check_and_skip_page('Hostname');
 }
 
 sub firstboot_registration {
+    my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'system_registered';
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    $firstboot->check_and_skip_page('Registration');
+}
+
+sub firstboot_finish {
+    my ($self, $custom_needle) = @_;
+    assert_screen 'installation_completed' . $custom_needle;    # Should now be "Configuration_completed". Kept for historical reasons.
+    send_key $cmd{finish};
 }
 
 sub run {
@@ -93,8 +108,6 @@ sub run {
         my $client_method = \&{"$client"};
         $client_method->($self, $custom_needle);
     }
-    assert_screen 'installation_completed' . $custom_needle;    # Should now be "Configuration_completed". Kept for historical reasons.
-    send_key $cmd{finish};
 }
 
 sub post_fail_hook {

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -36,6 +36,16 @@ sub firstboot_language_keyboard {
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
 }
 
+sub firstboot_keyboard {
+    my $firstboot = $testapi::distri->get_firstboot();
+    $firstboot->keyboard_page();
+}
+
+sub firstboot_NTP {
+    my $firstboot = $testapi::distri->get_firstboot();
+    $firstboot->NTP_page();
+}
+
 sub firstboot_licenses {
     my ($self, $custom_needle) = @_;
     # default TO value was not sufficient


### PR DESCRIPTION
**44bcc9ff973e965d4048f256e4d8a389429834aa: Enable POM structure and libyui for firstboot**
* Create initial POM structure
* Enable libyui in both autoyast and regular firstboot tests
* Introduce asserting pages with debug_label rather than with random page elements (not working yet, see https://progress.opensuse.org/issues/89638 and https://progress.opensuse.org/issues/89866)

464491dc7871823a1b99f824a37c4f72fb74b926: add 3 new clients in firstboot_custom (see https://progress.opensuse.org/issues/73474)

- Needles: 
- Verification run: 
[TW-firstboot](http://waaa-amazing.suse.cz/tests/14947) [TW-fisrtboot-custom](http://waaa-amazing.suse.cz/tests/14954) [TW-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14946) [LEAP-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14949) [LEAP-firstboot](http://waaa-amazing.suse.cz/tests/14950)
[SLE-firstboot](http://waaa-amazing.suse.cz/tests/14943) [SLE-firstboot-custom](http://waaa-amazing.suse.cz/tests/14944) [SLE-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14952) [SLE-firstboot-textmode](http://waaa-amazing.suse.cz/tests/14945)