### PR TITLE
Fix zypper to non-interactive in yast_virtualization

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2019 SUSE LLC
+# Copyright © 2016-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,7 +22,7 @@ sub run {
     send_key 'alt-f10';
     become_root;
     quit_packagekit;
-    if (script_run('zypper se -i yast2-vm') == 104) {
+    if (zypper_call('se yast2-vm', exitcode => [0, 104]) == 104) {
         record_soft_failure 'bsc#1083398 - YaST2-virtualization provides wrong components for SLED';
         zypper_call 'in yast2-vm';
     }


### PR DESCRIPTION
- Related ticket: [poo#91998](https://progress.opensuse.org/issues/91998)
- Verification run: [TW x86_64](https://openqa.opensuse.org/tests/1728977) | [TW aarch64](https://openqa.opensuse.org/tests/1728983) |  [Leap](https://openqa.opensuse.org/tests/latest?arch=aarch64&distri=opensuse&flavor=DVD&machine=aarch64&test=virtualization%40jknphy%2Fos-autoinst-distri-opensuse%23fix_yast_virtualization&version=15.3)