### PR TITLE
Adjust regexp to detect current and new snapshots

### DIFF
--- a/tests/transactional/verify_undelete_snapshots.pm
+++ b/tests/transactional/verify_undelete_snapshots.pm
@@ -32,7 +32,7 @@ sub run {
     }
 
     # Create some snapshots with a transactional update snapshot in the middle.
-    record_info "Check undel", "Snapshot #1 - Check that essential snapshots cannot be deleted, 
+    record_info "Check undel", "Snapshot #1 - Check that essential snapshots cannot be deleted,
                                 creates snapshots and installs a package";
     assert_script_run("snapper create -d \"Disposable snapshot #1\"");
     get_utt_packages;
@@ -43,8 +43,8 @@ sub run {
     my $next_snap_after_update;
     my $current_snap_after_update;
     foreach (@snapshots_after_update) {
-        $current_snap_after_update = $+{current_snap} if ($_ =~ /(?<current_snap>^\d+)\-/);
-        $next_snap_after_update    = $+{next_snap}    if ($_ =~ /(?<next_snap>^\d+)\+/);
+        $current_snap_after_update = $+{current_snap} if ($_ =~ /(?<current_snap>^\s*\d+)\-/);
+        $next_snap_after_update    = $+{next_snap}    if ($_ =~ /(?<next_snap>^\s*\d+)\+/);
     }
     die('Current snapshot was not marked with -') unless $current_snap_after_update;
     die('New snapshot not marked with +')         unless $next_snap_after_update;


### PR DESCRIPTION
Previously we had issue with the test, as in some runs we will get more
than 10 snapshots, so there will be space character in front of the
snapshot number for the output alignment.
Allowing blank symbols will fix this issue.

See [poo#91350](https://progress.opensuse.org/issues/91350).

## Verification runs
* https://openqa.suse.de/tests/5877586#step/verify_undelete_snapshots/21
* https://openqa.suse.de/tests/5878112#step/verify_undelete_snapshots/21
* https://openqa.suse.de/tests/5878638#step/verify_undelete_snapshots/21