### PR TITLE
Remove code that's dealing disk < 50 GB (poo#89975)

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -34,19 +34,6 @@ sub run {
         send_key 'alt-n';
     }
 
-    if (get_var("DUALBOOT")) {
-        if (is_sle('15+')) {
-            # Based on comment from Dev in bsc#1089723, 50GB disk is not a real-world use case for dual boot
-            # We use 50GB for dual-boot openQA testing in order to save space
-            assert_screen "delete-partition";
-            send_key "alt-g";
-            assert_and_click "resize-or-remove-ifneeded";
-            send_key "up";
-            assert_and_click "resize-ifneeded";
-            for (1 .. 3) { send_key "alt-n"; }
-        }
-    }
-
     # Storage NG introduces a new partitioning dialog. We detect this
     # by the existence of the "Guided Setup" button and set the
     # STORAGE_NG variable so later tests know about this.


### PR DESCRIPTION
- The windows qcow is updated and disk > 50GB now
- The code that's dealing disk < 50GB in dual boot testing is no longer needed

- Related ticket: https://progress.opensuse.org/issues/89975
- Needles: Have been added when debugging on o.s.d
- Verification run: 
gnome-dual-windows10@64bit_win https://openqa.nue.suse.com/tests/5818946
gnome-dual-windows10_extended@64bit_win https://openqa.nue.suse.com/tests/5818949
gnome-dual-windows10@windows_uefi_boot https://openqa.nue.suse.com/tests/5821699
