### PR TITLE
Fix grub_test_snapshot default snap was not shown

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -265,7 +265,9 @@ sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
     # assert needle to avoid send down key early in grub_test_snapshot.
-    assert_screen('snap-default', 120) if (get_var('OFW') || is_pvm || check_var('SLE_PRODUCT', 'hpc'));
+    if (get_var('OFW') || is_pvm || check_var('SLE_PRODUCT', 'hpc')) {
+        send_key_until_needlematch('snap-default', 'down', 60, 5);
+    }
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);


### PR DESCRIPTION
In grub_test_snapshot, if there are lots of snapshots, after rebooting
into snapshot we'll have lots of boot items in the grub boot list. so
the assert_screen 'default-snap' can't find the one with * before the
boot item. We need to move the cursor down to that item till we found it.


- Related ticket: https://progress.opensuse.org/issues/92458
- Needles: N/A
- Verification run: 
 https://openqa.nue.suse.com/t6158380
 https://openqa.nue.suse.com/t6158381

regression tests:
https://openqa.nue.suse.com/t6158379 
https://openqa.nue.suse.com/t6158382 
