### PR TITLE
publiccloud: cleanup obsoleted code

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -92,7 +92,7 @@ sub find_img {
 }
 
 sub upload_img {
-    my ($self, $file, $type) = @_;
+    my ($self, $file) = @_;
     my $img_name          = $self->file2name($file);
     my $uri               = $self->storage_name . '/' . $file;
     my $guest_os_features = get_var('PUBLIC_CLOUD_GCE_UPLOAD_GUEST_FEATURES', 'MULTI_IP_SUBNET,UEFI_COMPATIBLE,VIRTIO_SCSI_MULTIQUEUE');

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -26,9 +26,8 @@ sub run {
 
     my $provider = $self->provider_factory();
 
-    my $img_url    = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
+    my $img_url = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
     my ($img_name) = $img_url =~ /([^\/]+)$/;
-    my $img_type   = get_var('PUBLIC_CLOUD_IMAGE_TYPE');
 
     if (my $img_id = $provider->find_img($img_name)) {
         record_info('Info', "Image $img_id already exists!");
@@ -36,7 +35,7 @@ sub run {
     }
 
     assert_script_run("wget --no-check-certificate $img_url -O $img_name", timeout => 60 * 10);
-    $provider->upload_img($img_name, $img_type);
+    $provider->upload_img($img_name);
 }
 
 sub test_flags {


### PR DESCRIPTION
`$type` variable not used but still passed into a function

VR: http://autobot.qa.suse.de/tests/2441