### PR TITLE
x11/evolution/evolution_prepare_servers: Use openssl(cli) instead

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -38,7 +38,7 @@ sub run() {
         zypper_call("ar ${dovecot_repo} dovecot_repo");
 
         zypper_call("--gpg-auto-import-keys ref");
-        zypper_call("in dovecot /usr/bin/openssl", exitcode => [0, 102, 103]);
+        zypper_call("in dovecot 'openssl(cli)'", exitcode => [0, 102, 103]);
         zypper_call("rr dovecot_repo");
     } else {
         if (is_opensuse) {
@@ -46,7 +46,7 @@ sub run() {
             zypper_call("in --force-resolution postfix", exitcode => [0, 102, 103]);
             systemctl 'start postfix';
         }
-        zypper_call("in dovecot /usr/bin/openssl",   exitcode => [0, 102, 103]);
+        zypper_call("in dovecot 'openssl(cli)'",     exitcode => [0, 102, 103]);
         zypper_call("in --force-resolution postfix", exitcode => [0, 102, 103]) if is_jeos;
     }
 


### PR DESCRIPTION
Apparently the /usr/bin/openssl capability is only available if some other
package needs it, which isn't the case in some distros.

Verification runs:
Tumbleweed: https://openqa.opensuse.org/tests/1748925
15.3: https://openqa.opensuse.org/tests/1748924

On 42.3 I ran `zypper in 'openssl(cli)'` manually with success.