### PR TITLE
Replaces get_cmd_output in the integration_services_check_ip

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -226,21 +226,18 @@ Die, if this is not the case.
 
 =cut
 sub integration_services_check_ip {
-    # Workaround for poo#44771 "Can't call method "exec" on an undefined value"
-    select_console('svirt');
-    select_console('sut');
     # Host-side of Integration Services
     my $vmname = console('svirt')->name;
     my $ips_host_pov;
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        $ips_host_pov = console('svirt')->get_cmd_output(
-            'powershell -Command "Get-VM ' . $vmname . ' | Get-VMNetworkAdapter | Format-Table -HideTableHeaders IPAddresses"');
+        (undef, $ips_host_pov) = console('svirt')->run_cmd(
+            'powershell -Command "Get-VM ' . $vmname . ' | Get-VMNetworkAdapter | Format-Table -HideTableHeaders IPAddresses"', wantarray => 1);
     }
     elsif (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
-        $ips_host_pov = console('svirt')->get_cmd_output(
+        (undef, $ips_host_pov) = console('svirt')->run_cmd(
             "set -x; vmid=\$(vim-cmd vmsvc/getallvms | awk '/$vmname/ { print \$1 }');" .
               "if [ \$vmid ]; then vim-cmd vmsvc/get.guest \$vmid | awk '/ipAddress/ {print \$3}' " .
-              "| head -n1 | sed -e 's/\"//g' | sed -e 's/,//g'; fi", {domain => 'sshVMwareServer'});
+              "| head -n1 | sed -e 's/\"//g' | sed -e 's/,//g'; fi", domain => 'sshVMwareServer', wantarray => 1);
     }
     $ips_host_pov =~ m/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/;
     $ips_host_pov = $1;
@@ -261,8 +258,8 @@ are present and in working condition.
 
 =cut
 sub integration_services_check {
+    integration_services_check_ip();
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        integration_services_check_ip;
         # Guest-side of Integration Services
         assert_script_run('rpmquery hyper-v');
         assert_script_run('rpmverify hyper-v');
@@ -280,7 +277,6 @@ sub integration_services_check {
         assert_script_run('systemctl list-unit-files | grep hv_fcopy_daemon.service');
     }
     elsif (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
-        integration_services_check_ip;
         assert_script_run('rpmquery open-vm-tools');
         assert_script_run('rpmquery open-vm-tools-desktop') unless check_var('DESKTOP', 'textmode');
         assert_script_run('modinfo vmw_vmci');

--- a/tests/console/integration_services.pm
+++ b/tests/console/integration_services.pm
@@ -19,7 +19,7 @@ use warnings;
 sub run {
     select_console 'root-console';
 
-    integration_services_check;
+    integration_services_check();
 }
 
 1;


### PR DESCRIPTION
Due to the random timeout in the connection which is used to run `run_ssh_cmd`,                                                                                                                                                                                                
we can use `keep_open` to force the creation of a new connection.                                                                                                                                                                                                              
os-autoinst has already merged the corresponding commits[0][1] that make this possible,                                                                                                                                                                                        
as the paramemeter was not able to be passed through.                                                                                                                                                                                                                          
After the changes though the tests pass without the need to force the creation of a new                                                                                                                                                                                        
connection.                                                                                                                                                                                                                                                                    
So we replace only the `get_cmd_output` which is deprecated with the `run_cmd` directly,                                                                                                                                                                                       
which with it turns calls `run_ssh_cmd` with `keep_open`. But keep_open is hold optional                                                                                                                                                                                       
for now.

[0] https://github.com/os-autoinst/os-autoinst/pull/1643/files
[1] https://github.com/os-autoinst/os-autoinst/pull/1642/files

- Related ticket: https://progress.opensuse.org/issues/81878
- Verification run: http://aquarius.suse.cz/tests/5432#
https://openqa.suse.de/tests/overview.html?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2312332&version=15-SP3
