### PR TITLE
Add check_os_release test module to migration test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -480,7 +480,10 @@ sub load_online_migration_tests {
         loadtest "migration/online_migration/zypper_migration";
     }
     loadtest "migration/online_migration/post_migration";
-    loadtest "console/check_system_info" if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
+    if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE'))) {
+        loadtest "console/check_os_release";
+        loadtest "console/check_system_info";
+    }
 }
 
 sub load_patching_tests {
@@ -1199,7 +1202,10 @@ else {
             loadtest "console/consoletest_setup";
             loadtest 'console/integration_services' if is_hyperv || is_vmware;
             loadtest "console/zypper_lr";
-            loadtest "console/check_system_info" if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
+            if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE'))) {
+                loadtest "console/check_os_release";
+                loadtest "console/check_system_info";
+            }
         }
     }
     elsif (get_var("BOOT_HDD_IMAGE") && !is_jeos) {


### PR DESCRIPTION
Add check_os_release test module to migration test for online
migration and offline migration.

- Related ticket: https://progress.opensuse.org/issues/92428
- Verification run: 
 x86_64 offline:  http://openqa.suse.de/t6014769
s390x offline: http://openqa.suse.de/t6014775
ppc64le offline: http://openqa.suse.de/t6014776
aarch64 online: http://openqa.suse.de/t6014777
HPC online:  http://openqa.suse.de/t6014778
