### PR TITLE
Use correct repo url in leap fisrtboot test

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot_leap.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot_leap.xml
@@ -97,7 +97,7 @@
                 # the package cannot be installed the autoyast way, because of the package name (eg libyui-rest-api15)
                 # only zypper allows to install "by capability".
                 mv /var/run/zypp.pid /var/run/zypp.sav
-                zypper ar http://openqa.opensuse.org/assets/repo/openSUSE-Leap-{{VERSION}}-oss-Build{{BUILD}} leap
+                zypper ar {{MIRROR_HTTP}} OSS
                 zypper -n in libyui-rest-api
                 mv /var/run/zypp.sav /var/run/zypp.pid
                 systemctl disable firewalld


### PR DESCRIPTION
We have missed fixing repo url same way as we did for TW not to rely on
the hardcoded strings and simply reuse value of `MIRROR_HTTP`.

Fixes https://openqa.opensuse.org/tests/1703042

[Verification run](https://openqa.opensuse.org/tests/1705280#).
