### PR TITLE
Automate yast2 booloader with libyui REST API

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -25,6 +25,7 @@ use YaST::NetworkSettings::v4_3::NetworkSettingsController;
 use Installation::SystemRole::SystemRoleController;
 use YaST::SystemSettings::SystemSettingsController;
 use YaST::Firstboot::FirstbootController;
+use YaST::Bootloader::BootloaderController;
 
 sub get_partitioner {
     return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
@@ -60,6 +61,10 @@ sub get_suggested_partitioning() {
 
 sub get_firstboot {
     return YaST::Firstboot::FirstbootController->new();
+}
+
+sub get_bootloader {
+    return YaST::Bootloader::BootloaderController->new();
 }
 
 1;

--- a/lib/YaST/Bootloader/BootCodeOptionsPage.pm
+++ b/lib/YaST/Bootloader/BootCodeOptionsPage.pm
@@ -1,0 +1,111 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces all accessing methods for Bootloader
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Bootloader::BootCodeOptionsPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->{cmb_bootloader}        = $self->{app}->combobox({id => '"Bootloader::LoaderTypeWidget"'});
+    $self->{cb_write_to_partition} = $self->{app}->checkbox({id => 'boot'});
+    $self->{cb_bootdev}            = $self->{app}->checkbox({id => 'mbr'});
+    $self->{cb_custom_boot}        = $self->{app}->checkbox({id => 'custom'});
+    $self->{cmb_mbr_flag}          = $self->{app}->combobox({id => '"Bootloader::PMBRWidget"'});
+    $self->{cb_trusted_boot}       = $self->{app}->checkbox({id => '"Bootloader::TrustedBootWidget"'});
+    $self->{cb_generic_to_mbr}     = $self->{app}->checkbox({id => '"Bootloader::GenericMBRWidget"'});
+    $self->{cb_set_active_flag}    = $self->{app}->checkbox({id => '"Bootloader::ActivateWidget"'});
+    $self->{tb_boot_options}       = $self->{app}->tab({id => '"CWM::DumbTabPager"'});
+    $self->{btn_ok}                = $self->{app}->button({id => 'next'});
+    $self->{btn_cancel}            = $self->{app}->button({id => 'abort'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{tb_boot_options}->selected_tab();
+}
+
+sub get_bootloader_type {
+    my ($self) = @_;
+    return $self->{cmb_bootloader}->value();
+}
+
+sub get_write_to_mbr {
+    my ($self) = @_;
+    return $self->{cb_bootdev}->is_checked();
+}
+
+sub get_write_to_custom {
+    my ($self) = @_;
+    return $self->{cb_custom_boot}->is_checked();
+}
+
+sub get_trusted_boot_support {
+    my ($self) = @_;
+    return $self->{cb_custom_boot}->is_checked();
+}
+
+sub get_write_to_partition {
+    my ($self) = @_;
+    return $self->{cb_write_to_partition}->is_checked();
+}
+
+sub get_protective_mbr_flag {
+    my ($self) = @_;
+    return $self->{cmb_mbr_flag}->value();
+}
+
+sub get_set_active_flag {
+    my ($self) = @_;
+    return $self->{cb_set_active_flag}->is_checked();
+}
+
+sub get_write_generic_to_mbr {
+    my ($self) = @_;
+    return $self->{cb_generic_to_mbr}->is_checked();
+}
+
+sub check_write_to_partition {
+    my ($self) = @_;
+    $self->{cb_write_to_partition}->check();
+}
+
+sub check_write_generic_to_mbr {
+    my ($self) = @_;
+    $self->{cb_generic_to_mbr}->check();
+}
+
+sub uncheck_write_to_mbr {
+    my ($self) = @_;
+    $self->{cb_bootdev}->uncheck();
+}
+
+sub press_ok {
+    my ($self) = @_;
+    return $self->{btn_ok}->click();
+}
+
+sub press_cancel {
+    my ($self) = @_;
+    return $self->{btn_cancel}->click();
+}
+
+1;

--- a/lib/YaST/Bootloader/BootloaderController.pm
+++ b/lib/YaST/Bootloader/BootloaderController.pm
@@ -1,0 +1,77 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Controller for YaST bootloader module.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Bootloader::BootloaderController;
+use strict;
+use warnings;
+use YuiRestClient;
+use YaST::Bootloader::BootCodeOptionsPage;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->{BootCodePage} = YaST::Bootloader::BootCodeOptionsPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_boot_code_options_page {
+    my ($self) = @_;
+    die "Boot code options tab is not shown" unless $self->{BootCodePage}->is_shown();
+    return $self->{BootCodePage};
+}
+
+sub get_current_settings {
+    my ($self) = @_;
+    my %current_settings;
+    $current_settings{bootloader_type}              = $self->get_boot_code_options_page->get_bootloader_type();
+    $current_settings{write_to_partition}           = $self->get_boot_code_options_page->get_write_to_partition();
+    $current_settings{write_to_mbr}                 = $self->get_boot_code_options_page->get_write_to_mbr();
+    $current_settings{select_custom_boot_partition} = $self->get_boot_code_options_page->get_write_to_custom();
+    $current_settings{set_active_flag}              = $self->get_boot_code_options_page->get_set_active_flag();
+    $current_settings{write_generic_to_mbr}         = $self->get_boot_code_options_page->get_write_generic_to_mbr();
+    $current_settings{trusted_boot_support}         = $self->get_boot_code_options_page->get_trusted_boot_support();
+    $current_settings{protective_mbr_flag}          = $self->get_boot_code_options_page->get_protective_mbr_flag();
+    return %current_settings;
+}
+
+sub write_generic_to_mbr {
+    my ($self) = @_;
+    $self->get_boot_code_options_page->check_write_generic_to_mbr();
+}
+
+sub dont_write_to_mbr {
+    my ($self) = @_;
+    $self->get_boot_code_options_page->uncheck_write_to_mbr();
+}
+
+sub write_to_partition {
+    my ($self) = @_;
+    $self->get_boot_code_options_page->check_write_to_partition();
+}
+
+sub accept_changes {
+    my ($self) = @_;
+    $self->get_boot_code_options_page->press_ok();
+}
+
+sub cancel_changes {
+    my ($self) = @_;
+    $self->get_boot_code_options_page->press_cancel();
+}
+
+1;

--- a/lib/YuiRestClient/Widget/Tab.pm
+++ b/lib/YuiRestClient/Widget/Tab.pm
@@ -22,4 +22,10 @@ sub select {
     $self->action(action => YuiRestClient::Action::YUI_SELECT, value => $item);
 }
 
+sub selected_tab {
+    my ($self) = @_;
+    my $tabs = $self->property('items');
+    return map { $_->{label} } grep { $_->{selected} } @{$tabs};
+}
+
 1;

--- a/lib/cfg_files_utils.pm
+++ b/lib/cfg_files_utils.pm
@@ -99,6 +99,12 @@ sub validate_cfg_file {
                 $errors .= "Entry '$entry' is not found in '$path'.\n";
             }
         }
+
+        foreach my $not_entry (@{$cfg_file->{not_entries}}) {
+            if ($cfg_content =~ /$not_entry/) {
+                $errors .= "Unexpected entry '$not_entry' was found in '$path'.\n";
+            }
+        }
     }
 
     die "Configuration files validation failed:\n$errors" if $errors;

--- a/schedule/yast/yast2_gui/yast2_gui_opensuse.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_opensuse.yaml
@@ -20,6 +20,7 @@ schedule:
     - yast2_gui/yast2_control_center
     - x11/yast2_lan_restart
     - yast2_gui/yast2_bootloader
+    - yast2_gui/bootloader/bootcode_options
     - yast2_gui/yast2_datetime
     - yast2_gui/yast2_firewall
     - yast2_gui/yast2_hostnames
@@ -28,3 +29,5 @@ schedule:
     - yast2_gui/yast2_software_management
     - yast2_gui/yast2_users
     - yast2_gui/yast2_security
+test_data:
+    <<: !include test_data/yast/yast2_gui.yaml

--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -31,6 +31,7 @@ conditional_schedule:
         - yast2_gui/yast2_security
         - yast2_gui/yast2_firewall
         - yast2_gui/yast2_bootloader
+        - yast2_gui/bootloader/bootcode_options
         - x11/yast2_snapper
         - yast2_gui/yast2_lang
         - yast2_gui/yast2_users
@@ -137,3 +138,4 @@ test_data:
       - yast2_basis
       - yast2_desktop
       - yast2_server
+  <<: !include test_data/yast/yast2_gui.yaml

--- a/test_data/yast/yast2_gui.yaml
+++ b/test_data/yast/yast2_gui.yaml
@@ -1,0 +1,30 @@
+bootcode_options:
+  bootloader_type: GRUB2
+  write_to_partition: 0
+  write_to_mbr: 1
+  select_custom_boot_partition: 0
+  set_active_flag: 1
+  write_generic_to_mbr: 0
+  trusted_boot_support: 0
+  protective_mbr_flag: "do not change"
+bootcode_applied_params:
+  verify_current_options:
+    - path: /etc/default/grub_installdevice
+      entries:
+        - by-path
+        - activate
+  write_generic_to_mbr:
+    - path: /etc/default/grub_installdevice
+      entries:
+        - generic_mbr
+  dont_write_to_mbr:
+    - path: /etc/default/grub_installdevice
+      not_entries:
+        - by-path
+  write_to_partition:
+    - path: /etc/default/grub_installdevice
+      entries:
+        - by-uuid
+bootcode_device:
+  default: /dev/vda
+  write_to_partition: /dev/vda2

--- a/tests/yast2_gui/bootloader/bootcode_options.pm
+++ b/tests/yast2_gui/bootloader/bootcode_options.pm
@@ -1,0 +1,87 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# Summary: Open bootloader gui, verify default setting in ui, change
+# some settings and verify that they have been applied.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+use YaST::Module;
+use cfg_files_utils;
+use x11utils 'start_root_shell_in_xterm';
+use y2lan_restart_common 'close_xterm';
+
+my $bootloader;
+my $test_data;
+
+sub verify_current_options {
+    validate_cfg_file($test_data->{bootcode_applied_params}->{verify_current_options});
+    verify_boot_code();    # Validating beforehand as we cannot press cancel see boo#1186132
+    YaST::Module::run_actions {
+        my %current_settings = $bootloader->get_current_settings();
+        compare_settings({expected => $test_data->{bootcode_options}, current => \%current_settings});
+        $bootloader->accept_changes();
+    } module => 'bootloader', ui => 'qt';
+    validate_cfg_file($test_data->{bootcode_applied_params}->{verify_current_options});
+    verify_boot_code();
+}
+
+sub change_settings_then_verify {
+    my ($args) = @_;
+    my $action = $args->{action};
+    YaST::Module::run_actions {
+        record_info $action;
+        $bootloader->$action();
+        $bootloader->accept_changes();
+    } module => 'bootloader', ui => 'qt';
+    validate_cfg_file($test_data->{bootcode_applied_params}->{$action});    # verify changes in /etc/default/grub_installdevice
+    verify_boot_code({device => $args->{device}, generic_boot_code => $args->{generic_boot_code}});
+}
+
+sub verify_boot_code {    # Check if boot code is installed, defaults to GRUB on MBR
+    my ($args) = @_;
+    my $device = $args->{device} ? $args->{device} : $test_data->{bootcode_device}->{default};
+    if ($args->{generic_boot_code}) {
+        assert_script_run("dd if=$device bs=512 count=1 | hexdump -C | grep -v GRUB 2>&1 >/dev/null");
+        assert_script_run("dd if=$device bs=512 count=1 | hexdump -C | grep boot");
+    } else {
+        assert_script_run("dd if=$device bs=512 count=1 | hexdump -C | grep GRUB");
+    }
+}
+
+sub run {
+    $bootloader = $testapi::distri->get_bootloader();
+    $test_data  = get_test_suite_data();
+    start_root_shell_in_xterm();
+
+    # Check that UI is initialized with expected default parameters
+    verify_current_options();
+
+    # If we chose to enable "generic boot code" and also "write to MBR", GRUB must still be installed on MBR as
+    # it has priority over generic boot code.
+    change_settings_then_verify({action => 'write_generic_to_mbr'});
+
+    # Unselect write_to_mbr, verify that the GRUB is no longer on MBR but generic boot code is here instead,
+    # as it was enabled in previous step.
+    change_settings_then_verify({action => 'dont_write_to_mbr', generic_boot_code => 1});
+
+    # Select "write to partition" and see if GRUB is installed on the partition.
+    change_settings_then_verify({
+            action => 'write_to_partition',
+            device => $test_data->{bootcode_device}->{write_to_partition}});
+
+    close_xterm();
+}
+
+1;


### PR DESCRIPTION
See https://progress.opensuse.org/issues/88750
We want to test yast2 bootloader module using libyui-rest-api, to reduce the maintenance cost of the module. However as of now we have to keep the old one for svirt.

VRs:
TW: http://waaa-amazing.suse.cz/tests/15515
SLE: https://openqa.suse.de/tests/6061793