### PR TITLE
Fix call to opensusebasetest::handle_uefi_boot_disk_workaround in lib/grub_utils.pm.

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -68,7 +68,7 @@ sub handle_installer_medium_bootup {
     send_key 'ret';
 
     # use firmware boot manager of aarch64 to boot upgraded system
-    handle_uefi_boot_disk_workaround() if (check_var('ARCH', 'aarch64'));
+    'opensusebasetest'->handle_uefi_boot_disk_workaround() if (check_var('ARCH', 'aarch64'));
 }
 
 sub bug_workaround_bsc1005313 {


### PR DESCRIPTION
PR #12048 introduced `lib/grub_utils` and `tests/installation/handle_reboot`, but currently a call to `opensusebasetest::handle_uefi_boot_disk_workaround()` from `lib/grub_utils` fails to [locate the method](https://openqa.suse.de/tests/5845841#step/handle_reboot/6).

This PR fixes the call.

- Related ticket: https://progress.opensuse.org/issues/88786
- Failing tests: https://openqa.suse.de/tests/5845841#step/handle_reboot/6, https://openqa.opensuse.org/tests/1704954#step/grub_test/7
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/3892 (clone of 5845841) 
