### PR TITLE
Modify packages version check after migration

### DIFF
--- a/tests/console/check_package_version.pm
+++ b/tests/console/check_package_version.pm
@@ -25,11 +25,11 @@ use utils qw(systemctl zypper_call);
 use Mojo::Util 'trim';
 
 my %package = (
-    postgresql12 => '13.0.0',
-    python3      => '3.9.0',
+    postgresql13 => '13.0.0',
+    python39     => '3.9.0',
+    python3      => '3.6.0',
     mariadb      => '10.0.0'
 );
-
 sub cmp_version {
     my ($old, $new) = @_;
     my @newv = split(qr/-|\+/, $new);


### PR DESCRIPTION
The packages checked here have a new name after they are updated to
the required package version. Need to modify the packages name.

- Related ticket: https://progress.opensuse.org/issues/89728
- Verification run: https://openqa.suse.de/tests/5694519#step/check_package_version/3
