### PR TITLE
sssd: Setup support for GPO enforcement

### DIFF
--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -266,6 +266,17 @@ sub test_custom_services {
     assert_script_run("rm -rf /etc/firewalld/services/fbsql.xml");
 }
 
+sub test_default_backend {
+    validate_script_output('iptables', sub {
+        if (uses_iptables){
+	   qr/legacy/
+	} else {
+	  record_soft_failure('https://bugzilla.suse.com/show_bug.cgi?id=1206383') if qr/legacy/;
+	  qr/nf_tables/
+	}
+    });
+}
+
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
@@ -296,6 +307,9 @@ sub run {
 
     # Test #8 - Create a custom service
     test_custom_services;
+
+    # Test #9 - Ensure we have the correct backend
+    test_default_backend;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
GPO stands for Global Policy Objects which is a fancy acronym for an
ACL, in general we want to ensure that users that are explicitly denied
access to services (or have other kind of permissions on their profile)
can't login, and that sssd honors such options.

Prior to enabling the following settings, user bernhard (from geeko.com
domain) would be able to login via ssh to the SUT.

+access_provider = ad
+ad_gpo_access_control = enforcing


VR: 

* samba_adcli: Export relevant logs on failure
* Support getting journal files for enabled services
* opensusebasetest: Update the flow of error detection mechanism
* consoletest: Use serial terminal after parent's post_fail_hook
* Run parent post_fail_hooks to get better logging

At the moment, if the SUT is using a serial terminal, we simply return,
and let the rest of the post-fail-hook to do the work, so if the child
(e.g consoletest) doesn't call export_logs() or doesn't do any specific
actions, export_logs_basic will be called, and these logs aren't really
providing much.

VR:
* [sle-15-SP1-Server-DVD-Updates-aarch64-Build20210729-1-mau-extratests2@aarch64-virtio](https://openqa.suse.de/tests/6607376)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20210729-1-mau-extratests2@64bit](https://openqa.suse.de/tests/6607377)
* [sle-15-SP2-Server-DVD-Updates-x86_64-Build20210729-1-mau-extratests2@64bit](https://openqa.suse.de/tests/6607375)
* [sle-15-SP3-Server-DVD-Updates-aarch64-Build20210729-1-mau-extratests2@aarch64-virtio](https://openqa.suse.de/tests/6607373)
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20210729-1-mau-extratests2@64bit](https://openqa.suse.de/tests/6607381)