### PR TITLE
[WIP] Add more modules to firstboot_custom

### DIFF
--- a/data/autoyast_sle15/autoyast_firstboot.xml
+++ b/data/autoyast_sle15/autoyast_firstboot.xml
@@ -65,6 +65,7 @@
           <package>sles-release</package>
           <package>yast2-firstboot</package>
           <package>yast2-registration</package>
+          <!--<package>libyui-rest-api15</package>-->
         </packages>
         <patterns config:type="list">
           <pattern>apparmor</pattern>
@@ -77,7 +78,7 @@
           <pattern>minimal_base</pattern>
           <pattern>x11</pattern>
           <pattern>x11_enhanced</pattern>
-        </patterns>
+	</patterns>
     </software>
     <users config:type="list">
         <user>

--- a/data/yast2/firstboot/firstboot_custom-opensuse.xml
+++ b/data/yast2/firstboot/firstboot_custom-opensuse.xml
@@ -88,7 +88,7 @@
                 </module>
                 <module>
                     <label>Keyboard Layout</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_keyboard</name>
                 </module>
                 <module>
@@ -132,7 +132,7 @@
                 </module>
                 <module>
                     <label>NTP Client</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_ntp</name>
                 </module>
                 <module>

--- a/data/yast2/firstboot/firstboot_custom-sle.xml
+++ b/data/yast2/firstboot/firstboot_custom-sle.xml
@@ -80,7 +80,7 @@
                 </module>
                 <module>
                     <label>Keyboard Layout</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_keyboard</name>
                 </module>
                 <module>
@@ -110,7 +110,10 @@
                 <module>
                     <label>Network</label>
                     <name>inst_lan</name>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
+                    <arguments>
+                        <skip_detection config:type="boolean">true</skip_detection>
+                    </arguments>
                 </module>
                  <module>
                     <label>Automatic Configuration</label>
@@ -124,7 +127,7 @@
                 </module>
                 <module>
                     <label>NTP Client</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_ntp</name>
                 </module>
                 <module>

--- a/lib/YaST/Installer/GenericPage.pm
+++ b/lib/YaST/Installer/GenericPage.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+package YaST::Installer::GenericPage;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->{btn_next}           = $self->{app}->button({id => 'next'});
+    # $self->{debug_label} = $self->{app}->debug_label({debug_label => $debug_label}); # to be implemented as part of poo#89866
+    return $self;
+}
+
+sub assert_page {
+  return; # to be implemented as part of poo#89866
+}
+
+sub press_next {
+    my ($self) = @_;
+    return $self->{btn_next}->click();
+}
+
+1;

--- a/lib/YaST/Installer/InstallerController.pm
+++ b/lib/YaST/Installer/InstallerController.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Controller for firstboot page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Installer::InstallerController;
+use strict;
+use warnings;
+use YuiRestClient;
+use YaST::Installer::GenericPage;
+# use YaST::Installer::Firstboot::LanPage;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{GenericPage} = YaST::Installer::GenericPage->new({app => YuiRestClient::get_app()});
+#    $self->{LanPage} = YaST::Firstboot::LanPage->new({app => YuiRestPage::get_app()});
+    return $self;
+} 
+
+sub get_generic_page {
+    my ($self) = @_;
+    $self->{GenericPage};
+}
+
+sub get_lan_page {
+    my ($self) = @_;
+    $self->{LanPage};
+}
+    
+# sub inst_lan {
+#     my ($self) = @_;
+#     $self->{GenericPage}->assert_page('Network_settings');
+#     $self->get_lan_page->is_shown();
+#     $self->{GenericPage}->press_next();
+# }
+
+sub check_and_skip_page {
+    my ($self, $debug_label) = @_;
+    $self->get_generic_page->assert_page($debug_label);
+    $self->get_generic_page->press_next();
+}
+
+1;

--- a/lib/YaST/Installer/InstallerController.pm
+++ b/lib/YaST/Installer/InstallerController.pm
@@ -15,7 +15,9 @@ use strict;
 use warnings;
 use YuiRestClient;
 use YaST::Installer::GenericPage;
-# use YaST::Installer::Firstboot::LanPage;
+use YaST::Installer::LanPage;
+use YaST::Installer::KeyboardPage;
+use YaST::Installer::NTPPage;
 use testapi;
 
 sub new {
@@ -26,10 +28,12 @@ sub new {
 
 sub init {
     my ($self, $args) = @_;
-    $self->{GenericPage} = YaST::Installer::GenericPage->new({app => YuiRestClient::get_app()});
-#    $self->{LanPage} = YaST::Firstboot::LanPage->new({app => YuiRestPage::get_app()});
+    $self->{GenericPage}  = YaST::Installer::GenericPage->new({app => YuiRestClient::get_app()});
+    $self->{LanPage}      = YaST::Firstboot::LanPage->new({app => YuiRestClient::get_app()});
+    $self->{KeyboardPage} = YaST::Firstboot::KeyboardPage->new({app => YuiRestClient::get_app()});
+    $self->{NTPPage}      = YaST::Firstboot::NTPPage->new({app => YuiRestClient::get_app()});
     return $self;
-} 
+}
 
 sub get_generic_page {
     my ($self) = @_;
@@ -40,13 +44,34 @@ sub get_lan_page {
     my ($self) = @_;
     $self->{LanPage};
 }
-    
-# sub inst_lan {
-#     my ($self) = @_;
-#     $self->{GenericPage}->assert_page('Network_settings');
-#     $self->get_lan_page->is_shown();
-#     $self->{GenericPage}->press_next();
-# }
+
+sub get_NTP_page {
+    my ($self) = @_;
+    $self->{NTPPage};
+}
+
+sub get_keyboard_page {
+    my ($self) = @_;
+    $self->{KeyboardPage};
+}
+
+sub inst_lan {
+    my ($self) = @_;
+    $self->get_lan_page->is_shown();
+    $self->get_generic_page->press_next();
+}
+
+sub NTP_page {
+    my ($self) = @_;
+    $self->get_NTP_page->is_shown();
+    $self->get_generic_page->press_next();
+}
+
+sub keyboard_page {
+    my ($self) = @_;
+    $self->get_keyboard_page->is_shown();
+    $self->get_generic_page->press_next();
+}
 
 sub check_and_skip_page {
     my ($self, $debug_label) = @_;

--- a/lib/YaST/Installer/KeyboardPage.pm
+++ b/lib/YaST/Installer/KeyboardPage.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-package YaST::Installer::GenericPage;
+package YaST::Firstboot::KeyboardPage;
 use strict;
 use warnings;
 use testapi;
@@ -22,18 +22,15 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{btn_next} = $self->{app}->button({id => 'next'});
-    # $self->{debug_label} = $self->{app}->debug_label({debug_label => $debug_label}); # to be implemented as part of poo#89866
+    $self->{selectionbox} = $self->{app}->selectionbox({id => 'layout_list'});
     return $self;
 }
 
-sub assert_page {
-    return;    # to be implemented as part of poo#89866
-}
-
-sub press_next {
+sub is_shown {
     my ($self) = @_;
-    return $self->{btn_next}->click();
+    # Just check if we can select the first listed interface.
+    $self->{selectionbox}->exist();
+    save_screenshot;
 }
 
 1;

--- a/lib/YaST/Installer/LanPage.pm
+++ b/lib/YaST/Installer/LanPage.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-package YaST::Installer::GenericPage;
+package YaST::Firstboot::LanPage;
 use strict;
 use warnings;
 use testapi;
@@ -22,18 +22,15 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{btn_next} = $self->{app}->button({id => 'next'});
-    # $self->{debug_label} = $self->{app}->debug_label({debug_label => $debug_label}); # to be implemented as part of poo#89866
+    $self->{tbl_devices} = $self->{app}->table({id => '"Y2Network::Widgets::InterfacesTable"'});
     return $self;
 }
 
-sub assert_page {
-    return;    # to be implemented as part of poo#89866
-}
-
-sub press_next {
+sub is_shown {
     my ($self) = @_;
-    return $self->{btn_next}->click();
+    # Just check if we can select the first listed interface.
+    $self->{tbl_devices}->exist();
+    save_screenshot;
 }
 
 1;

--- a/lib/YaST/Installer/NTPPage.pm
+++ b/lib/YaST/Installer/NTPPage.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-package YaST::Installer::GenericPage;
+package YaST::Firstboot::NTPPage;
 use strict;
 use warnings;
 use testapi;
@@ -22,18 +22,14 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{btn_next} = $self->{app}->button({id => 'next'});
-    # $self->{debug_label} = $self->{app}->debug_label({debug_label => $debug_label}); # to be implemented as part of poo#89866
+    $self->{radiobutton_sync} = $self->{app}->radiobutton({id => 'sync'});
     return $self;
 }
 
-sub assert_page {
-    return;    # to be implemented as part of poo#89866
-}
-
-sub press_next {
+sub is_shown {
     my ($self) = @_;
-    return $self->{btn_next}->click();
+    $self->{radiobutton_sync}->exist();
+    save_screenshot;
 }
 
 1;

--- a/schedule/yast/firstboot/yast2_firstboot.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot.yaml
@@ -13,6 +13,7 @@ schedule:
     - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
+    - boot/check_libyui_firstboot
     - installation/yast2_firstboot
     - installation/first_boot
     - console/validate_yast2_firstboot_configuration

--- a/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
@@ -15,6 +15,7 @@ schedule:
     - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
+    - boot/check_libyui_firstboot
     - installation/yast2_firstboot
     - installation/first_boot
     - console/validate_yast2_firstboot_configuration

--- a/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
@@ -22,10 +22,12 @@ schedule:
 test_data:
     clients:
         - firstboot_language_keyboard
+        - firstboot_keyboard
         - firstboot_welcome
         - firstboot_licenses
         - firstboot_hostname
         - firstboot_timezone
+        - firstboot_NTP
         - firstboot_user
         - firstboot_finish
     custom_control_file: "firstboot_custom-opensuse.xml"

--- a/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
@@ -22,10 +22,13 @@ schedule:
 test_data:
     clients:
         - firstboot_language_keyboard
+        - firstboot_keyboard
         - firstboot_welcome
         - firstboot_licenses
         - firstboot_hostname
+        - firstboot_inst_lan
         - firstboot_timezone
+        - firstboot_NTP
         - firstboot_user
         - firstboot_finish
     custom_control_file: "firstboot_custom-sle.xml"

--- a/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
@@ -15,6 +15,7 @@ schedule:
     - installation/setup_libyui_firstboot
     - autoyast/autoyast_reboot
     - installation/grub_test
+    - boot/check_libyui_firstboot
     - installation/yast2_firstboot
     - installation/first_boot
     - console/validate_yast2_firstboot_configuration

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -190,6 +190,9 @@ sub run {
             send_key 'ret';    # press enter if grub timeout is disabled, like we have in reinstall scenarios
             last;              # if see grub, we get to the second stage, as it appears after bios-boot which we may miss
         }
+        elsif (match_has_tag('linuxrc-start-shell-after-installation')) {
+            type_string_slow "exit\n";
+        }
         elsif (match_has_tag('import-untrusted-gpg-key')) {
             handle_untrusted_gpg_key;
             @needles = grep { $_ ne 'import-untrusted-gpg-key' } @needles;

--- a/tests/boot/check_libyui_firstboot.pm
+++ b/tests/boot/check_libyui_firstboot.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Check that libyui is available before firstboot
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base 'bootbasetest';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    YuiRestClient::connect_to_app();
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/tests/installation/enable_y2_firstboot.pm
+++ b/tests/installation/enable_y2_firstboot.pm
@@ -18,6 +18,7 @@ use testapi;
 use utils qw(zypper_call clear_console);
 use scheduler 'get_test_suite_data';
 
+
 sub run {
     my $test_data = get_test_suite_data();
     my $base_path = "yast2/firstboot/";

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -36,6 +36,16 @@ sub firstboot_language_keyboard {
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
 }
 
+sub firstboot_keyboard {
+    my $firstboot = $testapi::distri->get_firstboot();
+    $firstboot->keyboard_page();
+}
+
+sub firstboot_NTP {
+    my $firstboot = $testapi::distri->get_firstboot();
+    $firstboot->NTP_page();
+}
+
 sub firstboot_licenses {
     my ($self, $custom_needle) = @_;
     # default TO value was not sufficient


### PR DESCRIPTION
464491dc7871823a1b99f824a37c4f72fb74b926: add 3 new clients in firstboot_custom (see https://progress.opensuse.org/issues/73474)

- Needles: 
- Verification run: 
[TW-firstboot](http://waaa-amazing.suse.cz/tests/14947) [TW-fisrtboot-custom](http://waaa-amazing.suse.cz/tests/14954) [TW-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14946) [LEAP-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14949) [LEAP-firstboot](http://waaa-amazing.suse.cz/tests/14950)
[SLE-firstboot](http://waaa-amazing.suse.cz/tests/14943) [SLE-firstboot-custom](http://waaa-amazing.suse.cz/tests/14944) [SLE-firstboot-autoyast](http://waaa-amazing.suse.cz/tests/14952) [SLE-firstboot-textmode](http://waaa-amazing.suse.cz/tests/14945)