### PR TITLE
kernel: Disable grub graphics for bare metal installation

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1427,7 +1427,7 @@ sub reconnect_mgmt_console {
     elsif (check_var('ARCH', 'x86_64')) {
         if (check_var('BACKEND', 'ipmi')) {
             select_console 'sol', await_console => 0;
-            assert_screen([qw(qa-net-selection prague-pxe-menu)], 300) unless get_var('IPXE_CONSOLE');
+            assert_screen([qw(qa-net-selection prague-pxe-menu grub2)], 300);
             # boot to hard disk is default
             send_key 'ret';
         }
@@ -1436,7 +1436,8 @@ sub reconnect_mgmt_console {
         if (check_var('BACKEND', 'ipmi')) {
             select_console 'sol', await_console => 0;
             # aarch64 baremetal machine takes longer to boot than 5 minutes
-            assert_screen([qw(qa-net-selection prague-pxe-menu)], 600) unless get_var('IPXE_CONSOLE');
+            assert_screen([qw(qa-net-selection prague-pxe-menu grub2)], 600);
+            send_key 'ret';
         }
     }
     else {

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -36,6 +36,8 @@ schedule:
     - installation/resolve_dependency_issues
     - installation/select_packages
     - installation/installation_overview
+    - installation/disable_grub_graphics
+    - installation/disable_grub_timeout
     - installation/start_install
     - installation/await_install
     - installation/logs_from_installation_system

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -34,6 +34,8 @@ schedule:
     - installation/resolve_dependency_issues
     - installation/select_packages
     - installation/installation_overview
+    - installation/disable_grub_graphics
+    - installation/disable_grub_timeout
     - installation/start_install
     - installation/await_install
     - installation/logs_from_installation_system

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -36,6 +36,8 @@ schedule:
     - installation/resolve_dependency_issues
     - installation/select_packages
     - installation/installation_overview
+    - installation/disable_grub_graphics
+    - installation/disable_grub_timeout
     - installation/start_install
     - installation/await_install
     - installation/logs_from_installation_system

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -34,6 +34,8 @@ schedule:
     - installation/resolve_dependency_issues
     - installation/select_packages
     - installation/installation_overview
+    - installation/disable_grub_graphics
+    - installation/disable_grub_timeout
     - installation/start_install
     - installation/await_install
     - installation/logs_from_installation_system

--- a/schedule/kernel/prepare_baremetal.yaml
+++ b/schedule/kernel/prepare_baremetal.yaml
@@ -21,6 +21,8 @@ schedule:
     - installation/user_settings_root
     - installation/resolve_dependency_issues
     - installation/installation_overview
+    - installation/disable_grub_graphics
+    - installation/disable_grub_timeout
     - installation/start_install
     - installation/await_install
     - installation/logs_from_installation_system

--- a/tests/installation/disable_grub_graphics.pm
+++ b/tests/installation/disable_grub_graphics.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,11 +18,21 @@ use testapi;
 sub run {
     my ($self) = shift;
 
-    send_key 'alt-c';
-    assert_screen 'inst-overview-options';
+    if (check_var('VIDEOMODE', 'text')) {
+        send_key 'alt-c';
+        assert_screen 'inst-overview-options';
 
-    send_key 'alt-b';
-    assert_screen 'installation-bootloader-config';
+        send_key 'alt-b';
+        assert_screen 'installation-bootloader-config';
+    }
+    else {
+        # Verify Installation Settings overview is displayed as starting point
+        assert_screen "installation-settings-overview-loaded";
+
+        # Select section booting on Installation Settings overview (video mode)
+        send_key_until_needlematch 'booting-section-selected', 'tab';
+        send_key 'ret';
+    }
     send_key 'alt-k';
     assert_screen 'installation-bootloader-kernel';
     if (match_has_tag 'graphic-console-enabled') {


### PR DESCRIPTION
Fix poo#77818: Grub menu was not resposive in IPMI SOL console for
IPXE scenarios. Console now works, it is possible to disable grub
timeout and confirm boot option during system boot.

- Related ticket: https://progress.opensuse.org/issues/77818
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1530
** Graphics console enabled: http://black-bit.suse.cz/tests/136#step/disable_grub_graphics/5
** Graphics console disable: http://black-bit.suse.cz/tests/136#step/disable_grub_graphics/6
- Verification run:
x86_64 ipxe tyrion: http://black-bit.suse.cz/tests/136
x86_64 ipxe tyrion: https://openqa.suse.de/tests/5860342
x86_64 ipxe coppi: https://openqa.suse.de/tests/5866986
x86_64 ipxe coppi-xen: https://openqa.suse.de/tests/5861929
x86_64 virt test pxe: https://openqa.suse.de/tests/5858965
aarch64: https://openqa.suse.de/tests/5861931
powervm: https://openqa.suse.de/tests/5861930