### PR TITLE
xfstests: use activate_kdump_cli to enable kdump

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -46,7 +46,7 @@ sub run {
 
     # Activate kdump
     prepare_for_kdump;
-    activate_kdump_without_yast;
+    activate_kdump_cli;
 
     # Reboot
     power_action('reboot');


### PR DESCRIPTION
 xfstests: use activate_kdump_cli to enable kdump

- Related ticket: https://progress.opensuse.org/issues/92752
- Needles: N/A
- Verification run: http://10.67.134.217/tests/11976