### PR TITLE
Increase timeout for yast_users

### DIFF
--- a/tests/yast2_cmd/yast_users.pm
+++ b/tests/yast2_cmd/yast_users.pm
@@ -35,7 +35,7 @@ sub run {
     if (script_run("yast users add username=test_yast password=suse") != 0) {
         record_soft_failure("bsc#1143516 for SLE15+: exit code is NOT zero");
     }
-    validate_script_output("yast users list local 2>&1 || echo BUG#1143516", sub { (m/test_yast/) and ((m/^BUG#1143516$/m) ? (!record_soft_failure("bsc#1143516 for SLE12SP2: exit code is NOT zero")) : return 1) });
+    validate_script_output("yast users list local 2>&1", sub { (m/test_yast/) }, timeout => 150);
 
     # changes the passwd of the new user and homedir, and delete this user
     assert_script_run("yast users edit username=test_yast new_uid=44444 home=/tmp/test_yast");


### PR DESCRIPTION
BUG#1143516 is resolved, so soft failure is be removed. Bumping timeout for "#yast users list local" due to sporadic timeout failures.

- Related ticket: https://progress.opensuse.org/issues/92431
- Verification runs: https://openqa.suse.de/tests/6058364#next_previous
(there seemed to be multiple unrelated issues with yast_users so a lot of VRs fail)
