### PR TITLE
Support chained SR-IOV tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -762,8 +762,16 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/update_package";
         loadtest "virt_autotest/reboot_and_wait_up_normal";
     }
+    elsif (get_var('START_DIRECTLY_AFTER_TEST')) {
+        #Skip host installation for tests run after another test which already installs host on same SUT
+        loadtest "virt_autotest/login_console";
+        if (get_var("SKIP_GUEST_INSTALL")) {
+            loadtest "virt_autotest/cleanup_service";
+            loadtest "virt_autotest/download_guest_assets";
+        }
+    }
     else {
-        if (!check_var('ARCH', 's390x')) {
+        if (!is_s390x) {
             load_boot_tests();
             if (get_var("AUTOYAST")) {
                 loadtest "autoyast/installation";
@@ -774,7 +782,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
                 loadtest "virt_autotest/login_console";
             }
         }
-        elsif (check_var('ARCH', 's390x')) {
+        else {
             loadtest "virt_autotest/login_console";
         }
         loadtest "virt_autotest/install_package";

--- a/tests/virt_autotest/cleanup_service.pm
+++ b/tests/virt_autotest/cleanup_service.pm
@@ -1,0 +1,31 @@
+# Summary: revert or cleanup the configuration files and restart services
+# Maintainer: Julie CAO <jcao@suse.com>
+package cleanup_service;
+
+use strict;
+use warnings;
+use base "virt_autotest_base";
+use testapi;
+use virt_utils qw(remove_vm);
+
+sub run {
+    #revert dns setting
+    if (script_run('ls /etc/resolv.conf.orig') == 0) {
+        script_run("mv /etc/resolv.conf.orig /etc/resolv.conf; mv /etc/named.conf.orig /etc/named.conf; mv /etc/ssh/ssh_config.orig /etc/ssh/ssh_config; mv /etc/dhcpd.conf.orig /etc/dhcpd.conf");
+        script_run("sed -irn '/^nameserver 192\\.168\\.123\\.1/d' /etc/resolv.conf");
+        script_run("rm /var/lib/named/testvirt.net.zone; rm /var/lib/named/123.168.192.zone");
+    }
+
+    #remove existing guests
+    my $listed_guests = script_output("virsh list --all | sed -n '/^-/,\$p' | sed '1d;/Domain-0/d' | awk '{print \$2;}'", 30);
+    remove_vm($_) foreach (split "\n", $listed_guests);
+
+    #remove br123 and restart services
+    assert_script_run "source /usr/share/qa/qa_test_virtualization/cleanup";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Description: create chain for sriov tests on DEVELOPING host only for now.

Root motive: all guests have chance to be tested in one build regardless failure

Advantage:
-[P0]all guests have chance to be run. creating chained tests is the only way to resolve this issue.
  --[P0]on xen, pv & fv guest will get run(pv or fv guest used to fail for an entire product cycle in 15sp3)
  --[P1]eg. on kvm,  in past case we open a bug for 15sp3 guest fail, dev always asked for 15sp2 result.
-[P3]test result listed separately

Disadvantage:
-[P1]test retriggering
  --the chaining tree is rather simple, only 2 level, 3 nodes for kvm, 6(or 3, have not decided) nodes for XEN
  --I am the only maintainer of these chained tests, I am familiar and have permission to retrigger tests
  --the two reasons above reduce the trouble

TBD:
-for sriov tests on host with other release, I have not decided to use chain.
-the actual result remains to be seen after several builds in OSD DEVELOPMENT group

- Verification run: 
[sriov tests on kvm](http://10.67.129.51/tests/2051#dependencies)   --- exected to be chained
[sriov tests on xen](http://10.67.129.51/tests/2072#dependencies)  --- exected to be chained
[prj1 test on arm](http://10.67.129.51/tests/2083)  --- expected to not be influenced
[[prj1 test on s390x](http://10.67.129.51/tests/2081)   --- expected to not be influenced

@alice-suse @guoxuguang @waynechen55 @nanzhang2020 Could you help review?