### PR TITLE
wicked: Fix t08_setup_second_card unexpected ip problem

### DIFF
--- a/tests/wicked/basic/sut/t08_setup_second_card.pm
+++ b/tests/wicked/basic/sut/t08_setup_second_card.pm
@@ -34,8 +34,9 @@ sub run {
     assert_script_run('echo "default ' . $static_ip_ref . ' - -" > /etc/sysconfig/network/routes');
     mutex_wait('dhcpdbasict08');
 
-    $self->wicked_command('ifup', $ctx->iface());
-    $self->wicked_command('ifup', $ctx->iface2());
+    # the timeout of 60 is a temporarly solution see: https://progress.opensuse.org/issues/89269#note-4
+    $self->wicked_command('ifup --timeout 60', $ctx->iface());
+    $self->wicked_command('ifup --timeout 60', $ctx->iface2());
 
     my $ip_iface1 = $self->get_current_ip($ctx->iface());
     my $ip_iface2 = $self->get_current_ip($ctx->iface2());


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/89269
- Verification run: https://openqa.suse.de/t5829101
