### PR TITLE
qemu: Use bootloader_start to work on s390x

### DIFF
--- a/schedule/functional/extra_tests_qemu.yaml
+++ b/schedule/functional/extra_tests_qemu.yaml
@@ -15,6 +15,7 @@ conditional_schedule:
             'opensuse':
                 - qemu/user
 schedule:
+    - installation/bootloader_start
     - boot/boot_to_desktop
     - qemu/info
     - qemu/qemu


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/68527
https://openqa.suse.de/t5904555