### PR TITLE
Install tar package for leap transactional_server

### DIFF
--- a/schedule/yast/transactional_server/transactional_server_opensuse.yaml
+++ b/schedule/yast/transactional_server/transactional_server_opensuse.yaml
@@ -1,0 +1,51 @@
+---
+name: transactional_server
+description: >
+  Installation of a Transactional Server which uses a read-only
+  root filesystem to provide atomic, automatic updates of a
+  system without interfering with the running system.
+vars:
+  HDDSIZEGB: 40
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role/validate_default_role
+  - installation/system_role/select_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - update/zypper_clear_repos
+  - console/zypper_ar
+  - console/zypper_ref
+  - console/hostname
+  - console/force_scheduled_tasks
+  - transactional/filesystem_ro
+  - '{{tar_package_install}}'
+  - transactional/transactional_update
+  - transactional/rebootmgr
+  - transactional/health_check
+test_data:
+  system_role:
+    default: null
+    selection: 'Transactional Server'
+conditional_schedule:
+  tar_package_install:
+    LEAP:
+      1:
+        - transactional/trup_install_tar

--- a/tests/transactional/trup_install_tar.pm
+++ b/tests/transactional/trup_install_tar.pm
@@ -1,0 +1,34 @@
+# Copyright © 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Module to install tar package via transactional-update. The system is
+# rebooted so changes take effect.
+
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use transactional;
+
+sub run {
+    select_console 'root-console';
+
+    record_info 'Install tar', 'Install package tar using transactional server and reboot';
+    trup_install "tar";
+}
+
+1;


### PR DESCRIPTION
The tar package is no longer installed by default on leap and that caused failure for transactional_update module

- Related ticket: https://progress.opensuse.org/issues/90564
- Verification runs: 
leap: http://falafel.suse.cz/tests/199
tumbleweed  : http://falafel.suse.cz/tests/196