### PR TITLE
Replaces stable_images with totest ones

### DIFF
--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -32,7 +32,7 @@ sub run {
     allow_selected_insecure_registries(runtime => 'docker');
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
-    for my $iname (@{$stable_names}) {
+    for my $iname (@{$image_names}) {
         record_info 'testing image', $iname;
         test_container_image(image => $iname, runtime => 'buildah');
         if (check_os_release('suse', 'PRETTY_NAME')) {

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -32,7 +32,7 @@ sub run {
     allow_selected_insecure_registries(runtime => 'podman');
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
-    for my $iname (@{$stable_names}) {
+    for my $iname (@{$image_names}) {
         record_info 'testing image', $iname;
         test_container_image(image => $iname, runtime => 'buildah');
         if (check_os_release('suse', 'PRETTY_NAME')) {


### PR DESCRIPTION
When we implemented the test[0] we used the stable images from
`registry.suse.com` and `registry.opensuse.org`.
Those images should be used only outside the SP3 container testing and in the
container_diff.

[0] https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12129/commits/7e2f5e29da3d4ddaba11439bc69deb4bb8a97b6c

- Related ticket: https://progress.opensuse.org/issues/92476
- Verification run: 
sle-15-SP3-Online-x86_64-Build187.1-containers_sle_image_on_sle_host@64bit -> https://openqa.suse.de/t5993686
sle-15-SP3-Online-x86_64-Build187.1-containers_basic@64bit -> https://openqa.suse.de/t5993687
opensuse-Tumbleweed-DVD-x86_64-Build20210508-extra_tests_textmode_containers@64bit -> https://openqa.opensuse.org/t1734723