### PR TITLE
Add basic systemtap tests

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -129,6 +129,7 @@ schedule:
     - console/shells
     - console/sudo
     - console/dstat
+    - console/systemtap
     - x11/evolution/evolution_prepare_servers
     - console/mutt
     - '{{sle_tests}}'

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -29,6 +29,7 @@ schedule:
   - console/suse_module_tools
   - console/aaa_base
   - console/gd
+  - console/systemtap
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:

--- a/tests/console/systemtap.pm
+++ b/tests/console/systemtap.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Basic systemtap functions
+# * Test simple hello world
+# * Test stap-server output
+# * Test simple probing
+# Maintainer: Anastasiadis Vasileios <vasilios.anastasiadis@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use kdump_utils;
+use version_utils qw(is_sle);
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    prepare_for_kdump();
+    zypper_call("in systemtap systemtap-docs kernel-devel systemtap-server");
+    assert_script_run("stap /usr/share/doc/packages/systemtap/examples/general/helloworld.stp | grep 'hello world'");
+    assert_script_run("stap-server condrestart | grep --line-buffered \"managed\"");
+    assert_script_run("stap -v -e 'probe vfs.read {printf(\"read performed\\n\"); exit()}'");
+}
+
+1;


### PR DESCRIPTION
A module testing simple systemtap functions. Namely, a simple Hello World function, basic systemtap-server command and simple probing command.

- Related ticket: https://progress.opensuse.org/issues/48977
- Needles:
- Verification run: [SLE15SP3](http://10.161.229.232/tests/168#step/systemtap/1) | [SLE15SP2](http://10.161.229.232/tests/164#step/systemtap/1) | [SLE15SP1](http://10.161.229.232/tests/172#step/systemtap/1) | [SLE15GA](http://10.161.229.232/tests/173#step/systemtap/1) | [SLE12SP2](http://10.161.229.232/tests/71#step/systemtap/1) | [SLE12SP3](http://10.161.229.232/tests/174#step/systemtap/1) [SLE12SP4](http://10.161.229.232/tests/175#step/systemtap/1) | [SLE12SP5](http://10.161.229.232/tests/176#step/systemtap/1)
