### PR TITLE
apache: Check apache subprocesses instead of pid file

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -139,7 +139,7 @@ sub run {
 
             # Run and test this new environment
             assert_script_run 'httpd2-prefork -f /tmp/prefork/httpd.conf';
-            assert_script_run 'while test -z /var/run/httpd.pid; do echo waiting for httpd2-prefork pid; done';
+            assert_script_run 'until ps aux|grep wwwrun; do echo waiting for httpd2-prefork pid; done';
             assert_script_run 'ps aux | grep "\-f /tmp/prefork/httpd.conf" | grep httpd2-prefork';
 
             # Run and test the old environment too


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/80668
- Verification run:
https://openqa.opensuse.org/tests/1663960 TW jeos
https://openqa.opensuse.org/tests/1663961 TW net
https://openqa.opensuse.org/tests/1663964 TW i586
https://openqa.opensuse.org/tests/1663965 TW arm
https://openqa.opensuse.org/tests/1663966 TW aarch64
http://dzedro.suse.cz/tests/17845 SLE 15 GA
http://dzedro.suse.cz/tests/17866 SLE 15 SP3

update: openSUSE does not execute this code