### PR TITLE
Unify YuiRestClient initialization

### DIFF
--- a/lib/Utils/Firewalld.pm
+++ b/lib/Utils/Firewalld.pm
@@ -1,0 +1,29 @@
+package Utils::Firewalld;
+use strict;
+use warnings;
+use Exporter 'import';
+use testapi;
+
+our @EXPORT_OK = qw(add_port_to_zone);
+
+=head1 Utils::Firewalld
+
+C<Utils::Firewalld> - Library for firewalld related functionality
+
+=cut
+
+
+=head2 add_port_to_zone
+
+    add_port_to_zone($port, $zone);
+
+Adds C<$port> to C<$zone> to permanent configuration, then reloads firewall.
+
+=cut
+sub add_port_to_zone {
+    my ($port, $zone) = @_;
+    assert_script_run("firewall-cmd --zone=$zone --add-port=$port/tcp --permanent");
+    assert_script_run('firewall-cmd --reload');
+}
+
+1;

--- a/lib/YaST/Module.pm
+++ b/lib/YaST/Module.pm
@@ -51,7 +51,7 @@ sub open {
     else {
         die "Unknown user interface: $ui";
     }
-    YuiRestClient::connect_to_running_app();
+    YuiRestClient::get_app()->check_connection();
 }
 
 =head2 close

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -13,74 +13,118 @@ package YuiRestClient;
 use strict;
 use warnings;
 
-use constant API_VERSION => 'v1';
+use constant {
+    API_VERSION => 'v1',
+    TIMEOUT     => 10,
+    INTERVAL    => 1
+};
 
 use testapi;
 use utils qw(enter_cmd_slow type_line_svirt save_svirt_pty zypper_call);
-use Utils::Backends qw(is_pvm is_ipmi);
+use Utils::Backends;
 use YuiRestClient::App;
 use YuiRestClient::Wait;
+use Utils::Architectures 'is_s390x';
 
-our $interval = 1;
-our $timeout  = 10;
-our $app;
-
-sub set_interval {
-    $interval = shift;
-}
-
-sub set_timeout {
-    $timeout = shift;
-}
-
-sub set_app {
-    $app = shift;
-}
+my $app;
+my $port;
+my $host;
 
 sub get_app {
+    my (%args) = @_;
+    $app = init_app(%args) unless $app;
     return $app;
 }
 
-sub get_yui_params_string {
-    my $port = get_required_var('YUI_PORT');
-    return "YUI_HTTP_PORT=$port YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1";
+sub get_host {
+    return $host;
 }
 
-sub connect_to_app {
-    my $port = get_required_var('YUI_PORT');
-    my $host = get_required_var('YUI_SERVER');
-    die "Cannot set libyui REST API server" unless $host;
-    record_info('PORT',   "Used port for libyui: $port");
-    record_info('SERVER', "Connecting to: $host");
-    my $app = YuiRestClient::App->new({
+sub get_port {
+    return $port;
+}
+
+sub set_interval {
+    my ($interval) = @_;
+    $app->get_widget_controller()->set_interval($interval);
+}
+
+sub set_timeout {
+    my ($timeout) = @_;
+    $app->get_widget_controller()->set_timeout($timeout);
+}
+
+sub init_app {
+    my (%args)       = @_;
+    my $timeout      = $args{timeout}  || TIMEOUT;
+    my $interval     = $args{interval} || INTERVAL;
+    my $installation = $args{installation};
+    $port = init_port();
+    $host = init_host($installation);
+
+    $app = YuiRestClient::App->new({
             port        => $port,
             host        => $host,
-            api_version => API_VERSION});
-    # As we start installer, REST API is not instantly available
-    $app->connect(timeout => 500, interval => 10);
-    set_app($app);
+            api_version => API_VERSION,
+            timeout     => $timeout,
+            interval    => $interval});
 }
 
-sub connect_to_running_app {
-    return get_app()->connect(timeout => 30, interval => 2);
+sub init_port {
+    return $port if defined $port;
+    $port = get_var('YUI_START_PORT', 39000);
+    $port += get_var('VNC') =~ /(?<vncport>\d+)/ ? $+{vncport} : int(rand(1000));
+    die "Cannot set port for YUI REST API" unless $port;
+
+    set_var('YUI_PORT', $port);
+    return $port;
 }
 
-sub setup_libyui_running_system {
-    zypper_call('in libyui-rest-api');
+sub init_host {
+    return $host if defined $host;
+    my ($installation)             = @_;
+    my $yuiport                    = init_port();
+    my $ip_regexp                  = qr/(?<ip>(\d+\.){3}\d+)/i;
+    my $get_ip_from_console_output = sub {
+        YuiRestClient::Wait::wait_until(object => sub {
+                my $ip = script_output('ip -o -4 addr list | sed -n 2p | awk \'{print $4}\' | cut -d/ -f1', proceed_on_failure => 1);
+                return $+{ip} if ($ip =~ $ip_regexp);
+        });
+    };
+    if (check_var('BACKEND', 'qemu')) {
+        $host = 'localhost';
+    } elsif (is_pvm || is_ipmi) {
+        $host = get_var('SUT_IP');
+    } elsif (get_var('S390_ZKVM')) {
+        $host = get_var('VIRSH_GUEST');
+    } elsif (check_var('BACKEND', 's390x')) {
+        $installation ? select_console('install-shell') : select_console('root-console');
+        $host = &$get_ip_from_console_output;
+        select_console('installation') if $installation;
+    } elsif (is_hyperv) {
+        my $boot_timeout = 500;
+        my $svirt        = select_console('svirt');
+        my $name         = $svirt->name;
+        my $cmd          = "powershell -Command \"Get-VM -Name $name | Select -ExpandProperty Networkadapters | Select IPAddresses\"";
+        $host = YuiRestClient::Wait::wait_until(object => sub {
+                my $ip = $svirt->get_cmd_output($cmd);
+                return $+{ip} if ($ip =~ $ip_regexp);
+        }, timeout => $boot_timeout, interval => 30);
+        select_console('sut', await_console => 0) if $installation;
+    } elsif (check_var('VIRSH_VMM_FAMILY', 'xen')) {
+        # For xen, when attempting to switch console while the installation loader is not finished, we end up with test failure.
+        assert_screen("yast-still-running", 500) if $installation;
+        select_console('root-console');
+        $host = &$get_ip_from_console_output;
+        select_console('installation') if $installation;
+    } elsif ($installation && is_ssh_installation) {
+        my $cmd = (is_s390x && is_svirt) ? "TERM=linux " : "";
+        $cmd .= get_yui_params_string($yuiport) . " yast.ssh";
+        enter_cmd($cmd);
+    }
 
-    my $port = get_required_var('YUI_PORT');
-    my $host = get_required_var('YUI_SERVER');
-    record_info('PORT',   "Used port for libyui: $port");
-    record_info('SERVER', "Connecting to: $host");
-    set_var('YUI_PARAMS', get_yui_params_string());
-    # Add the port to permanent config and restart firewalld to apply the changes immediately.
-    # This is needed, because if firewall is restarted for some reason, then the port become
-    # closed (e.g. it was faced while saving settings in yast2 lan) and further tests will not
-    # be able to communicate with YaST modules.
-    assert_script_run("firewall-cmd --zone=public --add-port=$port/tcp --permanent");
-    assert_script_run('firewall-cmd --reload');
-    my $app = YuiRestClient::App->new({port => $port, host => $host, api_version => API_VERSION});
-    set_app($app);
+    set_var('YUI_SERVER', $host);
+    return $host;
 }
 
 sub is_libyui_rest_api {
@@ -88,39 +132,18 @@ sub is_libyui_rest_api {
 }
 
 sub set_libyui_backend_vars {
-    my $yuiport = get_var('YUI_START_PORT', 39000);
-    $yuiport += get_var('VNC') =~ /(?<vncport>\d+)/ ? $+{vncport} : int(rand(1000));
-    die "Cannot set port for YUI REST API" unless $yuiport;
-
-    set_var('YUI_PORT', $yuiport);
-
-    unless (get_var('BOOT_HDD_IMAGE')) {
-        set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '')
-              . " extend=libyui-rest-api " . get_yui_params_string());
-    }
-
-    my $server;
+    my $yuiport = init_port();
     if (check_var('BACKEND', 'qemu')) {
         # On qemu we connect to the worker using port forwarding
-        $server = 'localhost';
         set_var('NICTYPE_USER_OPTIONS', "hostfwd=tcp::$yuiport-:$yuiport");
-    } elsif (is_pvm || is_ipmi) {
-        $server = get_var('SUT_IP');
-    } elsif (get_var('S390_ZKVM')) {
-        $server = get_var('VIRSH_GUEST');
     }
-
-    set_var('YUI_SERVER', $server);
+    set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '')
+          . " extend=libyui-rest-api " . get_yui_params_string($yuiport));
 }
 
-sub setup_libyui_firstboot {
-    my $port = get_var('YUI_PORT');
-    zypper_call('in libyui-rest-api');
-    assert_script_run "firewall-cmd --zone=public --add-port=$port/tcp --permanent";
-    foreach my $export ("YUI_HTTP_PORT=$port", "YUI_HTTP_REMOTE=1", "YUI_REUSE_PORT=1", "Y2DEBUG=1") {
-        assert_script_run "echo export $export >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api";
-    }
-    assert_script_run "chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api";
+sub get_yui_params_string {
+    my ($yuiport) = @_;
+    return "YUI_HTTP_PORT=$yuiport YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1";
 }
 
 1;

--- a/lib/YuiRestClient/App.pm
+++ b/lib/YuiRestClient/App.pm
@@ -44,7 +44,22 @@ sub new {
     }, $class;
 }
 
-sub connect {
+sub get_widget_controller {
+    my ($self) = @_;
+    return $self->{widget_controller};
+}
+
+sub get_port {
+    my ($self) = @_;
+    return $self->{port};
+}
+
+sub get_host {
+    my ($self) = @_;
+    return $self->{host};
+}
+
+sub check_connection {
     my ($self, %args) = @_;
     my $uri = YuiRestClient::Http::HttpClient::compose_uri(
         host => $self->{host},

--- a/lib/YuiRestClient/Http/WidgetController.pm
+++ b/lib/YuiRestClient/Http/WidgetController.pm
@@ -28,6 +28,16 @@ sub new {
     }, $class;
 }
 
+sub set_timeout {
+    my ($self, $timeout) = @_;
+    $self->{timeout} = $timeout;
+}
+
+sub set_interval {
+    my ($self, $interval) = @_;
+    $self->{interval} = $interval;
+}
+
 sub find {
     my ($self, $args) = @_;
 

--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -148,7 +148,7 @@ Save screenshot and upload widgets json file.
 sub upload_widgets_json {
     save_screenshot;
     if (get_var('YUI_REST_API')) {
-        my $json_content = to_json(YuiRestClient::connect_to_running_app());
+        my $json_content = to_json(YuiRestClient::get_app()->check_connection());
         my $json_path    = $autotest::current_test->{name} . '-widgets.json';
         save_tmp_file($json_path, $json_content);
         make_path('ulogs');

--- a/tests/installation/setup_libyui_firstboot.pm
+++ b/tests/installation/setup_libyui_firstboot.pm
@@ -23,10 +23,27 @@ use warnings;
 use base "installbasetest";
 use registration "add_suseconnect_product";
 use version_utils "is_sle";
+use utils qw(zypper_call);
+use YuiRestClient;
+use testapi;
+use Utils::Firewalld qw(add_port_to_zone);
 
 sub run {
     add_suseconnect_product('sle-module-development-tools') if is_sle;
-    YuiRestClient::setup_libyui_firstboot();
+    zypper_call('in libyui-rest-api');
+    my $app  = YuiRestClient::get_app();
+    my $port = $app->get_port();
+    record_info('SERVER', "Used host for libyui: " . $app->get_host());
+    record_info('PORT',   "Used port for libyui: " . $port);
+    # Add the port to permanent config and restart firewalld to apply the changes immediately.
+    # This is needed, because if firewall is restarted for some reason, then the port become
+    # closed (e.g. it was faced while saving settings in yast2 lan) and further tests will not
+    # be able to communicate with YaST modules.
+    add_port_to_zone($port, 'public');
+    foreach my $export ("YUI_HTTP_PORT=$port", "YUI_HTTP_REMOTE=1", "YUI_REUSE_PORT=1", "Y2DEBUG=1") {
+        assert_script_run "echo export $export >> /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api";
+    }
+    assert_script_run "chmod +x /usr/lib/YaST2/startup/Firstboot-Stage/S01-rest-api";
 }
 
 1;

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -26,6 +26,7 @@ use installation_user_settings qw(await_password_check enter_userinfo enter_root
 use version_utils qw(is_sle is_opensuse);
 use scheduler 'get_test_suite_data';
 use cfg_files_utils;
+use YuiRestClient;
 
 my $firstboot;
 my %settings;
@@ -107,7 +108,8 @@ sub firstboot_finish {
 
 sub run {
     my $self = shift;
-    YuiRestClient::connect_to_app();
+    my $app  = YuiRestClient::get_app();
+    $app->check_connection();
     wait_still_screen();
     $firstboot = $testapi::distri->get_firstboot();
     my $test_data     = get_test_suite_data();


### PR DESCRIPTION
The PR adjusts YuiRestClient by separating initialization logic from
architecture and scenario specific logic.

- Related ticket: https://progress.opensuse.org/issues/90773
- Verification runs: https://openqa.suse.de/tests/overview?build=181.1_oorlov&groupid=96&distri=sle&version=15-SP3
