### PR TITLE
Fix reboot handling on remote backends

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -30,8 +30,6 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot
-  - boot/reconnect_mgmt_console
-  - installation/grub_test
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -30,7 +30,6 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot
-  - boot/reconnect_mgmt_console
   - installation/first_boot
   - console/validate_ext4_fs
 test_data:

--- a/schedule/yast/msdos/msdos.yaml
+++ b/schedule/yast/msdos/msdos.yaml
@@ -48,8 +48,5 @@ conditional_schedule:
         - installation/logs_from_installation_system
       pvm_hmc:
         - installation/logs_from_installation_system
-    VIRSH_VMM_TYPE:
-      hvm:
-        - installation/grub_test
 test_data:
   <<: !include test_data/yast/msdos/msdos.yaml

--- a/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
@@ -1,0 +1,27 @@
+---
+name:           msdos@svirt-xen-pv
+description:    >
+  Test for installation on msdos partition table.
+vars:
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/msdos_partition_table
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/first_boot
+  - console/validate_fs_table
+test_data:
+  <<: !include test_data/yast/msdos/msdos_pv.yaml


### PR DESCRIPTION
Fix issues with scheduling after the changes, that were introduced in
"PR #12048" (Simplify scheduling for reboot handling).

- Related ticket: https://progress.opensuse.org/issues/88786
- Verification runs: https://openqa.suse.de/tests/overview.html?build=176.5_oorlov&groupid=96&version=15-SP3&distri=sle

**Please, also merge MR in Job Group settings repo: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/350**