### PR TITLE
Add clients in firstboot_custom

### DIFF
--- a/data/yast2/firstboot/firstboot_custom-opensuse.xml
+++ b/data/yast2/firstboot/firstboot_custom-opensuse.xml
@@ -77,7 +77,7 @@
                 </module>
                 <module>
                     <label>Language and Keyboard</label>
-                    <enabled config:type="boolean">true</enabled>
+                    <enabled config:type="boolean">false</enabled>
 		    <!-- step for configuration of both language and keyboard layout (fate#306296) -->
                     <name>firstboot_language_keyboard</name>
                 </module>
@@ -88,7 +88,7 @@
                 </module>
                 <module>
                     <label>Keyboard Layout</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_keyboard</name>
                 </module>
                 <module>
@@ -127,12 +127,12 @@
                  </module>
                 <module>
                     <label>Time and Date</label>
-                    <enabled config:type="boolean">true</enabled>
+                    <enabled config:type="boolean">false</enabled>
                     <name>firstboot_timezone</name>
                 </module>
                 <module>
                     <label>NTP Client</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_ntp</name>
                 </module>
                 <module>
@@ -152,7 +152,7 @@
                 </module>
                 <module>
                     <label>Root Password</label>
-                    <enabled config:type="boolean">true</enabled>
+                    <enabled config:type="boolean">false</enabled>
                     <name>firstboot_root</name>
                 </module>
                 <module>

--- a/data/yast2/firstboot/firstboot_custom-sle.xml
+++ b/data/yast2/firstboot/firstboot_custom-sle.xml
@@ -69,7 +69,7 @@
                 </module>
                 <module>
                     <label>Language and Keyboard</label>
-                    <enabled config:type="boolean">true</enabled>
+                    <enabled config:type="boolean">false</enabled>
 		    <!-- step for configuration of both language and keyboard layout (fate#306296) -->
                     <name>firstboot_language_keyboard</name>
                 </module>
@@ -80,7 +80,7 @@
                 </module>
                 <module>
                     <label>Keyboard Layout</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_keyboard</name>
                 </module>
                 <module>
@@ -110,7 +110,10 @@
                 <module>
                     <label>Network</label>
                     <name>inst_lan</name>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
+                    <arguments>
+                        <skip_detection config:type="boolean">true</skip_detection>
+                    </arguments>
                 </module>
                  <module>
                     <label>Automatic Configuration</label>
@@ -119,12 +122,12 @@
                  </module>
                 <module>
                     <label>Time and Date</label>
-                    <enabled config:type="boolean">true</enabled>
+                    <enabled config:type="boolean">false</enabled>
                     <name>firstboot_timezone</name>
                 </module>
                 <module>
                     <label>NTP Client</label>
-                    <enabled config:type="boolean">false</enabled>
+                    <enabled config:type="boolean">true</enabled>
                     <name>firstboot_ntp</name>
                 </module>
                 <module>
@@ -144,7 +147,7 @@
                 </module>
                 <module>
                     <label>Root Password</label>
-                    <enabled config:type="boolean">true</enabled>
+                    <enabled config:type="boolean">false</enabled>
                     <name>firstboot_root</name>
                 </module>
                 <module>

--- a/lib/YaST/Firstboot/FirstbootController.pm
+++ b/lib/YaST/Firstboot/FirstbootController.pm
@@ -15,6 +15,9 @@ use strict;
 use warnings;
 use YuiRestClient;
 use YaST::Firstboot::GenericPage;
+use YaST::Firstboot::LANSetupPage;
+use YaST::Firstboot::KeyboardLayoutPage;
+use YaST::Firstboot::NTPClientPage;
 
 sub new {
     my ($class, $args) = @_;
@@ -24,13 +27,49 @@ sub new {
 
 sub init {
     my ($self, $args) = @_;
-    $self->{GenericPage} = YaST::Firstboot::GenericPage->new({app => YuiRestClient::get_app()});
+    $self->{GenericPage}  = YaST::Firstboot::GenericPage->new({app => YuiRestClient::get_app()});
+    $self->{LanPage}      = YaST::Firstboot::LANSetupPage->new({app => YuiRestClient::get_app()});
+    $self->{KeyboardPage} = YaST::Firstboot::KeyboardLayoutPage->new({app => YuiRestClient::get_app()});
+    $self->{NTPPage}      = YaST::Firstboot::NTPClientPage->new({app => YuiRestClient::get_app()});
     return $self;
 }
 
 sub get_generic_page {
     my ($self) = @_;
     $self->{GenericPage};
+}
+
+sub get_NTP_page {
+    my ($self) = @_;
+    die "NTP layout page is not shown" unless $self->{NTPPage}->is_shown();
+    return $self->{NTPPage};
+}
+
+sub get_keyboard_page {
+    my ($self) = @_;
+    die "Keyboard layout page is not shown" unless $self->{KeyboardPage}->is_shown();
+    return $self->{KeyboardPage};
+}
+
+sub get_lan_page {
+    my ($self) = @_;
+    die "LAN setup page is not shown" unless $self->{LanPage}->is_shown();
+    return $self->{LanPage};
+}
+
+sub setup_LAN {
+    my ($self) = @_;
+    $self->get_lan_page->press_next();
+}
+
+sub setup_NTP {
+    my ($self) = @_;
+    $self->get_NTP_page->press_next();
+}
+
+sub setup_keyboard {
+    my ($self) = @_;
+    $self->get_keyboard_page->press_next();
 }
 
 sub press_next {

--- a/lib/YaST/Firstboot/KeyboardLayoutPage.pm
+++ b/lib/YaST/Firstboot/KeyboardLayoutPage.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for
+# firstboot Keyboard client
+
+package YaST::Firstboot::KeyboardLayoutPage;
+use parent 'YaST::Firstboot::GenericPage';
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->{selectionbox} = $self->{app}->selectionbox({id => 'layout_list'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{selectionbox}->exist();
+}
+
+1;

--- a/lib/YaST/Firstboot/LANSetupPage.pm
+++ b/lib/YaST/Firstboot/LANSetupPage.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for
+# firstboot LAN client
+
+package YaST::Firstboot::LANSetupPage;
+use parent 'YaST::Firstboot::GenericPage';
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->{tbl_devices} = $self->{app}->table({id => '"Y2Network::Widgets::InterfacesTable"'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    # Just check if we can select the first listed interface.
+    return $self->{tbl_devices}->exist();
+}
+
+1;

--- a/lib/YaST/Firstboot/NTPClientPage.pm
+++ b/lib/YaST/Firstboot/NTPClientPage.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for
+# firstboot NTP client
+
+package YaST::Firstboot::NTPClientPage;
+use parent 'YaST::Firstboot::GenericPage';
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->{radiobutton_sync} = $self->{app}->radiobutton({id => '"sync"'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{radiobutton_sync}->exist();
+}
+
+1;

--- a/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-opensuse.yaml
@@ -21,11 +21,11 @@ schedule:
     - console/validate_yast2_firstboot_configuration
 test_data:
     clients:
-        - firstboot_language_keyboard
+        - firstboot_keyboard
         - firstboot_welcome
         - firstboot_licenses
         - firstboot_hostname
-        - firstboot_timezone
+        - firstboot_NTP
         - firstboot_user
         - firstboot_finish
     custom_control_file: "firstboot_custom-opensuse.xml"

--- a/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_custom-sle.yaml
@@ -21,11 +21,12 @@ schedule:
     - console/validate_yast2_firstboot_configuration
 test_data:
     clients:
-        - firstboot_language_keyboard
+        - firstboot_keyboard
         - firstboot_welcome
         - firstboot_licenses
         - firstboot_hostname
-        - firstboot_timezone
+        - firstboot_lan
+        - firstboot_NTP
         - firstboot_user
         - firstboot_finish
     custom_control_file: "firstboot_custom-sle.xml"

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -7,8 +7,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Utilize OS using YaST2 Firstboot module
+# Summary: Setup OS using YaST2 Firstboot wizard
 # Doc: https://en.opensuse.org/YaST_Firstboot
+# In this test module, each firstboot "client" is treated by its own
+# function and functions are called by test data. Some of these
+# functions are using POM (see ui-framework-documentation.md) in which
+# case each client is treated as a page defined in lib/YaST/FIrstboot/
+
 # Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
 use base 'y2_module_basetest';
@@ -85,6 +90,24 @@ sub firstboot_registration {
     my $firstboot = $testapi::distri->get_firstboot();
     assert_screen 'system_registered';
     $firstboot->press_next();
+}
+
+sub firstboot_keyboard {
+    my $firstboot = $testapi::distri->get_firstboot();
+    save_screenshot;
+    $firstboot->setup_keyboard();
+}
+
+sub firstboot_NTP {
+    my $firstboot = $testapi::distri->get_firstboot();
+    save_screenshot;
+    $firstboot->setup_NTP();
+}
+
+sub firstboot_lan {
+    my $firstboot = $testapi::distri->get_firstboot();
+    save_screenshot;
+    $firstboot->setup_LAN();
 }
 
 sub firstboot_finish {


### PR DESCRIPTION
See https://progress.opensuse.org/issues/73474:
In order to extend coverage for yast2-firstboot , we can modify the yast2-firstboot configuration files of the relevant test suite:
https://openqa.suse.de/tests/4840750

There already is customized file replacing /etc/YaST2/firstboot.xml after merge of:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/10856

We should re-use yast2_firstboot_custom and use non-default settings for the modules if those are allowed.

Enable firstboot_ntp, firstboot_keyboard and inst_lan modules.

related bugs: bug#1177797 , bug#960081 , bug#1140199 , bug#1101514

VRs (updated)
https://openqa.opensuse.org/tests/1701175
https://openqa.suse.de/tests/5836018
