### PR TITLE
IPMI: Create GPT partition table after wiping drives

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1348,16 +1348,20 @@ sub prepare_disks {
     my $disks = script_output('lsblk -n -l -o NAME -d -e 7,11');
     for my $d (split('\n', $disks)) {
         script_run "wipefs -af /dev/$d";
-        if (get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_CANCEL_EXISTING'))
-        {
+        script_run "sync";
+        if (get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_CANCEL_EXISTING')) {
             create_encrypted_part(disk => $d);
             if (get_var('ETC_PASSWD') && get_var('ETC_SHADOW')) {
                 mimic_user_to_import(disk => $d,
                     passwd => get_var('ETC_PASSWD'),
                     shadow => get_var('ETC_SHADOW'));
             }
+        } else {
+            script_run "parted /dev/$d mklabel gpt";
+            script_run "sync";
         }
     }
+    script_run "lsblk";
 }
 
 1;


### PR DESCRIPTION
Hello,

this is follow up to #12025 as the installer still does not approach partitioning properly:
After calling the `wipefs` in [boot_from_pxe](http://openqa.qam.suse.cz/tests/19312/modules/boot_from_pxe/steps/21) test fails at [partitioning_firstdisk](http://openqa.qam.suse.cz/tests/19312/modules/partitioning_firstdisk/steps/6).

- Related ticket: [poo#81096](https://progress.opensuse.org/issues/81096)
- Verification run: [qam-xen-install@SLE12-SP5](http://openqa.qam.suse.cz/tests/19401)
