### PR TITLE
kdump: Don't do management console reconnect on IPMI backend

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -314,7 +314,8 @@ sub check_function {
         wait_screen_change { send_key 'ret' };
     }
     elsif (is_pvm || is_ipmi) {
-        reconnect_mgmt_console;
+        # Reconnect management console on pvm only after the crash, IPMI console is managed by wait_boot
+        reconnect_mgmt_console if is_pvm;
     }
     else {
         power_action('reboot', observe => 1, keepconsole => 1);


### PR DESCRIPTION
Fix poo#88458: Switch to management console after the crash  is
handled by standard boot process on IPMI backend.

It is simple alternative to  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12377 .
Use of `reconnect_mgmt_console if is_pvm` has  own ticket https://progress.opensuse.org/issues/73435 .

- Related ticket: https://progress.opensuse.org/issues/88458
- Needles:
- Verification run:
x86_64 qemu: https://openqa.suse.de/tests/5885690 
x86_64 ipmi: http://black-bit.suse.cz/tests/181#step/kdump/47 -- fixed by pr
powervm:  https://openqa.suse.de/tests/5885691