### PR TITLE
Disable Kdump from the YaST installer

### DIFF
--- a/schedule/sles4sap/installation/install_sles4sap.yaml
+++ b/schedule/sles4sap/installation/install_sles4sap.yaml
@@ -23,6 +23,7 @@ schedule:
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout
+  - installation/disable_kdump
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system

--- a/tests/installation/disable_kdump.pm
+++ b/tests/installation/disable_kdump.pm
@@ -1,0 +1,52 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Disable kdump from the Installer
+#   Since 15-SP3, the kdump module is part of the first installer stage
+#   and it is enabled by default.
+#   We need to disable it for properly testing sysctl settings linked
+#   to the RAM amount.
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+
+sub run {
+    my ($self) = shift;
+
+    # Verify Installation Settings overview is displayed as starting point
+    assert_screen "installation-settings-overview-loaded";
+
+    if (check_var('VIDEOMODE', 'text')) {
+        # Select section booting on Installation Settings overview on text mode
+        send_key $cmd{change};
+        assert_screen 'inst-overview-options';
+        send_key 'alt-k';
+    }
+    else {
+        # Select section kdump on Installation Settings overview (video mode)
+        send_key_until_needlematch 'kdump-section-selected', 'tab';
+        send_key 'ret';
+    }
+
+    assert_screen 'inst-kdump-settings';
+    # Disable kdump
+    send_key 'alt-d';
+    wait_still_screen(1);
+
+    save_screenshot;
+    send_key $cmd{ok};
+
+    # Adapting system setting needs longer time in case of installing/upgrading with multi-addons
+    assert_screen 'installation-settings-overview-loaded', 220;
+}
+
+1;


### PR DESCRIPTION
Since 15-SP3, the kdump module is part of the first installer stage and it is enabled by [default](https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP3/#bsc-1173624).
In this case, the system has less memory available and the sysctl settings regression tests will fail due to a huge gap in the settings linked to the RAM amount.

- Related ticket: N/A
- Needles: [MR](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1517)
- Verification run: 15-SP3 [textmode](http://1b143.qa.suse.de/tests/7451#step/disable_kdump/4) / [videomode](http://1b143.qa.suse.de/tests/7449#step/disable_kdump/23)
