### PR TITLE
Fix YaST module launch on x11

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -56,7 +56,7 @@ sub samba_server_setup {
     systemctl("restart smb");
 
     select_console 'x11';
-    y2_module_guitest::launch_yast2_module_x11(module => "samba-server", target_match => "samba-server-installation", match_timeout => 200);
+    y2_module_guitest::launch_yast2_module_x11("samba-server", target_match => "samba-server-installation", match_timeout => 200);
 
     send_key "alt-w";
     send_key "ctrl-a";

--- a/tests/x11/network/yast2_network_use_nm.pm
+++ b/tests/x11/network/yast2_network_use_nm.pm
@@ -35,7 +35,7 @@ sub run {
 
 sub configure_system {
     # we have to change the networkmanager form wicked to NetworkManager
-    y2_module_guitest::launch_yast2_module_x11 module => 'lan';
+    y2_module_guitest::launch_yast2_module_x11('lan');
     assert_screen 'yast2_control-center_network-opened';
 
     # switch to 'Global options'


### PR DESCRIPTION
After $self was removed from launch_yast2_module_x11, the first argument
become module name. Previously it passed in a wrong way, as a named
parameter, and it worked, because of unused $self.

The commit fixes the issue by passing module name as a positional
parameter.

Fixes https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12159#issuecomment-809971096

- Verification run: https://openqa.suse.de/tests/5741930
