### PR TITLE
Remove unused $self from launch_yast2_module_x11

### DIFF
--- a/lib/YaST/Module.pm
+++ b/lib/YaST/Module.pm
@@ -45,7 +45,7 @@ sub open {
         );
     }
     elsif ($ui eq 'qt') {
-        launch_yast2_module_x11('', $module, extra_vars => get_var('YUI_PARAMS'));
+        launch_yast2_module_x11($module, extra_vars => get_var('YUI_PARAMS'));
     }
     else {
         die "Unknown user interface: $ui";

--- a/lib/y2_module_guitest.pm
+++ b/lib/y2_module_guitest.pm
@@ -38,7 +38,7 @@ C<$maximize_window> option allows to maximize application window using shortcut.
 
 =cut
 sub launch_yast2_module_x11 {
-    my ($self, $module, %args) = @_;
+    my ($module, %args) = @_;
     $module //= '';
     $args{target_match} //= $module ? "yast2-$module-ui" : 'yast2-ui';
     my @tags = ['root-auth-dialog', ref $args{target_match} eq 'ARRAY' ? @{$args{target_match}} : $args{target_match}];

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -45,10 +45,8 @@ sub test_setup {
 }
 
 sub run {
-    my ($self) = @_;
-
     test_setup;
-    $self->launch_yast2_module_x11('scc', target_match => [qw(scc-registration packagekit-warning)], maximize_window => 1);
+    y2_module_guitest::launch_yast2_module_x11('scc', target_match => [qw(scc-registration packagekit-warning)], maximize_window => 1);
     if (match_has_tag 'packagekit-warning') {
         send_key 'alt-y';
         assert_screen 'scc-registration';

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -44,7 +44,7 @@ sub run {
     my ($addon, $uc_addon);
     my $perform_reboot;
     test_setup;
-    $self->launch_yast2_module_x11('add-on', target_match => [qw(addon-products packagekit-warning)]);
+    y2_module_guitest::launch_yast2_module_x11('add-on', target_match => [qw(addon-products packagekit-warning)]);
     if (match_has_tag 'packagekit-warning') {
         send_key 'alt-y';
         assert_screen 'addon-products';

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -102,11 +102,10 @@ sub initiator_connected_targets_tab {
 
 
 sub run {
-    my $self = shift;
     prepare_xterm_and_setup_static_network(ip => $test_data->{initiator_conf}->{ip}, message => 'Configure MM network - client');
     mutex_wait('iscsi_target_ready', undef, 'Target configuration in progress!');
     record_info 'Target Ready!', 'iSCSI target is configured, start initiator configuration';
-    my $module_name = $self->launch_yast2_module_x11('iscsi-client', target_match => 'iscsi-client');
+    my $module_name = y2_module_guitest::launch_yast2_module_x11('iscsi-client', target_match => 'iscsi-client');
     initiator_service_tab;
     initiator_discovered_targets_tab;
     initiator_connected_targets_tab;

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -213,7 +213,7 @@ sub run {
     display_targets(expected => qq('no open sessions'));
     # start yast2 wizard
     record_info 'iSCSI target', 'Start target configuration';
-    my $module_name = $self->launch_yast2_module_x11('iscsi-lio-server', target_match => 'iscsi-lio-server');
+    my $module_name = y2_module_guitest::launch_yast2_module_x11('iscsi-lio-server', target_match => 'iscsi-lio-server');
     target_service_tab;
     target_backstore_tab;
     wait_serial("$module_name-0", 180) || die "'yast2 iscsi-lio-server' didn't finish or exited with non-zero code";

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -18,7 +18,6 @@ use testapi;
 use utils;
 
 sub run {
-    my ($self) = @_;
     x11_start_program('xterm');
     send_key 'alt-f10';
     become_root;
@@ -27,7 +26,7 @@ sub run {
         record_soft_failure 'bsc#1083398 - YaST2-virtualization provides wrong components for SLED';
         zypper_call 'in yast2-vm';
     }
-    $self->launch_yast2_module_x11('virtualization');
+    y2_module_guitest::launch_yast2_module_x11('virtualization');
     # select everything
     if (check_var('ARCH', 'x86_64')) {
         send_key 'alt-x';    # XEN Server, only available on x86_64: bsc#1088175

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -23,9 +23,8 @@ use testapi;
 use utils 'type_string_slow_extended';
 
 sub run {
-    my $self = shift;
     select_console 'x11';
-    $self->launch_yast2_module_x11('bootloader', match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11('bootloader', match_timeout => 120);
 
     #	boot code options
     assert_and_click 'yast2-bootloader_grub2';

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -319,7 +319,6 @@ sub start_fonts {
 }
 
 sub run {
-    my $self = shift;
     select_console 'x11';
     if (is_sle '15+') {
         # kdump is disabled by default in the installer, so ensure that it's installed
@@ -333,7 +332,7 @@ sub run {
         record_soft_failure('bsc#1182241', "yast2-vpn is not pre-installed on TW");
         ensure_installed('yast2-vpn yast2-sudo yast2-tune yast2-kdump');
     }
-    $self->launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
+    y2_module_guitest::launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
 
     start_addon_products;
     start_media_check;

--- a/tests/yast2_gui/yast2_datetime.pm
+++ b/tests/yast2_gui/yast2_datetime.pm
@@ -21,9 +21,8 @@ use warnings;
 use testapi;
 
 sub run {
-    my $self = shift;
     select_console 'x11';
-    $self->launch_yast2_module_x11('timezone', target_match => [qw(yast2-datetime-ui yast2-datetime_ntp-conf require_install_chrony)], match_timeout => 90);
+    y2_module_guitest::launch_yast2_module_x11('timezone', target_match => [qw(yast2-datetime-ui yast2-datetime_ntp-conf require_install_chrony)], match_timeout => 90);
     if (match_has_tag 'yast2-datetime_ntp-conf') {
         send_key 'alt-d';
         send_key 'alt-o';

--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -74,11 +74,10 @@ sub susefirewall2 {
 }
 
 sub verify_service_stopped {
-    my $self = shift;
 
     record_info('Start-Up', "Managing the firewalld service: Stop");
     select_console 'x11', await_console => 0;
-    $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
+    y2_module_guitest::launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
     assert_screen 'yast2_firewall_start-up';
     change_service_configuration(after_writing => {stop => 'alt-t'});
     wait_screen_change { send_key $cmd{accept} };
@@ -89,11 +88,10 @@ sub verify_service_stopped {
 }
 
 sub verify_service_started {
-    my $self = shift;
 
     record_info('Start-Up', "Managing the firewalld service: Start");
     select_console 'x11', await_console => 0;
-    $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
+    y2_module_guitest::launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
     assert_screen 'yast2_firewall_start-up';
     change_service_configuration(after_writing => {start => 'alt-t'});
     wait_screen_change { send_key $cmd{accept} };
@@ -159,13 +157,12 @@ sub configure_zone {
 }
 
 sub configure_firewalld {
-    my $self = shift;
 
     record_info('Interface/Zones ', "Verify zone info changing default zone when interface assigned to default zone");
     my $iface = iface;
 
     select_console 'x11', await_console => 0;
-    $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
+    y2_module_guitest::launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
 
     verify_interface(device => $iface, zone => 'default');
     verify_zone(name => 'public', interfaces => $iface, default => 'default');
@@ -194,13 +191,12 @@ sub verify_firewalld_configuration {
 }
 
 sub run {
-    my $self = shift;
     select_console 'x11';
 
     if (is_sle('15+') || is_leap('15.0+') || is_tumbleweed) {
-        $self->verify_service_stopped;
-        $self->verify_service_started;
-        $self->configure_firewalld;
+        verify_service_stopped;
+        verify_service_started;
+        configure_firewalld;
         verify_firewalld_configuration;
         select_console 'x11', await_console => 0;
     }
@@ -208,7 +204,7 @@ sub run {
         select_console 'root-console';
         zypper_call('in yast2-http-server apache2 apache2-prefork', timeout => 1200);
         select_console 'x11', await_console => 0;
-        $self->launch_yast2_module_x11('firewall', match_timeout => 60);
+        y2_module_guitest::launch_yast2_module_x11('firewall', match_timeout => 60);
         susefirewall2;
     }
 }

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -22,7 +22,6 @@ use testapi;
 use utils qw(type_string_slow_extended clear_console);
 
 sub run {
-    my $self         = shift;
     my $module       = "host";
     my $hosts_params = {
         ip    => '195.135.221.134',
@@ -35,7 +34,7 @@ sub run {
     script_run "echo '80.92.65.53    n-tv.de ntv' >> /etc/hosts";
     clear_console;
     select_console 'x11';
-    $self->launch_yast2_module_x11($module, match_timeout => 90);
+    y2_module_guitest::launch_yast2_module_x11($module, match_timeout => 90);
     assert_and_click "yast2_hostnames_added";
     send_key 'alt-i';
     assert_screen 'yast2_hostnames_edit_popup';

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -140,8 +140,7 @@ sub test_http_instserver {
 }
 
 sub start_yast2_instserver {
-    my $self = shift;
-    $self->launch_yast2_module_x11("instserver", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("instserver", match_timeout => 120);
     wait_still_screen;
 }
 
@@ -153,17 +152,17 @@ sub run {
 
     select_console "x11";
 
-    start_yast2_instserver $self;
+    start_yast2_instserver;
     test_http_instserver;
 
-    start_yast2_instserver $self;
+    start_yast2_instserver;
     test_ftp_instserver;
 
-    start_yast2_instserver $self;
+    start_yast2_instserver;
     test_nfs_instserver;
 
     # clean existing config
-    start_yast2_instserver $self;
+    start_yast2_instserver;
     clean_env;
 }
 

--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -39,12 +39,11 @@ use utils;
 use version_utils "is_sle";
 
 sub run {
-    my $self = shift;
     select_console("x11");
     my $accept_keybind = is_sle("<=15-SP1") ? "alt-o" : "alt-a";
 
     # 1. start yast2 keyboard
-    $self->launch_yast2_module_x11("keyboard", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("keyboard", match_timeout => 120);
     send_key "alt-k";
     wait_still_screen 1;
     send_key "g";

--- a/tests/yast2_gui/yast2_lang.pm
+++ b/tests/yast2_gui/yast2_lang.pm
@@ -21,9 +21,8 @@ use warnings;
 use testapi;
 
 sub run {
-    my $self = shift;
     select_console 'x11';
-    $self->launch_yast2_module_x11('language', match_timeout => 240);
+    y2_module_guitest::launch_yast2_module_x11('language', match_timeout => 240);
 
     # check language details and change detailed locale setting
     assert_and_click 'yast2-lang_details';

--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -23,7 +23,6 @@ use y2_module_basetest 'is_network_manager_default';
 use version_utils 'is_sle';
 
 sub run {
-    my $self = shift;
 
     # keyboard shorcuts
     $cmd{global_options_tab} = 'alt-g';
@@ -35,7 +34,7 @@ sub run {
     $cmd{routing_tab}        = 'alt-u';
 
     select_console 'x11';
-    $self->launch_yast2_module_x11('lan', target_match => [qw(yast2-lan-ui yast2_still_susefirewall2 yast2-lan-warning-network-manager)], match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11('lan', target_match => [qw(yast2-lan-ui yast2_still_susefirewall2 yast2-lan-warning-network-manager)], match_timeout => 120);
     if (match_has_tag 'yast2_still_susefirewall2') {
         send_key $cmd{install};
         wait_still_screen;

--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -27,11 +27,10 @@ use warnings;
 use testapi;
 
 sub run {
-    my $self = shift;
     select_console "x11";
 
     # Password Settings
-    $self->launch_yast2_module_x11("security", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-pwd-settings";
     send_key "alt-m";
     wait_still_screen 1;
@@ -42,7 +41,7 @@ sub run {
     wait_screen_change { send_key "alt-o" };
 
     # Check previously set values + Login Settings
-    $self->launch_yast2_module_x11("security", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-pwd-settings";
     assert_screen "yast2_security-check-min-pwd-len-and-exp-days";
     assert_and_click "yast2_security-login-settings";
@@ -52,7 +51,7 @@ sub run {
     wait_screen_change { send_key "alt-o" };
 
     # Check previously set values + Miscellaneous Settings
-    $self->launch_yast2_module_x11("security", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-login-settings";
     assert_screen "yast2_security-login-attempts";
     # set file permissions to 'secure'
@@ -62,7 +61,7 @@ sub run {
     wait_screen_change { send_key "alt-o" };
 
     # Check previously set values
-    $self->launch_yast2_module_x11("security", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-misc-settings";
     assert_screen "yast2_security-file-perms-secure";
     wait_screen_change { send_key "alt-o" };

--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -18,9 +18,8 @@ use warnings;
 use testapi;
 
 sub run {
-    my $self = shift;
     select_console 'x11';
-    $self->launch_yast2_module_x11('sw_single', match_timeout => 100);
+    y2_module_guitest::launch_yast2_module_x11('sw_single', match_timeout => 100);
     # Accept => Exit, or get to the installation report
     send_key 'alt-a';
     # Installation may take some time

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -75,20 +75,18 @@ sub select_vdb {
 }
 
 sub start_y2sn {
-    my $self = shift;
-    $self->launch_yast2_module_x11("storage", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("storage", match_timeout => 120);
 
     wait_screen_change { send_key "alt-y" };
     wait_still_screen 5;
 }
 
 sub run {
-    my $self = shift;
     select_console "x11";
 
     ensure_installed 'lvm2' if is_tumbleweed;
 
-    start_y2sn $self;
+    start_y2sn;
     select_vdb;
 
     ### ADD PARTITION ###
@@ -130,7 +128,7 @@ sub run {
 
     ### RESIZE PARTITION ###
     wait_still_screen 3;
-    start_y2sn $self;
+    start_y2sn;
     select_vdb;
     # resize partition
     if (is_opensuse) {
@@ -171,7 +169,7 @@ sub run {
 
     ### DELETE PARTITION ###
     wait_still_screen 3;
-    start_y2sn $self;
+    start_y2sn;
     select_vdb;
     wait_screen_change { send_key "alt-l" };
     wait_still_screen 1;
@@ -185,7 +183,7 @@ sub run {
 
     ### CREATE VOLUME GROUP ###
     wait_still_screen 3;
-    start_y2sn $self;
+    start_y2sn;
     assert_and_click "yast2_storage_ng-select-vol-management";
     wait_screen_change { send_key "alt-a" };
     # alt-v doesn't work reliably, so we have to use assert_and_click
@@ -249,7 +247,7 @@ sub run {
 
     # Remove the volume group and all its logical volumes
     wait_still_screen 1;
-    start_y2sn $self;
+    start_y2sn;
     assert_and_click "yast2_storage_ng-select-vol-management";
     wait_screen_change { send_key(is_sle() ? "alt-l" : "alt-d") };
     wait_still_screen 1;

--- a/tests/yast2_gui/yast2_users.pm
+++ b/tests/yast2_gui/yast2_users.pm
@@ -18,9 +18,8 @@ use warnings;
 use testapi;
 
 sub run {
-    my $self = shift;
     select_console 'x11';
-    $self->launch_yast2_module_x11('users', match_timeout => 100);
+    y2_module_guitest::launch_yast2_module_x11('users', match_timeout => 100);
     send_key "alt-o";    # OK => Exit
 }
 


### PR DESCRIPTION
The commit removes $self from the function as a first parameter, as it
is does not share any context with the package where it is defined.
Also $self is not used inside the function.

- Verification runs: 
   - https://openqa.suse.de/tests/5687489
   - https://openqa.suse.de/t5687488
