### PR TITLE
thunderbird: Make the test more robust

### DIFF
--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -127,6 +127,7 @@ sub tb_send_message {
     send_key "tab";
     type_string "Test email send and receive.";
     assert_and_click "thunderbird_send-message";
+    wait_still_screen(2);
 
     if ($hostname eq 'client') {
         if (check_var('SLE_PRODUCT', 'sled')) {

--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -57,19 +57,17 @@ sub tb_setup_account {
 
     if ($proto eq 'pop') {
         assert_and_click 'thunderbird_wizard-imap-selected';
+        assert_and_click 'thunderbird_wizard-imap-pop-open';
         if (is_tumbleweed) {
-            assert_and_click 'thunderbird_wizard-imap-pop-open';
             assert_and_click 'thunderbird_SSL_pop3-selection-click-TW';
             assert_and_click 'thunderbird_SSL_auth_click';
             assert_and_click 'thunderbird_wizard-pop-done';
         }
         else {
-            assert_screen 'thunderbird_wizard-imap-pop-open';
-            send_key 'down';
-            send_key 'ret';
             # If use multimachine, select correct needles to configure thunderbird.
             if ($hostname eq 'client') {
                 assert_and_click 'thunderbird_SSL_auth_click';
+                wait_still_screen(2);
                 send_key 'down';
                 send_key 'ret';
             }

--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -78,6 +78,8 @@ sub tb_setup_account {
     # If use multimachine, select correct needles to configure thunderbird.
     if ($hostname eq 'client') {
         assert_and_click "thunderbird_SSL_done_config";
+        wait_still_screen(3);
+        assert_and_click 'thunderbird_SSL_done_config' unless check_screen('thunderbird_confirm_security_exception');
         assert_and_click "thunderbird_confirm_security_exception";
         assert_and_click "thunderbird_skip-system-integration";
         assert_and_click "thunderbird_get-messages";

--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -158,7 +158,7 @@ sub tb_check_email {
     wait_screen_change { send_key "shift-f5" };
     send_key "ctrl-shift-k";
     wait_screen_change { type_string "$mail_search" };
-    assert_screen "thunderbird_sent-message-received", 120;
+    send_key_until_needlematch "thunderbird_sent-message-received", 'shift-f5', 4, 30;
 
     # delete the message
     assert_and_click "thunderbird_select-message";

--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -77,6 +77,8 @@ sub tb_setup_account {
 
     # If use multimachine, select correct needles to configure thunderbird.
     if ($hostname eq 'client') {
+        send_key_until_needlematch 'thunderbird_SSL_done_config', 'alt-t', 4, 2;
+        wait_still_screen(2);
         assert_and_click "thunderbird_SSL_done_config";
         wait_still_screen(3);
         assert_and_click 'thunderbird_SSL_done_config' unless check_screen('thunderbird_confirm_security_exception');

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -28,6 +28,7 @@ sub run {
     my ($self) = @_;
     my $hostname = get_var('HOSTNAME');
     select_console 'root-console';
+    my $nm_id = is_sle('15-sp3+') ? script_output(q(awk -F= '/id/ {print$2}' /etc/NetworkManager/system-connections/*.nmconnection)) : 'Wired connection 1';
 
     # Do not use external DNS for our internal hostnames
     assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');
@@ -42,9 +43,9 @@ sub run {
         setup_static_mm_network('10.0.2.101/24');
 
         if (is_networkmanager) {
-            assert_script_run "nmcli connection modify 'Wired connection 1' ifname 'eth0' ip4 '10.0.2.101/24' gw4 10.0.2.2 ipv4.method manual ";
-            assert_script_run "nmcli connection down 'Wired connection 1'";
-            assert_script_run "nmcli connection up 'Wired connection 1'";
+            assert_script_run "nmcli connection modify '$nm_id' ifname 'eth0' ip4 '10.0.2.101/24' gw4 10.0.2.2 ipv4.method manual ";
+            assert_script_run "nmcli connection down '$nm_id'";
+            assert_script_run "nmcli connection up '$nm_id'";
         }
         else {
             assert_script_run 'systemctl restart  wicked';
@@ -54,9 +55,9 @@ sub run {
         setup_static_mm_network('10.0.2.102/24');
 
         if (is_networkmanager) {
-            assert_script_run "nmcli connection modify 'Wired connection 1' ifname 'eth0' ip4 '10.0.2.102/24' gw4 10.0.2.2 ipv4.method manual ";
-            assert_script_run "nmcli connection down 'Wired connection 1'";
-            assert_script_run "nmcli connection up 'Wired connection 1'";
+            assert_script_run "nmcli connection modify '$nm_id' ifname 'eth0' ip4 '10.0.2.102/24' gw4 10.0.2.2 ipv4.method manual ";
+            assert_script_run "nmcli connection down '$nm_id'";
+            assert_script_run "nmcli connection up '$nm_id'";
         }
         else {
             assert_script_run 'systemctl restart  wicked';


### PR DESCRIPTION
On Desktop 15 SP3 is connection id eth0 not like on older versions Wired conection 1

- Related ticket: https://progress.opensuse.org/issues/92509
- Verification run:
https://openqa.suse.de/tests/6097189 15 SP3
https://openqa.suse.de/tests/6095422 15 SP2