### PR TITLE
Update autoyast profiles due to failures on 15 SP3

### DIFF
--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -67,11 +67,9 @@
     <mode>
       <confirm config:type="boolean">false</confirm>
     </mode>
-    <final_reboot config:type="boolean">true</final_reboot>
   </general>
   <partitioning config:type="list">
     <drive>
-      <_id config:type="integer">0</_id>
       <device>/dev/disk/by-path/ccw-0.0.0000</device>
       <disklabel>gpt</disklabel>
       <enable_snapshots config:type="boolean">true</enable_snapshots>

--- a/data/autoyast_qam/15_installtest.xml.ep
+++ b/data/autoyast_qam/15_installtest.xml.ep
@@ -280,7 +280,6 @@
     <init-scripts config:type="list">
       <script>
         <filename>post.sh</filename>
-        <interpreter>shell</interpreter>
         <source><![CDATA[
 #!/bin/sh
 # turn off autorefresh on pool repos


### PR DESCRIPTION
Removed parts are not really required and make profile invalid on 15 SP3

- Fail: https://openqa.suse.de/tests/6013704#step/installation/3
- Verification run: https://openqa.suse.de/tests/6065977