### PR TITLE
Ignore Lynis WARNING "Test long execution" totally

### DIFF
--- a/lib/lynis/lynistest.pm
+++ b/lib/lynis/lynistest.pm
@@ -252,7 +252,7 @@ sub compare_lynis_section_content {
             # "File systems": "[WARNING]: Test BINARY-1000 had a long execution: 123.139555 seconds"
             # "Ports and packages": "[WARNING]: Test PKGS-7308 had a long execution: 21.594952 seconds"
             #    "[WARNING]: Test PKGS-7328 had a long execution: 11.963337 seconds"
-            my @exceptions = ("\\[WARNING\\]: Test .* had a long execution: .* seconds");
+            my @exceptions = ("  \\[WARNING\\]: Test .* had a long execution: .* seconds");
             for my $exception (@exceptions) {
                 if ($str_section_baseline =~ m/$exception/ || $str_section_current =~ m/$exception/) {
                     $str_section_baseline =~ s/$exception//g;


### PR DESCRIPTION
Sometimes Lynis tests will have a long execution then the output will contain this kind of warnings (  [WARNING]: Test CORE-1000 had a long execution: 15.772212 seconds).
The original PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12527
handles this issue to ignore the warnings on purpose but the fix is incomplete when comparing with baselines.
This PR will fix the defect.

poo#92614 - [Tumbleweed][security] test fails in 4_[+]_Boot_and_services

- Related ticket: https://progress.opensuse.org/issues/92614
- Needles: NA
- Verification run: https://openqa.opensuse.org/tests/1748514