### PR TITLE
Set YUI REST API parameters for ssh installations on powerVM and zkvm

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -47,8 +47,8 @@ sub get_yui_params_string {
 }
 
 sub connect_to_app {
-    my $port = get_var('YUI_PORT');
-    my $host = get_var('YUI_SERVER');
+    my $port = get_required_var('YUI_PORT');
+    my $host = get_required_var('YUI_SERVER');
     die "Cannot set libyui REST API server" unless $host;
     record_info('PORT',   "Used port for libyui: $port");
     record_info('SERVER', "Connecting to: $host");
@@ -68,8 +68,8 @@ sub connect_to_running_app {
 sub setup_libyui_running_system {
     zypper_call('in libyui-rest-api');
 
-    my $port = get_var('YUI_PORT');
-    my $host = get_var('YUI_SERVER');
+    my $port = get_required_var('YUI_PORT');
+    my $host = get_required_var('YUI_SERVER');
     record_info('PORT',   "Used port for libyui: $port");
     record_info('SERVER', "Connecting to: $host");
     set_var('YUI_PARAMS', get_yui_params_string());

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -41,6 +41,11 @@ sub get_app {
     return $app;
 }
 
+sub get_yui_params_string {
+    my $port = get_required_var('YUI_PORT');
+    return "YUI_HTTP_PORT=$port YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1";
+}
+
 sub connect_to_app {
     my $port = get_var('YUI_PORT');
     my $host = get_var('YUI_SERVER');
@@ -67,7 +72,7 @@ sub setup_libyui_running_system {
     my $host = get_var('YUI_SERVER');
     record_info('PORT',   "Used port for libyui: $port");
     record_info('SERVER', "Connecting to: $host");
-    set_var('YUI_PARAMS', "YUI_HTTP_PORT=$port YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1");
+    set_var('YUI_PARAMS', get_yui_params_string());
     # Add the port to permanent config and restart firewalld to apply the changes immediately.
     # This is needed, because if firewall is restarted for some reason, then the port become
     # closed (e.g. it was faced while saving settings in yast2 lan) and further tests will not
@@ -91,7 +96,7 @@ sub set_libyui_backend_vars {
 
     unless (get_var('BOOT_HDD_IMAGE')) {
         set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '')
-              . " extend=libyui-rest-api YUI_HTTP_PORT=$yuiport YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1");
+              . " extend=libyui-rest-api " . get_yui_params_string());
     }
 
     my $server;

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -25,6 +25,7 @@ use bootloader_setup;
 use registration 'registration_bootloader_params';
 use utils qw(get_netboot_mirror type_string_slow enter_cmd_slow);
 use version_utils 'is_upgrade';
+use YuiRestClient;
 
 our @EXPORT = qw(
   boot_pvm
@@ -133,7 +134,12 @@ sub prepare_pvm_installation {
     # Switch to installation console (ssh or vnc)
     select_console('installation');
     # We need to start installer only if it's pure ssh installation
-    enter_cmd("yast.ssh") if get_var('VIDEOMODE', '') =~ /ssh-x|text/;
+    # If libyui REST API is used, we set it up in installation/setup_libyui
+    if (get_var('VIDEOMODE', '') =~ /ssh-x|text/ && !get_var('YUI_REST_API')) {
+        # We need to set env variables when start installer in ssh
+        enter_cmd("yast.ssh");
+    }
+
     wait_still_screen;
 }
 

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -81,7 +81,11 @@ sub run {
         if (check_var("VIDEOMODE", "text")) {
             wait_serial("run 'yast.ssh'", 300) || die "linuxrc didn't finish";
             select_console("installation");
-            enter_cmd("TERM=linux yast.ssh") && record_soft_failure('bsc#1054448');
+            # If libyui REST API is used, we set it up in installation/setup_libyui
+            unless (get_var('YUI_REST_API')) {
+                enter_cmd("TERM=linux yast.ssh");
+                record_soft_failure('bsc#1054448');
+            }
         }
         else {
             # On s390x zKVM we have to process startshell in bootloader

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -39,7 +39,6 @@ sub run {
                 return $+{ip} if ($ip =~ $ip_regexp);
         }, timeout => $boot_timeout, interval => 30);
         set_var('YUI_SERVER', $ip);
-        #        select_console('sut', await_console => 0);
     } elsif (check_var('BACKEND', 's390x')) {
         select_console('install-shell');
         my $ip = YuiRestClient::Wait::wait_until(object => sub {

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -22,9 +22,10 @@ use strict;
 use warnings;
 use base "installbasetest";
 use testapi;
-use Utils::Backends qw(is_hyperv);
+use Utils::Backends qw(is_hyperv is_pvm is_svirt);
 use YuiRestClient;
 use YuiRestClient::Wait;
+use Utils::Architectures 'is_s390x';
 
 sub run {
     my $ip_regexp = qr/(?<ip>(\d+\.){3}\d+)/i;
@@ -54,7 +55,12 @@ sub run {
                 return $+{ip} if ($ip =~ $ip_regexp);
         });
         set_var('YUI_SERVER', $ip);
+    } elsif (is_ssh_installation) {
+        my $cmd = (is_s390x && is_svirt) ? "TERM=linux " : "";
+        $cmd .= YuiRestClient::get_yui_params_string() . " yast.ssh";
+        enter_cmd($cmd);
     }
+
     YuiRestClient::connect_to_app();
     select_console('installation');
 }

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -1,4 +1,4 @@
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use base "installbasetest";
 use testapi;
-use Utils::Backends qw(is_hyperv is_pvm is_svirt);
+use Utils::Backends;
 use YuiRestClient;
 use YuiRestClient::Wait;
 use Utils::Architectures 'is_s390x';


### PR DESCRIPTION
Libyui REST API linuxrc parameters we specify in the bootloader
are not passed to the installer, when it's started in the ssh, so we
should specify them in the same way, as we do when start YaST modules in
the installed system.

See [poo#90776](https://progress.opensuse.org/issues/90776).

[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%23pvm&version=15-SP3).