### PR TITLE
libreoffice: Use old and new table macro behavior based on version

### DIFF
--- a/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
+++ b/tests/x11/libreoffice/libreoffice_pyuno_bridge_no_evolution_dep.pm
@@ -25,6 +25,11 @@ use testapi;
 sub run {
     my $self = shift;
 
+    # get version of libreoffice
+    x11_start_program('xterm');
+    my $old_version = script_output('zypper se -i -s -x libreoffice|grep 6.4.5', proceed_on_failure => 1);
+    send_key 'alt-f4';
+
     # Open LibreOffice
     $self->libreoffice_start_program('oowriter');
 
@@ -36,12 +41,26 @@ sub run {
     send_key 'right';
     assert_and_click 'ooffice-writer-tools-run-macros';
 
-    # navigate to the Table sample item
-    assert_screen 'ooffice-writer-mymacros';
-    assert_and_click 'ooffice-writer-libreofficemacros';
-    wait_still_screen(2);
-    type_string "table\n";
-    assert_screen 'ooffice-table-sample';
+    if ($old_version) {
+        # navigate to the python samples item
+        assert_screen 'ooffice-writer-mymacros';
+        send_key 'down';
+        assert_and_click 'ooffice-writer-libreofficemacros';
+        wait_still_screen(2);
+        type_string "py\n";
+
+        assert_and_click 'ooffice-python-samples';
+        wait_still_screen(2);
+        send_key_until_needlematch 'ooffice-table-sample', 'down', 5, 1;
+    }
+    else {
+        # navigate to the Table sample item
+        assert_screen 'ooffice-writer-mymacros';
+        assert_and_click 'ooffice-writer-libreofficemacros';
+        wait_still_screen(2);
+        type_string "table\n";
+        assert_screen 'ooffice-table-sample';
+    }
     send_key 'tab';
 
     # run create table


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/90158
- Verification run:
https://openqa.suse.de/tests/5730316#step/libreoffice_pyuno_bridge_no_evolution_dep/15 15 SP2
https://openqa.suse.de/tests/5740048 15 SP3 wayland
https://openqa.suse.de/tests/5740322 15 SP3 x11