### PR TITLE
Implements docker firewall validation

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -23,7 +23,7 @@ use testapi;
 use registration;
 use utils qw(zypper_call systemctl file_content_replace);
 use version_utils qw(is_sle is_leap is_microos is_sle_micro is_opensuse is_jeos is_public_cloud get_os_release check_version);
-use containers::utils 'can_build_sle_base';
+use containers::utils qw(can_build_sle_base registry_url);
 
 our @EXPORT = qw(install_podman_when_needed install_docker_when_needed allow_selected_insecure_registries
   clean_container_host test_container_runtime test_container_image scc_apply_docker_image_credentials
@@ -109,7 +109,7 @@ sub allow_selected_insecure_registries {
     my %args    = @_;
     my $runtime = $args{runtime};
     die "You must define the runtime!" unless $runtime;
-    my $registry = get_var('REGISTRY', 'docker.io');
+    my $registry = registry_url();
 
     assert_script_run "echo $runtime ...";
     if ($runtime =~ /docker/) {

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -23,7 +23,8 @@ use warnings;
 use version_utils;
 use Mojo::Util 'trim';
 
-our @EXPORT = qw(test_seccomp basic_container_tests container_set_up get_vars build_img test_built_img can_build_sle_base check_docker_firewall get_docker_version check_runtime_version container_ip);
+our @EXPORT = qw(test_seccomp basic_container_tests container_set_up get_vars build_img test_built_img can_build_sle_base
+  check_docker_firewall get_docker_version check_runtime_version container_ip registry_url);
 
 sub test_seccomp {
     my $no_seccomp = script_run('docker info | tee /tmp/docker_info.txt | grep seccomp');
@@ -76,6 +77,19 @@ sub container_ip {
     my $ip = script_output "$runtime inspect $container --format='{{.NetworkSettings.IPAddress}}'";
     record_info "$ip";
     return $ip;
+}
+
+sub registry_url {
+    my ($container_name, $version_tag) = @_;
+    my $registry = get_var('REGISTRY', 'docker.io');
+    $registry = trim($registry);
+    # Images from docker.io registry are listed without the 'docker.io/library/'
+    # Images from custom registry are listed with the 'server/library/'
+    # We also filter images the same way they are listed.
+    my $repo = ($registry =~ /docker\.io/) ? "" : "$registry/library";
+    return $registry unless $container_name;
+    return sprintf("%s/%s", $repo, $container_name) unless $version_tag;
+    return sprintf("%s/%s:%s", $repo, $container_name, $version_tag);
 }
 
 sub basic_container_tests {
@@ -202,7 +216,7 @@ sub build_img {
     die "You must define the directory!" unless $dir;
     my $runtime = shift;
     die "You must define the runtime!" unless $runtime;
-    my $py_repo = get_var('REGISTRY', 'docker.io');
+    my $py_repo = registry_url('python', '3');
 
     assert_script_run("cd $dir");
     if ($runtime =~ /docker|podman/) {

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -21,8 +21,9 @@ use utils;
 use strict;
 use warnings;
 use version_utils;
+use Mojo::Util 'trim';
 
-our @EXPORT = qw(test_seccomp basic_container_tests container_set_up get_vars build_img test_built_img can_build_sle_base);
+our @EXPORT = qw(test_seccomp basic_container_tests container_set_up get_vars build_img test_built_img can_build_sle_base check_docker_firewall get_docker_version check_runtime_version container_ip);
 
 sub test_seccomp {
     my $no_seccomp = script_run('docker info | tee /tmp/docker_info.txt | grep seccomp');
@@ -41,20 +42,49 @@ sub test_seccomp {
     }
 }
 
+sub check_docker_firewall {
+    my $container_name = 'sut_container';
+    my $running        = script_output qq(docker ps -a -q | wc -l);
+    validate_script_output('ip a s docker0', sub { /state DOWN/ }) if $running != 0;
+    assert_script_run "firewall-cmd --list-all --zone=docker";
+    validate_script_output "firewall-cmd --list-interfaces --zone=docker",  sub { /docker0/ };
+    validate_script_output "firewall-cmd --list-interfaces --zone=trusted", sub { /^\s*$/ };
+    # Rules applied before DOCKER. Default is to listen to all tcp connections
+    # ex. output: "1           0        0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0"
+    validate_script_output "iptables -L DOCKER-USER -nvx --line-numbers", sub { /1.+all.+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0/ };
+    assert_script_run "docker run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine');
+    my $container_ip = container_ip($container_name, "docker");
+    # Each running container should have added a new entry to the DOCKER zone.
+    # ex. output: "1           0        0 ACCEPT     tcp  --  !docker0 docker0  0.0.0.0/0            172.17.0.2           tcp dpt:1234"
+    validate_script_output "iptables -L DOCKER -nvx --line-numbers", sub { /1.+ACCEPT.+!docker0 docker0.+$container_ip\s+tcp dpt:1234/ };
+    assert_script_run "docker kill $container_name ";
+}
+
+sub get_docker_version {
+    my $v = script_output("docker --version");
+    record_info "$v", $v =~ /(\d{2}\.\d{2})/;
+    return $v =~ /(\d{2}\.\d{2})/;
+}
+
+sub check_runtime_version {
+    my ($current, $other) = @_;
+    return check_version($other, $current, qr/\d{2}(?:\.\d+)/);
+}
+
+sub container_ip {
+    my ($container, $runtime) = @_;
+    my $ip = script_output "$runtime inspect $container --format='{{.NetworkSettings.IPAddress}}'";
+    record_info "$ip";
+    return $ip;
+}
+
 sub basic_container_tests {
     my %args    = @_;
     my $runtime = $args{runtime};
     die "You must define the runtime!" unless $runtime;
-
-    my $registry = get_var('REGISTRY', 'docker.io');
-    # Images from docker.io registry are listed without the 'docker.io/library/'
-    # Images from custom registry are listed with the 'server/library/'
-    # We also filter images the same way they are listed.
-    my $prefix = ($registry =~ /docker\.io/) ? "" : "$registry/library/";
-
     my $alpine_image_version = '3.6';
-    my $alpine               = "${prefix}alpine:$alpine_image_version";
-    my $hello_world          = "${prefix}hello-world";
+    my $alpine               = registry_url('alpine', $alpine_image_version);
+    my $hello_world          = registry_url('hello-world');
     my $leap                 = "registry.opensuse.org/opensuse/leap";
     my $tumbleweed           = "registry.opensuse.org/opensuse/tumbleweed";
 
@@ -172,12 +202,12 @@ sub build_img {
     die "You must define the directory!" unless $dir;
     my $runtime = shift;
     die "You must define the runtime!" unless $runtime;
-    my $registry = get_var('REGISTRY', 'docker.io');
+    my $py_repo = get_var('REGISTRY', 'docker.io');
 
     assert_script_run("cd $dir");
     if ($runtime =~ /docker|podman/) {
-        assert_script_run("$runtime image pull $registry/library/python:3", timeout => 300);
-        assert_script_run("$runtime tag $registry/library/python:3 python:3");
+        assert_script_run("$runtime image pull $py_repo", timeout => 300);
+        assert_script_run("$runtime tag $py_repo python:3");
         assert_script_run("$runtime build -t myapp BuildTest");
     }
     elsif ($runtime =~ /buildah/) {

--- a/tests/containers/docker.pm
+++ b/tests/containers/docker.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -11,6 +11,7 @@
 # Package: docker
 # Summary: Test docker installation and extended usage
 # - docker package can be installed
+# - firewall is configured correctly
 # - docker daemon can be started
 # - images can be searched on the Docker Hub
 # - images can be pulled from the Docker Hub
@@ -25,7 +26,7 @@
 # - attach a volume
 # - expose a port
 # - test networking outside of host
-# Maintainer: Flavio Castelli <fcastelli@suse.com>, Panagiotis Georgiadis <pgeorgiadis@suse.com>, Sergio Lindo Mansilla <slindomansilla@suse.com>, Anna Minou <anna.minou@suse.com>
+# Maintainer: qa-c team <qa-c@suse.de>
 
 use base "consoletest";
 use testapi;
@@ -50,6 +51,7 @@ sub run {
     test_seccomp();
     allow_selected_insecure_registries(runtime => 'docker');
 
+    check_docker_firewall() if (check_runtime_version(get_docker_version(), ">=20.10") && $self->firewall() eq 'firewalld');
     # Run basic docker tests
     basic_container_tests(runtime => "docker");
 

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -21,8 +21,8 @@
 
 use Mojo::Base qw(consoletest);
 use testapi;
-use utils;
 use containers::common;
+use containers::utils;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
@@ -35,7 +35,6 @@ sub run {
     install_docker_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => $runtime);
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
-
     for my $iname (@{$image_names}) {
         test_container_image(image => $iname, runtime => $runtime);
         test_rpm_db_backend(image => $iname, runtime => $runtime);


### PR DESCRIPTION
I added a small validation for the expected configuration of the firewall.
Briefly, makes sure that Docker firewall zone exists with an active docker0
interface and in turn this is not added on trusted zone. Run a container and
verify the iptables.

Applies firewall test in docker and docker_image
the tests implemented based on https://docs.docker.com/network/iptables/

- Related ticket: https://progress.opensuse.org/issues/89872
- Verification run: 
[OSD](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2312448)
[TW](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2312448&version=Tumbleweed)
[Leap](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2312448&version=15.3)
[sle-12-SP5](https://openqa.suse.de/tests/5954410)