### PR TITLE
Reschedules docker_runc only for opensuse and sle12-sp4

### DIFF
--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -31,7 +31,7 @@ sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     my @runtimes = ();
-    push @runtimes, "docker-runc" if (is_sle("<16") || is_leap("<16.0"));
+    push @runtimes, "docker-runc" if is_leap("<16.0");
     push @runtimes, "runc"        if !is_sle('=15');
 
     record_info 'Setup', 'Setup the environment';


### PR DESCRIPTION
Because the conflict[0] of docker_runc is expected for certain distros
as it is no longer used from them
it is being filtered out from the runtimes which are being tested.

[0] https://bugzilla.suse.com/show_bug.cgi?id=1185436

- Related ticket: https://progress.opensuse.org/issues/91941
Verification run: 
- [sle-15-SP3-Online.x86_64](http://aquarius.suse.cz/tests/5712)
- [sle-15-SP3-JeOS-for-MS-HyperV.x86_64](http://aquarius.suse.cz/tests/5714)
- [opensuse-Tumbleweed-DVD.x86_64](http://aquarius.suse.cz/tests/5711)
- [opensuse-15.3-DVD.x86_64](http://aquarius.suse.cz/tests/5715)
- [sle-15-SP2-Server-DVD-Updates.x86_64](http://aquarius.suse.cz/tests/5718)
- [sle-12-SP4-Server-DVD-Updates.x86_64](http://aquarius.suse.cz/tests/5717)
- [opensuse-Tumbleweed-JeOS-for-kvm-and-xen.x86_64](http://aquarius.suse.cz/tests/5719)
- [sle-15-SP2-AZURE-BYOS-Updates.x86_64](http://aquarius.suse.cz/tests/5710)
- [sle-15-SP3-JeOS-for-kvm-and-xen.x86_64](http://aquarius.suse.cz/tests/5713)

[TW](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2312433&version=Tumbleweed)
[Leap](https://openqa.opensuse.org/tests/1720942)
[15-SP3](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2312433&distri=sle&version=15-SP3)