### PR TITLE
Remove workaround for bsc#1175704

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1899,6 +1899,7 @@ sub install_patterns {
                 $cf_selected = 1;
             }
             elsif ($cf_selected == 1) {
+                record_soft_failure 'bsc#950763 CFEngine pattern is listed twice in installer';
                 next;
             }
         }
@@ -1908,22 +1909,7 @@ sub install_patterns {
         }
         # if pattern is common-criteria and PATTERNS is all, skip, poo#73645
         next if (($pt =~ /common-criteria/) && check_var('PATTERNS', 'all'));
-        my $ret = zypper_call("in -t pattern $pt", exitcode => [0, 4], timeout => 1800);
-        if ($ret == 4) {
-            if (($pt =~ /CFEngine/) && is_sle('>=12') && is_sle('<15')) {
-                record_soft_failure 'bsc#1175704 pattern:CFEngine-12-8.1.s390x requires patterns-adv-sys-mgmt-CFEngine, but this requirement cannot be provided';
-                my $para = '';
-                $para = '--force-resolution' if get_var('FORCE_DEPS');
-                zypper_call("in $para -t pattern $pt", timeout => 1800, exitcode => [0, 102, 103]);
-            }
-            else {
-                script_run('tac /var/log/zypper.log | grep -F -m1 -B10000 "Hi, me zypper" | tac | grep \'Exception.cc\' > /tmp/zlog.txt');
-                my $msg = "'zypper -n in -t pattern $pt failed with code $ret";
-                $msg .= "\n\nRelated zypper logs:\n";
-                $msg .= script_output('cat /tmp/zlog.txt');
-                die $msg;
-            }
-        }
+        zypper_call("in -t pattern $pt", timeout => 1800);
     }
 }
 


### PR DESCRIPTION
We need only select one CFEngine pattern for asmm for all patterns test (https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12481) which is a workaround for bsc#950763, so the bsc#1175704 is invalid and corresponding workaround should be removed. 

- Related ticket: https://progress.opensuse.org/issues/92266
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/5967804#