### PR TITLE
[virt_autotest] Add guest config xml and autoyast files for virt_logs_collector

### DIFF
--- a/data/virt_autotest/virt_logs_collector.sh
+++ b/data/virt_autotest/virt_logs_collector.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 #Obtain SLES release version and service pack level
 function get_sles_release() {

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -257,7 +257,13 @@ sub post_fail_hook {
     $self->post_run_test;
     save_screenshot;
 
-    if (get_var('VIRT_PRJ2_HOST_UPGRADE')) {
+    if (get_var('VIRT_PRJ1_GUEST_INSTALL')) {
+        #collect and upload guest autoyast control files
+        assert_script_run "cp -r /srv/www/htdocs/install/autoyast /guest_autoyast_files";
+        virt_utils::collect_host_and_guest_logs('', '/guest_autoyast_files', '');
+        assert_script_run "rm -rf /guest_autoyast_files";
+    }
+    elsif (get_var("VIRT_PRJ2_HOST_UPGRADE")) {
         virt_utils::collect_host_and_guest_logs('', '/root/autoupg.xml', '');
     }
     else {


### PR DESCRIPTION
- **Description:**

Refer to the latest guest installation failure osd links - 
[sle-15-SP3-Online-x86_64-Build161.1-gi-guest_sles15sp2-on-host_developing-kvm](https://149.44.176.58/tests/5661981#downloads)
[ sle-15-SP3-Online-x86_64-Build161.1-gi-guest_sles15sp2-on-host_developing-xen ](https://149.44.176.58/tests/5661982#downloads)

Figure out the guest autoyast control files were missed after call virt_logs_collector utility

So, try to use with virt_autotest_base->post_fail_hook()-> VIRT_PRJ1_GUEST_INSTALL-> collect and 
upload missed guest autoyast control files from vm host

Also, figure out the overwrote return status problem from bash pipeline situation,
So, use with "set -o pipefail" to keep up the same return status from bash pipeline situation

- Related ticket: https://progress.opensuse.org/issues/78882
- Verification run: 
[gi-guest_sles15sp2-on-host_developing-kvm](http://149.44.176.58/tests/5742664)
[gi-guest_sles15sp2-on-host_developing-xen](http://149.44.176.58/tests/5687500)
