### PR TITLE
Fix systemtap conflicts on update-install

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -49,6 +49,7 @@ sub has_conflict {
         'dpdk-devel'              => 'dpdk-thunderx-devel',
         'dpdk-kmp-default'        => 'dpdk-thunderx-kmp-default',
         'pulseaudio-module-gconf' => 'pulseaudio-module-gsettings',
+        'systemtap-sdt-devel'     => 'systemtap-headers',
     );
     return $conflict{$binary};
 }


### PR DESCRIPTION
Fix systemtap conflicts on update-install


- Related ticket: https://progress.opensuse.org/issues/92482
- Needles: no needles
- Issue reproduced: http://10.161.229.176/tests/796#step/update_install/58
- Verification run: http://10.161.229.176/tests/797#step/update_install/41