### PR TITLE
Disable dhcpd/named service to avoid dns service collision

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -878,6 +878,10 @@ systemctl stop firewalld
 systemctl disable firewalld
 systemctl stop apparmor
 systemctl disable apparmor
+systemctl stop named
+systemctl disable named
+systemctl stop dhcpd
+systemctl disable dhcpd
 iptables -P INPUT ACCEPT
 iptables -P FORWARD ACCEPT
 iptables -P OUTPUT ACCEPT

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -714,8 +714,11 @@ sub cleanup_host_and_guest_logs {
     #Clean dhcpd and named services up explicity
     if (get_var('VIRT_AUTOTEST')) {
         script_run("brctl addbr br123;brctl setfd br123 0;ip addr add 192.168.123.1/24 dev br123;ip link set br123 up");
-        script_run("service dhcpd restart") if (script_run("systemctl restart dhcpd") ne '0');
-        script_run("service named restart") if (script_run("systemctl restart named") ne '0');
+        if (!get_var('VIRT_UEFI_GUEST_INSTALL')) {
+            my @control_operation = ('restart');
+            virt_autotest::utils::manage_system_service('dhcpd', \@control_operation);
+            virt_autotest::utils::manage_system_service('named', \@control_operation);
+        }
     }
     my $logs_cleanup_script_url = data_url("virt_autotest/clean_up_virt_logs.sh");
     script_output("curl -s -o ~/clean_up_virt_logs.sh $logs_cleanup_script_url", 180, type_command => 0, proceed_on_failure => 0);


### PR DESCRIPTION
* **DNS/DHCP** service may malfunction if dnsmasq, named and dhcpd run at the same time, so stop and disable dhcpd/named in config_guest_network_bridge_policy to prevent [test run failure](https://openqa.suse.de/tests/6094109#step/uefi_guest_verification/55)
* **Skip** dhcpd and named services restart in cleanup_host_and_guest_logs if  use VIRT_UEFI_GUEST_INSTALL.
* **Verification run:**
  * [OSD verification run](https://openqa.suse.de/tests/6097341)
