### PR TITLE
Drop svirt_upload_assets from s390x SLES+HA tests

### DIFF
--- a/schedule/ha/bv/sles_ha_installation.yaml
+++ b/schedule/ha/bv/sles_ha_installation.yaml
@@ -55,7 +55,6 @@ schedule:
   - '{{after_reboot}}'
   - installation/first_boot
   - '{{create_hdd_tests}}'
-  - '{{svirt_upload_assets}}'
 conditional_schedule:
   check_iso_maxsize:
     CHECK_ISO_MAXSIZE:
@@ -75,6 +74,10 @@ conditional_schedule:
         - installation/grub_test
       ppc64le:
         - installation/grub_test
+  svirt_upload_assets:
+    BACKEND:
+      svirt:
+        - shutdown/svirt_upload_assets
   create_hdd_tests:
     CREATE_HDD:
       1:
@@ -84,7 +87,4 @@ conditional_schedule:
         - shutdown/grub_set_bootargs
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
-  svirt_upload_assets:
-    BACKEND:
-      svirt:
-        - shutdown/svirt_upload_assets
+        - '{{svirt_upload_assets}}'


### PR DESCRIPTION
... that do not require it

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/3789, http://mango.qa.suse.de/tests/3790, http://mango.qa.suse.de/tests/3793

`svirt_upload_assets` should only appear in the `create_hdd_ha_textmode` test shown above, and not in the other ones.
