### PR TITLE
Add required test variable check in addon_products_sle

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -152,6 +152,7 @@ sub test_addonurl {
 
 sub run {
     my ($self) = @_;
+    die 'Test module does not support !ADDONS&&!DUD_ADDONS&&!ADDONURL. Suggestion, specify "ADDONS: all-packages" to check that "Base" and "Server" are selected' unless get_var('ADDONS') || get_var('DUD_ADDONS') || get_var('ADDONURL');
 
     if (get_var('SKIP_INSTALLER_SCREEN', 0)) {
         advance_installer_window('inst-addon');


### PR DESCRIPTION
Inspired by https://chat.suse.de/channel/testing?msg=rKHctyBaEhq5wBPcW

Verification runs:

```
MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12534 https://openqa.suse.de/tests/6014937,https://openqa.suse.de/tests/5990308,https://openqa.suse.de/tests/5989113,https://openqa.suse.de/tests/5989102
```

* [sle-15-SP3-Full-x86_64-BuildBuild183.1_oorlov-skip_registration@64bit](https://openqa.suse.de/t6015394)
* [sle-15-SP3-Online-x86_64-Build187.1-addon-module-ftp@64bit](https://openqa.suse.de/t6015395)
* [sle-15-SP3-Full-x86_64-Build187.1-select_modules_and_patterns+registration@uefi](https://openqa.suse.de/t6015396)
* [sle-15-SP3-Full-x86_64-Build187.1-skip_registration@64bit](https://openqa.suse.de/t6015397)
* [sle-15-SP3-Online-x86_64-Build183.1-create_hdd_gnome@svirt-xen-hvm](https://openqa.suse.de/t6016694)