### PR TITLE
PublicCloud: Add openstack-client package to Tools image

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -83,7 +83,13 @@ sub run {
     my $azure_error = '/tmp/azure_error';
     record_info('Azure', script_output('az -v 2>' . $azure_error));
     assert_script_run('cat ' . $azure_error);
-    assert_script_run('test ! -s ' . $azure_error);
+    if (script_run('test -s ' . $azure_error)) {
+        die("Unexpected error in azure-cli") unless validate_script_output("cat $azure_error", m/Please let us know how we are doing .* and let us know if you're interested in trying out our newest features .*/);
+    }
+
+    # Install OpenStack cli
+    install_in_venv('python-openstackclient', 'openstack');
+    record_info('OpenStack', script_output('openstack --version'));
 
     # Install Google Cloud SDK
     assert_script_run("export CLOUDSDK_CORE_DISABLE_PROMPTS=1");


### PR DESCRIPTION
This will allow using this Helper VM to trigger the tests for JeOS OpenStack image in any OpenStack Cloud.

- Related ticket: https://progress.opensuse.org/issues/90704
- Verification run: http://fromm.arch.suse.de/tests/830
