### PR TITLE
Fix leap to sle rollback repos incorrect issue

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -26,7 +26,7 @@ use utils;
 use zypper;
 use registration;
 use qam 'remove_test_repositories';
-use version_utils qw(is_sle is_sles4sap);
+use version_utils qw(is_sle is_sles4sap is_leap_migration);
 
 our @EXPORT = qw(
   setup_sle
@@ -174,7 +174,10 @@ sub check_rollback_system {
         base_version=\$(echo \$version | cut -d'-' -f1)
         zypper lr | cut -d'|' -f3 | gawk '/SLE/ || /openSUSE/' | sed \"/\$version\\|Module.*\$base_version/d\"
     ", 100);
-    record_info('Incorrect Repos', $incorrect_repos, result => 'fail') if $incorrect_repos;
+    # for leap to sle migration, we'll have SLE-$VERSION-Updates in the leap repo.
+    if ($incorrect_repos) {
+        record_info('Incorrect Repos', $incorrect_repos, result => 'fail') unless (is_leap_migration && $incorrect_repos eq 'SLE-' . get_var("VERSION") . '-Updates');
+    }
 
     return unless is_sle;
     # Check SUSEConnect status for SLE


### PR DESCRIPTION
In leap to SLE migration, once we registered with SLE, it'll add
SLE-15-SP3-Updates repository to the existed repos. We need to take
care of this in the snapper_rollback's repo check.

- Related ticket: https://progress.opensuse.org/issues/90992
- Needles: N/A
- Verification run:  
   https://openqa.nue.suse.com/tests/5818679
   https://openqa.nue.suse.com/tests/5818391
   https://openqa.nue.suse.com/tests/5818458 regression
   https://openqa.nue.suse.com/tests/5818634 regression