### PR TITLE
Add an option to disable kdump configuration

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -24,7 +24,7 @@ use utils 'ensure_serialdev_permissions';
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump
   activate_kdump activate_kdump_cli activate_kdump_without_yast
   kdump_is_active do_kdump configure_service check_function
-  full_kdump_check);
+  full_kdump_check deactivate_kdump_cli);
 
 sub install_kernel_debuginfo {
     zypper_call 'ref';
@@ -196,6 +196,14 @@ sub activate_kdump_cli {
     assert_script_run('yast2 kdump fadump enable', 180) if check_var('FADUMP');
     assert_script_run('yast kdump show',           180);
     systemctl('enable kdump');
+}
+
+# Deactivate kdump using yast command line interface
+sub deactivate_kdump_cli {
+    # Disable the crashkernel option from the kernel grub cmdline
+    assert_script_run('yast kdump startup disable alloc_mem=0', 180);
+    # Disable the kdump service at boot time
+    systemctl('disable kdump');
 }
 
 sub activate_kdump_without_yast {

--- a/tests/sles4sap/robot_fw.pm
+++ b/tests/sles4sap/robot_fw.pm
@@ -19,6 +19,7 @@ use warnings;
 use version_utils qw(is_sle);
 use utils qw(zypper_call);
 use hacluster qw(is_package_installed);
+use kdump_utils qw(deactivate_kdump_cli);
 
 sub remove_value {
     my ($module, $parameter) = @_;
@@ -63,6 +64,15 @@ sub run {
     # Disable extra tuning for testing "from scratch" system
     if (check_var('SLE_PRODUCT', 'sles4sap')) {
         assert_script_run "systemctl disable sapconf";
+        $self->reboot;
+        select_console 'root-console';
+    }
+
+    # It can only happen on sle product
+    # Only use by test not fully migrated to YAML
+    if (get_var('DISABLE_KDUMP')) {
+        record_info('Disabling kdump', 'Disabling kdump and crashkernel option');
+        deactivate_kdump_cli;
         $self->reboot;
         select_console 'root-console';
     }


### PR DESCRIPTION
This PR adds a new function for disabling kdump.

The function is used inside the sysctl robot framework test to disable kdump because it books RAM for the crashkernel and some sysctl values are dependent on the RAM amount. It should be disabled to get the values matching those in the reference file.

- Failed test: https://openqa.suse.de/tests/5877115#step/Sysctl/94 - `kernel_panic_on_oops` set to 1 by kdump
- Related ticket: N/A
- Needles: N/A
- Verification run:  http://1b143.qa.suse.de/tests/8298
