### PR TITLE
Fix libyui REST API setup in firstboot test suites

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot.xml
@@ -94,7 +94,7 @@
                 # the package cannot be installed the autoyast way, because of the package name (eg libyui-rest-api15)
                 # only zypper allows to install "by capability".
                 mv /var/run/zypp.pid /var/run/zypp.sav
-                zypper ar https://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-i586-x86_64-Snapshot{{BUILD}} tumb
+                zypper ar {{MIRROR_HTTP}} OSS
                 zypper -n in libyui-rest-api
                 mv /var/run/zypp.sav /var/run/zypp.pid
                 systemctl disable firewalld

--- a/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
@@ -8,12 +8,13 @@ description:    >
   Firstboot.
 vars:
   AUTOYAST: autoyast_sle15/autoyast_firstboot.xml
+  AY_EXPAND_VARS: YUI_PORT
   DESKTOP: gnome
   NOAUTOLOGIN: 1
   YAST2_FIRSTBOOT_USERNAME: firstbootuser
+  YUI_REST_API: 1
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - autoyast/installation

--- a/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
@@ -9,9 +9,10 @@ description:    >
 vars:
   DESKTOP: gnome
   YAST2_FIRSTBOOT_USERNAME: firstbootuser
+  AY_EXPAND_VARS: YUI_PORT,BUILD,VERSION
+  YUI_REST_API: 1
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - autoyast/installation

--- a/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
@@ -9,7 +9,7 @@ description:    >
 vars:
   DESKTOP: gnome
   YAST2_FIRSTBOOT_USERNAME: firstbootuser
-  AY_EXPAND_VARS: YUI_PORT,BUILD,VERSION
+  AY_EXPAND_VARS: YUI_PORT,MIRROR_HTTP
   YUI_REST_API: 1
 schedule:
   - autoyast/prepare_profile

--- a/schedule/yast/firstboot/yast2_firstboot.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot.yaml
@@ -4,6 +4,7 @@ description:    >
     Smoke test for YaST2 firstboot module
 vars:
     YAST2_FIRSTBOOT_USERNAME: firstbootuser
+    YUI_REST_API: 1
 schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data

--- a/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
@@ -6,6 +6,7 @@ description:    >
     It also allows to see if we can use custom parameters in /etc/sysconfig/firstboot
 vars:
     YAST2_FIRSTBOOT_USERNAME: firstbootuser
+    YUI_REST_API: 1
 schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data

--- a/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
@@ -6,6 +6,7 @@ description:    >
     It also allows to see if we can use custom parameters in /etc/sysconfig/firstboot
 vars:
     YAST2_FIRSTBOOT_USERNAME: firstbootuser
+    YUI_REST_API: 1
 schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data


### PR DESCRIPTION
We have missed couple of settings, which are mandatory for the libyui RESTAPI.

Also introducing minor improvements, like using `MIRROR_HTTP` instead of partly hardcoded repo mirror.

See [poo#73474](https://progress.opensuse.org/issues/73474).

### Verification runs
* [TW AY](https://openqa.opensuse.org/tests/1697945)
* [TW firstboot](https://openqa.opensuse.org/tests/1696775)
* [TW firstboot custom](https://openqa.opensuse.org/t1697954)
* [SLE AY](https://openqa.suse.de/tests/5811404)
* [SLE firstboot](https://openqa.suse.de/t5811882)
* [SLE firstboot custom](https://openqa.suse.de/tests/5812000)