### PR TITLE
Update softfail in machinery test case

### DIFF
--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -24,14 +24,14 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    if (zypper_call('in machinery', exitcode => [0, 4]) == 4) {
-        if (is_sle) {
+    if (zypper_call 'in machinery', exitcode => [0, 4]) {
+        my $reported_pkgs_regex = q[(builder|kramdown)];
+        if (is_sle && !script_run(q{grep -E 'nothing\s+provides.*rubygem\(ruby.*} . $reported_pkgs_regex . q{\)' /var/log/zypper.log})) {
             record_soft_failure 'bsc#1124304 - Dependency of machinery missing (dep is in HA module)';
+            return;
+        } else {
+            die "Newly found missing dependency, please report in bsc#1124304!\n";
         }
-        elsif (is_opensuse) {
-            record_soft_failure 'boo#1142975 - Dependency of machinery missing in TW';
-        }
-        return;
     }
     validate_script_output 'machinery --help', sub { m/machinery - A systems management toolkit for Linux/ }, 100;
     if (get_var('ARCH') =~ /aarch64|ppc64le/ && \


### PR DESCRIPTION
Softfail only in case of known missing dependencies appea (rubygem(ruby:2.5.0:builder) and rubygem(ruby:2.5.0:kramdown))

- VRs:
  * [sle-15-Server-DVD-Updates-x86_64-Build20210407-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/4305#step/machinery/21)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build1.26-jeos-base+phub@uefi-virtio-vga](http://kepler.suse.cz/tests/4306#step/machinery/21)
