### PR TITLE
Convert the qem incident install test to yaml

### DIFF
--- a/schedule/ha/qam/common/qam_incident_install.yaml
+++ b/schedule/ha/qam/common/qam_incident_install.yaml
@@ -1,0 +1,19 @@
+name: qam_incident_install
+description: >
+  Test the maintenance update packages installation
+
+  The test is using an existing qcow2 (.*Installtest-HA.qcow2), which is updated
+  to the last version and then, the maintenance update package is installed.
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: textmode
+  INSTALLTEST: '1'
+schedule:
+  - '{{bootloader_zkvm}}'
+  - boot/boot_to_desktop
+  - qam-updinstall/update_install_mr
+conditional_schedule:
+  bootloader_zkvm:
+    BACKEND:
+      svirt:
+        - installation/bootloader_zkvm


### PR DESCRIPTION
We are in the process to fully convert our test suites to YAML, this PR migrates the following QEM test: 
`qam-incidentinstall-ha`
This test makes sure that the maintenance update packages can be installed.

- Related ticket: https://jira.suse.com/browse/TEAM-3811
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- [MR for the job group files](https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/307)
- Verification run: [x86_64](https://openqa.suse.de/tests/6136518#details) - [s390x](https://openqa.suse.de/tests/6137003#details)
