### PR TITLE
SLE Micro: skip registration for image installation

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro.xml
+++ b/data/autoyast_sle15/autoyast_sle-micro.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
-    <do_registration config:type="boolean">true</do_registration>
+    <do_registration config:type="boolean">false</do_registration>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <install_updates config:type="boolean">true</install_updates>
+    <install_updates config:type="boolean">false</install_updates>
     <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <bootloader>

--- a/schedule/sle-micro/autoyast.yaml
+++ b/schedule/sle-micro/autoyast.yaml
@@ -2,8 +2,6 @@ name:           sle_micro_autoyast
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
-vars:
-    AUTOYAST: autoyast_sle15/autoyast_sle-micro_50.xml
 schedule:
     - autoyast/prepare_profile
     - installation/bootloader_start

--- a/schedule/sle-micro/containers.yaml
+++ b/schedule/sle-micro/containers.yaml
@@ -2,10 +2,15 @@ name:           sle_micro_containers
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  registration:
+    SCC_REGISTER:
+      'installation':
+        - console/suseconnect_scc
 schedule:
-    - microos/disk_boot
-    - console/suseconnect_scc
-    - microos/toolbox
-    - containers/containers_3rd_party
-    - containers/podman
-    - containers/podman_image
+  - microos/disk_boot
+  - '{{registration}}'
+  - microos/toolbox
+  - containers/containers_3rd_party
+  - containers/podman
+  - containers/podman_image

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -2,18 +2,23 @@ name:           sle_micro_raw_image
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  registration:
+    SCC_REGISTER:
+      'installation':
+        - console/suseconnect_scc
 schedule:
-    - microos/disk_boot
-    - transactional/disable_grub
-    - console/suseconnect_scc
-    - microos/networking
-    - microos/libzypp_config
-    - microos/image_checks
-    - microos/one_line_checks
-    - microos/services_enabled
-    - transactional/filesystem_ro
-    - transactional/transactional_update
-    - transactional/rebootmgr
-    - transactional/health_check
-    - microos/journal_check
-    - shutdown/shutdown
+  - microos/disk_boot
+  - transactional/disable_grub
+  - '{{registration}}'
+  - microos/networking
+  - microos/libzypp_config
+  - microos/image_checks
+  - microos/one_line_checks
+  - microos/services_enabled
+  - transactional/filesystem_ro
+  - transactional/transactional_update
+  - transactional/rebootmgr
+  - transactional/health_check
+  - microos/journal_check
+  - shutdown/shutdown


### PR DESCRIPTION
As the product SLE Micro 5.1 does not exist yet in SCC, we should
skip SUSEConnect module.

- Related ticket: https://progress.opensuse.org/issues/90794
