### PR TITLE
Fix sap-installation-wizard xml files location

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -34,8 +34,8 @@ sub run {
 
     # Keep only the generic HANA partitioning profile and link it to the needed model
     # NOTE: fix name is used here (Dell), but something more flexible should be done later!
-    enter_cmd "rm -f /usr/share/YaST2/include/sap-installation-wizard/hana_partitioning_Dell*.xml";
-    enter_cmd "ln -s hana_partitioning.xml '/usr/share/YaST2/include/sap-installation-wizard/hana_partitioning_Dell Inc._generic.xml'";
+    enter_cmd "rm -f /usr/share/YaST2/data/y2sap//hana_partitioning_Dell*.xml";
+    enter_cmd "ln -s hana_partitioning.xml '/usr/share/YaST2/data/y2sap/hana_partitioning_Dell Inc._generic.xml'";
 
     # Add host's IP to /etc/hosts
     $self->add_hostname_to_hosts;


### PR DESCRIPTION
Since the last update of the sap-installation-wizard the XML files used for the partitioning have been moved to a new directory.
This commit fix some lines of code that haven't been changed yet.

- Related ticket: N/A
- Needles: N/A
- Verification run: tested manually on holmes IPMI server