### PR TITLE
Disable kdump only if it is installed

### DIFF
--- a/tests/sles4sap/robot_fw.pm
+++ b/tests/sles4sap/robot_fw.pm
@@ -70,7 +70,7 @@ sub run {
 
     # It can only happen on sle product
     # Only use by test not fully migrated to YAML
-    if (get_var('DISABLE_KDUMP')) {
+    if (get_var('DISABLE_KDUMP') && is_package_installed('kdump')) {
         record_info('Disabling kdump', 'Disabling kdump and crashkernel option');
         deactivate_kdump_cli;
         $self->reboot;


### PR DESCRIPTION
Kdump must be disabled only if it is installed, like that we can define DISABLE_KDUMP on all SLE15 versions.

- Related ticket: N/A
- Needles: N/A
- [MR for changing the YAML files](https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/109)
- Verification run: 
  - 15 SP1: [single incident](http://1b143.qa.suse.de/tests/8303) & [TestRepo](http://1b143.qa.suse.de/tests/8305)
  - 15: [single incident](http://1b143.qa.suse.de/tests/8306) & [TestRepo](http://1b143.qa.suse.de/tests/8302)
  - 12-SP5: [single incident](http://1b143.qa.suse.de/tests/8304) & [TestRepo](http://1b143.qa.suse.de/tests/8307)