### PR TITLE
Repace lynis soft failure poo and update baselines

### DIFF
--- a/data/lynis/baseline-lynis-audit-system-nocolors-Tumbleweed-x86_64-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-Tumbleweed-x86_64-gnome
@@ -1,5 +1,5 @@
 
-[ Lynis 3.0.3 ]
+[ Lynis 3.0.4 ]
 
 ################################################################################
   Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
@@ -17,11 +17,11 @@
 [2C- Checking profiles...[37C [ DONE ]
 
   ---------------------------------------------------
-  Program version:           3.0.3
+  Program version:           3.0.4
   Operating system:          Linux
   Operating system name:     openSUSE
-  Operating system version:  20210502
-  Kernel version:            5.12.0
+  Operating system version:  20210515
+  Kernel version:            5.12.3
   Hardware platform:         x86_64
   Hostname:                  susetest
   ---------------------------------------------------
@@ -51,6 +51,9 @@
 
 [+] Boot and services
 ------------------------------------
+
+  [WARNING]: Test CORE-1000 had a long execution: 15.772212 seconds
+
 [2C- Service Manager[42C [ systemd ]
 [2C- Checking UEFI boot[39C [ DISABLED ]
 [2C- Checking presence GRUB2[34C [ FOUND ]
@@ -105,13 +108,13 @@
 [8C- systemd-ask-password-console.service:[14C [ UNSAFE ]
 [8C- systemd-ask-password-plymouth.service:[13C [ UNSAFE ]
 [8C- systemd-initctl.service:[27C [ UNSAFE ]
-[8C- systemd-journald.service:[26C [ OK ]
-[8C- systemd-logind.service:[28C [ OK ]
+[8C- systemd-journald.service:[26C [ PROTECTED ]
+[8C- systemd-logind.service:[28C [ PROTECTED ]
 [8C- systemd-rfkill.service:[28C [ UNSAFE ]
-[8C- systemd-timesyncd.service:[25C [ OK ]
+[8C- systemd-timesyncd.service:[25C [ PROTECTED ]
 [8C- systemd-udevd.service:[29C [ MEDIUM ]
 [8C- udisks2.service:[35C [ UNSAFE ]
-[8C- upower.service:[36C [ OK ]
+[8C- upower.service:[36C [ PROTECTED ]
 [8C- user@0.service:[36C [ UNSAFE ]
 [8C- user@1000.service:[33C [ UNSAFE ]
 [8C- wpa_supplicant.service:[28C [ UNSAFE ]
@@ -206,7 +209,6 @@
 [4C- Module cramfs is blacklisted[27C [ OK ]
 [4C- Module freevxfs is blacklisted[25C [ OK ]
 [4C- Module hfs is blacklisted[30C [ OK ]
-[4C- Discovered kernel modules: cramfs freevxfs hfsplus jffs2 squashfs udf [0C
 
 [+] USB Devices
 ------------------------------------
@@ -241,10 +243,7 @@
 [4C- Searching RPM package manager[26C [ FOUND ]
 [6C- Querying RPM package manager[25C
 
-  [WARNING]: Test PKGS-7308 had a long execution: 20.221873 seconds
-
-
-  [WARNING]: Test PKGS-7328 had a long execution: 11.230931 seconds
+  [WARNING]: Test PKGS-7308 had a long execution: 17.144066 seconds
 
 [2C- Using Zypper to find vulnerable packages[17C [ NONE ]
 [2C- Checking package audit tool[30C [ INSTALLED ]
@@ -515,7 +514,7 @@
 
 [+] Hardening
 ------------------------------------
-[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed compiler(s)[34C [ NOT FOUND ]
 [4C- Installed malware scanner[30C [ NOT FOUND ]
 [4C- Non-native binary formats[30C [ NOT FOUND ]
 
@@ -529,12 +528,12 @@
   [WARNING]: Deprecated function used (logtext)
 
 [4CWarning: Package iio-sensor-proxy-3.0-1.6.x86_64 installs an unknown D-BUS autostart/system service: net.hadess.SensorProxy.conf[0C [ WARNING ]
-[4CWarning: Package bluez-5.58-1.2.x86_64 installs an unknown D-BUS autostart/system service: org.bluez.service[0C [ WARNING ]
-[4CWarning: Package flatpak-1.10.2-1.2.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.Flatpak.SystemHelper.service[0C [ WARNING ]
-[4CWarning: Package bolt-0.9-1.7.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.bolt.service[0C [ WARNING ]
+[4CWarning: Package bluez-5.58-1.3.x86_64 installs an unknown D-BUS autostart/system service: org.bluez.service[0C [ WARNING ]
+[4CWarning: Package flatpak-1.11.1-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.Flatpak.SystemHelper.service[0C [ WARNING ]
+[4CWarning: Package bolt-0.9-1.8.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.bolt.service[0C [ WARNING ]
 [4CWarning: Package fwupd-1.5.8-1.2.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.fwupd.service[0C [ WARNING ]
 [4CWarning: Package systemd-246.13-1.2.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
-[4CWarning: Package snapper-0.9.0-2.1.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.9.0-4.1.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
 
   [WARNING]: Deprecated function used (wait_for_keypress)
 
@@ -561,7 +560,7 @@
 
   [WARNING]: Deprecated function used (logtext)
 
-[4CRPATH "//usr/lib64/bash" on /usr/bin/bash is not allowed[1C [ WARNING ]
+[4CNo bad RPATH usage found in 7934 executables[13C [ OK ]
 
   [WARNING]: Deprecated function used (wait_for_keypress)
 
@@ -569,7 +568,7 @@
 [+] File systems
 ------------------------------------
 
-  [WARNING]: Test BINARY-1000 had a long execution: 117.446383 seconds
+  [WARNING]: Test BINARY-1000 had a long execution: 46.768346 seconds
 
 [2C- Starting look-up of symlinks in /tmp...[18C
 
@@ -623,7 +622,7 @@
 
 ================================================================================
 
-  -[ Lynis 3.0.3 Results ]-
+  -[ Lynis 3.0.4 Results ]-
 
   Warnings (2):
   ----------------------------
@@ -633,7 +632,7 @@
   ! iptables module(s) loaded, but no rules active [FIRE-4512] 
       https://cisofy.com/lynis/controls/FIRE-4512/
 
-  Suggestions (42):
+  Suggestions (40):
   ----------------------------
   * Set a password on GRUB boot loader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
       https://cisofy.com/lynis/controls/BOOT-5122/
@@ -650,11 +649,6 @@
 
   * When possible set expire dates for all password protected accounts [AUTH-9282] 
       https://cisofy.com/lynis/controls/AUTH-9282/
-
-  * Consider disabling unused kernel modules [FILE-6430] 
-    - Details  : /etc/modprobe.d/blacklist.conf
-    - Solution : Add 'install MODULENAME /bin/true' (without quotes)
-      https://cisofy.com/lynis/controls/FILE-6430/
 
   * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [USB-1000] 
       https://cisofy.com/lynis/controls/USB-1000/
@@ -772,9 +766,6 @@
     - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
       https://cisofy.com/lynis/controls/KRNL-6000/
 
-  * Harden compilers like restricting access to root user only [HRDN-7222] 
-      https://cisofy.com/lynis/controls/HRDN-7222/
-
   * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
     - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
       https://cisofy.com/lynis/controls/HRDN-7230/
@@ -790,8 +781,8 @@
 
   Lynis security scan details:
 
-  Hardening index : 92 [##################  ]
-  Tests performed : 261
+  Hardening index : 82 [################    ]
+  Tests performed : 262
   Plugins enabled : 0
 
   Components:
@@ -812,7 +803,7 @@
 
 ================================================================================
 
-  Lynis 3.0.3
+  Lynis 3.0.4
 
   Auditing, system hardening, and compliance for UNIX-based systems
   (Linux, macOS, BSD, and others)

--- a/data/lynis/baseline-lynis-audit-system-nocolors-Tumbleweed-x86_64-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-Tumbleweed-x86_64-textmode
@@ -1,5 +1,5 @@
 
-[ Lynis 3.0.3 ]
+[ Lynis 3.0.4 ]
 
 ################################################################################
   Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
@@ -17,11 +17,11 @@
 [2C- Checking profiles...[37C [ DONE ]
 
   ---------------------------------------------------
-  Program version:           3.0.3
+  Program version:           3.0.4
   Operating system:          Linux
   Operating system name:     openSUSE
-  Operating system version:  20210502
-  Kernel version:            5.12.0
+  Operating system version:  20210515
+  Kernel version:            5.12.3
   Hardware platform:         x86_64
   Hostname:                  susetest
   ---------------------------------------------------
@@ -94,10 +94,10 @@
 [8C- systemd-ask-password-console.service:[14C [ UNSAFE ]
 [8C- systemd-ask-password-plymouth.service:[13C [ UNSAFE ]
 [8C- systemd-initctl.service:[27C [ UNSAFE ]
-[8C- systemd-journald.service:[26C [ OK ]
-[8C- systemd-logind.service:[28C [ OK ]
+[8C- systemd-journald.service:[26C [ PROTECTED ]
+[8C- systemd-logind.service:[28C [ PROTECTED ]
 [8C- systemd-rfkill.service:[28C [ UNSAFE ]
-[8C- systemd-timesyncd.service:[25C [ OK ]
+[8C- systemd-timesyncd.service:[25C [ PROTECTED ]
 [8C- systemd-udevd.service:[29C [ MEDIUM ]
 [8C- user@0.service:[36C [ UNSAFE ]
 [8C- wickedd-auto4.service:[29C [ UNSAFE ]
@@ -193,7 +193,6 @@
 [4C- Module cramfs is blacklisted[27C [ OK ]
 [4C- Module freevxfs is blacklisted[25C [ OK ]
 [4C- Module hfs is blacklisted[30C [ OK ]
-[4C- Discovered kernel modules: cramfs freevxfs hfsplus jffs2 squashfs udf [0C
 
 [+] USB Devices
 ------------------------------------
@@ -382,7 +381,6 @@
 
 [+] Cryptography
 ------------------------------------
-[2C- Checking for expired SSL certificates [0/1][14C [ NONE ]
 [2C- Found 0 encrypted and 1 unencrypted swap devices in use.[1C [ OK ]
 [2C- Kernel entropy is sufficient[29C [ YES ]
 [2C- HW RNG & rngd[44C [ NO ]
@@ -493,7 +491,7 @@
 
 [+] Hardening
 ------------------------------------
-[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed compiler(s)[34C [ NOT FOUND ]
 [4C- Installed malware scanner[30C [ NOT FOUND ]
 [4C- Non-native binary formats[30C [ NOT FOUND ]
 
@@ -507,7 +505,7 @@
   [WARNING]: Deprecated function used (logtext)
 
 [4CWarning: Package systemd-246.13-1.2.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
-[4CWarning: Package snapper-0.9.0-2.1.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.9.0-4.1.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
 
   [WARNING]: Deprecated function used (wait_for_keypress)
 
@@ -534,7 +532,7 @@
 
   [WARNING]: Deprecated function used (logtext)
 
-[4CRPATH "//usr/lib64/bash" on /usr/bin/bash is not allowed[1C [ WARNING ]
+[4CNo bad RPATH usage found in 4244 executables[13C [ OK ]
 
   [WARNING]: Deprecated function used (wait_for_keypress)
 
@@ -542,7 +540,7 @@
 [+] File systems
 ------------------------------------
 
-  [WARNING]: Test BINARY-1000 had a long execution: 53.378980 seconds
+  [WARNING]: Test BINARY-1000 had a long execution: 30.115470 seconds
 
 [2C- Starting look-up of symlinks in /tmp...[18C
 
@@ -595,7 +593,7 @@
 
 ================================================================================
 
-  -[ Lynis 3.0.3 Results ]-
+  -[ Lynis 3.0.4 Results ]-
 
   Warnings (2):
   ----------------------------
@@ -605,7 +603,7 @@
   ! iptables module(s) loaded, but no rules active [FIRE-4512] 
       https://cisofy.com/lynis/controls/FIRE-4512/
 
-  Suggestions (41):
+  Suggestions (39):
   ----------------------------
   * Set a password on GRUB boot loader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
       https://cisofy.com/lynis/controls/BOOT-5122/
@@ -622,11 +620,6 @@
 
   * When possible set expire dates for all password protected accounts [AUTH-9282] 
       https://cisofy.com/lynis/controls/AUTH-9282/
-
-  * Consider disabling unused kernel modules [FILE-6430] 
-    - Details  : /etc/modprobe.d/blacklist.conf
-    - Solution : Add 'install MODULENAME /bin/true' (without quotes)
-      https://cisofy.com/lynis/controls/FILE-6430/
 
   * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [USB-1000] 
       https://cisofy.com/lynis/controls/USB-1000/
@@ -741,9 +734,6 @@
     - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
       https://cisofy.com/lynis/controls/KRNL-6000/
 
-  * Harden compilers like restricting access to root user only [HRDN-7222] 
-      https://cisofy.com/lynis/controls/HRDN-7222/
-
   * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
     - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
       https://cisofy.com/lynis/controls/HRDN-7230/
@@ -759,7 +749,7 @@
 
   Lynis security scan details:
 
-  Hardening index : 89 [#################   ]
+  Hardening index : 80 [################    ]
   Tests performed : 258
   Plugins enabled : 0
 
@@ -781,7 +771,7 @@
 
 ================================================================================
 
-  Lynis 3.0.3
+  Lynis 3.0.4
 
   Auditing, system hardening, and compliance for UNIX-based systems
   (Linux, macOS, BSD, and others)

--- a/lib/lynis/lynis_run.pm
+++ b/lib/lynis/lynis_run.pm
@@ -77,7 +77,7 @@ sub run {
         record_info("NotFound", "Not found \"$section_orig\" in baseline file");
         record_info("WARNING",  "New section \"$section_orig\" detected, please check and update the baseline!");
         # Set softfail for checking and updating the baseline
-        record_soft_failure("poo#78224, Not found \"$section_orig\" in baseline file, set softfail and only check results in \"current\"");
+        record_soft_failure("poo#91383, Not found \"$section_orig\" in baseline file, set softfail and only check results in \"current\"");
         @section_content_baseline = lynis::lynistest::parse_lynis_section_content($section_orig, "assets_private/$baseline_file");
         @section_content_current  = lynis::lynistest::parse_lynis_section_content($section_orig, "assets_private/$current_file");
         $results                  = lynis::lynistest::compare_lynis_section_content($found, \@section_content_baseline, \@section_content_current);

--- a/tests/security/lynis/lynis_analyze_system_audit.pm
+++ b/tests/security/lynis/lynis_analyze_system_audit.pm
@@ -47,7 +47,7 @@ sub run {
     @section_list_current = lynis::lynistest::parse_lynis_section_list("assets_private/$current_file");
 
     if (@section_list_baseline != @section_list_current) {
-        record_soft_failure("poo#78224, Section quantity are not the same");
+        record_soft_failure("poo#91383, Section quantity are not the same");
     }
 
     # Generate test cases/modules dynamically according to the sections,

--- a/tests/security/lynis/lynis_harden_index.pm
+++ b/tests/security/lynis/lynis_harden_index.pm
@@ -43,7 +43,7 @@ sub run {
     }
     else {
         record_info("NotSame", "\"Hardening index\" is NOT the same.\n Baseline: $out_b\n Current: $out_c");
-        record_soft_failure("poo#78224, \"Hardening index\" is NOT the same please check");
+        record_soft_failure("poo#91383, \"Hardening index\" is NOT the same please check");
     }
 }
 


### PR DESCRIPTION
Replace lynis soft failure poo with an unified one; update baseline files
on TW; filter out some exceptions (test execution time)

- Related ticket: https://progress.opensuse.org/issues/91386 https://progress.opensuse.org/issues/92614
- Needles: NA
- Verification run:
  https://openqa.opensuse.org/tests/1737858
  https://openqa.opensuse.org/tests/1737859
