### PR TITLE
Add schedules for SLES+HA installation scenarios

### DIFF
--- a/schedule/ha/bv/ha_textmode_extended.yaml
+++ b/schedule/ha/bv/ha_textmode_extended.yaml
@@ -1,0 +1,31 @@
+name: ha_textmode_extended
+description: >
+  Install SLES+HA and checks release notes and pre-selected modules.
+
+  This schedule requires the VIDEOMODE setting to be set to text either in a test
+  suite, command line or in the job group yaml configuration.
+vars:
+  CHECK_PRESELECTED_MODULES: '1'
+  CHECK_RELEASENOTES: '1'
+  HDDMODEL: scsi-hd
+  HDDSIZEGB: '15'
+  SCC_ADDONS: ha
+  SCC_REGISTER: installation
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/releasenotes
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install

--- a/schedule/ha/bv/sles_ha_installation.yaml
+++ b/schedule/ha/bv/sles_ha_installation.yaml
@@ -1,0 +1,90 @@
+name: sles_ha_installation
+description: >
+  Install SLES+HA.
+
+  In order to generate a qcow2 image with this schedule so it can be used by other tests,
+  add the settings CREATE_HDD and set it to 1 and PUBLISH_HDD_1 and set it to the name
+  of the qcow2 image to save; add these settings either in the job group configuration,
+  test suite or command line. Also add PUBLISH_PFLASH_VARS on uefi scenarios.
+
+  Add an SCC_REGISTER setting via job group configuration, command line or testsuite and
+  set it to 'installation' so the SUT is registered to SCC, or set it to 'never' to skip
+  registration. If setting it to 'never', also add an ADDONS setting defined to 'ha' so
+  the HA extension is added during installation. The corresponding setting for SCC (SCC_ADDONS)
+  is not needed as its defined in this schedule.
+
+  Also set SYSTEM_ROLE to default, minimal or textmode depending on the test; do not leave it
+  out as schedule can be used with either of the three values, but if default is not explicitly
+  set, test will chose textmode system role as DESKTOP is set to textmode in the schedule.
+
+  Below are optional settings.
+
+  Set CHECK_ISO_MAXSIZE to 1 to schedule the installation/isosize test module to check the ISO
+  size against the ISO_MAXSIZE setting. It is recommended to not schedule this module when
+  ISO_MAXSIZE is not defined in the medium.
+  Set CHECK_PRESELECTED_MODULES to true to verify pre-selected modules during registration
+  Set CHECK_RELEASENOTES to 1 to check release notes during installation
+  Use HDDMODEL to set the type of HDD, either virtio-blk, scsi-hd, etc.
+  Set VIDEOMODE to text to perform text-based installation.
+vars:
+  DESKTOP: textmode
+  HDDSIZEGB: '15'
+  INSTALLONLY: '1'
+  SCC_ADDONS: ha
+schedule:
+  - '{{check_iso_maxsize}}'
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - '{{releasenotes}}'
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - '{{after_reboot}}'
+  - installation/first_boot
+  - '{{create_hdd_tests}}'
+  - '{{svirt_upload_assets}}'
+conditional_schedule:
+  check_iso_maxsize:
+    CHECK_ISO_MAXSIZE:
+      1:
+        - installation/isosize
+  releasenotes:
+    CHECK_RELEASENOTES:
+      1:
+        - installation/releasenotes
+  after_reboot:
+    ARCH:
+      s390x:
+        - boot/reconnect_mgmt_console
+      aarch64:
+        - installation/grub_test
+      x86_64:
+        - installation/grub_test
+      ppc64le:
+        - installation/grub_test
+  create_hdd_tests:
+    CREATE_HDD:
+      1:
+        - console/system_prepare
+        - console/hostname
+        - console/force_scheduled_tasks
+        - shutdown/grub_set_bootargs
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
+  svirt_upload_assets:
+    BACKEND:
+      svirt:
+        - shutdown/svirt_upload_assets


### PR DESCRIPTION
Add YaML schedules for the SLES+HA installation scenarios currently defined in openqa.suse.de.

This is intended to work with a job group configuration similar to this:

```
...
    sle-15-SP3-Full-x86_64:
    - textmode+skip_registration_ha:
        testsuite: null
        settings: &textmode_install_full_medium
          ADDONS: ha
          HDDMODEL: scsi-hd
          SCC_REGISTER: never
          SYSTEM_ROLE: textmode
          VIDEOMODE: text
          YAML_SCHEDULE: schedule/ha/bv/sles_ha_installation.yaml
    - textmode+skip_registration_minimal_base+ha:
        testsuite: null
        settings:
          <<: *textmode_install_full_medium
          SYSTEM_ROLE: minimal
    sle-15-SP3-Online-x86_64:
    - ha_textmode_extended:
        testsuite: null
        settings: &ha_textmode_extended
          VIDEOMODE: text
          YAML_SCHEDULE: schedule/ha/bv/ha_textmode_extended.yaml
    - textmode_ha:
        testsuite: null
        settings: &textmode_install_online_medium
          CHECK_ISO_MAXSIZE: '1'
          SCC_REGISTER: installation
          SYSTEM_ROLE: textmode
          VIDEOMODE: text
          YAML_SCHEDULE: schedule/ha/bv/sles_ha_installation.yaml
    - textmode_minimal_base+ha:
        testsuite: null
        settings:
          <<: *textmode_install_online_medium
          SYSTEM_ROLE: minimal
    - create_hdd_ha_textmode:
        testsuite: null
        settings: &create_hdd_settings
          <<: *textmode_install_online_medium
          CREATE_HDD: '1'
          HDDMODEL: scsi-hd
          PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-Build%BUILD%-HA-BV.qcow2'
          SYSTEM_ROLE: default
...
    sle-15-SP3-Full-aarch64:
    - textmode+skip_registration_ha:
        testsuite: null
        settings:
          <<: *textmode_install_full_medium
    - textmode+skip_registration_minimal_base+ha:
        testsuite: null
        settings:
          <<: *textmode_install_full_medium
          SYSTEM_ROLE: minimal
    sle-15-SP3-Online-aarch64:
    - ha_textmode_extended:
        testsuite: null
        settings:
          <<: *ha_textmode_extended
    - textmode_ha:
        testsuite: null
        settings:
          <<: *textmode_install_online_medium
    - textmode_minimal_base+ha:
        testsuite: null
        settings:
          <<: *textmode_install_online_medium
          SYSTEM_ROLE: minimal
    - create_hdd_ha_textmode:
        testsuite: null
        settings:
          <<: *create_hdd_settings
          PUBLISH_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-Build%BUILD%-HA-BV-uefi-vars.qcow2'
...
```

- Job group configuration Merge Request: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/259
- Related ticket: https://jira.suse.com/browse/TEAM-3582
- Needles: N/A
- Verification runs:

create_hdd_ha_textmode (Online Medium, SCC Registration, HA system role): [aarch64](http://mango.qa.suse.de/tests/3763), [x86_64](http://mango.qa.suse.de/tests/3752)
Full Medium, Skip Registration, textmode system role: [aarch64](http://mango.qa.suse.de/tests/3756), [x86_64](http://mango.qa.suse.de/tests/3750)
Full Medium, Skip Registration, minimal system role: [aarch64](http://mango.qa.suse.de/tests/3757), [x86_64](http://mango.qa.suse.de/tests/3751)
Online Medium, SCC Registration, textmode system role: [aarch64](http://mango.qa.suse.de/tests/3762), [x86_64](http://mango.qa.suse.de/tests/3754)
Online Medium, SCC Registration, minimal system role: [aarch64](http://mango.qa.suse.de/tests/3761), [x86_64](http://mango.qa.suse.de/tests/3755)
Online Medium, SCC Registration, HA system role, extended checks: [aarch64](http://mango.qa.suse.de/tests/3759), [x86_64](http://mango.qa.suse.de/tests/3753)