### PR TITLE
Update windows installer, use smbd to upload WSL image

### DIFF
--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -102,8 +102,17 @@ sub run {
 
     # turn off hibernation and fast startup
     $self->open_powershell_as_admin;
-    $self->run_in_powershell(cmd => q{REG ADD "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Power" /v HiberbootEnabled /t REG_DWORD /d "0" /f});
+    $self->run_in_powershell(cmd => q{Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power" -Name HiberbootEnabled -Value 0});
     $self->run_in_powershell(cmd => 'powercfg /hibernate off');
+    # disable screen's fade to black
+    $self->run_in_powershell(cmd => 'powercfg -change -monitor-timeout-ac 0');
+    # adjust visusal effects to best performance
+    $self->run_in_powershell(cmd => q{Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects" -Name VisualFXSetting -Value 2});
+    # remove skype and xbox
+    $self->run_in_powershell(cmd => 'Get-AppxPackage -allusers Microsoft.SkypeApp | Remove-AppxPackage');
+    $self->run_in_powershell(cmd => 'Get-AppxPackage -allusers Microsoft.XboxApp | Remove-AppxPackage');
+    $self->run_in_powershell(cmd => 'Get-AppxPackage -allusers Microsoft.XboxGamingOverlay | Remove-AppxPackage');
+    $self->run_in_powershell(cmd => 'Get-AppxPackage -allusers Microsoft.YourPhone | Remove-AppxPackage');
 
     # poweroff
     $self->reboot_or_shutdown();

--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -47,8 +47,8 @@ sub run {
     assert_screen 'windows-desktop';
     $self->open_powershell_as_admin;
     $self->run_in_powershell(
-        cmd     => 'Invoke-WebRequest -Uri ' . autoinst_url("/assets/other/$wsl_appx_filename") . ' -O C:\\' . $wsl_appx_filename . ' -UseBasicParsing',
-        timeout => 750
+        cmd     => "Start-BitsTransfer -Source \\\\10.0.2.4\\qemu\\$wsl_appx_filename -Destination C:\\\\$wsl_appx_filename",
+        timeout => 60
     );
     $self->run_in_powershell(cmd => $powershell_cmds->{enable_developer_mode});
 

--- a/tests/wsl/wsl_cmd_check.pm
+++ b/tests/wsl/wsl_cmd_check.pm
@@ -32,7 +32,7 @@ sub run {
     $self->run_in_powershell(cmd => qq/wsl systemd-detect-virt | Select-String -Pattern "$expected{provider}"/, timeout => 60);
     $self->run_in_powershell(cmd => 'wsl /bin/bash -c "dmesg | head -n 20"');
     $self->run_in_powershell(cmd => 'wsl env');
-    $self->run_in_powershell(cmd => 'wsl locale');
+    $self->run_in_powershell(cmd => 'wsl locale', timeout => 60);
     $self->run_in_powershell(cmd => 'wsl date');
     if (is_opensuse || (is_sle && is_sut_reg)) {
         $self->run_in_powershell(cmd => 'wsl -u root zypper -q -n in python3', timeout => 120);


### PR DESCRIPTION
To enable samba image download we need to merge first
[smbd enablement feature](https://github.com/os-autoinst/os-autoinst/pull/1656).

- VRs:
  - [sle-15-SP3-WSL-x86_64-Build2.268-wsl-main+skip_reg@64bit](http://kepler.suse.cz/tests/4659#step/prepare_wsl_feature/14)
  - [windows installation](http://kepler.suse.cz/tests/4657#step/ms_win_firstboot/76)