### PR TITLE
SLE Micro 5.1: skip registration for DVD installation

### DIFF
--- a/schedule/sle-micro/containers.yaml
+++ b/schedule/sle-micro/containers.yaml
@@ -2,10 +2,14 @@ name:           sle_micro_containers
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  registration:
+    SCC_REGCODE:
+      - console/suseconnect_scc
 schedule:
-    - microos/disk_boot
-    - console/suseconnect_scc
-    - microos/toolbox
-    - containers/containers_3rd_party
-    - containers/podman
-    - containers/podman_image
+  - microos/disk_boot
+  - '{{registration}}'
+  - microos/toolbox
+  - containers/containers_3rd_party
+  - containers/podman
+  - containers/podman_image

--- a/schedule/sle-micro/dvd.yaml
+++ b/schedule/sle-micro/dvd.yaml
@@ -2,29 +2,33 @@ name:           sle_micro_dvd
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  registration:
+    SCC_REGCODE:
+      - installation/scc_registration
 schedule:
-    - installation/bootloader_start
-    - installation/welcome
-    - installation/accept_license
-    - installation/scc_registration
-    - installation/ntp_config_settings
-    - installation/user_settings_root
-    - installation/resolve_dependency_issues
-    - installation/installation_overview
-    - installation/disable_grub_timeout
-    - installation/start_install
-    - installation/await_install
-    - installation/logs_from_installation_system
-    - installation/reboot_after_installation
-    - microos/disk_boot
-    - console/textinfo
-    - microos/networking
-    - microos/libzypp_config
-    - microos/one_line_checks
-    - microos/services_enabled
-    - transactional/filesystem_ro
-    - transactional/transactional_update
-    - transactional/rebootmgr
-    - transactional/health_check
-    - microos/journal_check
-    - shutdown/shutdown
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - '{{registration}}'
+  - installation/ntp_config_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - microos/disk_boot
+  - console/textinfo
+  - microos/networking
+  - microos/libzypp_config
+  - microos/one_line_checks
+  - microos/services_enabled
+  - transactional/filesystem_ro
+  - transactional/transactional_update
+  - transactional/rebootmgr
+  - transactional/health_check
+  - microos/journal_check
+  - shutdown/shutdown

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -2,18 +2,22 @@ name:           sle_micro_raw_image
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  registration:
+    SCC_REGCODE:
+      - console/suseconnect_scc
 schedule:
-    - microos/disk_boot
-    - transactional/disable_grub
-    - console/suseconnect_scc
-    - microos/networking
-    - microos/libzypp_config
-    - microos/image_checks
-    - microos/one_line_checks
-    - microos/services_enabled
-    - transactional/filesystem_ro
-    - transactional/transactional_update
-    - transactional/rebootmgr
-    - transactional/health_check
-    - microos/journal_check
-    - shutdown/shutdown
+  - microos/disk_boot
+  - transactional/disable_grub
+  - '{{registration}}'
+  - microos/networking
+  - microos/libzypp_config
+  - microos/image_checks
+  - microos/one_line_checks
+  - microos/services_enabled
+  - transactional/filesystem_ro
+  - transactional/transactional_update
+  - transactional/rebootmgr
+  - transactional/health_check
+  - microos/journal_check
+  - shutdown/shutdown


### PR DESCRIPTION
The product is not yet known by SCC, so we need to skip registration
and suseconnect modules

- Related ticket: https://progress.opensuse.org/issues/90794
