### PR TITLE
Support tracker3 on modern distros

### DIFF
--- a/tests/x11/tracker/tracker_by_command.pm
+++ b/tests/x11/tracker/tracker_by_command.pm
@@ -24,7 +24,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_leap);
 
 sub run {
     x11_start_program('xterm');
@@ -32,11 +32,12 @@ sub run {
         script_run "tracker-search newfile";
     }
     else {
-        script_run 'tracker search emtpyfile';
+        my $trackercmd = (is_sle('<16') or is_leap('<16.0')) ? 'tracker' : 'tracker3';
+        script_run "$trackercmd search emtpyfile";
         record_soft_failure 'bsc#1074582 tracker can not index empty file automatically' if check_screen 'tracker-cmdsearch-noemptyfile', 30;
         # Wait 20s for tracker to index the test file
         wait_still_screen 20;
-        script_run "tracker search newfile";
+        script_run "$trackercmd search newfile";
     }
     assert_screen 'tracker-cmdsearch-newfile';
     send_key 'alt-f4';

--- a/tests/x11/tracker/tracker_by_command.pm
+++ b/tests/x11/tracker/tracker_by_command.pm
@@ -34,9 +34,7 @@ sub run {
     else {
         my $trackercmd = (is_sle('<16') or is_leap('<16.0')) ? 'tracker' : 'tracker3';
         script_run "$trackercmd search emptyfile";
-        record_soft_failure 'bsc#1074582 tracker can not index empty file automatically' if check_screen 'tracker-cmdsearch-noemptyfile', 30;
-        # Wait 20s for tracker to index the test file
-        wait_still_screen 20;
+        assert_screen('tracker-cmdsearch-emptyfile');
         script_run "$trackercmd search newfile";
     }
     assert_screen 'tracker-cmdsearch-newfile';

--- a/tests/x11/tracker/tracker_by_command.pm
+++ b/tests/x11/tracker/tracker_by_command.pm
@@ -12,7 +12,7 @@
 # Summary: Tracker: search from command line
 # - Launch xterm
 # - Run "tracker-search newfile" if version is older than SLE12SP2
-# - Otherwise, run "tracker search emtpyfile"
+# - Otherwise, run "tracker search emptyfile"
 # - Wait 20 seconds, run "tracker search newfile"
 # - Check output of command
 # - Close xterm
@@ -33,7 +33,7 @@ sub run {
     }
     else {
         my $trackercmd = (is_sle('<16') or is_leap('<16.0')) ? 'tracker' : 'tracker3';
-        script_run "$trackercmd search emtpyfile";
+        script_run "$trackercmd search emptyfile";
         record_soft_failure 'bsc#1074582 tracker can not index empty file automatically' if check_screen 'tracker-cmdsearch-noemptyfile', 30;
         # Wait 20s for tracker to index the test file
         wait_still_screen 20;

--- a/tests/x11/tracker/tracker_info.pm
+++ b/tests/x11/tracker/tracker_info.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_leap);
 
 sub run {
     x11_start_program('xterm');
@@ -31,7 +31,8 @@ sub run {
         script_run "tracker-info newpl.pl";
     }
     else {
-        script_run "tracker info newpl.pl";
+        my $trackercmd = (is_sle('<16') or is_leap('<16.0')) ? 'tracker' : 'tracker3';
+        script_run "$trackercmd info newpl.pl";
     }
     assert_screen 'tracker-info-newpl';
     send_key "alt-f4";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/71932
- Needles: new needle required for tracker-cmdsearch-emptyfile, possible with softfail if not matched
- Verification run: https://openqa.opensuse.org/tests/1749334
