### PR TITLE
LTP install both 32bit and 64bit package for QE devel + cleanup

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -30,6 +30,7 @@ use File::Basename 'basename';
 
 our @EXPORT = qw(
   get_ltproot
+  get_ltp_version_file
   init_ltp_tests
   loadtest_kernel
   prepare_ltp_env
@@ -48,7 +49,18 @@ sub shutdown_ltp {
 }
 
 sub get_ltproot {
-    return get_required_var('TEST_SUITE_NAME') =~ m/[-_]m32$/ ? '/opt/ltp-32' : '/opt/ltp';
+    # TEST_SUITE_NAME is for running 32bit tests (e.g. ltp_syscalls_m32),
+    # checking LTP_PKG is for install_ltp.pm which also uses prepare_ltp_env()
+    my $want_32bit = shift // (get_required_var('TEST_SUITE_NAME') =~ m/[-_]m32$/
+          || get_var('LTP_PKG', '') =~ m/^(ltp|qa_test_ltp)-32bit$/);
+
+    return $want_32bit ? '/opt/ltp-32' : '/opt/ltp';
+}
+
+sub get_ltp_version_file {
+    my $want_32bit = shift // get_required_var('TEST_SUITE_NAME') =~ m/[-_]m32$/;
+
+    return get_ltproot($want_32bit) . '/version';
 }
 
 # Set up basic shell environment for running LTP tests
@@ -203,7 +215,9 @@ sub schedule_tests {
     if ($ver_linux_out =~ qr'^Gnu C\s*(.*?)\s*$'m) {
         $environment->{gcc} = $1;
     }
-    $environment->{ltp_version}        = script_output('touch /opt/ltp_version; cat /opt/ltp_version');
+
+    my $file = get_ltp_version_file();
+    $environment->{ltp_version}        = script_output("touch $file; cat $file");
     $test_result_export->{environment} = $environment;
 
     if ($cmd_file =~ m/ltp-aiodio.part[134]/) {

--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -217,7 +217,9 @@ sub schedule_tests {
     }
 
     my $file = get_ltp_version_file();
-    $environment->{ltp_version}        = script_output("touch $file; cat $file");
+    $environment->{ltp_version} = script_output("touch $file; cat $file");
+    record_info("LTP version", $environment->{ltp_version});
+
     $test_result_export->{environment} = $environment;
 
     if ($cmd_file =~ m/ltp-aiodio.part[134]/) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -197,7 +197,8 @@ sub install_from_git {
     assert_script_run "find $prefix -name '*.run-test' > ~/openposix-test-list";
 
     # It is a shallow clone so 'git describe' won't work
-    script_run 'git log -1 --pretty=format:"git-%h" | tee ' . get_ltp_version_file();
+    record_info("LTP git", script_output('git log -1 --pretty=format:"git-%h" | tee '
+              . get_ltp_version_file()));
 }
 
 sub add_ltp_repo {
@@ -236,7 +237,8 @@ sub install_from_repo {
 
     for my $pkg (@pkgs) {
         my $want_32bit = $pkg =~ m/32bit/;
-        script_run "rpm -qi $pkg | tee " . get_ltp_version_file($want_32bit);
+        record_info("LTP pkg: $pkg", script_output("rpm -qi $pkg | tee "
+                  . get_ltp_version_file($want_32bit)));
         assert_script_run "find " . get_ltproot($want_32bit) .
           q(/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > ~/openposix-test-list);
     }

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -405,27 +405,6 @@ Runtime dependencies are needed to be listed both in this module (for git
 installation) and for all LTP rpm packages (for installation from repo), where
 listed as 'Recommends:'. See list of available LTP packages in LTP_PKG section.
 
-=head2 Example
-
-Example SLE test suite configuration for installation from repository:
-
-BOOT_HDD_IMAGE=1
-DESKTOP=textmode
-HDD_1=SLES-%VERSION%-%ARCH%-minimal_with_sdk_installed.qcow2
-INSTALL_LTP=from_repo
-ISO=SLE-%VERSION%-Server-DVD-%ARCH%-Build%BUILD%-Media1.iso
-ISO_1=SLE-%VERSION%-SDK-DVD-%ARCH%-Build%BUILD_SDK%-Media1.iso
-ISO_2=SLE-%VERSION%-WE-DVD-%ARCH%-Build%BUILD_WE%-Media1.iso
-PUBLISH_HDD_1=SLES-%VERSION%-%ARCH%-minimal_with_ltp_installed.qcow2
-QEMUCPUS=4
-QEMURAM=4096
-RUN_AFTER_TEST=sles12_minimal_base+sdk_create_hdd
-
-For openSUSE the configuration should be simpler as you can install git and the
-other dev tools from the main repository. You just need a text mode installation
-image to boot from (a graphical one will probably work as well). Depending how
-OpenQA is configured the ISO variable may not be necessary either.
-
 =head2 INSTALL_LTP
 
 Either should contain 'git' or 'repo'. Git is recommended for now. If you decide
@@ -472,6 +451,7 @@ Install both 64bit and 32bit LTP packages from nightly build.
 This is the default on x86_64 for QA for SLE product development and Tumbleweed.
 
 =head3 Available LTP packages
+
 https://confluence.suse.com/display/qasle/LTP+repositories
 
 * QA:Head/qa_test_ltp (IBS, stable - latest release, used for released products testing)
@@ -481,9 +461,6 @@ https://github.com/SUSE/qa-testsuites
 
 * QA:Head/ltp (IBS, nightly build)
 https://build.suse.de/package/show/QA:Head/ltp
-
-* benchmark/ltp (OBS, stable - latest release)
-https://build.opensuse.org/package/show/benchmark/ltp
 
 * benchmark:ltp:devel/ltp (OBS, nightly build)
 https://build.opensuse.org/package/show/benchmark:ltp:devel/ltp
@@ -504,5 +481,102 @@ Overrides the official LTP GitHub repository URL.
 
 Append custom group entries with appended group param via
 add_custom_grub_entries().
+
+=head2 SLES CONFIGURATION
+
+=head3 install_ltp+sle+Online
+
+BOOT_HDD_IMAGE=1
+DESKTOP=textmode
+GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb;slub_debug=FZPU
+HDD_1=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2
+INSTALL_LTP=from_repo
+LTP_PKG=ltp ltp-32bit
+PUBLISH_HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp.qcow2
+PUBLISH_PFLASH_VARS=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp-uefi-vars.qcow2
+QEMUCPUS=4
+QEMURAM=4096
+START_AFTER_TEST=create_hdd_minimal_base+sdk
+UEFI_PFLASH_VARS=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed-uefi-vars.qcow2
+
+=head3 install_ltp+sle+Online-KOTD
+
+BOOT_HDD_IMAGE=1
+DESKTOP=textmode
+GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb;slub_debug=FZPU
+HDD_1=%KOTD_HDD%
+INSTALL_KOTD=1
+INSTALL_LTP=from_repo
+LTP_PKG=ltp ltp-32bit
+PUBLISH_HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp.qcow2
+PUBLISH_PFLASH_VARS=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp-uefi-vars.qcow2
+QEMUCPUS=4
+QEMURAM=4096
+UEFI_PFLASH_VARS=%DISTRI%-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed-uefi-vars.qcow2
+
+=head3 install_ltp_spvm
+
+BOOT_HDD_IMAGE=1
+DESKTOP=textmode
+GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb
+INSTALL_LTP=from_repo
+NOVIDEO=1
+START_DIRECTLY_AFTER_TEST=default_kernel_spvm
+
+=head3 install_ltp_baremetal
+
+DESKTOP=textmode
+GA_REPO=http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
+GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb;slub_debug=FZPU
+GRUB_TIMEOUT=300
+INSTALL_LTP=from_repo
+LTP_PKG=ltp ltp-32bit
+START_DIRECTLY_AFTER_TEST=prepare_baremetal
+VNC_TYPING_LIMIT=50
+
+=head3 install_ltp+sle+Server-DVD-Incidents-Kernel-KOTD
+
+Incidents Kernel (released products) use qa_test_ltp package.
+
+BOOT_HDD_IMAGE=1
+DESKTOP=textmode
+GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb
+HDDSIZEGB=60
+HDD_1=SLES-%VERSION%-%ARCH%-minimal_installed_for_LTP.qcow2
+INSTALL_LTP=from_repo
+PUBLISH_HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp.qcow2
+PUBLISH_PFLASH_VARS=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp-uefi-vars.qcow2
+QEMUCPUS=4
+QEMURAM=4096
+UEFI_PFLASH_VARS=SLES-%VERSION%-%ARCH%-minimal_installed_for_LTP-uefi-vars.qcow2
+
+=head2 JeOS
+
+JeOS does not use install_ltp, it installs LTP for each runtest file.
+
+=head3 jeos-ltp-syscalls
+
+INSTALL_LTP=from_repo
+LTP_COMMAND_EXCLUDE=quotactl(01|04|06)|msgstress(03|04)
+LTP_COMMAND_FILE=syscalls
+SCC_ADDONS=base
+YAML_SCHEDULE=schedule/jeos/sle/jeos-ltp.yaml
+
+=head2 openSUSE CONFIGURATION
+
+=head3 install_ltp+opensuse+DVD
+
+BOOT_HDD_IMAGE=1
+DESKTOP=textmode
+GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb
+HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2
+INSTALL_LTP=from_repo
+LTP_ENV=LVM_DIR=/var/tmp/
+PUBLISH_HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp.qcow2
+PUBLISH_PFLASH_VARS=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp-uefi-vars.qcow2
+QEMUCPUS=4
+QEMURAM=4096
+START_AFTER_TEST=create_hdd_textmode
+UEFI_PFLASH_VARS=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2
 
 =cut

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -200,10 +200,6 @@ sub install_from_git {
     assert_script_run "find $prefix -name '*.run-test' > ~/openposix-test-list";
 }
 
-sub want_stable {
-    return get_var('LTP_STABLE', is_sle && is_released);
-}
-
 sub add_ltp_repo {
     my $repo = get_var('LTP_REPOSITORY');
 
@@ -225,7 +221,7 @@ sub add_ltp_repo {
 }
 
 sub install_from_repo {
-    my $pkg = get_var('LTP_PKG', (want_stable && is_sle) ? 'qa_test_ltp' : 'ltp');
+    my $pkg = get_var('LTP_PKG', (is_sle && is_released) ? 'qa_test_ltp' : 'ltp');
 
     zypper_call("in --recommends $pkg");
     script_run "rpm -qi $pkg | tee /opt/ltp_version";
@@ -426,10 +422,9 @@ platforms which do not support QCOW2 image snapshot (PowerVM, s390x backend).
 
 =head2 LTP_REPOSITORY
 
-When installing from repository default repository URL is generated (for SLES
+When installing from repository the default repository URL is generated (for SLES
 uses QA head repository in IBS, using QA_HEAD_REPO variable; for openSUSE
-Tumbleweed benchmark repository in OBS), with respect whether stable or nightly
-build LTP is required (see LTP_STABLE). Variable allows to use custom repository.
+Tumbleweed benchmark repository in OBS). Variable allows to use custom repository.
 When defined, it requires LTP_PKG to be set properly.
 
 Examples (these are set by default):
@@ -439,12 +434,6 @@ QA head repository for SLE12 SP5.
 
 https://download.opensuse.org/repositories/benchmark:/ltp:/devel/openSUSE_Tumbleweed_PowerPC
 Nightly build for openSUSE Tumbleweed ppc64le.
-
-=head2 LTP_STABLE
-
-When defined and installing from repository stable release. Default is stable
-for SLES QAM, otherwise nightly builds.
-NOTE: openSUSE does not have LTP stable package, only nightly builds.
 
 =head2 LTP_PKG
 
@@ -462,7 +451,7 @@ Stable LTP package in QA head repository.
 =head3 Available LTP packages
 https://confluence.suse.com/display/qasle/LTP+repositories
 
-* QA:Head/qa_test_ltp (IBS, stable - latest release, used by QAM)
+* QA:Head/qa_test_ltp (IBS, stable - latest release, used for released products testing)
 https://build.suse.de/package/show/QA:Head/qa_test_ltp
 Configured via
 https://github.com/SUSE/qa-testsuites

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -221,10 +221,12 @@ sub add_ltp_repo {
 }
 
 sub get_default_pkg {
-    my $pkg = 'ltp';
+    if (is_sle) {
+        return 'qa_test_ltp qa_test_ltp-32bit' if (is_released);
+        return 'ltp'                           if (is_jeos);
+    }
 
-    return 'qa_test_ltp' if (is_sle && is_released);
-    return $pkg;
+    return is_x86_64 ? 'ltp ltp-32bit' : 'ltp';
 }
 
 sub install_from_repo {
@@ -461,9 +463,11 @@ LTP_EXTRA_CONF_FLAGS="CFLAGS=-m32 LDFLAGS=-m32").
 
 LTP_PKG=qa_test_ltp
 Stable LTP package in QA head repository.
+This is the default for QA for SLE released products.
 
 LTP_PKG=ltp ltp-32bit
 Install both 64bit and 32bit LTP packages from nightly build.
+This is the default on x86_64 for QA for SLE product development and Tumbleweed.
 
 =head3 Available LTP packages
 https://confluence.suse.com/display/qasle/LTP+repositories


### PR DESCRIPTION
* Install also ltp-32bit for QA of the development
* Allow install more than one package in LTP_PKG
* Cleanup: drop `LTP_STABLE`
* Log LTP version with record_info()

Motivation for installing also ltp-32bit for QA of the development
Since b19aa7a99 LTP packages can be installed both 32bit and 64bit on
the same system. Installing both of them helps to avoid having special
job for QEMU: install_ltp+sle+Online-m32, install_ltp_baremetal_m32
(osd) and install_ltp+opensuse+DVD-m32 (o3) when installing from
packages. This speedup mainly baremetal testing, but also saves space
(drop extra QCOW2 image used just for 32bit LTP package).

These jobs for 32bit packages still needs to be used for LTP compilation
from git testing (which is not used for production, but just for
development or LTP prerelease testing).

Installation from git stays the same, installing only single chosen
version (due significant slow down).

Verification run:
* QE devel installing both packages `ltp ltp-32bit`: http://quasar.suse.cz/tests/6480 http://quasar.suse.cz/tests/6481
* QE released product installs `qa_test_ltp` by default: http://quasar.suse.cz/tests/6482#step/install_ltp/49
* `LTP_PKG` defined still works: `ltp ltp-32bit`: http://quasar.suse.cz/tests/6483, `ltp-32bit`: http://quasar.suse.cz/tests/6488
* LTP version with record_info(): install_ltp package: http://quasar.suse.cz/tests/6483#step/install_ltp/49 http://quasar.suse.cz/tests/6483#step/install_ltp/61 (both versions),  http://quasar.suse.cz/tests/6490#step/install_ltp/49 http://quasar.suse.cz/tests/6485#step/install_ltp/51 (single version jeOS), install_ltp git: http://quasar.suse.cz/tests/6489#step/boot_ltp/69 http://quasar.suse.cz/tests/6486#step/install_ltp/182 http://quasar.suse.cz/tests/6487#step/install_ltp/196

Done: https://build.suse.de/request/show/239213 https://build.opensuse.org/request/show/884059 https://github.com/SUSE/qa-testsuites/pull/950
