### PR TITLE
Add basic monitoring test in SLES4SAP

### DIFF
--- a/data/sles4sap/hana_cluster.conf
+++ b/data/sles4sap/hana_cluster.conf
@@ -1,16 +1,10 @@
-primitive dlm ocf:pacemaker:controld \
-        op start timeout=90 interval=0 \
-        op stop timeout=100 interval=0 \
-        op monitor timeout=20 interval=10 \
-        op_params start_delay=0 \
-        meta target-role=Started
 primitive rsc_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaTopology \
         params SID=%SID% InstanceNumber=%HDB_INSTANCE% \
         op monitor interval=10 timeout=600 \
         op start interval=0 timeout=600 \
         op stop interval=0 timeout=300
 primitive rsc_SAPHana_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHana \
-        params SID=%SID% InstanceNumber=%HDB_INSTANCE% PREFER_SITE_TAKEOVER=true AUTOMATED_REGISTER=%AUTOMATED_REGISTER% DUPLICATE_PRIMARY_TIMEOUT=7200 DIR_EXECUTABLE="" DIR_PROFILE="" INSTANCE_PROFILE="" \
+        params SID=%SID% InstanceNumber=%HDB_INSTANCE% PREFER_SITE_TAKEOVER=true AUTOMATED_REGISTER=%AUTOMATED_REGISTER% DUPLICATE_PRIMARY_TIMEOUT=7200 \
         op start interval=0 timeout=3600 \
         op stop interval=0 timeout=3600 \
         op promote interval=0 timeout=3600 \
@@ -23,13 +17,14 @@ primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% IPaddr2 \
         op monitor interval=10 timeout=20
 primitive rsc_stonith_sbd stonith:external/sbd \
         params pcmk_delay_max=15
-group base-group dlm \
-        meta target-role=Started
 ms msl_SAPHana_%SID%_HDB%HDB_INSTANCE% rsc_SAPHana_%SID%_HDB%HDB_INSTANCE% \
         meta clone-max=2 clone-node-max=1 interleave=true
-clone base-clone base-group \
-        meta target-role=Started
 clone cln_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% \
         meta clone-node-max=1 interleave=true
 colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started msl_SAPHana_%SID%_HDB%HDB_INSTANCE%:Master
 order ord_SAPHana_%SID%_HDB%HDB_INSTANCE% Optional: cln_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% msl_SAPHana_%SID%_HDB%HDB_INSTANCE%
+property SAPHanaSR: \
+        hana_prd_site_srHook_SECONDARY_SITE_NAME=SOK
+rsc_defaults rsc-options: \
+        resource-stickiness=1000 \
+        migration-threshold=5000

--- a/schedule/sles4sap/hana/hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/hana_cluster_node.yaml
@@ -52,8 +52,9 @@ schedule:
   - '{{wmp_setup}}'
   - '{{cluster_setup}}'
   - sles4sap/hana_cluster
-  - '{{wmp_basic_test}}'
+  - sles4sap/monitoring_services
   - '{{sap_suse_cluster_connector}}'
+  - '{{wmp_basic_test}}'
   - ha/fencing
   - '{{boot_to_desktop_node01}}'
   - ha/check_after_reboot

--- a/schedule/sles4sap/netweaver/netweaver_cluster_node.yaml
+++ b/schedule/sles4sap/netweaver/netweaver_cluster_node.yaml
@@ -47,6 +47,7 @@ schedule:
   - sles4sap/netweaver_filesystems
   - sles4sap/netweaver_install
   - sles4sap/netweaver_cluster
+  - sles4sap/monitoring_services
   - '{{sap_suse_cluster_connector}}'
   - ha/fencing
   - '{{boot_to_desktop}}'

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -160,6 +160,7 @@ sub run {
         barrier_create("HANA_INIT_CONF_$cluster_name",       $num_nodes);
         barrier_create("HANA_CREATED_CONF_$cluster_name",    $num_nodes);
         barrier_create("HANA_LOADED_CONF_$cluster_name",     $num_nodes);
+        barrier_create("MONITORING_CONF_DONE_$cluster_name", $num_nodes);
         # We have to create barriers for each nodes if we want to be able to fence *all* nodes
         foreach (1 .. $num_nodes) {
             barrier_create("HANA_RA_RESTART_${cluster_name}_NODE$_",      $num_nodes);

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -1,6 +1,6 @@
 # SUSE's SLES4SAP openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/sles4sap/monitoring_services.pm
+++ b/tests/sles4sap/monitoring_services.pm
@@ -1,0 +1,201 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Installation and basic tests of exporters for SLES4SAP monitoring
+# Maintainer: Loic Devulder <ldevulder@suse.com>
+
+use base 'sles4sap';
+use testapi;
+use strict;
+use warnings;
+use lockapi;
+use Utils::Systemd qw(systemctl);
+use utils qw(file_content_replace zypper_call);
+use hacluster qw(add_file_in_csync get_cluster_name get_hostname is_node wait_until_resources_started);
+
+sub configure_ha_exporter {
+    my $exporter_name = 'ha_cluster_exporter';
+    my $metrics_file  = "/tmp/${exporter_name}.metrics";
+
+    # Install needed packages
+    zypper_call "in prometheus-$exporter_name";
+
+    # Get the IP port and start exporter
+    my ($ha_exporter_port) = script_output("awk '/port:/ { print \$NF }' /etc/$exporter_name /usr/etc/$exporter_name 2>/dev/null", proceed_on_failure => 1) =~ /(\d+)/;
+    $ha_exporter_port ||= 9664;
+    systemctl "enable --now prometheus-$exporter_name";
+    systemctl "status prometheus-$exporter_name";
+    assert_script_run "curl -o $metrics_file http://localhost:$ha_exporter_port";
+
+    # Export metrics for later analysis
+    upload_logs $metrics_file;
+}
+
+sub configure_hanadb_exporter {
+    my (%args)                 = @_;
+    my $exporter_name          = 'hanadb_exporter';
+    my $config_dir             = "/usr/etc/$exporter_name";
+    my $hanadb_exporter_config = "$config_dir/$args{rsc_id}.json";
+    my $check_exporter         = 'false';
+    my $metrics_file           = "/tmp/$exporter_name.metrics";
+    my $hanadb_exporter_port;
+
+    # Install needed packages (hdcli contains dbapi)
+    zypper_call "in prometheus-$exporter_name";
+    assert_script_run "pip install \$(ls /hana/shared/$args{instance_sid}/hdbclient/hdbcli-*.tar.gz)";
+
+    # Modify the configuration file
+    assert_script_run "cp $config_dir/config.json.example $hanadb_exporter_config";
+    file_content_replace("$hanadb_exporter_config",
+        q(PASSWORD)             => $sles4sap::instance_password,
+        q(./logging_config.ini) => "$config_dir/logging_config.ini",
+        q(hanadb_exporter.log)  => "/var/log/${exporter_name}_$args{rsc_id}.log"
+    );
+
+    # Get the IP port and start exporter
+    ($hanadb_exporter_port) = script_output("awk '/exposition_port/ { print \$NF }' $hanadb_exporter_config", proceed_on_failure => 1) =~ /(\d+)/;
+    $hanadb_exporter_port ||= 9668;
+
+    # Add monitoring resource in the HA stack
+    if (get_var('HA_CLUSTER') and is_node(1)) {
+        my $hanadb_msl     = "msl_SAPHana_$args{rsc_id}";
+        my $hanadb_exp_rsc = "rsc_exporter_$args{rsc_id}";
+        $hanadb_exporter_port = 9668;
+        $check_exporter       = 'true';
+
+        # We need to add the configuration in csync2.conf
+        add_file_in_csync(value => "$hanadb_exporter_config");
+
+        # Add the monitoring resource
+        assert_script_run(
+            'crm configure primitive ' . $hanadb_exp_rsc . " systemd:prometheus-$exporter_name@" . $args{rsc_id}
+              . ' op start interval=0 timeout=100'
+              . ' op stop interval=0 timeout=100'
+              . ' op monitor interval=10'
+              . ' meta target-role=Stopped'
+        );
+
+        assert_script_run "crm configure colocation col_exporter_$args{rsc_id} +inf: $hanadb_exp_rsc:Started $hanadb_msl:Master";
+        assert_script_run "crm resource start $hanadb_exp_rsc";
+        wait_until_resources_started;
+    } elsif (!get_var('HA_CLUSTER')) {
+        $check_exporter = 'true';
+        systemctl "enable --now prometheus-$exporter_name\@$args{rsc_id}";
+    }
+
+    # Check that the exporter is running
+    if ($check_exporter eq 'true') {
+        systemctl "status prometheus-$exporter_name\@$args{rsc_id}";
+        assert_script_run "curl -o $metrics_file http://localhost:$hanadb_exporter_port";
+
+        # Export metrics for later analysis
+        upload_logs $metrics_file;
+    }
+}
+
+sub configure_sap_host_exporter {
+    my (%args)          = @_;
+    my $exporter_name   = 'sap_host_exporter';
+    my $default_config  = "/etc/$exporter_name/default.yaml";
+    my $exporter_config = "/etc/$exporter_name/$args{rsc_id}.yaml";
+    my $metrics_file    = "/tmp/${exporter_name}.metrics";
+
+    # Install needed packages
+    zypper_call "in prometheus-$exporter_name";
+
+    # Modify the configuration file
+    assert_script_run "cp $default_config $exporter_config";
+    file_content_replace("$exporter_config",
+        q(:50013) => ":5$args{instance_id}13"
+    );
+
+    # Get the IP port and start exporter
+    my ($exporter_port) = script_output("awk '/port:/ { print \$NF }' $exporter_config", proceed_on_failure => 1) =~ /(\d+)/;
+    $exporter_port ||= 9680;
+
+    if (get_var('HA_CLUSTER')) {
+        my $exporter_rsc = "rsc_exporter_$args{rsc_id}";
+
+        # Use mutex to be sure that only *one* node at a time can access the CIB
+        # NOTE: using 'support_server_ready' mutex because it already exists
+        #       and because mutex should be created at the beginning on support_server
+        mutex_lock 'support_server_ready';
+
+        # We need to add the configuration in csync2.conf
+        add_file_in_csync(value => "$exporter_config");
+
+        # Add the monitoring resource
+        assert_script_run(
+            'crm configure primitive ' . $exporter_rsc . " systemd:prometheus-$exporter_name@" . $args{rsc_id}
+              . ' op start interval=0 timeout=100'
+              . ' op stop interval=0 timeout=100'
+              . ' op monitor interval=10'
+              . ' meta target-role=Stopped'
+        );
+        assert_script_run "crm configure modgroup grp_$args{rsc_id} add $exporter_rsc";
+        assert_script_run "crm resource start $exporter_rsc";
+        wait_until_resources_started;
+
+        # Release the lock
+        mutex_unlock 'support_server_ready';
+    } else {
+        # Start exporter
+        systemctl "enable --now prometheus-$exporter_name\@$args{rsc_id}";
+    }
+
+    # Check that the exporter is running
+    systemctl "status prometheus-$exporter_name\@$args{rsc_id}";
+    assert_script_run "curl -o $metrics_file http://localhost:$exporter_port";
+
+    # Export metrics for later analysis
+    upload_logs $metrics_file;
+}
+
+sub configure_node_exporter {
+    my $monitoring_port = 9100;
+    my $metrics_file    = '/tmp/node_exporter.metrics';
+
+    # Install and start node_exporter
+    zypper_call 'in golang-github-prometheus-node_exporter';
+    systemctl 'enable --now prometheus-node_exporter';
+    systemctl 'status prometheus-node_exporter';
+
+    # Check that node_exporter is working as expected
+    assert_script_run "curl -o $metrics_file http://localhost:$monitoring_port/metrics";
+
+    # Export metrics for later analysis
+    upload_logs $metrics_file;
+}
+
+sub run {
+    my ($self)        = @_;
+    my $hostname      = get_hostname;
+    my $cluster_name  = get_cluster_name;
+    my $instance_sid  = get_required_var('INSTANCE_SID');
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my $instance_id   = get_required_var('INSTANCE_ID');
+    my $rsc_id        = "${instance_sid}_${instance_type}${instance_id}";
+
+    # Make sure that we have an opened terminal
+    $self->select_serial_terminal;
+
+    # Configure Exporters
+    configure_ha_exporter                                                       if get_var('HA_CLUSTER');
+    configure_hanadb_exporter(rsc_id => $rsc_id, instance_sid => $instance_sid) if get_var('HANA');
+    configure_sap_host_exporter(rsc_id => $rsc_id, instance_id => $instance_id) if get_var('NW');
+    barrier_wait "MONITORING_CONF_DONE_$cluster_name"                           if get_var('HA_CLUSTER');    # Synchronize the nodes if needed
+    configure_node_exporter;
+
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2017-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -59,9 +59,10 @@ sub run {
     assert_script_run "sed -i -e \"s/%HOSTNAME%/$hostname/g\" -e 's/%INSTANCE_ID%/$instance_id/g' -e 's/%INSTANCE_SID%/$sid/g' $params_file";
 
     # Create an appropiate start_dir.cd file and an unattended installation directory
-    my $cmd = 'ls | while read d; do if [ -d "$d" -a ! -h "$d" ]; then echo $d; fi ; done | sed -e "s@^@/sapinst/@"';
+    my $cmd = 'cd /sapinst ; ls | while read d; do if [ -d "$d" -a ! -h "$d" ]; then echo $d; fi ; done | sed -e "s@^@/sapinst/@" ; cd -';
     assert_script_run 'mkdir -p /sapinst/unattended';
-    assert_script_run "$cmd > /sapinst/unattended/start_dir.cd";
+    assert_script_run "($cmd) > /sapinst/unattended/start_dir.cd";
+    script_run 'cd -';
 
     # Create sapinst group
     assert_script_run "groupadd sapinst";


### PR DESCRIPTION
SUSE has implemented some monitoring tools for HA, HANA and NW server/cluster.

This commit adds basic monitoring check.

- Related ticket: N/A
- Needles: N/A
- Verification runs: [netweaver_node01](http://1b210.qa.suse.de/tests/8814), [netweaver_node02](http://1b210.qa.suse.de/tests/8815), [hana_node01](http://1b210.qa.suse.de/tests/8829), [hana_node02](http://1b210.qa.suse.de/tests/8830)

**EDIT:** new verification runs: [netweaver_node01](http://1b210.qa.suse.de/tests/8895), [netweaver_node02](http://1b210.qa.suse.de/tests/8896), [hana_node01](http://1b210.qa.suse.de/tests/8901), [hana_node02](http://1b210.qa.suse.de/tests/8902)