### PR TITLE
microos/journal_check: Add workaround for boo#1182961

### DIFF
--- a/tests/microos/journal_check.pm
+++ b/tests/microos/journal_check.pm
@@ -43,6 +43,7 @@ sub run {
         bsc_1177695         => 'kernel: parport_pc: `none\' invalid for parameter `dma\'',
         bsc_1178033         => 'kernel: ITS@0x8080000: Unable to locate ITS domain handle',
         bsc_1182500         => 'Failed to transition into init label \'system_u:system_r:init_t:s0\'',
+        bsc_1182961         => 'could not read from \'/sys/module/pcc_cpufreq/initstate\': No such device',
         bsc_1184970         => '.*rpc\.statd.*Failed to stat \/var\/lib\/nfs\/sm: No such file or directory',
         bsc_000000_FEATURE  => 'health-checker/fail.sh check" failed|Machine didn\'t come up correct, do a rollback',
     };


### PR DESCRIPTION
Add that error message to the whitelist, it's a WONTFIX bug.

Verification run: https://openqa.opensuse.org/tests/1748838
Only happens rarely, so probably won't show this PR "in action".
