### PR TITLE
Add schedule for HA pacemaker_cts_regression test

### DIFF
--- a/schedule/ha/bv/pacemaker_cts_regression.yaml
+++ b/schedule/ha/bv/pacemaker_cts_regression.yaml
@@ -1,0 +1,36 @@
+---
+name: pacemaker_cts_regression
+description: >
+  HA Pacemaker Cluster Test Suite - Single Machine Regression Test.
+
+  Schedule to test Pacemaker Cluster Test Suite in a single machine
+  job for the purpose of identifying regressions in pacemaker and
+  pacemaker-cts.
+
+  Most settings required by this test are defined below, but the
+  following extra settings must be provided via CLI, YAML job
+  group configuration or test suites.
+
+  HDD_1 must be defined to the path of the qcow2 image to use as SUT's
+  disk/boot device.
+  Similarly, if using UEFI boot, set UEFI_PFLASH_VARS to the patch of the
+  UEFI vars qcow2 image.
+  Finally, add any scheduler related settings such as START_AFTER_TEST
+  or PARALLEL_WITH.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: textmode
+  HA_CLUSTER: '1'
+  HDDMODEL: scsi-hd
+  HOSTNAME: cts-node
+  PACEMAKER_CTS_REG: '1'
+  QEMU_DISABLE_SNAPSHOTS: '1'
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/pacemaker_cts_regression


### PR DESCRIPTION
HA pacemaker_cts_regression test is a test that downloads pacemaker-cts and runs its single machine tests.

This PR introduces a YAML schedule to run the test so it can be fully migrated to YAML job template and YAML schedule.

This is intended to work with a YAML job template confguration such as the following:
```
...
    sle-15-SP3-Online-x86_64:
    - ha_pacemaker_cts_regression:
        testsuite: null
        settings: &pacemaker_cts_regression
          HDD_1: '%DISTRI%-%VERSION%-%ARCH%-Build%BUILD%-HA-BV.qcow2'
          START_AFTER_TEST: create_hdd_ha_textmode
          YAML_SCHEDULE: schedule/ha/bv/pacemaker_cts_regression.yaml
...
    sle-15-SP3-Online-aarch64:
    - ha_pacemaker_cts_regression:
        testsuite: null
        settings:
          <<: *pacemaker_cts_regression
          UEFI_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-Build%BUILD%-HA-BV-uefi-vars.qcow2'
...
    sle-15-SP3-Online-ppc64le:
    - ha_pacemaker_cts_regression:
        testsuite: null
        settings:
          <<: *pacemaker_cts_regression
...
    sle-15-SP3-Online-s390x:
    - ha_pacemaker_cts_regression:
        testsuite: null
        settings:
          <<: *pacemaker_cts_regression
```
- Related ticket: https://jira.suse.com/browse/TEAM-3751
- YAML Template Update: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/270
- Needles: N/A
- Verification run: [x86_64](http://mango.qa.suse.de/tests/3829), [aarch64](http://mango.qa.suse.de/tests/3828), [s390x](http://mango.qa.suse.de/tests/3830)
