### PR TITLE
firefox_html5: Handle youtube pop-up's

### DIFF
--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -25,9 +25,28 @@ use testapi;
 sub run {
     my ($self) = @_;
     $self->start_firefox_with_profile;
+
     $self->firefox_open_url('youtube.com/watch?v=Z4j5rJQMdOU');
-    assert_and_click('firefox-flashplayer-video_loaded');
-    assert_screen("firefox-testvideo");
+    while (check_screen([qw(firefox-youtube-signin firefox-accept-youtube-cookies)], 15)) {
+        if (match_has_tag('firefox-accept-youtube-cookies')) {
+            # get to the accept button with tab and space
+            wait_still_screen(2);
+            send_key('tab');
+            wait_still_screen(2);
+            send_key('spc');
+            wait_still_screen(2);
+            assert_and_click('firefox-accept-youtube-cookies-agree');
+            wait_still_screen(2);
+            next;
+        }
+        elsif (match_has_tag('firefox-youtube-signin')) {
+            assert_and_click('firefox-youtube-signin');
+            wait_still_screen(2);
+            next;
+        }
+        last;
+    }
+    send_key_until_needlematch('firefox-testvideo', 'spc', 5, 5);
     $self->exit_firefox;
 }
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/90275
- Verification run:
https://openqa.suse.de/tests/5752815#step/firefox_html5/15 15 SP3 wayland
https://openqa.suse.de/tests/5752816#step/firefox_html5/15 15 SP3 x11
https://openqa.suse.de/tests/5753504#step/firefox_html5/15 14 SP2 Desktop