### PR TITLE
Fix guest first boot issue with hyperv-uefi

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1002,8 +1002,6 @@ sub wait_boot_past_bootloader {
         select_console('x11');
     }
     elsif ($textmode || check_var('DESKTOP', 'textmode')) {
-        # Avoid return key not received occasionally for hyperv guest with uefi at first boot
-        send_key_until_needlematch('linux-login', 'ret') if (check_var('VIRSH_VMM_FAMILY', 'hyperv') && get_var('UEFI'));
         return $self->wait_boot_textmode(ready_time => $ready_time);
     }
 

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -88,6 +88,8 @@ sub run {
         # avoid timeout for booting to HDD
         send_key 'ret';
     }
+    # Avoid return key not received occasionally for hyperv-uefi guest at first boot
+    send_key 'ret' if (check_var('VIRSH_VMM_FAMILY', 'hyperv') && get_var('UEFI'));
 }
 
 sub test_flags {


### PR DESCRIPTION
To avoid return key not received occasionally at first boot for hyper-v guest with uefi, it requires to send one more return key after grub test finished. This is also an improvement for PR#12102.

- Related ticket: https://progress.opensuse.org/issues/90575
- Verification run: http://10.67.129.83/tests/136