### PR TITLE
Adjust btrfsmaintenance check for changes in presets

### DIFF
--- a/tests/console/btrfsmaintenance.pm
+++ b/tests/console/btrfsmaintenance.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_leap is_sle);
 
 sub btrfs_service_unavailable {
     my $service = $_[0];
@@ -56,7 +56,19 @@ sub run {
     assert_script_run('/usr/share/btrfsmaintenance/btrfs-balance.sh', timeout => 300);
     assert_script_run('/usr/share/btrfsmaintenance/btrfs-scrub.sh ',  timeout => 300);
     assert_script_run('systemctl restart btrfsmaintenance-refresh.service');
-    assert_script_run("systemctl is-enabled btrfsmaintenance-refresh");
+    # Check state of btrfsmaintenance-refresh units. Have to use (|| :) due to pipefail
+    assert_script_run('(systemctl is-enabled btrfsmaintenance-refresh.path || :) | grep enabled') unless is_sle("<15");
+    # Fixed in SP1:Update, but is out of general support and SP3 is based on an older snapshot currently
+    if (is_sle("<15-SP2") || is_sle("=15-SP3") || is_leap("=15.3")) {
+        assert_script_run('(systemctl is-enabled btrfsmaintenance-refresh.service || :) | grep enabled');
+        record_soft_failure('boo#1165780 - Preset is wrong and enables btrfsmaintenance-refresh.service instead of .path');
+    } elsif (is_sle("<=15-SP3") || is_leap("<=15.3")) {
+        # Preset is correct, btrfsmaintenance-refresh.service still has the [Install] section
+        assert_script_run('(systemctl is-enabled btrfsmaintenance-refresh.service || :) | grep disabled');
+    } else {
+        # Preset is correct, btrfsmaintenance-refresh.service dropped the [Install] section
+        assert_script_run('(systemctl is-enabled btrfsmaintenance-refresh.service || :) | grep static');
+    }
     # Check if btrfs-scrub and btrfs-balance are (somehow) enabled (results only in a info write)
     if (!is_sle('<15')) {
         die("btrfs-scrub service not active")   if btrfs_service_unavailable("scrub");


### PR DESCRIPTION
Various distro versions have different combinations of btrfsmaintenance and
systemd presets, do more fine grained checks.

Verification runs:
http://10.160.67.86/tests/870 (Tumbleweed)
http://10.160.67.86/tests/871 (Leap 15.2)
http://10.160.67.86/tests/873 (Leap 15.3)
