### PR TITLE
oomath: Only detect bsc#1184961 where the bug was released

### DIFF
--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'type_string_slow';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = shift;
@@ -41,7 +42,9 @@ sub run {
     }
 
     send_key 'alt-f4';
-    assert_screen([qw(dont-save-libreoffice-btn generic-desktop)]);
+    my @tags = ('dont-save-libreoffice-btn');
+    push @tags, 'generic-desktop' if is_sle;    # for bsc#1184961
+    assert_screen \@tags;
     record_soft_failure('bsc#1184961')           if match_has_tag('generic-desktop');
     assert_and_click 'dont-save-libreoffice-btn' if match_has_tag('dont-save-libreoffice-btn');
 }


### PR DESCRIPTION
Verification runs:
* [sle-15-SP2-Desktop-DVD-Updates-x86_64-Build20210421-1-qam-gnome@64bit](https://openqa.suse.de/t5869771) shows soft-fail as expected: https://openqa.suse.de/tests/5869771#step/oomath/6
* [opensuse-Tumbleweed-DVD-x86_64-Build20210419-gnome@64bit](https://openqa.opensuse.org/t1707678) save dialog still expected in Tumbleweed: https://openqa.opensuse.org/tests/1707678#step/oomath/6

https://progress.opensuse.org/issues/91275
https://bugzilla.suse.com/show_bug.cgi?id=1184961