### PR TITLE
Adds parent post_fail_hook for rootless_podman

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -84,6 +84,7 @@ sub post_fail_hook {
         $self->save_and_upload_log('ls -la /etc/zypp/credentials.d', "/tmp/credentials.d.perm.txt");
         assert_script_run "setfacl -x u:$testapi::username /etc/zypp/credentials.d/*";
     }
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
The module doesnt collect system logs so i add the missing
callback in the post_fail_hook

- Related ticket: https://progress.opensuse.org/issues/91821
