### PR TITLE
Migrate gnuhealth test to YAML

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -281,14 +281,6 @@ elsif (is_memtest) {
         loadtest "installation/memtest";
     }
 }
-elsif (get_var('GNUHEALTH')) {
-    boot_hdd_image;
-    loadtest 'gnuhealth/gnuhealth_install';
-    loadtest 'gnuhealth/gnuhealth_setup';
-    loadtest 'gnuhealth/gnuhealth_client_install';
-    loadtest 'gnuhealth/gnuhealth_client_preconfigure';
-    loadtest 'gnuhealth/gnuhealth_client_first_time';
-}
 elsif (is_rescuesystem) {
     loadtest "installation/rescuesystem";
     loadtest "installation/rescuesystem_validate_131";

--- a/schedule/functional/extra_tests_gnuhealth.yaml
+++ b/schedule/functional/extra_tests_gnuhealth.yaml
@@ -1,0 +1,11 @@
+name:           extra_tests_gnuhealth
+description:    >
+    Maintainer: dheidler.
+    Extra gnuhealth tests
+schedule:
+    - boot/boot_to_desktop
+    - gnuhealth/gnuhealth_install
+    - gnuhealth/gnuhealth_setup
+    - gnuhealth/gnuhealth_client_install
+    - gnuhealth/gnuhealth_client_preconfigure
+    - gnuhealth/gnuhealth_client_first_time


### PR DESCRIPTION
o3: gnuhealth test: `GNUHEALTH=1` --> `YAML_SCHEDULE=schedule/functional/extra_tests_gnuhealth.yaml`

Ticket: https://progress.opensuse.org/issues/68527
Verification: http://kazhua.qa.suse.de/tests/342