### PR TITLE
Public Cloud GCE Terraform version downgrade

### DIFF
--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    google = {
+      version = "= 3.65.0"
+      source = "hashicorp/google"
+    }
+  }
+}
+
 variable "cred_file" {
     default = "/root/google_credentials.json"
 }
@@ -81,7 +90,7 @@ resource "google_compute_instance" "openqa" {
     metadata = merge({
             sshKeys = "susetest:${file("/root/.ssh/id_rsa.pub")}"
             openqa_created_by = var.name
-            openqa_created_date = "${timestamp()}"
+            openqa_created_date = timestamp()
             openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
         }, var.tags)
 

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -31,7 +31,7 @@ sub run {
     if (get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD') == 1) {
         record_info('Skip download', 'Skipping download triggered by setting (QAM_PUBLICCLOUD_SKIP_DOWNLOAD = 1)');
     } else {
-        assert_script_run("du -sh ~/repos");
+        assert_script_run('du -sh ~/repos');
         assert_script_run("rsync -uva -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");


### PR DESCRIPTION
Hello,

we have to upgrade our Terraform file for GCE. This is just a hotfix.

- Related ticket: [poo#91944](https://progress.opensuse.org/issues/91944)
- Verification run: [problem](https://openqa.suse.de/tests/5917530) [solution](http://pdostal-server.suse.cz/tests/11765)
