### PR TITLE
Add openldap_to_389ds module to the regression test

### DIFF
--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -24,6 +24,7 @@ schedule:
   - console/consoletest_setup
   - console/check_upgraded_service
   - '{{regression_tests}}'
+  - '{{openldap_to_389ds}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
   - boot/snapper_rollback
@@ -47,6 +48,10 @@ conditional_schedule:
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
         - installation/install_service
+  openldap_to_389ds:
+    REGRESSION_389DS:
+      1:
+        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -24,6 +24,7 @@ schedule:
   - console/consoletest_setup
   - console/check_upgraded_service
   - '{{regression_tests}}'
+  - '{{openldap_to_389ds}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
   - boot/snapper_rollback
@@ -47,6 +48,10 @@ conditional_schedule:
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
         - installation/install_service
+  openldap_to_389ds:
+    REGRESSION_389DS:
+      1:
+        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -41,6 +41,7 @@ schedule:
   - console/consoletest_setup
   - '{{check_upgraded_service}}'
   - '{{regression_tests}}'
+  - '{{openldap_to_389ds}}'
 conditional_schedule:
   check_upgraded_service:
     REGRESSION_SERVICE:
@@ -50,6 +51,10 @@ conditional_schedule:
     REGRESSION_SERVICE:
       1:
         - installation/install_service
+  openldap_to_389ds:
+    REGRESSION_389DS:
+      1:
+        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -88,6 +88,7 @@ conditional_schedule:
         - console/zypper_lifecycle
         - console/orphaned_packages_check
         - console/consoletest_finish
+        - migration/openldap_to_389ds
 
       2:
         - console/supportutils

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -85,6 +85,7 @@ conditional_schedule:
         - console/upgrade_snapshots
         - console/zypper_lifecycle
         - console/consoletest_finish
+        - migration/openldap_to_389ds
         - x11/desktop_runner
         - x11/xterm
         - locale/keymap_or_locale_x11


### PR DESCRIPTION
Add openldap_to_389ds module to the regression test

- Related ticket: https://progress.opensuse.org/issues/90464
- Verification run: 
online: https://openqa.suse.de/tests/5825554#
offline: https://openqa.suse.de/tests/5825557#
