### PR TITLE
Consider QR as released products

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -359,7 +359,7 @@ sub is_hpc {
 Returns true if called on a released build
 =cut
 sub is_released {
-    return get_var('FLAVOR') =~ /Incidents/ || get_var('FLAVOR') =~ /Updates/;
+    return get_var('FLAVOR') =~ /Incidents|Updates|QR/;
 }
 
 


### PR DESCRIPTION
QR testing is missing in _is_released_ subroutine.

- Related ticket: https://openqa.suse.de/tests/5828580#step/podman_image/2
- Verification runs:
   * [sle-15-SP1-JeOS-for-kvm-and-xen-QR-x86_64](http://kepler.suse.cz/tests/4456#step/podman_image/145)
   * [sle-15-SP2-Server-DVD-Updates-x86_64-Build20210415-1-mau-extratests-docker@64bit](http://kepler.suse.cz/tests/4458#step/podman_image/145)
