### PR TITLE
utils: Allow ensure_ca_certificates_suse_installed() also in openSUSE

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -87,7 +87,6 @@ our @EXPORT = qw(
   script_run_interactive
   create_btrfs_subvolume
   file_content_replace
-  ensure_ca_certificates_suse_installed
   is_efi_boot
   install_patterns
   common_service_action
@@ -1748,22 +1747,6 @@ It could check a file be point to 'path' whether include 'value'.
 sub assert_file_content {
     my ($param, $value) = @_;
     assert_script_run("cat $param | grep $value");
-}
-
-=head2 ensure_ca_certificates_suse_installed
-    ensure_ca_certificates_suse_installed();
-
-This functions checks if ca-certificates-suse is installed and if it is not it adds the repository and installs it.
-
-=cut
-
-sub ensure_ca_certificates_suse_installed {
-    return unless is_sle;
-    if (script_run('rpm -qi ca-certificates-suse') == 1) {
-        my $distversion = get_required_var("VERSION") =~ s/-SP/_SP/r;    # 15 -> 15, 15-SP1 -> 15_SP1
-        zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_$distversion/SUSE:CA.repo");
-        zypper_call("in ca-certificates-suse");
-    }
 }
 
 # non empty */sys/firmware/efi/* must exist in UEFI mode

--- a/tests/console/libssh.pm
+++ b/tests/console/libssh.pm
@@ -34,6 +34,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use repo_tools qw(ensure_ca_certificates_suse_installed);
 use Utils::Systemd 'disable_and_stop_service';
 use version_utils;
 use registration 'add_suseconnect_product';

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -17,6 +17,7 @@ use Mojo::Base qw(consoletest);
 use testapi;
 use utils;
 use version_utils 'check_os_release';
+use repo_tools qw(ensure_ca_certificates_suse_installed);
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -15,12 +15,12 @@ use base 'wickedbase';
 use strict;
 use warnings;
 use testapi;
-use utils qw(zypper_call systemctl file_content_replace zypper_ar ensure_ca_certificates_suse_installed);
+use utils qw(zypper_call systemctl file_content_replace zypper_ar);
 use version_utils 'is_sle';
 use network_utils qw(iface setup_static_network);
 use serial_terminal;
 use main_common 'is_updates_tests';
-use repo_tools 'generate_version';
+use repo_tools qw(generate_version ensure_ca_certificates_suse_installed);
 
 sub run {
     my ($self, $ctx) = @_;


### PR DESCRIPTION
 * Use this function also within openSUSE.
 * Moved ensure_ca_certificates_suse_installed() to `repo_tools` to avoid circular dependencies between `utils` and `repo_tools`.
 * Update all users of that function.


- Verification run: 
  -  http://openqa.wicked.suse.de/tests/6733 (wicked Tumbleweed)
  - https://openqa.suse.de/t5642076 (mau-libssh SLE-12-SP5)
  - https://openqa.suse.de/t5642077 (containers_sle_image_on_sle_host SLE-15-SP3)
