### PR TITLE
Change regex to match different text order

### DIFF
--- a/tests/security/selinux/semanage_boolean.pm
+++ b/tests/security/selinux/semanage_boolean.pm
@@ -61,11 +61,9 @@ sub run {
     validate_script_output(
         "semanage boolean -l -C",
         sub {
-            m/
-            SELinux.*boolean.*State.*Default.*Description.*
-            ${test_boolean}.*(on.*,.*on).*Allow.*to.*
-            selinuxuser_execmod.*(on.*,.*on).*Allow.*to.*/sx
+            m/(?=.*SELinux\s+boolean\s+State\s+Default\s+Description)(?=.*${test_boolean}\s+\(on\s+,\s+on\))(?=.*selinuxuser_execmod\s+\(on\s+,\s+on\))/s;
         });
+
 
     # test option "-D": to delete boolean local customizations
     assert_script_run("semanage boolean -D");

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -44,6 +44,8 @@ sub run {
     # set SELINUXTYPE=minimum
     assert_script_run("sed -i -e 's/^SELINUXTYPE=/#SELINUXTYPE=/' $selinux_config_file");
     assert_script_run("echo 'SELINUXTYPE=minimum' >> $selinux_config_file");
+    assert_script_run("systemctl enable auditd");
+
 
     # reboot the vm and reconnect the console
     power_action("reboot", textmode => 1);


### PR DESCRIPTION
Change regex in semanage_boolean.pm to match different order of output texts so that this test can run on sle12sp5 . 
Enable auditd in sestatus.pm so that it can collect more log for later tests to run on sle12sp5 successfully
- Related ticket: https://progress.opensuse.org/issues/90065
- Needles: no
- Verification run:
- sles12sp5: http://10.67.17.201/tests/1347
- sles15sp2: http://10.67.17.201/tests/1348
- sles15sp3: http://10.67.17.201/tests/1350
