### PR TITLE
Add autofs tests for sles 15 sp3 functional

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -102,7 +102,6 @@ our @EXPORT = qw(
   load_hypervisor_tests
   load_yast2_gui_tests
   load_zdup_tests
-  load_mm_autofs_tests
   logcurrentenv
   map_incidents_to_repo
   need_clear_repos
@@ -3200,24 +3199,6 @@ sub load_lvm_tests {
         }
         else {
             loadtest 'installation/partitioning/lvm';
-        }
-    }
-}
-
-sub load_mm_autofs_tests {
-    if (get_var('AUTOFS')) {
-        set_var('INSTALLONLY', 1);
-        if (check_var('HOSTNAME', 'server')) {
-            barrier_create('AUTOFS_SUITE_READY', 2);
-            barrier_create('AUTOFS_FINISHED',    2);
-        }
-        boot_hdd_image;
-        loadtest 'network/setup_multimachine';
-        if (check_var('HOSTNAME', 'server')) {
-            loadtest "network/autofs_server";
-        }
-        else {
-            loadtest "network/autofs_client";
         }
     }
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -311,9 +311,6 @@ elsif (get_var('SECURITY_TEST')) {
     prepare_target();
     load_security_tests;
 }
-elsif (get_var('AUTOFS')) {
-    load_mm_autofs_tests;
-}
 else {
     if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {
         load_boot_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1164,9 +1164,6 @@ else {
             loadtest 'x11/evolution/evolution_meeting_pop';
         }
     }
-    elsif (get_var('AUTOFS')) {
-        load_mm_autofs_tests;
-    }
     elsif (get_var('UPGRADE_ON_ZVM')) {
         # Set origin and target version
         set_var('ORIGIN_SYSTEM_VERSION',  get_var('BASE_VERSION'));

--- a/schedule/functional/autofs.yaml
+++ b/schedule/functional/autofs.yaml
@@ -1,0 +1,16 @@
+---
+name: autofs
+description: >
+    Maintainer: zluo
+    Install and test autofs server on SLES
+conditional_schedule:
+    autofs:
+        HOSTNAME:
+            'client':
+                - network/autofs_client
+            'server':
+                - network/autofs_server
+schedule:
+    - boot/boot_to_desktop
+    - network/setup_multimachine
+    - '{{autofs}}'

--- a/tests/network/autofs_client.pm
+++ b/tests/network/autofs_client.pm
@@ -47,6 +47,9 @@ use strict;
 use warnings;
 
 sub run {
+    # autofs client needs mutex_wait
+    mutex_wait 'barrier_setup_done';
+
     select_console "root-console";
     my $nfs_server              = "10.0.2.101";
     my $remote_mount            = "/tmp/nfs/server";

--- a/tests/network/autofs_server.pm
+++ b/tests/network/autofs_server.pm
@@ -42,6 +42,11 @@ use strict;
 use warnings;
 
 sub run {
+    # MM tests autofs requires barrier_create
+    barrier_create('AUTOFS_SUITE_READY', 2);
+    barrier_create('AUTOFS_FINISHED',    2);
+    mutex_create 'barrier_setup_done';
+
     select_console "root-console";
     my $test_share_dir     = "/tmp/nfs/server";
     my $nfsidmap_share_dir = "/home/tux";
@@ -70,7 +75,6 @@ sub run {
     # common
     assert_script_run "cat /etc/exports";
     systemctl 'restart nfs-server';
-    mutex_create 'barrier_setup_done';
     barrier_wait 'AUTOFS_SUITE_READY';
     barrier_wait 'AUTOFS_FINISHED';
 }


### PR DESCRIPTION
remove load_mm_autofs_tests function from lib/main_common.pm
as well as the references to this function in products/opensuse/main.pm
and products/sle/main.pm
update mau-autofs test suite on OSD after merge and add yaml schedule

see https://progress.opensuse.org/issues/92158
verification runs:
http://10.160.64.152/tests/2612#dependencies
http://10.160.64.152/admin/test_suites