### PR TITLE
Remove TIMEOUT_SCALE in schedule for SLES4SAP

### DIFF
--- a/schedule/sles4sap/migration/migration_offline_sles4sap.yaml
+++ b/schedule/sles4sap/migration/migration_offline_sles4sap.yaml
@@ -16,7 +16,6 @@ vars:
   UPGRADE_TARGET_VERSION: '%VERSION%'
   HDDVERSION: '%ORIGIN_SYSTEM_VERSION%'
   BOOTFROM: d
-  TIMEOUT_SCALE: 2
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: sle-%HDDVERSION%-%ARCH%-sap-nw-noscc.qcow2
 schedule:

--- a/schedule/sles4sap/migration/migration_online_sles4sap.yaml
+++ b/schedule/sles4sap/migration/migration_online_sles4sap.yaml
@@ -20,7 +20,6 @@ vars:
   UPGRADE_TARGET_VERSION: '%VERSION%'
   HDDVERSION: '%ORIGIN_SYSTEM_VERSION%'
   BOOTFROM: d
-  TIMEOUT_SCALE: 2
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: sle-%HDDVERSION%-%ARCH%-sap-nw-noscc.qcow2
 schedule:

--- a/schedule/sles4sap/sles4sap_gnome_saptune_v2.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_v2.yaml
@@ -7,7 +7,6 @@ description: >
 vars:
   BOOTFROM: c
   BOOT_HDD_IMAGE: '1'
-  TIMEOUT_SCALE: '2'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
   # START_AFTER_TEST: create_hdd_sles4sap_gnome

--- a/schedule/sles4sap/sles4sapha_grafana_dashboards.yaml
+++ b/schedule/sles4sap/sles4sapha_grafana_dashboards.yaml
@@ -11,7 +11,6 @@ vars:
   BOOT_HDD_IMAGE: '1'
   DESKTOP: 'gnome'
   ROOT_ONLY: 1
-  TIMEOUT_SCALE: '2'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
   # START_AFTER_TEST: create_hdd_sles4sap_gnome


### PR DESCRIPTION
All timeout scales are now fully handled in the Job Group YAML files.

- Related ticket: N/A
- Needles: N/A
- Job Group YAML file MR: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/284
- Verification run: N/A