### PR TITLE
Alternative way of getting vm ip address using nmap

### DIFF
--- a/data/virt_autotest/fetch_logs_from_guest.sh
+++ b/data/virt_autotest/fetch_logs_from_guest.sh
@@ -49,8 +49,8 @@ function fetch_logs_from_guest_via_ssh() {
         local logs_folder=$3
         local guest_user="root"
         local guest_pass="novell"
-        local sshpass_scp_cmd="sshpass -p ${guest_pass} scp -r ${guest_user}@${guest_ipaddr}"
-        local sshpass_ssh_cmd="sshpass -p ${guest_pass} ssh ${guest_user}@${guest_ipaddr}"
+        local sshpass_scp_cmd="sshpass -p ${guest_pass} scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -r ${guest_user}@${guest_ipaddr}"
+        local sshpass_ssh_cmd="sshpass -p ${guest_pass} ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${guest_user}@${guest_ipaddr}"
         local guest_transformed=${guest_domain//./_}
 
         local ret_result=128
@@ -271,12 +271,45 @@ guest_ipaddress="";
 guest_hash_index=0
 dhcpd_lease_file="/var/lib/dhcp/db/dhcpd.leases"
 
+#Install necessary packages
+echo -e "Install necessary packages. zypper install -y sshpass nmap xmlstarlet libguestfs*" | tee -a ${fetch_logs_from_guest_log}
+zypper install -y sshpass nmap xmlstarlet libguestfs* | tee -a ${fetch_logs_from_guest_log}
+
+#Establish reachable networks and hosts database on host
+subnets_in_route=`ip route show all | awk '{print $1}' | grep -v default`
+subnets_scan_results=""
+subnets_scan_index=0
+echo -e "Subnets ${subnets_in_route[@]} are reachable on host judging by ip route show all" | tee -a ${fetch_logs_from_guest_log}
+echo -e "Establishing reachable hosts in subnets ${subnets_in_route[@]} database on host" | tee -a ${fetch_logs_from_guest_log}
+for single_subnet in ${subnets_in_route[@]};do
+    single_subnet_transformed=${single_subnet//./_}
+    single_subnet_transformed=${single_subnet_transformed/\//_}
+    scan_timestamp=`date "+%F-%H-%M-%S"`
+    mkdir -p "${virt_logs_folder}/nmap_subnets_scan_results"
+    single_subnet_scan_results=${virt_logs_folder}'/nmap_subnets_scan_results/nmap_scan_'${single_subnet_transformed}'_'${scan_timestamp}
+    subnets_scan_results[${subnets_scan_index}]=${single_subnet_scan_results}
+    echo -e "nmap -sn $single_subnet -oX $single_subnet_scan_results" | tee -a ${fetch_logs_from_guest_log}
+    nmap -sn $single_subnet -oX $single_subnet_scan_results | tee -a ${fetch_logs_from_guest_log}
+    subnets_scan_index=$(( ${subnets_scan_index} + 1 ))
+done
+
 #Establish virtual machine domain name and ip address mapping
 for guest_current in ${guest_domains_array[@]};do
     guest_macaddresses_array[${guest_hash_index}]=`virsh domiflist --domain ${guest_current} | grep -oE "([0-9|a-z]{2}:){5}[0-9|a-z]{2}"`
     guest_ipaddress=`tac $dhcpd_lease_file | awk '!($0 in S) {print; S[$0]}' | tac | grep -iE "${guest_macaddresses_array[${guest_hash_index}]}" -B8 | grep -oE "([0-9]{1,3}\.){3}[0-9]{1,3}" | tail -1`
+    if [[ -z ${guest_ipaddress} ]];then
+       for single_subnet_scan_results in ${subnets_scan_results[@]};do
+           guest_ipaddress=`xmlstarlet sel -t -v //address/@addr -n $single_subnet_scan_results | grep -i ${guest_macaddresses_array[${guest_hash_index}]} -B1 | grep -iv ${guest_macaddresses_array[${guest_hash_index}]}`
+           if [[ ! -z ${guest_ipaddress} ]];then
+               break
+           fi
+       done
+    fi
+    if [[ -z ${guest_ipaddress} ]];then
+       guest_ipaddress="NO_IP_ADDRESS_FOUND"
+    fi
     guest_hash_ipaddr[${guest_hash_index}]=${guest_ipaddress}
-    echo -e ${guest_current}:${guest_hash_ipaddr[${guest_hash_index}]} | tee -a ${virt_logs_collecor_log}
+    echo -e ${guest_current}:${guest_hash_ipaddr[${guest_hash_index}]} | tee -a ${fetch_logs_from_guest_log}
     guest_hash_index=$(( ${guest_hash_index} + 1 ))
 done
 


### PR DESCRIPTION
* **Current** virt_logs_collector.sh and fetch_logs_from_guest.sh scripts get virtual machine ip address from local dhcp lease file which might not be available if there is no local dhcpd service.
* **Nmap** looks like the perfect ultimate tool to be used to scan reachable subnets on host, then single out the virtual machine ip address by its macaddress.
* **So** if virtual machine ip address can not be obtained from local dhcp lease file, it can be obtained from nmap scan results.
* **Add** options "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" to ssh and scp command lines to increase success rate.
* **Verification run:**
  * [virt_logs_collector.log via guest console](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/6341708/uefi_guest_installation-virt_logs_collector.11.log)
  * [fetch_logs_from_guest.log via guest console](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/6341722/uefi_guest_installation-fetch_logs_from_guest.4.log)
  * [virt_logs_collector.log via ssh](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/6342045/uefi_guest_installation-virt_logs_collector.14.log)
  * [fetch_logs_from_guest.log via ssh](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/6342048/uefi_guest_installation-fetch_logs_from_guest.5.log)


