### PR TITLE
Revert "Schedule Samba/AD tests to Maintenance, on select versions"

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -43,36 +43,30 @@ conditional_schedule:
         - console/valgrind
         - console/zziplib
         - '{{arch_specific}}'
-        - network/samba/samba_adcli
       15-SP1:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
         - '{{arch_specific}}'
-        - network/samba/samba_adcli
       15:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
         - '{{arch_specific}}'
-        - network/samba/samba_adcli
       12-SP5:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
         - '{{arch_specific}}'
-        - network/samba/samba_adcli
       12-SP4:
         - console/osinfo_db
         - '{{arch_specific}}'
-        - network/samba/samba_adcli
       12-SP3:
         - console/osinfo_db
         - '{{arch_specific}}'
-        - network/samba/samba_adcli
   arch_specific:
     ARCH:
       x86_64:


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#12407

See: https://openqa.suse.de/tests/5906274#step/samba_adcli/25 and https://openqa.suse.de/tests/5905793#step/samba_adcli/25