### PR TITLE
transactional/tdup: Be a fatal milestone

### DIFF
--- a/tests/transactional/tdup.pm
+++ b/tests/transactional/tdup.pm
@@ -42,7 +42,10 @@ sub run {
     trup_call 'dup';
 
     check_reboot_changes;
+}
 
+sub test_flags {
+    return {fatal => 1, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
- If tdup fails, continuing the test makes no sense
- When a module after tdup fails, it must not revert to the pre-tdup state

Verification run: https://10.160.67.86/tests/934