### PR TITLE
Fix libssh test failure in sle15-sp3

### DIFF
--- a/tests/console/libssh.pm
+++ b/tests/console/libssh.pm
@@ -108,7 +108,7 @@ sub run {
     #  systemctl("start docker.service libvirtd.service sshd.service");
     systemctl("start libvirtd.service sshd.service");
     create_image if (script_output('docker images') !~ m/libssh_image/);    #Skip building If image is already available. This is for Fips test
-    assert_script_run("iptables -I INPUT 5 -p tcp --dport 22 -j ACCEPT");
+    assert_script_run("iptables -I INPUT -p tcp --dport 22 -j ACCEPT");
     assert_script_run("mkdir /tmp/test; echo -n libssh_testcase001 > /tmp/test/libssh_testfile");
     assert_script_run("qemu-img create -f raw /tmp/test/libssh_block.raw 20m");    #file to be uploaded to container for qemu block test
     assert_script_run('docker run -itd --name libssh_container --hostname container01 --add-host susetest:$(ip -4 addr show docker0 | grep -Po "inet \K[\d.]+") --privileged libssh_image');


### PR DESCRIPTION
Skip rule on position 5 of the table

- Related ticket: https://progress.opensuse.org/issues/92494
- Needles: N/A
- Verification run: [15sp3](http://10.161.229.247/tests/1994#step/libssh/115) | [15sp2](https://openqa.suse.de/tests/6136454) | [15sp1](https://openqa.suse.de/tests/6136497) | [15](https://openqa.suse.de/tests/6136453) | [12sp5](https://openqa.suse.de/tests/6136454)
