### PR TITLE
Better timeout and UNKNOWN state handling

### DIFF
--- a/data/virt_autotest/fetch_logs_from_guest.sh
+++ b/data/virt_autotest/fetch_logs_from_guest.sh
@@ -289,7 +289,7 @@ for single_subnet in ${subnets_in_route[@]};do
     single_subnet_scan_results=${virt_logs_folder}'/nmap_subnets_scan_results/nmap_scan_'${single_subnet_transformed}'_'${scan_timestamp}
     subnets_scan_results[${subnets_scan_index}]=${single_subnet_scan_results}
     echo -e "nmap -sn $single_subnet -oX $single_subnet_scan_results" | tee -a ${fetch_logs_from_guest_log}
-    nmap -sn $single_subnet -oX $single_subnet_scan_results | tee -a ${fetch_logs_from_guest_log}
+    nmap -T5 -sn $single_subnet -oX $single_subnet_scan_results | tee -a ${fetch_logs_from_guest_log}
     subnets_scan_index=$(( ${subnets_scan_index} + 1 ))
 done
 

--- a/data/virt_autotest/virt_logs_collector.sh
+++ b/data/virt_autotest/virt_logs_collector.sh
@@ -432,7 +432,7 @@ for single_subnet in ${subnets_in_route[@]};do
     single_subnet_scan_results=${virt_logs_folder}'/nmap_subnets_scan_results/nmap_scan_'${single_subnet_transformed}'_'${scan_timestamp}
     subnets_scan_results[${subnets_scan_index}]=${single_subnet_scan_results}
     echo -e "nmap -sn $single_subnet -oX $single_subnet_scan_results" | tee -a ${virt_logs_collecor_log}
-    nmap -sn $single_subnet -oX $single_subnet_scan_results  | tee -a ${virt_logs_collecor_log}
+    nmap -T5 -sn $single_subnet -oX $single_subnet_scan_results  | tee -a ${virt_logs_collecor_log}
     subnets_scan_index=$(( ${subnets_scan_index} + 1 ))
 done
 

--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -169,6 +169,7 @@ sub validate_guest_installations_results {
         if ($guest_instances{$_}->{guest_installation_result} eq '') {
             record_info("Guest $guest_instances{$_}->{guest_name} still has no installation result at the end.Makr it as UNKNOWN.", "It will be treated as a kind of failure !");
             $guest_instances{$_}->{guest_installation_result} = 'UNKNOWN';
+            $guest_instances{$_}->collect_guest_installation_logs_via_ssh;
         }
         $_overall_test_result = "$guest_instances{$_}->{guest_installation_result},$_overall_test_result";
     }
@@ -242,8 +243,8 @@ sub concurrent_guest_installations_run {
     $self->generate_guest_profiles(@_guest_profiles);
     $self->install_guest_instances;
     $self->monitor_concurrent_guest_installations;
-    $self->validate_guest_installations_results;
     $self->clean_up_guest_installations;
+    $self->validate_guest_installations_results;
     $self->junit_log_provision((caller(0))[3]);
     return $self;
 
@@ -254,7 +255,6 @@ sub post_fail_hook {
 
     $self->reveal_myself;
     $self->check_root_ssh_console;
-    $self->clean_up_guest_installations;
     $self->junit_log_provision((caller(0))[3]);
     $self->SUPER::post_fail_hook;
     return $self;


### PR DESCRIPTION
* **Increase** script_run timeout to "600 / get_var('TIMEOUT_SCALE', 1)" to suit OSD environment and become more tolerant towards extreme conditions. [A testsuite](https://openqa.suse.de/tests/6091356#step/uefi_guest_installation/345) already failed because of this. At the same time, make namp faster with -T5 option.
* **Introduce** parameter guest_netaddr_attached to store subnets  in which guest may reside. So nmap only do scan on these specific subnets in order to save time.
* **Additionally**, after thinking twice, it would be better to also do collect_guest_installation_logs_via_ssh for guest in UNKNOWN state, although there might not be too much to be collected.
* **Verification run:**
  * [Verification run 1](http://10.67.129.106/tests/1290)
  * [Verification run 2](http://10.67.129.106/tests/1291)
  * [OSD verification run](https://openqa.suse.de/tests/6097341)
