### PR TITLE
Various virtualization fixes

### DIFF
--- a/tests/virtualization/universal/dom_install.pm
+++ b/tests/virtualization/universal/dom_install.pm
@@ -32,7 +32,7 @@ sub run {
 
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "Install vm-dump-metrics on xl-$guest";
-        script_retry "ssh root\@$guest 'zypper -n in vm-dump-metrics'", delay => 30, retry => 6;
+        script_retry("ssh root\@$guest 'zypper -n in vm-dump-metrics'", delay => 120, retry => 3);
     }
 }
 

--- a/tests/virtualization/universal/finish.pm
+++ b/tests/virtualization/universal/finish.pm
@@ -22,12 +22,13 @@ use utils;
 
 sub run {
     my $self = shift;
+    # Switch to root console to prevent test issues from the desktop environment
+    # See https://progress.opensuse.org/issues/93204
+    select_console('root-console');
     $self->select_serial_terminal;
 
     # Show all guests
     assert_script_run 'virsh list --all';
-    wait_still_screen 1;
-
     script_run 'history -a';
 
     collect_virt_system_logs();

--- a/tests/virtualization/universal/guest_management.pm
+++ b/tests/virtualization/universal/guest_management.pm
@@ -54,9 +54,9 @@ sub run {
 
     record_info "START", "Start all guests";
     foreach my $guest (keys %virt_autotest::common::guests) {
-        if (script_retry("virsh start $guest", delay => 30, retry => 6) != 0) {
+        if (script_retry("virsh start $guest", delay => 120, retry => 3, die => 0) != 0) {
             restart_libvirtd;
-            script_retry "virsh start $guest", delay => 30, retry => 6;
+            script_retry("virsh start $guest", delay => 120, retry => 3);
         }
         script_retry "nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12;
     }

--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -105,8 +105,8 @@ sub test_add_virtual_disk {
                 my $lsblk = script_run("ssh root\@$guest lsblk | grep 'vd[b-z]'", 60);
                 record_soft_failure("lsblk failed - please check the output manually") if $lsblk != 0;
             } elsif (is_xen_host) {
-                script_run("ssh root\@$guest lsblk");
-                record_soft_failure("poo#88460 Hotplugging disk check not yet implemented for xen host");
+                my $lsblk = script_run("ssh root\@$guest lsblk | grep 'xvd[b-z]'", 60);
+                record_soft_failure("lsblk failed - please check the output manually") if $lsblk != 0;
             } else {
                 my $msg = "Unknown virtualization hosts";
                 record_soft_failure($msg);

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -78,7 +78,7 @@ sub add_pci_bridge {
         assert_script_run("virt-xml-validate $xml");
         assert_script_run("virsh define $xml");
 
-    } elsif (is_xen_host() && is_pv_guest($guest)) {
+    } elsif (is_xen_host()) {
         # We're skipping to add an additional bridge on xen
     } else {
         my $msg = "Unknown machine type";


### PR DESCRIPTION
This PR contains various virtualization fixes

* Update spectre/meltdown checker ([poo#91335](https://progress.opensuse.org/issues/91335))
* Fix for fails in `fails in dom-metrics/dom_install` ([poo#90587](https://progress.opensuse.org/issues/90587))
* Add hotplugging HDD check on xen ([poo#88460](https://progress.opensuse.org/issues/88460))
* Fix test failure in `waitfor_guests` (timeout issue) ([poo#91238](https://progress.opensuse.org/issues/91238))
* Fix test failure in `virtmanager/finish` ([poo#93204](https://progress.opensuse.org/issues/93204))

- Verification runs: [KVM](http://openqa.qam.suse.cz/tests/21506) | [XEN](http://openqa.qam.suse.cz/tests/21571)
