### PR TITLE
Drop sbsigntools in MOK and EFI test case

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -642,7 +642,7 @@ sub wait_grub {
     my $bootloader_time = $args{bootloader_time} // 100;
     my $in_grub         = $args{in_grub}         // 0;
     my @tags;
-    push @tags, 'shim-key-management'           if get_var('CHECK_MOK_IMPORT');
+    push @tags, 'shim-key-management'           if (get_var('CHECK_MOK_IMPORT') && get_var('UEFI'));
     push @tags, 'bootloader-shim-verification'  if get_var('MOK_VERBOSITY');
     push @tags, 'bootloader-shim-import-prompt' if get_var('UEFI');
     push @tags, 'grub2';


### PR DESCRIPTION
In order to unblock MOK and EFI testing due to missing package
_sbsigntools_, test case for now will check for the presence of
signatures in provided efi binaries.

- https://progress.opensuse.org/issues/93207
- VRs:
  - [sle-15-SP2-JeOS-for-kvm-and-xen-QR-x86_64-Build15.91-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/5153#step/verify_efi_mok/474)
  - [sle-15-SP2-JeOS-for-MS-HyperV-QR-x86_64-Build15.91-jeos-main@svirt-hyperv-uefi](http://kepler.suse.cz/tests/5154#)
