### PR TITLE
ovs: Migrate to YAML schedule

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -352,35 +352,6 @@ else {
             set_var('INSTALLONLY', 1);
             loadtest "iscsi/iscsi_client";
         }
-        if (get_var('OVS')) {
-            set_var('INSTALLONLY', 1);
-            if (check_var('HOSTNAME', 'server')) {
-                barrier_create('ipsec_done',          2);
-                barrier_create('traffic_check_done',  2);
-                barrier_create('certificate_signed',  2);
-                barrier_create('ipsec1_done',         2);
-                barrier_create('traffic_check_done1', 2);
-                barrier_create('ipsec2_done',         2);
-                barrier_create('traffic_check_done2', 2);
-                barrier_create('cert_done',           2);
-                barrier_create('host2_cert_ready',    2);
-                barrier_create('empty_directories',   2);
-                barrier_create('cacert_done',         2);
-                barrier_create('end_of_test',         2);
-                barrier_create('vtep_config',         2);
-                barrier_create('end',                 2);
-            }
-            loadtest 'installation/bootloader_start';
-            loadtest 'network/setup_multimachine';
-            if (check_var('HOSTNAME', 'server')) {
-                loadtest 'console/ovs_server';
-            }
-            else {
-                loadtest 'console/ovs_client';
-            }
-            return 1;
-        }
-
         if (get_var("REMOTE_CONTROLLER")) {
             loadtest "remote/remote_controller";
             load_inst_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1074,34 +1074,6 @@ else {
             loadtest 'console/rsync_client';
         }
     }
-    elsif (get_var('OVS')) {
-        set_var('INSTALLONLY', 1);
-        if (check_var('HOSTNAME', 'server')) {
-            barrier_create('ipsec_done',          2);
-            barrier_create('traffic_check_done',  2);
-            barrier_create('certificate_signed',  2);
-            barrier_create('ipsec1_done',         2);
-            barrier_create('traffic_check_done1', 2);
-            barrier_create('ipsec2_done',         2);
-            barrier_create('traffic_check_done2', 2);
-            barrier_create('cert_done',           2);
-            barrier_create('empty_directories',   2);
-            barrier_create('host2_cert_ready',    2);
-            barrier_create('cacert_done',         2);
-            barrier_create('end_of_test',         2);
-            barrier_create('vtep_config',         2);
-            barrier_create('end',                 2);
-        }
-        loadtest 'installation/bootloader_start';
-        boot_hdd_image;
-        loadtest 'network/setup_multimachine';
-        if (check_var('HOSTNAME', 'server')) {
-            loadtest 'console/ovs_server';
-        }
-        else {
-            loadtest 'console/ovs_client';
-        }
-    }
     elsif (get_var('QAM_CURL')) {
         set_var('INSTALLONLY', 1);
         boot_hdd_image;

--- a/schedule/functional/extra_tests_ovs.yaml
+++ b/schedule/functional/extra_tests_ovs.yaml
@@ -1,0 +1,16 @@
+name:           extra_tests_ovs
+description:    >
+    Maintainer: anminou.
+    Extra ovs tests
+conditional_schedule:
+    ovs:
+        HOSTNAME:
+            'client':
+                - console/ovs_client
+            'server':
+                - console/ovs_server
+schedule:
+    - boot/boot_to_desktop
+    - installation/bootloader_start
+    - network/setup_multimachine
+    - '{{ovs}}'

--- a/tests/console/ovs_client.pm
+++ b/tests/console/ovs_client.pm
@@ -48,6 +48,8 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
+    mutex_wait 'barrier_setup_done';
+
     # Install the needed packages
     zypper_call('in openvswitch-ipsec openvswitch-pki tcpdump openvswitch-vtep', timeout => 300);
 

--- a/tests/console/ovs_server.pm
+++ b/tests/console/ovs_server.pm
@@ -48,6 +48,22 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
+    barrier_create('ipsec_done',          2);
+    barrier_create('traffic_check_done',  2);
+    barrier_create('certificate_signed',  2);
+    barrier_create('ipsec1_done',         2);
+    barrier_create('traffic_check_done1', 2);
+    barrier_create('ipsec2_done',         2);
+    barrier_create('traffic_check_done2', 2);
+    barrier_create('cert_done',           2);
+    barrier_create('host2_cert_ready',    2);
+    barrier_create('empty_directories',   2);
+    barrier_create('cacert_done',         2);
+    barrier_create('end_of_test',         2);
+    barrier_create('vtep_config',         2);
+    barrier_create('end',                 2);
+    mutex_create 'barrier_setup_done';
+
     # Install the needed packages
     zypper_call('in openvswitch-ipsec tcpdump openvswitch-pki openvswitch-vtep', timeout => 300);
     systemctl 'start openvswitch',       timeout => 200;


### PR DESCRIPTION
After this is merged, on O3 and OSD in the `ovs_{client,server}` testsuite the config line `OVS=1` needs to be replaced by `YAML_SCHEDULE=schedule/functional/extra_tests_ovs.yaml`.

Ticket: https://progress.opensuse.org/issues/68527
Verification: http://kazhua.qa.suse.de/tests/336