### PR TITLE
networkd_init: install systemd-network on Leap 15.3 before testing

### DIFF
--- a/tests/networkd/networkd_init.pm
+++ b/tests/networkd/networkd_init.pm
@@ -35,7 +35,7 @@ sub run {
 
     my $pkg_repo            = get_var('MIRROR_HTTP', 'dvd:/?devices=/dev/sr0');
     my $release_pkg         = 'openSUSE-release';
-    my $systemd_network_pkg = (is_tumbleweed) ? 'systemd-network' : '';
+    my $systemd_network_pkg = (is_tumbleweed || is_leap('>=15.3')) ? 'systemd-network' : '';
     my $pkgs_to_install     = "systemd $systemd_network_pkg shadow zypper $release_pkg vim iproute2 iputils grep";
 
     $self->setup_nspawn_container("node1", $pkg_repo, $pkgs_to_install);


### PR DESCRIPTION
Since systemd-network has been splits to systemd-network package on SLE side, we can install systemd-network as well on Leap 15.3 for testing networkd function.

- Related fail test: https://openqa.opensuse.org/tests/1667386#step/networkd_dhcp/5
- Verification run: https://openqa.opensuse.org/tests/1667555
