### PR TITLE
Windows 10 installer refresh for 21H1 major update

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -82,7 +82,6 @@ sub run_in_powershell {
         wait_screen_change(sub { send_key 'ret' }, 10);
         wait_serial("${rc_hash}True", timeout => (exists $args{timeout}) ? $args{timeout} : 30) or
           die "Expected string (${rc_hash}True) was not found on serial";
-        send_key 'ctrl-l';
     }
 }
 

--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -8,11 +8,9 @@
 # without any warranty.
 
 # Summary: Boot windows image for the first time and provide basic user environment configuration
-# Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+# Maintainer: QAC team <qa-c@suse.de>
 
-use base "windowsbasetest";
-use strict;
-use warnings;
+use Mojo::Base qw(windowsbasetest);
 use testapi;
 
 sub run {
@@ -37,13 +35,13 @@ sub run {
     wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
     assert_and_click 'windows-create-account';
     wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
-    type_string $realname;    # input account name
+    type_string $realname;
     wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
     save_screenshot;
     assert_and_click 'windows-next';
     for (1 .. 2) {
         sleep 3;
-        type_password;        # input password
+        type_password;
         save_screenshot;
         assert_and_click 'windows-next';
     }
@@ -59,20 +57,13 @@ sub run {
         assert_and_click 'windows-next';
     }
 
-    foreach my $tag (qw(
-        windows-dont-use-speech-recognition
-        windows-turn-off-find-device
-        windows-dont-improve-inking&typing
-        windows-dont-user-my-location
-        windows-send-full-diagnostic-data
-        )) {
+    my $count        = 0;
+    my @privacy_menu = split(',', get_required_var('WIN_INSTALL_PRIVACY_NEEDLES'));
+    foreach my $tag (@privacy_menu) {
+        send_key('pgdn') if (++$count == 4);
         assert_and_click $tag;
         wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
     }
-
-    send_key 'pgdn';
-    assert_and_click 'windows-dont-get-tailored-experiences';
-    assert_and_click 'windows-dont-use-adID';
     assert_and_click 'windows-accept';
 
     assert_screen 'windows-make-cortana-personal-assistant';
@@ -113,6 +104,8 @@ sub run {
     $self->run_in_powershell(cmd => 'Get-AppxPackage -allusers Microsoft.XboxApp | Remove-AppxPackage');
     $self->run_in_powershell(cmd => 'Get-AppxPackage -allusers Microsoft.XboxGamingOverlay | Remove-AppxPackage');
     $self->run_in_powershell(cmd => 'Get-AppxPackage -allusers Microsoft.YourPhone | Remove-AppxPackage');
+    # remove cortana
+    $self->run_in_powershell(cmd => 'Get-AppxPackage -allusers Microsoft.549981C3F5F10 | Remove-AppxPackage');
 
     # poweroff
     $self->reboot_or_shutdown();

--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -32,11 +32,11 @@ q{New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppMod
     }
 };
 
-my $ms_kernel_link = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi';
 
 sub run {
     my ($self)            = @_;
     my $wsl_appx_filename = (split /\//, get_required_var('ASSET_1'))[-1];
+    my $ms_kernel_link    = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi';
     my $certs             = {
         opensuse => '/wsl/openSUSE-UEFI-CA-Certificate.crt',
         sle      => '/wsl/SLES-UEFI-CA-Certificate.crt'


### PR DESCRIPTION
MS has released new major update for Win10, therefore minor needle
changes had to be introduced in our installer job.

As of now, privacy menu list is driven by the list of needles specified in
`WIN_INSTALL_PRIVACY_NEEDLES` job variable.

- [needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/726)
- VRs
  * [bios_boot](http://kepler.suse.cz/tests/4996#step/ms_win_firstboot/75)
  * [uefi](http://kepler.suse.cz/tests/4997#live)