### PR TITLE
Update secureboot and mokutil test case

### DIFF
--- a/lib/jeos.pm
+++ b/lib/jeos.pm
@@ -32,7 +32,7 @@ sub reboot_image {
     my ($self, $msg) = @_;
     power_action('reboot', textmode => 1);
     record_info('reboot', $msg);
-    $self->wait_boot;
+    $self->wait_boot(bootloader_time => 150);
     $self->select_serial_terminal;
     ensure_serialdev_permissions;
 }

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -584,7 +584,7 @@ sub load_jeos_tests {
     }
 
     replace_opensuse_repos_tests      if is_repo_replacement_required;
-    loadtest 'console/verify_efi_mok' if get_var('MOK_VERBOSITY');
+    loadtest 'console/verify_efi_mok' if get_var 'CHECK_MOK_IMPORT';
 }
 
 sub installzdupstep_is_applicable {

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -17,6 +17,10 @@ conditional_schedule:
             'svirt-vmware65':
                 - installation/bootloader_svirt
                 - installation/bootloader_uefi
+    efi:
+        UEFI:
+            '1':
+                - console/verify_efi_mok
 schedule:
     - '{{bootloader}}'
     - jeos/firstrun
@@ -28,6 +32,7 @@ schedule:
     - jeos/build_key
     - console/prjconf_excluded_rpms
     - console/suseconnect_scc
+    - '{{efi}}'
     - jeos/glibc_locale
     - console/check_network
     - console/system_state

--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,47 +14,49 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use utils qw(zypper_call is_efi_boot);
-use version_utils qw(is_leap is_opensuse is_sle);
+use version_utils qw(is_leap is_opensuse is_sle is_jeos);
 use Utils::Backends qw(is_hyperv is_svirt_except_s390x);
 use jeos qw(reboot_image set_grub_gfxmode);
+use registration qw(add_suseconnect_product remove_suseconnect_product);
 use constant {
     SYSFS_EFI_BITS      => '/sys/firmware/efi/fw_platform_size',
-    FSTAB               => '/etc/fstab',
     GRUB_DEFAULT        => '/etc/default/grub',
     GRUB_CFG            => '/boot/grub2/grub.cfg',
-    SYSCONFIG_BOOTLADER => '/etc/sysconfig/bootloader'
+    SYSCONFIG_BOOTLADER => '/etc/sysconfig/bootloader',
+    MOCK_CRT            => '/boot/efi/EFI/mock.der'
 };
 
+my @errors;
+
 sub get_expected_efi_settings {
-    my $settings      = {};
-    my $efi_rec_label = (is_opensuse() ? (lc get_var('DISTRI')) : 'sles');
-    my $efi_exec      = $efi_rec_label . '/grubx64.efi';
+    my $settings = {};
+    $settings->{label} = is_opensuse() ? lc(get_var('DISTRI')) : 'sles';
+    $settings->{mount} = '/boot/efi';
 
     if (!get_var('DISABLE_SECUREBOOT', 0)) {
-        $efi_exec = $efi_rec_label . '/shim.efi';
-        $efi_rec_label .= '-secureboot';
+        $settings->{exec} = '/EFI/' . $settings->{label} . '/shim.efi';
+        $settings->{label} .= '-secureboot';
+    } else {
+        $settings->{exec} = '/EFI/' . $settings->{label} . '/grubx64.efi';
     }
-    $settings->{exec}  = '/EFI/' . $efi_exec;
-    $settings->{label} = $efi_rec_label;
 
     return $settings;
 }
+
 sub efibootmgr_current_boot {
     my $ebm_raw = script_output 'efibootmgr --verbose';
     my $h       = {};
 
     ($h->{bootid}) = $ebm_raw =~ /^BootCurrent:\s+(\d+)/m;
-    die("Missing BootCurrent: in efibootmgr output") unless (defined($h->{bootid}));
+    die 'Missing BootCurrent: in efibootmgr\'s output' unless $h->{bootid};
 
     if ($ebm_raw =~ /^(Boot$h->{bootid}\*\s+(.+)\s+(\S+\([^\)]+\)\/?)+.*|Boot$h->{bootid}\*\s+(.+))$/m) {
         $h->{label} = $2 // $4;
     }
-    die("Missing label in Boot$h->{bootid} entry") unless (exists($h->{label}) or defined($h->{label}));
+    (exists($h->{label}) && $h->{label}) or die "Missing label in Boot$h->{bootid} entry";
 
     ($h->{exec}) = $ebm_raw =~ /^Boot$h->{bootid}\*.*File\(([^\)]+)\).*/m;
-    if (defined($h->{exec})) {
-        $h->{exec} =~ s'\\'/'g;
-    }
+    $h->{exec} =~ s'\\'/'g;
 
     return $h;
 }
@@ -73,46 +75,32 @@ sub check_efi_state {
     my ($efi_guid_global, undef) = script_output('efivar --list-guids') =~ /\{((\w+-){4}\w+)\}.*\s+efi_guid_global\s+/;
     diag "Found efi guid=$efi_guid_global";
     diag('Expected state of SecureBoot: ' . get_var('DISABLE_SECUREBOOT', 0) ? 'Disabled' : 'Enabled');
-    validate_script_output
-      "od --address-radix=n --format=u1 /sys/firmware/efi/vars/SecureBoot-$efi_guid_global/data",
-      sub { $_ == !get_var('DISABLE_SECUREBOOT', 0) };
+
+    if (script_run("efivar -dn $efi_guid_global-SecureBoot") == !get_var('DISABLE_SECUREBOOT', 0)) {
+        push @errors, 'System\'s SecureBoot state is unexpected according to efivar';
+    }
 
     # get current boot information from efibootmgr
-    my $efi = efibootmgr_current_boot;
-
-    diag("Found:\nlabel=$efi->{label}\nexecutable=$efi->{exec}");
-    diag("Expected:\nlabel=$expected->{label}\nexecutable=$expected->{exec}");
-
-    if (exists $expected->{exec} && defined $expected->{exec}) {
+    my $found = efibootmgr_current_boot;
+    if (exists($expected->{exec}) && $expected->{exec}) {
         record_info "Expected", "EFI executable: $expected->{exec} ( $expected->{label} )";
-        if (exists $efi->{exec} && defined $efi->{exec}) {
-            ($efi->{exec} eq $expected->{exec} && $efi->{label} eq $expected->{label}) or die "System booted using unexpected efi binary\n";
-        } else {
-            die "No efi executable found!";
+        record_info "Found",    "EFI executable: $found->{exec} ( $found->{label} )";
+        unless (exists $found->{exec} && exists $found->{label} &&
+            $found->{exec} eq $expected->{exec} && $found->{label} eq $expected->{label}) {
+            push @errors, 'No efi executable found by efibootmgr or SUT booted using unexpected efi binary';
         }
-        record_info "Found", "EFI executable: $efi->{exec} ( $efi->{label} )";
     } else {
-        record_info "Fallback", "EFI label: $efi->{label}";
-        return;
+        record_info "Fallback", "EFI label: $found->{label}";
     }
 
-    return if (get_var('DISABLE_SECUREBOOT', 0));
+    # return only if SecureBoot is off or image has booted n Fallback mode
+    return if (get_var('DISABLE_SECUREBOOT', 0) || (!$found->{exec} && !$expected->{exec}));
 
-    my $issuer_regex = is_opensuse() ? qr/^\s+issuer:\s+\/CN=openSUSE Secure Boot CA/ :
-      qr/^\s+issuer:\s+\/CN=SUSE Linux Enterprise Secure Boot CA/;
+    my $issuer_regex = qr/Secure\s+Boot\s+CA/;
     diag("Verifying shim's certificate");
-    (grep /$issuer_regex/, split /\n/, script_output "sbverify --list $expected->{mount}/$efi->{exec}") or
-      die "No SUSE/openSUSE certificate has been found in sbverify's output";
     assert_script_run 'openssl x509 -in $(rpm -ql shim | grep crt) -inform DER -text -out shim.crt';
-    assert_script_run "sbverify --cert shim.crt $expected->{mount}/$efi->{exec}";
-
-    if (script_run "cat /proc/keys | tee -a /dev/$serialdev | grep asym") {
-        if (is_leap('=15.1')) {
-            record_soft_failure('boo#1170896 - secureboot keys not found in /proc/keys');
-        } else {
-            die "No asymetric keys in keyring";
-        }
-    }
+    assert_script_run "sbverify --cert shim.crt $expected->{mount}/$found->{exec}";
+    push @errors, 'No openSUSE/SUSE keys found in keyring(/proc/keys)' if script_output('cat /proc/keys') !~ $issuer_regex;
 }
 
 sub check_mok {
@@ -121,56 +109,51 @@ sub check_mok {
     diag('Expected regex used to verify SecureBoot: ' . $state);
     validate_script_output 'mokutil --sb-state', $state;
 
-    my $new_mok_keys = script_output('mokutil --list-new', proceed_on_failure => 1);
-    if ($new_mok_keys =~ /MokNew is empty/) {
+    if (script_output('mokutil --list-new', proceed_on_failure => 1) =~ /MokNew is empty/) {
         record_info 'MOK updates', 'No new certificates are expected to be enrolled';
-    } elsif ($new_mok_keys =~ /^Failed.*MokNew:.*directory/) {
-        record_soft_failure('bsc#1170889 -  mokutil: Failed to read MokNew');
     } else {
-        die "No new boot certificates are expected";
+        push @errors, 'No new boot certificates are expected';
     }
 
-    my $rc = script_run('mokutil --list-enrolled | grep ' . (is_sle() ? 'O=SUSE' : 'O=openSUSE'));
-    die "Unexpected certificate has been enrolled!\n" if ($rc && !get_var('DISABLE_SECUREBOOT', 0));
+    if (script_run(qq[mokutil --list-enrolled | tee /dev/$serialdev | grep -E "CN=.*SUSE"]) && !get_var('DISABLE_SECUREBOOT', 0)) {
+        push @errors, 'SUSE nor openSUSE certificate has not been found by mokutil';
+    }
 
-    unless (script_run 'test -f /boot/efi/EFI/mock.der') {
-        assert_script_run 'mokutil --list-enrolled | grep CN=MOCK';
-        assert_script_run 'mokutil --delete /boot/efi/EFI/mock.der --root-pw';
-        assert_script_run 'rm /boot/efi/EFI/mock.der';
-        assert_script_run 'mokutil --list-delete | grep CN=MOCK';
+    # In 3rd test object with SecureBoot, tests creates, imports and enrolles a mock certificate that should be removed
+    unless (script_run "test -f ${\MOCK_CRT}") {
+        record_info 'MOK delete', 'Removing MOCK certificate';
+        assert_script_run 'mokutil --list-enrolled | grep -E "CN=MOCK"';
+        if (script_output("mokutil --delete ${\MOCK_CRT} --root-pw") =~ /SKIP:\s+${\MOCK_CRT}\s+is\s+not\s+in\s+MokList/) {
+            push @errors, 'CN=MOCK certificate has not been found in MokList';
+        }
+        assert_script_run "rm ${\MOCK_CRT}";
+        assert_script_run 'mokutil --list-delete';
     }
 }
 
-sub virtualized_block_type {
-    my $backend        = join('_', grep { $_ } (get_required_var('BACKEND'), get_var('VIRSH_VMM_FAMILY')));
+sub get_esp_info {
     my $blk_dev_driver = {
         qemu         => 'virtblk',
         svirt_xen    => 'xvd',
         svirt_hyperv => 'scsi'
     };
-
-    return $blk_dev_driver->{$backend};
-}
-
-sub get_esp_from_parted {
-    my @parted_data = split /\n/, script_output 'parted --list --machine --script';
     # return a the first element (drive or partition number) from parted's output
-    my $extract_from_parted = sub { return (split /:/, shift())[0] };
-    # locate drive record_info
-    # old dos partition table is not supported in JeOS
-    my $vbt = virtualized_block_type();
-    my ($drive_raw_record) = grep(/gpt/ && /$vbt/, @parted_data) or die "No gpt table found!\n";
+    my ($drive, $esp_part_no);
+    my $vbd = $blk_dev_driver->{join('_', grep { $_ } (get_required_var('BACKEND'), get_var('VIRSH_VMM_FAMILY')))};
+    foreach my $line (split(/\n/, script_output('parted --list --machine --script'))) {
+        if (!defined($drive) && $line =~ /gpt/ && $line =~ /$vbd/) {
+            ($drive) = split(/:/, $line, 2);
+        }
+        if (!defined($esp_part_no) && $line =~ /boot,\s?esp/) {
+            ($esp_part_no) = split(/:/, $line, 2);
+        }
+    }
+    ($drive && $esp_part_no) or die "No ESP partition or GPT drive was detected from parted's output";
+    my ($esp_fs, $esp_mp) = split /\s+/, script_output "df --output=fstype,target --local $drive$esp_part_no | sed -e /^Type/d";
+    ($esp_fs && $esp_mp) or die "No mounted ESP partition was not found!\n";
 
-    # find possible boot partitions in JeOS image
-    my $boot_esp->{drive} = $extract_from_parted->($drive_raw_record);
-    map {
-        $boot_esp->{part_no}   = $extract_from_parted->($_);
-        $boot_esp->{partition} = $boot_esp->{drive} . $boot_esp->{part_no};
-    } grep(/boot,\s?esp/, @parted_data);
-
-    assert_script_run "parted --script $boot_esp->{drive} align-check optimal $boot_esp->{part_no}";
-
-    return $boot_esp;
+    assert_script_run "parted --script $drive align-check optimal $esp_part_no";
+    return {drive => $drive, partition => "$drive$esp_part_no", fs => $esp_fs, mount => $esp_mp};
 }
 
 sub verification {
@@ -185,40 +168,32 @@ sub verification {
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
+    is_efi_boot or die "Image did not boot in UEFI mode!\n";
 
-    my $esp_details = get_esp_from_parted;
-    die "Image did not boot in UEFI mode!\n"
-      unless ($esp_details && is_efi_boot && get_required_var('UEFI'));
+    my $esp_details = get_esp_info;
+
+    # run fs check on ESP
+    record_info "ESP", "Partition [$esp_details->{partition}], \nFilesystem [$esp_details->{fs}],\nMountPoint [$esp_details->{mount}]";
+    assert_script_run "umount $esp_details->{mount}";
+    assert_script_run "fsck.vfat -tvV $esp_details->{partition}";
+    assert_script_run "mount $esp_details->{mount}";
 
     my $pkgs = 'efivar mokutil';
     $pkgs .= ' dosfstools' if (is_leap('<15.2') || is_sle('<15-sp2'));
     unless (get_var('DISABLE_SECUREBOOT', 0)) {
+        $pkgs .= ' sbsigntools';
+        add_suseconnect_product 'PackageHub' if is_sle('=15-sp3');
         # temporary hack for sle, due to missing sbsigntools package
-        if (is_sle) {
+        if (is_sle('<=15-sp2') && !is_sle('=15')) {
             (my $version = get_var('VERSION')) =~ s/-/_/g;
-            $version =~ s/SP3/SP2/g;
             zypper_call("ar -p 101 --refresh --no-gpgcheck http://download.opensuse.org/repositories/Base:/System/SLE_$version/ sb_signtools");
         }
-        $pkgs .= ' sbsigntools';
     }
     zypper_call "in $pkgs";
 
-    # store ESP's file system and mount point
-    my ($efi_p_fs, $efi_p_mp) = split(/\s+/,
-        script_output 'df --output=fstype,target,source --local | grep ' . $esp_details->{partition});
-    ($efi_p_fs && $efi_p_mp && $esp_details->{partition}) or die "No mounted ESP partition was not found!\n";
-
-    record_info "esp [$esp_details->{partition}]", "\nFilesystem [$efi_p_fs],\nMountPoint [$efi_p_mp]";
-
-    # run fs check on ESP
-    assert_script_run "umount $efi_p_mp";
-    assert_script_run "fsck.vfat -tvV $esp_details->{partition}";
-    assert_script_run "mount $efi_p_mp";
-
     my $exp_data = get_expected_efi_settings;
-    $exp_data->{mount} = $efi_p_mp;
     ## default efi boot, no restart, but set gfxmode before reboot
-    $self->verification(undef, undef, sub {
+    $self->verification(undef, ((is_jeos) ? undef : $exp_data), sub {
             set_grub_gfxmode;
             assert_script_run('grub2-script-check --verbose ' . GRUB_CFG);
         }
@@ -227,7 +202,7 @@ sub run {
     if (get_var('DISABLE_SECUREBOOT')) {
         $self->verification('After grub2-install', $exp_data, sub {
                 assert_script_run('sed -ie s/SECURE_BOOT=.*/SECURE_BOOT=no/ ' . SYSCONFIG_BOOTLADER);
-                assert_script_run "grub2-install --efi-directory=$efi_p_mp --target=x86_64-efi $esp_details->{drive}";
+                assert_script_run "grub2-install --efi-directory=$esp_details->{mount} --target=x86_64-efi $esp_details->{drive}";
                 assert_script_run('grub2-mkconfig -o ' . GRUB_CFG);
             }
         );
@@ -242,11 +217,11 @@ sub run {
         );
         $self->verification('Import mock key to MOK', $exp_data, sub {
                 assert_script_run 'openssl req -new -x509 -newkey rsa:2048 -sha256 -keyout key.asc -out cert.pem -nodes -days 666 -subj "/CN=MOCK/"';
-                assert_script_run 'openssl x509 -in cert.pem -outform der -out /boot/efi/EFI/mock.der';
-                assert_script_run 'mokutil --import /boot/efi/EFI/mock.der --root-pw';
+                assert_script_run "openssl x509 -in cert.pem -outform der -out ${\MOCK_CRT}";
+                assert_script_run "mokutil --import ${\MOCK_CRT} --root-pw";
                 assert_script_run 'mokutil --list-new';
             }
-        );
+        ) if get_var('CHECK_MOK_IMPORT');
     }
 
     ## Keep previous configuration
@@ -257,19 +232,27 @@ sub run {
         }
     );
 
-    unless (get_var('DISABLE_SECUREBOOT', 0)) {
-        zypper_call 'rm sbsigntools';
-        zypper_call 'rr sb_signtools' if is_sle;
-    }
+    # Print errors
+    die join("\n", @errors) if (@errors);
+}
+
+sub cleanup {
+    script_run 'zypper -n rm sbsigntools';
+    remove_suseconnect_product 'PackageHub' if is_sle('=15-sp3');
+    # temporary hack for sle, due to missing sbsigntools package
+    script_run 'zypper -n rr sb_signtools' if is_sle('<=15-sp2') && !is_sle('=15');
 }
 
 sub post_fail_hook {
     select_console('root-console');
 
+    cleanup unless get_var('DISABLE_SECUREBOOT', 0);
     upload_logs(GRUB_DEFAULT,        log_name => 'etc_default_grub.txt');
     upload_logs(GRUB_CFG,            log_name => 'grub.cfg');
     upload_logs(SYSCONFIG_BOOTLADER, log_name => 'etc_sysconfig_bootloader.txt');
-    upload_logs(FSTAB,               log_name => 'fstab.txt');
+    upload_logs('/etc/fstab',        log_name => 'fstab.txt');
 }
+
+sub post_run_hook { cleanup unless get_var('DISABLE_SECUREBOOT', 0); }
 
 1;


### PR DESCRIPTION
Test objects:
- mokutil:
    - query enrolled certificates
    - import and remove mock certificate
    - check secureboot status

- sbsignutil
    - verify shim certificate
    - list certificates

- update-bootloader reinit and shim install

- Verification runs:
  * [sle-15-SP3-JeOS-for-MS-HyperV-x86_64](http://kepler.suse.cz/tests/4897#)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-](http://kepler.suse.cz/tests/4893#step/verify_efi_mok/1)
  * [sle-15-SP2-JeOS-for-kvm-and-xen-QR-x86_64-Build15.87-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/4892#step/verify_efi_mok/1)
  * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64](http://kepler.suse.cz/tests/4888)
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen](http://kepler.suse.cz/tests/4886#step/verify_efi_mok/1)
  * [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64](http://kepler.suse.cz/tests/4887#step/verify_efi_mok/1)
