### PR TITLE
Use upstream runltp-ng repo for runltp modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,27 +10,3 @@ tools/tidy
 docs/*.html
 docs/**/*.html
 /script/yaml_generator/env/
-
-# -*- mode: gitignore; -*-
-*~
-\#*\#
-/.emacs.desktop
-/.emacs.desktop.lock
-*.elc
-auto-save-list
-tramp
-.\#*
-
-# Org-mode
-.org-id-locations
-*_archive
-
-# flymake-mode
-*_flymake.*
-
-# eshell files
-/eshell/history
-/eshell/lastdir
-
-# elpa packages
-/elpa/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,27 @@ tools/tidy
 docs/*.html
 docs/**/*.html
 /script/yaml_generator/env/
+
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/

--- a/variables.md
+++ b/variables.md
@@ -86,6 +86,8 @@ LIVECD | boolean | false | Indicates live image being used.
 LIVE_INSTALLATION | boolean | false | If set, boots the live media and starts the builtin NET installer.
 LIVE_UPGRADE | boolean | false | If set, boots the live media and starts the builtin NET installer in upgrade mode.
 LIVETEST | boolean | false | Indicates test of live system.
+LTP_RUN_NG_BRANCH | string | | Define the branch of the LTP_RUN_NG_REPO.
+LTP_RUN_NG_REPO | string | | Define the runltp-ng repo to be used. Default in publiccloud/run_ltp.pm is the upstream master branch from https://github.com/metan-ucw/runltp-ng.git.
 LVM | boolean | false | Use lvm for partitioning.
 LVM_THIN_LV | boolean | false | Use thin provisioning logical volumes for partitioning,
 MACHINE | string | | Define machine name which defines worker specific configuration, including WORKER_CLASS.


### PR DESCRIPTION
https://github.com/metan-ucw/runltp-ng/pull/24 adds missing functionality
to the upstream project. And with that we can replace the runltp-ng with
the upstream one.


- Related ticket: https://progress.opensuse.org/issues/88131
- [Verification run: ](https://openqa.suse.de/tests/overview.html?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2312168&version=15-SP3)
