### PR TITLE
boottime: exclude build variable where it does not make sense

### DIFF
--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -346,11 +346,12 @@ sub store_in_db {
         os_flavor         => get_required_var('FLAVOR'),
         os_version        => get_required_var('VERSION'),
         os_build          => get_required_var('BUILD'),
-        os_pc_build       => get_required_var('PUBLIC_CLOUD_BUILD'),
-        os_pc_kiwi_build  => get_required_var('PUBLIC_CLOUD_BUILD_KIWI'),
         os_kernel_release => $results->{kernel_release},
         os_kernel_version => $results->{kernel_version},
     };
+
+    $tags->{os_pc_build}      = get_var('PUBLIC_CLOUD_QAM') ? 'N/A' : get_required_var('PUBLIC_CLOUD_BUILD');
+    $tags->{os_pc_kiwi_build} = get_var('PUBLIC_CLOUD_QAM') ? 'N/A' : get_required_var('PUBLIC_CLOUD_BUILD_KIWI');
 
     # Store values in influx-db
     my $data = {


### PR DESCRIPTION
Runs which testing updates installation are running against images
already uploaded into Public Cloud provider so we have no easy way
to get PUBLIC_CLOUD_KIWI and PUBLIC_CLOUD_BUILD. This is why we hardcode
them to NA in such cases