### PR TITLE
Schedule existing console tests to qem

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -30,6 +30,8 @@ schedule:
   - console/aaa_base
   - console/gd
   - console/systemtap
+  - console/openvswitch_ssl
+  - console/journald_fss
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:
@@ -71,4 +73,7 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/mutt
+        - console/vsftpd
+      aarch64:
+        - console/vsftpd
 ...


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/93264
- Needles: N/A
- Verification run: 
x86_64 : [15-SP2](http://10.161.229.247/tests/1885) | [15-SP1](https://openqa.suse.de/tests/6033325) | [15 ](https://openqa.suse.de/tests/6032174#details) | [12-SP5](https://openqa.suse.de/tests/6033329) | [12-SP4](https://openqa.suse.de/tests/6033330) | [12-SP3](https://openqa.suse.de/tests/6033331)
aarch64 : [15-SP2](https://openqa.suse.de/tests/6037537) | [15-SP1](https://openqa.suse.de/tests/6037540) | [15](https://openqa.suse.de/tests/6037542) | [12-SP5](https://openqa.suse.de/tests/6037545) 
s390x : [15-SP3](https://openqa.suse.de/tests/6143649#step/journald_fss/20) | [15-SP2](https://openqa.suse.de/tests/6143650#step/journald_fss/20) | [15-SP1](https://openqa.suse.de/tests/6143651#step/journald_fss/20) | [15](https://openqa.suse.de/tests/6143844#step/journald_fss/20) | [12-SP5](https://openqa.suse.de/tests/6143653#step/journald_fss/20)

