### PR TITLE
Extends buildah_image to run images with docker

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -115,7 +115,7 @@ sub allow_selected_insecure_registries {
         assert_script_run("mkdir -p /etc/docker");
         assert_script_run('cat /etc/docker/daemon.json; true');
         assert_script_run(
-            'echo "{ \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\", \"' . $registry . '\"] }" > /etc/docker/daemon.json');
+'echo "{ \"debug\": true, \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\", \"' . $registry . '\"] }" > /etc/docker/daemon.json');
         assert_script_run('cat /etc/docker/daemon.json');
         systemctl('restart docker');
     } elsif ($runtime =~ /podman/) {

--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -21,9 +21,10 @@ schedule:
   - boot/boot_to_desktop
   - containers/podman
   - '{{podman_image}}'
-  - containers/buildah_image
+  - containers/buildah_podman
   - containers/docker
   - '{{docker_image}}'
+  - containers/buildah_docker
   - containers/docker_runc
   - containers/docker_compose
   - containers/zypper_docker

--- a/schedule/containers/extra_tests_textmode_containers.yaml
+++ b/schedule/containers/extra_tests_textmode_containers.yaml
@@ -21,6 +21,7 @@ schedule:
   - boot/boot_to_desktop
   - containers/podman
   - '{{podman_image}}'
+  - containers/buildah_image
   - containers/docker
   - '{{docker_image}}'
   - containers/docker_runc

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -16,7 +16,8 @@ schedule:
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/podman_image
-  - containers/buildah_image
+  - containers/buildah_podman
+  - containers/buildah_docker
   - containers/docker_image
   - containers/container_diff
   - '{{validate_btrfs}}'

--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -28,39 +28,28 @@ sub run {
     my ($image_names, $stable_names) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
     install_buildah_when_needed($host_distri);
-    install_podman_when_needed($host_distri);
     install_docker_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => 'docker');
-    allow_selected_insecure_registries(runtime => 'podman');
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
-    for my $iname (@{$image_names}) {
+    for my $iname (@{$stable_names}) {
+        record_info 'testing image', $iname;
         test_container_image(image => $iname, runtime => 'buildah');
         if (check_os_release('suse', 'PRETTY_NAME')) {
-            # sle15-working-container is the default name given to a container. it is created in test_container_image
-            my $prefix_img_name = +(split /\//, +(split /:/, $iname)[0])[-1];
+            # Use container which it is created in test_container_image
+            # Buildah default name is conducted by <image-name>-working-container
+            my ($prefix_img_name) = $iname =~ /([^\/:]+)(:.+)?$/;
             test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah');
             # Due to the steps from the test_opensuse_based_image previously,
             # the image has been committed as refreshed
-            test_containered_app(runtime => 'podman',
-                buildah    => 1,
-                dockerfile => 'Dockerfile.suse',
-                base       => 'refreshed');
-            assert_script_run "podman rmi -f myapp";
             test_containered_app(runtime => 'docker',
                 buildah    => 1,
                 dockerfile => 'Dockerfile.suse',
                 base       => 'refreshed');
-            if (is_sle) {
-                my $container_id = script_output "docker ps -aqf 'ancestor=myapp'";
-                assert_script_run "docker cp /etc/SUSEConnect $container_id:/etc/SUSEConnect";
-                assert_script_run "docker cp /etc/zypp/credentials.d/SCCcredentials $container_id:/etc/zypp/credentials.d/SCCcredentials";
-                assert_script_run "docker exec -it $container_id zypper lr";
-            }
         }
     }
+
     scc_restore_docker_image_credentials();
-    clean_container_host(runtime => 'podman');
     clean_container_host(runtime => 'docker');
     clean_container_host(runtime => 'buildah');
 }

--- a/tests/containers/buildah_image.pm
+++ b/tests/containers/buildah_image.pm
@@ -27,7 +27,6 @@ use version_utils 'is_sle';
 sub run {
     my ($image_names, $stable_names) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
-
     install_buildah_when_needed($host_distri);
     install_podman_when_needed($host_distri);
     install_docker_when_needed($host_distri);

--- a/tests/containers/buildah_image.pm
+++ b/tests/containers/buildah_image.pm
@@ -22,6 +22,7 @@ use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
+use version_utils 'is_sle';
 
 sub run {
     my ($image_names, $stable_names) = get_suse_container_urls();
@@ -29,6 +30,8 @@ sub run {
 
     install_buildah_when_needed($host_distri);
     install_podman_when_needed($host_distri);
+    install_docker_when_needed($host_distri);
+    allow_selected_insecure_registries(runtime => 'docker');
     allow_selected_insecure_registries(runtime => 'podman');
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
@@ -39,13 +42,26 @@ sub run {
             test_opensuse_based_image(image => 'sle15-working-container', runtime => 'buildah');
             # Due to the steps from the test_opensuse_based_image previously,
             # the image has been committed as refreshed
-            test_containered_app(runtime => 'buildah',
+            test_containered_app(runtime => 'podman',
+                buildah    => 1,
                 dockerfile => 'Dockerfile.suse',
                 base       => 'refreshed');
+            assert_script_run "podman rmi -f myapp";
+            test_containered_app(runtime => 'docker',
+                buildah    => 1,
+                dockerfile => 'Dockerfile.suse',
+                base       => 'refreshed');
+            if (is_sle) {
+                my $container_id = script_output "docker ps -aqf 'ancestor=myapp'";
+                assert_script_run "docker cp /etc/SUSEConnect $container_id:/etc/SUSEConnect";
+                assert_script_run "docker cp /etc/zypp/credentials.d/SCCcredentials $container_id:/etc/zypp/credentials.d/SCCcredentials";
+                assert_script_run "docker exec -it $container_id zypper lr";
+            }
         }
     }
     scc_restore_docker_image_credentials();
     clean_container_host(runtime => 'podman');
+    clean_container_host(runtime => 'docker');
     clean_container_host(runtime => 'buildah');
 }
 

--- a/tests/containers/buildah_image.pm
+++ b/tests/containers/buildah_image.pm
@@ -38,7 +38,8 @@ sub run {
         test_container_image(image => $iname, runtime => 'buildah');
         if (check_os_release('suse', 'PRETTY_NAME')) {
             # sle15-working-container is the default name given to a container. it is created in test_container_image
-            test_opensuse_based_image(image => 'sle15-working-container', runtime => 'buildah');
+            my $prefix_img_name = +(split /\//, +(split /:/, $iname)[0])[-1];
+            test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah');
             # Due to the steps from the test_opensuse_based_image previously,
             # the image has been committed as refreshed
             test_containered_app(runtime => 'podman',

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: buildah
+# Summary: building OCI-compatible sle base images with buildah.
+# - install buildah
+# - create and run container
+# - build image with service and test connectivity
+# - cleanup system (images, containers)
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use utils;
+use containers::common;
+use containers::container_images;
+use containers::urls 'get_suse_container_urls';
+use version_utils qw(get_os_release check_os_release);
+
+sub run {
+    my ($image_names, $stable_names) = get_suse_container_urls();
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
+    install_buildah_when_needed($host_distri);
+    install_podman_when_needed($host_distri);
+    allow_selected_insecure_registries(runtime => 'podman');
+    scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
+
+    for my $iname (@{$stable_names}) {
+        record_info 'testing image', $iname;
+        test_container_image(image => $iname, runtime => 'buildah');
+        if (check_os_release('suse', 'PRETTY_NAME')) {
+            # Use container which it is created in test_container_image
+            # Buildah default name is conducted by <image-name>-working-container
+            my ($prefix_img_name) = $iname =~ /([^\/:]+)(:.+)?$/;
+            record_info $prefix_img_name;
+            test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah');
+            # Due to the steps from the test_opensuse_based_image previously,
+            # the image has been committed as refreshed
+            test_containered_app(runtime => 'podman',
+                buildah    => 1,
+                dockerfile => 'Dockerfile.suse',
+                base       => 'refreshed');
+        }
+    }
+    scc_restore_docker_image_credentials();
+    clean_container_host(runtime => 'podman');
+    clean_container_host(runtime => 'buildah');
+}
+
+1;


### PR DESCRIPTION
Images built by buildah needs to push to the local registry to be used.
Test implements a few extra steps required to make sure that an image
coming from a buildah build can run zypper-docker.

i have also setup daemon.json to debug mode. this is nice to have for debugging as the journal has only
 info level records

There is a problem with one of the validations where returns some warning                                                                                                                                                                    
but it is not reproducable locally. i filed a bug and added a soft-fail                                                                                                                                                                      
to the test.                                                                                                                                                                                                                                 
The warning has to do with the config files that installed by                                                                                                                                                                                
libcontainers-common. Specifically from /etc/containers/mounts.conf.                                                                                                                                                                         
                                                                                                                                                                                                                                             
Another issue found and filed as a bug where the TW image cant install curl.                                                                                                                                                                 
So failure should be expected on opensuse

- Related ticket: https://progress.opensuse.org/issues/88141
- [Verification run 15-SP3: ](https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2312129&version=15-SP3)
-[Verification run  TW: ](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2312129&version=Tumbleweed)