### PR TITLE
containers/urls.pm: Test new location for container images during SLE GA

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -18,7 +18,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_microos is_sle_micro);
+use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_microos is_sle_micro is_released);
 
 our @EXPORT = qw(
   get_opensuse_registry_prefix
@@ -68,9 +68,16 @@ sub get_suse_container_urls {
             push @stable_names, "registry.suse.com/suse/sles${nodashversion}";
         }
     }
-    elsif (is_sle(">=15", $version)) {
+    elsif (is_sle(">=15", $version) && is_released) {
         my $lowerversion = lc $version;
+        # Location for maintenance builds
         push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/totest/images/suse/sle15:${dotversion}";
+        push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
+    }
+    elsif (is_sle(">=15-sp3", $version)) {
+        my $lowerversion = lc $version;
+        # Location for GA builds
+        push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/ga/test/images/suse/sle15:${dotversion}";
         push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
     }
     elsif (is_sle_micro) {


### PR DESCRIPTION
It split up now, as they have to be built differently and it's built in SLE-15-SP3:GA anyway. This way it follows the same release flow as other deliverables.

- Related ticket: https://progress.opensuse.org/issues/90926
- Verification run: Can't do, at least not now
