### PR TITLE
[libreoffice_open_specified_file] revert enter_cmd changes

### DIFF
--- a/tests/x11/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11/libreoffice/libreoffice_open_specified_file.pm
@@ -39,7 +39,7 @@ sub run {
         wait_still_screen 3;
         send_key "ctrl-l";
         save_screenshot;
-        enter_cmd_slow "test.$tag";
+        type_string_slow "test.$tag\n";
         wait_still_screen 3, 7;
         assert_screen("libreoffice-test-$tag", 120);
         if (match_has_tag('ooffice-tip-of-the-day')) {


### PR DESCRIPTION
It looks like enter_cmd_slow in this case works too randomly
