### PR TITLE
Fix failures on apparmor_profile & yast2_apparmor

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -631,6 +631,11 @@ sub adminer_database_delete {
     send_key_until_needlematch("adminer-database-dropped", 'ret', 10, 1);
     # Exit x11 and turn to console
     send_key "alt-f4";
+    # Handle exceptions when "Quit and close tabs" in Firefox, the warning FYI:
+    # "You are about to close 2 tabs. Are you sure want to continue?"
+    if (check_screen("firefox-quit-and-close-tabs", 5)) {
+        assert_and_click("firefox-close-tabs");
+    }
     assert_screen("generic-desktop");
     select_console("root-console");
     send_key "ctrl-c";

--- a/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
+++ b/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
@@ -47,6 +47,8 @@ sub run {
     send_key "alt-e";
     assert_screen("AppArmor-Settings-Enable-Apparmor");
     wait_screen_change { send_key "alt-q" };
+    # Handle exception: the cursor disappears for no reason sometimes
+    type_string("\n");
     clear_console;
     assert_screen("root-console-x11");
     type_string("systemctl status apparmor | tee \n");


### PR DESCRIPTION
There are some random failures on apparmor_profile and yast2_apparmor then enhence code to handle the exceptions
poo#89446 - [sle][security][sle15sp3][aarch64] test fails in settings_disable_enable_apparmor of yast2_apparmor case
poo#89839 - [sle][security][sle15sp3] test fails in apache2_changehat: code enhancement and new needles needed to handle exceptions

- Related ticket:
  https://progress.opensuse.org/issues/89446
  https://progress.opensuse.org/issues/89839
- Needles: added to gitlab already
- Verification run:
  aarch64: https://openqa.suse.de/tests/5668865
  s390: https://openqa.suse.de/tests/5656412
