### PR TITLE
Enable LTP incident uninstall tests only if KGRAFT=1

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -211,7 +211,7 @@ sub schedule_tests {
 
     parse_runfiles($cmd_file, $test_result_export);
 
-    if (check_var('UNINSTALL_INCIDENT', 1)) {
+    if (check_var('KGRAFT', 1) && check_var('UNINSTALL_INCIDENT', 1)) {
         loadtest_kernel 'uninstall_incident';
         parse_runfiles($cmd_file, $test_result_export, '_postun');
     }


### PR DESCRIPTION
I've accidentally pushed a test version of livepatch uninstall code to PR #11919 which is missing the check whether `KGRAFT=1`. The missing check would not break anything but some tests of regular kernel releases would be needlessly run twice.

- Related ticket: https://progress.opensuse.org/issues/80788
- Needles: N/A
- Verification runs:
  - Kgraft: https://openqa.suse.de/tests/5755211
  - KOTD: https://openqa.suse.de/tests/5755210
