### PR TITLE
openssl_alpn: ensure openssl cli tools are installed

### DIFF
--- a/tests/console/openssl_alpn.pm
+++ b/tests/console/openssl_alpn.pm
@@ -28,6 +28,7 @@ use utils;
 sub run {
     select_console 'root-console';
 
+    zypper_call 'in "openssl(cli)"';
     assert_script_run 'openssl req -newkey rsa:2048 -nodes -keyout domain.key -x509 -days 365 -out domain.crt -subj "/C=CZ/L=Prague/O=SUSE/CN=alpn.suse.cz"';
 
     clear_console;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/92413
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1758378
