### PR TITLE
xfstests: Add SCRATCH_LOGDEV for some tests

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -136,6 +136,13 @@ sub do_partition_for_xfstests {
         script_run("echo 'export SCRATCH_DEV_POOL=\"$SCRATCH_DEV_POOL\"' >> $CONFIG_FILE");
         set_var('XFSTESTS_SCRATCH_DEV_POOL', $SCRATCH_DEV_POOL);
     }
+    # Create SCRATCH_LOGDEV with disk partition
+    if (get_var('XFSTESTS_LOGDEV')) {
+        my $logdev = create_partition($para{dev}, $part_type, 100);
+        format_partition($logdev, $para{fstype});
+        script_run("echo export SCRATCH_LOGDEV=$logdev >> $CONFIG_FILE");
+        script_run("echo export USE_EXTERNAL=yes >> $CONFIG_FILE");
+    }
     # Sync
     script_run('sync');
 }
@@ -186,6 +193,17 @@ sub create_loop_device_by_rootsize {
     else {
         script_run("echo 'export SCRATCH_DEV_POOL=\"/dev/loop1 /dev/loop2 /dev/loop3 /dev/loop4 /dev/loop5\"' >> $CONFIG_FILE");
         set_var('XFSTESTS_SCRATCH_DEV_POOL', '/dev/loop1 /dev/loop2 /dev/loop3 /dev/loop4 /dev/loop5');
+    }
+    # Create SCRATCH_LOGDEV with loop device
+    if (get_var('XFSTESTS_LOGDEV')) {
+        my $logdev      = "/dev/loop100";
+        my $logdev_name = "logdev";
+
+        assert_script_run("fallocate -l 100M $INST_DIR/$logdev_name",  300);
+        assert_script_run("losetup -P $logdev $INST_DIR/$logdev_name", 300);
+        format_partition("$INST_DIR/logdev_name", $para{fstype});
+        script_run("echo export SCRATCH_LOGDEV=$logdev >> $CONFIG_FILE");
+        script_run("echo export USE_EXTERNAL=yes >> $CONFIG_FILE");
     }
     # Sync
     script_run('sync');


### PR DESCRIPTION
Some test not run by requires $SCRATCH_LOGDEV, add one LOGDEV to test this kind of tests.

- Related ticket: https://progress.opensuse.org/issues/81841
- Needles: N/A
- Verification run: 
http://10.67.133.102/tests/282 (logdev with disk partition)
http://10.67.133.102/tests/277 (no logdev)
http://10.67.133.102/tests/276 (logdev with loop device)
