### PR TITLE
Hyper-V SVirt: Repair New-VHD command

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -178,7 +178,7 @@ sub run {
             else {
                 my $disk_path = "$root\\cache\\${name}_${n}.vhdx";
                 push @disk_paths, $disk_path;
-                hyperv_cmd("$ps New-VHD -Path $disk_path -Dynamic -SizeBytes ${hddsize}GB");
+                hyperv_cmd(qq($ps "\$ProgressPreference='SilentlyContinue'; New-VHD -Path $disk_path -Dynamic -SizeBytes ${hddsize}GB"));
             }
         }
         hyperv_cmd("$ps New-VM -VMName $name -Generation $vm_generation -SwitchName $hyperv_switch_name -MemoryStartupBytes ${ramsize}MB");


### PR DESCRIPTION
Hello,

before, I patched SVirt Hyper-V commands so they work on Windows 2019 Server too.
Unfortunately, I forget about one line, which I would like to repair in this pull request.

- Previous PR: #12098 os-autoinst#1631
- Verification run: [openqa.suse.de/t5821095](https://openqa.suse.de/t5821095) (thanks to @nanzhang2020)