### PR TITLE
Fix LibyuiClient setup on ssh installation

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -130,10 +130,6 @@ sub init_host {
         select_console('root-console');
         $host = &$get_ip_from_console_output;
         select_console('installation') if $installation;
-    } elsif ($installation && is_ssh_installation) {
-        my $cmd = (is_s390x && is_svirt) ? "TERM=linux " : "";
-        $cmd .= get_yui_params_string($yuiport) . " yast.ssh";
-        enter_cmd($cmd);
     }
 
     set_var('YUI_SERVER', $host);

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -21,13 +21,22 @@
 use strict;
 use warnings;
 use base "installbasetest";
+use Utils::Backends qw(is_svirt is_ssh_installation);
+use Utils::Architectures qw(is_s390x);
 use testapi;
 use YuiRestClient;
 
 sub run {
-    my $app = YuiRestClient::get_app(installation => 1);
+    my $app  = YuiRestClient::get_app(installation => 1);
+    my $port = $app->get_port();
     record_info('SERVER', "Used host for libyui: " . $app->get_host());
-    record_info('PORT',   "Used port for libyui: " . $app->get_port());
+    record_info('PORT',   "Used port for libyui: " . $port);
+
+    if (is_ssh_installation) {
+        my $cmd = (is_s390x && is_svirt) ? "TERM=linux " : "";
+        $cmd .= YuiRestClient::get_yui_params_string($port) . " yast.ssh";
+        enter_cmd($cmd);
+    }
     $app->check_connection(timeout => 500, interval => 10);
 }
 


### PR DESCRIPTION
A part of the code related to ssh installation was placed in init_host
function, but it should be  apart of setup_libyui, as bootloader_pvm was
designed in a way, that if LibyuiClient is used then it should be
responsible to start the installation over ssh.

- Verification run: https://openqa.suse.de/t5984336
