### PR TITLE
Adapt boottime and LTP tests for QAM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2827,48 +2827,66 @@ sub load_extra_tests_kernel {
     loadtest "kernel/tuned";
 }
 
-sub load_publiccloud_tests {
-    if (get_var('PUBLIC_CLOUD_PREPARE_TOOLS')) {
-        loadtest "publiccloud/prepare_tools";
-    }
-    elsif (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS') && !get_var('PUBLIC_CLOUD_QAM')) {
-        loadtest "publiccloud/img_proof";
-    }
-    elsif (get_var('PUBLIC_CLOUD_QAM')) {
-        loadtest "publiccloud/download_repos";
-        my $args = OpenQA::Test::RunArgs->new();
-        loadtest "publiccloud/ssh_interactive_init", run_args => $args;
-        loadtest "publiccloud/register_system",      run_args => $args;
-        loadtest "publiccloud/transfer_repos",       run_args => $args;
-        loadtest "publiccloud/patch_and_reboot",     run_args => $args;
-        if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
-            loadtest("publiccloud/img_proof", run_args => $args);
-        } else {
-            loadtest "publiccloud/ssh_interactive_start", run_args => $args;
-            loadtest "publiccloud/instance_overview" unless get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
+sub load_qam_publiccloud_tests {
+    my $args = OpenQA::Test::RunArgs->new();
+
+    loadtest "publiccloud/download_repos";
+    loadtest "publiccloud/ssh_interactive_init", run_args => $args;
+    loadtest "publiccloud/register_system",      run_args => $args;
+    loadtest "publiccloud/transfer_repos",       run_args => $args;
+    loadtest "publiccloud/patch_and_reboot",     run_args => $args;
+    if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
+        loadtest("publiccloud/img_proof", run_args => $args);
+    } elsif (get_var('PUBLIC_CLOUD_LTP')) {
+        loadtest('publiccloud/run_ltp', run_args => $args);
+    } elsif (get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME')) {
+        loadtest('publiccloud/boottime', run_args => $args);
+    } elsif (get_var('PUBLIC_CLOUD_FIO')) {
+        loadtest('publiccloud/storage_perf', run_args => $args);
+    } else {
+        loadtest "publiccloud/ssh_interactive_start", run_args => $args;
+        loadtest "publiccloud/instance_overview" unless get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
+        if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
             load_extra_tests_prepare();
-            load_extra_tests_docker()  if (get_var('PUBLIC_CLOUD_CONTAINERS'));
-            load_extra_tests_console() if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS'));
-            loadtest "publiccloud/ssh_interactive_end", run_args => $args;
+            load_extra_tests_console();
         }
+        if (get_var('PUBLIC_CLOUD_CONTAINERS')) {
+            load_extra_tests_prepare();
+            load_extra_tests_console();
+        }
+        # Finalize
+        loadtest("publiccloud/ssh_interactive_end", run_args => $args);
     }
-    elsif (get_var('PUBLIC_CLOUD_LTP')) {
-        loadtest 'publiccloud/run_ltp';
-    }
-    elsif (get_var('PUBLIC_CLOUD_SLES4SAP')) {
-        loadtest 'publiccloud/sles4sap';
-    }
-    elsif (get_var('PUBLIC_CLOUD_ACCNET')) {
-        loadtest 'publiccloud/az_accelerated_net';
-    }
-    elsif (get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME')) {
-        loadtest "publiccloud/boottime";
-    }
-    elsif (get_var('PUBLIC_CLOUD_FIO')) {
-        loadtest 'publiccloud/storage_perf';
-    }
-    elsif (get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) {
-        loadtest "publiccloud/upload_image";
+}
+
+sub load_publiccloud_tests {
+    if (get_var('PUBLIC_CLOUD_QAM')) {
+        load_qam_publiccloud_tests();
+    } else {
+        if (get_var('PUBLIC_CLOUD_PREPARE_TOOLS')) {
+            loadtest "publiccloud/prepare_tools";
+        }
+        elsif (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
+            loadtest "publiccloud/img_proof";
+        }
+        elsif (get_var('PUBLIC_CLOUD_LTP')) {
+            loadtest 'publiccloud/run_ltp';
+        }
+        elsif (get_var('PUBLIC_CLOUD_SLES4SAP')) {
+            loadtest 'publiccloud/sles4sap';
+        }
+        elsif (get_var('PUBLIC_CLOUD_ACCNET')) {
+            loadtest 'publiccloud/az_accelerated_net';
+        }
+        elsif (get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME')) {
+            loadtest "publiccloud/boottime";
+        }
+        elsif (get_var('PUBLIC_CLOUD_FIO')) {
+            loadtest 'publiccloud/storage_perf';
+        }
+        elsif (get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) {
+            loadtest "publiccloud/upload_image";
+        }
     }
 }
 


### PR DESCRIPTION
Adapt the boottime flavors, LTP and the publiccloud schedule to incorporate ltp and boottime into QAM test runs.

- Related ticket: https://progress.opensuse.org/issues/90083
- Verification run: [Azure-Latest](http://duck-norris.qam.suse.de/tests/5913) | [15-SP2-GCE-BYOS-Updates mau-extratests](http://duck-norris.qam.suse.de/tests/5920) | [15-SP2-EC2-Updates imgproof](http://duck-norris.qam.suse.de/tests/5929) | [15-SP2-GCE-Updates QAM New schema](http://duck-norris.qam.suse.de/tests/5922)