### PR TITLE
Containers: create schedule for only container packages and features

### DIFF
--- a/schedule/containers/engines_and_tools.yaml
+++ b/schedule/containers/engines_and_tools.yaml
@@ -1,0 +1,24 @@
+name:           extra_tests_textmode_containers
+description:    >
+  Maintainer: qa-c@suse.de.
+  This schedule is focused on testing the related container packages and features,
+  but not the official container images from SUSE and openSUSE.
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+schedule:
+  - '{{boot}}'
+  - boot/boot_to_desktop
+  - containers/podman
+  - containers/buildah_podman
+  - containers/docker
+  - containers/buildah_docker
+  - containers/docker_runc
+  - containers/docker_compose
+  - containers/zypper_docker
+  - containers/containers_3rd_party
+  - containers/registry
+  - console/coredump_collect
+  - containers/rootless_podman


### PR DESCRIPTION
This schedule doesn't include the test of official images.

