### PR TITLE
Use libyui REST API for the disk selection

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetupController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetupController.pm
@@ -19,8 +19,9 @@ use warnings;
 
 use YuiRestClient;
 
-use Installation::Partitioner::LibstorageNG::v4_3::PartitioningSchemePage;
 use Installation::Partitioner::LibstorageNG::v4_3::FilesystemOptionsPage;
+use Installation::Partitioner::LibstorageNG::v4_3::PartitioningSchemePage;
+use Installation::Partitioner::LibstorageNG::v4_3::SelectDisksToUsePage;
 
 =head1 PARTITION_SETUP
 
@@ -39,8 +40,9 @@ sub new {
 
 sub init {
     my ($self, $args) = @_;
-    $self->{PartitioningSchemePage} = Installation::Partitioner::LibstorageNG::v4_3::PartitioningSchemePage->new({app => YuiRestClient::get_app()});
     $self->{FilesystemOptionsPage}  = Installation::Partitioner::LibstorageNG::v4_3::FilesystemOptionsPage->new({app => YuiRestClient::get_app()});
+    $self->{PartitioningSchemePage} = Installation::Partitioner::LibstorageNG::v4_3::PartitioningSchemePage->new({app => YuiRestClient::get_app()});
+    $self->{SelectDisksToUsePage}   = Installation::Partitioner::LibstorageNG::v4_3::SelectDisksToUsePage->new({app => YuiRestClient::get_app()});
     return $self;
 }
 
@@ -54,6 +56,18 @@ sub get_filesystem_options_page {
     my ($self) = @_;
     die "Filesystem Options is not displayed" unless $self->{FilesystemOptionsPage}->is_shown();
     return $self->{FilesystemOptionsPage};
+}
+
+sub get_select_disks_to_use_page {
+    my ($self) = @_;
+    die "Disk to use selection page is not displayed" unless $self->{SelectDisksToUsePage}->is_shown();
+    return $self->{SelectDisksToUsePage};
+}
+
+sub setup_disks_to_use {
+    my ($self, @disks) = @_;
+    $self->get_select_disks_to_use_page()->select_hard_disks(@disks);
+    $self->get_select_disks_to_use_page()->press_next();
 }
 
 sub setup_partitioning_scheme {

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/SelectDisksToUsePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/SelectDisksToUsePage.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Select Hard Disk(s)
+# Page in Guided Setup in case multiple disks are available in the system.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Partitioner::LibstorageNG::v4_3::SelectDisksToUsePage;
+use strict;
+use warnings FATAL => 'all';
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self) = shift;
+    $self->{btn_next}                = $self->{app}->button({id => 'next'});
+    $self->{lbl_select_disks_to_use} = $self->{app}->label({label => 'Select one or more (max 3) hard disks'});
+    return $self;
+}
+
+sub _get_disk_checkbox {
+    my ($self, $disk) = @_;
+    return $self->{app}->checkbox({id => "\"/dev/$disk\""});
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{lbl_select_disks_to_use}->exist();
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->{btn_next}->click();
+}
+
+sub select_hard_disks {
+    my ($self, @disks) = @_;
+    foreach my $disk (@disks) {
+        $self->_get_disk_checkbox($disk)->check();
+    }
+}
+
+1;

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -46,6 +46,5 @@ test_data:
   guided_partitioning:
     disks:
       - vda
-  disks:
-    - vda
+  unused_disks:
     - vdb

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -4,16 +4,19 @@ description: >
   This is also used as a prerequisite for real hardware tests to select
   the right disk for installation and not a "random" one.
 name: select_disk
+vars:
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_firstdisk
-  - installation/partitioning_finish
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
@@ -25,6 +28,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - "{{reconnect_mgmt_console}}"
   - installation/grub_test
   - installation/first_boot
@@ -39,6 +43,9 @@ conditional_schedule:
       pvm_hmc:
         - boot/reconnect_mgmt_console
 test_data:
+  guided_partitioning:
+    disks:
+      - vda
   disks:
     - vda
     - vdb

--- a/schedule/yast/select_disk/select_disk_opensuse.yaml
+++ b/schedule/yast/select_disk/select_disk_opensuse.yaml
@@ -4,17 +4,19 @@ description: >
   Test the selection of "first" disk with the guided setup in partitioning.
   This is also used as a prerequisite for real hardware tests to select
   the right disk for installation and not a "random" one.
+vars:
+  YUI_REST_API: 1
 schedule:
-  - installation/isosize
-  - installation/bootloader
+  - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_firstdisk
-  - installation/partitioning_finish
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/resolve_dependency_issues
@@ -24,10 +26,14 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/teardown_libyui
   - installation/grub_test
   - installation/first_boot
   - console/validate_first_disk_selection
 test_data:
+  guided_partitioning:
+    disks:
+      - vda
   disks:
     - vda
     - vdb

--- a/schedule/yast/select_disk/select_disk_opensuse.yaml
+++ b/schedule/yast/select_disk/select_disk_opensuse.yaml
@@ -34,6 +34,5 @@ test_data:
   guided_partitioning:
     disks:
       - vda
-  disks:
-    - vda
+  unused_disks:
     - vdb

--- a/test_data/yast/4disks_pvm.yaml
+++ b/test_data/yast/4disks_pvm.yaml
@@ -1,8 +1,7 @@
 guided_partitioning:
   disks:
     - sda
-disks:
-  - sda
+unused_disks:
   - sdb
   - sdc
   - sdd

--- a/test_data/yast/4disks_pvm.yaml
+++ b/test_data/yast/4disks_pvm.yaml
@@ -1,3 +1,6 @@
+guided_partitioning:
+  disks:
+    - sda
 disks:
   - sda
   - sdb

--- a/tests/console/validate_first_disk_selection.pm
+++ b/tests/console/validate_first_disk_selection.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -36,21 +36,23 @@ sub run {
     select_console 'root-console';
 
     my @errors;
-    my @expected_disks = @{get_test_suite_data()->{disks}};
+    my $test_data    = get_test_suite_data();
+    my @used_disks   = @{$test_data->{guided_partitioning}->{disks}};
+    my @unused_disks = @{$test_data->{unused_disks}};
 
     # list info about block devices
     my @lsblk_output = split(/\n/, script_output('lsblk -n'));
     # get list of disk names
-    my @disks = map { (split ' ', $_)[0] } grep { /disk/ } @lsblk_output;
+    my @actual_disks = map { (split ' ', $_)[0] } grep { /disk/ } @lsblk_output;
     # compare disks found with expected
-    compare_disks(expected => \@expected_disks, got => \@disks);
-    # get first disk names
-    my $first_disk = shift @expected_disks;
+    compare_disks(expected => [@used_disks, @unused_disks], got => \@actual_disks);
     # check existing partitioning in first disk
-    push @errors, "First disk $first_disk was not used for partitioning."
-      unless (grep { /$first_disk\d/ } @lsblk_output) > 0;
+    for my $disk (@used_disks) {
+        push @errors, "Disk $disk was not used for partitioning."
+          unless (grep { /$disk\d/ } @lsblk_output) > 0;
+    }
     # Check for non-existing partitioning/mount points/swap in remaining disks
-    for my $disk (@expected_disks) {
+    for my $disk (@unused_disks) {
         push @errors, "Disk $disk was wrongly used during partitioning."
           if (grep { /$disk.*(\/|[SWAP])/ } @lsblk_output) > 0;
     }

--- a/tests/installation/partitioning/guided_setup.pm
+++ b/tests/installation/partitioning/guided_setup.pm
@@ -19,7 +19,8 @@ use scheduler 'get_test_suite_data';
 sub run {
     my $test_data    = get_test_suite_data()->{guided_partitioning};
     my $guided_setup = $testapi::distri->get_guided_partitioner();
-
+    # Select disks to use, if multiple disks are available
+    $guided_setup->setup_disks_to_use(@{$test_data->{disks}}) if $test_data->{disks};
     $guided_setup->setup_partitioning_scheme($test_data->{partitioning_scheme});
     $guided_setup->setup_filesystem_options($test_data->{filesystem_options});
 }


### PR DESCRIPTION
Reworked #12204 as that one broke couple of tests due to attempt to reuse old controller.

In guided setup we have additional steps in case multiple disks are
available, so user can select which disks to use, select which disk use
for the root partition and what to do with the existing partitions.

Adding initial structure to handle this step of guided setup.

Once we finish migrating Guided Partitioning to REST API, we can re-use it in all tests.

See [poo#89932](https://progress.opensuse.org/issues/89932).

## Verification runs
* [SLES](https://openqa.suse.de/tests/overview?distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%23yast)
* [openSUSE select_disk](https://openqa.opensuse.org/tests/1691746)
* [TW cryptlvm](https://openqa.opensuse.org/tests/1691764)