### PR TITLE
Fix yamllint warnings

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,8 @@
 extends: default
 rules:
+  comments:
+    level: error
+    require-starting-space: true
   line-length:
     max: 160
   document-start: disable

--- a/schedule/jeos/sle/jeos-base+phub.yaml
+++ b/schedule/jeos/sle/jeos-base+phub.yaml
@@ -29,7 +29,7 @@ schedule:
     - console/prjconf_excluded_rpms
     - console/suseconnect_scc
     - console/machinery
-    #- sysauth/sssd
+    # - sysauth/sssd
     - containers/docker_compose
     - network/cifs
     - console/orphaned_packages_check

--- a/schedule/security/389ds_sssd.yaml
+++ b/schedule/security/389ds_sssd.yaml
@@ -1,3 +1,4 @@
+name: 389ds_sssd
 description:    >
     This is for 389ds and sssd authentication
 schedule:

--- a/tools/test_yaml_valid
+++ b/tools/test_yaml_valid
@@ -35,8 +35,13 @@ for my $file (@ARGV) {
     }
     if ($file =~ m{schedule/}) {
         my @errors = $validator->validate($data);
-        is(scalar @errors, 0, "$file passes schema validation")
-            or diag @errors;
+        if (@errors) {
+            fail("$file has invalid schema");
+            diag "Error: @errors";
+        }
+        else {
+            pass("$file has valid schema");
+        }
     }
 }
 


### PR DESCRIPTION
The commit fixes yamllint warnings:
   - for missing starting space in comment;
   - for missed 'name' property.

Also, the PR makes such fails to be errors and to fail CI.

The warnings occurred every time on CI.

Please, see the example of warnings: 
https://github.com/OleksandrOrlov/os-autoinst-distri-opensuse/runs/2342749185?check_suite_focus=true
https://github.com/OleksandrOrlov/os-autoinst-distri-opensuse/runs/2362103025?check_suite_focus=true (here it failed with 
```
not ok 626 - schedule/security/389ds_sssd.yaml passes schema validation
#   Failed test 'schedule/security/389ds_sssd.yaml passes schema validation'
#   at tools/test_yaml_valid line 38.
#          got: '1'
#     expected: '0'
# /name: Missing property.
```