### PR TITLE
Move HAWK CPU usage test only to jobs with HAWKGUI_TEST_ROLE

### DIFF
--- a/tests/ha/check_hawk.pm
+++ b/tests/ha/check_hawk.pm
@@ -95,12 +95,11 @@ sub run {
     # Keep a screenshot for this test
     save_screenshot;
 
-    check_hawk_cpu(idle_check => 1);
-
     barrier_wait("HAWK_CHECKED_$cluster_name");
 
     # If testing HAWK GUI, also wait for those barriers
     if (get_var('HAWKGUI_TEST_ROLE')) {
+        check_hawk_cpu(idle_check => 1);
         barrier_wait("HAWK_GUI_INIT_$cluster_name");
         check_hawk_cpu;
         barrier_wait("HAWK_GUI_CHECKED_$cluster_name");


### PR DESCRIPTION
Move HAWK CPU usage test only to jobs with **HAWKGUI_TEST_ROLE** setting defined.

- Related ticket: https://jira.suse.com/browse/TEAM-2801
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/4051 & http://mango.qa.suse.de/tests/4052
