### PR TITLE
SLE Micro: Handle Updates repositories

### DIFF
--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -7,6 +7,7 @@ BEGIN {
     unshift @INC, dirname(__FILE__) . '/../../lib';
 }
 use utils;
+use testapi;
 use main_common;
 
 init_main();
@@ -15,9 +16,24 @@ my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
 testapi::set_distribution(susedistribution->new());
 
-#######################
-# Testing starts here #
-#######################
+
+# Handle updates from repos defined in OS_TEST_TEMPLATE combined with the list
+# of issues defined in OS_TEST_ISSUES.
+# OS_TEST_ISSUES is set by openQABot and metadata repo used in maintenance
+# (https://gitlab.suse.de/qa-maintenance/metadata)
+# OS_TEST_TEMPLATE must be set at openQA job level.
+# The array of repositories will be stored in MAINT_TEST_REPO for futher
+# installation by the maintenance jobs.
+if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
+    my %incidents;
+    my %u_url;
+    $incidents{OS} = get_var('OS_TEST_ISSUES',   '');
+    $u_url{OS}     = get_var('OS_TEST_TEMPLATE', '');
+
+    my $repos = map_incidents_to_repo(\%incidents, \%u_url);
+    set_var('MAINT_TEST_REPO', $repos);
+}
+
 return 1 if load_yaml_schedule;
 
 1;

--- a/schedule/sle-micro/autoyast.yaml
+++ b/schedule/sle-micro/autoyast.yaml
@@ -2,21 +2,27 @@ name:           sle_micro_autoyast
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  maintenance:
+    FLAVOR:
+      'DVD-Updates':
+        - transactional/install_updates
 schedule:
-    - autoyast/prepare_profile
-    - installation/bootloader_start
-    - autoyast/installation
-    - autoyast/console
-    - autoyast/login
-    - autoyast/logs
-    - console/textinfo
-    - microos/networking
-    - microos/libzypp_config
-    - microos/one_line_checks
-    - microos/services_enabled
-    - transactional/filesystem_ro
-    - transactional/transactional_update
-    - transactional/rebootmgr
-    - transactional/health_check
-    - microos/journal_check
-    - shutdown/shutdown
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/logs
+  - console/textinfo
+  - '{{maintenance}}'
+  - microos/networking
+  - microos/libzypp_config
+  - microos/one_line_checks
+  - microos/services_enabled
+  - transactional/filesystem_ro
+  - transactional/transactional_update
+  - transactional/rebootmgr
+  - transactional/health_check
+  - microos/journal_check
+  - shutdown/shutdown

--- a/schedule/sle-micro/containers.yaml
+++ b/schedule/sle-micro/containers.yaml
@@ -7,9 +7,14 @@ conditional_schedule:
     SCC_REGISTER:
       'installation':
         - console/suseconnect_scc
+  maintenance:
+    FLAVOR:
+      'MicroOS-Image-Updates':
+        - transactional/install_updates
 schedule:
   - microos/disk_boot
   - '{{registration}}'
+  - '{{maintenance}}'
   - microos/toolbox
   - containers/containers_3rd_party
   - containers/podman

--- a/schedule/sle-micro/dvd.yaml
+++ b/schedule/sle-micro/dvd.yaml
@@ -2,29 +2,35 @@ name:           sle_micro_dvd
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  maintenance:
+    FLAVOR:
+      'DVD-Updates':
+        - transactional/install_updates
 schedule:
-    - installation/bootloader_start
-    - installation/welcome
-    - installation/accept_license
-    - installation/scc_registration
-    - installation/ntp_config_settings
-    - installation/user_settings_root
-    - installation/resolve_dependency_issues
-    - installation/installation_overview
-    - installation/disable_grub_timeout
-    - installation/start_install
-    - installation/await_install
-    - installation/logs_from_installation_system
-    - installation/reboot_after_installation
-    - microos/disk_boot
-    - console/textinfo
-    - microos/networking
-    - microos/libzypp_config
-    - microos/one_line_checks
-    - microos/services_enabled
-    - transactional/filesystem_ro
-    - transactional/transactional_update
-    - transactional/rebootmgr
-    - transactional/health_check
-    - microos/journal_check
-    - shutdown/shutdown
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/ntp_config_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - microos/disk_boot
+  - console/textinfo
+  - '{{maintenance}}'
+  - microos/networking
+  - microos/libzypp_config
+  - microos/one_line_checks
+  - microos/services_enabled
+  - transactional/filesystem_ro
+  - transactional/transactional_update
+  - transactional/rebootmgr
+  - transactional/health_check
+  - microos/journal_check
+  - shutdown/shutdown

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -7,10 +7,15 @@ conditional_schedule:
     SCC_REGISTER:
       'installation':
         - console/suseconnect_scc
+  maintenance:
+    FLAVOR:
+      'MicroOS-Image-Updates':
+        - transactional/install_updates
 schedule:
   - microos/disk_boot
   - transactional/disable_grub
   - '{{registration}}'
+  - '{{maintenance}}'
   - microos/networking
   - microos/libzypp_config
   - microos/image_checks

--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Install Update repos in transactional server
+# Maintainer: qac team <qa-c@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use qam;
+use transactional;
+use version_utils 'is_sle_micro';
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+    if (is_sle_micro) {
+        assert_script_run 'curl http://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt';
+        assert_script_run 'update-ca-certificates -v';
+    }
+    add_test_repositories;
+    record_info 'Updates', script_output('zypper lu');
+    trup_call 'up';
+    check_reboot_changes;
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
For SLE Micro we don't want SCC_ADDONS to be set in the job cause
we can't register against those modules (they don't exist), but
we still want to trigger tests for any existing update in 15-SP2.
So, we use the ADDONS variable to create MAINT_TEST_REPO which
points to all the repositories to be installed.

- Related ticket: https://progress.opensuse.org/issues/91118
- VRs: [DVD-Updates](http://fromm.arch.suse.de/tests/1023) [Image-Updates](http://fromm.arch.suse.de/tests/1026)
