### PR TITLE
RFC: Make all installbasetests milestones

### DIFF
--- a/lib/installbasetest.pm
+++ b/lib/installbasetest.pm
@@ -3,10 +3,10 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 
-# All steps in the installation are 'fatal'.
+# All steps in the installation are 'fatal' and 'milestones'.
 
 sub test_flags {
-    return {fatal => 1};
+    return {fatal => 1, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
Those modules are important for succeeding tests, so avoid that a snapshot of a previous state is restored.

This potentially increases the number of snapshots taken, but os-autoinst after https://github.com/os-autoinst/os-autoinst/pull/1483 doesn't create snapshots when the next test is a fatal milestone, which should be the majority of cases. There are some cases where there's a non-installbasetest in a row of installbasetests, like "logs_from_installation_system" which now cause the preceding test to take a snapshot. However, previously failures in that module would've caused the test to abort because there wasn't a usable snapshot taken FWICT.

RFC because in this case, snapshots are practically only utilized when the test is going to fail anyway, so this might slow down some scenarios.

Verification run: https://openqa.opensuse.org/tests/1707671