### PR TITLE
Fix opensuse snapper_rollback load issue

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1750,9 +1750,9 @@ sub load_rollback_tests {
     # For continuous migration test from SLE11SP4, the filesystem is 'ext3' and btrfs snapshot is not supported.
     # For HPC migration test with 'management server' role, the filesystem is 'xfs', btrfs snapshot is not supported.
     loadtest "boot/grub_test_snapshot" unless check_var('VIRSH_VMM_TYPE', 'linux') || get_var('FILESYSTEM') =~ /ext3|xfs/;
-    # Skip load version switch for online migration
-    loadtest "migration/version_switch_origin_system" if (!get_var("ONLINE_MIGRATION"));
-    if (get_var('UPGRADE') || get_var('ZDUP')) {
+    # Skip load version switch for online migration and opensuse perfomance test
+    loadtest "migration/version_switch_origin_system" if (!get_var("ONLINE_MIGRATION") && !(is_opensuse && get_var('SOFTFAIL_BSC1063638') && get_var('ROLLBACK_AFTER_MIGRATION')));
+    if (get_var('UPGRADE') || get_var('ZDUP') || (is_opensuse && get_var('SOFTFAIL_BSC1063638') && get_var('ROLLBACK_AFTER_MIGRATION'))) {
         loadtest "boot/snapper_rollback";
     }
     if (get_var('MIGRATION_ROLLBACK')) {

--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -22,7 +22,7 @@ use version_utils;
 
 sub run {
     my ($self) = @_;
-    if (is_leap_migration && (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'kde'))) {
+    if ((is_leap_migration || is_opensuse) && (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'kde'))) {
         assert_screen 'generic-desktop', 90;
     }
     else {


### PR DESCRIPTION
For more test coverage, We need to add the snapper_rollback module to the system_performance test.
To make it we need to add ROLLBACK_AFTER_MIGRATION=1, FILESYSTEM=btrfs to the test case.

- Related ticket:  https://progress.opensuse.org/issues/91992
- Needles: N/A
- Verification run: 
  https://openqa.opensuse.org/tests/1716989
  https://openqa.opensuse.org/tests/1734752
  https://openqa.opensuse.org/tests/1734753
  https://openqa.opensuse.org/tests/1736027
  https://openqa.opensuse.org/tests/1735986