### PR TITLE
Fix update_install for dpdk:

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -44,7 +44,10 @@ sub has_conflict {
         'cluster-md-kmp-default' => 'kernel-default-base',
         'dlm-kmp-default'        => 'kernel-default-base',
         'gfs2-kmp-default'       => 'kernel-default-base',
-        'ocfs2-kmp-default'      => 'kernel-default-base'
+        'ocfs2-kmp-default'      => 'kernel-default-base',
+        dpdk                     => 'dpdk-thunderx',
+        'dpdk-devel'             => 'dpdk-thunderx-devel',
+        'dpdk-kmp-default'       => 'dpdk-thunderx-kmp-default',
     );
     return $conflict{$binary};
 }


### PR DESCRIPTION
Add a conflict between dpdk and dpdk-thunderx (only affecting arm)

- Verification run: https://openqa.suse.de/tests/5725891