### PR TITLE
RFC: scheduler: Avoid precedence for variable coming from YAML_SCHEDULE

### DIFF
--- a/declarative-schedule-doc.md
+++ b/declarative-schedule-doc.md
@@ -66,7 +66,7 @@ test_data:
     - item2
   hash:
     key1: value1
-    key2: value2  
+    key2: value2
 ```
 Previous structure contains the following sections:
 
@@ -77,6 +77,9 @@ Name of the test suite
 Description of the test suite.
 
 #### vars
+
+Already existing variables do have precedence over variables set in the YAML_SCHEDULE file.
+
 Most of your settings could be migrated from openQA WebUI to this declarative way, for instance:
   - `BOOTFROM: c`
   - `BOOT_HDD_IMAGE: 1`
@@ -204,11 +207,11 @@ test_data:
         - size: 3mb
   <<: !include path/to/test_data.yaml
 ```
-Test data sometimes is more related to a particular schedule, sometimes  
-to other test data shared with other test suites and sometimes it is a mix.  
-In those cases, `YAML_TEST_DATA` setting can be used to give us the flexibility  
-to avoid duplicate schedule files just because they have different data and due  
-to it will be pointing to a test data file. Only for this particular case,  
+Test data sometimes is more related to a particular schedule, sometimes
+to other test data shared with other test suites and sometimes it is a mix.
+In those cases, `YAML_TEST_DATA` setting can be used to give us the flexibility
+to avoid duplicate schedule files just because they have different data and due
+to it will be pointing to a test data file. Only for this particular case,
 the possibility to use `$include` functionality in test data file is allowed. For instance:
 
 In your yaml for your Job Group configuration for one product you could have:

--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -141,7 +141,7 @@ sub load_yaml_schedule {
         my $schedule              = $ypp->load_file($root_project_dir . $yamlfile);
         my %schedule_vars         = parse_vars($schedule);
         my $test_context_instance = undef;
-        while (my ($var, $value) = each %schedule_vars) { set_var($var, $value) }
+        while (my ($var, $value) = each %schedule_vars) { set_var($var, get_var($var, $value)) }
         my @schedule_modules = parse_schedule($schedule);
         parse_test_suite_data($schedule);
         $test_context_instance = get_var('TEST_CONTEXT')->new() if defined get_var('TEST_CONTEXT');


### PR DESCRIPTION
This change the precedence of variables specified in the YAML_SCHEDULE
files.

Existing variables do have precedence over the variables coming from
YAMLE_SCHEDULE file.

E.g. if I would post a job with some `VAR=Foo` but `VAR=blub` is already
defined in YAML_SCHEDULE, I would never be able to change that variable
via that post.

---
This https://openqa.suse.de/tests/5649756 is such a job where I realized it. 
```bash
openqa-cli api --host https://openqa.suse.de -X POST jobs 'ARCH=x86_64' 'AUTOYAST=autoyast_opensuse/autoyast_wicked_x86_64.xml.ep' 'AUTOYAST_ADD_REPOS=http://download.opensuse.org/distribution/leap/15.2/repo/oss/,http://download.opensuse.org/update/leap/15.2/oss/' 'AUTOYAST_CONFIRM=0' 'BACKEND=qemu' 'BETA=0' 'BUILD=No-Branch' 'CASEDIR=https://github.com/cfconrad/os-autoinst-distri-opensuse#wicked_autoyast' 'DESKTOP=textmode' 'DISTRI=opensuse' 'DVD=1' 'FLAVOR=CI' 'HDDSIZEGB=30' 'ISO_URL=https://dist.suse.de/install/openSUSE-Leap-15.2/openSUSE-Leap-15.2-DVD-x86_64-Build695.1-Media.iso' 'MACHINE=64bit' 'NOIMAGES=1' 'NOVIDEO=1' 'PUBLISH_HDD_1=Leap_15_2.qcow2' 'PUBLISH_PFLASH_VARS=Leap_15_2-uefi-vars.qcow2' 'QEMUCPU=qemu64' 'QEMUVGA=cirrus' 'SCC_REGCODE=deedc51104e549deb' 'TEST=create_hdd_autoyast_wicked' 'VERSION=15.2' 'WICKED_CREATE_HDD=1' 'WORKER_CLASS=qemu_x86_64' 'ZYPPER_WHITELISTED_ORPHANS=openSUSE-release-dvd' '_GROUP_ID=14' '_SKIP_POST_FAIL_HOOKS=1'
````
My post contained a `AUTOYAST=xxx` but the used `YAML_SCHEDULE` contained also a `AUTOYAST` variable which always overwrote the one from the command-line.
The `YAML_SCHEDULE` variable was inherit from the configured testsuites...


- Verification run: https://openqa.suse.de/tests/5649998
