### PR TITLE
Fix AutoYaST mini in PowerVM

### DIFF
--- a/data/autoyast_sle15/mini_remote.xml
+++ b/data/autoyast_sle15/mini_remote.xml
@@ -24,6 +24,12 @@
     <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>
+    <partitioning config:type="list">
+        <drive>
+            <device>/dev/sda</device>
+            <initialize config:type="boolean">true</initialize> 
+        </drive>
+    </partitioning>
     <services-manager>
         <default_target>multi-user</default_target>
         <services>

--- a/schedule/yast/autoyast/autoyast_mini_spvm.yaml
+++ b/schedule/yast/autoyast/autoyast_mini_spvm.yaml
@@ -7,6 +7,7 @@ vars:
   AUTOYAST: autoyast_sle15/mini_remote.xml
   AUTOYAST_CONFIRM: 1
   DESKTOP: textmode
+  KEEP_DISKS: 1
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start


### PR DESCRIPTION
We were pre-formatting the disk at the same time that AutoYaST is
running and once the Beta warning dissapears there is nothing to
stop AutoYaST to continue and create a planning for partitioning
before we finish the wiping out process.

In general the logic to pre-format works for other scenarios so
we just need to keep the disk intact in this case and modify the
profile to wipe out the disk.

- Related ticket: [poo#92464](https://progress.opensuse.org/issues/92464)
- Verification run: [autoyast_mini@ppc64le-hmc-single-disk](https://openqa.suse.de/tests/5994814)