### PR TITLE
Add HA priority fencing test to qem

### DIFF
--- a/schedule/ha/qam/common/qam_ha_priority_fencing.yaml
+++ b/schedule/ha/qam/common/qam_ha_priority_fencing.yaml
@@ -1,6 +1,6 @@
-name:           ha_priority_fencing
+name:           qam_ha_priority_fencing
 description:    >
-  Create a 2 nodes cluster for testing the priority fencing delay feature
+  Create a 2 nodes cluster for testing the priority fencing delay feature used for the maintenance process.
 
   Schedule for priority fencing delay test cluster nodes. Use HA_CLUSTER_SETUP setting
   in the job group so the schedule loads the tests for a node running


### PR DESCRIPTION
This PR adds the file for testing the HA priority fencing test when a HA maintenance update happens.

- Related ticket: https://jira.suse.com/browse/TEAM-2116
- Needles: N/A
- [YAML configuration file for job group](https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/285)
- Verification run: 
  - 15 [node1](http://1b143.qa.suse.de/tests/8114) [node2](http://1b143.qa.suse.de/tests/8115)
  - 15SP3 [node1](http://1b143.qa.suse.de/tests/8143) [node2](http://1b143.qa.suse.de/tests/8144)