### PR TITLE
Fix sudo for publiccloud 12-SP5 runs

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -54,7 +54,7 @@ sub run {
     # Prepare a file with content '1' for later IO redirection test
     assert_script_run 'echo 1 >/run/openqa_sudo_test';
     # prepare sudoers and test user
-    assert_script_run 'echo "bernhard ALL = (root) NOPASSWD: /usr/bin/journalctl, /usr/bin/dd, /usr/bin/cat, PASSWD: /usr/bin/zypper, /usr/bin/su" >/etc/sudoers.d/test';
+    assert_script_run 'echo "bernhard ALL = (root) NOPASSWD: /usr/bin/journalctl, /usr/bin/dd, /usr/bin/cat, PASSWD: /usr/bin/zypper, /usr/bin/su, /usr/bin/id, /bin/bash" >/etc/sudoers.d/test';
     # use script_run because yes is still writing to the pipe and then command is exiting with 141
     script_run "groupadd sudo_group && useradd -m -d /home/sudo_test -G sudo_group,\$(stat -c %G /dev/$serialdev) sudo_test && yes $test_password|passwd -q sudo_test";
     assert_script_run 'echo "%sudo_group ALL = (root) NOPASSWD: /usr/bin/journalctl, PASSWD: /usr/bin/zypper" >/etc/sudoers.d/sudo_group';


### PR DESCRIPTION
`sudo` on PC 12-SP5 requires additional commands to be added to sudoers.

- Related ticket: https://progress.opensuse.org/issues/90197
- Verification run: [12-SP5 Azure-Standard-gen2](http://duck-norris.qam.suse.de/tests/5571#step/sudo/1) | [SLES 15-SP1](http://duck-norris.qam.suse.de/tests/5577) | [SLES12-SP5](http://duck-norris.qam.suse.de/tests/5578) | [SLES12-SP4](http://duck-norris.qam.suse.de/tests/5582) | [SLES12-SP3](http://duck-norris.qam.suse.de/tests/5580) | [Tumbleweed](http://duck-norris.qam.suse.de/tests/5581)
