### PR TITLE
Use libyui api for yast2 lan dhcp hostname setting

### DIFF
--- a/lib/YaST/Module.pm
+++ b/lib/YaST/Module.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces methods that are common for all YaST modules.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Module;
+use strict;
+use warnings;
+use testapi;
+use YuiRestClient;
+use y2_module_guitest qw(launch_yast2_module_x11);
+use y2_module_consoletest qw(yast2_console_exec);
+
+=head2 open($args)
+
+   open(module => $module, ui => $ui);
+
+Unified method to open YaST module while using LibyuiClient. Allows to open the module with both ncurses and Qt UI.
+After starting the module ensures that connection to libyui-rest-api server is established.
+
+C<$module> - Module to open. e.g. lan, storage, partitioner etc.
+            (full list of available yast2 modules can be observed by running 'yast2 -l' in console);
+C<$ui> - User interface the module is expected to be opened with (Possible values: ncurses, qt).
+
+=cut
+
+sub open {
+    my ($args) = @_;
+    my $module = $args->{module};
+    my $ui     = lc($args->{ui});
+    die 'No module name specified.'    unless defined $module;
+    die 'No user interface specified.' unless defined $ui;
+    if ($ui eq 'ncurses') {
+        yast2_console_exec(
+            yast2_module => $module,
+            yast2_opts   => '--ncurses',
+            extra_vars   => get_var('YUI_PARAMS')
+        );
+    }
+    elsif ($ui eq 'qt') {
+        launch_yast2_module_x11('', $module, extra_vars => get_var('YUI_PARAMS'));
+    }
+    else {
+        die "Unknown user interface: $ui";
+    }
+    YuiRestClient::connect_to_app_running_system();
+}
+
+1;

--- a/lib/YaST/NetworkSettings/AbstractNetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/AbstractNetworkSettingsController.pm
@@ -21,12 +21,17 @@ use YaST::NetworkSettings::NetworkCardSetup::VLANAddressTab;
 
 sub new {
     my ($class, $args) = @_;
-    my $self = bless {
-        OverviewTab    => YaST::NetworkSettings::OverviewTab->new(),
-        AddressTab     => YaST::NetworkSettings::NetworkCardSetup::AddressTab->new(),
-        GeneralTab     => YaST::NetworkSettings::NetworkCardSetup::GeneralTab->new(),
-        VLANAddressTab => YaST::NetworkSettings::NetworkCardSetup::VLANAddressTab->new()
-    }, $class;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{OverviewTab}    = YaST::NetworkSettings::OverviewTab->new();
+    $self->{AddressTab}     = YaST::NetworkSettings::NetworkCardSetup::AddressTab->new();
+    $self->{GeneralTab}     = YaST::NetworkSettings::NetworkCardSetup::GeneralTab->new();
+    $self->{VLANAddressTab} = YaST::NetworkSettings::NetworkCardSetup::VLANAddressTab->new();
+    return $self;
 }
 
 sub get_overview_tab {
@@ -150,7 +155,5 @@ sub save_changes {
     my ($self) = @_;
     $self->get_overview_tab()->press_ok();
 }
-
-
 
 1;

--- a/lib/YaST/NetworkSettings/ActionButtons.pm
+++ b/lib/YaST/NetworkSettings/ActionButtons.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods action buttons in yast2 lan YaST module.
+# The buttons in the bottom of the screen that are available across all the pages (e.g. "Next", "Cancel");
+# This is a part of a screen and it has to be included in Network Settings Controller.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::NetworkSettings::ActionButtons;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_ok} = $self->{app}->button({id => 'next'});
+    return $self;
+}
+
+sub press_ok {
+    my ($self) = @_;
+    $self->{btn_ok}->click();
+}
+
+1;

--- a/lib/YaST/NetworkSettings/HostnameDNSTab.pm
+++ b/lib/YaST/NetworkSettings/HostnameDNSTab.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Hostname/DNS
+# Tab in yast2 lan module dialog.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::NetworkSettings::HostnameDNSTab;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{cb_set_hostname_via_dhcp} = $self->{app}->combobox({id => '"DHCP_HOSTNAME"'});
+    return $self;
+}
+
+sub select_option_in_hostname_via_dhcp {
+    my ($self, $option) = @_;
+    $self->{cb_set_hostname_via_dhcp}->select($option);
+}
+
+1;

--- a/lib/YaST/NetworkSettings/TopNavigationBar.pm
+++ b/lib/YaST/NetworkSettings/TopNavigationBar.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods Top Navigation Bar in yast2 lan YaST module.
+# This is a part of a screen and it has to be included in Network Settings Controller.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::NetworkSettings::TopNavigationBar;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{menu_bar} = $self->{app}->menucollection({id => '_cwm_tab'});
+    return $self;
+}
+
+sub select_hostname_dns_tab {
+    my ($self) = @_;
+    $self->{menu_bar}->select('Ho&stname/DNS');
+}
+
+1;

--- a/lib/YaST/NetworkSettings/v3/NetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/v3/NetworkSettingsController.pm
@@ -21,7 +21,13 @@ use YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab;
 
 sub new {
     my ($class, $args) = @_;
-    my $self = $class->SUPER::new($args);
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->SUPER::init($args);
     $self->{HardwareDialog}    = YaST::NetworkSettings::NetworkCardSetup::HardwareDialog->new();
     $self->{BridgedDevicesTab} = YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab->new({tab_shortcut => 'alt-i', bridged_devices_shortcut => 'alt-d'});
     $self->{BondSlavesTab}     = YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab->new({tab_shortcut => 'alt-o'});

--- a/lib/YaST/NetworkSettings/v4/NetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/v4/NetworkSettingsController.pm
@@ -21,7 +21,13 @@ use YaST::NetworkSettings::NetworkCardSetup::BondSlavesTab;
 
 sub new {
     my ($class, $args) = @_;
-    my $self = $class->SUPER::new($args);
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->SUPER::init($args);
     $self->{DeviceTypeDialog}       = YaST::NetworkSettings::NetworkCardSetup::DeviceTypeDialog->new();
     $self->{BridgedDevicesTabOnAdd} = YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab->new({tab_shortcut => 'alt-v', bridged_devices_shortcut => 'alt-i'});
     $self->{BridgedDevicesTabOnEdit} = YaST::NetworkSettings::NetworkCardSetup::BridgedDevicesTab->new({tab_shortcut => 'alt-b', bridged_devices_shortcut => 'alt-i'});

--- a/lib/YaST/NetworkSettings/v4_3/NetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/v4_3/NetworkSettingsController.pm
@@ -15,10 +15,46 @@ package YaST::NetworkSettings::v4_3::NetworkSettingsController;
 use parent 'YaST::NetworkSettings::v4::NetworkSettingsController';
 use strict;
 use warnings;
+use YaST::NetworkSettings::TopNavigationBar;
+use YaST::NetworkSettings::HostnameDNSTab;
+use YaST::NetworkSettings::ActionButtons;
+use YaST::Warning::Notification;
+use YuiRestClient;
 
 sub new {
     my ($class, $args) = @_;
-    return $class->SUPER::new($args);
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->SUPER::init($args);
+    $self->{TopNavigationBar}    = YaST::NetworkSettings::TopNavigationBar->new({app => YuiRestClient::get_app()});
+    $self->{HostnameDNSTab}      = YaST::NetworkSettings::HostnameDNSTab->new({app => YuiRestClient::get_app()});
+    $self->{ActionButtons}       = YaST::NetworkSettings::ActionButtons->new({app => YuiRestClient::get_app()});
+    $self->{NotificationWarning} = YaST::Warning::Notification->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_top_navigation_bar {
+    my ($self) = @_;
+    return $self->{TopNavigationBar};
+}
+
+sub get_hostname_dns_tab {
+    my ($self) = @_;
+    return $self->{HostnameDNSTab};
+}
+
+sub get_action_buttons {
+    my ($self) = @_;
+    return $self->{ActionButtons};
+}
+
+sub get_notification_warning {
+    my ($self) = @_;
+    return $self->{NotificationWarning};
 }
 
 sub view_bond_slave_without_editing {
@@ -27,6 +63,23 @@ sub view_bond_slave_without_editing {
     $self->get_overview_tab()->press_edit();
     $self->get_bond_slaves_tab_on_edit()->select_tab();
     $self->get_bond_slaves_tab_on_edit()->press_next();
+}
+
+sub confirm_warning {
+    my ($self) = @_;
+    $self->get_notification_warning()->confirm();
+}
+
+sub set_hostname_via_dhcp {
+    my ($self, $args) = @_;
+    my $dhcp_option = $args->{dhcp_option};
+    $self->get_top_navigation_bar()->select_hostname_dns_tab();
+    $self->get_hostname_dns_tab()->select_option_in_hostname_via_dhcp($dhcp_option);
+}
+
+sub save_changes {
+    my ($self) = @_;
+    $self->get_action_buttons()->press_ok();
 }
 
 1;

--- a/lib/YaST/Warning/Notification.pm
+++ b/lib/YaST/Warning/Notification.pm
@@ -1,0 +1,52 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces methods to control Notification Dialog
+# which has only "Ok" button.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Warning::Notification;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_ok}      = $self->{app}->button({id => 'ok_msg'});
+    $self->{lbl_header}  = $self->{app}->label({label => 'Warning'});
+    $self->{lbl_warning} = $self->{app}->label({type  => 'YLabel'});
+    return $self;
+}
+
+sub confirm {
+    my ($self) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->is_shown();
+    });
+    $self->press_ok();
+}
+
+sub press_ok {
+    my ($self) = @_;
+    $self->{btn_ok}->click();
+}
+
+sub is_shown {
+    my ($self) = @_;
+    $self->{lbl_header}->exist();
+}
+
+1;

--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -6,11 +6,13 @@ use strict;
 use warnings;
 use testapi;
 use Utils::Backends 'is_hyperv';
+use Exporter 'import';
+our @EXPORT_OK = qw(yast2_console_exec);
 
 sub yast2_console_exec {
     my %args = @_;
     die "Yast2 module has not been found among function arguments!\n" unless (defined($args{yast2_module}));
-    my $y2_start    = y2_module_basetest::with_yast_env_variables() . ' yast2 ';
+    my $y2_start    = y2_module_basetest::with_yast_env_variables($args{extra_vars}) . ' yast2 ';
     my $module_name = 'yast2-' . $args{yast2_module} . '-status';
     $y2_start .= (defined($args{yast2_opts})) ?
       $args{yast2_opts} . ' ' . $args{yast2_module} :

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -87,7 +87,7 @@ Accept warning for Networkmanager controls network device.
 
 =cut
 sub open_network_settings {
-    $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'lan');
+    $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'lan', extra_vars => get_var('YUI_PARAMS'));
     # 'Global Options' tab is opened after accepting the warning on the systems
     # with Network Manager.
     # Thus, there is no way to select device in Overview tab on such systems, so

--- a/lib/yast2_lan_hostname_base.pm
+++ b/lib/yast2_lan_hostname_base.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: yast2-network
+# Summary: Base test module for all the tests modules of yast2 lan.
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+package yast2_lan_hostname_base;
+use parent "y2_module_consoletest";
+use strict;
+use warnings;
+use testapi;
+use YuiRestClient;
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->SUPER::post_fail_hook;
+    script_run 'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
+    upload_logs '/etc/sysconfig/network/ifcfg-$iface';
+    upload_logs '/etc/sysconfig/network/dhcp';
+}
+
+1;

--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -10,6 +10,7 @@ vars:
   SOFTFAIL_BSC1063638: 1
   VALIDATE_ETC_HOSTS: 1
   YUI_REST_API: 1
+  SCC_ADDONS: sdk
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
@@ -22,6 +23,7 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/scc_cleanup_reregister
+        - console/suseconnect_scc
         - console/setup_libyui_running_system
         - yast2_gui/yast2_control_center
         - yast2_gui/yast2_expert_partitioner
@@ -54,6 +56,7 @@ conditional_schedule:
         - yast2_gui/yast2_lan_restart_bond
       ppc64le:
         - console/scc_cleanup_reregister
+        - console/suseconnect_scc
         - console/setup_libyui_running_system
         - yast2_gui/yast2_expert_partitioner
         - yast2_gui/yast2_software_management

--- a/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml
@@ -4,11 +4,16 @@ description:    >
   Test for yast2 UI, ncurses only. Running on created gnome images
   which provides both text console for ncurses UI tests as well as
   the gnome environment for the GUI tests.
+vars:
+  YUI_REST_API: 1
+  SCC_ADDONS: sdk
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
   - console/prepare_test_data
   - console/consoletest_setup
+  - console/suseconnect_scc
+  - console/setup_libyui_running_system
   - console/yast2_i
   - "{{yast_modules}}"
   - console/coredump_collect
@@ -26,7 +31,9 @@ conditional_schedule:
         - console/yast2_ftp
         - console/yast2_apparmor
         - console/yast2_lan
-        - console/yast2_lan_hostname
+        - console/yast2_lan_hostname/dhcp_no
+        - console/yast2_lan_hostname/dhcp_yes
+        - console/yast2_lan_hostname/dhcp_yes_eth
         - console/yast2_settings
         - console/yast2_dns_server
         - console/yast2_nfs_server
@@ -44,7 +51,12 @@ conditional_schedule:
         - console/yast2_ntpclient
         - console/yast2_tftp
         - console/yast2_lan
-        - console/yast2_lan_hostname
+        - console/yast2_lan_hostname/dhcp_no
+        - console/yast2_lan_hostname/dhcp_yes
+        - console/yast2_lan_hostname/dhcp_yes_eth
         - console/yast2_dns_server
         - console/yast2_nfs_client
         - console/yast2_snapper_ncurses
+test_data:
+  yast2_lan_hostname:
+    ui: ncurses

--- a/schedule/yast/yast2_ncurses/yast2_ncurses_opensuse.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_opensuse.yaml
@@ -1,0 +1,34 @@
+---
+name:           yast2_ncurses
+description:    >
+  Test for yast2 UI, ncurses only. Running on created gnome
+  images which provides both text console for ncurses UI tests
+  as well as the gnome environment for the GUI tests.
+vars:
+  YUI_REST_API: 1
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/setup_libyui_running_system
+  - console/yast2_rmt
+  - console/yast2_ntpclient
+  - console/yast2_tftp
+  - console/yast2_proxy
+  - console/yast2_vnc
+  - console/yast2_http
+  - console/yast2_ftp
+  - console/yast2_apparmor
+  - console/yast2_lan
+  - console/yast2_lan_device_settings
+  - console/yast2_lan_hostname/dhcp_no
+  - console/yast2_lan_hostname/dhcp_yes
+  - console/yast2_lan_hostname/dhcp_yes_eth
+  - console/yast2_dns_server
+  - console/yast2_nfs_client
+  - console/yast2_snapper_ncurses
+test_data:
+  yast2_lan_hostname:
+    ui: ncurses
+    confirm_warning: 1

--- a/tests/console/setup_libyui_running_system.pm
+++ b/tests/console/setup_libyui_running_system.pm
@@ -30,4 +30,8 @@ sub run {
     YuiRestClient::setup_libyui_running_system();
 }
 
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
 1;

--- a/tests/console/yast2_lan_hostname/dhcp_no.pm
+++ b/tests/console/yast2_lan_hostname/dhcp_no.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: yast2-network
+# Summary: Verify that correct value is stored in network config when
+# setting hostname via DHCP to 'no' in YaST2 lan module (https://bugzilla.suse.com/show_bug.cgi?id=984890)
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use parent 'yast2_lan_hostname_base';
+use strict;
+use warnings;
+use testapi;
+use scheduler qw(get_test_suite_data);
+use YaST::Module;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    YaST::Module::open({module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui}});
+    my $network_settings = $testapi::distri->get_network_settings();
+    $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
+    $network_settings->set_hostname_via_dhcp({dhcp_option => 'no'});
+    $network_settings->save_changes();
+
+    assert_screen 'console-visible', 180;
+    wait_still_screen;
+    assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
+}
+
+1;

--- a/tests/console/yast2_lan_hostname/dhcp_yes.pm
+++ b/tests/console/yast2_lan_hostname/dhcp_yes.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: yast2-network
+# Summary: Verify that correct value is stored in network config when
+# setting hostname via DHCP to 'yes: any' in YaST2 lan module (https://bugzilla.suse.com/show_bug.cgi?id=984890)
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use parent 'yast2_lan_hostname_base';
+use strict;
+use warnings;
+use testapi;
+use scheduler qw(get_test_suite_data);
+use YaST::Module;
+
+sub run {
+    my $test_data = get_test_suite_data();
+    YaST::Module::open({module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui}});
+    my $network_settings = $testapi::distri->get_network_settings();
+    $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
+    $network_settings->set_hostname_via_dhcp({dhcp_option => 'yes: any'});
+    $network_settings->save_changes();
+
+    assert_screen 'console-visible', 180;
+    wait_still_screen;
+    assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep yes';
+}
+
+1;

--- a/tests/console/yast2_lan_hostname/dhcp_yes_eth.pm
+++ b/tests/console/yast2_lan_hostname/dhcp_yes_eth.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: yast2-network
+# Summary: Verify that correct value is stored in network config when
+# setting hostname via DHCP to 'yes: <ethernet network interface>' in
+# YaST2 lan module (https://bugzilla.suse.com/show_bug.cgi?id=984890)
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use parent 'yast2_lan_hostname_base';
+use strict;
+use warnings;
+use testapi;
+use scheduler qw(get_test_suite_data);
+use YaST::Module;
+
+sub run {
+    select_console 'root-console';
+    my $network_interface = script_output('ls /sys/class/net | grep ^e');
+    my $test_data         = get_test_suite_data();
+
+    YaST::Module::open({module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui}});
+    my $network_settings = $testapi::distri->get_network_settings();
+    $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
+    $network_settings->set_hostname_via_dhcp({dhcp_option => "yes: $network_interface"});
+    $network_settings->save_changes();
+
+    assert_screen 'console-visible', 180;
+    wait_still_screen;
+    assert_script_run 'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
+    assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/ifcfg-$iface|grep yes';
+    assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
+}
+
+1;

--- a/tests/yast2_gui/yast2_expert_partitioner.pm
+++ b/tests/yast2_gui/yast2_expert_partitioner.pm
@@ -39,6 +39,7 @@ use warnings;
 use testapi;
 use YuiRestClient;
 use scheduler 'get_test_suite_data';
+use YaST::Module;
 
 my $partitioner;
 my $test_data;
@@ -49,16 +50,13 @@ sub pre_run_hook {
 }
 
 sub open_expert_partitioner {
-    my ($self) = shift;
-    $self->launch_yast2_module_x11('storage', extra_vars => get_var('YUI_PARAMS'));
-    YuiRestClient::connect_to_app_running_system();
+    YaST::Module::open({module => 'storage', ui => 'qt'});
     $partitioner->get_confirmation_warning_controller()->confirm_only_use_if_familiar();
 }
 
 sub add_custom_partition {
-    my ($self) = shift;
     my $disk = $test_data->{disks}[0];
-    $self->open_expert_partitioner;
+    open_expert_partitioner;
     $partitioner->add_partition_on_gpt_disk({
             disk      => $disk->{name},
             partition => $disk->{partitions}[0]
@@ -82,8 +80,7 @@ sub verify_custom_partition {
 }
 
 sub resize_custom_partition {
-    my ($self) = shift;
-    $self->open_expert_partitioner;
+    open_expert_partitioner;
     $partitioner->resize_partition({
             disk      => $test_data->{disks}[0]->{name},
             partition => $test_data->{disks}[0]->{partitions}[1]
@@ -96,8 +93,7 @@ sub verify_resized_partition {
 }
 
 sub delete_resized_partition {
-    my ($self) = shift;
-    $self->open_expert_partitioner;
+    open_expert_partitioner;
     $partitioner->delete_partition({
             disk      => $test_data->{disks}[0]->{name},
             partition => $test_data->{disks}[0]->{partitions}[1]
@@ -106,8 +102,7 @@ sub delete_resized_partition {
 }
 
 sub add_logical_volumes {
-    my ($self) = shift;
-    $self->open_expert_partitioner;
+    open_expert_partitioner;
     $partitioner->setup_lvm($test_data->{lvm});
     $partitioner->show_summary_and_accept_changes();
 }
@@ -123,8 +118,7 @@ sub verify_logical_volumes {
 }
 
 sub delete_volume_group {
-    my ($self) = shift;
-    $self->open_expert_partitioner;
+    open_expert_partitioner;
     my $vg = $test_data->{lvm}->{volume_groups}[0];
 
     $partitioner->delete_volume_group($vg->{name});
@@ -132,17 +126,16 @@ sub delete_volume_group {
 }
 
 sub run {
-    my ($self) = shift;
     select_console "x11";
 
-    $self->add_custom_partition;
+    add_custom_partition;
     verify_custom_partition;
-    $self->resize_custom_partition;
+    resize_custom_partition;
     verify_resized_partition;
-    $self->delete_resized_partition;
-    $self->add_logical_volumes;
+    delete_resized_partition;
+    add_logical_volumes;
     verify_logical_volumes;
-    $self->delete_volume_group;
+    delete_volume_group;
 }
 
 1;


### PR DESCRIPTION
The commit rewrites yast2_lan_hostname tests to use libyui-rest-api.

Also the test cases are separated for the cases when 'no', 'yes: any'
and 'yes: eth0' are set for hostname via DHCP.

- Verification runs: 
   - https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=162.7_oorlov&groupid=96
   - https://openqa.opensuse.org/tests/1670503
   - https://openqa.opensuse.org/tests/1670504
   - https://openqa.opensuse.org/tests/1670505
   - https://openqa.opensuse.org/tests/1670506
   - https://openqa.opensuse.org/tests/1670507
   - https://openqa.opensuse.org/tests/1670508

**The following update is required on o3 in Job Groups**:
 - openSUSE Tumbleweed
 - openSUSE Tumbleweed AArch64
 - openSUSE Tumbleweed PowerPC
 - openSUSE Leap 15

```yaml
- yast2_ncurses:
    settings:
       YAML_SCHEDULE: schedule/yast/yast2_ncurses/yast2_ncurses_opensuse.yaml
```