### PR TITLE
Disable kdump for 15-SP2 SAP installation

### DIFF
--- a/schedule/qam/15-SP1/qam-create_hdd_sle_sap_gnome.yml
+++ b/schedule/qam/15-SP1/qam-create_hdd_sle_sap_gnome.yml
@@ -19,6 +19,7 @@ schedule:
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout
+  - installation/disable_kdump
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation

--- a/tests/sles4sap/robot_fw.pm
+++ b/tests/sles4sap/robot_fw.pm
@@ -80,8 +80,6 @@ sub run {
         # PARAMETER  : What parameters have changed.
         # TEST_NAME  : The function needs to be trigger only in the targeted test.
         if ($robot_test eq "sysctl.robot") {
-            # bsc#1181925 - kernel.panic_on_oops is not consistent
-            add_softfail("sysctl.robot", "15-SP1", "bsc#1181925", qw(Sysctl_kernel_panic_on_oops));
             # bsc#1181163 - unexpected values for net.ipv6.conf.lo.use_tempaddr and net.ipv6.conf.lo.accept_redirects
             add_softfail("sysctl.robot", "15-SP1", "bsc#1181163", qw(Sysctl_net_ipv6_conf_lo_accept_redirects Sysctl_net_ipv6_conf_lo_use_tempaddr));
         }


### PR DESCRIPTION
Fix for [bsc#1181925](https://bugzilla.suse.com/show_bug.cgi?id=1181925)

We need to disable kdump on SAP 15-SP1 installation because it changes the value of the `kernel.panic_on_oops` sysctl, which makes the robot framework test [complain](https://openqa.suse.de/tests/5826131#step/robot_fw/65).

The PR also removes the softfail for `kernel.panic_on_oops`.

- Related ticket: N/A 
- Needles: already merged
- Verification run: [15-SP1 create_hdd](http://1b143.qa.suse.de/tests/8287) - [robot test](http://1b143.qa.suse.de/tests/8291)
