### PR TITLE
Continue subsequent test when SRIOV test module fails

### DIFF
--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -357,6 +357,10 @@ sub plugin_vf_device {
     assert_script_run "ssh root\@$vm \"lspci -vvv -s $vf->{vm_bdf}\"";
     $vf->{vm_nic} = script_output "ssh root\@$vm \"grep '$vf->{vm_mac}' /sys/class/net/*/address | cut -d'/' -f5 | head -n1\"";
     record_info("VF plugged to vm", "$vf->{host_id} \nGuest: $vm\nbdf='$vf->{vm_bdf}'   mac_address='$vf->{vm_mac}'   nic='$vf->{vm_nic}'");
+    if ($vf->{vm_nic} eq '') {
+        script_output "ssh root\@$vm \"for FILE in /sys/class/net/*/address; do echo \\\$FILE; cat \\\$FILE; done\"";    #for debug
+        die "Fail to get NIC in $vm: nic='$vf->{vm_nic}'";
+    }
 }
 
 


### PR DESCRIPTION
- support libvirt on sles12sp5 xen host
- abort test when fail to get NIC in guest
- Continue subsequent test when SRIOV test module fails


Related ticket: 
- https://progress.opensuse.org/issues/91980
- https://progress.opensuse.org/issues/91923

Verification run: 
- [gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.nue.suse.com/tests/5980936)
- [gi-guest_developing-on-host_sles15sp2-xen](https://openqa.nue.suse.com/tests/5980937)
- [gi-guest_developing-on-host_sles12sp5-xen](http://10.67.129.51/tests/2180)