### PR TITLE
 hwsim_wpa2_enterprise_setup: Adopt AppArmor profile

### DIFF
--- a/tests/x11/network/hwsim_wpa2_enterprise_setup.pm
+++ b/tests/x11/network/hwsim_wpa2_enterprise_setup.pm
@@ -20,9 +20,8 @@ use utils;
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
+    $self->select_serial_terminal();
     assert_script_run "modprobe mac80211_hwsim radios=2 |& tee /dev/$serialdev";
-    save_screenshot;
 
     $self->install_packages;
     $self->prepare_NM;
@@ -35,14 +34,13 @@ sub run {
 
 sub install_packages {
     my $required_packages = 'NetworkManager hostapd';
-    enter_cmd "# installing required packages";
+    enter_cmd 'echo "# installing required packages"';
     quit_packagekit;
     zypper_call("in $required_packages");
 }
 
 sub prepare_NM {
-    enter_cmd "# configure NetworkManager to ignore one of the hwsim interfaces";
-    release_key 'shift';    # workaround for stuck key
+    enter_cmd 'echo "# configure NetworkManager to ignore one of the hwsim interfaces"';
 
     my $nm_conf = '/etc/NetworkManager/NetworkManager.conf';
     assert_script_run "echo \"[keyfile]\" >> $nm_conf";
@@ -53,42 +51,39 @@ sub generate_certs {
     assert_script_run 'mkdir -p wpa_enterprise_certificates/{CA,server}';
     assert_script_run 'cd wpa_enterprise_certificates';
 
-    enter_cmd "# generate private keys";
+    enter_cmd 'echo "# generate private keys"';
     assert_script_run 'openssl genrsa -out CA/CA.key 4096';
     assert_script_run 'openssl genrsa -out server/server.key 4096';
-    save_screenshot;
 
-    enter_cmd "# generate certificate for CA";
+    enter_cmd 'echo "# generate certificate for CA"';
     assert_script_run 'openssl req -x509 -new -nodes -key CA/CA.key -sha256 -days 3650 -out CA/CA.crt -subj "/"';
 
-    enter_cmd "# generate certificate signing request for server";
+    enter_cmd 'echo "# generate certificate signing request for server"';
     assert_script_run 'openssl req -new -key server/server.key -out server/server.csr -subj "/"';
-    save_screenshot;
 
-    enter_cmd "# sign csr with the key/cert from the CA";
+    enter_cmd 'echo "# sign csr with the key/cert from the CA"';
     assert_script_run 'openssl x509 -req -in server/server.csr -CA CA/CA.crt -CAkey CA/CA.key -CAcreateserial -out server/server.crt -days 3650 -sha256';
-    save_screenshot;
 }
 
 sub configure_hostapd {
-    enter_cmd "# configure hostapd";
+    enter_cmd 'echo "# configure hostapd"';
     assert_script_run 'wget -O /etc/hostapd.conf ' . data_url('hostapd_wpa2-enterprise.conf');
 
-    enter_cmd "# create wpa2 enterprise user";
+    enter_cmd 'echo "# create wpa2 enterprise user"';
     assert_script_run 'echo \"franz.nord@example.com\" PEAP >> /etc/hostapd.eap_user';
     assert_script_run 'echo \"franz.nord@example.com\" MSCHAPV2 \"nots3cr3t\" [2]>> /etc/hostapd.eap_user';
 }
 
 sub adopt_apparmor {
     if (script_output('systemctl is-active apparmor', proceed_on_failure => 1) eq 'active') {
-        enter_cmd "# adopt AppArmor";
+        enter_cmd 'echo "# adopt AppArmor"';
         enter_cmd q(test ! -e /etc/apparmor.d/usr.sbin.hostapd || sed -i -E 's/^}$/  \/root\/wpa_enterprise_certificates\/** r,\n}/' /etc/apparmor.d/usr.sbin.hostapd);
         systemctl 'reload apparmor';
     }
 }
 
 sub reload_services {
-    enter_cmd "# reload required services";
+    enter_cmd 'echo "# reload required services"';
     systemctl 'restart NetworkManager';
     systemctl 'restart hostapd';
     systemctl 'is-active hostapd';


### PR DESCRIPTION
With SR https://build.opensuse.org/request/show/874698 a AppArmor profile was
added. But this test store the EAP certificates in
`/root/wpa_enterprise_certificates` where we do not have permissions to read.

This change add read permissions to `/root/wpa_enterprise_certificates/**` via
the AppArmor profile.

Also change to serial terminal.

See: https://bugzilla.opensuse.org/show_bug.cgi?id=1184917
VR: http://cfconrad-vm.qa.suse.de/tests/8133
