### PR TITLE
toolkits: Migrate to YAML scheduling

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1747,19 +1747,6 @@ sub load_extra_tests {
     return 1;
 }
 
-sub load_extra_tests_toolkits {
-    loadtest "x11/toolkits/prepare";
-    loadtest "x11/toolkits/x11";
-    loadtest "x11/toolkits/tk";
-    loadtest "x11/toolkits/fltk";
-    loadtest "x11/toolkits/motif";
-    loadtest "x11/toolkits/gtk2";
-    loadtest "x11/toolkits/gtk3";
-    loadtest "x11/toolkits/qt5";
-    loadtest "x11/toolkits/swing";
-    return 1;
-}
-
 sub load_rollback_tests {
     return if check_var('ARCH', 's390x');
     # On Xen PV we don't have GRUB.

--- a/schedule/functional/extra_tests_toolkits.yaml
+++ b/schedule/functional/extra_tests_toolkits.yaml
@@ -1,0 +1,19 @@
+name:           extra_tests_toolkits
+description:    >
+    Maintainer: dheidler.
+    Extra toolkit tests
+schedule:
+    - boot/boot_to_desktop
+    - console/system_prepare
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - x11/toolkits/prepare
+    - x11/toolkits/x11
+    - x11/toolkits/tk
+    - x11/toolkits/fltk
+    - x11/toolkits/motif
+    - x11/toolkits/gtk2
+    - x11/toolkits/gtk3
+    - x11/toolkits/qt5
+    - x11/toolkits/swing
+    - console/coredump_collect


### PR DESCRIPTION
After this is merged, on O3 and OSD in the `toolkits` testsuite the config line `EXTRATESTS=prepare,toolkits` needs to be replaced by `YAML_SCHEDULE=schedule/functional/extra_tests_toolkits.yaml`.

Ticket: https://progress.opensuse.org/issues/68527
Verification:
TW: http://kazhua.qa.suse.de/tests/340
SLE: http://kazhua.qa.suse.de/tests/339