### PR TITLE
Fix schedule lvm_thin_provisioning

### DIFF
--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -29,7 +29,6 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/teardown_libyui
   # Called on BACKEND: svirt
   - '{{reconnect_mgmt_console}}'
   - installation/teardown_libyui


### PR DESCRIPTION
Fix scheduling the test module twice: https://openqa.suse.de/tests/5750126#step/teardown_libyui#1/1
