### PR TITLE
Schedule Samba/AD tests

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -30,6 +30,7 @@ schedule:
   - console/aaa_base
   - console/gd
   - console/systemtap
+  - network/samba/samba_adcli
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:


### PR DESCRIPTION
Schedule Samba/AD tests to Maintenance tests

- Related ticket: https://progress.opensuse.org/issues/72169
- - Verification run: 
  12-SP3 - http://10.161.228.111/tests/4000
  12-SP4 - http://10.161.228.111/tests/3997
  12-SP5 - http://10.161.228.111/tests/3996
  15 - http://10.161.228.111/tests/3999
  15-SP1 - http://10.161.228.111/tests/3998
  15-SP2 -http://10.161.228.111/tests/3991



