### PR TITLE
Use lilbyui REST API in btrfs_libstorage-ng on zVM and ipmi

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -5,16 +5,18 @@ description:    >
 vars:
   DESKTOP: textmode
   FILESYSTEM: btrfs
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_filesystem
-  - installation/partitioning_finish
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
@@ -32,6 +34,9 @@ schedule:
   - console/validate_no_cow_attribute
   - console/verify_separate_home
 test_data:
+  guided_partitioning:
+    disks:
+      - sda
   device: sda
   table_type: gpt
   subvolume:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -4,17 +4,19 @@ description:    >
 vars:
   DESKTOP: gnome
   FILESYSTEM: btrfs
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/disk_activation
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_filesystem
-  - installation/partitioning_finish
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root


### PR DESCRIPTION
We didn't have setup working on zVM (see https://progress.opensuse.org/issues/90776), now it works, so we can enable it
there. On ipmi it worked already, so we just can start using it.

[Verification runs](https://openqa.suse.de/tests/overview?version=15-SP3&build=rwx788%2Fos-autoinst-distri-opensuse%23zvm&distri=sle).

See [poo#91130](https://progress.opensuse.org/issues/91130).