### PR TITLE
s390x arch cannot use setterm command

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -29,7 +29,7 @@ use List::MoreUtils 'uniq';
 
 sub run {
     select_console('root-console');
-    assert_script_run('setterm -blank 0');
+    assert_script_run('setterm -blank 0') unless (check_var('ARCH', 's390x'));
 
     assert_script_run("SUSEConnect --status-text > /dev/$serialdev", timeout => 180);
 


### PR DESCRIPTION
s390x arch cannot support setterm command

- Related ticket: https://progress.opensuse.org/issues/xyz
- Verification run: http://openqa.suse.de/t5993084