### PR TITLE
 Replace old methods for firstboot language and keyboard

### DIFF
--- a/lib/YaST/Firstboot/FirstbootController.pm
+++ b/lib/YaST/Firstboot/FirstbootController.pm
@@ -18,6 +18,7 @@ use YaST::Firstboot::GenericPage;
 use YaST::Firstboot::LANSetupPage;
 use YaST::Firstboot::KeyboardLayoutPage;
 use YaST::Firstboot::NTPClientPage;
+use YaST::Firstboot::LanguageAndKeyboardPage;
 
 sub new {
     my ($class, $args) = @_;
@@ -27,10 +28,11 @@ sub new {
 
 sub init {
     my ($self, $args) = @_;
-    $self->{GenericPage}  = YaST::Firstboot::GenericPage->new({app => YuiRestClient::get_app()});
-    $self->{LanPage}      = YaST::Firstboot::LANSetupPage->new({app => YuiRestClient::get_app()});
-    $self->{KeyboardPage} = YaST::Firstboot::KeyboardLayoutPage->new({app => YuiRestClient::get_app()});
-    $self->{NTPPage}      = YaST::Firstboot::NTPClientPage->new({app => YuiRestClient::get_app()});
+    $self->{GenericPage}             = YaST::Firstboot::GenericPage->new({app => YuiRestClient::get_app()});
+    $self->{LanPage}                 = YaST::Firstboot::LANSetupPage->new({app => YuiRestClient::get_app()});
+    $self->{KeyboardPage}            = YaST::Firstboot::KeyboardLayoutPage->new({app => YuiRestClient::get_app()});
+    $self->{NTPPage}                 = YaST::Firstboot::NTPClientPage->new({app => YuiRestClient::get_app()});
+    $self->{LanguageAndKeyboardPage} = YaST::Firstboot::LanguageAndKeyboardPage->new({app => YuiRestClient::get_app()});
     return $self;
 }
 
@@ -49,6 +51,12 @@ sub get_keyboard_page {
     my ($self) = @_;
     die "Keyboard layout page is not shown" unless $self->{KeyboardPage}->is_shown();
     return $self->{KeyboardPage};
+}
+
+sub get_language_and_keyboard_page {
+    my ($self) = @_;
+    die "Language and Keyboard page is not shown" unless $self->{LanguageAndKeyboardPage}->is_shown();
+    return $self->{LanguageAndKeyboardPage};
 }
 
 sub get_lan_page {
@@ -75,6 +83,19 @@ sub setup_keyboard {
 sub press_next {
     my ($self) = @_;
     $self->get_generic_page->press_next();
+}
+
+sub get_language_and_keyboard {
+    my ($self) = @_;
+    my %settings;
+    $settings{language} = $self->get_language_and_keyboard_page->get_selected_language();
+    $settings{keyboard} = $self->get_language_and_keyboard_page->get_selected_keyboard();
+    return %settings;
+}
+
+sub setup_language_and_keyboard {
+    my ($self) = @_;
+    $self->press_next();
 }
 
 1;

--- a/lib/YaST/Firstboot/LanguageAndKeyboardPage.pm
+++ b/lib/YaST/Firstboot/LanguageAndKeyboardPage.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for
+# firstboot Language and Keyboard client
+
+package YaST::Firstboot::LanguageAndKeyboardPage;
+use parent 'YaST::Firstboot::GenericPage';
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->{cb_keyboard} = $self->{app}->combobox({id => 'keyboard'});
+    $self->{cb_language} = $self->{app}->combobox({id => 'language'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{cb_language}->exist();
+}
+
+sub get_selected_language {
+    my ($self) = @_;
+    return $self->{cb_language}->value();
+}
+
+sub get_selected_keyboard {
+    my ($self) = @_;
+    return $self->{cb_keyboard}->value();
+}
+
+1;

--- a/lib/cfg_files_utils.pm
+++ b/lib/cfg_files_utils.pm
@@ -14,13 +14,38 @@ package cfg_files_utils;
 use Exporter 'import';
 use strict;
 use warnings;
+use Test::Assert ':all';
+use Data::Dumper;
+$Data::Dumper::Sortkeys = 1;
 
 use testapi;
 
 our @EXPORT = qw(
   validate_cfg_file
+  compare_settings
 );
 
+=head2 compare_settings
+
+  compare_settings({ expected => $value_1, current => value_2 })
+
+Method validates that the given hash references contain the
+same data. In any other case, the data from both structures 
+are printed, accompanied by an error message.
+
+=cut
+
+sub compare_settings {
+    my ($args) = @_;
+    eval {
+        assert_deep_equals($args->{expected}, $args->{current});
+        record_info("Compare settings", "Settings comparison passed");
+    } or do {
+        print "$@\n";
+        die "The system settings deviate from expectations. \n
+    Expected: " . Dumper($args->{expected}) . "\nGot: " . Dumper($args->{current}) . "\n";
+    };
+}
 
 =head2 validate_cfg_file
 

--- a/test_data/yast/firstboot/yast2_firstboot.yaml
+++ b/test_data/yast/firstboot/yast2_firstboot.yaml
@@ -6,3 +6,6 @@ clients:
   - firstboot_user
   - firstboot_root
   - firstboot_finish
+settings:
+  language: "English (US)"
+  keyboard: "English (US)"

--- a/test_data/yast/firstboot/yast2_firstboot_sle.yaml
+++ b/test_data/yast/firstboot/yast2_firstboot_sle.yaml
@@ -7,3 +7,6 @@ clients:
   - firstboot_root
   - firstboot_registration
   - firstboot_finish
+settings:
+  language: "English (US)"
+  keyboard: "English (US)"


### PR DESCRIPTION
Changing firstboot language and keyboard function, in order to avoid using needles and start using libyui for assertion. 

- Related ticket: https://progress.opensuse.org/issues/89866
- Verification runs: 
SLE: 
firstboot: 
   -with error: http://falafel.suse.cz/tests/293
   -without error: http://falafel.suse.cz/tests/292
textmode: https://openqa.suse.de/tests/5939401
autoyast: https://openqa.suse.de/tests/5939402
custom: https://openqa.suse.de/tests/5939403
Tumbleweed:
yast2_firstboot@64bit -> https://openqa.opensuse.org/t1725385
autoyast_y2_firstboot@64bit -> https://openqa.opensuse.org/t1725386
yast2_firstboot_custom@64bit -> https://openqa.opensuse.org/t1725387