### PR TITLE
console/snapper_used_space: Deal with btrfs compression

### DIFF
--- a/tests/console/snapper_used_space.pm
+++ b/tests/console/snapper_used_space.pm
@@ -21,9 +21,9 @@ use strict;
 use warnings;
 use testapi;
 
-use constant COLUMN_FILTER    => "awk -F '|' '{print \$1  \$6}'";                   # Filter by columns: # and Used Space
-use constant SUBVOLUME_FILTER => "tail -n4 | sed -n 2,3p | cut -d ' ' -f2";         # Subvolume IDs
-use constant CREATE_BIG_FILE  => "dd if=/dev/zero of=/big-data bs=1M count=1024";
+use constant COLUMN_FILTER    => "awk -F '|' '{print \$1  \$6}'";              # Filter by columns: # and Used Space
+use constant SUBVOLUME_FILTER => "tail -n4 | sed -n 2,3p | cut -d ' ' -f2";    # Subvolume IDs
+use constant CREATE_BIG_FILE  => "touch /big-data && btrfs prop set /big-data compression '' && dd if=/dev/zero of=/big-data bs=1M count=1024";
 use constant REMOVE_BIG_FILE  => "rm /big-data";
 
 =head2 ensure_size_displayed


### PR DESCRIPTION
Btrfs quotas count the compressed data. Explicitly disable compression for the
created file to make it match the expected size of 1GiB everywhere.

Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1185492

Verification runs:
https://openqa.opensuse.org/tests/1720719 (Leap 15.3 AArch64 JeOS with btrfs compression)
https://openqa.opensuse.org/tests/1720726 (Tumbleweed x86_64 JeOS without btrfs compression)
