### PR TITLE
Make yast2_lan_restart_* modules work on svirt-xen-hvm

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -37,11 +37,26 @@ sub get_app {
 }
 
 sub get_host {
+    my (%args) = @_;
+    $host = init_host(%args) unless $host;
     return $host;
 }
 
 sub get_port {
+    $port = init_port() unless $port;
     return $port;
+}
+
+sub set_host {
+    my ($yuihost) = @_;
+    $host = $yuihost;
+    $app->get_widget_controller()->set_host($yuihost);
+}
+
+sub set_port {
+    my ($yuiport) = @_;
+    $port = $yuiport;
+    $app->get_widget_controller()->set_host($yuiport);
 }
 
 sub set_interval {
@@ -71,7 +86,6 @@ sub init_app {
 }
 
 sub init_port {
-    return $port if defined $port;
     $port = get_var('YUI_START_PORT', 39000);
     $port += get_var('VNC') =~ /(?<vncport>\d+)/ ? $+{vncport} : int(rand(1000));
     die "Cannot set port for YUI REST API" unless $port;
@@ -81,9 +95,8 @@ sub init_port {
 }
 
 sub init_host {
-    return $host if defined $host;
     my ($installation)             = @_;
-    my $yuiport                    = init_port();
+    my $yuiport                    = get_port();
     my $ip_regexp                  = qr/(?<ip>(\d+\.){3}\d+)/i;
     my $get_ip_from_console_output = sub {
         YuiRestClient::Wait::wait_until(object => sub {
@@ -132,7 +145,7 @@ sub is_libyui_rest_api {
 }
 
 sub set_libyui_backend_vars {
-    my $yuiport = init_port();
+    my $yuiport = get_port();
     if (check_var('BACKEND', 'qemu')) {
         # On qemu we connect to the worker using port forwarding
         set_var('NICTYPE_USER_OPTIONS', "hostfwd=tcp::$yuiport-:$yuiport");

--- a/lib/YuiRestClient/Http/WidgetController.pm
+++ b/lib/YuiRestClient/Http/WidgetController.pm
@@ -38,6 +38,16 @@ sub set_interval {
     $self->{interval} = $interval;
 }
 
+sub set_host {
+    my ($self, $host) = @_;
+    $self->{host} = $host;
+}
+
+sub set_port {
+    my ($self, $port) = @_;
+    $self->{port} = $port;
+}
+
 sub find {
     my ($self, $args) = @_;
 

--- a/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
@@ -9,12 +9,17 @@ vars:
     HDDSIZEGB: 20
     SOFTFAIL_BSC1063638: 1
     VALIDATE_ETC_HOSTS: 1
+    SCC_ADDONS: sdk
+    YUI_REST_API: 1
 schedule:
     - installation/bootloader_svirt
     - boot/boot_to_desktop
     - console/prepare_test_data
     - console/consoletest_setup
     - console/hostname
+    - console/validate_installed_patterns
+    - console/scc_cleanup_reregister
+    - console/setup_libyui_running_system
     - yast2_gui/yast2_software_management
     - yast2_gui/yast2_users
     - yast2_gui/yast2_datetime
@@ -27,7 +32,6 @@ schedule:
     - yast2_gui/yast2_lan_restart_bridge
     - yast2_gui/yast2_lan_restart_vlan
     - yast2_gui/yast2_lan_restart_bond
-    - console/validate_installed_patterns
 test_data:
     software:
         patterns:

--- a/tests/yast2_gui/yast2_lan_restart_bond.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bond.pm
@@ -26,11 +26,12 @@
 # Delete the Bond device.
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
 
-use base 'y2_installbase';
+use base 'y2_module_guitest';
 use strict;
 use warnings;
 use testapi;
 use y2lan_restart_common qw(initialize_y2lan open_network_settings check_network_status wait_for_xterm_to_be_visible clear_journal_log close_xterm);
+use YuiRestClient;
 
 my $network_settings;
 
@@ -41,7 +42,12 @@ sub pre_run_hook {
     $network_settings = $testapi::distri->get_network_settings();
     $network_settings->add_bond_slave();
     $network_settings->save_changes();
+    # After network settings were changed, DHCP may assign another IP address (e.g. on xen-hvm).
+    # Init IP address again, so that libyui will be able to communicate with the YaST module.
+    YuiRestClient::set_host(YuiRestClient::init_host());
+    select_console('x11', await_console => 0);
     wait_for_xterm_to_be_visible();
+    clear_journal_log();
     $self->SUPER::pre_run_hook;
 }
 
@@ -51,7 +57,6 @@ sub run {
     $network_settings->view_bond_slave_without_editing();
     $network_settings->save_changes();
     wait_for_xterm_to_be_visible();
-    clear_journal_log();
     check_network_status('no_restart_or_reload', 'bond');
 }
 

--- a/tests/yast2_gui/yast2_lan_restart_bridge.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bridge.pm
@@ -26,11 +26,12 @@
 # Delete the Bridged device.
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
 
-use base 'y2_installbase';
+use base 'y2_module_guitest';
 use strict;
 use warnings;
 use testapi;
 use y2lan_restart_common qw(initialize_y2lan open_network_settings check_network_status wait_for_xterm_to_be_visible clear_journal_log close_xterm);
+use YuiRestClient;
 
 my $network_settings;
 
@@ -41,7 +42,12 @@ sub pre_run_hook {
     $network_settings = $testapi::distri->get_network_settings();
     $network_settings->add_bridged_device();
     $network_settings->save_changes();
+    # After network settings were changed, DHCP may assign another IP address (e.g. on xen-hvm).
+    # Init IP address again, so that libyui will be able to communicate with the YaST module.
+    YuiRestClient::set_host(YuiRestClient::init_host());
+    select_console('x11', await_console => 0);
     wait_for_xterm_to_be_visible();
+    clear_journal_log();
     $self->SUPER::pre_run_hook;
 }
 
@@ -51,7 +57,6 @@ sub run {
     $network_settings->view_bridged_device_without_editing();
     $network_settings->save_changes();
     wait_for_xterm_to_be_visible();
-    clear_journal_log();
     check_network_status('no_restart_or_reload', 'bridge');
 }
 

--- a/tests/yast2_gui/yast2_lan_restart_vlan.pm
+++ b/tests/yast2_gui/yast2_lan_restart_vlan.pm
@@ -26,11 +26,12 @@
 # Delete the VLAN device.
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
 
-use base 'y2_installbase';
+use base 'y2_module_guitest';
 use strict;
 use warnings;
 use testapi;
 use y2lan_restart_common qw(initialize_y2lan open_network_settings check_network_status wait_for_xterm_to_be_visible clear_journal_log close_xterm);
+use YuiRestClient;
 
 my $network_settings;
 
@@ -41,7 +42,12 @@ sub pre_run_hook {
     $network_settings = $testapi::distri->get_network_settings();
     $network_settings->add_vlan_device();
     $network_settings->save_changes();
+    # After network settings were changed, DHCP may assign another IP address (e.g. on xen-hvm).
+    # Init IP address again, so that libyui will be able to communicate with the YaST module.
+    YuiRestClient::set_host(YuiRestClient::init_host());
+    select_console('x11', await_console => 0);
     wait_for_xterm_to_be_visible();
+    clear_journal_log();
     $self->SUPER::pre_run_hook;
 }
 
@@ -51,7 +57,6 @@ sub run {
     $network_settings->view_vlan_device_without_editing();
     $network_settings->save_changes();
     wait_for_xterm_to_be_visible();
-    clear_journal_log();
     check_network_status('no_restart_or_reload', 'vlan');
 }
 


### PR DESCRIPTION
The test was using YRestClient in some internal functions, but the Client was not set up.

The PR sets it up.

Also, I've adjusted the test to properly check that network is restarted and it found a bug, which I've raised on bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1185775

So, the failures are expected and they show that the issue exists.

- Related ticket: https://progress.opensuse.org/issues/90773
- Verification runs: 
   - svirt-xen-hvm: https://openqa.suse.de/tests/5968140
   - x64: https://openqa.suse.de/tests/5968141