### PR TITLE
Fix the 389ds dscreate timeout issue

### DIFF
--- a/tests/migration/openldap_to_389ds.pm
+++ b/tests/migration/openldap_to_389ds.pm
@@ -72,7 +72,7 @@ sub run {
     # Prepare data file for migration
     assert_script_run "sed -i 's/^root_password.*/root_password = $password/' ./instance.inf";
     assert_script_run "mkdir slapd.d";
-    assert_script_run("dscreate from-file ./instance.inf", timeout => 120);
+    assert_script_run("dscreate from-file ./instance.inf", timeout => 180);
     assert_script_run "dsctl localhost status";
     assert_script_run "slaptest -f slapd.conf -F ./slapd.d";
 


### PR DESCRIPTION
It need more time to run the dscreate cmd, so increase the timeout value from 120s to 180s to make it more robust.

- Related ticket: https://progress.opensuse.org/issues/92272
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/6060650#
