### PR TITLE
Enable ssh service for minimalx TW installation on zVM

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -16,6 +16,7 @@ package Distribution::Opensuse::Tumbleweed;
 use strict;
 use warnings FATAL => 'all';
 use parent 'susedistribution';
+use Installation::Overview::OverviewController;
 use Installation::Partitioner::LibstorageNG::v4_3::SuggestedPartitioningController;
 use Installation::Partitioner::LibstorageNG::v4_3::GuidedSetupController;
 use Installation::Partitioner::LibstorageNG::GuidedSetupController;
@@ -35,6 +36,10 @@ sub get_guided_partitioner {
 
 sub get_expert_partitioner {
     return Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerController->new();
+}
+
+sub get_overview_controller {
+    return Installation::Overview::OverviewController->new();
 }
 
 sub get_network_settings {

--- a/lib/Installation/Overview/OverviewController.pm
+++ b/lib/Installation/Overview/OverviewController.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for the Overview Page
+#          of the installer.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Overview::OverviewController;
+use strict;
+use warnings;
+use Installation::Overview::OverviewPage;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{OverviewPage} = Installation::Overview::OverviewPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_overview_page {
+    my ($self) = @_;
+    die "Installation Overview Page is not displayed" unless $self->{OverviewPage}->is_shown();
+    return $self->{OverviewPage};
+}
+
+sub enable_ssh_service {
+    my ($self) = @_;
+    if (!$self->get_overview_page()->is_ssh_enabled()) {
+        $self->get_overview_page()->enable_ssh_service();
+    }
+    if (!$self->get_overview_page()->is_ssh_port_open()) {
+        $self->get_overview_page()->open_ssh_port();
+    }
+    return $self;
+}
+
+1;

--- a/lib/Installation/Overview/OverviewPage.pm
+++ b/lib/Installation/Overview/OverviewPage.pm
@@ -1,0 +1,77 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The module provides interface to act on the Overview page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Overview::OverviewPage;
+use strict;
+use warnings;
+use YuiRestClient::Wait;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_install}  = $self->{app}->button({id => 'next'});
+    $self->{txt_overview} = $self->{app}->richtext({id => 'proposal'});
+
+    return $self;
+}
+
+sub get_overview_content {
+    my ($self) = @_;
+    return $self->{txt_overview}->text();
+}
+
+sub enable_ssh_service {
+    my ($self) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->{txt_overview}->activate_link('security--enable_sshd');
+            return $self->is_ssh_enabled;
+    });
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{txt_overview}->exist();
+}
+
+sub is_ssh_enabled {
+    my ($self) = @_;
+    my $overview_content = $self->get_overview_content();
+    return ($overview_content =~ m/SSH service will be enabled/);
+}
+
+sub is_ssh_port_open {
+    my ($self) = @_;
+    my $overview_content = $self->get_overview_content();
+    return ($overview_content =~ m/SSH port will be open/);
+}
+
+sub open_ssh_port {
+    my ($self) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->{txt_overview}->activate_link('security--open_ssh');
+            return $self->is_ssh_port_open;
+    });
+}
+
+sub press_install {
+    my ($self) = @_;
+    return $self->{btn_install}->click();
+}
+
+1;

--- a/lib/YuiRestClient/Widget/RichText.pm
+++ b/lib/YuiRestClient/Widget/RichText.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,12 +13,18 @@ package YuiRestClient::Widget::RichText;
 
 use strict;
 use warnings;
+use YuiRestClient::Action;
 
 use parent 'YuiRestClient::Widget::Base';
 
 sub text {
     my ($self) = @_;
     return $self->property('text');
+}
+
+sub activate_link {
+    my ($self, $link) = @_;
+    return $self->action(action => YuiRestClient::Action::YUI_SELECT, value => $link);
 }
 
 1;

--- a/schedule/yast/minimalx_zvm.yaml
+++ b/schedule/yast/minimalx_zvm.yaml
@@ -1,0 +1,45 @@
+---
+name: minimalx
+description: >
+  As default but explicitly unselecting DE patterns, for example gnome, to have
+  only a "minimal X" environment preserved, for example icewm. On zVM we should
+  explicitly enable ssh service, as required for the test execution in the
+  installed system
+vars:
+  DESKTOP: minimalx
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/welcome
+  - installation/disk_activation
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role/select_role
+  - installation/partitioning/accept_proposed_layout
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/select_patterns
+  - installation/overview/enable_ssh_service
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/handle_reboot
+  - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - update/zypper_clear_repos
+  - console/zypper_ar
+  - console/zypper_ref
+  - console/zypper_lr
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/firewall_enabled
+  - console/sshd
+  - console/orphaned_packages_check
+test_data:
+  system_role:
+    selection: 'Generic Desktop'

--- a/tests/installation/overview/enable_ssh_service.pm
+++ b/tests/installation/overview/enable_ssh_service.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for the Overview Page
+#          of the installer.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+
+sub run {
+    $testapi::distri->get_overview_controller()->enable_ssh_service();
+    save_screenshot;
+}
+
+1;


### PR DESCRIPTION
The ssh port has been opened, but the ssh service is disabled, this PR enables ssh service, and creates structure to extend its' functionality with the libyui REST API.

See [poo#88491](https://progress.opensuse.org/issues/88491).

Requires setting `YAML_SCHEDULE=schedule/yast/minimalx_zvm.yaml` in the job group.

[Verification run](https://openqa.opensuse.org/tests/1708618#) ( Fails due to https://bugzilla.opensuse.org/show_bug.cgi?id=1185107 )