### PR TITLE
lib/transactional: Verify exit status in trup_call

### DIFF
--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -53,7 +53,7 @@ sub rbm_set_window {
 #1 Test instant reboot
 sub check_strategy_instantly {
     rbm_call "set-strategy instantly";
-    trup_call "reboot ptf install" . rpmver('interactive'), 0;
+    trup_call "reboot ptf install" . rpmver('interactive');
     process_reboot(expected_grub => is_pvm() ? 0 : 1);
     rbm_call "get-strategy | grep instantly";
 }
@@ -64,7 +64,7 @@ sub check_strategy_maint_window {
 
     # Trigger reboot during maint-window
     rbm_set_window '-5minutes';
-    trup_call "reboot pkg install" . rpmver('feature'), 0;
+    trup_call "reboot pkg install" . rpmver('feature');
     process_reboot(expected_grub => is_pvm() ? 0 : 1);
 
     # Trigger reboot and wait for maintenance window

--- a/tests/transactional/tdup.pm
+++ b/tests/transactional/tdup.pm
@@ -39,7 +39,7 @@ sub run {
 
     zypper_call '--gpg-auto-import-keys ref';
 
-    trup_call 'dup';
+    trup_call 'dup', timeout => 600;
 
     check_reboot_changes;
 }

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -99,7 +99,7 @@ sub run {
     if (is_leap) {
         record_info 'Broken packages test skipped';
     } else {
-        trup_call "cleanup up", 2;
+        trup_call "cleanup up", exit_code => 1;
         check_reboot_changes 0;
     }
 


### PR DESCRIPTION
While trup_call has code for waiting for the exit status, it didn't do much:
- It waited only for the expected exit status, so a mismatch would time out
- Mismatches were ignored completely

This commit changes it so that trup_call waits for transactional-update to
finish and then succeeds only exit status is as expected.

This is only possible when removing the code for the "$check == 0" case, but
that doesn't appear to be necessary: Even with rebootmgr doing an instant
reboot, the exit status reaches the serial console. This is not guaranteed by
the code (rebootmgrd calls systemctl reboot, both are async), but appears to
work in practice.

Opinions or suggestions on ^ are appreciated. (cc @laenion).

Verification runs:

microos-old2microosnext: https://openqa.opensuse.org/tests/1751180
microos: https://openqa.opensuse.org/tests/1751181
