### PR TITLE
Configure load_jeos_tests scheduling to run ltp tests in opensuse

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (C) 2018-2020 SUSE LLC
+# Copyright © 2018-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -565,29 +565,27 @@ sub load_system_role_tests {
 }
 sub load_jeos_tests {
     # loadtest 'jeos/sccreg';
-    unless (get_var('LTP_COMMAND_FILE')) {
-        if ((is_arm || is_aarch64) && is_opensuse()) {
-            # Enable jeos-firstboot, due to boo#1020019
-            load_boot_tests();
-            loadtest "jeos/prepare_firstboot";
-        }
+    if ((is_arm || is_aarch64) && is_opensuse()) {
+        # Enable jeos-firstboot, due to boo#1020019
         load_boot_tests();
-        loadtest "jeos/firstrun";
-        loadtest "jeos/record_machine_id";
-        unless (get_var('INSTALL_LTP')) {
-            loadtest "console/force_scheduled_tasks";
-            loadtest "jeos/grub2_gfxmode";
-            loadtest "jeos/diskusage";
-            loadtest "jeos/build_key";
-            loadtest "console/prjconf_excluded_rpms";
-        }
-        if (is_sle) {
-            loadtest "console/suseconnect_scc";
-        }
-
-        replace_opensuse_repos_tests      if is_repo_replacement_required;
-        loadtest 'console/verify_efi_mok' if get_var('MOK_VERBOSITY');
+        loadtest "jeos/prepare_firstboot";
     }
+    load_boot_tests();
+    loadtest "jeos/firstrun";
+    loadtest "jeos/record_machine_id";
+    unless (get_var('INSTALL_LTP')) {
+        loadtest "console/force_scheduled_tasks";
+        loadtest "jeos/grub2_gfxmode";
+        loadtest "jeos/diskusage";
+        loadtest "jeos/build_key";
+        loadtest "console/prjconf_excluded_rpms";
+    }
+    if (is_sle) {
+        loadtest "console/suseconnect_scc";
+    }
+
+    replace_opensuse_repos_tests      if is_repo_replacement_required;
+    loadtest 'console/verify_efi_mok' if get_var('MOK_VERBOSITY');
 }
 
 sub installzdupstep_is_applicable {


### PR DESCRIPTION
`unless (get_var('LTP_COMMAND_FILE'))` is removed as it was blocking the
scheduling. ltp must have LTP_COMMAND_FILE and INSTALL_LTP.

`load_jeos_tests` was forcing `bootloader_uefi` to get scheduled twice.
i didnt find any reason for that so i refactored that particular code.

the VR run with the following variables.
- INSTALL_LTP=from_repo LTP_TIMEOUT=3600 LTP_COMMAND_FILE="syscalls" KERNEL_BASE=1 CLEAR_REPOS=1 LTP_COMMAND_EXCLUDE="quotactl(01|04|06)|msgstress(03|04)" TEST=jeos_ltp_syscalls
- INSTALL_LTP=from_repo LTP_TIMEOUT=3600 LTP_COMMAND_FILE=containers KERNEL_BASE=1 CLEAR_REPOS=1 LTP_COMMAND_EXCLUDE=netns_sysfs TEST=jeos_ltp_containers
- INSTALL_LTP=from_repo LTP_TIMEOUT=3600 LTP_COMMAND_FILE=cve KERNEL_BASE=1 CLEAR_REPOS=1 TEST=jeos_ltp_cve
- INSTALL_LTP=from_repo LTP_TIMEOUT=3600 LTP_COMMAND_FILE=dio KERNEL_BASE=1 CLEAR_REPOS=1 TEST=jeos_ltp_dio
- INSTALL_LTP=from_repo LTP_TIMEOUT=3600 LTP_COMMAND_FILE=syscalls-ipc KERNEL_BASE=1 CLEAR_REPOS=1 LTP_COMMAND_EXCLUDE="msgstress(03|04)" TEST=jeos_ltp_syscalls-ipc


NOTE: jeos_ltp_dio has all the tests skipped

- Related ticket: https://progress.opensuse.org/issues/67717
- Verification run: 
- [jeos+breaking changes on o3](https://openqa.opensuse.org/tests/overview.html?distri=opensuse&version=Tumbleweed&build=b10n1k%2Fos-autoinst-distri-opensuse%2367717_ltp_jeos_o3)
- [jeos on OSD](https://openqa.suse.de/tests/overview.html?build=b10n1k%2Fos-autoinst-distri-opensuse%2367717_ltp_jeos_o3&version=15-SP3&distri=sle)
- updatedVR
- [o3](https://openqa.opensuse.org/tests/overview.html?build=b10n1k%2Fos-autoinst-distri-opensuse%2312309&version=Tumbleweed&distri=opensuse)
- [OSD](https://openqa.suse.de/tests/overview.html?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2312309)

