### PR TITLE
Use REST API for the disk selection in the select_disk scenario

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -16,13 +16,13 @@ package Distribution::Opensuse::Tumbleweed;
 use strict;
 use warnings FATAL => 'all';
 use parent 'susedistribution';
-use Installation::Partitioner::LibstorageNG::GuidedSetupController;
+use Installation::Partitioner::LibstorageNG::v4_3::GuidedSetupController;
 use Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerController;
 use YaST::NetworkSettings::v4_3::NetworkSettingsController;
 use Installation::SystemRole::SystemRoleController;
 
 sub get_partitioner {
-    return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
+    return Installation::Partitioner::LibstorageNG::v4_3::GuidedSetupController->new();
 }
 
 sub get_expert_partitioner {

--- a/lib/Installation/Partitioner/LibstorageNG/GuidedSetupController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/GuidedSetupController.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,7 +10,7 @@
 # Summary: The class introduces business actions for Guided Setup of
 # Libstorage-NG Partitioner.
 
-# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package Installation::Partitioner::LibstorageNG::GuidedSetupController;
 use strict;
@@ -25,14 +25,20 @@ use Installation::Partitioner::LibstorageNG::SelectHardDisksPage;
 
 sub new {
     my ($class, $args) = @_;
-    my $self = bless {
-        SuggestedPartitioningPage => Installation::Partitioner::LibstorageNG::SuggestedPartitioningPage->new(),
-        PartitioningSchemePage    => Installation::Partitioner::LibstorageNG::PartitioningSchemePage->new(),
-        TooSimplePasswordDialog   => Installation::Partitioner::LibstorageNG::TooSimplePasswordDialog->new(),
-        FileSystemOptionsPage     => Installation::Partitioner::LibstorageNG::FileSystemOptionsPage->new(),
-        FileSystemOptionsLvmPage  => Installation::Partitioner::LibstorageNG::FileSystemOptionsLvmPage->new(),
-        SelectHardDisksPage       => Installation::Partitioner::LibstorageNG::SelectHardDisksPage->new()
-    }, $class;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+
+    $self->{SuggestedPartitioningPage} = Installation::Partitioner::LibstorageNG::SuggestedPartitioningPage->new();
+    $self->{PartitioningSchemePage}    = Installation::Partitioner::LibstorageNG::PartitioningSchemePage->new();
+    $self->{TooSimplePasswordDialog}   = Installation::Partitioner::LibstorageNG::TooSimplePasswordDialog->new();
+    $self->{FileSystemOptionsPage}     = Installation::Partitioner::LibstorageNG::FileSystemOptionsPage->new();
+    $self->{FileSystemOptionsLvmPage}  = Installation::Partitioner::LibstorageNG::FileSystemOptionsLvmPage->new();
+    $self->{SelectHardDisksPage}       = Installation::Partitioner::LibstorageNG::SelectHardDisksPage->new();
+    return $self;
 }
 
 sub get_suggested_partitioning_page {

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetupController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetupController.pm
@@ -1,0 +1,74 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for Guided Setup of
+# Libstorage-NG Partitioner using REST API.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Partitioner::LibstorageNG::v4_3::GuidedSetupController;
+
+use parent 'Installation::Partitioner::LibstorageNG::GuidedSetupController';
+use strict;
+use warnings;
+
+use Installation::Partitioner::LibstorageNG::v4_3::SelectDisksToUsePage;
+
+=head1 PARTITION_SETUP
+
+=head2 SYNOPSIS
+
+The class introduces business actions for Guided Setup of Libstorage-NG
+Partitioner using REST API.
+
+=cut
+
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->SUPER::init($args);
+    $self->{SelectDisksToUsePage} = Installation::Partitioner::LibstorageNG::v4_3::SelectDisksToUsePage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_select_disks_to_use_page {
+    my ($self) = @_;
+    die "Disk to use selection page is not displayed" unless $self->{SelectDisksToUsePage}->is_shown();
+    return $self->{SelectDisksToUsePage};
+}
+
+=head2 guided_setup
+
+ guided_setup($self, %args);
+
+Method setups partitioning using guided setup using provided configuration details.
+Following keys can be used:
+C<$args{disks}> - Define list of disks to be used (in case of multidisk setup)
+C<$args{existing_partitions}> - Process existing partitions, in case those do exist
+on the selected disks
+
+=cut
+
+sub guided_setup {
+    my ($self, %args) = @_;
+    $self->get_suggested_partitioning_page()->press_guided_setup_button();
+    if (my @disks = @{$args{disks}}) {
+        $self->get_select_disks_to_use_page()->select_hard_disks(@disks);
+    }
+    $self->_set_partitioning(%args);
+    $self->get_suggested_partitioning_page()->press_next();
+}
+
+1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/SelectDisksToUsePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/SelectDisksToUsePage.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Select Hard Disk(s)
+# Page in Guided Setup in case multiple disks are available in the system.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Partitioner::LibstorageNG::v4_3::SelectDisksToUsePage;
+use strict;
+use warnings FATAL => 'all';
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self) = shift;
+    $self->{btn_next}                = $self->{app}->button({id => 'next'});
+    $self->{lbl_select_disks_to_use} = $self->{app}->label({label => 'Select one or more (max 3) hard disks'});
+    return $self;
+}
+
+sub get_disk_checkbox {
+    my ($self, $disk) = @_;
+    return $self->{app}->checkbox({id => "\"/dev/$disk\""});
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{lbl_select_disks_to_use}->exist();
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->{btn_next}->click();
+}
+
+sub select_hard_disks {
+    my ($self, @disks) = @_;
+    foreach my $disk (@disks) {
+        $self->get_disk_checkbox($disk)->check();
+    }
+    $self->press_next();
+}
+
+1;

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -44,6 +44,5 @@ test_data:
   guided_partitioning:
     disks:
       - vda
-  disks:
-    - vda
+  unused_disks:
     - vdb

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -4,16 +4,17 @@ description: >
   This is also used as a prerequisite for real hardware tests to select
   the right disk for installation and not a "random" one.
 name: select_disk
+vars:
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_firstdisk
-  - installation/partitioning_finish
+  - installation/partitioning/guided_setup
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
@@ -25,6 +26,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - "{{reconnect_mgmt_console}}"
   - installation/grub_test
   - installation/first_boot
@@ -39,6 +41,9 @@ conditional_schedule:
       pvm_hmc:
         - boot/reconnect_mgmt_console
 test_data:
+  guided_partitioning:
+    disks:
+      - vda
   disks:
     - vda
     - vdb

--- a/schedule/yast/select_disk/select_disk_opensuse.yaml
+++ b/schedule/yast/select_disk/select_disk_opensuse.yaml
@@ -32,6 +32,5 @@ test_data:
   guided_partitioning:
     disks:
       - vda
-  disks:
-    - vda
+  unused_disks:
     - vdb

--- a/schedule/yast/select_disk/select_disk_opensuse.yaml
+++ b/schedule/yast/select_disk/select_disk_opensuse.yaml
@@ -4,17 +4,17 @@ description: >
   Test the selection of "first" disk with the guided setup in partitioning.
   This is also used as a prerequisite for real hardware tests to select
   the right disk for installation and not a "random" one.
+vars:
+  YUI_REST_API: 1
 schedule:
-  - installation/isosize
-  - installation/bootloader
+  - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_firstdisk
-  - installation/partitioning_finish
+  - installation/partitioning/guided_setup
   - installation/installer_timezone
   - installation/user_settings
   - installation/resolve_dependency_issues
@@ -24,10 +24,14 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/validate_first_disk_selection
 test_data:
+  guided_partitioning:
+    disks:
+      - vda
   disks:
     - vda
     - vdb

--- a/test_data/yast/4disks_pvm.yaml
+++ b/test_data/yast/4disks_pvm.yaml
@@ -1,8 +1,7 @@
 guided_partitioning:
   disks:
     - sda
-disks:
-  - sda
+unused_disks:
   - sdb
   - sdc
   - sdd

--- a/test_data/yast/4disks_pvm.yaml
+++ b/test_data/yast/4disks_pvm.yaml
@@ -1,3 +1,6 @@
+guided_partitioning:
+  disks:
+    - sda
 disks:
   - sda
   - sdb

--- a/tests/console/validate_first_disk_selection.pm
+++ b/tests/console/validate_first_disk_selection.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -36,21 +36,23 @@ sub run {
     select_console 'root-console';
 
     my @errors;
-    my @expected_disks = @{get_test_suite_data()->{disks}};
+    my $test_data    = get_test_suite_data();
+    my @used_disks   = @{$test_data->{guided_partitioning}->{disks}};
+    my @unused_disks = @{$test_data->{unused_disks}};
 
     # list info about block devices
     my @lsblk_output = split(/\n/, script_output('lsblk -n'));
     # get list of disk names
-    my @disks = map { (split ' ', $_)[0] } grep { /disk/ } @lsblk_output;
+    my @actual_disks = map { (split ' ', $_)[0] } grep { /disk/ } @lsblk_output;
     # compare disks found with expected
-    compare_disks(expected => \@expected_disks, got => \@disks);
-    # get first disk names
-    my $first_disk = shift @expected_disks;
+    compare_disks(expected => [@used_disks, @unused_disks], got => \@actual_disks);
     # check existing partitioning in first disk
-    push @errors, "First disk $first_disk was not used for partitioning."
-      unless (grep { /$first_disk\d/ } @lsblk_output) > 0;
+    for my $disk (@used_disks) {
+        push @errors, "Disk $disk was not used for partitioning."
+          unless (grep { /$disk\d/ } @lsblk_output) > 0;
+    }
     # Check for non-existing partitioning/mount points/swap in remaining disks
-    for my $disk (@expected_disks) {
+    for my $disk (@unused_disks) {
         push @errors, "Disk $disk was wrongly used during partitioning."
           if (grep { /$disk.*(\/|[SWAP])/ } @lsblk_output) > 0;
     }

--- a/tests/installation/partitioning/guided_setup.pm
+++ b/tests/installation/partitioning/guided_setup.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The test module performs guided partitioning
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+use scheduler;
+
+sub run {
+    my $partitioner = $testapi::distri->get_partitioner();
+    my $test_data   = get_test_suite_data();
+    $partitioner->guided_setup(%{$test_data->{guided_partitioning}});
+}
+
+1;


### PR DESCRIPTION
In guided setup we have additional steps in case multiple disks are
available, so user can select which disks to use, select which disk use
for the root partition and what to do with the existing partitions.

Adding initial structure to handle this step of guided setup.

Once we finish migrating Guided Partitioning to REST API, we can re-use it in all tests.

See [poo#89932](https://progress.opensuse.org/issues/89932).

## Verification runs
* [SLES](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23yast)
* [openSUSE](https://openqa.opensuse.org/tests/1684869)
