### PR TITLE
setup_online_repos: introducing different online repos list for 15.3

### DIFF
--- a/tests/installation/setup_online_repos.pm
+++ b/tests/installation/setup_online_repos.pm
@@ -24,6 +24,10 @@ sub run {
     if (is_leap('<15.1')) {
         @default_repos = qw(update-non-oss update-oss main-non-oss main-oss debug-main untested-update debug-update source);
     }
+    elsif (is_leap('>=15.3')) {
+        # 15.3 has introduced additional repositories
+        @default_repos = qw(update-sle update-backports update-non-oss main-non-oss update-oss main-oss debug-backports-update debug-update untested-update source debug-main);
+    }
     else {
         @default_repos = qw(update-non-oss main-non-oss update-oss main-oss debug-update untested-update source debug-main);
     }


### PR DESCRIPTION
15.3 has introduced additional update repositories for Backports updates, Backports debug updates, and sle updates from the external repository list https://github.com/openSUSE/download.o.o/blob/master/YaST/Repos/_openSUSE_Leap_15.3_Default.xml , this change adding these repositories to setup_online_repos and make sure they're enabled by default except the debug one.

failing run: https://openqa.opensuse.org/tests/1759870#step/setup_online_repos/11
verification run: https://openqa.opensuse.org/tests/1760586#step/setup_online_repos/14

you can reference to https://bugzilla.opensuse.org/show_bug.cgi?id=1186593 also