### PR TITLE
Get debug output when rke1 cluster test fails

### DIFF
--- a/tests/rancher/rancher_rke1_master.pm
+++ b/tests/rancher/rancher_rke1_master.pm
@@ -67,5 +67,19 @@ sub run {
     systemctl('stop docker.service');
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+
+    my @targets = ("master", "worker1", "worker2");
+    foreach my $target (@targets) {
+        record_info $target, "Getting debug logs from $target host";
+        script_run "ssh root\@$target journalctl --no-pager";
+        script_run "ssh root\@$target docker ps";
+        script_run "ssh root\@$target 'docker ps -q | xargs -L 1 docker logs'";
+    }
+
+    $self->SUPER::post_fail_hook;
+}
+
 1;
 


### PR DESCRIPTION
Hello,

as the deployment of `rke1` is distributed (we deploy from master to all 3 nodes) it
is hard to get the debug output. Because of that I add `post_fail_hook` to collect it.

- Verification run: [pdostal-server.suse.cz](http://pdostal-server.suse.cz/tests/11875#step/rancher_rke1_master/144)
