### PR TITLE
Public Cloud: Terraform: Keep current providers version and fix the file syntax

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -4,6 +4,10 @@ terraform {
       version = "= 2.56.0"
       source = "hashicorp/azurerm"
     }
+    random = {
+      version = "= 3.1.0"
+      source = "hashicorp/random"
+    }
   }
 }
 

--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      version = "= 2.56.0"
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+
 provider "azurerm" {
     features {}
 }

--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -79,8 +79,8 @@ resource "azurerm_resource_group" "openqa-group" {
 
     tags = merge({
             openqa_created_by = var.name
-            openqa_created_date = "${timestamp()}"
-            openqa_created_id = "${element(random_id.service.*.hex, 0)}"
+            openqa_created_date = timestamp()
+            openqa_created_id = element(random_id.service.*.hex, 0)
         }, var.tags)
 }
 
@@ -161,7 +161,7 @@ resource "azurerm_virtual_machine" "openqa-vm" {
     name                  = "${var.name}-${element(random_id.service.*.hex, count.index)}"
     location              = var.region
     resource_group_name   = azurerm_resource_group.openqa-group.name
-    network_interface_ids = ["${azurerm_network_interface.openqa-nic[count.index].id}"]
+    network_interface_ids = [azurerm_network_interface.openqa-nic[count.index].id]
     vm_size               = var.type
     count                 = var.instance_count
 
@@ -195,8 +195,8 @@ resource "azurerm_virtual_machine" "openqa-vm" {
 
     tags = merge({
             openqa_created_by = var.name
-            openqa_created_date = "${timestamp()}"
-            openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+            openqa_created_date = timestamp()
+            openqa_created_id = element(random_id.service.*.hex, count.index)
         }, var.tags)
 
 
@@ -226,15 +226,15 @@ resource "azurerm_managed_disk" "ssd_disk" {
 
 
 output "vm_name" {
-    value = "${azurerm_virtual_machine.openqa-vm.*.id}"
+    value = azurerm_virtual_machine.openqa-vm.*.id
 }
 
 data "azurerm_public_ip" "openqa-publicip" {
-    name                = "${azurerm_public_ip.openqa-publicip[count.index].name}"
-    resource_group_name = "${azurerm_virtual_machine.openqa-vm.0.resource_group_name}"
+    name                = azurerm_public_ip.openqa-publicip[count.index].name
+    resource_group_name = azurerm_virtual_machine.openqa-vm.0.resource_group_name
     count               = var.instance_count
 }
 
 output "public_ip" {
-    value = "${data.azurerm_public_ip.openqa-publicip.*.ip_address}"
+    value = data.azurerm_public_ip.openqa-publicip.*.ip_address
 }

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "= 3.37.0"
+      source = "hashicorp/aws"
+    }
+  }
+}
+
 variable "region" {
     default = "eu-central-1"
 }

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -4,6 +4,10 @@ terraform {
       version = "= 3.37.0"
       source = "hashicorp/aws"
     }
+    random = {
+      version = "= 3.1.0"
+      source = "hashicorp/random"
+    }
   }
 }
 

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -85,8 +85,8 @@ resource "aws_security_group" "basic_sg" {
 
     tags = merge({
             openqa_created_by = var.name
-            openqa_created_date = "${timestamp()}"
-            openqa_created_id = "${element(random_id.service.*.hex, 0)}"
+            openqa_created_date = timestamp()
+            openqa_created_id = element(random_id.service.*.hex, 0)
         }, var.tags)
 }
 
@@ -95,12 +95,12 @@ resource "aws_instance" "openqa" {
     ami             = var.image_id
     instance_type   = var.type
     key_name        = aws_key_pair.openqa-keypair.key_name
-    security_groups = ["${aws_security_group.basic_sg.name}"]
+    security_groups = [aws_security_group.basic_sg.name]
 
     tags = merge({
             openqa_created_by = var.name
-            openqa_created_date = "${timestamp()}"
-            openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+            openqa_created_date = timestamp()
+            openqa_created_id = element(random_id.service.*.hex, count.index)
         }, var.tags)
 }
 
@@ -118,15 +118,15 @@ resource "aws_ebs_volume" "ssd_disk" {
     type              = var.extra-disk-type
     tags = merge({
             openqa_created_by = var.name
-            openqa_created_date = "${timestamp()}"
-            openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+            openqa_created_date = timestamp()
+            openqa_created_id = element(random_id.service.*.hex, count.index)
         }, var.tags)
 }
 
 output "public_ip" {
-    value = "${aws_instance.openqa.*.public_ip}"
+    value = aws_instance.openqa.*.public_ip
 }
 
 output "vm_name" {
-    value = "${aws_instance.openqa.*.id}"
+    value = aws_instance.openqa.*.id
 }

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -95,7 +95,7 @@ resource "google_compute_instance" "openqa" {
             sshKeys = "susetest:${file("/root/.ssh/id_rsa.pub")}"
             openqa_created_by = var.name
             openqa_created_date = timestamp()
-            openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+            openqa_created_id = element(random_id.service.*.hex, count.index)
         }, var.tags)
 
     network_interface {
@@ -134,14 +134,14 @@ resource "google_compute_disk" "default" {
     physical_block_size_bytes = 4096
     labels = {
         openqa_created_by = var.name
-        openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+        openqa_created_id = element(random_id.service.*.hex, count.index)
     }
 }
 
 output "public_ip" {
-    value = "${google_compute_instance.openqa.*.network_interface.0.access_config.0.nat_ip}"
+    value = google_compute_instance.openqa.*.network_interface.0.access_config.0.nat_ip
 }
 
 output "vm_name" {
-    value = "${google_compute_instance.openqa.*.name}"
+    value = google_compute_instance.openqa.*.name
 }

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -8,6 +8,10 @@ terraform {
       version = "= 3.1.0"
       source = "hashicorp/random"
     }
+    external = {
+      version = "= 2.1.0"
+      source = "hashicorp/external"
+    }
   }
 }
 

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -4,6 +4,10 @@ terraform {
       version = "= 3.65.0"
       source = "hashicorp/google"
     }
+    random = {
+      version = "= 3.1.0"
+      source = "hashicorp/random"
+    }
   }
 }
 


### PR DESCRIPTION
This is to protect our Terraform Public Cloud workflow so we providers of specific version.

- Related ticket: [poo#91944](https://progress.opensuse.org/issues/91944)
- Verification run: [AWS](http://pdostal-server.suse.cz/tests/11784) [Azure](http://pdostal-server.suse.cz/tests/11785) [Google](http://pdostal-server.suse.cz/tests/11786)