### PR TITLE
Correct vboxautostart service name

### DIFF
--- a/lib/vagrant.pm
+++ b/lib/vagrant.pm
@@ -24,6 +24,6 @@ sub setup_vagrant_virtualbox {
 
     zypper_call("in vagrant virtualbox");
     systemctl("start vboxdrv");
-    systemctl("start vboxautostart");
+    systemctl("start vboxautostart-service");
     assert_script_run("usermod -a -G vboxusers bernhard");
 }


### PR DESCRIPTION
Upstream renamed the service from `vboxautostart` to `vboxautostart-service`

- Related ticket: https://progress.opensuse.org/issues/91968
- Needles: not required
- Verification run: https://openqa.opensuse.org/t1720049