### PR TITLE
Increase time to wait for password prompt in ha-cluster-join

### DIFF
--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -60,7 +60,7 @@ sub run {
     wait_for_password_prompt(needle => 'ha-cluster-join-password', timeout => $join_timeout);
     type_password;
     send_key 'ret';
-    if (check_var('TWO_NODES', 'no') && wait_for_password_prompt(needle => 'ha-cluster-join-3nodes-password', timeout => 60, failok => 1)) {
+    if (check_var('TWO_NODES', 'no') && wait_for_password_prompt(needle => 'ha-cluster-join-3nodes-password', timeout => 150, failok => 1)) {
         type_password;
         send_key 'ret';
     }


### PR DESCRIPTION
[Changes introduced in crmsh](https://openqa.suse.de/tests/5791490#step/ha_cluster_join/8) include a 120s wait time in the cluster bootstrap scripts for some scenarios (more than 3 cluster nodes, for example). Current test code waits at most 60s for the second password prompt when setting up a cluster with more than 3 nodes which is not enough if this prompt takes longer to be shown.

- Related ticket: N/A
- Failing Test: https://openqa.suse.de/tests/5791490#step/ha_cluster_join/8
- Needles: N/A
- Verification run: N/A
