### PR TITLE
Remove register_system softfail 

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -765,13 +765,7 @@ sub yast_scc_registration {
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module, yast2_opts => $args{yast2_opts});
     # For Aarch64 if the worker run with heavy loads, it will
     # timeout in nearly 120 seconds. So we set it to 150.
-    assert_screen_with_soft_timeout(
-        'scc-registration',
-        timeout      => (check_var('ARCH', 'aarch64')) ? 150 : 90,
-        soft_timeout => 30,
-        bugref       => 'wait longer time to start yast2 scc in case of multiple jobs start to execute it in parallel on a same worker'
-    );
-
+    assert_screen('scc-registration', timeout => (check_var('ARCH', 'aarch64')) ? 150 : 90,);
     fill_in_registration_data;
     wait_serial("$module_name-0", 150) || die "yast scc failed";
     # To check repos validity after registration, call 'validate_repos' as needed


### PR DESCRIPTION
In register_system we use assert_screen_with_soft_timeout, which needs a bug ref, we use a placeholder without bug there. 
This resulted in the test result is always soft fail even all modules passed. We can try to use assert_screen here to verify it.

- Related ticket: https://progress.opensuse.org/issues/92545
- Needles: N/A
- Verification run: 
  http://openqa.nue.suse.com/t6003055 
  http://openqa.nue.suse.com/t6003056 