### PR TITLE
Reorder the checks to avoid invalid state.

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -68,15 +68,18 @@ sub run {
             }
             # Check, if there are more updates available
             elsif (match_has_tag('updates_available-tray')) {
-                # look again
-                if (check_screen 'updates_available-tray', 30) {
+                # Look again
+                if (check_screen 'updates_none', 30) {
+                    # There were no updates but the tray icon persisted.
+                    record_soft_failure 'boo#1041112';
+                    last;
+                }
+                elsif (check_screen 'updates_available-tray', 30) {
+                    # There were updates. Do the update again
                     assert_and_click("updates_available-tray");
                 }
                 else {
-                    # Make sure, that there are no updates, otherwise fail
-                    assert_screen 'updates_none';
-                    record_soft_failure 'boo#1041112';
-                    last;
+                    die "Invalid state.";
                 }
             }
         }


### PR DESCRIPTION
The fix reorders the way the test checks if the tray indicator is still in an "updates available" after updates have already been applied.

Before, the test checked if it was in the "available" state, and if it was, checked again. That check might erroneously succeed if the indicator didn't change fast enough.

Now the test checks it is in the "available" state and then if it is, checks if it is in the "no updates" state.
If there really are updates then that check will fail and the test will move to the updating state.
If there are not, the test will conclude

- Related ticket: https://progress.opensuse.org/issues/90305
- Needles: No new needles needed.
- Verification run: [TW](http://apappas-openqa.qam.suse.de/tests/3) [Leap 15.2](http://apappas-openqa.qam.suse.de/tests/4)

[This](http://apappas-openqa.qam.suse.de/tests/4#step/updates_packagekit_kde/24) and the next screenshot show the two checks.

