### PR TITLE
Add stack backtraces and screenshot/json for REST API failures

### DIFF
--- a/lib/YaST/Module.pm
+++ b/lib/YaST/Module.pm
@@ -51,7 +51,7 @@ sub open {
     else {
         die "Unknown user interface: $ui";
     }
-    YuiRestClient::connect_to_app_running_system();
+    YuiRestClient::connect_to_running_app();
 }
 
 =head2 close

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -19,7 +19,6 @@ use testapi;
 use utils qw(enter_cmd_slow type_line_svirt save_svirt_pty zypper_call);
 use Utils::Backends qw(is_pvm is_ipmi);
 use YuiRestClient::App;
-use registration;
 use YuiRestClient::Wait;
 
 our $interval = 1;
@@ -48,14 +47,17 @@ sub connect_to_app {
     die "Cannot set libyui REST API server" unless $host;
     record_info('PORT',   "Used port for libyui: $port");
     record_info('SERVER', "Connecting to: $host");
-    my $app = YuiRestClient::App->new({port => $port, host => $host, api_version => API_VERSION});
+    my $app = YuiRestClient::App->new({
+            port        => $port,
+            host        => $host,
+            api_version => API_VERSION});
     # As we start installer, REST API is not instantly available
     $app->connect(timeout => 500, interval => 10);
     set_app($app);
 }
 
-sub connect_to_app_running_system {
-    get_app()->connect(timeout => 30, interval => 2);
+sub connect_to_running_app {
+    return get_app()->connect(timeout => 30, interval => 2);
 }
 
 sub setup_libyui_running_system {

--- a/lib/YuiRestClient/App.pm
+++ b/lib/YuiRestClient/App.pm
@@ -36,6 +36,7 @@ sub new {
     return bless {
         port              => $args->{port},
         host              => $args->{host},
+        api_version       => $args->{api_version},
         timeout           => $args->{timeout},
         interval          => $args->{interval},
         widget_controller =>
@@ -45,10 +46,13 @@ sub new {
 
 sub connect {
     my ($self, %args) = @_;
-    my $uri = YuiRestClient::Http::HttpClient::compose_uri(host => $self->{host}, port => $self->{port});
+    my $uri = YuiRestClient::Http::HttpClient::compose_uri(
+        host => $self->{host},
+        port => $self->{port},
+        path => $self->{api_version} . '/widgets');
     YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_get($uri);
-            return 1 if $response;
+            return $response->json if $response;
         },
         message => "Connection to YUI REST server failed",
         %args);

--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -1,0 +1,168 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package y2_base;
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+
+use ipmi_backend_utils;
+use network_utils;
+use y2_logs_helper 'get_available_compression';
+
+use testapi;
+
+use Carp::Always;
+use File::Copy 'copy';
+use File::Path 'make_path';
+use Mojo::JSON 'to_json';
+
+use YuiRestClient;
+
+=head1 y2_base
+
+C<y2_base> - Base class for YaST related functionality in installation and 
+running system.
+
+=cut
+
+sub save_strace_gdb_output {
+    my ($self, $is_yast_module) = @_;
+    return if (get_var('NOLOGS'));
+
+    # Collect yast2 installer or yast2 module trace if is still running
+    if (!script_run(qq{ps -eo pid,comm | grep -i [y]2start | cut -f 2 -d " " > /dev/$serialdev}, 0)) {
+        chomp(my $yast_pid = wait_serial(qr/^[\d{4}]/, 10));
+        return unless defined($yast_pid);
+        my $trace_timeout = 120;
+        my $strace_log    = '/tmp/yast_trace.log';
+        my $strace_ret    = script_run("timeout $trace_timeout strace -f -o $strace_log -tt -p $yast_pid", ($trace_timeout + 5));
+
+        upload_logs($strace_log, failok => 1) if script_run "! [[ -e $strace_log ]]";
+
+        # collect installer proc fs files
+        my @procfs_files = qw(
+          mounts
+          mountinfo
+          mountstats
+          maps
+          status
+          stack
+          cmdline
+          environ
+          smaps);
+
+        my $opt = defined($is_yast_module) ? 'module' : 'installer';
+        foreach (@procfs_files) {
+            $self->save_and_upload_log("cat /proc/$yast_pid/$_", "/tmp/yast2-$opt.$_");
+        }
+        # We enable gdb differently in the installer and in the installed SUT
+        my $system_management_locked;
+        if ($is_yast_module) {
+            $system_management_locked = zypper_call('in gdb', exitcode => [0, 7]) == 7;
+        }
+        else {
+            script_run 'extend gdb';
+        }
+        unless ($system_management_locked) {
+            my $gdb_output = '/tmp/yast_gdb.log';
+            my $gdb_ret    = script_run("gdb attach $yast_pid --batch -q -ex 'thread apply all bt' -ex q > $gdb_output", ($trace_timeout + 5));
+            upload_logs($gdb_output, failok => 1) if script_run '! [[ -e /tmp/yast_gdb.log ]]';
+        }
+    }
+}
+
+sub save_system_logs {
+    my ($self) = @_;
+
+    return if (get_var('NOLOGS'));
+
+    if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
+        script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
+        script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';
+        upload_logs('/tmp/btrfs-filesystem-df-mnt.txt',    failok => 1);
+        upload_logs('/tmp/btrfs-filesystem-usage-mnt.txt', failok => 1);
+    }
+    script_run 'df -h';
+    script_run 'df > /tmp/df.txt';
+    upload_logs('/tmp/df.txt', failok => 1);
+
+    # Log connections
+    script_run('ss -tulpn > /tmp/connections.txt');
+    upload_logs('/tmp/connections.txt', failok => 1);
+    # Check network traffic
+    script_run('for run in {1..10}; do echo "RUN: $run"; nstat; sleep 3; done | tee /tmp/network_traffic.log');
+    upload_logs('/tmp/network_traffic.log', failok => 1);
+    # Check VM load
+    script_run('for run in {1..3}; do echo "RUN: $run"; vmstat; sleep 5; done | tee /tmp/cpu_mem_usage.log');
+    upload_logs('/tmp/cpu_mem_usage.log', failok => 1);
+
+    $self->save_and_upload_log('pstree',  '/tmp/pstree');
+    $self->save_and_upload_log('ps auxf', '/tmp/ps_auxf');
+}
+
+sub save_upload_y2logs {
+    my ($self, %args) = @_;
+
+    return if (get_var('NOLOGS'));
+    $args{suffix} //= '';
+
+    # Do not test/recover network if collect from installation system, as it won't work anyway with current approach
+    # Do not recover network on non-qemu backend, as not implemented yet
+    $args{no_ntwrk_recovery} //= (get_var('BACKEND') !~ /qemu/);
+
+    # Try to recover network if cannot reach gw and upload logs if everything works
+    if (can_upload_logs() || (!$args{no_ntwrk_recovery} && recover_network())) {
+        script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';
+        my $filename = "/tmp/y2logs$args{suffix}.tar" . get_available_compression();
+        script_run "save_y2logs $filename", 180;
+        upload_logs($filename, failok => 1);
+    } else {    # Redirect logs content to serial
+        script_run("journalctl -b --no-pager -o short-precise > /dev/$serialdev");
+        script_run("dmesg > /dev/$serialdev");
+        script_run("cat /var/log/YaST/y2log > /dev/$serialdev");
+    }
+    save_screenshot();
+    # We skip parsing yast2 logs in each installation scenario, but only if
+    # test has failed or we want to explicitly identify failures
+    $self->investigate_yast2_failure() unless $args{skip_logs_investigation};
+}
+
+=head2 upload_widgets_json
+
+ upload_widgets_json();
+
+Save screenshot and upload widgets json file.
+
+=cut
+
+sub upload_widgets_json {
+    save_screenshot;
+    if (get_var('YUI_REST_API')) {
+        my $json_content = to_json(YuiRestClient::connect_to_running_app());
+        my $json_path    = $autotest::current_test->{name} . '-widgets.json';
+        print "*****\n";
+        print "$json_path";
+        print "*****\n";
+        save_tmp_file($json_path, $json_content);
+        make_path('ulogs');
+        copy(hashed_string($json_path), "ulogs/$json_path");
+    }
+}
+
+sub post_fail_hook {
+    my $self = shift;
+    upload_widgets_json();
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -1,5 +1,5 @@
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2020 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,12 +15,12 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 package y2_installbase;
 
-use base "installbasetest";
+use parent 'y2_base';
 use strict;
 use warnings;
-use ipmi_backend_utils;
+
 use testapi;
-use network_utils;
+
 use version_utils qw(is_microos is_sle);
 use y2_logs_helper 'get_available_compression';
 use utils qw(type_string_slow zypper_call);
@@ -361,6 +361,7 @@ sub use_wicked {
     script_run("for i in *[0-9]; do echo BOOTPROTO=dhcp > /etc/sysconfig/network/ifcfg-\$i; wicked --debug all ifup \$i; done", 600);
     save_screenshot;
 }
+
 sub use_ifconfig {
     script_run "dhcpcd eth0";
 }
@@ -511,33 +512,6 @@ sub deal_with_dependency_issues {
     }
 }
 
-sub save_upload_y2logs {
-    my ($self, %args) = @_;
-
-    return if (get_var('NOLOGS'));
-    $args{suffix} //= '';
-
-    # Do not test/recover network if collect from installation system, as it won't work anyway with current approach
-    # Do not recover network on non-qemu backend, as not implemented yet
-    $args{no_ntwrk_recovery} //= (get_var('BACKEND') !~ /qemu/);
-
-    # Try to recover network if cannot reach gw and upload logs if everything works
-    if (can_upload_logs() || (!$args{no_ntwrk_recovery} && recover_network())) {
-        script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';
-        my $filename = "/tmp/y2logs$args{suffix}.tar" . get_available_compression();
-        script_run "save_y2logs $filename", 180;
-        upload_logs($filename, failok => 1);
-    } else {    # Redirect logs content to serial
-        script_run("journalctl -b --no-pager -o short-precise > /dev/$serialdev");
-        script_run("dmesg > /dev/$serialdev");
-        script_run("cat /var/log/YaST/y2log > /dev/$serialdev");
-    }
-    save_screenshot();
-    # We skip parsing yast2 logs in each installation scenario, but only if
-    # test has failed or we want to explicitly identify failures
-    $self->investigate_yast2_failure() unless $args{skip_logs_investigation};
-}
-
 sub save_remote_upload_y2logs {
     my ($self, %args) = @_;
 
@@ -553,81 +527,6 @@ sub save_remote_upload_y2logs {
     enter_cmd "curl --form upload=\@$filename --form upname=$upname " . autoinst_url("/uploadlog/$upname") . "";
     save_screenshot();
     $self->investigate_yast2_failure();
-}
-
-sub save_system_logs {
-    my ($self) = @_;
-
-    return if (get_var('NOLOGS'));
-
-    if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
-        script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
-        script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';
-        upload_logs('/tmp/btrfs-filesystem-df-mnt.txt',    failok => 1);
-        upload_logs('/tmp/btrfs-filesystem-usage-mnt.txt', failok => 1);
-    }
-    script_run 'df -h';
-    script_run 'df > /tmp/df.txt';
-    upload_logs('/tmp/df.txt', failok => 1);
-
-    # Log connections
-    script_run('ss -tulpn > /tmp/connections.txt');
-    upload_logs('/tmp/connections.txt', failok => 1);
-    # Check network traffic
-    script_run('for run in {1..10}; do echo "RUN: $run"; nstat; sleep 3; done | tee /tmp/network_traffic.log');
-    upload_logs('/tmp/network_traffic.log', failok => 1);
-    # Check VM load
-    script_run('for run in {1..3}; do echo "RUN: $run"; vmstat; sleep 5; done | tee /tmp/cpu_mem_usage.log');
-    upload_logs('/tmp/cpu_mem_usage.log', failok => 1);
-
-    $self->save_and_upload_log('pstree',  '/tmp/pstree');
-    $self->save_and_upload_log('ps auxf', '/tmp/ps_auxf');
-}
-
-sub save_strace_gdb_output {
-    my ($self, $is_yast_module) = @_;
-    return if (get_var('NOLOGS'));
-
-    # Collect yast2 installer or yast2 module trace if is still running
-    if (!script_run(qq{ps -eo pid,comm | grep -i [y]2start | cut -f 2 -d " " > /dev/$serialdev}, 0)) {
-        chomp(my $yast_pid = wait_serial(qr/^[\d{4}]/, 10));
-        return unless defined($yast_pid);
-        my $trace_timeout = 120;
-        my $strace_log    = '/tmp/yast_trace.log';
-        my $strace_ret    = script_run("timeout $trace_timeout strace -f -o $strace_log -tt -p $yast_pid", ($trace_timeout + 5));
-
-        upload_logs($strace_log, failok => 1) if script_run "! [[ -e $strace_log ]]";
-
-        # collect installer proc fs files
-        my @procfs_files = qw(
-          mounts
-          mountinfo
-          mountstats
-          maps
-          status
-          stack
-          cmdline
-          environ
-          smaps);
-
-        my $opt = defined($is_yast_module) ? 'module' : 'installer';
-        foreach (@procfs_files) {
-            $self->save_and_upload_log("cat /proc/$yast_pid/$_", "/tmp/yast2-$opt.$_");
-        }
-        # We enable gdb differently in the installer and in the installed SUT
-        my $system_management_locked;
-        if ($is_yast_module) {
-            $system_management_locked = zypper_call('in gdb', exitcode => [0, 7]) == 7;
-        }
-        else {
-            script_run 'extend gdb';
-        }
-        unless ($system_management_locked) {
-            my $gdb_output = '/tmp/yast_gdb.log';
-            my $gdb_ret    = script_run("gdb attach $yast_pid --batch -q -ex 'thread apply all bt' -ex q > $gdb_output", ($trace_timeout + 5));
-            upload_logs($gdb_output, failok => 1) if script_run '! [[ -e /tmp/yast_gdb.log ]]';
-        }
-    }
 }
 
 sub post_run_hook {
@@ -660,6 +559,11 @@ sub post_fail_hook {
         # Collect yast2 installer  strace and gbd debug output if is still running
         $self->save_strace_gdb_output;
     }
+}
+
+# All steps in the installation are 'fatal'.
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;

--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -5,7 +5,7 @@ This module provides common subroutines for YaST2 modules in graphical and text 
 =cut
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,14 +17,13 @@ This module provides common subroutines for YaST2 modules in graphical and text 
 
 package y2_module_basetest;
 
-use parent 'opensusebasetest';
+use parent 'y2_base';
 use Exporter 'import';
 
 use strict;
 use warnings;
 use testapi;
 use utils 'show_tasks_in_blocked_state';
-use y2_installbase;
 use version_utils qw(is_opensuse is_leap is_tumbleweed);
 
 our @EXPORT = qw(is_network_manager_default
@@ -110,7 +109,7 @@ sub wait_for_exit {
 
 sub post_fail_hook {
     my $self = shift;
-
+    $self->upload_widgets_json();
     my $defer_blocked_task_info = testapi::is_serial_terminal();
     show_tasks_in_blocked_state unless ($defer_blocked_task_info);
 
@@ -120,10 +119,10 @@ sub post_fail_hook {
     show_tasks_in_blocked_state if ($defer_blocked_task_info);
 
     $self->remount_tmp_if_ro;
-    y2_installbase::save_upload_y2logs($self);
+    $self->save_upload_y2logs();
     upload_logs('/var/log/zypper.log', failok => 1);
-    y2_installbase::save_system_logs($self);
-    y2_installbase::save_strace_gdb_output($self, 'yast');
+    $self->save_system_logs();
+    $self->save_strace_gdb_output('yast');
 }
 
 1;

--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (c) 2016-2019 SUSE LLC
+# Copyright (c) 2016-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -25,7 +25,6 @@ use base "y2_module_consoletest";
 use testapi;
 use utils;
 use version_utils;
-use y2_installbase;
 
 sub vsftd_setup_checker {
     my ($self, $config_ref) = @_;
@@ -242,7 +241,7 @@ sub post_fail_hook {
 
     upload_logs('/etc/vsftpd.conf');
     upload_logs('/tmp/failed_vsftpd_directives.log');
-    y2_installbase::save_upload_y2logs;
+    $self->save_upload_y2logs();
 }
 
 1;

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016-2020 SUSE LLC
+# Copyright © 2016-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use migration;
 use registration;
 use qam;
 use Utils::Backends 'is_pvm';
-use y2_installbase;
+use y2_base;
 
 
 sub patching_sle {
@@ -226,6 +226,6 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
-    y2_installbase::save_upload_y2logs;
+    y2_base::save_upload_y2logs;
 }
 1;

--- a/tests/x11/network/yast2_network_use_nm.pm
+++ b/tests/x11/network/yast2_network_use_nm.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,7 +14,7 @@
 
 use base 'x11test';
 use y2_module_guitest 'launch_yast2_module_x11';
-use y2_installbase;
+use y2_base;
 use strict;
 use warnings;
 use testapi;
@@ -59,7 +59,7 @@ sub configure_system {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
-    y2_installbase::save_upload_y2logs($self);
+    y2_base::save_upload_y2logs($self);
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
See [poo#89482](https://progress.opensuse.org/issues/89482)
Verification run: [SLE](https://openqa.suse.de/tests/overview.html?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23improve_post_fail_rest_api&version=15-SP3) | [openSUSE-Tumbleweed-x86_64](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=ext4%40jknphy%2Fos-autoinst-distri-opensuse%23improve_post_fail_rest_api&version=Tumbleweed#live) | [opensuse-Tumbleweed-DVD-ppc64le](https://openqa.opensuse.org/tests/latest?arch=ppc64le&distri=opensuse&flavor=DVD&machine=ppc64le&test=RAID0%40jknphy%2Fos-autoinst-distri-opensuse%23improve_post_fail_rest_api&version=Tumbleweed) | [opensuse-15.3](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=RAID0_gpt%40jknphy%2Fos-autoinst-distri-opensuse%23improve_post_fail_rest_api&version=15.3#live)
