### PR TITLE
Check the product and modules repos after migration via zypper lr output information

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -480,7 +480,7 @@ sub load_online_migration_tests {
         loadtest "migration/online_migration/zypper_migration";
     }
     loadtest "migration/online_migration/post_migration";
-    loadtest "console/check_system_info" if (is_sle && (get_var('FLAVOR') =~ /Milestone/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
+    loadtest "console/check_system_info" if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
 }
 
 sub load_patching_tests {
@@ -1229,7 +1229,7 @@ else {
             loadtest "console/consoletest_setup";
             loadtest 'console/integration_services' if is_hyperv || is_vmware;
             loadtest "console/zypper_lr";
-            loadtest "console/check_system_info" if (is_sle && (get_var('FLAVOR') =~ /Milestone/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
+            loadtest "console/check_system_info" if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
         }
     }
     elsif (get_var("BOOT_HDD_IMAGE") && !is_jeos) {

--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -37,6 +37,7 @@ schedule:
   - installation/system_workarounds
   - migration/post_upgrade
   - console/system_prepare
+  - console/check_system_info
   - console/check_network
   - console/system_state
   - console/prepare_test_data

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -18,6 +18,7 @@ schedule:
   - '{{migration_method}}'
   - migration/online_migration/post_migration
   - console/system_prepare
+  - console/check_system_info
   - console/check_network
   - console/system_state
   - console/prepare_test_data

--- a/schedule/migration/offline_spvm_Upgrade.yaml
+++ b/schedule/migration/offline_spvm_Upgrade.yaml
@@ -20,5 +20,6 @@ schedule:
   - console/system_prepare
   - console/consoletest_setup
   - console/zypper_lr
+  - console/check_system_info
   - boot/grub_test_snapshot
   - boot/snapper_rollback

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -36,6 +36,7 @@ schedule:
   - installation/first_boot
   - migration/post_upgrade
   - console/system_prepare
+  - console/check_system_info
   - console/check_network
   - console/system_state
   - console/prepare_test_data

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -18,6 +18,7 @@ schedule:
   - '{{migration_method}}'
   - migration/online_migration/post_migration
   - console/system_prepare
+  - console/check_system_info
   - console/check_network
   - console/system_state
   - console/prepare_test_data

--- a/schedule/migration/s390x-zVM-Upgrade.yaml
+++ b/schedule/migration/s390x-zVM-Upgrade.yaml
@@ -20,6 +20,7 @@ schedule:
   - console/system_prepare
   - console/consoletest_setup
   - console/zypper_lr
+  - console/check_system_info
   - '{{regression_tests}}'
 conditional_schedule:
   regression_tests:

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -35,6 +35,7 @@ schedule:
   - installation/first_boot
   - migration/post_upgrade
   - console/system_prepare
+  - console/check_system_info
   - console/check_network
   - console/system_state
   - console/prepare_test_data

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -19,6 +19,7 @@ schedule:
   - '{{migration_method}}'
   - migration/online_migration/post_migration
   - console/system_prepare
+  - console/check_system_info
   - console/check_network
   - console/system_state
   - console/prepare_test_data

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -36,6 +36,7 @@ schedule:
   - installation/first_boot
   - migration/post_upgrade
   - console/system_prepare
+  - console/check_system_info
   - console/check_network
   - console/system_state
   - console/prepare_test_data

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -19,6 +19,7 @@ schedule:
   - '{{migration_method}}'
   - migration/online_migration/post_migration
   - console/system_prepare
+  - console/check_system_info
   - console/check_network
   - console/system_state
   - console/prepare_test_data


### PR DESCRIPTION
Check the product and modules' repos after migration via zypper lr output information
Need to check whether the target product and modules' repos are
existing and being correct after migration. Refer bsc#1185062

- Related ticket: https://progress.opensuse.org/issues/91569
- Verification run: http://openqa.suse.de/t5893899
      http://openqa.suse.de/t5893901
  https://openqa.suse.de/tests/5893922#
sles12sp4 upgrade sles15sp3: https://openqa.suse.de/tests/5894232#
online upgrade via rmt:; https://openqa.suse.de/tests/5894233
Failed case: https://openqa.suse.de/tests/5896068#step/check_system_info/12
zvm: https://openqa.suse.de/tests/5896307
spvm: https://openqa.suse.de/tests/5903466