### PR TITLE
Fix reboot_gnome vnc lost connection issue

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -147,6 +147,9 @@ sub full_users_check {
         record_info('Unsupported on non-gnome', "This test is only supported on gnome, quit for your DESKTOP is $desktop", result => 'fail');
         return;
     }
+    # reset consoles before select x11 console will make the connect operation
+    # more stable on s390x
+    reset_consoles             if check_var('ARCH',    's390x');
     turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     select_console 'x11', await_console => 0;
     wait_still_screen 5;

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,7 +23,8 @@ use utils 'is_boot_encrypted';
 sub run {
     my ($self) = @_;
     # 'keepconsole => 1' is workaround for bsc#1044072
-    power_action('reboot', keepconsole => 1);
+    # Poo#80184, it's not suitable to keep console for s390x after reboot.
+    power_action('reboot', keepconsole => (check_var('ARCH', 's390x')) ? 0 : 1);
 
     # In 88388900d2dfe267230972c6905b3cc18fb288cf the wait timeout was
     # bumped, due to tianocore being a bit slower, this brings this module


### PR DESCRIPTION
Keep console after reboot is not suitable for s390x, on s390x it will reconnect console and reconnect vnc after reboot, to make the vnc re-connect more stable, we'd better don't keep console on s390x.

- Related ticket: https://progress.opensuse.org/issues/80184
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/6120337#step/reboot_gnome/7
                          http://openqa.nue.suse.com/tests/6120343#step/reboot_gnome/8  #run on x86_64 to avoid regression
