### PR TITLE
clamav: Remove workaround for fixed bsc#1183881

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -74,7 +74,8 @@ sub run {
     # Verify the database
     assert_script_run 'sigtool -i /var/lib/clamav/main.cvd';
     assert_script_run 'sigtool -i /var/lib/clamav/bytecode.cvd';
-    assert_script_run 'sigtool -i /var/lib/clamav/daily.cvd';
+    # CLD files are uncompressed and unsigned versions of the CVD that have had CDIFFs applied
+    assert_script_run 'sigtool -i /var/lib/clamav/daily.cvd || sigtool -i /var/lib/clamav/daily.cld';
 
     # Clamd start timeout sometimes. The default systemd timeout is 90s,
     # override it with a longer duration in runtime.

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -54,17 +54,11 @@ sub run {
 
     # Initialize and download ClamAV database
     # First from local mirror, it's much faster, then from official clamav db
-    if (is_sle('=15')) {
-        record_soft_failure('bsc#1183881');
-        assert_script_run('freshclam', 700);
-    }
-    else {
-        my $host = is_sle ? 'openqa.suse.de' : 'openqa.opensuse.org';
-        assert_script_run("sed -i '/mirror1/i PrivateMirror $host/assets/repo/cvd' /etc/freshclam.conf");
-        assert_script_run('freshclam');
-        assert_script_run("sed -i '/PrivateMirror $host/d' /etc/freshclam.conf");
-        assert_script_run('freshclam');
-    }
+    my $host = is_sle ? 'openqa.suse.de' : 'openqa.opensuse.org';
+    assert_script_run("sed -i '/mirror1/i PrivateMirror $host/assets/repo/cvd' /etc/freshclam.conf");
+    assert_script_run('freshclam');
+    assert_script_run("sed -i '/PrivateMirror $host/d' /etc/freshclam.conf");
+    assert_script_run('freshclam');
 
     # clamd takes a lot of memory at startup so a swap partition is needed on JeOS
     # But openSUSE aarch64 JeOS has already a swap and BTRFS does not support swapfile

--- a/tests/console/krb5.pm
+++ b/tests/console/krb5.pm
@@ -27,7 +27,7 @@ sub logout_and_verify_shell_availability {
     script_run 'logout', 0;
     # verify shell is ready with simple command
     # avoid fail due to following command being typed while logout in progress
-    script_retry('w', delay => 1, retry => 3);
+    script_retry('w', delay => 2, retry => 5);
 }
 
 sub run {


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1183881

krb5: increase will be hopefully enough ...
serial_terminal.txt :
```
# logout
timeout 30 w; echo QCLJM-$?-
timeout 30 w; echo QCLJM-$?-
# timeout 30 w; echo QCLJM-$?-
```

- Verification run:
https://openqa.suse.de/tests/6010627 15 GA x86_64
https://openqa.suse.de/tests/6010626 15 GA s390x
https://openqa.suse.de/tests/6010625 15 GA aarch64
https://openqa.suse.de/tests/6010628 15 SP2 x86_64
https://openqa.suse.de/tests/6010629 15 SP2 s390x
https://openqa.suse.de/tests/6010630 15 SP2 aarch64
https://openqa.opensuse.org/tests/1738319 TW x86_64
