### PR TITLE
Checked the system upgrade to expected build ID

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -61,6 +61,13 @@ sub run {
         my $out = script_output("zypper lr | grep -i $name", 200, proceed_on_failure => 1);
         die "zypper lr command output does not include $name" if ($out eq '');
     }
+
+    # Checked to get expected buildID with proxy scc upgrade
+    if ((get_var('SCC_URL', "") =~ /proxy/) && !get_var("MEDIA_UPGRADE") && get_var("BUILD_SLE") && !get_var("ONLINE_MIGRATION")) {
+        my $build_id = get_var("BUILD_SLE");
+        my $build    = script_output("zypper lr --url | grep -i $build_id", 200, proceed_on_failure => 1);
+        die "System does not upgrade to expected build ID: $build_id" if ($build eq '');
+    }
 }
 
 1;


### PR DESCRIPTION
Checked the system upgrade to expected build ID, only for offline
migration without media upgrade. Only offline migration can get the repo resource from openqa media. We can get build ID from the repo resource.

- Related ticket: https://progress.opensuse.org/issues/91935
- Verification run: 
  s390x media upgrade: https://openqa.suse.de/tests/6010069
  aarch64 online: https://openqa.suse.de/tests/6010068
  ppc64le offline media: http://openqa.suse.de/t6009903
  x86_64 milestone: http://openqa.suse.de/t6009904
  x86_64 HPC: http://openqa.suse.de/t6009900  