### PR TITLE
Reenable kdump testing on JeOS

### DIFF
--- a/schedule/jeos/sle/jeos-base+phub.yaml
+++ b/schedule/jeos/sle/jeos-base+phub.yaml
@@ -33,4 +33,3 @@ schedule:
     - containers/docker_compose
     - network/cifs
     - console/orphaned_packages_check
-    - console/prjconf_excluded_rpms

--- a/schedule/jeos/sle/jeos-extratest.yaml
+++ b/schedule/jeos/sle/jeos-extratest.yaml
@@ -17,22 +17,6 @@ conditional_schedule:
             'svirt-vmware65':
                 - installation/bootloader_svirt
                 - installation/bootloader_uefi
-    kdump:
-        MACHINE:
-            '64bit-virtio-vga':
-                - console/kdump_and_crash
-            'uefi-virtio-vga':
-                - console/kdump_and_crash
-            'svirt-hyperv-uefi':
-                - console/kdump_and_crash
-            'svirt-hyperv':
-                - console/kdump_and_crash
-            'svirt-vmware65':
-                - console/kdump_and_crash
-            'svirt-xen-pv':
-                - console/kdump_and_crash
-            'aarch64':
-                - console/kdump_and_crash
 schedule:
     - '{{bootloader}}'
     - jeos/firstrun
@@ -70,4 +54,4 @@ schedule:
     - console/dstat
     - console/journalctl
     - console/procps
-    - '{{kdump}}'
+    - console/kdump_and_crash


### PR DESCRIPTION
As xen host server has been updated and [bsc#1181989 - openQA job causes libvirtd to dump core when running kdump inside domain](https://bugzilla.suse.com/show_bug.cgi?id=1181989) has been closed by now, we can reenable kdump testing in HVM guests again.

Project config test case has been accidentally included twice in phub test suite.
