### PR TITLE
btrfsmaintenance: Capture output to help debugging

### DIFF
--- a/lib/Utils/Systemd.pm
+++ b/lib/Utils/Systemd.pm
@@ -69,7 +69,7 @@ sub systemctl {
     croak "systemctl(): no command specified" if ($command =~ /^ *$/);
     my $expect_false  = $args{expect_false} ? '! ' : '';
     my @script_params = ("${expect_false}systemctl --no-pager $command", timeout => $args{timeout}, fail_message => $args{fail_message});
-    if ($command =~ /^(re)?start ([^ ]+)/) {
+    if ($command =~ /^(start|restart|enable) ([^ ]+)/) {
         my $unit_name = $2;
         $started_systemd_services{$unit_name} = 1;
     }

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -50,7 +50,8 @@ Method executed when run() finishes and the module has result => 'fail'
 sub post_fail_hook {
     my ($self) = shift;
     $self->SUPER::post_fail_hook;
-    select_console('log-console');
+    # select_console('log-console');
+    $self->select_serial_terminal;
     $self->remount_tmp_if_ro;
     $self->export_logs_basic;
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1310,11 +1310,24 @@ base method using C<$self-E<gt>SUPER::post_fail_hook;> at the end.
 =cut
 sub post_fail_hook {
     my ($self) = @_;
-    return if is_serial_terminal();    # unless VIRTIO_CONSOLE=0 nothing below make sense
-
-    show_tasks_in_blocked_state;
 
     return if (get_var('NOLOGS'));
+
+    if (!$self->is_serial_terminal()) {
+        # In case the system is stuck in shutting down or during boot up, press
+        # 'esc' just in case the plymouth splash screen is shown and we can not
+        # see any interesting console logs.
+        send_key 'esc';
+        save_screenshot;
+        # the space prevents the esc from eating up the next alphanumerical
+        # character typed into the console
+        send_key 'spc';
+
+        # We also want to try getting the tasks and stuff if it's possible
+        show_tasks_in_blocked_state;
+
+    }
+
 
     # just output error if selected program doesn't exist instead of collecting all logs
     # set current variables in x11_start_program
@@ -1354,15 +1367,6 @@ sub post_fail_hook {
         my $io_status = script_output("sed -n 's/^.*da / /p' /proc/diskstats | cut -d' ' -f10");
         record_info('System I/O status:', ($io_status =~ /^0$/) ? 'idle' : 'busy');
     }
-
-    # In case the system is stuck in shutting down or during boot up, press
-    # 'esc' just in case the plymouth splash screen is shown and we can not
-    # see any interesting console logs.
-    send_key 'esc';
-    save_screenshot;
-    # the space prevents the esc from eating up the next alphanumerical
-    # character typed into the console
-    send_key 'spc';
 
     $self->export_logs;
 }


### PR DESCRIPTION
When a job fails due to btrfs maintenance service being in a certain
unexpected state, it is difficult to know what happened without looking
at the data returned by assert_scrip_run, switching to script output
helps a bit more in this case

See: https://openqa.suse.de/tests/5846464
VR: https://openqa.suse.de/t5869239