### PR TITLE
Add schedule for PC download test

### DIFF
--- a/schedule/publiccloud/qem_publiccloud_download_testrepos.yml
+++ b/schedule/publiccloud/qem_publiccloud_download_testrepos.yml
@@ -1,0 +1,9 @@
+---
+name: qem_publiccloud_download_testrepos
+description: |
+  Download QAM test repositories to local the helper openQA instance.
+  Those updates will later on be transferred to the PC instance.
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/download_repos
+  - shutdown/shutdown


### PR DESCRIPTION
Adds the YAML schedule for the test of downloading the test repos for publiccloud test runs.

- Related ticket: https://progress.opensuse.org/issues/90965
- Verification run: http://duck-norris.qam.suse.de/tests/5922