### PR TITLE
[virt_autotest] enable osd s390x prj4_guest_upgrade test

### DIFF
--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -20,6 +20,8 @@ use Data::Dumper;
 use XML::Writer;
 use IO::File;
 use virt_utils;
+use Utils::Architectures;
+use upload_system_log;
 
 sub analyzeResult {
     die "You need to overload analyzeResult in your class";
@@ -192,7 +194,7 @@ sub run_test {
 
     my $test_cmd = $self->get_script_run();
     #FOR S390X LPAR
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         virt_utils::lpar_cmd("$test_cmd");
         return;
     }
@@ -253,6 +255,14 @@ sub upload_guest_assets {
 
 sub post_fail_hook {
     my ($self) = shift;
+
+    #FOR S390X LPAR
+    if (is_s390x) {
+        #collect and upload supportconfig log from S390X LPAR
+        upload_system_log::upload_supportconfig_log();
+        script_run "rm -rf scc_*";
+        return;
+    }
 
     $self->post_run_test;
     save_screenshot;


### PR DESCRIPTION
Try to enable the following osd s390x prj4_guest_upgrade test:
s390:Guest upgrade: SLES15SP2-KVM (Host) SLES15SP2 -> Developing Guest
s390:Guest upgrade: SLES12SP5-KVM (Host) SLES12SP5 -> Developing Guest

- Related ticket: https://progress.opensuse.org/issues/91145
- Related PR: https://github.com/SUSE/qa-automation/pull/765
- Verification run: 
s390x
PASS
[prj4_guest_upgrade_sles15sp2_on_sles15sp2-kvm ](http://10.67.131.5/tests/410)
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](http://10.67.131.5/tests/412)
FAIL
[prj4_guest_upgrade_sles15sp2_on_sles15sp2-kvm ](http://10.67.131.5/tests/450)
x86_64
[prj4_guest_upgrade_sles15sp2_on_sles15sp2-kvm](https://openqa.suse.de/tests/6003737#)
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](https://openqa.suse.de/tests/6003736#)
aarch64
[prj4_guest_upgrade_sles15sp2_on_sles15sp2-kvm](https://openqa.suse.de/tests/6003735#)
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](https://openqa.suse.de/tests/6003734#)