### PR TITLE
Creates separate schedulers for podman and docker

### DIFF
--- a/schedule/containers/engines_and_tools_docker.yaml
+++ b/schedule/containers/engines_and_tools_docker.yaml
@@ -1,8 +1,8 @@
-name:           extra_tests_textmode_containers
+name:           engines_and_tools_docker
 description:    >
-  Maintainer: qa-c@suse.de.
+  Maintainer: qa-c@suse.de
   This schedule is focused on testing the related container packages and features,
-  but not the official container images from SUSE and openSUSE.
+  with docker but not the official container images from SUSE and openSUSE
 conditional_schedule:
   boot:
     ARCH:
@@ -21,23 +21,11 @@ conditional_schedule:
   supported:
     HOST_VERSION:
       15-SP3:
-        - containers/podman
-        - containers/buildah_podman
         - containers/buildah_docker
-        - containers/rootless_podman
-        - containers/podman_3rd_party_images
       15-SP2:
-        - containers/podman
-        - containers/buildah_podman
         - containers/buildah_docker
-        - containers/rootless_podman
-        - containers/podman_3rd_party_images
       15-SP1:
-        - containers/podman
-        - containers/buildah_podman
         - containers/buildah_docker
-        - containers/rootless_podman
-        - containers/podman_3rd_party_images
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop

--- a/schedule/containers/engines_and_tools_podman.yaml
+++ b/schedule/containers/engines_and_tools_podman.yaml
@@ -1,0 +1,18 @@
+name:           engines_and_tools_podman
+description:    >
+  Maintainer: qa-c@suse.de
+  This schedule is focused on testing the related container packages and features,
+  with podman but not the official container images from SUSE and openSUSE
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+schedule:
+  - '{{boot}}'
+  - boot/boot_to_desktop
+  - containers/podman
+  - containers/buildah_podman
+  - containers/rootless_podman
+  - containers/podman_3rd_party_images
+  - console/coredump_collect

--- a/schedule/containers/extra_tests_textmode_containers_docker.yaml
+++ b/schedule/containers/extra_tests_textmode_containers_docker.yaml
@@ -1,16 +1,12 @@
-name:           extra_tests_textmode_containers
+name:           extra_tests_textmode_containers_docker
 description:    >
   Maintainer: qa-c@suse.de.
-  Extra tests about software in containers module
+  Extra tests about software in containers module with docker
 conditional_schedule:
   boot:
     ARCH:
       's390x':
         - installation/bootloader_start
-  podman_image:
-    DISTRI:
-      'opensuse':
-        - containers/podman_image
   docker_image:
     DISTRI:
       'opensuse':
@@ -19,9 +15,6 @@ conditional_schedule:
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
-  - containers/podman
-  - '{{podman_image}}'
-  - containers/buildah_podman
   - containers/docker
   - '{{docker_image}}'
   - containers/buildah_docker
@@ -29,7 +22,5 @@ schedule:
   - containers/docker_compose
   - containers/zypper_docker
   - containers/docker_3rd_party_images
-  - containers/podman_3rd_party_images
   - containers/registry
   - console/coredump_collect
-  - containers/rootless_podman

--- a/schedule/containers/extra_tests_textmode_containers_podman.yaml
+++ b/schedule/containers/extra_tests_textmode_containers_podman.yaml
@@ -1,0 +1,20 @@
+name:           extra_tests_textmode_containers_podman
+description:    >
+  Maintainer: qa-c@suse.de.
+  Extra tests about software in containers module with podman
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+  podman_image:
+    DISTRI:
+      'opensuse':
+        - containers/podman_image
+schedule:
+  - '{{boot}}'
+  - boot/boot_to_desktop
+  - containers/podman
+  - '{{podman_image}}'
+  - containers/buildah_podman
+  - containers/rootless_podman

--- a/schedule/containers/sle_image_on_sle_host_docker.yaml
+++ b/schedule/containers/sle_image_on_sle_host_docker.yaml
@@ -1,30 +1,24 @@
-name:           sle_image_on_sle_host
+name:           sle_image_on_sle_host_docker
 description:    >
-  Maintainer: jalausuch@suse.com, qa-c@suse.de.
-  Extra tests about software in containers module
+  Maintainer: qa-c@suse.de
+  Container images specific tests with docker
 conditional_schedule:
   boot:
     ARCH:
       's390x':
         - installation/bootloader_start
-  podman_buildah:
+  buildah_docker:
     HOST_VERSION:
       15-SP3:
-        - containers/podman_image
         - containers/buildah_docker
-        - containers/buildah_podman
       15-SP2:
-        - containers/podman_image
         - containers/buildah_docker
-        - containers/buildah_podman
       15-SP1:
-        - containers/podman_image
         - containers/buildah_docker
-        - containers/buildah_podman
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/docker_image
-  - '{{podman_buildah}}'
+  - '{{buildah_docker}}'
   - containers/container_diff

--- a/schedule/containers/sle_image_on_sle_host_podman.yaml
+++ b/schedule/containers/sle_image_on_sle_host_podman.yaml
@@ -1,0 +1,15 @@
+name:           sle_image_on_sle_host_podman
+description:    >
+  Maintainer: qa-c@suse.de
+  Container images specific tests with podman
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+schedule:
+  - '{{boot}}'
+  - boot/boot_to_desktop
+  - containers/host_configuration
+  - containers/podman_image
+  - containers/buildah_podman


### PR DESCRIPTION
As a first step I have splitted the scheduling into *_docker and *_podman.
This will affect container_basic and containers_sle_image_on_sle_host.
I think this does not need to apply for our test on centos, ubuntu and
opensuse(not sure for the last)

- Related ticket: https://progress.opensuse.org/issues/92389
- Verification run: 
[extra_tests_textmode_containers_podman](https://openqa.suse.de/t5994428)
[extra_tests_textmode_containers_docker](https://openqa.suse.de/t5994435)
[sle_image_on_sle_host_docker](https://openqa.suse.de/t5994648)
[sle_image_on_sle_host_podman](https://openqa.suse.de/t5994586)

UPDATE:
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2312508
https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2312508&version=Tumbleweed