### PR TITLE
Revert "Skip systemd workarounds in other testsuites"

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -63,24 +63,21 @@ sub qaset_config {
     my $testsuites = "\n\t" . join("\n\t", @list) . "\n";
     assert_script_run("echo 'SQ_TEST_RUN_LIST=($testsuites)' > /root/qaset/config");
 
-    # If running the systemd testsuite we need to workaround several issues
-    if (index($testsuites, "systemd") != -1) {
-        if (is_sle('>=15')) {
-            # poo88597 We need an executable boot.local to avoid failing rc-local service test for sle15+
-            my $boot_local = "/etc/init.d/boot.local";
-            assert_script_run("echo '#!/bin/sh' > $boot_local");
-            assert_script_run("chmod +x $boot_local");
-        }
+    if (is_sle('>=15')) {
+        # poo88597 We need an executable boot.local to avoid failing rc-local service test for sle15+
+        my $boot_local = "/etc/init.d/boot.local";
+        assert_script_run("echo '#!/bin/sh' > $boot_local");
+        assert_script_run("chmod +x $boot_local");
+    }
 
-        # Reset the failed state of all units so that only new failures are recorded
-        assert_script_run("systemctl reset-failed");
+    # Reset the failed state of all units so that only new failures are recorded
+    assert_script_run("systemctl reset-failed");
 
-        # Workaround for bsc#1183229 (mdmonitor.service cannot run for newer mdadm versions)
-        my $mdadm_version         = script_output("rpm -q --qf '%{VERSION}-%{RELEASE}\n' mdadm");
-        my $working_mdadm_version = '4.1-15.20.1';
-        if (package_version_cmp($mdadm_version, $working_mdadm_version) > 0) {
-            zypper_call("in -f mdadm-$working_mdadm_version");
-        }
+    # Workaround for bsc#1183229 (mdmonitor.service cannot run for newer mdadm versions)
+    my $mdadm_version         = script_output("rpm -q --qf '%{VERSION}-%{RELEASE}\n' mdadm");
+    my $working_mdadm_version = '4.1-15.20.1';
+    if (package_version_cmp($mdadm_version, $working_mdadm_version) > 0) {
+        zypper_call("in -f mdadm-$working_mdadm_version");
     }
 }
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#12151
To fix several openqa tests. See more info in the original PR comments

poo# https://progress.opensuse.org/issues/89966

