### PR TITLE
Fix container test on CentOS

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -118,10 +118,13 @@ sub login {
         send_key 'ret';
     }
     die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
+    # Some (older) versions of bash don't take changes to the terminal during runtime into account. Re-exec it.
+    enter_cmd('export TERM=dumb; stty cols 2048; exec $SHELL');
+    die 'Failed to confirm that shell re-exec was successful' unless wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
     enter_cmd(qq/PS1="$serial_term_prompt"/);
     wait_serial(qr/PS1="$serial_term_prompt"/);
     # TODO: Send 'tput rmam' instead/also
-    assert_script_run('export TERM=dumb; stty cols 2048');
+    assert_script_run('export TERM=dumb');
     assert_script_run('echo Logged into $(tty)', timeout => $bmwqemu::default_timeout, result_title => 'vconsole_login');
 }
 

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -37,5 +37,9 @@ sub run {
     }
 }
 
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
 1;
 


### PR DESCRIPTION
Fix serial_terminal with older versions of bash:

Some older versions of bash don't take terminal geometry changes during runtime
into account. To work around that, re-exec the shell after adjusting the width.

This caused validation of typed commands to fail and such it ran into the 90s timeout for each, delaying the test progress significantly. Until now, the CentOS test took ~55min to complete!
With the recent change to `host_configuration` in #12507, it got even more confused and the test failed completely.
With this PR, the test works reliably and passes in less than 5min.

Also set test flags for `containers/host_configuration`.

Verification runs:
TW container on CentOS: http://10.160.67.86/tests/954 https://openqa.opensuse.org/tests/1736131
Container tests on 15.2: https://openqa.opensuse.org/tests/1736516

Touches serial_terminal, so probably needs more VRs. Any wishes?