### PR TITLE
Fix snapper list timeout in record_disk_info

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -154,7 +154,9 @@ sub record_disk_info {
     if ($out =~ /btrfs/) {
         assert_script_run 'btrfs filesystem df / | tee /tmp/btrfs-filesystem-df.txt';
         assert_script_run 'btrfs filesystem usage / | tee /tmp/btrfs-filesystem-usage.txt';
-        assert_script_run('snapper list | tee /tmp/snapper-list.txt', 180) unless (is_sles4sap());
+        # we can use disable-used-space option to make 'snapper list' faster, if it has that option.
+        assert_script_run("(snapper --help | grep -q -- --disable-used-space && snapper list --disable-used-space || snapper list) | tee /tmp/snapper-list.txt", 180) unless (is_sles4sap());
+
         upload_logs '/tmp/btrfs-filesystem-df.txt';
         upload_logs '/tmp/btrfs-filesystem-usage.txt';
         upload_logs '/tmp/snapper-list.txt' unless (is_sles4sap());


### PR DESCRIPTION
To fast the snapper list command, we can use disable-used-space
option to avoid timeout on some slow machine.

- Related ticket: https://progress.opensuse.org/issues/90059
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/5677673
  https://openqa.nue.suse.com/tests/5685675