### PR TITLE
Fix AZURE-BYOS-Updates flavor

### DIFF
--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -113,7 +113,7 @@ our $thresholds_by_flavor = {
         analyze => $default_azure_analyze_thresholds,
         blame   => $default_blame_thresholds,
     },
-    'Azure-BYOS-Updates' => {
+    'AZURE-BYOS-Updates' => {
         analyze => $default_azure_analyze_thresholds,
         blame   => $default_blame_thresholds,
     },


### PR DESCRIPTION
Fixes the wrong naming for AZURE-BYOS-Updates flavor.

- Related ticket: https://progress.opensuse.org/issues/90965
- Verification run: http://duck-norris.qam.suse.de/tests/5973
