### PR TITLE
Install shim and mokutil for JeOS aarch64 and RPi testing

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -83,16 +83,21 @@ sub prepare_for_kdump {
 
     # disable packagekitd
     quit_packagekit;
+    my @pkgs = qw(yast2-kdump kdump);
     if ($test_type eq 'before') {
         # On ppc64le, sometime the console font will be distorted into pseudo graphics characters.
         # we need to reset the console font.
         assert_script_run('/usr/lib/systemd/systemd-vconsole-setup') if check_var('ARCH', 'ppc64le');
-        zypper_call('in yast2-kdump kdump');
     }
     else {
-        zypper_call('in yast2-kdump kdump crash');
+        push @pkgs, qw(crash);
     }
-    zypper_call('in mokutil') if is_jeos && get_var('UEFI') && !check_var('ARCH', 'aarch64');
+
+    if (is_jeos && get_var('UEFI')) {
+        push @pkgs, is_aarch64 ? qw(mokutil shim) : qw(mokutil);
+    }
+
+    zypper_call "in @pkgs";
 
     return if ($test_type eq 'before');
 


### PR DESCRIPTION
Include _shim_ among pre-install packages for JeOS kvm aarch64 and RPi images.

- Related ticket: [[aarch64][rpi] test fails in kdump_and_crash - handle missing package installation dialogue](https://progress.opensuse.org/issues/90770)
- Verification runs:
  - [sle-15-SP3-JeOS-for-kvm-and-xen-aarch64](https://openqa.suse.de/tests/5790620#step/kdump_and_crash/71)
  - [sle-15-SP3-JeOS-for-RaspberryPi-aarch64](https://openqa.suse.de/tests/5790655#step/kdump_and_crash/71)
  - [jeos-extratest@uefi-virtio-vga](http://kepler.suse.cz/tests/4276#step/kdump_and_crash/1)
  - [jeos-extratest@64bit-virtio-vga](http://kepler.suse.cz/tests/4275#step/kdump_and_crash/1)
  - [jeos-extratest@svirt-xen-hvm](http://kepler.suse.cz/tests/4274#step/kdump_and_crash/1)