### PR TITLE
Load pynfs also on o3

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -77,6 +77,7 @@ our @EXPORT = qw(
   load_nfv_master_tests
   load_nfv_trafficgen_tests
   load_public_cloud_patterns_validation_tests
+  load_pynfs_tests
   load_transactional_role_tests
   load_reboot_tests
   load_rescuecd_tests
@@ -3238,6 +3239,12 @@ sub load_kernel_baremetal_tests {
     loadtest "toolchain/install";
     # some tests want to build and run a custom kernel
     loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
+}
+
+sub load_pynfs_tests {
+    loadtest "pynfs/install";
+    loadtest "pynfs/run";
+    loadtest "pynfs/generate_report";
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -268,6 +268,10 @@ if (is_kernel_test()) {
 elsif (get_var('NFV')) {
     load_nfv_tests();
 }
+elsif (get_var("PYNFS")) {
+    loadtest "boot/boot_to_desktop";
+    load_pynfs_tests;
+}
 elsif (get_var("REGRESSION")) {
     load_common_x11;
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -744,11 +744,7 @@ elsif (get_var("BTRFS_PROGS")) {
 }
 elsif (get_var("PYNFS")) {
     prepare_target;
-    if (check_var('PYNFS', 'installation')) {
-        loadtest "pynfs/install";
-        loadtest "pynfs/run";
-        loadtest "pynfs/generate_report";
-    }
+    load_pynfs_tests;
 }
 elsif (get_var("VIRT_AUTOTEST")) {
     if (get_var('REPO_0_TO_INSTALL', '')) {


### PR DESCRIPTION
This requires to move loading pynfs to new function load_pynfs_tests().

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

Related ticket: https://progress.opensuse.org/issues/91353
Fixes: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12535 

Verification run:
- sles 15sp3: http://quasar.suse.cz/tests/6729
- openSUSE Tumbleweed: http://quasar.suse.cz/tests/6728 http://quasar.suse.cz/tests/6727
