### PR TITLE
Fix haproxy in docker-compose after upgrade to 2.4

### DIFF
--- a/data/containers/docker-compose.yml
+++ b/data/containers/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     ports:
       - "8080:80"
+    # Port 80 is privileged but haproxy 2.4 runs as user by default.
+    # Docker on Tumbleweed has this by default
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=0
     networks:
       - backend
       - frontend


### PR DESCRIPTION
Since 2.4, haproxy defaults to run has user "haproxy", which isn't allowed to
bind to ports below 1024. Docker on TW allows this by default, but on Leap it
needs to be granted explicitly.

Verification run: https://openqa.opensuse.org/tests/1750726
