### PR TITLE
Remove checks on /var/log/messages

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -34,7 +34,6 @@ use power_action_utils qw(power_action);
 use constant {
     PERSISTENT_LOG_DIR => '/var/log/journal',
     DROPIN_DIR         => '/etc/systemd/journald.conf.d',
-    SYSLOG             => '/var/log/messages',
     SEALING_DELAY      => 10
 };
 
@@ -102,7 +101,6 @@ sub assert_test_log_entries {
         foreach (keys(%{$entries})) {
             script_retry("journalctl --boot=$bootid --identifier=batman --priority=$_ --output=short | grep $entries->{$_}",
                 retry => 5, delay => 2);
-            assert_script_run("grep $entries->{$_} ${\ SYSLOG }") if is_sle;
         }
     }
 }
@@ -160,7 +158,6 @@ sub run {
         # rsyslog must be there by design
         assert_script_run 'rpm -q rsyslog';
         assert_script_run 'test -S /run/systemd/journal/syslog';
-        upload_logs('/var/log/messages');
         systemctl 'restart systemd-journald';
     }
 


### PR DESCRIPTION
SLES no longer uses syslog+console for system messages as it's already
deprecated, see https://build.suse.de/request/show/238016#n43

See: https://openqa.suse.de/tests/5814510#step/journalctl/57