### PR TITLE
Enable POM structure and libyui for firstboot

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot.xml
@@ -67,4 +67,39 @@
         <timeout config:type="integer">0</timeout>
       </yesno_messages>
     </report>
+    <scripts>
+        <chroot-scripts config:type="list">
+            <script>
+            <chrooted config:type="boolean">true</chrooted>
+                <source>
+                    <![CDATA[#!/bin/bash
+                    # Enable libyui-rest-api in firstboot (requires an init script).
+                    for i in YUI_HTTP_PORT={{YUI_PORT}} YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1 Y2DEBUG=1; do
+                    echo "export $i" >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    done
+                    chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    ]]>
+                </source>
+            </script>
+        </chroot-scripts>
+        <post-scripts config:type="list">
+            <script>
+            <filename>install_libyui.sh</filename>
+            <interpreter>shell</interpreter>
+            <location/>
+            <feedback config:type="boolean">false</feedback>
+            <source><![CDATA[#!/bin/sh
+                # Regarding rpm lock see Q9@ https://documentation.suse.com/de-de/sles/15-SP1/html/SLES-all/app-ay-faq.html
+                # quote : "during the post-script phase, YaST still has an exclusive lock on the RPM database."
+                # the package cannot be installed the autoyast way, because of the package name (eg libyui-rest-api15)
+                # only zypper allows to install "by capability".
+                mv /var/run/zypp.pid /var/run/zypp.sav
+                zypper ar https://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-i586-x86_64-Snapshot{{BUILD}} tumb
+                zypper -n in libyui-rest-api
+                mv /var/run/zypp.sav /var/run/zypp.pid
+                systemctl disable firewalld
+                ]]></source>
+            </script>
+        </post-scripts>
+    </scripts>
 </profile>

--- a/data/autoyast_opensuse/autoyast_firstboot_leap.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot_leap.xml
@@ -70,4 +70,39 @@
         <timeout config:type="integer">0</timeout>
       </yesno_messages>
     </report>
+        <scripts>
+        <chroot-scripts config:type="list">
+            <script>
+            <chrooted config:type="boolean">true</chrooted>
+                <source>
+                    <![CDATA[#!/bin/bash
+                    # Enable libyui-rest-api in firstboot (requires an init script).
+                    for i in YUI_HTTP_PORT={{YUI_PORT}} YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1 Y2DEBUG=1; do
+                    echo "export $i" >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    done
+                    chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    ]]>
+                </source>
+            </script>
+        </chroot-scripts>
+        <post-scripts config:type="list">
+            <script>
+            <filename>install_libyui.sh</filename>
+            <interpreter>shell</interpreter>
+            <location/>
+            <feedback config:type="boolean">false</feedback>
+            <source><![CDATA[#!/bin/sh
+                # Regarding rpm lock see Q9@ https://documentation.suse.com/de-de/sles/15-SP1/html/SLES-all/app-ay-faq.html
+                # quote : "during the post-script phase, YaST still has an exclusive lock on the RPM database."
+                # the package cannot be installed the autoyast way, because of the package name (eg libyui-rest-api15)
+                # only zypper allows to install "by capability".
+                mv /var/run/zypp.pid /var/run/zypp.sav
+                zypper ar http://openqa.opensuse.org/assets/repo/openSUSE-Leap-{{VERSION}}-oss-Build{{BUILD}} leap
+                zypper -n in libyui-rest-api
+                mv /var/run/zypp.sav /var/run/zypp.pid
+                systemctl disable firewalld
+                ]]></source>
+            </script>
+        </post-scripts>
+    </scripts>
 </profile>

--- a/data/autoyast_sle15/autoyast_firstboot.xml
+++ b/data/autoyast_sle15/autoyast_firstboot.xml
@@ -20,6 +20,11 @@
           <arch>{{ARCH}}</arch>
         </addon>
         <addon>
+          <name>sle-module-development-tools</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+        <addon>
           <name>sle-module-desktop-applications</name>
           <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
@@ -34,6 +39,23 @@
     <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>
+      <firewall>
+        <zones config:type="list">
+            <zone>
+                <name>external</name>
+                <services config:type="list">
+                    <service>http</service>
+                    <service>https</service>
+                </services>
+                <ports config:type="list">
+                    <port>{{YUI_PORT}}/tcp</port>
+                </ports>
+            </zone>
+        </zones>
+        <log_denied_packets>off</log_denied_packets>
+        <enable_firewall config:type="boolean">false</enable_firewall>
+        <start_firewall config:type="boolean">false</start_firewall>
+    </firewall>
     <software>
         <products config:type="list">
             <product>SLES</product>
@@ -95,4 +117,37 @@
         <timeout config:type="integer">0</timeout>
       </yesno_messages>
     </report>
+    <scripts>
+        <chroot-scripts config:type="list">
+            <script>
+            <chrooted config:type="boolean">true</chrooted>
+                <source>
+                    <![CDATA[#!/bin/bash
+                    # Enable libyui-rest-api in firstboot (requires an init script).
+                    for i in YUI_HTTP_PORT={{YUI_PORT}} YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1 Y2DEBUG=1; do
+                    echo "export $i" >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    done
+                    chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api;
+                    ]]>
+                </source>
+            </script>
+        </chroot-scripts>
+        <post-scripts config:type="list">
+            <script>
+            <filename>install_libyui.sh</filename>
+            <interpreter>shell</interpreter>
+            <location/>
+            <feedback config:type="boolean">false</feedback>
+            <source><![CDATA[#!/bin/sh 
+                # Regarding rpm lock see Q9@ https://documentation.suse.com/de-de/sles/15-SP1/html/SLES-all/app-ay-faq.html
+                # quote : "during the post-script phase, YaST still has an exclusive lock on the RPM database."
+                # the package cannot be installed the autoyast way, because of the package name (eg libyui-rest-api15)
+                # only zypper allows to install "by capability".
+                mv /var/run/zypp.pid /var/run/zypp.sav
+                zypper -n in libyui-rest-api
+                mv /var/run/zypp.sav /var/run/zypp.pid
+                ]]></source>
+            </script>
+        </post-scripts>
+    </scripts>
 </profile>

--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -23,6 +23,7 @@ use Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerController;
 use YaST::NetworkSettings::v4_3::NetworkSettingsController;
 use Installation::SystemRole::SystemRoleController;
 use YaST::SystemSettings::SystemSettingsController;
+use YaST::Firstboot::FirstbootController;
 
 sub get_partitioner {
     return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
@@ -50,6 +51,10 @@ sub get_system_settings {
 
 sub get_suggested_partitioning() {
     return Installation::Partitioner::LibstorageNG::v4_3::SuggestedPartitioningController->new();
+}
+
+sub get_firstboot {
+    return YaST::Firstboot::FirstbootController->new();
 }
 
 1;

--- a/lib/YaST/Firstboot/FirstbootController.pm
+++ b/lib/YaST/Firstboot/FirstbootController.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Controller for firstboot wizard.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firstboot::FirstbootController;
+use strict;
+use warnings;
+use YuiRestClient;
+use YaST::Firstboot::GenericPage;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{GenericPage} = YaST::Firstboot::GenericPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_generic_page {
+    my ($self) = @_;
+    $self->{GenericPage};
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->get_generic_page->press_next();
+}
+
+1;

--- a/lib/YaST/Firstboot/GenericPage.pm
+++ b/lib/YaST/Firstboot/GenericPage.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Handle common parts in all firstboot pages.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firstboot::GenericPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->{btn_next} = $self->{app}->button({id => 'next'});
+    return $self;
+}
+
+sub press_next {
+    my ($self) = @_;
+    return $self->{btn_next}->click();
+}
+
+1;

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -135,4 +135,15 @@ sub set_libyui_backend_vars {
     set_var('YUI_SERVER', $server);
 }
 
+sub setup_libyui_firstboot {
+    my $port = get_var('YUI_PORT');
+    record_info("YUIPORT", "Port that will be used by libyui_rest_api:" . get_var('YUI_PORT'));
+    zypper_call('in libyui-rest-api');
+    assert_script_run "firewall-cmd --zone=public --add-port=$port/tcp --permanent";
+    foreach my $export ("YUI_HTTP_PORT=$port", "YUI_HTTP_REMOTE=1", "YUI_REUSE_PORT=1", "Y2DEBUG=1") {
+        assert_script_run "echo export $export >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api";
+    }
+    assert_script_run "chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api";
+}
+
 1;

--- a/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
@@ -15,6 +15,7 @@ schedule:
   - autoyast/prepare_profile
   - installation/isosize
   - installation/bootloader_start
+  - installation/setup_libyui
   - autoyast/installation
   - installation/yast2_firstboot
   - installation/first_boot

--- a/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
@@ -13,6 +13,7 @@ schedule:
   - autoyast/prepare_profile
   - installation/isosize
   - installation/bootloader_start
+  - installation/setup_libyui
   - autoyast/installation
   - installation/yast2_firstboot
   - installation/first_boot

--- a/schedule/yast/firstboot/yast2_firstboot.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot.yaml
@@ -10,6 +10,7 @@ schedule:
     - console/consoletest_setup
     - console/hostname
     - installation/enable_y2_firstboot
+    - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
     - installation/yast2_firstboot

--- a/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
@@ -12,6 +12,7 @@ schedule:
     - console/consoletest_setup
     - console/hostname
     - installation/enable_y2_firstboot
+    - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
     - installation/yast2_firstboot
@@ -25,5 +26,6 @@ test_data:
         - firstboot_hostname
         - firstboot_timezone
         - firstboot_user
+        - firstboot_finish
     custom_control_file: "firstboot_custom-opensuse.xml"
     sysconfig_firstboot: "sysconfig_firstboot"

--- a/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
@@ -12,6 +12,7 @@ schedule:
     - console/consoletest_setup
     - console/hostname
     - installation/enable_y2_firstboot
+    - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
     - installation/yast2_firstboot
@@ -25,5 +26,6 @@ test_data:
         - firstboot_hostname
         - firstboot_timezone
         - firstboot_user
+        - firstboot_finish
     custom_control_file: "firstboot_custom-sle.xml"
     sysconfig_firstboot: "sysconfig_firstboot"

--- a/test_data/yast/firstboot/yast2_firstboot.yaml
+++ b/test_data/yast/firstboot/yast2_firstboot.yaml
@@ -5,3 +5,4 @@ clients:
   - firstboot_timezone
   - firstboot_user
   - firstboot_root
+  - firstboot_finish

--- a/test_data/yast/firstboot/yast2_firstboot_sle.yaml
+++ b/test_data/yast/firstboot/yast2_firstboot_sle.yaml
@@ -6,3 +6,4 @@ clients:
   - firstboot_user
   - firstboot_root
   - firstboot_registration
+  - firstboot_finish

--- a/tests/installation/setup_libyui_firstboot.pm
+++ b/tests/installation/setup_libyui_firstboot.pm
@@ -1,0 +1,32 @@
+# Copyright © 2020 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Enable libyui for firstboot. Temporary module until
+# https://progress.opensuse.org/issues/90368 is done.
+
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "installbasetest";
+use registration "add_suseconnect_product";
+use version_utils "is_sle";
+
+sub run {
+    add_suseconnect_product('sle-module-development-tools') if is_sle;
+    YuiRestClient::setup_libyui_firstboot();
+}
+
+1;

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -50,13 +50,15 @@ sub firstboot_licenses {
 
 sub firstboot_welcome {
     my ($self, $custom_needle) = @_;
+    my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'welcome' . $custom_needle;
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    $firstboot->press_next();
 }
 
 sub firstboot_timezone {
+    my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'inst-timezone';
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    $firstboot->press_next();
 }
 
 sub firstboot_user {
@@ -74,17 +76,26 @@ sub firstboot_root {
 }
 
 sub firstboot_hostname {
+    my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'hostname';
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    $firstboot->press_next();
 }
 
 sub firstboot_registration {
+    my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'system_registered';
-    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    $firstboot->press_next();
+}
+
+sub firstboot_finish {
+    my ($self, $custom_needle) = @_;
+    assert_screen 'installation_completed' . $custom_needle;    # Should now be "Configuration_completed". Kept for historical reasons.
+    send_key $cmd{finish};
 }
 
 sub run {
-    my $self          = shift;
+    my $self = shift;
+    YuiRestClient::connect_to_app();
     my $test_data     = get_test_suite_data();
     my $custom_needle = $test_data->{custom_control_file} ? "_custom" : undef;
     foreach my $client (@{$test_data->{clients}}) {
@@ -93,8 +104,6 @@ sub run {
         my $client_method = \&{"$client"};
         $client_method->($self, $custom_needle);
     }
-    assert_screen 'installation_completed' . $custom_needle;    # Should now be "Configuration_completed". Kept for historical reasons.
-    send_key $cmd{finish};
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
4f74e655aaedad31d2e665c267aa15b6024415cf: Enable POM structure and libyui for firstboot

Create initial POM structure
Enable libyui in both autoyast and regular firstboot tests
Introduce asserting pages with debug_label rather than with random page elements (not working yet, see https://progress.opensuse.org/issues/89638 and https://progress.opensuse.org/issues/89866)

Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/716
- Verification run: 
[TW-firstboot](http://waaa-amazing.suse.cz/tests/14988) [TW-fisrtboot-custom](http://waaa-amazing.suse.cz/tests/14973) [TW-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14985) [LEAP-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14986) [LEAP-firstboot](http://waaa-amazing.suse.cz/tests/14976)
[SLE-firstboot](http://waaa-amazing.suse.cz/tests/14977) [SLE-firstboot-custom](http://waaa-amazing.suse.cz/tests/14978) [SLE-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14987) [SLE-firstboot-textmode](http://waaa-amazing.suse.cz/tests/14980)
