### PR TITLE
pynfs: Initialize pynfs test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -739,6 +739,14 @@ elsif (get_var("BTRFS_PROGS")) {
     loadtest "btrfs-progs/run";
     loadtest "btrfs-progs/generate_report";
 }
+elsif (get_var("PYNFS")) {
+    prepare_target;
+    if (check_var('PYNFS', 'installation')) {
+        loadtest "pynfs/install";
+        loadtest "pynfs/run";
+        loadtest "pynfs/generate_report";
+    }
+}
 elsif (get_var("VIRT_AUTOTEST")) {
     if (get_var('REPO_0_TO_INSTALL', '')) {
         #Before host installation starts, swtich to version REPO_0_TO_INSTALL if it is set

--- a/tests/pynfs/generate_report.pm
+++ b/tests/pynfs/generate_report.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Upload logs and generate report
+# Maintainer: Yong Sun <yosun@suse.com>
+package generate_report;
+
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use File::Basename;
+use testapi;
+use upload_system_log;
+
+sub upload_log {
+    my $log_file = "./log.txt";
+    my $timeout  = 90;
+    my $folder   = get_required_var('PYNFS') || 'nfs4.0';
+    assert_script_run("cd ~/pynfs/$folder");
+
+    #show failures and save to log
+    script_run('../nfs4.0/showresults.py log.txt | grep -A 2 FAILURE | grep -v PASS | tee fails.txt');
+    upload_logs('fails.txt', timeout => $timeout, log_name => 'upload-failure');
+
+    #raw log
+    upload_logs($log_file, timeout => $timeout, log_name => 'upload-raw');
+
+    #analys log
+    script_run('./showresults.py log.txt > result.txt');
+    upload_logs('result.txt', timeout => $timeout, log_name => 'upload-analys');
+}
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    upload_log();
+    upload_system_logs();
+}
+
+1;

--- a/tests/pynfs/install.pm
+++ b/tests/pynfs/install.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Install pynfs
+# Maintainer: Yong Sun <yosun@suse.com>
+package install;
+
+use 5.018;
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use utils;
+use testapi;
+
+sub install_dependencies {
+    my @deps = qw(
+      git
+      krb5-devel
+      python3-devel
+      swig
+      python3-gssapi
+      python3-ply
+      nfs-client
+      nfs-kernel-server
+    );
+    zypper_call('in ' . join(' ', @deps));
+}
+
+sub install_pynfs {
+    install_dependencies;
+    assert_script_run('git clone -q --depth 1 git://git.linux-nfs.org/projects/bfields/pynfs.git && cd ./pynfs');
+    record_info('pynfs git version', script_output('git log -1 --pretty=format:"git-%h" | tee version.txt'));
+    assert_script_run('./setup.py build && ./setup.py build_ext --inplace');
+}
+
+sub setup_nfs_server {
+    assert_script_run('mkdir -p /exportdir && echo \'/exportdir *(rw,no_root_squash,insecure)\' >/etc/exports && systemctl restart nfs-server');
+}
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Disable PackageKit
+    quit_packagekit;
+
+    install_pynfs;
+    setup_nfs_server;
+}
+
+1;

--- a/tests/pynfs/run.pm
+++ b/tests/pynfs/run.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run tests
+# Maintainer: Yong Sun <yosun@suse.com>
+package run;
+
+use 5.018;
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use File::Basename;
+use testapi;
+use utils;
+use power_action_utils 'power_action';
+
+sub server_test_all {
+    my $self   = shift;
+    my $folder = get_required_var('PYNFS') || 'nfs4.0';
+    assert_script_run("cd ./$folder");
+    script_run('./testserver.py --outfile ${logf:-log.txt} --maketree ${serv:-localhost}:${export:-/exportdir} all', 3600);
+}
+
+
+sub run {
+    my $self = shift;
+    select_console('root-console');
+    script_run('cd ~/pynfs');
+    server_test_all;
+}
+
+1;
+
+=head1 Configuration
+
+Example configuration for SLE:
+
+BOOT_HDD_IMAGE=1
+DESKTOP=textmode
+HDD_1=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2
+PYNFS=nfs4.0
+UEFI_PFLASH_VARS=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed-uefi-vars.qcow2
+START_AFTER_TEST=create_hdd_minimal_base+sdk
+
+=cut


### PR DESCRIPTION
Create pynfs testsuite in openqa. This PR could support nfs-server 4.0 and 4.1 test.
Log enhancement is in todo list, it will not fail when subtests fails is known issue. The installation part not take too much time(only about 3 minutes), so no need to create qcow2 file after installation part.

- Related ticket: https://progress.opensuse.org/issues/91353
- Verification run: 
nfs4.0 http://10.67.133.133/tests/33#step/run/4
nfs4.1 http://10.67.133.133/tests/35#step/run/4