### PR TITLE
Rancher: k3s & rke1: Deploy Kubernetes cluster (multimachine)

### DIFF
--- a/data/rancher/rke1.yaml
+++ b/data/rancher/rke1.yaml
@@ -1,0 +1,15 @@
+nodes:
+  - address: master
+    user: root
+    role:
+      - controlplane
+      - etcd
+  - address: worker1
+    user: root
+    role:
+      - worker
+  - address: worker2
+    user: root
+    role:
+      - worker
+

--- a/schedule/rancher/rancher-k3s-master.yaml
+++ b/schedule/rancher/rancher-k3s-master.yaml
@@ -1,0 +1,7 @@
+---
+name: rancher
+description:    >
+    Tests for Rancher in openSUSE
+schedule:
+    - boot/boot_to_desktop
+    - rancher/rancher_k3s_master

--- a/schedule/rancher/rancher-k3s-worker.yaml
+++ b/schedule/rancher/rancher-k3s-worker.yaml
@@ -1,0 +1,7 @@
+---
+name: rancher
+description:    >
+    Tests for Rancher in openSUSE
+schedule:
+    - boot/boot_to_desktop
+    - rancher/rancher_k3s_worker

--- a/schedule/rancher/rancher-rke1-master.yaml
+++ b/schedule/rancher/rancher-rke1-master.yaml
@@ -1,0 +1,7 @@
+---
+name: rancher
+description:    >
+    Tests for Rancher in openSUSE
+schedule:
+    - boot/boot_to_desktop
+    - rancher/rancher_rke1_master

--- a/schedule/rancher/rancher-rke1-worker.yaml
+++ b/schedule/rancher/rancher-rke1-worker.yaml
@@ -1,0 +1,7 @@
+---
+name: rancher
+description:    >
+    Tests for Rancher in openSUSE
+schedule:
+    - boot/boot_to_desktop
+    - rancher/rancher_rke1_worker

--- a/schedule/rancher/rancher_supportserver.yaml
+++ b/schedule/rancher/rancher_supportserver.yaml
@@ -1,0 +1,9 @@
+---
+name: rancher
+description: >
+    Rancher support server test suite schedule
+schedule:
+ - support_server/login
+ - support_server/setup
+ - rancher/rancher_supportserver
+ - support_server/wait_children

--- a/tests/rancher/rancher_k3s_master.pm
+++ b/tests/rancher/rancher_k3s_master.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: One master node whene k3s server runs and cluster is tested..
+# Maintainer: Pavel Dostal <pdostal@suse.com>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+use rancher::utils;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    mutex_wait('support_server_ready');
+    prepare_mm_network();
+
+    assert_script_run("curl -L https://get.k3s.io -o ~/get_k3s", 360);
+    assert_script_run("chmod +rx ~/get_k3s");
+
+    assert_script_run("./get_k3s", 600);
+    script_retry("kubectl get node | grep ' Ready '", delay => 3, retry => 10);
+    script_run("cat /var/lib/rancher/k3s/server/node-token");
+
+    barrier_wait('cluster_prepared');
+
+    systemctl('status k3s');
+
+    # Wait untill all workers are visible and Ready. Currently we've 1 master and 2 workers
+    script_retry("[ `kubectl get node | grep ' Ready ' | wc -l` -eq 3 ]", delay => 15, retry => 40);
+
+    barrier_wait('cluster_deployed');
+
+    assert_script_run("kubectl get node");
+    kubectl_basic_test();
+
+    barrier_wait('cluster_test_done');
+
+    systemctl('stop k3s');
+}
+
+1;
+

--- a/tests/rancher/rancher_k3s_worker.pm
+++ b/tests/rancher/rancher_k3s_worker.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Two worker nodes where k3s agent runs.
+#   All workers wait for master to test the cluster.
+# Maintainer: Pavel Dostal <pdostal@suse.com>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+use rancher::utils;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    mutex_wait('support_server_ready');
+    prepare_mm_network();
+
+    assert_script_run("curl -L https://get.k3s.io -o ~/get_k3s", 360);
+    assert_script_run("chmod +rx ~/get_k3s");
+
+    assert_script_run('ssh-keyscan master >> ~/.ssh/known_hosts');
+    exec_and_insert_password('ssh-copy-id root@master');
+
+    barrier_wait('cluster_prepared');
+
+    my $token = script_output('ssh root@master cat /var/lib/rancher/k3s/server/node-token', timeout => 90);
+
+    script_run 'curl -sk https://master:6443/';
+    assert_script_run("K3S_TOKEN=$token K3S_URL=https://master:6443 ./get_k3s", 600);
+
+    barrier_wait('cluster_deployed');
+
+    barrier_wait('cluster_test_done');
+
+    systemctl('stop k3s-agent');
+}
+
+1;
+

--- a/tests/rancher/rancher_rke1_master.pm
+++ b/tests/rancher/rancher_rke1_master.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: One master node whene rke1 runs and deploys the cluster and cluster is tested..
+# Maintainer: Pavel Dostal <pdostal@suse.com>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+use version_utils;
+use rancher::utils;
+use containers::common;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    mutex_wait('support_server_ready');
+    prepare_mm_network();
+
+    assert_script_run("curl -L https://github.com/rancher/rke/releases/download/v1.1.15/rke_linux-amd64 -o ~/rke", 360);
+    assert_script_run("chmod +rx ~/rke");
+
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    install_docker_when_needed($host_distri);
+    zypper_call('in kubernetes-client');
+
+    barrier_wait('cluster_prepared');
+
+    assert_script_run('ssh-keyscan master >> ~/.ssh/known_hosts');
+    exec_and_insert_password('ssh-copy-id root@master');
+    assert_script_run('ssh-keyscan worker1 >> ~/.ssh/known_hosts');
+    exec_and_insert_password('ssh-copy-id root@worker1');
+    assert_script_run('ssh-keyscan worker2 >> ~/.ssh/known_hosts');
+    exec_and_insert_password('ssh-copy-id root@worker2');
+
+    assert_script_run("curl -o cluster.yml " . data_url("rancher/rke1.yaml"));
+    script_run('cat cluster.yml');
+    assert_script_run("./rke up", 600);
+
+    assert_script_run("mkdir ~/.kube");
+    assert_script_run("cp kube_config_cluster.yml ~/.kube/config");
+    assert_script_run("chmod 600 ~/.kube/config");
+
+    # Wait untill all workers are visible and Ready. Currently we've 1 master and 2 workers
+    script_retry("[ `kubectl get node | grep ' Ready ' | wc -l` -eq 3 ]", delay => 15, retry => 40);
+
+    barrier_wait('cluster_deployed');
+
+    assert_script_run("kubectl get nodes");
+    kubectl_basic_test();
+
+    assert_script_run 'yes | ./rke remove';
+
+    barrier_wait('cluster_test_done');
+
+    systemctl('stop docker.service');
+}
+
+1;
+

--- a/tests/rancher/rancher_rke1_worker.pm
+++ b/tests/rancher/rancher_rke1_worker.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Two workers deployed by rke1 Kubernetes cluster.
+#   All workers wait for master to test the cluster.
+# Maintainer: Pavel Dostal <pdostal@suse.com>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+use version_utils;
+use rancher::utils;
+use containers::common;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    mutex_wait('support_server_ready');
+    prepare_mm_network();
+
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    install_docker_when_needed($host_distri);
+
+    barrier_wait('cluster_prepared');
+
+    barrier_wait('cluster_deployed');
+
+    assert_script_run("docker ps");
+
+    barrier_wait('cluster_test_done');
+
+    systemctl('stop docker.service');
+}
+
+1;
+

--- a/tests/rancher/rancher_supportserver.pm
+++ b/tests/rancher/rancher_supportserver.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Setup multimachine barriers as supportserver is the parent task
+# Maintainer: Pavel Dostal <pdostal@suse.com>
+
+use base 'x11test';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+use mm_network;
+use Utils::Systemd 'disable_and_stop_service';
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+    barrier_create('cluster_prepared',  3);
+    barrier_create('cluster_deployed',  3);
+    barrier_create('cluster_test_done', 3);
+}
+
+1;
+

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -156,6 +156,7 @@ sub setup_dns_server {
                -e '/^NETCONFIG_DNS_FORWARDER_FALLBACK=/ s/yes/no/' /etc/sysconfig/network/config
         sed -i '/^NAMED_CONF_INCLUDE_FILES=/ s/=.*/="openqa.zones"/' /etc/sysconfig/named
         sed -i 's|#forwarders.*;|include "/etc/named.d/forwarders.conf";|' /etc/named.conf
+        sed -i 's|#dnssec-validation .*;|dnssec-validation no;|' /etc/named.conf
         curl -f -v $named_url/openqa.zones > /etc/named.d/openqa.zones
         curl -f -v $named_url/openqa.test.zone > /var/lib/named/master/openqa.test.zone
         curl -f -v $named_url/2.0.10.in-addr.arpa.zone > /var/lib/named/master/2.0.10.in-addr.arpa.zone


### PR DESCRIPTION
## Rancher maintains 2 Kubernetes distribution, both production grade:
 * k3s: Single binary containing containerd backend. Can be run as
   server or agent on each node of cluster. SQLite is used by default
   instead of ETCD. MySQL and Postgres also supported.
   No prerequisity. Intended for edge computing.
 * RKE: Deployed remotely over SSH on top of Docker which is the only
   required component of the underlying OS. Standard ETCD database
   in container. Each node and its roles are defined in YAML.
   Resource hungry, datacenter grade.

## Each scenario needs:
 1) Support Server: As Internet gateway, DHCP and DNS server.
 2) Master node for the control node and it's database
 3) ‎4. Worker nodes joining the cluster.

## TO-DO:
 * Run more tests on top of the Kubernetes cluster.
 * Implement the same for rke2 (not in production yet).

## Verification runs:
 * [rke1](http://pdostal-server.suse.cz/tests/11596)
 * [k3s](http://pdostal-server.suse.cz/tests/11592)

## Resources:
 * [k3s webpage](https://k3s.io/)
 * [k3s github repository](https://github.com/k3s-io/k3s)
 * [rke1 github repository](https://github.com/rancher/rke)
 * [rke1 cluster.yaml](https://rancher.com/docs/rke/latest/en/example-yamls/#minimal-cluster-yml-example)
 * [rke1 deploy guide](https://rancher.com/docs/rke/latest/en/installation/#prepare-the-nodes-for-the-kubernetes-cluster)

This project was inspired by the awesome [SUSE @Home](https://github.com/SUSE/suse-at-home) workshop.
This was done as [HackWeek 20](https://hackweek.suse.com/20/projects/create-openqa-multimachine-tests-for-deploying-kubernetes-on-tumbleweed-using-both-k3s-and-rke1) project.