### PR TITLE
Avoid btrfs console messages

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -567,8 +567,8 @@ sub load_jeos_tests {
     load_boot_tests();
     loadtest "jeos/firstrun";
     loadtest "jeos/record_machine_id";
+    loadtest "console/force_scheduled_tasks";
     unless (get_var('INSTALL_LTP')) {
-        loadtest "console/force_scheduled_tasks";
         loadtest "jeos/grub2_gfxmode";
         loadtest "jeos/diskusage";
         loadtest "jeos/build_key";


### PR DESCRIPTION
LTP shutdown proceedure was failing due to polluted tty by btrfs
messages. Adding _force_scheduled_tasks_ should prevent this behaviour.

- Related ticket: [[qac][JeOS][LTP[opensuse] - Start ltp testing in oS JeOS](https://progress.opensuse.org/issues/67717)
- VRs:
  - [syscalls local run](http://kepler.suse.cz/tests/5044#step/shutdown_ltp/52)

