### PR TITLE
Fix encrypt validation

### DIFF
--- a/test_data/yast/encryption/activate_encrypted_volume.yaml
+++ b/test_data/yast/encryption/activate_encrypted_volume.yaml
@@ -1,4 +1,4 @@
-mapped_device: '/dev/mapper/cr-auto-2'
+mapped_device: '/dev/mapper/cr-auto-1'
 device_status:
   message: 'is active and is in use.'
   properties:


### PR DESCRIPTION
/dev/mapper/cr-auto-2 was changed to /dev/mapper/cr-auto-1. The commit
adapts test data to the changes.

Example of fail: https://openqa.suse.de/tests/5641164

- Verification run: https://openqa.suse.de/tests/5641982
