### PR TITLE
Make serial console more stable for pxe boot

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -45,6 +45,9 @@ sub run {
             select_console 'sol', await_console => 0;
         }
     }
+    if (!check_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600)) {
+        ipmi_backend_utils::ipmitool 'chassis power reset';
+    }
     assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600);
 
     # boot bare-metal/IPMI machine


### PR DESCRIPTION
Sometimes the ipmi backend worker cannot initialize immediately, especially the hp machine.
So do ipmi power reset at first pxe boot failure to resolve this.

- Related ticket: https://progress.opensuse.org/issues/89854
- Needles: N/A
- Verification run: 
http://openqa.qa2.suse.asia/tests/31128 (first pxe boot failure)
http://openqa.qa2.suse.asia/tests/31129 (first pxe boot success)
