### PR TITLE
Fix buildah tests on openSUSE

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -197,10 +197,8 @@ sub test_opensuse_based_image {
             if (script_output("$runtime run $image grep PRETTY_NAME /etc/os-release") =~ /WARN.+from \"\/etc\/containers\/mounts.conf\" doesn\'t exist, skipping/) {
                 record_soft_failure "bcs#1183482 - libcontainers-common contains SLE files on TW";
             }
-            else {
-                validate_script_output("$runtime run $image grep PRETTY_NAME /etc/os-release | cut -d= -f2",
-                    sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ });
-            }
+            validate_script_output("$runtime run $image grep PRETTY_NAME /etc/os-release | cut -d= -f2",
+                sub { /"openSUSE (Leap )?${version}.*"/ });
         }
         else {
             validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };


### PR DESCRIPTION
It uses cut to only get the value, but also expected the key in the output.

https://progress.opensuse.org/issues/90513

Verification run: https://openqa.opensuse.org/tests/1708935
