### PR TITLE
LTP: Adapt paths on 32bit to /opt/ltp-32 prefix

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -29,11 +29,12 @@ use version_utils 'is_jeos';
 use File::Basename 'basename';
 
 our @EXPORT = qw(
+  get_ltproot
+  init_ltp_tests
   loadtest_kernel
-  shutdown_ltp
   prepare_ltp_env
   schedule_tests
-  init_ltp_tests
+  shutdown_ltp
 );
 
 sub loadtest_kernel {
@@ -46,11 +47,15 @@ sub shutdown_ltp {
     loadtest_kernel('shutdown_ltp', @_);
 }
 
+sub get_ltproot {
+    return get_required_var('TEST_SUITE_NAME') =~ m/[-_]m32$/ ? '/opt/ltp-32' : '/opt/ltp';
+}
+
 # Set up basic shell environment for running LTP tests
 sub prepare_ltp_env {
     my $ltp_env = get_var('LTP_ENV');
 
-    assert_script_run('export LTPROOT=/opt/ltp; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
+    assert_script_run('export LTPROOT=' . get_ltproot() . '; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 
     # setup for LTP networking tests
     assert_script_run("export PASSWD='$testapi::password'");
@@ -265,7 +270,7 @@ sub parse_runfiles {
                 $cmd_pattern, $cmd_exclude, $test_result_export, $suffix);
         }
         else {
-            parse_runtest_file($name, read_runfile("/opt/ltp/runtest/$name"),
+            parse_runtest_file($name, read_runfile(get_ltproot() . "/runtest/$name"),
                 $cmd_pattern, $cmd_exclude, $test_result_export, $suffix);
         }
     }

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -177,8 +177,10 @@ sub install_from_git {
     my $url         = get_var('LTP_GIT_URL', 'https://github.com/linux-test-project/ltp');
     my $rel         = get_var('LTP_RELEASE');
     my $timeout     = (is_aarch64 || is_s390x) ? 7200 : 1440;
-    my $configure   = './configure --with-open-posix-testsuite --with-realtime-testsuite';
+    my $prefix      = get_ltproot();
+    my $configure   = "./configure --with-open-posix-testsuite --with-realtime-testsuite --prefix=$prefix";
     my $extra_flags = get_var('LTP_EXTRA_CONF_FLAGS', '');
+
     if ($rel) {
         $rel = ' -b ' . $rel;
     }
@@ -195,7 +197,7 @@ sub install_from_git {
     assert_script_run 'make -j$(getconf _NPROCESSORS_ONLN)', timeout => $timeout;
     script_run 'export CREATE_ENTRIES=1';
     assert_script_run 'make install', timeout => 360;
-    assert_script_run "find /opt/ltp -name '*.run-test' > ~/openposix-test-list";
+    assert_script_run "find $prefix -name '*.run-test' > ~/openposix-test-list";
 }
 
 sub want_stable {
@@ -227,7 +229,7 @@ sub install_from_repo {
 
     zypper_call("in --recommends $pkg");
     script_run "rpm -qi $pkg | tee /opt/ltp_version";
-    assert_script_run q(find /opt/ltp/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > ~/openposix-test-list);
+    assert_script_run "find " . get_ltproot() . q(/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > ~/openposix-test-list);
 }
 
 sub setup_network {

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -20,6 +20,7 @@ use utils;
 use repo_tools 'generate_version';
 use Mojo::UserAgent;
 use publiccloud::utils "is_byos";
+use LTP::utils "get_ltproot";
 
 our $root_dir = '/root';
 
@@ -82,7 +83,7 @@ sub run {
     my $runltp_ng_repo   = get_var("LTP_RUN_NG_REPO",   "https://github.com/metan-ucw/runltp-ng.git");
     my $runltp_ng_branch = get_var("LTP_RUN_NG_BRANCH", "master");
     assert_script_run("git clone -q --single-branch -b $runltp_ng_branch --depth 1 $runltp_ng_repo");
-    $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh', timeout => 300);
+    $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 ' . get_ltproot() . '/IDcheck.sh', timeout => 300);
     record_info('Kernel info', $instance->run_ssh_command(cmd => q(rpm -qa 'kernel*' --qf '%{NAME}\n' | sort | uniq | xargs rpm -qi)));
 
     my $reset_cmd     = $root_dir . '/restart_instance.sh ' . $self->instance_log_args();


### PR DESCRIPTION
We decided to configure LTP intel 32bit packages in OBS/IBS to install into /opt/ltp-32. Thus adapt LTP prefix in tests when installing from package.

To be consistent also configure this prefix for LTP installation from git (compilation).

Verification run:
**SLE 15-SP3** (using `20210407.7ce5bf9c6`)
- install_ltp 32bit from package http://quasar.suse.cz/tests/6347
- install_ltp 64bit from package http://quasar.suse.cz/tests/6323
- install_ltp 32bit from git http://quasar.suse.cz/tests/6333
- install_ltp 64bit from git http://quasar.suse.cz/tests/6336
- ltp_syscalls_m32 http://quasar.suse.cz/tests/6348

**Tumbleweed** (using `20210407.7ce5bf9c6`)
- install_ltp 32bit from package http://quasar.suse.cz/tests/6331
- install_ltp 64bit from package http://quasar.suse.cz/tests/6324
- install_ltp 32bit from git http://quasar.suse.cz/tests/6337
- install_ltp 64bit from git http://quasar.suse.cz/tests/6335
- ltp_syscalls_m32 http://quasar.suse.cz/tests/6338