### PR TITLE
containers: remove duplicated function call

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -133,9 +133,6 @@ sub build_with_zypper_docker {
 
     my $local_images_list = script_output("$runtime image ls");
     die("$runtime $derived_image not found") unless ($local_images_list =~ $derived_image);
-
-    record_info("Testing derived");
-    test_opensuse_based_image(image => $derived_image, runtime => $runtime);
 }
 
 sub test_opensuse_based_image {


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/containers/docker_image.pm#L43  - in this line we still calling this function even after this patch will be merged 