### PR TITLE
Add rsync tests for sles 15 functional

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1067,21 +1067,6 @@ else {
             loadtest "console/yast2_nfs4_client";
         }
     }
-    elsif (get_var('QAM_RSYNC')) {
-        set_var('INSTALLONLY', 1);
-        if (check_var('HOSTNAME', 'server')) {
-            barrier_create('rsync_setup',    2);
-            barrier_create('rsync_finished', 2);
-        }
-        boot_hdd_image;
-        loadtest 'network/setup_multimachine';
-        if (check_var('HOSTNAME', 'server')) {
-            loadtest 'console/rsync_server';
-        }
-        else {
-            loadtest 'console/rsync_client';
-        }
-    }
     elsif (get_var('QAM_CURL')) {
         set_var('INSTALLONLY', 1);
         boot_hdd_image;

--- a/schedule/functional/rsync.yaml
+++ b/schedule/functional/rsync.yaml
@@ -1,0 +1,16 @@
+---
+name: rsync
+description: >
+    Maintainer: zluo
+    Install and test rsync
+conditional_schedule:
+    rsync:
+        HOSTNAME:
+            'client':
+                - console/rsync_client
+            'server':
+                - console/rsync_server
+schedule:
+    - boot/boot_to_desktop
+    - network/setup_multimachine
+    - '{{rsync}}'

--- a/tests/console/rsync_server.pm
+++ b/tests/console/rsync_server.pm
@@ -25,6 +25,9 @@ use version_utils;
 
 
 sub run {
+    barrier_create('rsync_setup',    2);
+    barrier_create('rsync_finished', 2);
+    mutex_create 'barrier_setup_done';
     select_console 'root-console';
 
     #preparation of rsync config files
@@ -65,7 +68,6 @@ true';
     assert_script_run 'echo "third file" > /srv/rsync_test/pub/file3';
 
     #setup of rsync server done
-    mutex_create 'barrier_setup_done';
     barrier_wait 'rsync_setup';
     #client tries to list and download files
     barrier_wait 'rsync_finished';


### PR DESCRIPTION
update rsync_server.pm for switching to yaml schedule.
remove job group from sle/main.pm so that qam-rsync tests can use yaml
schedule later.

see https://progress.opensuse.org/issues/92911
verification runs:
http://10.160.64.152/tests/2660#dependencies
