### PR TITLE
Disable kdump for 15sp1 sles4sap qem qcow2 image

### DIFF
--- a/schedule/qam/15-SP1/qam-create_hdd_sles4sap_gnome.yml
+++ b/schedule/qam/15-SP1/qam-create_hdd_sles4sap_gnome.yml
@@ -19,6 +19,7 @@ schedule:
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout
+  - installation/disable_kdump
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation


### PR DESCRIPTION
On 15-SP1 QEM, we need to disable kdump to fix this [issue](https://openqa.suse.de/tests/5843898) - [bsc](https://bugzilla.suse.com/show_bug.cgi?id=1182285)

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
