### PR TITLE
Add extend key usage CodeSigning for mok

### DIFF
--- a/data/openssl/gencert_conf/mok_cert.conf
+++ b/data/openssl/gencert_conf/mok_cert.conf
@@ -18,3 +18,4 @@ basicConstraints=critical,CA:FALSE
 keyUsage=digitalSignature
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid
+extendedKeyUsage=codeSigning


### PR DESCRIPTION
Based on bsc#1185326, the newly signed shim
merged the EKU CodeSigning fix to enforce the
extra check. hence adding this to cert.

- Related ticket: https://progress.opensuse.org/issues/91806
- Needles: n/a
- Verification run: https://openqa.nue.suse.com/tests/5904145
