### PR TITLE
Increase audit2allow log size

### DIFF
--- a/tests/security/selinux/audit2allow.pm
+++ b/tests/security/selinux/audit2allow.pm
@@ -41,7 +41,7 @@ sub run {
     assert_script_run("cp $original_audit $audit_log");
     validate_script_output("audit2allow -a",            sub { m/allow\ .*_t\ .*;.*/sx });
     validate_script_output("audit2allow -i $audit_log", sub { m/allow\ .*_t\ .*;.*/sx });
-    assert_script_run("tail -n 100 $audit_log > $audit_log_short");
+    assert_script_run("tail -n 500 $audit_log > $audit_log_short");
     validate_script_output(
         "audit2allow -w -i $audit_log_short",
         sub {


### PR DESCRIPTION
Increasing file size considered due to failures on 15 SP2 https://openqa.suse.de/tests/6149165#next_previous
Related to #12604

- Related ticket: https://progress.opensuse.org/issues/90737
- Needles: no needles
- Verification run: http://10.161.229.176/tests/872#