### PR TITLE
Fix tests/publiccloud/download_repos.pm mv command

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -90,8 +90,7 @@ sub run {
         die "Empty test repositories" if ($check_empty_repos && $size < 1000);
     }
     # The maintenance *.repo files all point to download.suse.de, but we are using dist.suse.de, so we need to rename the directory
-    # Note: This is a temporary fix, the correct way is to use download.suse.de
-    assert_script_run("mv ~/repos/dist.suse.de ~/repos/download.suse.de");
+    assert_script_run("if [ -d ~/repos/dist.suse.de ]; then mv ~/repos/dist.suse.de ~/repos/download.suse.de; fi");
     assert_script_run("cd");
 }
 


### PR DESCRIPTION
This is just follow up to #12568:
 * We should check that `~/repos/dist.suse.de` exists before moving it.
 * Both `download.suse.de` as well as `dist.suse.de` is possible.

- Verification run: [no repos](http://pdostal-server.suse.cz/tests/11810) [download.suse.de repos](http://pdostal-server.suse.cz/tests/11809) [dist.suse.de repos](http://pdostal-server.suse.cz/tests/11808)
