### PR TITLE
Add system prepare modules to the schedule

### DIFF
--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -45,6 +45,8 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/validate_multipath
 test_data:
   <<: !include test_data/yast/multipath.yaml


### PR DESCRIPTION
We have modules to setup the load in order to have stable execution of
the test suites. Tests started to fail sporadically, so we should
schedule those.

See [poo#90140](https://progress.opensuse.org/issues/90140).

[Verification run](https://openqa.suse.de/tests/5786076).