### PR TITLE
Remove WORKER_CLASS setting from the 15SP3 HA YAML

### DIFF
--- a/schedule/ha/qam/common/qam_cluster_node.yaml
+++ b/schedule/ha/qam/common/qam_cluster_node.yaml
@@ -37,7 +37,6 @@ vars:
   # LVM locking daemon used since SLE 15
   USE_SUPPORT_SERVER: '1'
   VIRTIO_CONSOLE: '0'
-  WORKER_CLASS: tap
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-HA-BV.qcow2
 schedule:


### PR DESCRIPTION
The WORKER_CLASS setting shouldn't be in the YAML scheduling file.

- Failed test: https://openqa.suse.de/tests/6057860#step/iscsi_client/5
- Related ticket: https://progress.opensuse.org/issues/92527
- Needles: N/A
- Verification run: N/A
