### PR TITLE
Make windows_server_setup more robust (poo#88436)

### DIFF
--- a/tests/x11/remote_desktop/windows_server_setup.pm
+++ b/tests/x11/remote_desktop/windows_server_setup.pm
@@ -23,8 +23,10 @@ sub run {
 
     assert_and_click "start";
     sleep 5;
+    assert_and_click "system-settings";
+    wait_still_screen;
     type_string "allow remote connections";
-    assert_and_click "start_menu-remote_access-controlpanel";
+    assert_and_click "windows-settings-allow-remote-connections";
 
     assert_and_click "show-settings";
     assert_and_click "allow-remote-connections";


### PR DESCRIPTION
The test windows_server_setup failed frequently, change the code to make it more robust.

- Related ticket: https://progress.opensuse.org/issues/88436

- Needles for TW: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/722
- Needles for SLE: have been committed when debugging on o.s.d

- Verification run: 
- SLE:
[ - desktopapps-remote-desktop-xrdp-client2@64bit-virtio-vga](https://openqa.nue.suse.com/tests/5903954)
[ - desktopapps-remote-desktop-xrdp-server2@64bit-virtio-vga](https://openqa.nue.suse.com/tests/5903953)
- TW:
[- desktopapps-remote-desktop-xrdp-server2@64bit_virtio](http://10.163.42.54/tests/1726#)
[- desktopapps-remote-desktop-xrdp-client2@64bit_virtio](http://10.163.42.54/tests/1727#)

