### PR TITLE
Install two selinux two packages to cover sle12sp5

### DIFF
--- a/tests/security/selinux/audit2allow.pm
+++ b/tests/security/selinux/audit2allow.pm
@@ -65,14 +65,18 @@ sub run {
         die "ERROR:\ \"$test_module\"\ module\ was\ not\ removed!";
     }
 
-    if (is_sle) {
+    if (is_sle('>=15')) {
         # generate reference policy using installed macros
         # install needed pkgs for interface
         add_suseconnect_product("sle-module-desktop-applications");
         add_suseconnect_product("sle-module-development-tools");
+        zypper_call("in policycoreutils-devel");
+    } elsif (is_sle('<15')) {
+        zypper_call("in selinux-policy-devel");
+    } else {
+        zypper_call("in policycoreutils-devel");
     }
 
-    zypper_call("in policycoreutils-devel");
     # call sepolgen-ifgen to generate the interface descriptions
     assert_script_run("sepolgen-ifgen");
     # run "# audit2allow -R" to generate reference policy and verify the policy format

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -76,6 +76,8 @@ sub run {
             assert_script_run "wget --quiet " . data_url("selinux/$file");
             assert_script_run("rpm -ivh --nosignature --nodeps --noplugins $file");
         }
+    } else {
+        zypper_call("in selinux-policy-minimum");
     }
 
     # record the pkgs' version for reference


### PR DESCRIPTION
Install selinux-policy-minimum and selinux-policy-devel  so selinux tests can run on sle12sp5. It won't affect sle15sp3 tests.
- Related ticket: https://progress.opensuse.org/issues/90056
- Needles: no
- Verification run: 
- sles12sp5: http://10.67.17.201/tests/1347
- sles15sp2: http://10.67.17.201/tests/1348
- sles15sp3: http://10.67.17.201/tests/1350
