### PR TITLE
Add leap KDE to SLE migration with yast2 migration

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -22,7 +22,7 @@ use version_utils;
 
 sub run {
     my ($self) = @_;
-    if (is_leap_migration && check_var('DESKTOP', 'gnome')) {
+    if (is_leap_migration && (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'kde'))) {
         assert_screen 'generic-desktop', 90;
     }
     else {

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -19,7 +19,7 @@ use utils;
 use version_utils;
 use power_action_utils 'power_action';
 use version_utils qw(is_desktop_installed is_sle);
-use x11utils qw(ensure_unlocked_desktop turn_off_gnome_screensaver);
+use x11utils qw(ensure_unlocked_desktop turn_off_screensaver);
 use Utils::Backends 'is_pvm';
 
 sub yast2_migration_gnome_remote {
@@ -112,8 +112,8 @@ sub run {
         mouse_hide(1);
         assert_screen 'generic-desktop';
 
+        turn_off_screensaver();
         x11_start_program('xterm');
-        turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
         become_root;
         if (check_var('HDDVERSION', '12') && get_var('MIGRATION_REMOVE_ADDONS')) {
             # use latest yast2-registration version because is not officially available


### PR DESCRIPTION
In leap KDE to SLE yast2 migration, we need to disable the
screensaver during the migration. And in snapper_rollback
when roll back to leap, we don't need to check the display manager
for the kde and gnome desktop.

- Related ticket: https://progress.opensuse.org/issues/91263
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/5887332
  https://openqa.nue.suse.com/tests/5888023
  https://openqa.nue.suse.com/tests/5888041
  http://openqa.nue.suse.com/tests/5893937 from SLES15 gnome
  https://openqa.opensuse.org/tests/1711790 from opensuse
  https://openqa.nue.suse.com/tests/5894049 leap to sle gnome