### PR TITLE
transactional_update: Drop Leap Beta handling, no longer necessary

### DIFF
--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -67,12 +67,6 @@ sub run {
 
     script_run "rebootmgrctl set-strategy off";
 
-    if (is_opensuse && get_var('BETA')) {
-        record_info 'Remove pkgs', 'Remove preinstalled packages on Leap BETA';
-        trup_call "pkg remove update-test-[^t]*";
-        process_reboot(trigger => 1);
-    }
-
     get_utt_packages;
 
     record_info 'Install ptf', 'Install package - snapshot #1';


### PR DESCRIPTION
After patterns-base changes, the update-test- packages are no longer
installed by default.

Verification run: https://openqa.opensuse.org/tests/1668478