### PR TITLE
logs_from_salt ignore temporal network error

### DIFF
--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -102,6 +102,7 @@ sub logs_from_salt {
     my $error = "cat /var/log/salt/* | grep -i 'CRITICAL\\|ERROR\\|Traceback' ";
     $error .= "| grep -vi 'Error while parsing IPv\\|Error loading module\\|Unable to resolve address\\|SaltReqTimeoutError' ";
     $error .= "| grep -vi 'has cached the public key for this node\\|Minion unable to successfully connect to a Salt Master'";
+    $error .= "| grep -vi 'Error while bringing up minion for multi-master'";
     if (script_run("$error") != 1) {
         die "Salt logs are containing errors!";
     }


### PR DESCRIPTION
From time to time, `Salt` test fails as it detects `error` message.
As this error is temporal and does not effect the cluster I ignore it.

- Verification run: [failure](https://openqa.suse.de/tests/6142592#step/salt_minion/94), [success](http://pdostal-server.suse.cz/tests/11880)
