### PR TITLE
389ds test should be put in console test process for yaml schedule

### DIFF
--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -5,6 +5,7 @@ description:    |
   #support service check test, normally set '0' for package media test.
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   #means regression test part2 include x11 test and some performance related test.
+  #REGRESSION_389DS: '1' means load 389ds test.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -42,6 +43,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - '{{check_upgraded_service}}'
+  - '{{openldap_to_389ds}}'
   - '{{regression_tests}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
@@ -59,6 +61,10 @@ conditional_schedule:
     REGRESSION_SERVICE:
       1:
         - installation/install_service
+  openldap_to_389ds:
+    REGRESSION_389DS:
+      1:
+        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -4,6 +4,7 @@ description:    |
   #REGRESSION_LTSS: '1' means base system supports ltss test.
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   # means regression test part2 include x11 test and some performance related test.
+  #REGRESSION_389DS: '1' means load 389ds test.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -23,8 +24,8 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/check_upgraded_service
-  - '{{regression_tests}}'
   - '{{openldap_to_389ds}}'
+  - '{{regression_tests}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
   - boot/snapper_rollback

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -5,6 +5,7 @@ description:    |
   #support service check test, normally set '0' for package media test.
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   #means regression test part2 include x11 test and some performance related test.
+  #REGRESSION_389DS: '1' means load 389ds test.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -41,6 +42,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - '{{check_upgraded_service}}'
+  - '{{openldap_to_389ds}}'
   - '{{regression_tests}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
@@ -58,6 +60,10 @@ conditional_schedule:
     REGRESSION_SERVICE:
       1:
         - installation/install_service
+  openldap_to_389ds:
+    REGRESSION_389DS:
+      1:
+        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -4,6 +4,7 @@ description:    |
   #REGRESSION_LTSS: '1' means base system supports ltss test.
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   # means regression test part2 include x11 test and some performance related test.
+  #REGRESSION_389DS: '1' means load 389ds test.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -23,8 +24,8 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/check_upgraded_service
-  - '{{regression_tests}}'
   - '{{openldap_to_389ds}}'
+  - '{{regression_tests}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
   - boot/snapper_rollback

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -5,6 +5,7 @@ description:    |
   #support service check test, normally set '0' for package media test.
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   #means regression test part2 include x11 test and some performance related test.
+  #REGRESSION_389DS: '1' means load 389ds test.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -40,8 +41,8 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - '{{check_upgraded_service}}'
-  - '{{regression_tests}}'
   - '{{openldap_to_389ds}}'
+  - '{{regression_tests}}'
 conditional_schedule:
   check_upgraded_service:
     REGRESSION_SERVICE:

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -4,6 +4,7 @@ description:    |
   #REGRESSION_LTSS: '1' means base system supports ltss test.
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   # means regression test part2 include x11 test and some performance related test.
+  #REGRESSION_389DS: '1' means load 389ds test.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -23,6 +24,7 @@ schedule:
   - console/system_state
   - console/prepare_test_data
   - console/consoletest_setup
+  - '{{openldap_to_389ds}}'
   - '{{regression_tests}}'
 conditional_schedule:
   remove_ltss:
@@ -42,6 +44,10 @@ conditional_schedule:
         - migration/online_migration/online_migration_setup
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
+  openldap_to_389ds:
+    REGRESSION_389DS:
+      1:
+        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -41,6 +41,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - '{{check_upgraded_service}}'
+  - migration/openldap_to_389ds
   - '{{regression_tests}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
@@ -88,7 +89,6 @@ conditional_schedule:
         - console/zypper_lifecycle
         - console/orphaned_packages_check
         - console/consoletest_finish
-        - migration/openldap_to_389ds
 
       2:
         - console/supportutils

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -23,6 +23,7 @@ schedule:
   - console/system_state
   - console/prepare_test_data
   - console/consoletest_setup
+  - migration/openldap_to_389ds
   - '{{regression_tests}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
@@ -85,7 +86,6 @@ conditional_schedule:
         - console/upgrade_snapshots
         - console/zypper_lifecycle
         - console/consoletest_finish
-        - migration/openldap_to_389ds
         - x11/desktop_runner
         - x11/xterm
         - locale/keymap_or_locale_x11

--- a/tests/migration/openldap_to_389ds.pm
+++ b/tests/migration/openldap_to_389ds.pm
@@ -72,7 +72,7 @@ sub run {
     # Prepare data file for migration
     assert_script_run "sed -i 's/^root_password.*/root_password = $password/' ./instance.inf";
     assert_script_run "mkdir slapd.d";
-    assert_script_run("dscreate from-file ./instance.inf", timeout => 60);
+    assert_script_run("dscreate from-file ./instance.inf", timeout => 120);
     assert_script_run "dsctl localhost status";
     assert_script_run "slaptest -f slapd.conf -F ./slapd.d";
 


### PR DESCRIPTION
389ds test should be put in console test process for yaml schedule, that is between console_setup and consolefinish_test.

- Related ticket: https://progress.opensuse.org/issues/91683
                        https://progress.opensuse.org/issues/91857
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/5896131# x86_64 online
                         http://openqa.nue.suse.com/tests/5896996# x86_64 offline
                         http://openqa.nue.suse.com/tests/5905384#step/openldap_to_389ds/2  ppc64le online
                         http://openqa.nue.suse.com/tests/5909796# ppc64le offline 