### PR TITLE
mutt: Fix missing 'a' hotkey

### DIFF
--- a/tests/console/mutt.pm
+++ b/tests/console/mutt.pm
@@ -54,6 +54,7 @@ sub run {
 
     record_info 'receive mail', 'Run mutt as a user to read the mail';
     enter_cmd "mutt";
+    send_key 'a';
     assert_screen 'mutt-message-list';
     send_key 'ret';
     assert_screen 'mutt-show-mail';


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12294
tried to fix a previous unintended change but missed the 'a' key press

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12297 https://openqa.suse.de/tests/5812398 SCHEDULE=tests/installation/bootloader_start,tests/boot/boot_to_desktop,tests/console/prepare_test_data,tests/x11/evolution/evolution_prepare_servers,tests/console/mutt
```

* https://openqa.suse.de/t5820095
