### PR TITLE
boot_to_desktop: close activities screen of GNOME 40+

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1040,6 +1040,10 @@ sub wait_boot_past_bootloader {
         last if $ret;
         $timeout -= $check_interval;
     }
+    # Starting with GNOME 40, upon login, the activities screen is open (assuming the
+    # user will want to start something. For openQA, we simply press 'esc' to close
+    # it again and really end up on the desktop
+    send_key('esc') if match_has_tag('gnome-activities');
     # if we reached a logged in desktop we are done here
     return 1 if match_has_tag('generic-desktop') || match_has_tag('opensuse-welcome');
     # the last check after previous intervals must be fatal


### PR DESCRIPTION
- Related ticket: N/A
- Needles: N/A
- Verification runs: 
  -  https://openqa.opensuse.org/t1697994
  - https://openqa.opensuse.org/tests/1698016
