### PR TITLE
Check architecture in upgrade_select module

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -39,6 +39,8 @@ sub run {
         send_key $cmd{next};
     }
     if (match_has_tag("select-for-update")) {
+        my $arch = get_var("ARCH");
+        assert_screen('select-for-update-' . "$arch");
         send_key $cmd{next};
     }
     # The SLE15-SP2 license page moved after registration.


### PR DESCRIPTION
Add the architecture checking in upgrade_select module.

- Related ticket: https://progress.opensuse.org/issues/37946
- Verification run: 
Graphic interface:
https://openqa.nue.suse.com/tests/6164533#step/upgrade_select/2
https://openqa.nue.suse.com/tests/6164534#step/upgrade_select/2
https://openqa.nue.suse.com/tests/6164535#step/upgrade_select/2
https://openqa.nue.suse.com/tests/6190384#step/upgrade_select/2
https://openqa.nue.suse.com/tests/6164760#step/upgrade_select/2
Textmode:
https://openqa.nue.suse.com/tests/6164615#step/upgrade_select/2
https://openqa.nue.suse.com/tests/6164616#step/upgrade_select/2
https://openqa.nue.suse.com/tests/6164743#step/upgrade_select/2
https://openqa.nue.suse.com/tests/6191128#step/upgrade_select/2

