### PR TITLE
qemu: Migrate to YAML scheduling

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1584,13 +1584,6 @@ sub load_extra_tests_opensuse {
     loadtest "console/libqca2";
 }
 
-sub load_extra_tests_qemu {
-    loadtest "qemu/info";
-    loadtest "qemu/qemu";
-    loadtest "qemu/kvm" unless (is_aarch64 || is_ppc64le);    # nested kvm is not yet implemented on ARM and kvm not supported on ppc64le
-    loadtest "qemu/user" if is_opensuse;
-}
-
 sub load_extra_tests_geo_console {
     loadtest "appgeo/gdal" if is_tumbleweed;
 }

--- a/schedule/functional/extra_tests_qemu.yaml
+++ b/schedule/functional/extra_tests_qemu.yaml
@@ -1,0 +1,22 @@
+name:           extra_tests_qemu
+description:    >
+    Maintainer: dheidler.
+    Extra qemu tests
+conditional_schedule:
+    kvm:
+        ARCH:
+            # nested kvm is not yet implemented on ARM and kvm not supported on ppc64le
+            'x86_64':
+                - qemu/kvm
+            's390x':
+                - qemu/kvm
+    user:
+        DISTRI:
+            'opensuse':
+                - qemu/user
+schedule:
+    - boot/boot_to_desktop
+    - qemu/info
+    - qemu/qemu
+    - '{{kvm}}'
+    - '{{user}}'


### PR DESCRIPTION
After this is merged, on O3 and OSD in the `qemu` testsuite the config line `EXTRATESTS=qemu` needs to be replaced by `YAML_SCHEDULE=schedule/functional/extra_tests_qemu.yaml`.

Ticket: https://progress.opensuse.org/issues/68527
Verification:
TW: http://kazhua.qa.suse.de/tests/337
SLE: http://kazhua.qa.suse.de/tests/338