### PR TITLE
LTP: Fix Tumbleweed aarch64 repo URL

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -212,7 +212,6 @@ sub add_ltp_repo {
         }
 
         my $arch = '';
-        $arch = "_ARM"      if is_aarch64();
         $arch = "_PowerPC"  if is_ppc64le();
         $arch = "_zSystems" if is_s390x();
 


### PR DESCRIPTION
aarch64 is now part of official URL [1], thus the old one [2] does not work any more.

[1] https://download.opensuse.org/repositories/benchmark:/ltp:/devel/openSUSE_Tumbleweed/
[2] https://download.opensuse.org/repositories/benchmark:/ltp:/devel/openSUSE_Factory_ARM/