### PR TITLE
Containers: check that we have rpm-ndb for 15-SP3

### DIFF
--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -38,6 +38,7 @@ sub run {
 
     for my $iname (@{$image_names}) {
         test_container_image(image => $iname, runtime => $runtime);
+        test_rpm_db_backend(image => $iname, runtime => $runtime);
         build_container_image(image => $iname, runtime => $runtime);
         if (check_os_release('suse', 'PRETTY_NAME')) {
             test_opensuse_based_image(image => $iname, runtime => $runtime);

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -28,6 +28,7 @@ sub run {
     allow_selected_insecure_registries(runtime => $runtime);
     for my $iname (@{$image_names}) {
         test_container_image(image => $iname, runtime => $runtime);
+        test_rpm_db_backend(image => $iname, runtime => $runtime);
         build_container_image(image => $iname, runtime => $runtime);
         if (check_os_release('suse', 'PRETTY_NAME')) {
             test_opensuse_based_image(image => $iname, runtime => $runtime);


### PR DESCRIPTION
rpm has been replaced by rpm-ndb in base container image for 15-SP3
This is an easy way to check if the container image we are pulling
uses ndb or bdb as rpm db backend.
