### PR TITLE
Networkd: Migrate to YAML scheduling

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -76,7 +76,6 @@ our @EXPORT = qw(
   load_jeos_tests
   load_kernel_baremetal_tests
   load_kernel_tests
-  load_networkd_tests
   load_nfv_master_tests
   load_nfv_trafficgen_tests
   load_public_cloud_patterns_validation_tests
@@ -1895,13 +1894,6 @@ sub load_wicked_create_hdd {
 
 sub load_extra_tests_udev {
     loadtest "kernel/udev_no_symlink";
-}
-
-sub load_networkd_tests {
-    loadtest 'networkd/networkd_init';
-    loadtest 'networkd/networkd_dhcp';
-    loadtest 'networkd/networkd_vlan';
-    loadtest 'networkd/networkd_bridge';
 }
 
 sub load_nfv_master_tests {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -265,10 +265,6 @@ if (is_jeos) {
 if (is_kernel_test()) {
     load_kernel_tests();
 }
-elsif (get_var("NETWORKD")) {
-    boot_hdd_image();
-    load_networkd_tests();
-}
 elsif (get_var('NFV')) {
     load_nfv_tests();
 }

--- a/schedule/functional/extra_tests_networkd.yaml
+++ b/schedule/functional/extra_tests_networkd.yaml
@@ -1,0 +1,11 @@
+name:           extra_tests_networkd
+description:    >
+    Maintainer: dheidler.
+    Extra networkd tests
+schedule:
+    - boot/boot_to_desktop
+    - networkd/networkd_init
+    - networkd/networkd_dhcp
+    - networkd/networkd_vlan
+    - networkd/networkd_bridge
+    - console/coredump_collect


### PR DESCRIPTION
After this is merged, on O3 in the `networkd` testsuite the config line `NETWORKD=1` needs to be replaced by `YAML_SCHEDULE=schedule/functional/extra_tests_networkd.yaml`.

Ticket: https://progress.opensuse.org/issues/68527
Verification: http://kazhua.qa.suse.de/tests/326