### PR TITLE
Migrate mediacheck to YAML scheduling

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -49,8 +49,6 @@ our @EXPORT = qw(
   is_kernel_test
   is_ltp_test
   is_livesystem
-  is_mediacheck
-  is_mediacheck
   is_memtest
   is_memtest
   is_server
@@ -322,10 +320,6 @@ sub is_memtest {
     return get_var('MEMTEST');
 }
 
-sub is_mediacheck {
-    return get_var('MEDIACHECK');
-}
-
 sub is_desktop {
     return get_var('FLAVOR', '') =~ /^Desktop/ || check_var('SLE_PRODUCT', 'sled');
 }
@@ -387,7 +381,7 @@ sub load_svirt_vm_setup_tests {
     else {
         loadtest "installation/bootloader_svirt" unless get_var('UPGRADE');
     }
-    unless (is_installcheck || is_memtest || is_rescuesystem || is_mediacheck) {
+    unless (is_installcheck || is_memtest || is_rescuesystem) {
         load_svirt_boot_tests;
     }
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -271,10 +271,6 @@ elsif (get_var('NFV')) {
 elsif (get_var("REGRESSION")) {
     load_common_x11;
 }
-elsif (is_mediacheck) {
-    load_svirt_vm_setup_tests;
-    loadtest "installation/mediacheck";
-}
 elsif (is_memtest) {
     if (!get_var("OFW")) {    #no memtest on PPC
         load_svirt_vm_setup_tests;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -625,10 +625,6 @@ elsif (get_var("FEATURE")) {
     prepare_target();
     load_feature_tests();
 }
-elsif (is_mediacheck) {
-    load_svirt_vm_setup_tests;
-    loadtest "installation/mediacheck";
-}
 elsif (is_memtest) {
     if (!get_var("OFW")) {    #no memtest on PPC
         load_svirt_vm_setup_tests;


### PR DESCRIPTION
After this is merged, on O3 and OSD in the `mediacheck` testsuite the config line `MEDIACHECK=1` needs to be replaced by `YAML_SCHEDULE=schedule/yast/mediacheck.yaml`
Ticket: https://progress.opensuse.org/issues/68527
Verification: https://progress.opensuse.org/issues/68527