### PR TITLE
Schedule Samba/AD tests to Maintenance, on select versions

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -43,30 +43,36 @@ conditional_schedule:
         - console/valgrind
         - console/zziplib
         - '{{arch_specific}}'
+        - network/samba/samba_adcli
       15-SP1:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
         - '{{arch_specific}}'
+        - network/samba/samba_adcli
       15:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
         - '{{arch_specific}}'
+        - network/samba/samba_adcli
       12-SP5:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
         - '{{arch_specific}}'
+        - network/samba/samba_adcli
       12-SP4:
         - console/osinfo_db
         - '{{arch_specific}}'
+        - network/samba/samba_adcli
       12-SP3:
         - console/osinfo_db
         - '{{arch_specific}}'
+        - network/samba/samba_adcli
   arch_specific:
     ARCH:
       x86_64:


### PR DESCRIPTION
This is a follow up to: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12394