### PR TITLE
Add tests for HA&SAP grafana dashboards

### DIFF
--- a/schedule/sles4sap/sles4sapha_grafana_dashboards.yaml
+++ b/schedule/sles4sap/sles4sapha_grafana_dashboards.yaml
@@ -1,0 +1,21 @@
+---
+name: sles4sapha_grafana_dashboards
+description: >
+  Basic tests for HA & SAP Grafana dashboards
+
+  Install the main grafana package as well as the HA & SAP dashboards packages
+  Start grafana and make sure all the dashboards imported well
+  Finally some simple graphical tests are done
+vars:
+  BOOTFROM: c
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: 'gnome'
+  ROOT_ONLY: 1
+  TIMEOUT_SCALE: '2'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
+  # START_AFTER_TEST: create_hdd_sles4sap_gnome
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/grafana_dashboards

--- a/tests/sles4sap/grafana_dashboards.pm
+++ b/tests/sles4sap/grafana_dashboards.pm
@@ -1,0 +1,69 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Basic tests for HA & SAP grafana dashboards
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base "sles4sap";
+use testapi;
+use strict;
+use warnings;
+use hacluster qw(get_my_ip);
+use registration;
+use utils qw(zypper_call systemctl);
+
+sub run {
+    my ($self)      = @_;
+    my $grafana_log = '/var/log/grafana/grafana.log';
+    my $ip          = get_my_ip();
+    my $timeout     = bmwqemu::scale_timeout(30);
+
+    # Register the PackageHub module and install Grafana
+    add_suseconnect_product(get_addon_fullname('phub'));
+    zypper_call("in grafana");
+
+    # Install HA & SAP grafana dashboards
+    zypper_call("in grafana-ha-cluster-dashboards grafana-sap-hana-dashboards grafana-sap-netweaver-dashboards");
+    systemctl 'start grafana-server.service';
+    systemctl '-l status grafana-server.service';
+    upload_logs "$grafana_log";
+
+    # Check if all the dashboards are loaded when the grafana server starts
+    if (script_run "(( \$(grep -c 'failed to load dashboard' $grafana_log) == 0 ))") {
+        my $failed_dashboard = script_output "awk -F'/|.json' '/failed to load dashboard from/ {print \$7}' $grafana_log | sort -u";
+        $failed_dashboard =~ tr{\n}{ };
+        record_info("Dashboard error", "Failed to load dashboard(s): $failed_dashboard");
+        die 'One or more dashboards failed to load, check the grafana log for details';
+    }
+
+    # Basic graphical tests
+    select_console 'displaymanager';
+    $self->handle_displaymanager_login();
+    x11_start_program("firefox --private-window http://$ip:3000", target_match => 'grafana-login', match_timeout => $timeout);
+    type_string "admin";
+    send_key 'tab';
+    type_string "admin";
+    send_key 'tab';
+    send_key 'ret';
+    assert_screen "new-password", $timeout;
+    type_password;
+    send_key 'tab';
+    type_password;
+    send_key 'tab';
+    send_key 'ret';
+    assert_and_click "grafana-home",          $timeout;
+    assert_and_click "select_suse-dashboard", $timeout;
+    assert_screen "check_suse-dashboard",     $timeout;
+
+    # Close the browser and back to the desktop
+    send_key 'alt-f4';
+    assert_screen('generic-desktop');
+}
+
+1;


### PR DESCRIPTION
This PR adds new tests for HA&SAP grafana dashboards.
It is part of the monitoring testing solution.

- Related ticket: https://jira.suse.com/browse/TEAM-3692
- Needles: [MR](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1520)
- Verification run: 15-SP2 [passed test](http://1b143.qa.suse.de/tests/7511) - [failed test](http://1b143.qa.suse.de/tests/7504) (I've intentionally corrupted the json files for checking the behaviour).
I was not able to run the test on 15-SP3 due to [bsc#1183690](https://bugzilla.suse.com/show_bug.cgi?id=1183690)