### PR TITLE
Increase ltp test timeout per 900 sec

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -93,6 +93,7 @@ sub run {
 
     my $cmd = 'perl -I runltp-ng runltp-ng/runltp-ng ';
     $cmd .= '--logname=ltp_log ';
+    $cmd .= '--timeout=900 ';
     $cmd .= '--run ' . get_required_var('COMMAND_FILE') . ' ';
     $cmd .= '--exclude \'' . get_required_var('COMMAND_EXCLUDE') . '\' ';
     $cmd .= '--backend=ssh';


### PR DESCRIPTION
I am told that the writev03 takes ~520 sec to run.                                                                                                                                                                                           
So i tested it with 900 sec (as the kernel/run_ltp by default)                                                                                                                                                                              
and works.    

- Verification run: https://openqa.suse.de/tests/5805177
