### PR TITLE
Add 15SP2 QU specific version of the ext4 on xen-pv schedule

### DIFF
--- a/schedule/qam/QR/15-SP2/ext4@yast-xen-pv.yaml
+++ b/schedule/qam/QR/15-SP2/ext4@yast-xen-pv.yaml
@@ -1,0 +1,34 @@
+---
+name:           ext4@yast-xen-pv
+description:    >
+  Test for ext4 filesystem in svirt-xen-pv.
+  Test modules 'grub_disable_timeout' and 'grub_test' in xen-pv are not scheduled
+  due to grub2 doesnt support xfb console.
+vars:
+  DESKTOP: gnome
+  FILESYSTEM: ext4
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/first_boot
+  - console/validate_ext4_fs
+test_data:
+  <<: !include test_data/yast/ext4/ext4.yaml
+  device: /dev/xvdb
+  table_type: gpt


### PR DESCRIPTION
Fork the ext4@xen-pv schedule (as is, but version 932ef156e06593a0d5e951453cbef7eebfe468c1 from schedule/yast/ext4) since changes for 15-SP3 broke 15-SP2 QU testing.

- Related ticket: https://progress.opensuse.org/issues/91106
- Verification run: https://openqa.suse.de/tests/5821620
