### PR TITLE
Exclude containers in consoletests in non openSUSE distros

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1211,7 +1211,7 @@ sub load_consoletests {
         loadtest "console/mysql_srv";
         # disable these tests of server packages for SLED (poo#36436)
         load_console_server_tests() unless is_desktop;
-        load_extra_tests_docker()   unless (is_desktop || !is_released);
+        load_extra_tests_docker()   unless (!is_opensuse || is_desktop || !is_released);
     }
     if (check_var("DESKTOP", "xfce")) {
         loadtest "console/xfce_gnome_deps";


### PR DESCRIPTION
In [SLE](https://openqa.suse.de/tests/5851151), we test containers separately and don't want them to be part of consoletests.

- Follow up to: #12032
- Verification run: [Leap 15.2](http://pdostal-server.suse.cz/tests/11703#)
