### PR TITLE
clamav: Update db only from local mirror

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -62,8 +62,6 @@ sub run {
         my $host = is_sle ? 'openqa.suse.de' : 'openqa.opensuse.org';
         assert_script_run("sed -i '/mirror1/i PrivateMirror $host/assets/repo/cvd' /etc/freshclam.conf");
         assert_script_run('freshclam');
-        assert_script_run("sed -i '/PrivateMirror $host/d' /etc/freshclam.conf");
-        assert_script_run('freshclam');
     }
 
     # clamd takes a lot of memory at startup so a swap partition is needed on JeOS


### PR DESCRIPTION
Sometimes clamav does fail because local db is behind,
but for some reason daily.cvd is not updated, only daily.cld is.

https://openqa.suse.de/tests/5746449#step/clamav/27
https://openqa.opensuse.org/tests/1682801#step/clamav/27

- Related ticket: https://progress.opensuse.org/issues/89401
- Verification run:
https://openqa.opensuse.org/tests/1687013 TW
https://openqa.suse.de/tests/5746992 12 SP3
