### PR TITLE
LTP: Fix openposix on 32bit

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -194,7 +194,8 @@ sub install_from_git {
     assert_script_run 'make -j$(getconf _NPROCESSORS_ONLN)', timeout => $timeout;
     script_run 'export CREATE_ENTRIES=1';
     assert_script_run 'make install', timeout => 360;
-    assert_script_run "find $prefix -name '*.run-test' > ~/openposix-test-list";
+    assert_script_run "find $prefix -name '*.run-test' > "
+      . get_ltp_openposix_test_list_file();
 
     # It is a shallow clone so 'git describe' won't work
     record_info("LTP git", script_output('git log -1 --pretty=format:"git-%h" | tee '
@@ -246,7 +247,8 @@ sub install_from_repo {
         record_info("LTP pkg: $pkg", script_output("rpm -qi $pkg | tee "
                   . get_ltp_version_file($want_32bit)));
         assert_script_run "find " . get_ltproot($want_32bit) .
-          q(/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > ~/openposix-test-list);
+          q(/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > )
+          . get_ltp_openposix_test_list_file($want_32bit);
     }
 }
 


### PR DESCRIPTION
Fixes: cbfb4dcc7 ("LTP: Allow install more than one package in LTP_PKG")

This fixes `libgcc_s.so.1 must be installed for pthread_cancel to work` on various tests
(SLES: https://openqa.suse.de/tests/5821925#step/mq_timedsend_12-1/4, reproduced also locally on Tumbleweed http://quasar.suse.cz/tests/6531#step/pthread_barrier_wait_2-1/5)

Verification run:
SLES 15-SP3 (default both 64bit and 32bit packages)
- install_ltp+sle+Online@64bit http://quasar.suse.cz/tests/6564
http://quasar.suse.cz/tests/6564/file/serial_terminal.txt
```
find /opt/ltp/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > /opt/ltp/runtest/openposix-test-list
find /opt/ltp-32/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > /opt/ltp-32/runtest/openposix-test-list-32bit
```
- ltp_openposix@64bit http://quasar.suse.cz/tests/6566 no failure again

openSUSE Tumbleweed (default both 64bit and 32bit packages)
- install_ltp+opensuse+DVD@64bit http://quasar.suse.cz/tests/6565
http://quasar.suse.cz/tests/6565/file/serial_terminal.txt
```
find /opt/ltp/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > /opt/ltp/runtest/openposix-test-list
find /opt/ltp-32/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > /opt/ltp-32/runtest/openposix-test-list-32bit
```
- ltp_openposix@64bit http://quasar.suse.cz/tests/6567 fails only `pthread_cond_destroy_2-1` (known bug https://github.com/linux-test-project/ltp/issues/746)