### PR TITLE
Fix the key loss issue while launching x3270_ssl

### DIFF
--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -73,8 +73,7 @@ sub run {
     # Launch x3270
     # Add noverifycert option if x3270 is or greater than v3.6ga
     my $noverifycert = ($current_ver < 3.6 ? '' : '-noverifycert');
-    type_string "x3270 -trace $noverifycert -tracefile $tracelog_file L:localhost:8443\n";
-
+    script_run "x3270 -trace $noverifycert -tracefile $tracelog_file L:localhost:8443";
     assert_screen 'x3270_fips_launched_with_TLS_SSL';
 
     # Exit and back to generic desktop
@@ -89,7 +88,13 @@ sub run {
     clear_console;
 
     type_string "cat $tracelog_file | tee /dev/$serialdev\n";
-    wait_serial "TLS/SSL tunneled connection complete", 5 || die "x3270 output doesn't match";
+
+    if ($current_ver >= 3.6) {
+        wait_serial "SSL_connect trace: SSLOK  SSL negotiation finished successfully", 5 || die "x3270 output doesn't match";
+    }
+    else {
+        wait_serial "TLS/SSL tunneled connection complete", 5 || die "x3270 output doesn't match";
+    }
 
     #Clean
     script_run "rm -f $tracelog_file $cert_file $key_file";


### PR DESCRIPTION
**Description:**

Use type_string to input the command lead to key loss sometimes, it could be a performance issue in openQA, I have tried to rerun it, and can work well actually. This PR is a workaround to use script_run to input the command to launch x3270.

1. Workaround to use script_run to input the command
2. Add wait_serial output message for new 3.6 version

- Related ticket: https://progress.opensuse.org/issues/89945
- Needles: NA
- Error snapshot: https://openqa.suse.de/tests/5647288#step/x3270_ssl/22
- Verification run: https://openqa.suse.de/tests/5657422#step/x3270_ssl/23
