### PR TITLE
Fix leap to sle register_system and zypper yast migration issues

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -592,8 +592,9 @@ sub fill_in_registration_data {
             push @tags, 'untrusted-ca-cert';
         }
         # The SLE15-SP2 license page moved after registration.
-        push @tags, 'license-agreement'          if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
-        push @tags, 'license-agreement-accepted' if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
+        push @tags, 'license-agreement'                 if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
+        push @tags, 'license-agreement-accepted'        if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
+        push @tags, 'leap-to-sle-registrition-finished' if (is_leap_migration);
         # The "Extension and Module Selection" won't be shown during upgrade to sle15, refer to:
         # https://bugzilla.suse.com/show_bug.cgi?id=1070031#c11
         push @tags, 'inst-addon' if is_sle('15+') && is_upgrade;
@@ -660,6 +661,10 @@ sub fill_in_registration_data {
                 send_key $cmd{next};
                 assert_screen "remove-repository";
                 send_key $cmd{next};
+            }
+            elsif (match_has_tag('leap-to-sle-registrition-finished')) {
+                # leap to sle do not need to add any addons
+                return;
             }
         }
     }

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -212,7 +212,7 @@ sub run {
     send_key "alt-n";
     # migration via smt will install packagehub and NVIDIA compute, we need click trust
     # gpg keys; Same with leap to sle migration, need to trust packagehub gpg key.
-    if ((get_var('SMT_URL') =~ /smt/) || (is_leap_migration)) {
+    if (get_var('SMT_URL') =~ /smt/) {
         assert_screen 'import-untrusted-gpg-key', 60;
         send_key 'alt-t';
         if ((check_var('ARCH', 'x86_64')) && (!(is_leap_migration)) || (check_var('ARCH', 'aarch64'))) {

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -83,7 +83,9 @@ sub run {
         elsif ($out =~ $zypper_migration_conflict)
         {
             if (check_var("BREAK_DEPS", '1')) {
-                send_key '1';
+                # This is a workaround for leap to sle migration, we need choose 2 to resolve conflicts.
+                # Normally we do not need resolve any conflicts during migration.
+                is_leap_migration ? send_key '2' : send_key '1';
                 send_key 'ret';
             } else {
                 save_screenshot;


### PR DESCRIPTION
For leap to sle migration, in the register system module, we don't
need to check the addon screen. the register will exit once the reg code
works.

In yast migration and zypper migration, we need to take care of the leap
to make both migrations works.


- Related ticket: https://progress.opensuse.org/issues/90185
- Needles: N/A
- Verification run:  
    https://openqa.nue.suse.com/tests/5686269
    https://openqa.nue.suse.com/tests/5778013 this case failed for file conflicts
    https://openqa.nue.suse.com/tests/5778060 
    https://openqa.nue.suse.com/t5778372        this failed for Max_job_timeout
