### PR TITLE
Fix desktopapps-documentation failures on Gnome40

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -918,10 +918,9 @@ sub gnote_search_and_close {
 sub cleanup_gnote {
     my ($self, $needle) = @_;
     send_key 'esc';    #back to all notes interface
-    send_key_until_needlematch $needle, 'down', 6;
-    wait_screen_change { send_key 'delete' };
-    wait_screen_change { send_key 'tab' };
-    wait_screen_change { send_key 'ret' };
+    assert_and_click($needle, button => 'right');
+    assert_and_click "delete-new-note";
+    assert_and_click "really-delete-note";
     send_key 'ctrl-w';
 }
 

--- a/tests/x11/gnote/gnote_undo_redo.pm
+++ b/tests/x11/gnote/gnote_undo_redo.pm
@@ -51,9 +51,7 @@ sub run {
 
     #assure undo and redo take effect after save note and re-enter note
     assert_and_click 'gnote-back2allnotes';
-    send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
-    wait_still_screen 3;
-    send_key "ret";
+    assert_and_dclick 'gnote-new-note-matched';
     $self->undo_redo_once;
 
     #clean: remove the created new note

--- a/tests/x11/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11/libreoffice/libreoffice_double_click_file.pm
@@ -30,8 +30,7 @@ sub run {
 
     # open gnome file manager- nautilus for testing
     x11_start_program('nautilus');
-    send_key_until_needlematch("nautilus-Documents-matched", "right");
-    send_key "ret";
+    assert_and_dclick "nautilus-Documents-matched";
     wait_still_screen(3);
 
     # open test files of different formats


### PR DESCRIPTION
Update the way to cleanup gnote to fix failure in cleanup_gnote
Update the way of opening new note to fix failure in gnote_undo_redo
Update the way to select Documents icon in nautilus to fix failure in libreoffice_double_click_file
Verification test runs on TW (GNOME 40) and SLE15SP3 (GNOME 3.34) are provided in below section.

- Related ticket: https://progress.opensuse.org/issues/91079
- Needles: Have been added when debugging on o.o.o and o.s.d
- Verification run: 
- TW: https://openqa.opensuse.org/tests/1757280
- SLE15SP3: https://openqa.nue.suse.com/tests/6098973
