### PR TITLE
Validate md raid using test data

### DIFF
--- a/schedule/yast/raid/raid0_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid0_opensuse_gpt.yaml
@@ -31,6 +31,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid0_gpt_bios_boot.yaml

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -34,6 +34,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid0_gpt_bios_boot.yaml

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid0_prep_boot.yaml

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -32,12 +32,14 @@ schedule:
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
   <<: !include test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 0
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - sda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 1
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - sda3
@@ -66,6 +69,7 @@ test_data:
           should_mount: 1
           mount_point: '/boot'
     - raid_level: 0
+      name: md2
       chunk_size: '64 KiB'
       devices:
         - sda4

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid0_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid10_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid10_opensuse_gpt.yaml
@@ -31,11 +31,13 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:
     - raid_level: 10
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -49,6 +51,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -33,11 +33,13 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:
     - raid_level: 10
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid10_prep_boot.yaml

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -32,12 +32,14 @@ schedule:
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
   <<: !include test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 10
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - sda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 1
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - sda3
@@ -66,6 +69,7 @@ test_data:
           should_mount: 1
           mount_point: '/boot'
     - raid_level: 0
+      name: md2
       chunk_size: '64 KiB'
       devices:
         - sda4

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid10_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid1_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid1_opensuse_gpt.yaml
@@ -31,11 +31,13 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:
     - raid_level: 1
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -50,6 +52,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -33,11 +33,13 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:
     - raid_level: 1
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid1_prep_boot.yaml

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -32,12 +32,14 @@ schedule:
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
   <<: !include test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 1
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - sda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 1
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - sda3
@@ -66,6 +69,7 @@ test_data:
           should_mount: 1
           mount_point: '/boot'
     - raid_level: 0
+      name: md2
       chunk_size: '64 KiB'
       devices:
         - sda4

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   disks:
@@ -87,6 +88,7 @@ test_data:
           id: linux-raid
   mds:
     - raid_level: 1
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -100,6 +102,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/schedule/yast/raid/raid5_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid5_opensuse_gpt.yaml
@@ -31,11 +31,13 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:
     - raid_level: 5
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -49,6 +51,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -33,11 +33,13 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:
     - raid_level: 5
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid5_prep_boot.yaml

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -32,12 +32,14 @@ schedule:
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
   <<: !include test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 5
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - sda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 1
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - sda3
@@ -66,6 +69,7 @@ test_data:
           should_mount: 1
           mount_point: '/boot'
     - raid_level: 0
+      name: md2
       chunk_size: '64 KiB'
       devices:
         - sda4

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid5_gpt_uefi_test_data.yaml

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -33,11 +33,13 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:
     - raid_level: 6
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid6_prep_boot.yaml

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -32,12 +32,14 @@ schedule:
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   # We have same partitioning layout for all raid tests, except mds
   <<: !include test_data/yast/raid/raid_prep_boot_test_data_pvm.yaml
   mds:
     - raid_level: 6
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - sda2
@@ -51,6 +53,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 1
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - sda3
@@ -66,6 +69,7 @@ test_data:
           should_mount: 1
           mount_point: '/boot'
     - raid_level: 0
+      name: md2
       chunk_size: '64 KiB'
       devices:
         - sda4

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -33,6 +33,7 @@ schedule:
   - console/system_prepare
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
+  - console/validate_md_raid
   - console/validate_raid
 test_data:
   disks:
@@ -87,6 +88,7 @@ test_data:
           id: linux-raid
   mds:
     - raid_level: 6
+      name: md0
       chunk_size: '64 KiB'
       devices:
         - vda2
@@ -101,6 +103,7 @@ test_data:
         mounting_options:
           should_mount: 1
     - raid_level: 0
+      name: md1
       chunk_size: '64 KiB'
       devices:
         - vda3

--- a/test_data/yast/raid/raid0_gpt_bios_boot.yaml
+++ b/test_data/yast/raid/raid0_gpt_bios_boot.yaml
@@ -2,6 +2,7 @@
 asset_files: "/var/log/YaST2/y2log*"
 mds:
   - raid_level: 0
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -15,6 +16,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 0
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3

--- a/test_data/yast/raid/raid0_gpt_uefi_test_data.yaml
+++ b/test_data/yast/raid/raid0_gpt_uefi_test_data.yaml
@@ -50,6 +50,7 @@ disks:
         id: linux-raid
 mds:
   - raid_level: 0
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -63,6 +64,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 0
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3

--- a/test_data/yast/raid/raid0_prep_boot.yaml
+++ b/test_data/yast/raid/raid0_prep_boot.yaml
@@ -2,6 +2,7 @@
 <<: !include test_data/yast/raid/raid_disks_prep_boot.yaml
 mds:
   - raid_level: 0
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -15,6 +16,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 1
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3
@@ -30,6 +32,7 @@ mds:
         should_mount: 1
         mount_point: '/boot'
   - raid_level: 0
+    name: md2
     chunk_size: '64 KiB'
     devices:
       - vda4

--- a/test_data/yast/raid/raid10_gpt_uefi_test_data.yaml
+++ b/test_data/yast/raid/raid10_gpt_uefi_test_data.yaml
@@ -50,6 +50,7 @@ disks:
         id: linux-raid
 mds:
   - raid_level: 10
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -63,6 +64,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 0
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3

--- a/test_data/yast/raid/raid10_prep_boot.yaml
+++ b/test_data/yast/raid/raid10_prep_boot.yaml
@@ -2,6 +2,7 @@
 <<: !include test_data/yast/raid/raid_disks_prep_boot.yaml
 mds:
   - raid_level: 10
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -15,6 +16,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 1
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3
@@ -30,6 +32,7 @@ mds:
         should_mount: 1
         mount_point: '/boot'
   - raid_level: 0
+    name: md2
     chunk_size: '64 KiB'
     devices:
       - vda4

--- a/test_data/yast/raid/raid1_gpt_uefi_test_data.yaml
+++ b/test_data/yast/raid/raid1_gpt_uefi_test_data.yaml
@@ -50,6 +50,7 @@ disks:
         id: linux-raid
 mds:
   - raid_level: 1
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -63,6 +64,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 0
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3

--- a/test_data/yast/raid/raid1_prep_boot.yaml
+++ b/test_data/yast/raid/raid1_prep_boot.yaml
@@ -2,6 +2,7 @@
 <<: !include test_data/yast/raid/raid_disks_prep_boot.yaml
 mds:
   - raid_level: 1
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -15,6 +16,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 1
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3
@@ -30,6 +32,7 @@ mds:
         should_mount: 1
         mount_point: '/boot'
   - raid_level: 0
+    name: md2
     chunk_size: '64 KiB'
     devices:
       - vda4

--- a/test_data/yast/raid/raid5_gpt_uefi_test_data.yaml
+++ b/test_data/yast/raid/raid5_gpt_uefi_test_data.yaml
@@ -50,6 +50,7 @@ disks:
         id: linux-raid
 mds:
   - raid_level: 5
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -63,6 +64,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 0
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3

--- a/test_data/yast/raid/raid5_prep_boot.yaml
+++ b/test_data/yast/raid/raid5_prep_boot.yaml
@@ -2,6 +2,7 @@
 <<: !include test_data/yast/raid/raid_disks_prep_boot.yaml
 mds:
   - raid_level: 5
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -15,6 +16,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 1
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3
@@ -31,6 +33,7 @@ mds:
         should_mount: 1
         mount_point: '/boot'
   - raid_level: 0
+    name: md2
     chunk_size: '64 KiB'
     devices:
       - vda4

--- a/test_data/yast/raid/raid6_prep_boot.yaml
+++ b/test_data/yast/raid/raid6_prep_boot.yaml
@@ -2,6 +2,7 @@
 <<: !include test_data/yast/raid/raid_disks_prep_boot.yaml
 mds:
   - raid_level: 6
+    name: md0
     chunk_size: '64 KiB'
     devices:
       - vda2
@@ -15,6 +16,7 @@ mds:
       mounting_options:
         should_mount: 1
   - raid_level: 1
+    name: md1
     chunk_size: '64 KiB'
     devices:
       - vda3
@@ -30,6 +32,7 @@ mds:
         should_mount: 1
         mount_point: '/boot'
   - raid_level: 0
+    name: md2
     chunk_size: '64 KiB'
     devices:
       - vda4

--- a/tests/console/validate_md_raid.pm
+++ b/tests/console/validate_md_raid.pm
@@ -1,0 +1,68 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test data driven RAID partitioning layout validation,
+# Should replace console/validate_raid.pm which uses hardcoded regular
+# expressions.
+# Module uses same structure as we use to setup raid with extra values:
+#   mds:
+#     - raid_level: 5
+#       name: md0
+#       devices:
+#         - vda2
+#         - vdb2
+#         - vdc2
+#         - vdd2
+#     - raid_level: 0
+#       name: md1
+#       devices:
+#         - vda3
+#         - vdb3
+#         - vdc3
+#         - vdd3
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_suite_data';
+
+use Config::Tiny;
+use Test::Assert ':all';
+
+
+sub run {
+    select_console 'root-console';
+
+    my $test_data = get_test_suite_data();
+    my ($mdadm_output, $mdadm_cfg);
+
+    foreach my $md (@{$test_data->{mds}}) {
+        $mdadm_output = script_output('mdadm --detail --export /dev/' . $md->{name});
+        # Settings are in the root section, use '_' key, see Config::Tiny documentation
+        $mdadm_cfg = Config::Tiny->read_string($mdadm_output)->{_};
+
+        assert_equals($mdadm_cfg->{MD_LEVEL},   'raid' . $md->{raid_level}, "Wrong raid level for $md->{name}");
+        assert_equals($mdadm_cfg->{MD_DEVICES}, scalar(@{$md->{devices}}),  "Wrong number of devices for $md->{name}");
+
+        foreach my $disk (@{$md->{devices}}) {
+            assert_equals($mdadm_cfg->{"MD_DEVICE_dev_${disk}_DEV"}, "/dev/$disk", "$disk is not used as a raid device of $md->{name}");
+        }
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->SUPER::post_fail_hook;
+    $self->save_and_upload_log('mdadm --detail', 'mdadm_output.txt');
+    upload_logs('/proc/mdstat', failok => 1);
+}
+
+1;


### PR DESCRIPTION
Old module uses regular expressions, we switch to the approach to have
well defined granular test data. New module uses this input to validate
raid. Once we migrate all the tests to use test data, we can get rid of 
`validate_raid` test module.
`lsblk` part will be addressed separately, so not removing old module from 
the schedule. It will be addressed in [poo#91755](https://progress.opensuse.org/issues/91755).

See [poo#91758](https://progress.opensuse.org/issues/91758).

#### Verification runs
* [openSUSE](https://openqa.opensuse.org/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23raid&distri=opensuse)
* [SLES](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%23raid&distri=sle&version=15-SP3)