### PR TITLE
Check old version exist in legacy module for PostgreSQL12

### DIFF
--- a/tests/console/check_package_version.pm
+++ b/tests/console/check_package_version.pm
@@ -30,6 +30,11 @@ my %package = (
     python3      => '3.6.0',
     mariadb      => '10.0.0'
 );
+
+my %locpak = (
+    postgresql12 => "SLE-Module-Legacy"
+);
+
 sub cmp_version {
     my ($old, $new) = @_;
     my @newv = split(qr/-|\+/, $new);
@@ -47,12 +52,20 @@ sub cmp_packages {
     for my $line (split(/\r?\n/, $output)) {
         if (trim($line) =~ m/^\d+\.\d+(\.\d+)?/) {
             $out = $line;
-            record_soft_failure("The $pcks version is $out, but request is $pckv") if (!cmp_version($pckv, $out));
+            record_info("Package version", "The $pcks version is $out, but request is $pckv", result => 'fail') if (!cmp_version($pckv, $out));
         }
     }
     if ($out eq '') {
-        record_soft_failure("The $pcks is not existed");
+        record_info("Package version", "The $pcks is not existed", result => 'fail');
     }
+}
+
+sub loc_packages {
+    my ($pac, $loc) = @_;
+    record_info($pac, "$pac check package location");
+    my $output = script_output("zypper se -xs $pac | grep -w $pac | head -1 | awk -F '|' '{print \$6}'", 100, proceed_on_failure => 1);
+    diag "location:" . $output;
+    record_info("Location", "$loc doesn't have package $pac", result => 'fail') if ($output !~ /$loc/);
 }
 
 sub run {
@@ -61,6 +74,10 @@ sub run {
 
     foreach my $key (keys %package) {
         my $pcks = cmp_packages($key, $package{$key});
+    }
+
+    foreach my $key (keys %locpak) {
+        loc_packages($key, $locpak{$key});
     }
 
 }


### PR DESCRIPTION
Check old version exist in legacy module for PostgreSQL12

- Related ticket: https://progress.opensuse.org/issues/89818
- Verification run: https://openqa.suse.de/tests/5802157#step/check_package_version/23