### PR TITLE
Pre-format DASD disk in ext4

### DIFF
--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -5,7 +5,7 @@ description:    >
   Requires disk activation and grub is not displayed due to console reconnection.
 vars:
   FILESYSTEM: ext4
-  FORMAT_DASD: install
+  FORMAT_DASD: pre_install
 schedule:
   - installation/bootloader_start
   - installation/welcome


### PR DESCRIPTION
- Related ticket: [poo#92101](https://progress.opensuse.org/issues/92101)
- Verification run: [4x ext4_yast ](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_pre_format_dasda&version=15-SP3)

Now YaST always delete the partition table and nothing else (as there are not other partitions in the disk) and assign same number to the partition which will create.