### PR TITLE
Fix 'snapper list --disable-used-space' timeout on Aarch64

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -39,7 +39,7 @@ sub run {
     my $ret     = script_run("snapper --help | grep disable-used-space");
     my $disable = '';
     $disable = '--disable-used-space' unless $ret;
-    assert_script_run("snapper list $disable | tail -n 2 | grep rollback", 180);
+    assert_script_run("snapper list $disable | tail -n 2 | grep rollback", 240);
     power_action('reboot', textmode => 1, keepconsole => 1);
     reconnect_mgmt_console if is_pvm;
     $self->wait_boot(ready_time => 300, bootloader_time => 300);


### PR DESCRIPTION
On Aarch64 the 'snapper list --disable-used-space' will timeout in
180 seconds. We need to enlarge it.

- Related ticket: https://progress.opensuse.org/issues/91731
- Needles: N/A
- Verification run: 
 https://openqa.nue.suse.com/t5967772 
 https://openqa.nue.suse.com/t5967773
