### PR TITLE
Fix setup_libyui for opensuse

### DIFF
--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -39,6 +39,7 @@ sub run {
                 return $+{ip} if ($ip =~ $ip_regexp);
         }, timeout => $boot_timeout, interval => 30);
         set_var('YUI_SERVER', $ip);
+        select_console('sut', await_console => 0);
     } elsif (check_var('BACKEND', 's390x')) {
         select_console('install-shell');
         my $ip = YuiRestClient::Wait::wait_until(object => sub {
@@ -46,7 +47,9 @@ sub run {
                 return $+{ip} if ($ip =~ $ip_regexp);
         });
         set_var('YUI_SERVER', $ip);
+        select_console('installation');
     } elsif (check_var('VIRSH_VMM_FAMILY', 'xen')) {
+        # For xen, when attempting to switch console while the installation loader is not finished, we end up with test failure.
         assert_screen "inst-betawarning", 500;
         select_console('root-console');
         my $ip = YuiRestClient::Wait::wait_until(object => sub {
@@ -54,14 +57,13 @@ sub run {
                 return $+{ip} if ($ip =~ $ip_regexp);
         });
         set_var('YUI_SERVER', $ip);
+        select_console('installation');
     } elsif (is_ssh_installation) {
         my $cmd = (is_s390x && is_svirt) ? "TERM=linux " : "";
         $cmd .= YuiRestClient::get_yui_params_string() . " yast.ssh";
         enter_cmd($cmd);
     }
-
     YuiRestClient::connect_to_app();
-    select_console('installation');
 }
 
 1;


### PR DESCRIPTION
There are a lot of failures for opensuse on setup_libyui because the select_console("installation") does not recognize the installer loading as installation console. For most architectures, we don't switch consoles, so moving the select_console in the conditions, should fix this issue.

VRs for some random opensuse tests that were failing and for some sle tests for the archs related to the conditions:
Opensuse:
- RAID5_gpt: http://falafel.suse.cz/tests/228
- autoyast_y2_firstboot: http://falafel.suse.cz/tests/229  (this failure is unrelated)
- lvm-encrypt-separate-boot: http://falafel.suse.cz/tests/230

SLE:
- s390x-kvm-sle12 -> https://openqa.suse.de/t5907182
- ext4_yast@svirt-xen-hvm -> https://openqa.suse.de/t5907186
- ext4_yast@svirt-xen-pv -> https://openqa.suse.de/t5907187
- msdos@svirt-hyperv -> https://openqa.suse.de/t5907847
- textmode@ppc64le-hmc -> https://openqa.suse.de/t5909836