### PR TITLE
Add hardfail for empty downloaded update repo

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -81,6 +81,9 @@ sub run {
         assert_script_run("echo 'Download completed' >> ~/repos/qem_download_status.txt");
         upload_logs('/tmp/repos.list.txt');
         upload_logs('qem_download_status.txt');
+        # Ensure the repos are not empty, otherwise we have the wrong template link
+        $size = script_output('du -s ~/repos | awk \'{print$1}\'');
+        die "Empty test repositories" if (!get_var('QAM_PUBLICCLOUD_IGNORE_EMPTY_REPO', 0) && $size < 10000);
     }
     assert_script_run("cd");
 }


### PR DESCRIPTION
When the downloaded update repository is empty (<10 MB), the
publiccloud download repo test now triggers a hardfailure.

- Related ticket: https://progress.opensuse.org/issues/92599
- Verification run: [12-SP5](http://duck-norris.qam.suse.de/tests/6096) | [15-SP2](http://duck-norris.qam.suse.de/tests/6097) | [15-SP2 with empty repos](http://duck-norris.qam.suse.de/tests/6098#step/download_repos/54) (expected failure)
