### PR TITLE
Set textmode system role on pvm

### DIFF
--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -9,6 +9,7 @@ description:    >
 vars:
   DESKTOP: textmode
   ENABLE_ALL_SCC_MODULES: 1
+  SYSTEM_ROLE: textmode
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/test_data/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/test_data/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -8,7 +8,6 @@ software:
     - base
     - devel_yast
     - enhanced_base
-    - fonts
     - x11
     - yast2_basis
     - yast2_desktop


### PR DESCRIPTION
The commit adds 'SYSTEM_ROLE: textmode' openQA variable to
select_modules_and_patterns for pvm to select the textmode system role
during installation.

**Please, also merge Job Group Settings:** https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/348
- Related ticket: https://progress.opensuse.org/issues/88615
- Verification runs: https://openqa.suse.de/tests/overview.html?version=15-SP3&groupid=96&build=172.3_oorlov&distri=sle
