### PR TITLE
Users test only support to be run on gnome

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -138,6 +138,12 @@ sub full_users_check {
     my (%hash) = @_;
     my $stage = $hash{stage};
 
+    # Since the users test is only supported on gnome, will quit the test if not on gnome.
+    my $desktop = get_var('DESKTOP');
+    if (!check_var("DESKTOP", "gnome")) {
+        record_info('Unsupported on non-gnome', "This test is only supported on gnome, quit for your DESKTOP is $desktop", result => 'fail');
+        return;
+    }
     turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     select_console 'x11', await_console => 0;
     wait_still_screen 5;


### PR DESCRIPTION
The users test in service check only support to be run on gnome, so for other settings of DESKTOP will record it and return.

- Related ticket: https://progress.opensuse.org/issues/90143
- Needles: N/A
- Verification run:  http://openqa.nue.suse.com/tests/5686703