### PR TITLE
Uploaded zypper lr log, deleted duplicated check and updated leap to sle bless list check

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils;
 use registration;
 use List::MoreUtils 'uniq';
 
@@ -31,21 +31,21 @@ sub run {
     select_console('root-console');
     assert_script_run('setterm -blank 0') unless (check_var('ARCH', 's390x'));
 
-    assert_script_run("SUSEConnect --status-text > /dev/$serialdev", timeout => 180);
-
     if (!get_var('MILESTONE_VERSION')) {
         assert_script_run('cat /etc/issue');
     } else {
         my $milestone_version = get_var('MILESTONE_VERSION');
         assert_script_run("grep -w $milestone_version /etc/issue");
     }
-    assert_script_run('cat /etc/os-release');
+
+    script_run('zypper lr | tee /tmp/zypperlr.txt');
 
     my $myaddons = get_var('SCC_ADDONS', "");
-    $myaddons = $myaddons . ",base,serverapp"                             if (is_sle('15+') && check_var('SLE_PRODUCT', 'sles'));
-    $myaddons = $myaddons . ",base,desktop,we,python2"                    if (is_sle('15+') && check_var('SLE_PRODUCT', 'sled'));
-    $myaddons = $myaddons . ",base,serverapp,desktop,dev,lgm,python2,wsm" if (is_sle('<15', get_var('ORIGIN_SYSTEM_VERSION')) && is_sle('15+'));
-    $myaddons = $myaddons . ",python2"                                    if (is_sle('=15', get_var('ORIGIN_SYSTEM_VERSION')) && is_sle('15+'));
+    $myaddons .= ",base,serverapp"                                  if (is_sle('15+')                                   && check_var('SLE_PRODUCT', 'sles'));
+    $myaddons .= ",base,desktop,we,python2"                         if (is_sle('15+')                                   && check_var('SLE_PRODUCT', 'sled'));
+    $myaddons .= ",base,serverapp,desktop,dev,lgm,python2,wsm"      if (is_sle('<15', get_var('ORIGIN_SYSTEM_VERSION')) && is_sle('15+'));
+    $myaddons .= ",python2"                                         if (is_sle('=15', get_var('ORIGIN_SYSTEM_VERSION')) && is_sle('15+'));
+    $myaddons .= ",base,serverapp,desktop,dev,lgm,python2,wsm,phub" if (is_leap_migration);
 
     # After upgrade, system doesn't include ltss extension
     $myaddons =~ s/ltss,?//g;
@@ -61,6 +61,12 @@ sub run {
         my $out = script_output("zypper lr | grep -i $name", 200, proceed_on_failure => 1);
         die "zypper lr command output does not include $name" if ($out eq '');
     }
+}
+
+sub post_fail_hook {
+    my $self = shift;
+    upload_logs '/tmp/zypperlr.txt';
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
If check_system_info failed, upload zypper lr log
Deleted duplicated check at check_system_info module
Leap to sle upgrade bless list need be added

- Related ticket: https://progress.opensuse.org/issues/92638
https://progress.opensuse.org/issues/92632
https://progress.opensuse.org/issues/92641
- Verification run: 
y2log check: https://openqa.suse.de/tests/6058032
leap to sle: https://openqa.suse.de/tests/6058052#
https://openqa.suse.de/tests/6058711#details