### PR TITLE
Implements docker firewall validation

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">false</do_registration>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">false</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+  </suse_register>
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <name>SUSE-MicroOS-<%= $get_var->('VERSION') %>-Updates</name>
+        <alias>SUSE-MicroOS-<%= $get_var->('VERSION') %>-Updates</alias>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Updates/SUSE-MicroOS/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+      <hiddenmenu>false</hiddenmenu>
+    </global>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <software>
+    <products config:type="list">
+      <product>SUSE-MicroOS</product>
+    </products>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <packages config:type="list">
+      <package>grub2</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>basesystem</pattern>
+      <pattern>microos-container_runtime</pattern>
+      <pattern>microos-selinux</pattern>
+    </patterns>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -21,8 +21,9 @@ use utils;
 use strict;
 use warnings;
 use version_utils;
+use Mojo::Util 'trim';
 
-our @EXPORT = qw(test_seccomp basic_container_tests container_set_up get_vars build_img test_built_img can_build_sle_base);
+our @EXPORT = qw(test_seccomp basic_container_tests container_set_up get_vars build_img test_built_img can_build_sle_base check_docker_firewall get_docker_version check_runtime_version container_ip registry_url);
 
 sub test_seccomp {
     my $no_seccomp = script_run('docker info | tee /tmp/docker_info.txt | grep seccomp');
@@ -41,20 +42,61 @@ sub test_seccomp {
     }
 }
 
-sub basic_container_tests {
-    my %args    = @_;
-    my $runtime = $args{runtime};
-    die "You must define the runtime!" unless $runtime;
+sub check_docker_firewall {
+    my $container_name = 'sut_container';
+    my $running        = script_output qq(docker ps -a -q | wc -l);
+    validate_script_output('ip a s docker0', sub { /state DOWN/ }) if $running != 0;
+    assert_script_run "firewall-cmd --list-all --zone=docker";
+    validate_script_output "firewall-cmd --list-interfaces --zone=docker",  sub { /docker0/ };
+    validate_script_output "firewall-cmd --list-interfaces --zone=trusted", sub { /^\s*$/ };
+    # Rules applied before DOCKER. Default is to listen to all tcp connections
+    # ex. output: "1           0        0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0"
+    validate_script_output "iptables -L DOCKER-USER -nvx --line-numbers", sub { /1.+all.+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0/ };
+    assert_script_run "docker run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine');
+    my $container_ip = container_ip($container_name, "docker");
+    # Each running container should have added a new entry to the DOCKER zone.
+    # ex. output: "1           0        0 ACCEPT     tcp  --  !docker0 docker0  0.0.0.0/0            172.17.0.2           tcp dpt:1234"
+    validate_script_output "iptables -L DOCKER -nvx --line-numbers", sub { /1.+ACCEPT.+!docker0 docker0.+$container_ip\s+tcp dpt:1234/ };
+    assert_script_run "docker kill $container_name ";
+}
 
+sub get_docker_version {
+    my $v = script_output("docker --version");
+    record_info "$v", $v =~ /(\d{2}\.\d{2})/;
+    return $v =~ /(\d{2}\.\d{2})/;
+}
+
+sub check_runtime_version {
+    my ($current, $other) = @_;
+    return check_version($other, $current, qr/\d{2}(?:\.\d+)/);
+}
+
+sub container_ip {
+    my ($container, $runtime) = @_;
+    my $ip = script_output "$runtime inspect $container --format='{{.NetworkSettings.IPAddress}}'";
+    record_info "$ip";
+    return $ip;
+}
+
+sub registry_url {
+    my ($container_name, $version_tag) = @_;
     my $registry = get_var('REGISTRY', 'docker.io');
     # Images from docker.io registry are listed without the 'docker.io/library/'
     # Images from custom registry are listed with the 'server/library/'
     # We also filter images the same way they are listed.
-    my $prefix = ($registry =~ /docker\.io/) ? "" : "$registry/library/";
+    my $repo = ($registry =~ /docker\.io/) ? "" : "$registry/library";
+    return $registry unless $container_name;
+    return sprintf("%s/%s", $repo, $container_name) unless $version_tag;
+    return sprintf("%s/%s:%s", $repo, $container_name, $version_tag);
+}
 
+sub basic_container_tests {
+    my %args    = @_;
+    my $runtime = $args{runtime};
+    die "You must define the runtime!" unless $runtime;
     my $alpine_image_version = '3.6';
-    my $alpine               = "${prefix}alpine:$alpine_image_version";
-    my $hello_world          = "${prefix}hello-world";
+    my $alpine               = registry_url('alpine', $alpine_image_version);
+    my $hello_world          = registry_url('hello-world');
     my $leap                 = "registry.opensuse.org/opensuse/leap";
     my $tumbleweed           = "registry.opensuse.org/opensuse/tumbleweed";
 
@@ -172,12 +214,12 @@ sub build_img {
     die "You must define the directory!" unless $dir;
     my $runtime = shift;
     die "You must define the runtime!" unless $runtime;
-    my $registry = get_var('REGISTRY', 'docker.io');
+    my $py_repo = registry_url('python', '3');
 
     assert_script_run("cd $dir");
     if ($runtime =~ /docker|podman/) {
-        assert_script_run("$runtime image pull $registry/library/python:3", timeout => 300);
-        assert_script_run("$runtime tag $registry/library/python:3 python:3");
+        assert_script_run("$runtime image pull $py_repo", timeout => 300);
+        assert_script_run("$runtime tag $py_repo python:3");
         assert_script_run("$runtime build -t myapp BuildTest");
     }
     elsif ($runtime =~ /buildah/) {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1968,7 +1968,7 @@ sub load_x11_gnome {
 sub load_x11_other {
     if (check_var("DESKTOP", "gnome")) {
         loadtest "x11/brasero/brasero_launch";
-        loadtest "x11/gnomeapps/gnome_documents";
+        loadtest "x11/gnomeapps/gnome_documents" if (is_sle('<16') || is_leap('<16'));
         loadtest "x11/totem/totem_launch";
         if (is_sle '15+') {
             loadtest "x11/xterm";


### PR DESCRIPTION
I added a small validation for the expected configuration of the firewall.
Briefly, makes sure that Docker firewall zone exists with an active docker0
interface and in turn this is not added on trusted zone. Run a container and
verify the iptables.

Applies firewall test in docker and docker_image
the tests implemented based on https://docs.docker.com/network/iptables/

- Related ticket: https://progress.opensuse.org/issues/89872
- Verification run: 
[OSD](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2312448)
[TW](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2312448&version=Tumbleweed)
[Leap](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2312448&version=15.3)
[sle-12-SP5](https://openqa.suse.de/tests/5954410)