### PR TITLE
Set checkpoint "Standard" for hyperv 2016 and 2019

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -184,7 +184,7 @@ sub run {
         hyperv_cmd("$ps New-VM -VMName $name -Generation $vm_generation -SwitchName $hyperv_switch_name -MemoryStartupBytes ${ramsize}MB");
         # Create 'Standard' checkpoints with application's memory, on Hyper-V 2016
         # the default is 'Production' (i.e. snapshot on guest level).
-        hyperv_cmd("$ps Set-VM -VMName $name -CheckpointType Standard") if $winserver eq '2016';
+        hyperv_cmd("$ps Set-VM -VMName $name -CheckpointType Standard") if $winserver eq '2016_or_2019';
         if ($iso) {
             hyperv_cmd("$ps Remove-VMDvdDrive -VMName $name -ControllerNumber 1 -ControllerLocation 0") unless $winserver eq '2012r2' and get_var('UEFI');
             hyperv_cmd("$ps Add-VMDvdDrive -VMName $name -Path $iso");


### PR DESCRIPTION
- [[jeos][sporadic] test fails or incompletes in snapper_jeos_cli with reason auto_review:"(?s)backend died: xfreerdp did not start.*svirt"](https://progress.opensuse.org/issues/80886)
- VRs:
  - [sle-15-SP2-JeOS-for-MS-HyperV-QR-x86_64-Build15.89-jeos-filesystem@svirt-hyperv](http://kepler.suse.cz/tests/5119)
  - [sle-15-SP3-JeOS-for-MS-HyperV-x86_64-Build2.36-jeos-base+phub@svirt-hyperv-uefi ](http://kepler.suse.cz/tests/5120)
