### PR TITLE
Revert "Workaround for exit of oomath not asking to save changes"

### DIFF
--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -33,17 +33,19 @@ sub run {
     my $retries = 7;
     for (1 .. $retries) {
         type_string_slow "E %PHI = H %PHI\nnewline\n1 = 1";
-        last                                                             if check_screen('test-oomath-1', 2);
+        last                                                             if check_screen [qw(test-oomath-1 oomath-bsc1127895)];
         die "Could not match on correct formula within multiple retries" if $_ == $retries;
         record_info 'workaround', 'retrying unstable formula typing, see https://progress.opensuse.org/issues/53795 for details';
         send_key 'ctrl-a';
         send_key 'delete';
     }
-
-    send_key 'alt-f4';
-    assert_screen([qw(dont-save-libreoffice-btn generic-desktop)]);
-    record_soft_failure('bsc#1184961')           if match_has_tag('generic-desktop');
-    assert_and_click 'dont-save-libreoffice-btn' if match_has_tag('dont-save-libreoffice-btn');
+    if (match_has_tag('oomath-bsc1127895')) {
+        record_soft_failure 'bsc#1127895';
+        send_key 'alt-f4';
+    } else {
+        send_key 'alt-f4';
+        assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
+    }
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#12349

This oomath bug can lead to data-loss - imaging a user modifying a file for 30 minutes, pressing ctrl-q and not being asked to save the file

this does not sound acceptable as a soft-failure.

