### PR TITLE
Add yast2_system_settings module for yast2_gui

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -20,6 +20,7 @@ use Installation::Partitioner::LibstorageNG::GuidedSetupController;
 use Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerController;
 use YaST::NetworkSettings::v4_3::NetworkSettingsController;
 use Installation::SystemRole::SystemRoleController;
+use YaST::SystemSettings::SystemSettingsController;
 
 sub get_partitioner {
     return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
@@ -35,6 +36,10 @@ sub get_network_settings {
 
 sub get_system_role_controller() {
     return Installation::SystemRole::SystemRoleController->new();
+}
+
+sub get_system_settings {
+    return YaST::SystemSettings::SystemSettingsController->new();
 }
 
 1;

--- a/lib/Distribution/Sle/15sp2.pm
+++ b/lib/Distribution/Sle/15sp2.pm
@@ -19,6 +19,7 @@ use parent 'susedistribution';
 use Installation::Partitioner::LibstorageNG::GuidedSetupController;
 use Installation::Partitioner::LibstorageNG::v4::ExpertPartitionerController;
 use YaST::NetworkSettings::v4::NetworkSettingsController;
+use YaST::SystemSettings::SystemSettingsController;
 
 sub get_partitioner {
     return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
@@ -30,6 +31,10 @@ sub get_expert_partitioner {
 
 sub get_network_settings {
     return YaST::NetworkSettings::v4::NetworkSettingsController->new();
+}
+
+sub get_system_settings {
+    return YaST::SystemSettings::SystemSettingsController->new();
 }
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ErrorDialog.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ErrorDialog.pm
@@ -41,4 +41,17 @@ sub press_ok {
     $self->{btn_ok}->click();
 }
 
+sub is_shown {
+    my ($self) = @_;
+    $self->{lbl_heading}->exist();
+}
+
+sub confirm {
+    my ($self) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->is_shown();
+    });
+    $self->press_ok();
+}
+
 1;

--- a/lib/YaST/SystemSettings/AddPCIIDPopup.pm
+++ b/lib/YaST/SystemSettings/AddPCIIDPopup.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for YaST module
+# PCI ID add pop-up window.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::SystemSettings::AddPCIIDPopup;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_ok}    = $self->{app}->button({id => 'ok'});
+    $self->{tb_driver} = $self->{app}->textbox({id => 'driver'});
+    $self->{tb_sysdir} = $self->{app}->textbox({id => 'sysdir'});
+    return $self;
+}
+
+sub press_ok {
+    my ($self) = @_;
+    $self->{btn_ok}->click();
+    return $self;
+}
+
+sub set_driver {
+    my ($self, $driver) = @_;
+    $self->{tb_driver}->set($driver);
+}
+
+sub set_sysdir {
+    my ($self, $sysdir) = @_;
+    $self->{tb_sysdir}->set($sysdir);
+}
+
+1;

--- a/lib/YaST/SystemSettings/KernelSettingsTab.pm
+++ b/lib/YaST/SystemSettings/KernelSettingsTab.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for YaST module
+# Kernel Settings Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::SystemSettings::KernelSettingsTab;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{cb_sysrq} = $self->{app}->checkbox({id => '"sysrq"'});
+    return $self;
+}
+
+sub uncheck_sysrq {
+    my ($self) = @_;
+    $self->{cb_sysrq}->uncheck();
+}
+
+sub check_sysrq {
+    my ($self) = @_;
+    $self->{cb_sysrq}->check();
+}
+
+1;

--- a/lib/YaST/SystemSettings/PCIIDSetupTab.pm
+++ b/lib/YaST/SystemSettings/PCIIDSetupTab.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for PCI ID Setup
+# Tab of systems settings YaST module.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::SystemSettings::PCIIDSetupTab;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{menu_btn_add} = $self->{app}->menucollection({label => 'Add...'});
+    $self->{btn_delete}   = $self->{app}->button({id => 'delete'});
+    return $self;
+}
+
+sub press_add_pci_id_from_list {
+    my ($self) = @_;
+    $self->{menu_btn_add}->select('&From List');
+    return $self;
+}
+
+sub press_delete {
+    my ($self) = @_;
+    $self->{btn_delete}->click();
+    return $self;
+}
+
+1;

--- a/lib/YaST/SystemSettings/SystemSettingsController.pm
+++ b/lib/YaST/SystemSettings/SystemSettingsController.pm
@@ -1,0 +1,98 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces actions System Settings Dialog.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::SystemSettings::SystemSettingsController;
+use strict;
+use warnings;
+use YaST::SystemSettings::SystemSettingsPage;
+use Installation::Partitioner::LibstorageNG::v4_3::ErrorDialog;
+use YaST::SystemSettings::PCIIDSetupTab;
+use YaST::SystemSettings::AddPCIIDPopup;
+use YaST::SystemSettings::KernelSettingsTab;
+
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{SystemSettingsPage} = YaST::SystemSettings::SystemSettingsPage->new({app => YuiRestClient::get_app()});
+    $self->{ErrorDialog}        = Installation::Partitioner::LibstorageNG::v4_3::ErrorDialog->new({app => YuiRestClient::get_app()});
+    $self->{KernelSettingsTab}  = YaST::SystemSettings::KernelSettingsTab->new({app => YuiRestClient::get_app()});
+    $self->{AddPCIIDPopup}      = YaST::SystemSettings::AddPCIIDPopup->new({app => YuiRestClient::get_app()});
+    $self->{PCIIDSetupTab}      = YaST::SystemSettings::PCIIDSetupTab->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_kernel_settings_tab {
+    my ($self) = @_;
+    return $self->{KernelSettingsTab};
+}
+
+sub get_pci_id_setup_tab {
+    my ($self) = @_;
+    return $self->{PCIIDSetupTab};
+}
+
+sub get_add_pci_id_popup {
+    my ($self) = @_;
+    return $self->{AddPCIIDPopup};
+}
+
+sub get_error_dialog {
+    my ($self) = @_;
+    return $self->{ErrorDialog};
+}
+
+sub get_system_settings_page {
+    my ($self) = @_;
+    return $self->{SystemSettingsPage};
+}
+
+sub add_pci_id_from_list {
+    my ($self, $args) = @_;
+    $self->get_pci_id_setup_tab->press_add_pci_id_from_list();
+    $self->get_add_pci_id_popup->set_driver($args->{driver});
+    $self->get_add_pci_id_popup->set_sysdir($args->{sysdir});
+    $self->get_add_pci_id_popup->press_ok();
+    $self->get_system_settings_page->press_ok();
+}
+
+sub remove_pci_id {
+    my ($self) = @_;
+    $self->get_pci_id_setup_tab->press_delete();
+    $self->get_system_settings_page->press_ok();
+}
+
+sub setup_kernel_settings_sysrq {
+    my ($self, $action) = @_;
+    $self->get_system_settings_page->switch_tab_kernel();
+    $self->set_sysrq_option($action);
+    $self->get_system_settings_page->press_ok();
+}
+
+sub set_sysrq_option {
+    my ($self, $action) = @_;
+    if ($action eq "enable") {
+        $self->get_kernel_settings_tab->check_sysrq();
+    } elsif ($action eq "disable") {
+        $self->get_kernel_settings_tab->uncheck_sysrq();
+    } else {
+        die "Unknown request";
+    }
+}
+
+1;

--- a/lib/YaST/SystemSettings/SystemSettingsPage.pm
+++ b/lib/YaST/SystemSettings/SystemSettingsPage.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for YaST module
+# System Settings Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::SystemSettings::SystemSettingsPage;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_ok}  = $self->{app}->button({id => 'next'});
+    $self->{tab_cwm} = $self->{app}->tab({id => '_cwm_tab'});
+    return $self;
+}
+
+sub press_ok {
+    my ($self) = @_;
+    $self->{btn_ok}->click();
+    return $self;
+}
+
+sub switch_tab_kernel {
+    my ($self) = @_;
+    $self->{tab_cwm}->select("&Kernel Settings");
+    return $self;
+}
+
+1;

--- a/lib/YuiRestClient/App.pm
+++ b/lib/YuiRestClient/App.pm
@@ -28,6 +28,7 @@ use YuiRestClient::Widget::ItemSelector;
 use YuiRestClient::Widget::Table;
 use YuiRestClient::Widget::Textbox;
 use YuiRestClient::Widget::Tree;
+use YuiRestClient::Widget::Tab;
 
 sub new {
     my ($class, $args) = @_;
@@ -148,5 +149,14 @@ sub tree {
             filter            => $filter
     });
 }
+
+sub tab {
+    my ($self, $filter) = @_;
+    return YuiRestClient::Widget::Tab->new({
+            widget_controller => $self->{widget_controller},
+            filter            => $filter
+    });
+}
+
 
 1;

--- a/lib/YuiRestClient/Widget/Tab.pm
+++ b/lib/YuiRestClient/Widget/Tab.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YuiRestClient::Widget::Tab;
+
+use strict;
+use warnings;
+
+use parent 'YuiRestClient::Widget::Base';
+use YuiRestClient::Action;
+
+sub select {
+    my ($self, $item) = @_;
+    $self->action(action => YuiRestClient::Action::YUI_SELECT, value => $item);
+}
+
+1;

--- a/schedule/yast/yast2_gui/yast2_gui_opensuse.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_opensuse.yaml
@@ -9,11 +9,14 @@ vars:
     HDDSIZEGB: 20
     SOFTFAIL_BSC1063638: 1
     VALIDATE_ETC_HOSTS: 1
+    YUI_REST_API: 1
 schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup
     - console/hostname
+    - console/setup_libyui_running_system
+    - yast2_gui/yast2_system_settings
     - yast2_gui/yast2_control_center
     - x11/yast2_lan_restart
     - yast2_gui/yast2_bootloader

--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -23,8 +23,8 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/scc_cleanup_reregister
-        - console/suseconnect_scc
         - console/setup_libyui_running_system
+        - yast2_gui/yast2_system_settings
         - yast2_gui/yast2_control_center
         - yast2_gui/yast2_expert_partitioner
         - yast2_gui/yast2_software_management
@@ -43,6 +43,9 @@ conditional_schedule:
         - yast2_gui/yast2_lan_restart_vlan
         - yast2_gui/yast2_lan_restart_bond
       aarch64:
+        - console/scc_cleanup_reregister
+        - console/setup_libyui_running_system
+        - yast2_gui/yast2_system_settings
         - yast2_gui/yast2_software_management
         - yast2_gui/yast2_security
         - x11/yast2_snapper
@@ -56,8 +59,8 @@ conditional_schedule:
         - yast2_gui/yast2_lan_restart_bond
       ppc64le:
         - console/scc_cleanup_reregister
-        - console/suseconnect_scc
         - console/setup_libyui_running_system
+        - yast2_gui/yast2_system_settings
         - yast2_gui/yast2_expert_partitioner
         - yast2_gui/yast2_software_management
         - yast2_gui/yast2_security

--- a/tests/yast2_gui/yast2_system_settings.pm
+++ b/tests/yast2_gui/yast2_system_settings.pm
@@ -1,0 +1,87 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run yast2 system_settings module, attempt to add a non existing
+# driver in the PCI ID setup and validate the error message. Disable the sysrq
+# keys at the kernel settings and validate the change in the system configuration.
+# Enable sysrq and validate again.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use YuiRestClient;
+use YaST::Module;
+use y2lan_restart_common 'close_xterm';
+use utils 'zypper_call';
+use x11utils 'start_root_shell_in_xterm';
+
+my $system_settings;
+
+sub pre_run_hook {
+    $system_settings = $testapi::distri->get_system_settings();
+    install_package_via_xterm("yast2-tune");
+}
+
+sub validate_sysrq_config {
+    my $expected_status = shift;
+    record_info("Validate sysrq", "Validate that sysrq is $expected_status in configuration files");
+    my %config_value = (disabled => 0, enabled => 1);
+    x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');
+    my $is_enabled = script_output("cat /proc/sys/kernel/sysrq");
+    $is_enabled = substr($is_enabled, 0, 1);
+    die "/proc/sys/kernel/sysrq has value $is_enabled , but sysrq should be $expected_status"
+      unless ($is_enabled eq $config_value{$expected_status});
+    $is_enabled = script_output("cat /etc/sysctl.d/70-yast.conf | grep sysrq");
+    $is_enabled = substr($is_enabled, -1, 1);
+    die "sysrq.kernel=$is_enabled in /etc/sysctl.d/70-yast.conf , but sysrq should be $expected_status"
+      unless ($is_enabled eq $config_value{$expected_status});
+    close_xterm();
+}
+
+sub install_package_via_xterm {
+    my $package = shift;
+    start_root_shell_in_xterm();
+    zypper_call("in $package");
+    close_xterm();
+}
+
+sub sysrq_config {
+    my $action = shift;
+    record_info("$action sysrq", "$action sysrq using yast");
+    YaST::Module::open({module => 'system_settings', ui => 'qt'});
+    $system_settings->setup_kernel_settings_sysrq($action);
+}
+
+sub add_invalid_pci_id {
+    record_info("PCI ID Setup", "Add an invalid PCI ID and handle the expected error message");
+    YaST::Module::open({module => 'system_settings', ui => 'qt'});
+    $system_settings->add_pci_id_from_list({driver => 'random', sysdir => 'random'});
+    $system_settings->get_error_dialog()->confirm();
+}
+
+sub remove_pci_id {
+    record_info("Remove PCI ID", "Remove the first PCI ID in the table");
+    YaST::Module::open({module => 'system_settings', ui => 'qt'});
+    $system_settings->remove_pci_id();
+}
+
+sub run {
+    select_console 'x11';
+    add_invalid_pci_id();
+    remove_pci_id();
+    sysrq_config("disable");
+    validate_sysrq_config("disabled");
+    sysrq_config("enable");
+    validate_sysrq_config("enabled");
+}
+
+1;


### PR DESCRIPTION
Adding module yast2_system_settings for yast2_gui test scenario

- Related ticket: https://progress.opensuse.org/issues/88361
- Verification runs:  
Tumbleweed
64bit   :  https://openqa.opensuse.org/t1684721
SLE
64bit      :  https://openqa.suse.de/t5742052
ppc64    :  https://openqa.suse.de/t5742053
aarch64 :  https://openqa.suse.de/t5742054