### PR TITLE
lib/transactional: Don't pass --no-selfupdate to transactional-update

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -149,7 +149,7 @@ sub trup_call {
     # Always wait for rollback.service to be finished before triggering manually transactional-update
     ensure_rollback_service_not_running();
 
-    script_run "transactional-update --no-selfupdate $cmd", 0;
+    script_run "transactional-update $cmd", 0;
     if ($cmd =~ /pkg |ptf /) {
         if (wait_serial "Continue?") {
             send_key "ret";


### PR DESCRIPTION
In some scenarios, like upgrading an older system to the newest version, doing
the selfupdate is actually wanted and sometimes even necessary.

It's a no-op in cases where the running system is equal or newer than the
active repositories, so this should not make a difference in other tests.

Related bug: https://bugzilla.opensuse.org/show_bug.cgi?id=1185290
Verification run:
MicroOS old to MicroOS next: http://10.160.67.86/tests/962
MicroOS DVD install: http://10.160.67.86/tests/963