### PR TITLE
Add soft fail for bsc#1182928 on installation/await_install

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -88,7 +88,7 @@ sub run {
 
     # workaround for yast popups and
     # detect "Wrong Digest" error to end test earlier
-    my @tags = qw(rebootnow yast2_wrong_digest yast2_package_retry yast_error);
+    my @tags = qw(rebootnow yast2_wrong_digest yast2_package_retry yast_error initializing-target-directory-failed);
     if (get_var('UPGRADE') || get_var('LIVE_UPGRADE')) {
         push(@tags, 'ERROR-removing-package');
         push(@tags, 'DIALOG-packages-notifications');
@@ -186,6 +186,12 @@ sub run {
         #
         if (match_has_tag 'package-update-found') {
             send_key 'alt-n';
+            next;
+        }
+        # rpm cache failed to load
+        if (match_has_tag 'initializing-target-directory-failed') {
+            record_soft_failure "bsc#1182928 - Initializing the target directory failed";
+            send_key 'alt-o';
             next;
         }
         last;


### PR DESCRIPTION
Without this, tests can cycle up to **MAX_JOB_TIME** on the unexpected screen, for example: https://openqa.suse.de/tests/5676805

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1182928
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1519
- Verification run: [SLES4SAP 15 Graphical Installation on ppc64le](http://mango.qa.suse.de/tests/3807#step/await_install/2), [qam-create_hdd_sle_sap_gnome](http://mango.qa.suse.de/tests/3811#step/await_install/1), [SLES4SAP 15-SP3 Graphical Installation on ppc64le](http://mango.qa.suse.de/tests/3813)

Failure in verification runs is expected due to bsc#1182928, which is still present in SLES 15: https://openqa.suse.de/group_overview/165. Added a verification run in 15-SP3 to have also a passing test.

Note that [qam-create_hdd_sle_sap_gnome](http://mango.qa.suse.de/tests/3811#step/await_install/1) is a clone of https://openqa.suse.de/tests/5676805. With the changes in place test finished in under 20 minutes, instead of the 2 hours of the original, which would help to free up resources at the very least.
