### PR TITLE
Add ovs-vtep regression test

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -371,6 +371,8 @@ else {
                 barrier_create('empty_directories',   2);
                 barrier_create('cacert_done',         2);
                 barrier_create('end_of_test',         2);
+                barrier_create('vtep_config',         2);
+                barrier_create('end',                 2);
             }
             loadtest 'installation/bootloader_start';
             loadtest 'network/setup_multimachine';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1089,6 +1089,8 @@ else {
             barrier_create('host2_cert_ready',    2);
             barrier_create('cacert_done',         2);
             barrier_create('end_of_test',         2);
+            barrier_create('vtep_config',         2);
+            barrier_create('end',                 2);
         }
         loadtest 'installation/bootloader_start';
         boot_hdd_image;


### PR DESCRIPTION
Add a testcase for openvswitch-vtep

- Related ticket: https://progress.opensuse.org/issues/86075
- Needles: N/A
- Verification run: 
Tumbleweed [ovs-server](http://10.163.41.158/tests/421) | [ovs-client](http://10.163.41.158/tests/422)
SLES 15-SP3 [ovs-server](http://10.163.41.158/tests/445) | [ovs-client](http://10.163.41.158/tests/446)
SLES 15-SP2 pending
