### PR TITLE
Fix validate_zfcp test module

### DIFF
--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -49,11 +49,11 @@ test_data:
           online: 1
           port_type: 'NPIV VPORT'
         fcp_luns:
-          - wwpn: '0x500507630718d3b3'
+          - wwpn: '0x500507630708d3b3'
             scsi:
               peripheral_type: disk
               vendor_model_revision: 'IBM'
-          - wwpn: '0x500507630713d3b3'
+          - wwpn: '0x500507630703d3b3'
             scsi:
               peripheral_type: disk
               vendor_model_revision: 'IBM'


### PR DESCRIPTION
One more cable was attached, so that WWPN values for 'fa' adaptor were
changed.

The commit updates the WWPN values to the actual ones.

- Verification run: https://openqa.suse.de/tests/5940437
