### PR TITLE
hwsim_wpa2_enterprise_setup: Use root-console instead of virtio-terminal

### DIFF
--- a/tests/x11/network/hwsim_wpa2_enterprise_setup.pm
+++ b/tests/x11/network/hwsim_wpa2_enterprise_setup.pm
@@ -20,7 +20,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    $self->select_serial_terminal();
+    select_console('root-console');
     assert_script_run "modprobe mac80211_hwsim radios=2 |& tee /dev/$serialdev";
 
     $self->install_packages;


### PR DESCRIPTION
virtio-terminal has some problems with snapshot loading,
see: https://github.com/os-autoinst/os-autoinst/pull/1675

This is a interim solution to get around this issue.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1184917
- Verification run: http://cfconrad-vm.qa.suse.de/tests/8143
