### PR TITLE
Add back generic confirmation warnings to be used in tests

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerController.pm
@@ -75,6 +75,8 @@ sub init {
     $self->{RaidOptionsPage}                   = Installation::Partitioner::LibstorageNG::v4_3::RaidOptionsPage->new({app => YuiRestClient::get_app()});
     $self->{FstabOptionsPage}                  = Installation::Partitioner::LibstorageNG::v4_3::FstabOptionsPage->new({app => YuiRestClient::get_app()});
 
+    $self->{ConfirmationWarning}         = Installation::Warnings::ConfirmationWarning->new({app => YuiRestClient::get_app()});
+    $self->{ConfirmationWarningRichText} = Installation::Warnings::ConfirmationWarningRichText->new({app => YuiRestClient::get_app()});
     $self->{OnlyUseIfFamiliarWarning}    = Installation::Warnings::ConfirmationWarning->new({app => YuiRestClient::get_app()});
     $self->{DeletePartitionWarning}      = Installation::Warnings::ConfirmationWarning->new({app => YuiRestClient::get_app()});
     $self->{DeleteVolumeGroupWarning}    = Installation::Warnings::ConfirmationWarning->new({app => YuiRestClient::get_app()});
@@ -128,6 +130,11 @@ sub get_delete_volume_group_warning {
         die "Delete volume warning is not displayed";
     }
     return $self->{DeleteVolumeGroupWarning};
+}
+
+sub get_confirmation_warning {
+    my ($self) = @_;
+    return $self->{ConfirmationWarning};
 }
 
 sub get_confirmation_warning_rich_text {


### PR DESCRIPTION
Warnings for now can be evaluated as part of the navigation or in the test itself. This fix the possibility to assert its text
in the test, which was broken in PR #12610.

- Related ticket: [poo#91581](https://progress.opensuse.org/issues/91581)
- Verification run: [SLE](https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_confirmation_warnings) | [openSUSE](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_confirmation_warnings)
