### PR TITLE
 Send a "up" key to refresh serial output to avoid the grub2 screen missing sometimes.

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -179,7 +179,12 @@ sub boot_hmc_pvm {
     # don't wait for it, otherwise we miss the menu
     type_string "mkvterm -m $hmc_machine_name --id $lpar_id\n";
     # skip further preperations if system is already installed
-    return if get_var('BOOT_HDD_IMAGE');
+    # PowerVM, send "up" key to refresh the serial terminal in case
+    # it is already entered into grub2 menu
+    if (get_var('BOOT_HDD_IMAGE')) {
+        send_key('up');
+        return;
+    }
     get_into_net_boot;
     prepare_pvm_installation;
 }


### PR DESCRIPTION
As the grub page already showup, then connect serial console, it cannot
get the grub page. Send up key to refresh the serial output

- Related ticket: https://progress.opensuse.org/issues/90806
- Verification run: 
Need refresh case: http://openqa.suse.de/t5802147
                               http://openqa.suse.de/t5802148
Don't need refresh:  http://openqa.suse.de/t5802149
                               http://openqa.suse.de/t5802150