### PR TITLE
Enable basesystem source repo for multipath-tools source

### DIFF
--- a/tests/console/systemd_rpm_macros.pm
+++ b/tests/console/systemd_rpm_macros.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -42,8 +42,11 @@ sub run {
 
     # Test build of multipath-tools on tw, or SLE >= 15
     if (is_sle '>=15') {
+        # enable & disable source repo for multipat-tools source
+        assert_script_run(q(zypper mr -e --refresh $(zypper lr|awk '/Basesystem.*Source/ {print$5}')));
         add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
         build_mt();
+        assert_script_run(q(zypper mr -d $(zypper lr|awk '/Basesystem.*Source/ {print$5}')));
     } elsif (is_tumbleweed) {
         zypper_call("ar -f http://download.opensuse.org/source/tumbleweed/repo/oss/ my-source-repo");
         build_mt();


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/92500
- Verification run:
https://openqa.suse.de/tests/6001686 15 SP3 x86_64
https://openqa.suse.de/tests/6001735 15 SP3 s3890x
https://openqa.suse.de/tests/6001595 15 SP3 aarch64