### PR TITLE
Checked ss command output information and used more exact search cond…

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -109,7 +109,7 @@ sub run {
     # Port forwarding (bsc#1131709 bsc#1133386)
     assert_script_run "( ssh -NL 4242:localhost:22 $ssh_testman\@localhost & )";
     assert_script_run "( ssh -NR 0.0.0.0:5252:localhost:22 $ssh_testman\@localhost & )";
-    assert_script_run 'until ss -tulpn|egrep "4242|5252";do sleep 1;done';
+    assert_script_run 'until ss -tulpn|grep sshd|egrep "4242|5252";do sleep 1;done';
     assert_script_run "ssh-keyscan -p 4242 localhost >> ~/.ssh/known_hosts";
     assert_script_run "ssh-keyscan -p 5252 localhost >> ~/.ssh/known_hosts";
 


### PR DESCRIPTION
Checked ss command output information and used more exact search condition

- Related ticket: https://progress.opensuse.org/issues/89981
- Verification run: https://openqa.suse.de/tests/5686209#step/sshd/84

Sometimes, the command until ss -tulpn|grep sshd|egrep "4242|5252";do sleep 1;done; searched the information not correct. Like: the search result: 
tcp   LISTEN 0      128                                *:80               *:*    users:(("httpd-prefork",pid=5254,fd=4),("httpd-prefork",pid=5253,fd=4),("httpd-prefork",pid=5252,fd=4),("httpd-prefork",pid=5251,fd=4),("httpd-prefork",pid=5250,fd=4),("httpd-prefork",pid=5137,fd=4))
q9cUE-0-
It searched pid=5252. But we need get the port information.
So add users  information 'sshd' as: until ss -tulpn|grep sshd|egrep "4242|5252";do sleep 1;done;
It can get correct port information like:
tcp   LISTEN 0      128                        127.0.0.1:5252       0.0.0.0:*    users:(("sshd",pid=19631,fd=12))                                               
tcp   LISTEN 0      128                            [::1]:5252          [::]:*    users:(("sshd",pid=19631,fd=11))                                               
3SYut-0-