### PR TITLE
LTP/WhiteList: Don't require LTP_KNOWN_ISSUES

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -31,8 +31,10 @@ use Mojo::File 'path';
 our @EXPORT = qw(download_whitelist override_known_failures is_test_disabled);
 
 sub download_whitelist {
-    my $path = get_required_var('LTP_KNOWN_ISSUES');
-    my $res  = Mojo::UserAgent->new->get($path)->result;
+    my $path = get_var('LTP_KNOWN_ISSUES');
+    return undef unless defined($path);
+
+    my $res = Mojo::UserAgent->new->get($path)->result;
     unless ($res->is_success) {
         record_info("File not downloaded!", $res->message, result => 'softfail');
         set_var('LTP_KNOWN_ISSUES', undef);
@@ -47,7 +49,10 @@ sub download_whitelist {
 sub find_whitelist_entry {
     my ($env, $suite, $test) = @_;
 
-    my $content = path(get_required_var('LTP_KNOWN_ISSUES'))->slurp;
+    my $path = get_var('LTP_KNOWN_ISSUES');
+    return undef unless defined($path);
+
+    my $content = path($path)->slurp;
     my $issues  = Mojo::JSON::decode_json($content);
     return undef unless $issues;
     return undef unless exists $issues->{$suite};

--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -114,7 +114,7 @@ sub init_ltp_tests {
     my $is_network = $cmd_file =~ m/^\s*(net|net_stress)\./;
     my $is_ima     = $cmd_file =~ m/^ima$/i;
 
-    download_whitelist if get_var('LTP_KNOWN_ISSUES');
+    download_whitelist;
     script_run('env');
 
     my $kernel_pkg_log = '/tmp/kernel-pkg.txt';


### PR DESCRIPTION
To fix failing Tumbleweed:
https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=20210427&groupid=32

19040e506 (PR #12416) introduced hard dependency on LTP_KNOWN_ISSUES, but Tumbleweed and SLES QA does not have prepared config yet.

Verification run:
- SLES http://quasar.suse.cz/tests/6661
- Tumbleweed http://quasar.suse.cz/tests/6662
- released products (have `LTP_KNOWN_ISSUES`) http://quasar.suse.cz/tests/6664#step/move_pages12/8