### PR TITLE
Fix for podman when curl is up to date in the container

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -112,7 +112,7 @@ sub basic_container_tests {
     if (script_run("$runtime container exec $container_name zypper -n in curl", 300)) {
         record_info('poo#40958 - curl install failure, try with force-resolution.');
         my $output = script_output("$runtime container exec $container_name zypper in --force-resolution -y -n curl", 600);
-        die('error: curl not installed in the container') unless (($output =~ m/Installing: curl.*done/) || ($output =~ m/curl .* already installed/));
+        die('error: curl not installed in the container') unless (($output =~ m/Installing: curl.*done/) || ($output =~ m/\'curl\' .* already installed/));
     }
     assert_script_run("$runtime container commit $container_name tw:saved", 240);
 

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -112,7 +112,7 @@ sub basic_container_tests {
     if (script_run("$runtime container exec $container_name zypper -n in curl", 300)) {
         record_info('poo#40958 - curl install failure, try with force-resolution.');
         my $output = script_output("$runtime container exec $container_name zypper in --force-resolution -y -n curl", 600);
-        die('error: curl not installed in the container') unless ($output =~ m/Installing: curl.*done/);
+        die('error: curl not installed in the container') unless (($output =~ m/Installing: curl.*done/) || ($output =~ m/curl .* already installed/));
     }
     assert_script_run("$runtime container commit $container_name tw:saved", 240);
 


### PR DESCRIPTION
This is a fix for a situation where openQA tries to install curl where
it is already installed (at least for cloud).

Fixes poo#90173 [qem][ec2][arm] test failure in podman

Test run at:
http://10.161.229.209/tests/221

