### PR TITLE
Install required "sssd-ldap" package for 389ds

### DIFF
--- a/tests/security/389ds/tls_389ds_sssd_client.pm
+++ b/tests/security/389ds/tls_389ds_sssd_client.pm
@@ -38,7 +38,7 @@ sub run {
     my $uid         = '1003';
 
     # Install 389-ds and sssd on client
-    zypper_call("in 389-ds sssd");
+    zypper_call("in 389-ds sssd sssd-ldap");
 
     # Disable and stop the nscd daemon because it conflicts with sssd
     disable_and_stop_service("nscd", ignore_failure => 1);
@@ -70,6 +70,11 @@ sub run {
     # Make sure ldap user can login from client as well
     assert_script_run("LDAPTLS_REQCERT=never ldapwhoami -H ldaps://$remote_name.example.com:636 -x");
     assert_script_run("id $ldap_user | grep $uid");
+}
+
+sub post_fail_hook {
+    upload_logs("/var/log/messages");
+    upload_logs("/etc/sssd/sssd.conf");
 }
 
 1;


### PR DESCRIPTION
Based on bug 1184692, the required "sssd-ldap" package
is not installed as dependency of package "389-ds" and
"sssd" in newer SLES15SP3 drop, so fix it in code.
At the same time, add some post fail hook scripts to collect logs.

- Related ticket: https://progress.opensuse.org/issues/91160
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/5825391
