### PR TITLE
Support SR-IOV test running on SLE12SP5 host

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -32,7 +32,7 @@ use testapi;
 use DateTime;
 use Utils::Architectures 'is_s390x';
 
-our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest is_xen_host is_kvm_host
+our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest is_guest_ballooned is_xen_host is_kvm_host
   check_host check_guest print_cmd_output_to_file ssh_setup ssh_copy_id create_guest import_guest install_default_packages
   upload_y2logs ensure_default_net_is_active ensure_guest_started ensure_online add_guest_to_hosts restart_libvirtd remove_additional_disks
   remove_additional_nic collect_virt_system_logs shutdown_guests wait_guest_online start_guests is_guest_online wait_guests_shutdown);
@@ -70,6 +70,17 @@ sub is_fv_guest {
 sub is_pv_guest {
     my $guest = shift;
     return $guest =~ /\bpv\b/;
+}
+
+#return 1 if max_mem > memory in vm configuration file in libvirt
+sub is_guest_ballooned {
+    my $guest = shift;
+
+    my $mem     = "";
+    my $cur_mem = "";
+    $mem     = script_output "virsh dumpxml $guest | xmlstarlet sel -t -v //memory";
+    $cur_mem = script_output "virsh dumpxml $guest | xmlstarlet sel -t -v //currentMemory";
+    return $mem > $cur_mem;
 }
 
 #return 1 if test is expected to run on KVM hypervisor


### PR DESCRIPTION
- for sles15sp1+ kvm, PCIe replaces PCI. We need add pcie controllers to support hotplugging more SR-IOV Ethernet vf devices
- since xen 4.13, <xen> is a new feature to enable passthrough devices to guest.
- increase timeout for sles12sp5 guest bootup
- enable udev debug

Related ticket: https://progress.opensuse.org/issues/78960
Verification run: 
  - [sle15sp2/sp3 guest on-host_sles15sp3-kvm](https://openqa.nue.suse.com/tests/5868830)
  - [sle15sp2 pv guest on-host_sles15sp3-xen](https://openqa.nue.suse.com/tests/5868831)
  - [sle15sp3 fv guest on-host_sles15sp3-xen](https://openqa.nue.suse.com/tests/5869765)
  - [sle15sp3 guest on-host_sles12sp5-kvm](http://10.67.129.51/tests/2133)
  - [sle15sp3 fv guest on-host_sles12sp5-xen](http://10.67.129.51/tests/2120)
  - [sle15sp3 pv guest on-host_sles12sp5-xen](http://10.67.129.51/tests/2129)