### PR TITLE
Adjust yast2_storage_ng test for the 15-sp3 runs

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1424,10 +1424,10 @@ sub load_extra_tests_y2uitest_gui {
     # On openSUSE, the scheduling happens in schedule/yast2_gui.yaml
     if (get_var("QAM_YAST2UI")) {
         loadtest "yast2_gui/yast2_bootloader" if is_sle("12-SP2+");
-        loadtest "yast2_gui/yast2_storage_ng" if is_sle("15+") || is_leap("15.0+") || is_tumbleweed;
         loadtest "yast2_gui/yast2_security"   if is_sle("12-SP2+");
         loadtest "yast2_gui/yast2_keyboard"   if is_sle("12-SP2+");
         loadtest "yast2_gui/yast2_instserver" unless (is_sle('<12-SP3') || is_leap('<15.0'));
+        loadtest "yast2_gui/yast2_storage_ng" if is_sle("15+") || is_leap("15.0+") || is_tumbleweed;
     }
 }
 

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -132,6 +132,12 @@ sub test_http_instserver {
     # finish wizard
     send_key_and_wait("alt-f", 3);
     # check that the http instserver is working
+    if (is_sle("15-sp3+")) {
+        select_console "root-console";
+        zypper_call 'rm --clean-deps apache2';
+        zypper_call 'in apache2';
+        assert_script_run("systemctl start apache2");
+    }
     x11_start_program "xterm";
     wait_still_screen 2, 2;
     validate_script_output("curl -s http://localhost/test/instserver/CD1/ | grep title", sub { m/.*Index of \/test\/instserver\/CD1.*/ });
@@ -164,7 +170,7 @@ sub run {
     # clean existing config
     start_yast2_instserver;
     clean_env;
-}
 
+}
 1;
 


### PR DESCRIPTION
`yast2_storage_ng` fails in 15-sp3 Maintenance:Test Repo in osd, because of some changes in the yast2 GUI

- Related ticket: https://progress.opensuse.org/issues/92524
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1533 + https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1535
- Verification run: SLES [15-SP3](https://openqa.suse.de/tests/6129977#step/yast2_storage_ng/78) | [15-SP2](https://openqa.suse.de/tests/6129981#step/yast2_storage_ng/84) | [15-SP1](https://openqa.suse.de/tests/6130046#step/yast2_storage_ng/86) | [15](https://openqa.suse.de/tests/6130047#step/yast2_storage_ng/85) 