### PR TITLE
Revert "sles4sap: Change mr_test repository"

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -35,7 +35,7 @@ sub reboot_wait {
 sub setup {
     my ($self) = @_;
 
-    my $tarball = get_var('MR_TEST_TARBALL', 'https://gitlab.suse.de/qa-css/mr_test/-/archive/master/mr_test-master.tar.gz');
+    my $tarball = get_var('MR_TEST_TARBALL', 'https://gitlab.suse.de/rbranco/mr_test/-/archive/master/mr_test-master.tar.gz');
 
     $self->select_serial_terminal;
     # Disable packagekit


### PR DESCRIPTION
We need a repository with public visibility to download it from the openQA's SUT.  Currently we can't create one within `qa-css`.  Maybe it's a bug in Gitlab.

A ticket was opened for this: SD-45915