### PR TITLE
Revert "Merge pull request #12166 from os-autoinst/revert-12141-journal_testing"

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -33,10 +33,15 @@ use Utils::Architectures qw(is_s390x);
 use power_action_utils qw(power_action);
 use constant {
     PERSISTENT_LOG_DIR => '/var/log/journal',
-    DROPIN_DIR         => '/etc/systemd/journald.conf.d/',
+    DROPIN_DIR         => '/etc/systemd/journald.conf.d',
     SYSLOG             => '/var/log/messages',
     SEALING_DELAY      => 10
 };
+
+# If the daemon is stopped uncleanly, or if the files are found to be corrupted, they are renamed using the ".journal~" suffix
+sub corrupted_logfiles {
+    return script_output('find /var/log/journal/ -iname "*.journal~" -type f -print0') ne "";
+}
 
 sub is_journal_empty {
     my ($args, $filename) = @_;
@@ -51,7 +56,7 @@ sub verify_journal {
     my $cmd = 'journalctl --verify';
     $cmd .= " --verify-key=$fss_key" if defined($fss_key);
 
-    script_run('journactl --flush');    # ensure data is written to persistent log
+    assert_script_run('journalctl --flush');    # ensure data is written to persistent log
     return if (script_run("$cmd 2>&1 | tee errs") == 0);
     # Check for https://bugzilla.suse.com/show_bug.cgi?id=1171858, corruption bug when FSS is enabled
     if (defined($fss_key) && (script_run("grep 'tag/entry realtime timestamp out of synchronization' errs") == 0)) {
@@ -61,8 +66,10 @@ sub verify_journal {
     } elsif (defined($fss_key) && (script_run("egrep 'No sealing yet,.*of entries not sealed.' errs") == 0)) {
         die "Sealing is not working!\n";
         # Check for https://bugzilla.suse.com/show_bug.cgi?id=1178193, a race condition for `journalctl --verify`
-    } elsif ((script_run("grep 'File corruption detected' errs") == 0) && script_run("$cmd")) {
+    } elsif (script_run("grep 'File corruption detected' errs") == 0) {
         record_soft_failure("bsc#1178193 - Journal corruption race condition");
+    } elsif (corrupted_logfiles) {
+        die "The daemon is stopped not in a clean way, or corrupted files have been detected\n";
     } else {
         assert_script_run("mv errs journalctl-verify-err.txt");
         upload_logs('journalctl-verify-err.txt');
@@ -100,13 +107,32 @@ sub assert_test_log_entries {
     }
 }
 
+sub rotatelogs_and_verify {
+    my @existing_rotations    = split('\n', script_output('find /var/log/journal/ -regex ".*system\@.*" -o -regex ".*user-.*"'));
+    my $systemd_journal_birth = script_output 'stat -c %W /var/log/journal/$(cat /etc/machine-id)/system.journal';
+    my @errors;
+    assert_script_run('journalctl --rotate');
+    ($systemd_journal_birth >= script_output('stat -c %W /var/log/journal/$(cat /etc/machine-id)/system.journal')) &&
+      push @errors, 'New system.journal file has not been created!';
+    (@existing_rotations >= script_output('find /var/log/journal/ -regex ".*system\@.*" -o -regex ".*user-.*" |wc -l')) &&
+      push @errors, 'Logs have not been rotated!';
+
+    foreach my $emsg (@errors) {
+        if (($emsg eq 'New system.journal file has not been created!') && (is_leap('<15.3') || is_sle('<15-sp3'))) {
+            record_soft_failure 'bsc#1183721 - brtime of file is empty';
+        } else {
+            die join('\n', @errors);
+        }
+    }
+}
+
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     my %log_entries = (
-        info  => q{'We need to call batman'},
-        err   => q{'We NEED to call the batman NOW'},
-        emerg => q{'CALL THE BATMAN NOW!1!! AARRGGH!!'}
+        info  => q{'(Testing, journalctl.pm) We need to call batman'},
+        err   => q{'(Testing, journalctl.pm) We NEED to call the batman NOW'},
+        emerg => q{'(Testing, journalctl.pm) CALL THE BATMAN NOW!1!! AARRGGH!!'}
     );
     my @boots;
 
@@ -191,7 +217,7 @@ sub run {
         script_run('socat pty,raw,echo=0,link=/dev/ttyS100 pty,raw,echo=0,link=/dev/ttyS101 & true');
         assert_script_run('jobs | grep socat', fail_message => "socat is not running");
         # Redirect journal to virtual serial console and syslog
-        assert_script_run "echo -e '[Journal]\nForwardToConsole=yes\nTTYPath=/dev/ttyS100\nMaxLevelConsole=info' | tee ${\ DROPIN_DIR }/fw-ttyS100.conf";
+        assert_script_run qq(echo -e '[Journal]\\nForwardToConsole=yes\\nTTYPath=/dev/ttyS100\\nMaxLevelConsole=info' |tee ${\ DROPIN_DIR }/fw-ttyS100.conf);
         systemctl 'restart systemd-journald.service';
         script_run('cat /dev/ttyS101 > /var/tmp/journal_serial.out & true');
         assert_script_run('echo "journal redirect output started (grep for: aeru4Poh eiDeik5l)" | systemd-cat -p info -t redirect');
@@ -208,7 +234,6 @@ sub run {
     assert_script_run 'journalctl --sync';
     assert_script_run 'journalctl --flush';
     verify_journal();
-    # Write second series of messages with different log priority
 
     if (is_sle('=15') && is_s390x) {
         zypper_call 'in haveged';
@@ -228,12 +253,13 @@ sub run {
 
     # Set new log entries for FSS checks
     %log_entries = (
-        info  => q{'We need to call batman-after sealing'},
-        err   => q{'We NEED to call the batman NOW-after sealing'},
-        emerg => q{'CALL THE BATMAN NOW!1!! AARRGGH!!-after sealing'}
+        info  => q{'(Testing, journalctl.pm) We need to call batman-after sealing'},
+        err   => q{'(Testing, journalctl.pm) We NEED to call the batman NOW-after sealing'},
+        emerg => q{'(Testing, journalctl.pm) CALL THE BATMAN NOW!1!! AARRGGH!!-after sealing'}
     );
-    assert_script_run('journalctl --rotate');
+    rotatelogs_and_verify;
     # remove first bootid
+    # Write second series of messages with different log priority
     shift @boots;
     write_test_log_entries \%log_entries;
     assert_test_log_entries(\%log_entries, \@boots);
@@ -241,7 +267,7 @@ sub run {
     sleep ${\SEALING_DELAY};
     verify_journal($keyid);
     # Rotate once more and verify the journal afterwards
-    assert_script_run('journalctl --rotate');
+    rotatelogs_and_verify;
     # Additional journalctl commands/use cases
     assert_script_run('journalctl --vacuum-size=100M');
     assert_script_run('journalctl --vacuum-time=1years');
@@ -258,12 +284,18 @@ sub cleanup {
 }
 
 sub post_fail_hook {
+
     select_console 'log-console';
-    shift->save_and_upload_log('journalctl', '/tmp/journalctl.txt', {screenshot => 1});
+    script_run 'cp -a /var/log/journal /var/log/journal-backup';
+    script_run 'tar Jcvf journal-backup.tar.xz /var/log/journal-backup';
+    sleep 5;
+    script_run 'tar Jcvf journal.tar.xz /var/log/journal/';
     if (script_run('test -s /var/tmp/journalctl-setup-keys.txt') == 0) {
         upload_logs('/var/tmp/journalctl-setup-keys.txt');
     }
     upload_logs('/etc/systemd/journald.conf');
+    upload_logs('./journal.tar.xz');
+    upload_logs('./journal-backup.tar.xz');
     cleanup();
 }
 


### PR DESCRIPTION
This reverts commit 95f5387, reversing changes made to 423f506.

Eventually a bug has been identified in `coreutils` package that `stat` does not return value of `brtime`.

* https://progress.opensuse.org/issues/90251
* https://bugzilla.suse.com/show_bug.cgi?id=1183721
- Verification runs:
  * [sle-12-SP3-Server-DVD-Updates-x86_64-Build20210318-1-mau-extratests1@64bit](http://kepler.suse.cz/tests/4070#step/journalctl/293)
  * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build31.380-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/4110#step/journalctl/270)
  * [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build7.20-jeos-extra@64bit_virtio-2G - https://build.opensuse.org/request/show/882523](http://kepler.suse.cz/tests/4114#step/journalctl/22)
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20210311-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/4108#step/journalctl/308)
  * [tw-dvd](http://kepler.suse.cz/tests/4111#step/journalctl/352)
  * [leap15.3](http://kepler.suse.cz/tests/4112#step/journalctl/330)
