### PR TITLE
Raise assert_screen time limit for yast2_lan

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -330,7 +330,7 @@ Confirm if a warning popup for Networkmanager controls networking.
 
 =cut
 sub handle_Networkmanager_controlled {
-    assert_screen 'Networkmanager_controlled', 90;
+    assert_screen 'Networkmanager_controlled', 300;
     send_key "ret";    # confirm networkmanager popup
     assert_screen "Networkmanager_controlled-approved";
     send_key "alt-c";


### PR DESCRIPTION
The test sporadically fails for KDE

- Related ticket: https://progress.opensuse.org/issues/91911
- Verification runs: https://openqa.opensuse.org/tests/1728460#next_previous
