### PR TITLE
Revert "Schedule Samba/AD tests"

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -30,7 +30,6 @@ schedule:
   - console/aaa_base
   - console/gd
   - console/systemtap
-  - network/samba/samba_adcli
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#12386

Causing https://openqa.suse.de/tests/5888489#investigation