### PR TITLE
Add stable way to check if YaST module is closed

### DIFF
--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(is_network_manager_default
   continue_info_network_manager_default
   accept_warning_network_manager_default
   with_yast_env_variables
+  wait_for_exit
 );
 
 =head2 with_yast_env_variables
@@ -85,6 +86,26 @@ sub accept_warning_network_manager_default {
     assert_screen 'yast2-lan-warning-network-manager';
     send_key $cmd{ok};
     assert_screen 'yast2_lan-global-tab';
+}
+
+
+=head2 wait_for_exit
+
+ wait_for_exit(module => $module, timeout => $timeout);
+
+Wait for string yast2-$module-status-0 (which has been
+previously used to open the module) to appear in the serial output
+using a timeout in order to ensure that the module exited.
+
+C<module> module to wait for exit.
+C<timeout> timeout to wait on the serial.
+
+=cut
+sub wait_for_exit {
+    my %args = @_;
+    $args{timeout} //= 60;
+    wait_serial("yast2-$args{module}-status-0", timeout => $args{timeout}) ||
+      die "Fail! yast2 $args{module} is not closed or non-zero code returned.";
 }
 
 sub post_fail_hook {

--- a/tests/console/yast2_lan_hostname/dhcp_no.pm
+++ b/tests/console/yast2_lan_hostname/dhcp_no.pm
@@ -21,14 +21,13 @@ use YaST::Module;
 
 sub run {
     my $test_data = get_test_suite_data();
-    YaST::Module::open({module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui}});
-    my $network_settings = $testapi::distri->get_network_settings();
-    $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
-    $network_settings->set_hostname_via_dhcp({dhcp_option => 'no'});
-    $network_settings->save_changes();
+    YaST::Module::run_actions {
+        my $network_settings = $testapi::distri->get_network_settings();
+        $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
+        $network_settings->set_hostname_via_dhcp({dhcp_option => 'no'});
+        $network_settings->save_changes();
+    } module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui};
 
-    assert_screen 'console-visible', 180;
-    wait_still_screen;
     assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
 }
 

--- a/tests/console/yast2_lan_hostname/dhcp_yes.pm
+++ b/tests/console/yast2_lan_hostname/dhcp_yes.pm
@@ -21,14 +21,13 @@ use YaST::Module;
 
 sub run {
     my $test_data = get_test_suite_data();
-    YaST::Module::open({module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui}});
-    my $network_settings = $testapi::distri->get_network_settings();
-    $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
-    $network_settings->set_hostname_via_dhcp({dhcp_option => 'yes: any'});
-    $network_settings->save_changes();
+    YaST::Module::run_actions {
+        my $network_settings = $testapi::distri->get_network_settings();
+        $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
+        $network_settings->set_hostname_via_dhcp({dhcp_option => 'yes: any'});
+        $network_settings->save_changes();
+    } module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui};
 
-    assert_screen 'console-visible', 180;
-    wait_still_screen;
     assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep yes';
 }
 

--- a/tests/console/yast2_lan_hostname/dhcp_yes_eth.pm
+++ b/tests/console/yast2_lan_hostname/dhcp_yes_eth.pm
@@ -25,14 +25,13 @@ sub run {
     my $network_interface = script_output('ls /sys/class/net | grep ^e');
     my $test_data         = get_test_suite_data();
 
-    YaST::Module::open({module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui}});
-    my $network_settings = $testapi::distri->get_network_settings();
-    $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
-    $network_settings->set_hostname_via_dhcp({dhcp_option => "yes: $network_interface"});
-    $network_settings->save_changes();
+    YaST::Module::run_actions {
+        my $network_settings = $testapi::distri->get_network_settings();
+        $network_settings->confirm_warning() if $test_data->{yast2_lan_hostname}->{confirm_warning};
+        $network_settings->set_hostname_via_dhcp({dhcp_option => "yes: $network_interface"});
+        $network_settings->save_changes();
+    } module => 'lan', ui => $test_data->{yast2_lan_hostname}->{ui};
 
-    assert_screen 'console-visible', 180;
-    wait_still_screen;
     assert_script_run 'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
     assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/ifcfg-$iface|grep yes';
     assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';

--- a/tests/yast2_gui/yast2_expert_partitioner.pm
+++ b/tests/yast2_gui/yast2_expert_partitioner.pm
@@ -49,19 +49,16 @@ sub pre_run_hook {
     $test_data   = get_test_suite_data();
 }
 
-sub open_expert_partitioner {
-    YaST::Module::open({module => 'storage', ui => 'qt'});
-    $partitioner->get_confirmation_warning_controller()->confirm_only_use_if_familiar();
-}
-
 sub add_custom_partition {
     my $disk = $test_data->{disks}[0];
-    open_expert_partitioner;
-    $partitioner->add_partition_on_gpt_disk({
-            disk      => $disk->{name},
-            partition => $disk->{partitions}[0]
-    });
-    $partitioner->show_summary_and_accept_changes();
+    YaST::Module::run_actions {
+        $partitioner->get_confirmation_warning_controller()->confirm_only_use_if_familiar();
+        $partitioner->add_partition_on_gpt_disk({
+                disk      => $disk->{name},
+                partition => $disk->{partitions}[0]
+        });
+        $partitioner->show_summary_and_accept_changes();
+    } module => 'storage', ui => 'qt';
 }
 
 sub verify_custom_partition {
@@ -80,12 +77,14 @@ sub verify_custom_partition {
 }
 
 sub resize_custom_partition {
-    open_expert_partitioner;
-    $partitioner->resize_partition({
-            disk      => $test_data->{disks}[0]->{name},
-            partition => $test_data->{disks}[0]->{partitions}[1]
-    });
-    $partitioner->show_summary_and_accept_changes();
+    YaST::Module::run_actions {
+        $partitioner->get_confirmation_warning_controller()->confirm_only_use_if_familiar();
+        $partitioner->resize_partition({
+                disk      => $test_data->{disks}[0]->{name},
+                partition => $test_data->{disks}[0]->{partitions}[1]
+        });
+        $partitioner->show_summary_and_accept_changes();
+    } module => 'storage', ui => 'qt';
 }
 
 sub verify_resized_partition {
@@ -93,18 +92,22 @@ sub verify_resized_partition {
 }
 
 sub delete_resized_partition {
-    open_expert_partitioner;
-    $partitioner->delete_partition({
-            disk      => $test_data->{disks}[0]->{name},
-            partition => $test_data->{disks}[0]->{partitions}[1]
-    });
-    $partitioner->show_summary_and_accept_changes();
+    YaST::Module::run_actions {
+        $partitioner->get_confirmation_warning_controller()->confirm_only_use_if_familiar();
+        $partitioner->delete_partition({
+                disk      => $test_data->{disks}[0]->{name},
+                partition => $test_data->{disks}[0]->{partitions}[1]
+        });
+        $partitioner->show_summary_and_accept_changes();
+    } module => 'storage', ui => 'qt';
 }
 
 sub add_logical_volumes {
-    open_expert_partitioner;
-    $partitioner->setup_lvm($test_data->{lvm});
-    $partitioner->show_summary_and_accept_changes();
+    YaST::Module::run_actions {
+        $partitioner->get_confirmation_warning_controller()->confirm_only_use_if_familiar();
+        $partitioner->setup_lvm($test_data->{lvm});
+        $partitioner->show_summary_and_accept_changes();
+    } module => 'storage', ui => 'qt';
 }
 
 sub verify_logical_volumes {
@@ -118,11 +121,12 @@ sub verify_logical_volumes {
 }
 
 sub delete_volume_group {
-    open_expert_partitioner;
-    my $vg = $test_data->{lvm}->{volume_groups}[0];
-
-    $partitioner->delete_volume_group($vg->{name});
-    $partitioner->show_summary_and_accept_changes();
+    YaST::Module::run_actions {
+        $partitioner->get_confirmation_warning_controller()->confirm_only_use_if_familiar();
+        my $vg = $test_data->{lvm}->{volume_groups}[0];
+        $partitioner->delete_volume_group($vg->{name});
+        $partitioner->show_summary_and_accept_changes();
+    } module => 'storage', ui => 'qt';
 }
 
 sub run {

--- a/tests/yast2_gui/yast2_system_settings.pm
+++ b/tests/yast2_gui/yast2_system_settings.pm
@@ -57,21 +57,24 @@ sub install_package_via_xterm {
 sub sysrq_config {
     my $action = shift;
     record_info("$action sysrq", "$action sysrq using yast");
-    YaST::Module::open({module => 'system_settings', ui => 'qt'});
+    YaST::Module::open(module => 'system_settings', ui => 'qt');
     $system_settings->setup_kernel_settings_sysrq($action);
+    YaST::Module::close(module => 'system_settings');
 }
 
 sub add_invalid_pci_id {
     record_info("PCI ID Setup", "Add an invalid PCI ID and handle the expected error message");
-    YaST::Module::open({module => 'system_settings', ui => 'qt'});
+    YaST::Module::open(module => 'system_settings', ui => 'qt');
     $system_settings->add_pci_id_from_list({driver => 'random', sysdir => 'random'});
     $system_settings->get_error_dialog()->confirm();
+    YaST::Module::close(module => 'system_settings');
 }
 
 sub remove_pci_id {
     record_info("Remove PCI ID", "Remove the first PCI ID in the table");
-    YaST::Module::open({module => 'system_settings', ui => 'qt'});
+    YaST::Module::open(module => 'system_settings', ui => 'qt');
     $system_settings->remove_pci_id();
+    YaST::Module::close(module => 'system_settings');
 }
 
 sub run {


### PR DESCRIPTION
- Related ticket: [poo#89938](https://progress.opensuse.org/issues/89938)
- Verification run: [yast2_gui & yast2_ncurses_gnome](https://openqa.suse.de/tests/overview?version=15-SP3&build=jknphy%2Fos-autoinst-distri-opensuse%23ensure_yast_module_closed&distri=sle)
