### PR TITLE
transactional/transactional_update: Really don't rely on repos in staging

### DIFF
--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -89,18 +89,18 @@ sub run {
         record_info 'Update #2', 'System should be up to date - no changes expected';
         trup_call 'cleanup up';
         check_reboot_changes 0;
-    }
 
-    # Check that zypper does not return 0 if update was aborted
-    record_info 'Broken pkg', 'Install broken package poo#18644 - snapshot #3';
-    trup_call "pkg install" . rpmver('broken');
-    check_reboot_changes;
-    # Systems with repositories would downgrade on DUP
-    if (is_leap) {
-        record_info 'Broken packages test skipped';
-    } else {
-        trup_call "cleanup up", exit_code => 1;
-        check_reboot_changes 0;
+        # Check that zypper does not return 0 if update was aborted
+        record_info 'Broken pkg', 'Install broken package poo#18644 - snapshot #3';
+        trup_call "pkg install" . rpmver('broken');
+        check_reboot_changes;
+        # Systems with repositories would downgrade on DUP
+        if (is_leap) {
+            record_info 'Broken packages test skipped';
+        } else {
+            trup_call "cleanup up", exit_code => 1;
+            check_reboot_changes 0;
+        }
     }
 
     record_info 'Remove pkg', 'Remove package - snapshot #4';


### PR DESCRIPTION
The code directly below the "unless(is_staging)" block also relied on repos,
move it inside. Without repos, there's no update-test-broken package which
zypper can update to, so the update does not fail.

Verification runs:
TW staging: https://openqa.opensuse.org/tests/1752065
TW microos: https://openqa.opensuse.org/tests/1752070