### PR TITLE
Move extra_tests_dracut to YAML scheduling

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1563,10 +1563,6 @@ sub load_extra_tests_zypper {
     loadtest 'console/zypper_extend';
 }
 
-sub load_extra_tests_dracut {
-    loadtest "console/dracut";
-}
-
 sub load_extra_tests_perl_bootloader {
     loadtest "console/perl_bootloader";
 }

--- a/schedule/functional/extra_tests_dracut.yaml
+++ b/schedule/functional/extra_tests_dracut.yaml
@@ -1,0 +1,8 @@
+name:           extra_tests_dracut
+description:    >
+    Maintainer: dheidler.
+    Extra dracut tests
+schedule:
+    - boot/boot_to_desktop
+    - console/dracut
+    - console/coredump_collect


### PR DESCRIPTION
After this is merged, on O3 and OSD in the `extra_tests_dracut` testsuite the config line `EXTRATEST=dracut` needs to be replaced by `YAML_SCHEDULE=schedule/functional/extra_tests_dracut.yaml`.

Ticket: https://progress.opensuse.org/issues/68527
Verification:

SLE: https://openqa.suse.de/tests/5847308
TW: http://kazhua.qa.suse.de/tests/324