### PR TITLE
Fix sestatus failure on aarch64 by handling grub

### DIFF
--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -25,6 +25,7 @@ use warnings;
 use testapi;
 use utils;
 use Utils::Backends 'is_pvm';
+use Utils::Architectures 'is_aarch64';
 
 sub run {
     my ($self) = @_;
@@ -35,7 +36,10 @@ sub run {
     validate_script_output("sestatus", sub { m/SELinux status: .*disabled/ });
 
     # workaround for "selinux-auto-relabel" in case: auto relabel then trigger reboot
-    assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=8/\' /etc/default/grub");
+    my $results = script_run("zypper --non-interactive se selinux-autorelabel");
+    if (!$results) {
+        assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=8/\' /etc/default/grub");
+    }
 
     # enable SELinux in grub
     add_grub_cmdline_settings('security=selinux selinux=1 enforcing=0', update_grub => 1);


### PR DESCRIPTION
poo#91794 - [sle][security][sle15sp3][178.1]test fails in sestatus

- Related ticket: https://progress.opensuse.org/issues/91794
- Needles: N/A
- Verification run: 
sle15sp3 aarch64: https://openqa.suse.de/tests/5919267
sle15sp3 s390x: https://openqa.suse.de/tests/5919101
sle15sp3 x86_64: https://openqa.suse.de/tests/5919100
TW 20210427: https://openqa.opensuse.org/tests/1719243
