### PR TITLE
Skip certificate check on upload_image

### DIFF
--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -35,7 +35,7 @@ sub run {
         return;
     }
 
-    assert_script_run("wget $img_url -O $img_name", timeout => 60 * 10);
+    assert_script_run("wget --no-check-certificate $img_url -O $img_name", timeout => 60 * 10);
     $provider->upload_img($img_name, $img_type);
 }
 


### PR DESCRIPTION
Skit certificate validation to make upload_image also work with images
from download.suse.de

- Verification run: [Before](http://duck-norris.qam.suse.de/tests/5625) | [After](http://duck-norris.qam.suse.de/t5630)
