### PR TITLE
Do not remove ESPOS before migration

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -33,7 +33,6 @@ our @EXPORT = qw(
   setup_migration
   register_system_in_textmode
   remove_ltss
-  remove_espos
   disable_installation_repos
   record_disk_info
   check_rollback_system
@@ -118,19 +117,6 @@ sub remove_ltss {
             zypper_call 'rm sles-ltss-release-POOL';
         }
         set_var('SCC_ADDONS', join(',', grep { $_ ne 'ltss' } @$scc_addons));
-    }
-}
-
-# Remove ESPOS product before migration
-# Also remove espos from SCC_ADDONS setting for registration in upgrade target
-sub remove_espos {
-    if (get_var('SCC_ADDONS', '') =~ /espos/) {
-        my $scc_addons = get_var_array('SCC_ADDONS');
-        record_info 'remove espos', 'got all updates from espos channel, now remove espos and drop it from SCC_ADDONS before migration';
-        if (check_var('SLE_PRODUCT', 'hpc')) {
-            remove_suseconnect_product('SLE_HPC-ESPOS');
-            set_var('SCC_ADDONS', join(',', grep { $_ ne 'espos' } @$scc_addons));
-        }
     }
 }
 

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -31,7 +31,6 @@ sub run {
     fully_patch_system;
     install_patterns() if (get_var('PATTERNS'));
     remove_ltss;
-    remove_espos;
     power_action('reboot', keepconsole => 1, textmode => 1);
     reconnect_mgmt_console if is_pvm;
 

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -93,8 +93,6 @@ sub patching_sle {
     #migration with LTSS is not possible, remove it before upgrade
     remove_ltss;
 
-    #migration with ESPOS is not possible, remove it before upgrade
-    remove_espos;
     if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ || get_var('KEEP_REGISTERED')) {
         # The system is registered.
         set_var('HDD_SCC_REGISTERED', 1);


### PR DESCRIPTION
ESPOS is an integral part of the product, no need to deregister it
before migration.

- Related ticket: https://progress.opensuse.org/issues/91266
- Verification run: 
https://openqa.nue.suse.com/tests/5924207#step/installation_overview/1
https://openqa.nue.suse.com/tests/5924206#step/zypper_migration/2
https://openqa.nue.suse.com/tests/5924208#step/installation_overview/1
https://openqa.nue.suse.com/tests/5924209#step/zypper_migration/2