### PR TITLE
susedistribution: ensure_user() -- check for user first

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -631,7 +631,7 @@ Make sure the right user is logged in, e.g. when using remote shells
 =cut
 sub ensure_user {
     my ($user) = @_;
-    enter_cmd("su - $user") if $user ne 'root';
+    enter_cmd(sprintf('test "$(id -un)" == "%s" || su - "%s"', $user, $user)) if $user ne 'root';
 }
 
 =head2 hyperv_console_switch


### PR DESCRIPTION
Only call `su -u $user` if we are not already the `$user` otherwise we
would get a login prompt again.

In particular it is about this line: https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/lib/susedistribution.pm#L844

From my opinion it fails for `user-console` where we are already the user and would lead to a login prompt.