### PR TITLE
publiccloud: Use serial_terminal to setup PC instance 

### DIFF
--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 our @ISA    = qw(Exporter);
-our @EXPORT = qw(ssh_interactive_tunnel ssh_interactive_join ssh_interactive_leave);
+our @EXPORT = qw(ssh_interactive_tunnel ssh_interactive_leave);
 
 sub ssh_interactive_tunnel {
     my ($instance) = @_;
@@ -40,18 +40,9 @@ sub ssh_interactive_tunnel {
 
     set_var('SERIALDEV_',               $serialdev);
     set_var('_SSH_TUNNELS_INITIALIZED', 1);
-}
 
-sub ssh_interactive_join {
-    # Open SSH interactive session and check the serial console works
-    enter_cmd("ssh -yt sut");
-    wait_serial("ssh_serial_ready", 90) if (get_var("AUTOINST_URL_HOSTNAME", '') !~ /localhost/);
-
-    # Prepare the environment to use the SSH tunnel for upload/download from the worker
     set_var('AUTOINST_URL_HOSTNAME', 'localhost');
     set_sshserial_dev();
-
-    $testapi::distri->set_standard_prompt('root');
 }
 
 sub ssh_interactive_leave {

--- a/lib/publiccloud/ssh_interactive_init.pm
+++ b/lib/publiccloud/ssh_interactive_init.pm
@@ -25,7 +25,7 @@ use warnings;
 use testapi;
 
 sub post_fail_hook {
-    select_host_console(await_console => 0);
+    select_host_console(force => 1);
     assert_script_run('cd /root/terraform');
     script_run('terraform destroy -no-color -auto-approve', 240);
 }

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -18,7 +18,6 @@ use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tu
 use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop);
 use Utils::Backends qw(has_serial_over_ssh set_sshserial_dev use_ssh_serial_console is_remote_backend);
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
-use publiccloud::ssh_interactive 'ssh_interactive_join';
 use Cwd;
 use autotest 'query_isotovideo';
 
@@ -840,7 +839,7 @@ sub activate_console {
     }
     if (get_var('TUNNELED') && $name !~ /tunnel/) {
         die "Console '$console' activated in TUNNEL mode activated but tunnel(s) are not yet initialized, use the 'tunnel' console and call 'setup_ssh_tunnels' first" unless get_var('_SSH_TUNNELS_INITIALIZED');
-        (get_var('PUBLIC_CLOUD')) ? ssh_interactive_join() : $self->script_run('ssh -t sut', 0);
+        $self->script_run('ssh -t sut', 0);
         ensure_user($user) unless (get_var('PUBLIC_CLOUD'));
     }
     set_var('CONSOLE_JUST_ACTIVATED', 1);

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -295,9 +295,7 @@ sub measure_timings {
         $instance         = $args->{my_instance};
         $provider         = $args->{my_provider};
         $self->{provider} = $args->{my_provider};    # required for cleanup
-        select_host_console();
     } else {
-        $self->select_serial_terminal;
         $provider = $self->provider_factory();
         $instance = $self->{my_instance} = $provider->create_instance(check_connectivity => 0);
     }
@@ -405,7 +403,7 @@ sub check_thresholds {
 
 sub run {
     my ($self, $args) = @_;
-    $self->select_serial_terminal;
+    select_host_console();
 
     my $results = $self->measure_timings($args);
     $self->store_in_db($results);

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -63,14 +63,14 @@ sub run {
                 record_soft_failure("Download failed (rc=$ret):\n$maintrepo");
                 script_run("echo 'Download failed for $maintrepo ...' >> ~/repos/qem_download_status.txt");
             } else {
-                assert_script_run("echo -en '# $maintrepo:\\n\\n' >> /tmp/repos.list.txt");
-                script_run("echo 'Downloaded $maintrepo: `du -hs $maintrepo`' >> ~/repos/qem_download_status.txt");
+                assert_script_run("echo -en '\\n" . ('#' x 80) . "\\n# $maintrepo:\\n' >> /tmp/repos.list.txt");
+                assert_script_run("echo 'Downloaded $maintrepo:' \$(du -hs $parent | cut -f1) >> ~/repos/qem_download_status.txt");
                 if (script_run("ls $parent*.repo") == 0) {
                     assert_script_run("sed -i \"1 s/\\]/_\$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 4)]/\" $parent*.repo");
                     assert_script_run("find $parent >> /tmp/repos.list.txt");
                 } else {
                     record_soft_failure("No .repo file found in $parent. This directory will be removed.");
-                    script_run("echo 'No .repo found for $maintrepo' >> ~/repos/qem_download_status.txt");
+                    assert_script_run("echo 'No .repo found for $maintrepo' >> ~/repos/qem_download_status.txt");
                     assert_script_run("rm -rf $parent");
                 }
             }
@@ -78,7 +78,7 @@ sub run {
 
         my $size = script_output("du -hs ~/repos");
         record_info("Repo size", "Total repositories size: $size");
-        script_run("echo 'Download completed' >> ~/repos/qem_download_status.txt");
+        assert_script_run("echo 'Download completed' >> ~/repos/qem_download_status.txt");
         upload_logs('/tmp/repos.list.txt');
         upload_logs('qem_download_status.txt');
     }

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -103,14 +103,14 @@ sub run {
     my $provider;
     my $instance;
 
+    select_host_console();
+
     # QAM passes the instance as argument
     if (get_var('PUBLIC_CLOUD_QAM')) {
         $instance         = $args->{my_instance};
         $provider         = $args->{my_provider};
         $self->{provider} = $args->{my_provider};    # required for cleanup
-        select_host_console();
     } else {
-        $self->select_serial_terminal;
         $provider = $self->provider_factory();
         $instance = $provider->create_instance();
     }

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -69,9 +69,8 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
+    select_host_console(force => 1);
     # Destroy the public cloud instance
-    ssh_interactive_leave();
-    select_host_console(await_console => 0);
     $self->{provider}->cleanup();
 }
 

--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -24,13 +24,13 @@ use publiccloud::utils qw(select_host_console is_ondemand);
 sub run {
     my ($self, $args) = @_;
 
+    select_host_console();    # select console on the host, not the PC instance
+
     if (is_ondemand) {
         # on OnDemand image we use `registercloudguest` to register and configure the repositories
         $args->{my_instance}->retry_ssh_command("sudo registercloudguest", timeout => 420, retry => 3);
     } else {
         my @addons = split(/,/, get_var('SCC_ADDONS', ''));
-
-        select_host_console();    # select console on the host, not the PC instance
 
         # note: ssh_script_retry dies on failure
         my $regcode = get_required_var('SCC_REGCODE');

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -53,13 +53,12 @@ sub run {
     my $provider;
     my $instance;
 
+    select_host_console();
+
     if (get_var('PUBLIC_CLOUD_QAM')) {
         $instance = $self->{my_instance} = $args->{my_instance};
         $provider = $self->{provider}    = $args->{my_provider};    # required for cleanup
-        select_host_console(await_console => 0);
-        assert_script_run("true");                                  # Ensure the host console is activated propely
     } else {
-        $self->select_serial_terminal;
         $provider = $self->provider_factory();
         $instance = $self->{my_instance} = $provider->create_instance();
         $instance->wait_for_guestregister();

--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -19,10 +19,7 @@ use utils;
 
 sub run {
     my ($self, $args) = @_;
-    select_console 'root-console';
-
-    ssh_interactive_leave();
-    select_host_console(await_console => 0);
+    select_host_console(force => 1);
     $args->{my_provider}->cleanup();
 }
 

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -16,17 +16,40 @@ use Mojo::Base 'publiccloud::ssh_interactive_init';
 use publiccloud::ssh_interactive;
 use testapi;
 use utils;
+use publiccloud::utils "select_host_console";
 
 sub run {
     my ($self, $args) = @_;
-    select_console 'tunnel-console';
+
+    # This ensure that we have used the setup console, even if no module was run before.
+    select_host_console();
+    my $setup_console = current_console();
 
     # Establish the tunnel (it will stay active in foreground and occupy this console!)
+    select_console('tunnel-console');
     ssh_interactive_tunnel($args->{my_instance});
 
-    # Switch to root-console and SSH to the instance
-    # every other loaded test must stay in root-console
-    select_console 'root-console';
+    # Enable ssh connection on setup console, this is done normally with the
+    # first activation hook in susedistribution:activate_console()
+    if ($setup_console !~ /tunnel/) {
+        select_console($setup_console);
+        script_run('ssh -t sut', timeout => 0);
+    }
+
+    die("expect ssh serial") unless (get_var('SERIALDEV') =~ /ssh/);
+
+    # Verify most important consoles
+    select_console('root-console');
+    assert_script_run('test -e /dev/' . get_var('SERIALDEV'));
+    assert_script_run('test $(id -un) == "root"');
+
+    select_console('user-console');
+    assert_script_run('test -e /dev/' . get_var('SERIALDEV'));
+    assert_script_run('test $(id -un) == "' . $testapi::username . '"');
+
+    $self->select_serial_terminal();
+    assert_script_run('test -e /dev/' . get_var('SERIALDEV'));
+    assert_script_run('test $(id -un) == "root"');
 }
 
 1;


### PR DESCRIPTION
This can speedup a usual extramau testrun from ~60min to ~30min.

Behavior:
  The function `select_host_console()` gives always a serial_terminal
  console on the **host** (not the Public Cloud instance).
  If this function is called, while TUNNELED is already setup, we die()
  unless the `force=>1` parameter is given, which kill the TUNNELED
  session.

  The trick is, that we call `select_serial_teriminal()` with `TUNNELED
  == 0` and do the `ssh -ty` hook after the preconfiguration is done.

- Related ticket: ???
- Verification run: ~https://openqa.suse.de/tests/5779825~
  - https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12236#issuecomment-816155083