### PR TITLE
ipxe: Set EFI options for pxe bootdev

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -53,7 +53,9 @@ sub set_pxe_boot {
         my $stdout = ipmitool('chassis bootparam get 5');
         last if $stdout =~ m/Force PXE/;
         diag "setting boot device to pxe";
-        ipmitool("chassis bootdev pxe");
+        my $options;
+        $options = 'options=efiboot' if get_var('IPXE_UEFI');
+        ipmitool("chassis bootdev pxe ${options}");
         sleep(3);
     }
 }


### PR DESCRIPTION
Fix poo#92203: If previous job/test changed boot order, new
installation job didn't boot from network. Ipmitool command must
contain options=efiboot to correctly set EFI boot order.

- Related ticket: https://progress.opensuse.org/issues/92203
- Needles: none
- Verification run: 
aarch64 efi: https://openqa.suse.de/tests/5961311
x86_64 legacy: https://openqa.suse.de/tests/5961310