### PR TITLE
lib/containers/urls.pm: drop Jump 15.2, handle Leap 15.3 for all archs

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -84,10 +84,10 @@ sub get_suse_container_urls {
         push @image_names,  "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";
         push @stable_names, "registry.opensuse.org/opensuse/tumbleweed";
     }
-    elsif ($version eq "Jump:15.2") {
-        # Jump 15.2 uses opensuse/leap:15.2.1, just hardcode this special case
-        push @image_names,  "registry.opensuse.org/opensuse/jump/15.2/images/totest/containers/opensuse/leap:15.2.1";
-        push @stable_names, "registry.opensuse.org/opensuse/leap:15.2.1";
+    elsif (is_leap(">=15.3")) {
+        # All archs in the same location
+        push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
+        push @stable_names, "registry.opensuse.org/opensuse/leap:${version}";
     }
     elsif ((is_leap(">15.0") || is_microos(">15.0")) && check_var('ARCH', 'x86_64')) {
         push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/90110
- Verification run: https://openqa.opensuse.org/tests/1667708
