### PR TITLE
[WIP]Add edit of optional kernel parameters to bare metal installation

### DIFF
--- a/schedule/kernel/prepare_baremetal.yaml
+++ b/schedule/kernel/prepare_baremetal.yaml
@@ -21,6 +21,7 @@ schedule:
     - installation/user_settings_root
     - installation/resolve_dependency_issues
     - installation/installation_overview
+    - installation/edit_optional_kernel_cmd_parameters
     - installation/disable_grub_graphics
     - installation/disable_grub_timeout
     - installation/start_install


### PR DESCRIPTION
Enhancement poo#91587: We need to modify kernel parameters during
installation already. Variable OPT_KERNEL_PARAMS have to be defined in
test suite or in the job schedule.

- Related ticket: https://progress.opensuse.org/issues/91587
- Needles: none
- Verification run:
