### PR TITLE
Fix ima/evm digital signature reboot failed issue

### DIFF
--- a/tests/security/ima/ima_appraisal_digital_signatures.pm
+++ b/tests/security/ima/ima_appraisal_digital_signatures.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 #
 # Summary: Test IMA appraisal using digital signatures
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#49154
+# Tags: poo#49154, poo#92347
 
 use base "opensusebasetest";
 use strict;
@@ -64,26 +64,32 @@ sub run {
         m/security\.ima=[0-9a-zA-Z+\/]{355}/;
     };
 
-    # Prepare mok ceritificate file
-    assert_script_run "mkdir -p /etc/keys/ima";
-    assert_script_run "cp $cert_der /etc/keys/ima/";
+    if (script_run("grep CONFIG_INTEGRITY_TRUSTED_KEYRING=y /boot/config-`uname -r`") == 0) {
+        record_soft_failure("bsc#1157432 for SLE15SP2+: CA could not be loaded into the .ima or .evm keyring");
+    }
+    else {
+        # Prepare mok ceritificate file
+        assert_script_run "mkdir -p /etc/keys/ima";
+        assert_script_run "cp $cert_der /etc/keys/ima/";
 
-    assert_script_run "wget --quiet " . data_url("ima/ima_appraisal_ds_policy" . " -O /etc/sysconfig/ima-policy");
+        assert_script_run "wget --quiet " . data_url("ima/ima_appraisal_ds_policy" . " -O /etc/sysconfig/ima-policy");
 
-    replace_grub_cmdline_settings('ima_appraise=fix', '', update_grub => 1);
+        replace_grub_cmdline_settings('ima_appraise=fix', '', update_grub => 1);
 
-    power_action('reboot', textmode => 1);
-    $self->wait_boot(textmode => 1);
-    $self->select_serial_terminal;
+        power_action('reboot', textmode => 1);
+        $self->wait_boot(textmode => 1);
+        $self->select_serial_terminal;
 
-    assert_script_run "dmesg | grep IMA:.*completed";
+        assert_script_run "dmesg | grep IMA:.*completed";
 
-    # Remove security.ima attribute manually, and verify it is empty
-    assert_script_run "setfattr -x security.ima $sample_app";
-    validate_script_output "getfattr -m security.ima -d $sample_app", sub { m/^$/ };
+        # Remove security.ima attribute manually, and verify it is empty
+        assert_script_run "setfattr -x security.ima $sample_app";
+        validate_script_output "getfattr -m security.ima -d $sample_app", sub { m/^$/ };
 
-    my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);
-    die "$sample_app should not have permission to run" if ($ret !~ "\Q$sample_app\E: *Permission denied");
+        my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);
+        die "$sample_app should not have permission to run" if ($ret !~ "\Q$sample_app\E: *Permission denied");
+
+    }
 }
 
 sub test_flags {

--- a/tests/security/ima/ima_verify.pm
+++ b/tests/security/ima/ima_verify.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
 # Summary: Test IMA verify function provided by evmctl
 # Note: This case should come after 'ima_apprasial_digital_signatures'
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#49562
+# Tags: poo#49562, poo#92347
 
 use base "opensusebasetest";
 use strict;
@@ -33,25 +33,29 @@ sub run {
     my $mok_priv = '/root/certs/key.asc';
     my $cert_der = "/root/certs/ima_cert.der";
 
-    # Make sure IMA is in the enforce mode
-    validate_script_output "grep -E 'ima_appraise=(fix|log|off)' /etc/default/grub || echo 'IMA enforced'", sub { m/IMA enforced/ };
-    assert_script_run("test -e /etc/sysconfig/ima-policy", fail_message => 'ima-policy file is missing');
+    if (script_run("grep CONFIG_INTEGRITY_TRUSTED_KEYRING=y /boot/config-`uname -r`") == 0) {
+        record_soft_failure("bsc#1157432 for SLE15SP2+: CA could not be loaded into the .ima or .evm keyring");
+    }
+    else {
+        # Make sure IMA is in the enforce mode
+        validate_script_output "grep -E 'ima_appraise=(fix|log|off)' /etc/default/grub || echo 'IMA enforced'", sub { m/IMA enforced/ };
+        assert_script_run("test -e /etc/sysconfig/ima-policy", fail_message => 'ima-policy file is missing');
+        assert_script_run "evmctl ima_sign -a sha256 -k $mok_priv $sample_app";
 
-    assert_script_run "evmctl ima_sign -a sha256 -k $mok_priv $sample_app";
+        validate_script_output "getfattr -m security.ima -d $sample_app", sub {
+            # Base64 armored security.ima content (358 chars), we do not match the
+            # last three ones here for simplicity
+            m/security\.ima=[0-9a-zA-Z+\/]{355}/;
+        };
+        assert_script_run "evmctl ima_verify -k $cert_der $sample_app";
 
-    validate_script_output "getfattr -m security.ima -d $sample_app", sub {
-        # Base64 armored security.ima content (358 chars), we do not match the
-        # last three ones here for simplicity
-        m/security\.ima=[0-9a-zA-Z+\/]{355}/;
-    };
-    assert_script_run "evmctl ima_verify -k $cert_der $sample_app";
+        assert_script_run "setfattr -x security.ima $sample_app";
 
-    assert_script_run "setfattr -x security.ima $sample_app";
-
-    validate_script_output "evmctl ima_verify -k $cert_der $sample_app || true", sub {
-        m/getxattr\sfailed.*\Q$sample_app\E.*
-          No\sdata\savailable/sxx
-    };
+        validate_script_output "evmctl ima_verify -k $cert_der $sample_app || true", sub {
+            m/getxattr\sfailed.*\Q$sample_app\E.*
+              No\sdata\savailable/sxx
+        };
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Due to bsc#1157432, the public ceriticate could not be loaded into the
.ima or .evm keyring, so we should fix the logic for now, we can only
test in user level rather than kernel side

- Related ticket: https://progress.opensuse.org/issues/92347
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/6108401 - ima
                            https://openqa.suse.de/tests/6108400 - evm
