### PR TITLE
Adds openqa_formatter option to run_ltp

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -109,6 +109,7 @@ sub run {
     $cmd .= ':host=' . $instance->public_ip;
     $cmd .= ':reset_command=\'' . $reset_cmd . '\'';
     $cmd .= ':ssh_opts=\'-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\' ';
+    $cmd .= '--json_filter=openqa ';
     assert_script_run($cmd, timeout => get_var('LTP_TIMEOUT', 30 * 60));
 }
 


### PR DESCRIPTION
This PR depends on https://github.com/metan-ucw/runltp-ng/pull/26                                                                                                                                                                            
We add `--openqa_format` option in runltp_ng to convert the json data                                                                                                                                                                        
to something compatible with the OpenQA parser to get external results                                                                                                                                                                       
output. 

- Related ticket: https://progress.opensuse.org/issues/91485
- Verification run: http://aquarius.suse.cz/tests/5507
