### PR TITLE
lib/main_common: Support version switch when working with older HDD

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1878,9 +1878,15 @@ sub load_nfv_trafficgen_tests {
 }
 
 sub load_iso_in_external_tests {
+    # Switch to the version of the booted HDD if different
+    if (get_var("ORIGIN_SYSTEM_VERSION")) {
+        set_var("UPGRADE_TARGET_VERSION", get_var("VERSION"));
+        loadtest "migration/version_switch_origin_system";
+    }
     loadtest "boot/boot_to_desktop";
     loadtest "console/copy_iso_to_external_drive";
     loadtest "x11/reboot_and_install";
+    loadtest "migration/version_switch_upgrade_target" if get_var("UPGRADE_TARGET_VERSION");
 }
 
 sub load_x11_installation {
@@ -2899,11 +2905,17 @@ sub load_common_opensuse_sle_tests {
 }
 
 sub load_ssh_key_import_tests {
+    # Switch to the version of the booted HDD if different
+    if (get_var("ORIGIN_SYSTEM_VERSION")) {
+        set_var("UPGRADE_TARGET_VERSION", get_var("VERSION"));
+        loadtest "migration/version_switch_origin_system";
+    }
     loadtest "boot/boot_to_desktop";
     # setup ssh key, we know what ssh keys we have and can verify if they are imported or not
     loadtest "x11/ssh_key_check";
     # reboot after test specific setup and start installation/update
     loadtest "x11/reboot_and_install";
+    loadtest "migration/version_switch_upgrade_target" if get_var("UPGRADE_TARGET_VERSION");
     load_inst_tests();
     load_reboot_tests();
     # verify previous defined ssh keys

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -27,6 +27,13 @@ sub run {
     power_action('reboot');
     workaround_type_encrypted_passphrase;
 
+    # If the target has a different version, make sure the matching needles are used
+    # for the bootmenu below already.
+    if (get_var('UPGRADE_TARGET_VERSION')) {
+        # Switch to upgrade target version and reload needles
+        set_var('VERSION', get_var('UPGRADE_TARGET_VERSION'), reload_needles => 1);
+    }
+
     # on s390 zKVM we handle the boot of the patched system differently
     set_var('PATCHED_SYSTEM', 1) if get_var('PATCH');
     return                       if get_var('S390_ZKVM');


### PR DESCRIPTION
The load_iso_in_external_tests and load_ssh_key_import_tests usually boot from
a HDD with a different version on it. The test behaviour has to adapt to the
original version until booting the target installer.

I'm a bit confused by the mixing of `ORIGIN_SYSTEM_VERSION` and `HDDVERSION`. Ideally there's a switch to `HDDVERSION` instead of `ORIGIN_SYSTEM_VERSION`, but there's no such module.

- Related ticket: https://progress.opensuse.org/issues/92945
- Verification runs:
TW import_ssh_keys: https://openqa.opensuse.org/tests/1758586
TW external_iso: https://openqa.opensuse.org/tests/1758590