### PR TITLE
GNOME 40: handle new activities behaviour for opensuse-welcome

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -387,7 +387,8 @@ Also handle workarounds when needed.
 =cut
 sub handle_welcome_screen {
     my (%args) = @_;
-    assert_screen([qw(opensuse-welcome opensuse-welcome-boo1169203)], $args{timeout});
+    assert_screen([qw(opensuse-welcome opensuse-welcome-boo1169203 opensuse-welcome-gnome40-activities)], $args{timeout});
+    send_key 'esc'                              if match_has_tag('opensuse-welcome-gnome40-activities');
     workaround_broken_opensuse_welcome_window() if match_has_tag("opensuse-welcome-boo1169203");
     untick_welcome_on_next_startup;
 }


### PR DESCRIPTION
To handle the new behaviour of GNOME 40 which puts you in the activities mode on first boot, meaning something needs to give opensuse-welcome focus to be able to do the rest of the test

Pressing `esc` seems like the easiest way of doing that

Needles already created