### PR TITLE
Print container build files in serial console

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -45,7 +45,7 @@ sub build_container_image {
     assert_script_run("cd $dir");
 
     # Create basic Dockerfile
-    assert_script_run("echo -e 'FROM $image\nENV WORLD_VAR Arda' > Dockerfile");
+    assert_script_run("echo -e 'FROM $image\\nENV WORLD_VAR Arda' > Dockerfile");
 
     # Build the image
     assert_script_run("$runtime build -t dockerfile_derived .");

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -156,21 +156,14 @@ sub container_set_up {
     my ($dir, $file, $base) = @_;
     die "You must define the directory!"  unless $dir;
     die "You must define the Dockerfile!" unless $file;
-    my $basename_expected = script_run("grep baseimage_var $dir/BuildTest/$file");
-    die "Base image name is required for $file" if !$basename_expected && $base;
 
-    record_info "Dockerfile: $file";
-    assert_script_run("mkdir -p $dir/BuildTest");
+    record_info('Downloading', "Dockerfile: containers/$file\nApplication: containers/app.py\nRequirements: containers/requirements.txt\nTemplate: containers/index.html");
+    assert_script_run "mkdir -p $dir/BuildTest/templates";
     assert_script_run "curl -f -v " . data_url('containers/app.py') . " > $dir/BuildTest/app.py";
-    record_info('app.py', script_output("cat $dir/BuildTest/app.py"));
     assert_script_run "curl -f -v " . data_url("containers/$file") . " > $dir/BuildTest/Dockerfile";
     assert_script_run "sed -i 's,baseimage_var,$base,1' $dir/BuildTest/Dockerfile" if defined $base;
-    record_info('Dockerfile', script_output("cat $dir/BuildTest/Dockerfile"));
     assert_script_run "curl -f -v " . data_url('containers/requirements.txt') . " > $dir/BuildTest/requirements.txt";
-    record_info('requirements.txt', script_output("cat $dir/BuildTest/requirements.txt"));
-    assert_script_run("mkdir -p $dir/BuildTest/templates");
     assert_script_run "curl -f -v " . data_url('containers/index.html') . " > $dir/BuildTest/templates/index.html";
-
 }
 
 # Build the image


### PR DESCRIPTION
[cat error](https://progress.opensuse.org/attachments/11174/failure.jpg) shows up on non-qemu hypervisors only. This problem happens in `record_info` statements that are printing content of files stored in data directory are not really modified by the code.

* https://progress.opensuse.org/issues/90701
- Verification runs: 
   * [Build1.25-jeos-container-engines_and_tools@uefi-virtio-vga](http://kepler.suse.cz/tests/4231#)
   * [sle-15-SP3-JeOS-for-VMware-x86_64](https://openqa.suse.de/tests/5780087)
   * [sle-15-SP3-JeOS-for-MS-HyperV-x86_64](https://openqa.suse.de/tests/5779430#step/podman/86)
   * [svirt-xen-pv ](https://openqa.suse.de/tests/5785694)