### PR TITLE
Consider LTSS in case of salt-minion check

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -557,7 +557,7 @@ sub verify_software {
     $zypper_args .= $args{pattern} ? ' -t pattern' : ' -t package';
     # Negate condition if package should not be available
     my $cmd = $args{available} ? '' : '! ';
-    $cmd .= "zypper --non-interactive se -n $zypper_args --match-exact --details @{[ $args{name} ]}";
+    $cmd .= "zypper --quiet --non-interactive se -n $zypper_args --match-exact --details @{[ $args{name} ]}";
     # Verify repo only if package expected to be available
     if ($args{repo} && $args{available}) {
         $cmd .= ' | grep ' . $args{repo};

--- a/tests/console/validate_packages_and_patterns.pm
+++ b/tests/console/validate_packages_and_patterns.pm
@@ -28,11 +28,11 @@ my %software = ();
 # Define test data
 
 $software{'salt-minion'} = {
-    repo      => 'Basesystem',
-    installed => is_jeos() ? 1 : 0,       # On JeOS Salt is present in the default image
+    repo      => get_var('SCC_REGCODE_LTSS') ? 'LTSS' : 'Basesystem',
+    installed => is_jeos()                   ? 1      : 0,              # On JeOS Salt is present in the default image
     condition => sub { is_sle('15+') },
 };
-$software{'update-test-feature'} = {      # See poo#36451
+$software{'update-test-feature'} = {                                    # See poo#36451
     repo      => is_sle('15+') ? 'Basesystem' : 'SLES',
     installed => 0,
     available => sub { get_var('BETA') },


### PR DESCRIPTION
sle15sp1 product is in LTSS and salt-minion package update has ended up
in LTSS product repo instead of Basesystem as the module expects.
Fix [false negative](https://bugzilla.suse.com/show_bug.cgi?id=1183006#c3)

- Verification runs: 
   * [sle-15-SP3-Online-x86_64-Build174.1-extra_tests_textmode@64bit](http://kepler.suse.cz/tests/4360#step/validate_packages_and_patterns/12)
   * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build37.8.36](http://kepler.suse.cz/tests/4359#step/validate_packages_and_patterns/10)
