### PR TITLE
Revert "Need send ret key to handle login for KDE desktop"

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -21,7 +21,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle is_leap is_upgrade);
+use version_utils qw(is_sle is_leap);
 use utils 'assert_and_click_until_screen_change';
 use Utils::Architectures 'is_aarch64';
 
@@ -211,7 +211,7 @@ sub handle_login {
     elsif (match_has_tag('displaymanager-user-prompt') || get_var('DM_NEEDS_USERNAME')) {
         type_string "$myuser\n";
     }
-    elsif (check_var('DESKTOP', 'gnome') || (check_var('DESKTOP', 'kde') && is_upgrade)) {
+    elsif (check_var('DESKTOP', 'gnome')) {
         if ($user_selected || (is_sle('<15') || is_leap('<15.0'))) {
             send_key 'ret';
         }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#12132

The failure seen in https://progress.opensuse.org/issues/88467 is actually in GNOME, as KDE is replaced by GNOME during the upgrade. So the fix is incorrect and I'm suspecting that it actually breaks upgrade tests on openSUSE now: https://openqa.opensuse.org/tests/1669648

Verification run: https://openqa.opensuse.org/tests/1670109 (passed `user_gui_login`)