### PR TITLE
Move upload_supportconfig_log() to utils and use it

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -26,6 +26,7 @@ use Exporter;
 use strict;
 use warnings;
 use utils;
+use upload_system_log 'upload_supportconfig_log';
 use version_utils;
 use testapi;
 use DateTime;
@@ -339,6 +340,8 @@ sub collect_virt_system_logs {
     assert_script_run 'for guest in `virsh list --all --name`; do virsh dumpxml $guest > /tmp/dumpxml/$guest.xml; done';
     assert_script_run 'tar czvf /tmp/dumpxml.tar.gz /tmp/dumpxml/';
     upload_asset '/tmp/dumpxml.tar.gz';
+
+    upload_system_log::upload_supportconfig_log();
 }
 
 # is_guest_online($guest) check if the given guests is online by probing for an open ssh port

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -33,6 +33,7 @@ use Data::Dumper;
 use XML::Writer;
 use IO::File;
 use utils 'script_retry';
+use upload_system_log 'upload_supportconfig_log';
 use proxymode;
 use version_utils 'is_sle';
 use virt_autotest_base;
@@ -294,7 +295,8 @@ sub upload_debug_log {
         script_run("xl dmesg > /tmp/xl-dmesg.log");
         virt_autotest_base::upload_virt_logs("/tmp/dmesg.log /var/log/libvirt /var/log/messages /var/log/xen /var/lib/xen/dump /tmp/xl-dmesg.log", "libvirt-virtual-network-debug-logs");
     }
-    virt_utils::upload_supportconfig_log;
+    upload_system_log::upload_supportconfig_log();
+    script_run("rm -rf scc_* nts_*");
 }
 
 sub check_guest_status {

--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -19,6 +19,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use upload_system_log 'upload_supportconfig_log';
 
 sub run {
     my $self = shift;
@@ -26,7 +27,7 @@ sub run {
 
     my $options = get_var('SUPPORTCOFIG_OPTIONS', '');
     assert_script_run "rm -rf nts_* scc_* ||:";
-    assert_script_run "supportconfig $options -t . -B test", 2000;
+    upload_supportconfig_log(file_name => 'test', options => $options, timeout => 2000);
 
     # bcc#1166774
     if (script_run("test -d scc_test") == 0) {

--- a/tests/remote_lab/poc.pm
+++ b/tests/remote_lab/poc.pm
@@ -16,15 +16,13 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-
+use upload_system_log 'upload_supportconfig_log';
 
 sub run {
     my ($self) = @_;
     select_console 'root-console';
     assert_script_run('hostname | grep -q suse1', fail_message => 'It seems we are not on the right remote SUT host');
-    assert_script_run('supportconfig',            600);
-    assert_script_run('mv $(ls -t /var/log/*.tbz | head -1) supportconfig.tbz');
-    upload_logs('supportconfig.tbz');
+    upload_supportconfig_log();
 }
 
 1;

--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -17,7 +17,7 @@ use warnings;
 use testapi;
 use lockapi;
 use mmapi;
-use virt_utils 'upload_supportconfig_log';
+use upload_system_log 'upload_supportconfig_log';
 use virt_autotest::utils qw(is_xen_host);
 
 sub run {
@@ -67,7 +67,8 @@ sub run {
     }
     my $logs = "/var/log/libvirt /var/log/messages $xen_logs";
     virt_autotest_base::upload_virt_logs($logs, "guest-migration-dst-logs");
-    virt_utils::upload_supportconfig_log;
+    upload_system_log::upload_supportconfig_log();
+    script_run("rm -rf scc_* nts_*");
     save_screenshot;
 
     #mark dst upload log done

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -30,7 +30,7 @@ use virt_autotest::utils;
 use version_utils qw(is_sle get_os_release);
 
 our @EXPORT
-  = qw(enable_debug_logging update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk upload_supportconfig_log get_guest_list remove_vm download_guest_assets restore_downloaded_guests is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles is_registered_sles);
+  = qw(enable_debug_logging update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk get_guest_list remove_vm download_guest_assets restore_downloaded_guests is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles is_registered_sles);
 
 sub enable_debug_logging {
 
@@ -390,16 +390,6 @@ sub remove_vm {
     if ($is_persistent_vm eq "yes") {
         assert_script_run("virsh undefine $vm", 30);
     }
-}
-
-
-sub upload_supportconfig_log {
-    my $datetab = script_output("date '+%Y%m%d%H%M%S'");
-    script_run("cd;supportconfig -t . -B supportconfig.$datetab", 600);
-    script_run("tar zcvfP supportconfig.$datetab.tar.gz *supportconfig.$datetab");
-    upload_logs("supportconfig.$datetab.tar.gz");
-    script_run("rm -rf *supportconfig.*");
-    save_screenshot;
 }
 
 # Download guest image and xml from a NFS location to local

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -26,7 +26,7 @@ sub run {
     $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
 
     # Ensure additional package is installed
-    zypper_call '-t in libvirt-client iputils nmap';
+    zypper_call '-t in libvirt-client iputils nmap supportutils';
 
     assert_script_run "mkdir -p /var/lib/libvirt/images/xen/";
 


### PR DESCRIPTION
Hello,

while trying to get the supportconfig archive from SUT I noticed
existing subroutine called `upload_supportconfig_log()` placed in
`tests/virt_autotest/guest_migration_dst.pm` so I refactored it and moved
into lib/utils.pm as I think it can be used in various placces. I also
updated all the places calling `supportconfig` to use this instead.

- Related ticket: [poo#88515](https://progress.opensuse.org/issues/88515)
- Verification run: [extratests2@64bit](http://pdostal-server.suse.cz/tests/11679) [qam-kvm-install@ipmi-javor](http://pdostal-server.suse.cz/tests/11649)
