### PR TITLE
Improve failure reporting in verify_license_translations

### DIFF
--- a/tests/installation/licensing/verify_license_translations.pm
+++ b/tests/installation/licensing/verify_license_translations.pm
@@ -68,8 +68,8 @@ sub run {
         $eula_page->select_language($translation->{language});
         my $eula_txt = $eula_page->get_eula_content();
         if ($eula_txt !~ /$translation->{text}/) {
-            $errors .= "EULA content for the language: '$translation->{language}' didn't validate.\n" .
-              "Expected:\n$translation->{text}\nActual:\n$eula_txt\n\n";
+            $errors .= "EULA content for the language: '$translation->{language}' didn't validate. Please, see autoints-log for the detailed content of EULA\n";
+            diag("EULA validation failed:\nExpected:\n$translation->{text}\nActual:\n$eula_txt\n\n");
         }
     }
     # Assert no errors


### PR DESCRIPTION
Empty box was shown in openQA when the test module is failed during
license translations verifying.

The commit fixes the issue by removing EULA text from the failure box, as
it took too much space on failures and openQA seems to be not able to
process such huge messages in the failure box.

The actual and expected EULA text is moved to the logs output. 
So, that it can be viewed in case of failure.

- Related ticket: https://progress.opensuse.org/issues/92443
- Verification run: https://openqa.suse.de/tests/6102541#step/verify_license_translations/2
