### PR TITLE
Use eth0 for network manager device name on 15-SP3+

### DIFF
--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -28,7 +28,7 @@ sub run {
     my ($self) = @_;
     my $hostname = get_var('HOSTNAME');
     select_console 'root-console';
-    my $nm_id = is_sle('15-sp3+') ? script_output(q(awk -F= '/id/ {print$2}' /etc/NetworkManager/system-connections/*.nmconnection)) : 'Wired connection 1';
+    my $nm_id = is_sle('15-sp3+') ? 'eth0' : 'Wired connection 1';
 
     # Do not use external DNS for our internal hostnames
     assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/92509
- Verification run: https://openqa.suse.de/tests/6108572