### PR TITLE
Accept multiple CONTAINER_IMAGE_VERSIONS for containers/ _image testing

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -114,7 +114,6 @@ sub build_with_zypper_docker {
         return;
     }
 
-    # zypper docker can only update image if version is same as SUT
     if ($distri eq 'sle') {
         my $pretty_version = $version =~ s/-SP/ SP/r;
         my $betaversion    = get_var('BETA') ? '\s\([^)]+\)' : '';
@@ -136,7 +135,9 @@ sub build_with_zypper_docker {
     die("$runtime $derived_image not found") unless ($local_images_list =~ $derived_image);
 
     record_info("Testing derived", "Derived image: $derived_image");
-    test_opensuse_based_image(image => $derived_image, runtime => $runtime);
+    test_opensuse_based_image(image => $derived_image, runtime => $runtime, version => $version);
+
+    assert_script_run("docker rmi -f $derived_image");
 }
 
 sub test_opensuse_based_image {

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -21,20 +21,27 @@ use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
 
 sub run {
-    my ($image_names, $stable_names) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
     my $runtime = "podman";
     install_podman_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => $runtime);
-    for my $iname (@{$image_names}) {
-        test_container_image(image => $iname, runtime => $runtime);
-        test_rpm_db_backend(image => $iname, runtime => $runtime);
-        build_container_image(image => $iname, runtime => $runtime);
-        if (check_os_release('suse', 'PRETTY_NAME')) {
-            test_opensuse_based_image(image => $iname, runtime => $runtime);
-        }
-        else {
-            exec_on_container($iname, $runtime, 'cat /etc/os-release');
+
+    # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
+    my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
+
+    for my $version (split(/,/, $versions)) {
+        record_info "IMAGE", "We are testing image for $version now.";
+        my ($image_names, $stable_names) = get_suse_container_urls($version);
+        for my $iname (@{$image_names}) {
+            test_container_image(image => $iname, runtime => $runtime);
+            test_rpm_db_backend(image => $iname, runtime => $runtime);
+            build_container_image(image => $iname, runtime => $runtime);
+            if (check_os_release('suse', 'PRETTY_NAME')) {
+                test_opensuse_based_image(image => $iname, runtime => $runtime, version => $version);
+            }
+            else {
+                exec_on_container($iname, $runtime, 'cat /etc/os-release');
+            }
         }
     }
     clean_container_host(runtime => $runtime);

--- a/variables.md
+++ b/variables.md
@@ -118,6 +118,7 @@ QA_TESTSUITE | string | | Comma or semicolon separated a list of the automation 
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
 REBOOT_TIMEOUT | integer | 0 | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
 REGISTRY | string | docker.io | Registry to pull third-party container images from
+CONTAINER_IMAGE_VERSIONS | string | | List of comma-separated versions from `get_suse_container_urls()` to test in `tests/containers/*_image.pm`
 REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.
 REMOTE_REPOINST | boolean | | Use linuxrc features to install OS from specified repository (install) while booting installer from DVD (instsys)
 REPO_* | string | | Url pointing to the mirrored repo. REPO_0 contains installation iso.


### PR DESCRIPTION
As we don't want to always test all the SLE images but perhaps only one specific I introduced `CONTAINER_VERSIONS` variable which is optimal and can hold comma-separated list of desired versions.

- Related ticket: [poo#93228](https://progress.opensuse.org/issues/93228)
- Verification run: [SLE with multiple images](http://pdostal-server.suse.cz/tests/11954) [SLE with single image](http://pdostal-server.suse.cz/tests/11958) [openSUSE](http://pdostal-server.suse.cz/tests/11956)
