### PR TITLE
Increase timeout for switching console

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -758,7 +758,7 @@ sub activate_console {
             push(@tags, 'wsl-linux-prompt')    if (get_var('FLAVOR') eq 'WSL');
             # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet,
             # or premature typing of credentials on sle15+
-            my $stilltime = is_sle('15+') ? 5 : 1;
+            my $stilltime = is_sle('15+') ? 6 : 1;
             wait_still_screen $stilltime;
             # we need to wait more than five seconds here to pass the idle timeout in
             # case the system is still booting (https://bugzilla.novell.com/show_bug.cgi?id=895602)


### PR DESCRIPTION
There is sporadic failure for ppc, when switching tty. The current timeout for wait_still _screen is not enough.
- Results with raised timeout :
https://openqa.suse.de/tests/5742098#next_previous
- Results with current timeout :
https://openqa.suse.de/tests/5742224#next_previous

- Related ticket: https://progress.opensuse.org/issues/90140