### PR TITLE
Fix service check's kdump ncurses font issue

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -82,6 +82,9 @@ sub prepare_for_kdump {
     # disable packagekitd
     quit_packagekit;
     if ($test_type eq 'before') {
+        # On ppc64le, sometime the console font will be distorted into pseudo graphics characters.
+        # we need to reset the console font.
+        assert_script_run('/usr/lib/systemd/systemd-vconsole-setup') if check_var('ARCH', 'ppc64le');
         zypper_call('in yast2-kdump kdump');
     }
     else {


### PR DESCRIPTION
On ppc64le, sometimes the console font will be distorted into pseudo graphics characters. 
We need to reset the console font to fix it.

- Related ticket: https://progress.opensuse.org/issues/90323
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/5694550
   https://openqa.nue.suse.com/tests/5694551
   https://openqa.nue.suse.com/tests/5696065