### PR TITLE
Increase some timers for php7_postgresql tests

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -284,7 +284,11 @@ EOF
         assert_script_run 'sudo update-alternatives --set postgresql $PG_OLDEST';
         assert_script_run 'initdb -D /tmp/psql';
         assert_script_run 'pg_ctl -D /tmp/psql start';
-        assert_script_run 'pg_ctl -D /tmp/psql status';
+        if (script_run('pg_ctl -D /tmp/psql status')) {
+            record_info('status', 'wait 5s more before status query');
+            sleep(5);
+            assert_script_run 'pg_ctl -D /tmp/psql status';
+        }
         assert_script_run 'pg_ctl -D /tmp/psql stop';
         assert_script_run 'sudo update-alternatives --set postgresql $PG_LATEST';
         assert_script_run 'initdb -D /var/lib/pgsql/data2';
@@ -313,7 +317,7 @@ EOF
     # check if db contains old and new table row
     assert_script_run 'p -d dvdrental -c "SELECT * FROM customer WHERE first_name = \'openQA\'"|grep openQA';
     assert_script_run 'p -d dvdrental -c "SELECT * FROM customer WHERE last_name = \'Davidson\'"|grep Davidson';
-    type_string "exit\n", wait_still_screen => 1;
+    type_string "exit\n", wait_still_screen => 3;
 }
 
 =head2 test_mysql


### PR DESCRIPTION
Required to avoid transient textmode test PowerPC or aarch64 failures
eg on TW for ppc64 and ppc64le or aarch64:
https://openqa.opensuse.org/tests/1677589#step/php7_postgresql/125
https://openqa.opensuse.org/tests/1677600#step/php7_postgresql/199
https://openqa.opensuse.org/tests/1678542#step/php7_postgresql/41   

- Related ticket: https://progress.opensuse.org/issues/88439
- Needles: none
- Verification run: 
  https://openqa.opensuse.org/t1678129 ppc64le
  https://openqa.opensuse.org/t1679088 ppc64
  https://openqa.opensuse.org/t1679089 x86_64 
  https://openqa.opensuse.org/t1679113 aarch64

