### PR TITLE
Fix lmod debug information

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -229,6 +229,9 @@ Check service before migration, zypper install service package, enable, start an
 =cut
 sub install_services {
     my ($service) = @_;
+    # turn off lmod shell debug information
+    assert_script_run('echo export LMOD_SH_DBG_ON=1 >> /etc/bash.bashrc.local');
+    assert_script_run '. /etc/bash.bashrc.local';
     foreach my $s (sort keys %$service) {
         my $srv_pkg_name  = $service->{$s}->{srv_pkg_name};
         my $srv_proc_name = $service->{$s}->{srv_proc_name};


### PR DESCRIPTION
In some cases, we'd install lua-lmod package which will turn on the
lmod warning message. this will casue the script_out output mingled
output to cause errors. We can set LMOD_SH_DBG_ON=1 in 
/etc/bash.bashrc.local to turn off it.

- Related ticket: https://progress.opensuse.org/issues/89590
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/5677222
  https://openqa.nue.suse.com/tests/5677232
  https://openqa.nue.suse.com/tests/5677368
  