### PR TITLE
Fix string expansion of 12-SP2 post-LTSS update repo

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -365,7 +365,7 @@ sub run {
     # https://progress.opensuse.org/issues/90522
     if (is_sle('=12-SP2')) {
         my $arch = get_var('ARCH');
-        zypper_call('ar -G -f http://dist.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP2-LTSS-ERICSSON/$arch/update/ 12-SP2-LTSS-ERICSSON');
+        zypper_call("ar -G -f http://dist.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP2-LTSS-ERICSSON/$arch/update/ 12-SP2-LTSS-ERICSSON");
     }
 
     my $repo        = get_var('KOTD_REPO');


### PR DESCRIPTION
Fix of missing string expansion in PR #12234 and #12238. Remember kids, always create a verification run before you merge.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/5789007
