### PR TITLE
Send EOF to serial terminal

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -107,6 +107,9 @@ sub login {
     # after reboot and start typing the username before the console is actually
     # ready to accept it
     wait_serial(qr/login:\s*$/i, timeout => 5, quiet => 1);
+    # make sure that login prompt appears even when the console has been
+    # previously used
+    type_string(qq(\cd));
     # newline nudges the guest to display the login prompt, if this behaviour
     # changes then remove it
     send_key 'ret';


### PR DESCRIPTION
Motivation: [Failed login](https://openqa.opensuse.org/tests/1466407#step/btrfsmaintenance/1)

Transition from `rescue` to `default` target terminates both user sessions on
both previously logged consoles (tty and ttyS) in QEMU.
Unfortunately in case of failure, serial terminal might not been able to match
login prompt and eating the stale buffer does not help to recover login prompt.
Issuing `ctrl+d` might work for now.
This issue seems to block further testing [current state in osd](https://openqa.suse.de/tests/5900337#step/cifs/1)

- [Original PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/11405)

- VRs:
    - [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build2.25-jeos-filesystem@uefi-virtio-vga](http://kepler.suse.cz/tests/4686#step/snapper_used_space/1)
    - [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build2.25-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/4685#step/snapper_used_space/1)
    - [sle-15-SP3-JeOS-for-kvm-and-xen-aarch64-Build2.25-jeos-filesystem@aarch64](https://openqa.suse.de/t5904925)
    - [sle-15-SP3-Online-x86_64-Build178.1-extra_tests_filesystem@64bit](http://kepler.suse.cz/tests/4687#step/snapper_used_space/1)