### PR TITLE
armnn: do not run test with default backend if ARMNN_BACKENDS is set

### DIFF
--- a/tests/ai_ml/armnn.pm
+++ b/tests/ai_ml/armnn.pm
@@ -142,8 +142,8 @@ sub run {
     # Test TensorFlow Lite backend
     record_info('TF Lite', "TensorFlow Lite backend");
     armnn_tf_lite_test_prepare;
-    # Run with default backend
-    armnn_tf_lite_test_run;
+    # Run with default backend, if no specific backend required
+    armnn_tf_lite_test_run if !defined($armnn_backends);
     # Run with explicit backend, if requested
     armnn_tf_lite_test_run(backend => $_) for split(/,/, $armnn_backends);
     cleanup_model_folder;
@@ -151,7 +151,7 @@ sub run {
     # Test TensorFlow backend
     record_info('TensorFlow', "TensorFlow backend");
     armnn_tf_test_prepare;
-    armnn_tf_test_run;
+    armnn_tf_test_run if !defined($armnn_backends);
     armnn_tf_test_run(backend => $_) for split(/,/, $armnn_backends);
     cleanup_model_folder;
 
@@ -162,7 +162,7 @@ sub run {
     } else {
         record_info('ONNX', "ONNX backend");
         armnn_onnx_test_prepare;
-        armnn_onnx_test_run;
+        armnn_onnx_test_run if !defined($armnn_backends);
         armnn_onnx_test_run(backend => $_) for split(/,/, $armnn_backends);
         cleanup_model_folder;
     }
@@ -170,7 +170,7 @@ sub run {
     # Test Caffe backend
     record_info('Caffe', "Caffe backend");
     armnn_caffe_test_prepare;
-    armnn_caffe_test_run;
+    armnn_caffe_test_run if !defined($armnn_backends);
     armnn_caffe_test_run(backend => $_) for split(/,/, $armnn_backends);
     cleanup_model_folder;
 }


### PR DESCRIPTION
Upstream does not set any order for default backends, so sometimes, the slow `CpuRef` backend is used and test fails. So, let's define fast `CPuAcc` backend and do not run any default run when no backends are defined by the test. 
- Verification run: 
  -  https://openqa.opensuse.org/t1727024 with `ARMNN_BACKENDS="CpuAcc"`
  - https://openqa.opensuse.org/t1727025 without `ARMNN_BACKENDS`
