### PR TITLE
Disable a GCC warning as we test uninitialized use in valgrind.

### DIFF
--- a/data/valgrind/valgrind-test.sh
+++ b/data/valgrind/valgrind-test.sh
@@ -34,7 +34,8 @@ fi
 set -e
 
 echo "Compiling test program ... "
-gcc -Wall -Werror -Wextra -std=c99 -g2 -O0 -o valgrind-test valgrind-test.c
+# Disable -Wmaybe-uninitialized because we test a use of an uninitiazed memory.
+gcc -Wall -Werror -Wextra -Wno-maybe-uninitialized -std=c99 -g2 -O0 -o valgrind-test valgrind-test.c
 
 echo "Testing valgrind ... "
 valgrind --tool=memcheck --trace-children=yes ./valgrind-test 2>/dev/null


### PR DESCRIPTION
Fixes https://progress.opensuse.org/issues/93240
