### PR TITLE
Fix online_migration_setup and post_migration wait tty6 failed

### DIFF
--- a/tests/migration/online_migration/online_migration_setup.pm
+++ b/tests/migration/online_migration/online_migration_setup.pm
@@ -27,7 +27,7 @@ sub run {
     #
     # If source system is minimal installation then boot to textmode
     # we don't care about source system start time because our SUT is upgraded one
-    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => is_sles4sap);
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 400, ready_time => 600, nologin => is_sles4sap);
     $self->setup_migration();
 }
 

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -141,7 +141,7 @@ sub run {
     # with other than the SAP Administrator
     #
     # sometimes reboot takes longer time after online migration, give more time
-    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 400, ready_time => 600, nologin => is_sles4sap);
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 500, ready_time => 600, nologin => is_sles4sap);
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
In online_migration_setup and post_migration we need to wait more time for the bootloader_time to wait for the system to boot up.

- Related ticket: https://progress.opensuse.org/issues/91704
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t6081553 
  https://openqa.nue.suse.com/t6081554 

  https://openqa.nue.suse.com/t6081675 
  https://openqa.nue.suse.com/t6081677 
