### PR TITLE
Set vmware boot device from the input parameter

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -330,7 +330,7 @@ sub run {
 
     # connects to a guest VNC session
     select_console('sut', await_console => 0);
-    vmware_set_permanent_boot_device('cdrom');
+    vmware_set_permanent_boot_device($boot_device);
 }
 
 


### PR DESCRIPTION
For vmware guest booting, it's hard code to boot from cdrom. That will block the guest booting after system rebooting during online upgrade, so changing to get the boot device from the parameter "BOOTFROM".

- Related ticket: https://progress.opensuse.org/issues/88446
- Verification run: https://openqa.nue.suse.com/tests/6033812
