### PR TITLE
Remove systemtap from tumbleweed and SLE15-SP3

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -129,7 +129,6 @@ schedule:
     - console/shells
     - console/sudo
     - console/dstat
-    - console/systemtap
     - x11/evolution/evolution_prepare_servers
     - console/mutt
     - '{{sle_tests}}'


### PR DESCRIPTION
The new systemtap test is [failing in Tumbleweed](https://openqa.opensuse.org/tests/1696741#step/systemtap/1).
It will be removed until fixed.