### PR TITLE
Fix sporadic issue in yast2_rmt

### DIFF
--- a/tests/console/yast2_rmt.pm
+++ b/tests/console/yast2_rmt.pm
@@ -58,6 +58,7 @@ sub test_ui {
     send_key "spc";
     send_key "alt-n";
     assert_screen "yast2_rmt_service_status";
+    wait_still_screen;
     send_key "alt-n";
     assert_screen "yast2_rmt_config_summary";
     send_key "alt-f";


### PR DESCRIPTION
According to the video needle for checking RMT Service Status
can match before the popup Starting RMT appears or after
disappears, producing the sporadic failure when we click next and
has matched before the popup.

Without the fix, it fails 2 out of 5.

- Related ticket: [poo#91404](https://progress.opensuse.org/issues/91404)
- Verification run: [5x yast2_ncurses_gnome](https://openqa.suse.de/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%23fix_yast2_rmt&distri=sle&version=15-SP3)
