### PR TITLE
Wait longer for SCC during addon registration

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -165,8 +165,8 @@ sub run {
         if ($self->process_unsigned_files([qw(inst-addon addon-products)])) {
             assert_screen_with_soft_timeout(
                 [qw(inst-addon addon-products)],
-                timeout      => check_var('BACKEND', 'pvm_hmc') ? 600 : 60,
-                soft_timeout => 30,
+                timeout      => check_var('BACKEND', 'pvm_hmc') ? 600 : 120,
+                soft_timeout => 60,
                 bugref       => 'bsc#1166504');
         }
     }


### PR DESCRIPTION
We get every once in a while a reminder that there's a soft failure here, but this can happen due to network being busy most of the time, so bumping the hard and soft timeouts
would allow us to really see if there's a bigger problem (Like Network actually down :))

See [this job](https://openqa.suse.de/tests/3443316#step/addon_products_sle/11) and [bsc#1124963](https://bugzilla.suse.com/show_bug.cgi?id=1123963) for motivation.

VR: https://openqa.suse.de/t5692936

CC @digitaltom