### PR TITLE
Fix timeout for libyui in running system

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -54,7 +54,7 @@ sub connect_to_app {
 }
 
 sub connect_to_app_running_system {
-    get_app()->connect(timeout => 500, interval => 10);
+    get_app()->connect(timeout => 30, interval => 2);
 }
 
 sub process_start_shell {


### PR DESCRIPTION
Decrease timeout for libyui connection to app in installed system.

- Related ticket: [poo#89941](https://progress.opensuse.org/issues/89941)
- Verification run: [yast2_gui & yast2_ncurses_gnome](https://openqa.suse.de/tests/overview?version=15-SP3&build=jknphy%2Fos-autoinst-distri-opensuse%23rest_api_timeout_running_sys&distri=sle)

Note: there are some error with needles in VR not seen in production unrelated with this task.
