### PR TITLE
Remove softfail bsc#1081584 from updates_packagekit_gpk

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -62,7 +62,6 @@ sub run {
         select_console 'root-console';
         if (script_run 'rpm -q "gnome-packagekit"') {
             zypper_call("in gnome-packagekit", timeout => 90);
-            record_soft_failure 'bsc#1081584';
         }
     }
     select_console 'x11', await_console => 0;


### PR DESCRIPTION
bsc#1081584 got fixed, so remove softfail from the test module.
see https://progress.opensuse.org/issues/36138
verification run:
http://10.160.64.152/tests/874#step/updates_packagekit_gpk/
