### PR TITLE
Pynfs: Detect test failure and other fixes

### DIFF
--- a/tests/pynfs/generate_report.pm
+++ b/tests/pynfs/generate_report.pm
@@ -19,21 +19,17 @@ use testapi;
 use upload_system_log;
 
 sub upload_log {
-    my $log_file = "./log.txt";
-    my $timeout  = 90;
-    my $folder   = get_required_var('PYNFS');
+    my $folder = get_required_var('PYNFS');
+
     assert_script_run("cd ~/pynfs/$folder");
 
-    #show failures and save to log
-    script_run('../nfs4.0/showresults.py log.txt | grep -A 2 FAILURE | grep -v PASS | tee fails.txt');
-    upload_logs('fails.txt', timeout => $timeout, log_name => 'upload-failure');
+    upload_logs('result-raw.txt', failok => 1);
 
-    #raw log
-    upload_logs($log_file, timeout => $timeout, log_name => 'upload-raw');
+    script_run('../showresults.py result-raw.txt > result-analysis.txt');
+    upload_logs('result-analysis.txt', failok => 1);
 
-    #analys log
-    script_run('./showresults.py log.txt > result.txt');
-    upload_logs('result.txt', timeout => $timeout, log_name => 'upload-analys');
+    script_run('grep -A 2 FAILURE result-analysis.txt | grep -v PASS > result-fail.txt');
+    upload_logs('result-fail.txt', failok => 1);
 }
 
 sub run {

--- a/tests/pynfs/generate_report.pm
+++ b/tests/pynfs/generate_report.pm
@@ -21,7 +21,7 @@ use upload_system_log;
 sub upload_log {
     my $log_file = "./log.txt";
     my $timeout  = 90;
-    my $folder   = get_required_var('PYNFS') || 'nfs4.0';
+    my $folder   = get_required_var('PYNFS');
     assert_script_run("cd ~/pynfs/$folder");
 
     #show failures and save to log

--- a/tests/pynfs/generate_report.pm
+++ b/tests/pynfs/generate_report.pm
@@ -19,6 +19,7 @@ use testapi;
 use upload_system_log;
 
 sub upload_log {
+    my $self   = shift;
     my $folder = get_required_var('PYNFS');
 
     assert_script_run("cd ~/pynfs/$folder");
@@ -30,13 +31,18 @@ sub upload_log {
 
     script_run('grep -A 2 FAILURE result-analysis.txt | grep -v PASS > result-fail.txt');
     upload_logs('result-fail.txt', failok => 1);
+
+    if (script_run('[ -s result-fail.txt ]') == 0) {
+        $self->result("fail");
+        record_info("failed tests", script_output('cat result-fail.txt'), result => 'fail');
+    }
 }
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    upload_log();
+    $self->upload_log();
     upload_system_logs();
 }
 

--- a/tests/pynfs/install.pm
+++ b/tests/pynfs/install.pm
@@ -35,7 +35,7 @@ sub install_dependencies {
 sub install_pynfs {
     install_dependencies;
     assert_script_run('git clone -q --depth 1 git://git.linux-nfs.org/projects/bfields/pynfs.git && cd ./pynfs');
-    record_info('pynfs git version', script_output('git log -1 --pretty=format:"git-%h" | tee version.txt'));
+    record_info('pynfs git version', script_output('git log -1 --pretty=format:"git-%h" | tee'));
     assert_script_run('./setup.py build && ./setup.py build_ext --inplace');
 }
 

--- a/tests/pynfs/run.pm
+++ b/tests/pynfs/run.pm
@@ -22,11 +22,11 @@ use power_action_utils 'power_action';
 
 sub server_test_all {
     my $self   = shift;
-    my $folder = get_required_var('PYNFS') || 'nfs4.0';
+    my $folder = get_required_var('PYNFS');
+
     assert_script_run("cd ./$folder");
     script_run('./testserver.py --outfile log.txt --maketree localhost:/exportdir all', 3600);
 }
-
 
 sub run {
     my $self = shift;

--- a/tests/pynfs/run.pm
+++ b/tests/pynfs/run.pm
@@ -30,7 +30,8 @@ sub server_test_all {
 
 sub run {
     my $self = shift;
-    select_console('root-console');
+    $self->select_serial_terminal;
+
     script_run('cd ~/pynfs');
     server_test_all;
 }

--- a/tests/pynfs/run.pm
+++ b/tests/pynfs/run.pm
@@ -24,7 +24,7 @@ sub server_test_all {
     my $self   = shift;
     my $folder = get_required_var('PYNFS') || 'nfs4.0';
     assert_script_run("cd ./$folder");
-    script_run('./testserver.py --outfile ${logf:-log.txt} --maketree ${serv:-localhost}:${export:-/exportdir} all', 3600);
+    script_run('./testserver.py --outfile log.txt --maketree localhost:/exportdir all', 3600);
 }
 
 

--- a/tests/pynfs/run.pm
+++ b/tests/pynfs/run.pm
@@ -25,7 +25,7 @@ sub server_test_all {
     my $folder = get_required_var('PYNFS');
 
     assert_script_run("cd ./$folder");
-    script_run('./testserver.py --outfile log.txt --maketree localhost:/exportdir all', 3600);
+    script_run('./testserver.py --outfile result-raw.txt --maketree localhost:/exportdir all', 3600);
 }
 
 sub run {


### PR DESCRIPTION
Few commits to to improve 
* b751e9f5d pynfs: Detect test failure
* 70f68fa73 pynfs/generate_report: Log generation cleanup
* bc444c3f9 pynfs: Remove unused version.txt
* 26ec03097 pynfs: Use serial/virtio console
* 513bae192 pynfs: Remove useless default parameter
* a86b32010 pynfs: Cleanup testserver.py startup

Related ticket: https://progress.opensuse.org/issues/91353
Fixes: #12535
Verification run:
It contains detected failures, which was the main point of this PR
- SLES 15 SP3: http://quasar.suse.cz/tests/6752#step/generate_report/30
- Tumbleweed: http://quasar.suse.cz/tests/6750#step/generate_report/30, http://quasar.suse.cz/tests/6751#step/generate_report/30
