### PR TITLE
[virt_autotest] enable upload logs for host online upgrade fail at reboot_and_wait_up_upgrade test module

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -17,6 +17,7 @@ use testapi;
 use virt_utils 'clean_up_red_disks';
 use base 'reboot_and_wait_up';
 use virt_autotest::utils;
+use opensusebasetest;
 
 sub run {
     my $self = shift;
@@ -52,10 +53,20 @@ sub run {
 sub post_fail_hook {
     my ($self) = shift;
     reset_consoles;
-    select_console('root-console');
-    if (check_var('offline_upgrade', 'yes')) {
-        $self->upload_y2logs;
-        upload_logs("/mnt/root/autoupg.xml", failok => 1);
+    select_console('root-ssh');
+    if (get_var('VIRT_PRJ2_HOST_UPGRADE')) {
+        if (check_var('offline_upgrade', 'yes')) {
+            #host offline upgrade
+            $self->upload_y2logs;
+            upload_logs("/mnt/root/autoupg.xml", failok => 1);
+        }
+        else {
+            #host online upgrade
+            opensusebasetest::upload_coredumps;
+            save_screenshot;
+
+            virt_utils::collect_host_and_guest_logs;
+        }
     }
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
- Description
Currently, reboot_and_wait_up_upgrade test module just only handle host offline upgrade. 
Now,  this PR to enable collect and upload logs during host online upgrade fail at 
reboot_and_wait_up_upgrade test module. 
Thus, we can cover collect and upload logs both host online upgrade and host offline upgrade 
fail at reboot_and_wait_up_upgrade test module together. 

- Related ticket: 
https://progress.opensuse.org/issues/80874
- Verification run: 
validation run to confirm collect and upload logs during host online upgrade fail 
at reboot_and_wait_up_upgrade test module  call `post_fail_hook`
[prj2_host_upgrade_sles15sp2_to_developing_kvm](http://10.67.131.5/tests/349#downloads)
validation run to confirm collect and upload logs during host offline upgrade fail 
at reboot_and_wait_up_upgrade test module  call `post_fail_hook`
[prj2_host_upgrade_sles12sp5_to_developing_kvm](http://10.67.131.5/tests/351#downloads)
x86_64
[prj2_host_upgrade_sles12sp5_to_developing_kvm](https://openqa.suse.de/tests/5839501)
[prj2_host_upgrade_sles15sp2_to_developing_kvm](https://openqa.suse.de/tests/5839494)
[prj2_host_upgrade_sles15sp2_to_developing_xen](https://openqa.suse.de/tests/5839497l)
[prj2_host_upgrade_sles11sp4_to_developing_kvm](https://openqa.suse.de/tests/5839498)
aarch64 - arm64
[prj2_host_upgrade_sles12sp5_to_developing_kvm](https://openqa.suse.de/tests/5839499)
[prj2_host_upgrade_sles15sp2_to_developing_kvm](https://openqa.suse.de/tests/5839500)
