### PR TITLE
Adapt samba_adcli test to use a dedicated AD server

### DIFF
--- a/data/supportserver/samba/krb5.conf
+++ b/data/supportserver/samba/krb5.conf
@@ -16,8 +16,8 @@
 
 [realms]
 GEEKO.COM = {
-        kdc = win-r70413psjm4.geeko.com
-        admin_server = win-r70413psjm4.geeko.com
+        kdc = win2019dcadprovider.phobos.qa.suse.de
+        admin_server = win2019dcadprovider.phobos.qa.suse.de
         default_domain = geeko.com
         auth_to_local = RULE:[1:$1@$0]
 }

--- a/data/supportserver/samba/smb.conf
+++ b/data/supportserver/samba/smb.conf
@@ -9,7 +9,7 @@
         domain logons = No
         domain master = Auto
         local master = Yes
-        netbios name = SLES-VM
+        # netbios name = SLES-VM
         os level = 65
         passdb backend = smbpasswd
         preferred master = Yes


### PR DESCRIPTION
See [progress ticket](https://progress.opensuse.org/issues/72169)

For now: http://phobos.qa.suse.de/tests/3857465#step/samba_adcli/38