### PR TITLE
Autoapply LTP whitelist to duplicate test runs

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -57,6 +57,7 @@ sub override_known_failures {
         @issues = @{$issues->{$suite}};
     }
     else {
+        $test =~ s/_postun$//g if check_var('KGRAFT', 1) && check_var('UNINSTALL_INCIDENT', 1);
         return unless exists $issues->{$suite}->{$test};
         @issues = @{$issues->{$suite}->{$test}};
     }


### PR DESCRIPTION
Automatically apply whitelist for `${test}` to `${test}_postun` during livepatch uninstall test jobs. It's the same test, just running after the livepatch has been reverted to previous version.

- Related ticket: https://progress.opensuse.org/issues/80788
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/5791732
