### PR TITLE
system_prepare: Increase timeout to not fail in case of zypper retry

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -90,7 +90,7 @@ sub run {
         }
     }
 
-    assert_script_run 'rpm -q systemd-coredump || zypper -n in systemd-coredump || true' if get_var('COLLECT_COREDUMPS');
+    assert_script_run 'rpm -q systemd-coredump || zypper -n in systemd-coredump || true', timeout => 200 if get_var('COLLECT_COREDUMPS');
 
     # stop and disable PackageKit
     quit_packagekit;


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/5939617#step/system_prepare/6
- Verification run: https://openqa.suse.de/tests/5940438