### PR TITLE
[wip] Add skip_grub_confirmation to reconnect_mgmt_console

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -314,7 +314,7 @@ sub check_function {
         wait_screen_change { send_key 'ret' };
     }
     elsif (is_pvm || is_ipmi) {
-        reconnect_mgmt_console;
+        reconnect_mgmt_console(grub_skip_confirmation => is_ipmi);
     }
     else {
         power_action('reboot', observe => 1, keepconsole => 1);

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1351,17 +1351,18 @@ sub _handle_login_not_found {
 
 =head2 reconnect_mgmt_console
 
- reconnect_mgmt_console([timeout => $timeout]);
+ reconnect_mgmt_console([timeout => $timeout], [grub_expected_twice => $grub_expected_twice], [grub_skip_confirmation => $grub_skip_confirmation]);
 
 After each reboot we have to reconnect to the management console on remote backends.
 C<$timeout> can be set to some specific time and if during reboot GRUB is shown twice C<grub_expected_twice>
-can be set to 1.
+can be set to 1. Grub option confirmation by return key can be skipped if is C<grub_skip_confirmation> set.
 
 =cut
 sub reconnect_mgmt_console {
     my (%args) = @_;
-    $args{timeout}             //= 300;
-    $args{grub_expected_twice} //= 0;
+    $args{timeout}                //= 300;
+    $args{grub_expected_twice}    //= 0;
+    $args{grub_skip_confirmation} //= 0;
 
     if (check_var('ARCH', 's390x')) {
         my $login_ready = serial_terminal::get_login_message();
@@ -1429,7 +1430,7 @@ sub reconnect_mgmt_console {
             select_console 'sol', await_console => 0;
             assert_screen([qw(qa-net-selection prague-pxe-menu grub2)], 300);
             # boot to hard disk is default
-            send_key 'ret';
+            send_key 'ret' unless $args{grub_skip_confirmation};
         }
     }
     elsif (check_var('ARCH', 'aarch64')) {
@@ -1437,7 +1438,7 @@ sub reconnect_mgmt_console {
             select_console 'sol', await_console => 0;
             # aarch64 baremetal machine takes longer to boot than 5 minutes
             assert_screen([qw(qa-net-selection prague-pxe-menu grub2)], 600);
-            send_key 'ret';
+            send_key 'ret' unless $args{grub_skip_confirmation};
         }
     }
     else {


### PR DESCRIPTION
Fix poo#88458: Kdump on bare metal doesn't need grub confirmation in
reconnect_mgm_console and we need to skip it. New option skip_grub_confirmation
was introduced to function which reconnects management console. Doc
string for reconnect_mgm_console was updated with all options.

- Related ticket: https://progress.opensuse.org/issues/88458
- Needles: none
- Verification:  
x86_64 qemu: https://openqa.suse.de/tests/5878150 <-- not impacted pr
x86_64 ipmi: http://black-bit.suse.cz/tests/171#step/kdump/47  <--- fixed by pr
powervm: https://openqa.suse.de/tests/5878102#step/kdump_and_crash/49 <-- not impacted by pr





