### PR TITLE
openssl_alpn: explicitly install openssl instead of any provider of openssl(cli)

### DIFF
--- a/tests/console/openssl_alpn.pm
+++ b/tests/console/openssl_alpn.pm
@@ -28,7 +28,7 @@ use utils;
 sub run {
     select_console 'root-console';
 
-    zypper_call 'in "openssl(cli)"';
+    zypper_call 'in openssl';
     assert_script_run 'openssl req -newkey rsa:2048 -nodes -keyout domain.key -x509 -days 365 -out domain.crt -subj "/C=CZ/L=Prague/O=SUSE/CN=alpn.suse.cz"';
 
     clear_console;


### PR DESCRIPTION
Due to https://bugzilla.opensuse.org/show_bug.cgi?id=1186649 there is currently
no way to favor a provider across transactions. But the test ex[licitly is called
openssl_*, so forcing the usage of openssl sounds correct in any case

- Related ticket: related to tests/console/openssl_alpn.pm
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1761289 (in progress)
