### PR TITLE
ncurses: Try to draw a bold red line and upload more info on failure

### DIFF
--- a/tests/console/ncurses.pm
+++ b/tests/console/ncurses.pm
@@ -24,7 +24,10 @@ use utils qw(clear_console zypper_call);
 sub run {
     select_console 'root-console';
     zypper_call 'in dialog';
-    script_run 'dialog --yesno "test for boo#1054448" 3 20';
+    # Try to draw a bold red line
+    script_run('echo "$(tput smacs;tput setaf 1;tput bold)lqqqqqqqqqqqqqqk$(tput rmacs;tput sgr0)"');
+    # Try a simple yes/no dialog
+    script_run 'dialog --yesno "test for boo#1054448" 3 20 | tee boo_1054448.tee';
     assert_screen([qw(ncurses-simple-dialog ncurses-simple-dialog-broken-boo1183234)]);
     if (match_has_tag 'ncurses-simple-dialog-broken-boo1183234') {
         die "boo#1183234: Console misconfigured, ncurses UI broken!\n";
@@ -45,6 +48,7 @@ sub post_fail_hook {
     my $self = shift;
     $self->SUPER::post_fail_hook;
     upload_logs('/etc/sysconfig/console');
+    upload_logs('boo_1054448.tee');
     script_run('echo $TERM');
 }
 


### PR DESCRIPTION
This is a follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12123
Bug assignee asked more information/tests.

- Verification run: https://openqa.opensuse.org/t1665447
