### PR TITLE
Fix wpa_supplicant test

### DIFF
--- a/data/wpa_supplicant/wpa_supplicant_test.sh
+++ b/data/wpa_supplicant/wpa_supplicant_test.sh
@@ -14,7 +14,7 @@ function cleanup() {
 		kill $hostapd_pid
 	fi
 	modprobe -r mac80211_hwsim
-	rm -f wifi_scan.txt networks.txt status.txt hostapd.log hostapd.com dnsmasq.log dhclinet.log
+	rm -f wifi_scan.txt networks.txt status.txt hostapd.com dnsmasq.log dhclinet.log
 	rm -f /etc/sysconfig/network/ifcfg-wlan1
 	wpa_cli -i wlan1 terminate >/dev/null 2>/dev/null
 	ip netns pids wifi_master | xargs kill


### PR DESCRIPTION
AppArmor prevents the hostpad config file from being read. so execution of aa-disable hostapd before starting hostapd.  

- Related ticket: https://progress.opensuse.org/issues/90002
- Needles: No
- Verification run: 
Tumbleweed - http://10.161.229.147/tests/592#step/wpa_supplicant/1
SLE15 SP2 VR  - http://10.161.229.147/tests/591#step/wpa_supplicant/1
LEAP - http://10.161.229.147/tests/593#step/wpa_supplicant/1
