### PR TITLE
Add modules to btrfs_libstorage-ng and lvm+cancel_existing_cryptlvm

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -38,6 +38,8 @@ schedule:
   # Called on BACKEND: qemu
   - '{{grub_test}}'
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/check_resume
   - console/validate_no_cow_attribute
   # On all the backends except s390x, /home is located on a separate partition

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -26,6 +26,8 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/check_resume
   - console/validate_no_cow_attribute
   - console/verify_separate_home

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -27,6 +27,8 @@ schedule:
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/check_resume
   - console/validate_no_cow_attribute
   - console/verify_no_separate_home

--- a/schedule/yast/btrfs/btrfs_sle_libstorage.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage.yaml
@@ -35,6 +35,8 @@ schedule:
   # Called on BACKEND: qemu
   - '{{grub_test}}'
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/validate_no_cow_attribute
   # On all the architectures except s390x, /home is located on a separate partition
   - '{{validate_home_partition}}'

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -33,6 +33,8 @@ schedule:
   - boot/reconnect_mgmt_console
   - installation/grub_test
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/check_resume
   - console/verify_separate_home
   - console/validate_file_system

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -31,6 +31,8 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/validate_lvm
 test_data:
   enc_disk_part: vda2

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -32,6 +32,8 @@ schedule:
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/validate_lvm
 test_data:
   enc_disk_part: sda1


### PR DESCRIPTION
Schedule missing force_scheduled_tasks might be causing delays when SUT is attempting to switch tty for ppc.

- Related ticket: https://progress.opensuse.org/issues/90140
- Verification runs:
btrfs_libstorage-ng@64bit -> https://openqa.suse.de/t5779136
btrfs_libstorage-ng@s390x-kvm-sle12 -> https://openqa.suse.de/t5779137
btrfs_libstorage-ng@ppc64le -> https://openqa.suse.de/t5779138
btrfs_libstorage-ng@aarch64 -> https://openqa.suse.de/t5779139
btrfs_libstorage-ng@64bit-ipmi -> https://openqa.suse.de/t5779141
btrfs_libstorage-ng@ppc64le-hmc-single-disk -> https://openqa.suse.de/t5779142
btrfs_libstorage-ng@s390x-kvm-sle15 -> https://openqa.suse.de/t5779143
btrfs_libstorage-ng@s390x-zVM-vswitch-l2 -> https://openqa.suse.de/t5779144
btrfs_libstorage-ng@s390x-zVM-vswitch-l3 -> https://openqa.suse.de/t5779145
lvm+cancel_existing_cryptlvm@64bit -> https://openqa.suse.de/t5779146
lvm+cancel_existing_cryptlvm@ppc64le -> https://openqa.suse.de/t5779147
lvm+cancel_existing_cryptlvm@aarch64 -> https://openqa.suse.de/t5779148
lvm+cancel_existing_cryptlvm@ppc64le-hmc-single-disk -> https://openqa.suse.de/t5779149