### PR TITLE
Fix yast_virtualization test module

### DIFF
--- a/schedule/virtualization/virtualization.yaml
+++ b/schedule/virtualization/virtualization.yaml
@@ -1,0 +1,11 @@
+name:           virtualization
+description:    >
+  Test virtualization stack using libvirt and virt-manager.
+schedule:
+  - boot/boot_to_desktop
+  - x11/disable_screensaver
+  - virtualization/yast_virtualization
+  - virtualization/virt_install
+  - virtualization/virt_top
+  - virtualization/virtman_install
+  - virtualization/virtman_view

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -38,7 +38,7 @@ sub run {
 
     # launch the installation
     send_key 'alt-a';
-    assert_screen([qw(yast_virtualization_installed yast_virtualization_bridge)], 600);
+    assert_screen([qw(yast_virtualization_installed yast_virtualization_bridge)], 800);
     if (match_has_tag('yast_virtualization_bridge')) {
         # select yes
         send_key 'alt-y';


### PR DESCRIPTION
The test module failed during package installation. The commit fixes the
issue by disabling screensaver and increasing timeout to check the
installation is successful.

**After Merge Job Group settings should be updated for Tumbleweed (x64 and aarch64) and Leap 15.3:**
https://openqa.opensuse.org/admin/job_templates/1
https://openqa.opensuse.org/admin/job_templates/3
https://openqa.opensuse.org/admin/job_templates/50

```yaml
- virtualization:
    settings:
      YAML_SCHEDULE=schedule/virtualization/virtualization.yaml
```

- Related ticket: https://progress.opensuse.org/issues/89978
- Verification run (I've started 40 Jobs and no one failed on `yast_virtualization` step): https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=1714090_oorlov&groupid=38
