### PR TITLE
Adopt selinux tests into QEM test repo tests

### DIFF
--- a/schedule/qam/common/security/selinux.yml
+++ b/schedule/qam/common/security/selinux.yml
@@ -1,0 +1,31 @@
+---
+name: selinux
+conditional_schedule:
+  versions:
+    VERSION:
+      "15-SP2":
+      - security/selinux/semanage_boolean
+      - security/selinux/fixfiles
+      - security/selinux/print_se_context
+      - security/selinux/audit2allow
+      "12-SP5":
+      - security/selinux/print_se_context
+      - security/selinux/audit2allow
+      - security/selinux/semanage_boolean
+  chcat:
+    VERSION:
+      "15-SP2":
+      - security/selinux/chcat
+schedule:
+- boot/boot_to_desktop
+- security/selinux/selinux_setup
+- security/selinux/sestatus
+- security/selinux/selinux_smoke
+- security/selinux/enforcing_mode_setup
+- security/selinux/semanage_fcontext
+- '{{versions}}'
+- security/selinux/semodule
+- security/selinux/setsebool
+- security/selinux/restorecon
+- security/selinux/chcon
+- '{{chcat}}'


### PR DESCRIPTION
Adopt selinux tests into QEM test repo tests for sle12sp5 and sle15sp2 
- Related ticket: https://progress.opensuse.org/issues/58841
- Needles: no
- Verification run: 
- sles12sp5: http://10.67.17.201/tests/1347
- sles15sp2: http://10.67.17.201/tests/1348
- sles15sp3: http://10.67.17.201/tests/1350
- Tumbleweed-x86_64-20210312: http://10.67.17.201/tests/1360