### PR TITLE
Add install_qatestset to support different MU version for product_version_cfg

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -32,6 +32,8 @@ sub setup_environment {
 
     assert_script_run("wget -N -P $ver_path $ver_cfg 2>&1");
     if (get_var("HANA_PERF")) {
+        my $rel_ver = get_var('VERSION');
+        assert_script_run("if [ ! -f /root/.product_version_cfg ]; then cp /root/.product_version_cfg.$rel_ver /root/.product_version_cfg; fi");
         assert_script_run("/usr/share/qa/qaset/bin/deploy_hana_perf.sh $runid $mitigation_switch");
         assert_script_run("ls /root/qaset/deploy_hana_perf_env.done");
         if (my $qaset_config = get_var("QASET_CONFIG")) {


### PR DESCRIPTION
We need test different MU release at same time, splitting product_version_cfg to product_version_cfg.$VERSION can help to implement this request. 
Currently, the followed files are created, this solution can help us to avoid always modifying product_version_cfg for each version.
.product_version_cfg         <--- For development testing
.product_version_cfg.12-SP5  <--- For MU 12-SP5 testing
.product_version_cfg.15-SP1   <--- For MU 15-SP1 testing
.product_version_cfg.12-SP4  <--- For MU 12-SP4 testing
.product_version_cfg.15           <--- For MU 15 testing
.product_version_cfg.15-SP2   <--- For MU 15-SP2 testing

- Verification run: http://openqa.qa2.suse.asia/tests/33250#
