### PR TITLE
Improve needle match before grub for encrypted disk

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -631,9 +631,9 @@ sub wait_grub {
     push @tags, 'bootloader-shim-verification'  if get_var('MOK_VERBOSITY');
     push @tags, 'bootloader-shim-import-prompt' if get_var('UEFI');
     push @tags, 'grub2';
-    push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');    # LIVETEST won't to do installation and no grub2 menu show up
-    push @tags, 'bootloader'                      if get_var('OFW');
-    push @tags, 'encrypted-disk-password-prompt'  if get_var('ENCRYPT');
+    push @tags, 'boot-live-' . get_var('DESKTOP')     if get_var('LIVETEST');    # LIVETEST won't to do installation and no grub2 menu show up
+    push @tags, 'bootloader'                          if get_var('OFW');
+    push @tags, 'encrypted-disk-password-prompt-grub' if get_var('ENCRYPT');
     if (get_var('ONLINE_MIGRATION')) {
         push @tags, 'migration-source-system-grub2';
     }
@@ -706,7 +706,7 @@ sub wait_grub {
     elsif (match_has_tag('inst-bootmenu')) {
         $self->wait_grub_to_boot_on_local_disk;
     }
-    elsif (match_has_tag('encrypted-disk-password-prompt')) {
+    elsif (match_has_tag('encrypted-disk-password-prompt-grub')) {
         # unlock encrypted disk before grub
         workaround_type_encrypted_passphrase;
         assert_screen("grub2", timeout => ((is_pvm) ? 300 : 90));


### PR DESCRIPTION
Fix poo#81174: Needle match for password prompt before grub doesn't
match situation where we are really before grub, it has match for
generic password prompt for encryption. Needle is now grub specific.


New needle with tag encrypted-disk-password-prompt-grub was created, added area with  "Welcome to GRUB!" (one more needle to match mkvterm on pvm).

Example:
http://black-bit.suse.cz/tests/103#step/boot_to_desktop/1

- Related ticket: https://progress.opensuse.org/issues/81174
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1527
- Verification run:
extra_tests_kdump_multipath_lvm_encrypt x86_64: https://openqa.suse.de/tests/5825989
extra_tests_kdump_multipath_lvm_encrypt ppc64le: https://openqa.suse.de/tests/5826049
extra_tests_kdump_multipath_lvm_encrypt aarch64: https://openqa.suse.de/tests/5826272#live (fail is known bug)
extra_tests_fadump_lvm_encrypt powervm: https://openqa.suse.de/tests/5826273
cryptlvm_minimal_x: https://openqa.suse.de/tests/5825999

Tumbleweed cryptlvm: http://black-bit.suse.cz/tests/105 
Didn't find any other suitable job on ooo. Missing test suites extra_tests_kdump_multipath* is known gap and will be handled as part of factory first (fix gap for kernel group).