### PR TITLE
kdump: Add check for vmcore

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -327,6 +327,8 @@ sub check_function {
     assert_script_run 'find /var/crash/';
 
     if ($args{test_type} eq 'function') {
+        # Check, that vmcore exists, otherwise fail
+        assert_script_run('ls -lah /var/crash/*/vmcore');
         my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`*";
         validate_script_output "$crash_cmd", sub { m/PANIC:\s([^\s]+)/ }, 600;
     }


### PR DESCRIPTION
Enhancement poo#91329: Test will correctly fail on missing /var/crash/*/vmcore.

- Related ticket: https://progress.opensuse.org/issues/91329
- Needles: none
- Verification run: 
aarch64: https://openqa.suse.de/tests/5844997 - fail reported, as wanted
x86_64: https://openqa.suse.de/tests/5844996