### PR TITLE
Fix service check's console services ncurses font issue at bashrc file

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -84,14 +84,7 @@ sub prepare_for_kdump {
     # disable packagekitd
     quit_packagekit;
     my @pkgs = qw(yast2-kdump kdump);
-    if ($test_type eq 'before') {
-        # On ppc64le, sometime the console font will be distorted into pseudo graphics characters.
-        # we need to reset the console font.
-        assert_script_run('/usr/lib/systemd/systemd-vconsole-setup') if check_var('ARCH', 'ppc64le');
-    }
-    else {
-        push @pkgs, qw(crash);
-    }
+    push @pkgs, qw(crash);
 
     if (is_jeos && get_var('UEFI')) {
         push @pkgs, is_aarch64 ? qw(mokutil shim) : qw(mokutil);

--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -231,6 +231,9 @@ sub install_services {
     my ($service) = @_;
     # turn off lmod shell debug information
     assert_script_run('echo export LMOD_SH_DBG_ON=1 >> /etc/bash.bashrc.local');
+    # On ppc64le, sometime the console font will be distorted into pseudo graphics characters.
+    # we need to reset the console font. As it impacted all the console services, added this command to bashrc file
+    assert_script_run('echo /usr/lib/systemd/systemd-vconsole-setup >> /etc/bash.bashrc.local') if check_var('ARCH', 'ppc64le');
     assert_script_run '. /etc/bash.bashrc.local';
     foreach my $s (sort keys %$service) {
         my $srv_pkg_name  = $service->{$s}->{srv_pkg_name};


### PR DESCRIPTION
On ppc64le, sometimes the console font will be distorted into pseudo graphics characters.
We need to reset the console font to fix it. As it impacted all the console services, added this command to bashrc file
Before it only put the code to fix kdump problem. Now all the console service has this problem, put this command to bashrc file, so it can fix all console font problem.


  -  Related ticket: https://progress.opensuse.org/issues/90518
  -  Verification run: https://openqa.suse.de/tests/5767536#
