### PR TITLE
LTP: Record kernel version and packages

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -23,6 +23,7 @@ use utils 'assert_secureboot_status';
 sub run {
     my ($self) = @_;
     my $cmd_file = get_var('LTP_COMMAND_FILE') || '';
+
     # Use standard boot for ipmi backend with IPXE
     if (check_var('BACKEND', 'ipmi') && !get_var('IPXE_CONSOLE')) {
         record_info('INFO', 'IPMI boot');
@@ -41,13 +42,14 @@ sub run {
     $self->select_serial_terminal;
     assert_secureboot_status(1) if (get_var('SECUREBOOT'));
 
+    log_versions;
+
     # check kGraft patch if KGRAFT=1
     if (check_var('KGRAFT', '1') && !check_var('REMOVE_KGRAFT', '1')) {
         assert_script_run("uname -v| grep -E '(/kGraft-|/lp-)'");
     }
 
-    prepare_ltp_env();
-    upload_logs('/boot/config-$(uname -r)', failok => 1);
+    prepare_ltp_env;
     init_ltp_tests($cmd_file);
 
     # If the command file (runtest file) is set then we dynamically schedule

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -344,6 +344,8 @@ sub run {
         install_from_repo();
     }
 
+    log_versions;
+
     zypper_call('in efivar') if is_sle('12+') || is_opensuse;
 
     $grub_param .= ' console=hvc0'     if (get_var('ARCH') eq 'ppc64le');

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -181,12 +181,11 @@ sub install_from_git {
     my $configure   = "./configure --with-open-posix-testsuite --with-realtime-testsuite --prefix=$prefix";
     my $extra_flags = get_var('LTP_EXTRA_CONF_FLAGS', '');
 
-    if ($rel) {
-        $rel = ' -b ' . $rel;
-    }
-    my $ret = script_run("git clone -q --depth 1 $url" . $rel, timeout => 360);
+    $rel = "-b $rel" if ($rel);
+
+    my $ret = script_run("git clone -q --depth 1 $url $rel", timeout => 360);
     if (!defined($ret) || $ret) {
-        assert_script_run("git clone -q $url" . $rel, timeout => 360);
+        assert_script_run("git clone -q $url $rel", timeout => 360);
     }
     assert_script_run 'cd ltp';
     assert_script_run 'make autotools';


### PR DESCRIPTION
LTP: Record kernel version and packages in both `boot_ltp.pm` and `install_ltp.pm`. It's required to keep affected versions a bit longer (after logs are pruned).

Recording both pkg info and uname in case there are more kernel packages.

Expected failure should be needed only for kernel-default-extra, which is not on Tumbleweed.

Also check for `get_var('KERNEL_BASE')` when deciding which kernel package to install.

Move some debugging info to newly created `log_versions()` from elsewhere to be run on all cases of `install_ltp.pm`.
    
Verification run:
- 15-SP3 KOTD: http://quasar.suse.cz/tests/6811
- Tumbleweed: http://quasar.suse.cz/tests/6812
- 12-SP5: http://quasar.suse.cz/tests/6813
- 11-SP3: http://quasar.suse.cz/tests/6814
- install_ltp Tumbleweed: http://quasar.suse.cz/tests/6815
- install_ltp 15-SP3: http://quasar.suse.cz/tests/6816

UPDATE: I retested newly added second commit: http://quasar.suse.cz/tests/6823#settings