### PR TITLE
Initialize both arguments of record_info in container tests

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -215,7 +215,7 @@ sub test_container_image {
             assert_script_run("buildah inspect --format='{{.FromImage}}' $image | grep '$image'");
         }
         my $container = script_output("buildah from $image");
-        record_info $container;
+        record_info 'Container', qq[Testing:\nContainer "$container" based on image "$image"];
         assert_script_run("buildah run $container $smoketest");
     } else {
         # Pull the image if necessary

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -110,7 +110,7 @@ sub build_with_zypper_docker {
 
     # The zypper-docker works only on openSUSE or on SLE based image on SLE host
     unless (($host_id =~ 'sles' && $image_id =~ 'sles') || $image_id =~ 'opensuse') {
-        record_info 'The zypper-docker only works for openSUSE based images and SLE based images on SLE host.';
+        record_info 'Warning!', 'The zypper-docker only works for openSUSE based images and SLE based images on SLE host.';
         return;
     }
 
@@ -135,7 +135,7 @@ sub build_with_zypper_docker {
     my $local_images_list = script_output("$runtime image ls");
     die("$runtime $derived_image not found") unless ($local_images_list =~ $derived_image);
 
-    record_info("Testing derived");
+    record_info("Testing derived", "Derived image: $derived_image");
     test_opensuse_based_image(image => $derived_image, runtime => $runtime);
 }
 
@@ -272,7 +272,7 @@ sub test_zypper_on_container {
         # Verify the image works
         assert_script_run("$runtime run --rm refreshed-image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
     }
-    record_info "zypper test completed";
+    record_info "The End", "zypper test completed";
 }
 
 sub ensure_container_rpm_updates {

--- a/lib/containers/runtime.pm
+++ b/lib/containers/runtime.pm
@@ -44,7 +44,7 @@ sub build {
     die 'wrong number of arguments' if @_ < 3;
     #TODO add build with URL https://docs.docker.com/engine/reference/commandline/build/
     $self->_rt_assert_script_run("build -f $dockerfile_path/Dockerfile -t $container_tag $dockerfile_path", 300);
-    record_info "$container_tag created";
+    record_info "$container_tag created", "";
 }
 
 =head2 up


### PR DESCRIPTION
```
[2021-04-09T10:48:47.777 CEST] [debug] <<< testapi::record_info(title="sle15-working-container", output=undef, result="ok")
Use of uninitialized value $_[0] in join or string at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/File.pm line 141.
```

- Related ticket: [[VMware][hyperv] test fails in buildah_docker](https://progress.opensuse.org/issues/90701)
- Verification runs: 
  * [sle-15-SP1-JeOS-for-MS-HyperV-x86_64](https://openqa.suse.de/tests/5796505)
  * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64](https://openqa.suse.de/tests/5796504)
  * [sle-15-SP3-JeOS-for-VMware-x86_64](https://openqa.suse.de/tests/5796506)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64](https://openqa.suse.de/tests/5796509)
