### PR TITLE
Schedule sssd in functional and opensuse group

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -46,7 +46,7 @@ conditional_schedule:
                 - console/gdb
                 - console/perf
                 - console/salt
-                - sysauth/sssd
+                - console/sssd_389ds_functional
                 - console/libgpiod
                 - console/libgcrypt
                 - console/gd

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -9,7 +9,8 @@ schedule:
     - console/python_scientific
     - '{{wpa_supplicant}}'
     - console/vmstat
-    - sysauth/sssd
+    - console/sssd_389ds_functional
+    - console/sssd_openldap_functional
     - console/coredump_collect
 conditional_schedule:
     wpa_supplicant:

--- a/tests/console/sssd_openldap_functional.pm
+++ b/tests/console/sssd_openldap_functional.pm
@@ -37,38 +37,35 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 
 sub run {
     select_console("root-console");
-    if (!get_var("SSSD_OPENLDAP_FUNCTIONAL_SETUP")) {
-        if (is_sle) {
-            add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
-            is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
-        }
-        zypper_call("in sssd sssd-ldap openldap2-client sshpass docker");
-        systemctl('enable --now docker');
-        #Select container base image by specifying variable BASE_IMAGE_TAG. (for sles using sle15sp3 by default)
-        my $pkgs = "openldap2 sudo";
-        my $tag  = get_var("BASE_IMAGE_TAG");
-        unless ($tag) {
-            if (is_opensuse) { $tag = (is_tumbleweed) ? "opensuse/tumbleweed" : "opensuse/leap";
-            } else           { $tag = "registry.suse.com/suse/sle15:15.3"; }
-        }
-        # build container
-        # build image, create container, setup openldap database and import testing data
-        assert_script_run("mkdir /tmp/sssd && cd /tmp/sssd");
-        assert_script_run("curl -s " . "--remote-name-all " . data_url('sssd/openldap/{user.ldif,slapd.conf,Dockerfile}'));
-        assert_script_run("curl -s " . "--remote-name-all " . data_url('sssd/openldap/ldapserver.{key,crt,csr}'));
-        assert_script_run(qq(docker build -t openldap2_image --build-arg tag="$tag" --build-arg pkgs="$pkgs" .), timeout => 600);
-        assert_script_run('docker run -itd --name ldap_container --hostname ldapserver --restart=always openldap2_image');
-        assert_script_run("docker exec ldap_container sed -n '/ldapserver/p' /etc/hosts >> /etc/hosts");
-
-        # Configure sssd on the host
-        assert_script_run("curl -s " . data_url("sssd/openldap/sssd.conf") . " -o /etc/sssd/sssd.conf");
-        assert_script_run("curl -s " . data_url("sssd/openldap/nsswitch.conf") . " -o /etc/nsswitch.conf");
-        assert_script_run("curl -s " . data_url("sssd/openldap/ldapserver.crt") . " -o /etc/sssd/ldapserver.crt");
-        assert_script_run("curl -s " . data_url("sssd/openldap/config") . " --create-dirs -o ~/.ssh/config");
-        systemctl('disable --now nscd.service');
-        systemctl("enable --now sssd.service");
-        set_var("SSSD_OPENLDAP_FUNCTIONAL_SETUP", 1);
+    if (is_sle) {
+        add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
+        is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
     }
+    zypper_call("in sssd sssd-ldap openldap2-client sshpass docker");
+    systemctl('enable --now docker');
+    #Select container base image by specifying variable BASE_IMAGE_TAG. (for sles using sle15sp3 by default)
+    my $pkgs = "openldap2 sudo";
+    my $tag  = get_var("BASE_IMAGE_TAG");
+    unless ($tag) {
+        if (is_opensuse) { $tag = (is_tumbleweed) ? "opensuse/tumbleweed" : "opensuse/leap";
+        } else           { $tag = "registry.suse.com/suse/sle15:15.3"; }
+    }
+    # build container
+    # build image, create container, setup openldap database and import testing data
+    assert_script_run("mkdir /tmp/sssd && cd /tmp/sssd");
+    assert_script_run("curl -s " . "--remote-name-all " . data_url('sssd/openldap/{user.ldif,slapd.conf,Dockerfile}'));
+    assert_script_run("curl -s " . "--remote-name-all " . data_url('sssd/openldap/ldapserver.{key,crt,csr}'));
+    assert_script_run(qq(docker build -t openldap2_image --build-arg tag="$tag" --build-arg pkgs="$pkgs" .), timeout => 600);
+    assert_script_run('docker run -itd --name ldap_container --hostname ldapserver --restart=always openldap2_image');
+    assert_script_run("docker exec ldap_container sed -n '/ldapserver/p' /etc/hosts >> /etc/hosts");
+
+    # Configure sssd on the host
+    assert_script_run("curl -s " . data_url("sssd/openldap/sssd.conf") . " -o /etc/sssd/sssd.conf");
+    assert_script_run("curl -s " . data_url("sssd/openldap/nsswitch.conf") . " -o /etc/nsswitch.conf");
+    assert_script_run("curl -s " . data_url("sssd/openldap/ldapserver.crt") . " -o /etc/sssd/ldapserver.crt");
+    assert_script_run("curl -s " . data_url("sssd/openldap/config") . " --create-dirs -o ~/.ssh/config");
+    systemctl('disable --now nscd.service');
+    systemctl("enable --now sssd.service");
 
     #execute test cases
     #get remote user indentity
@@ -97,6 +94,10 @@ sub run {
     validate_script_output('sshpass -p open5use ssh adam@localhost whoami', sub { m/adam/ });
     #offline sudo run a command as another user
     validate_script_output('sshpass -p open5use ssh adam@localhost "echo open5use|sudo -S -u bob /usr/bin/cat /home/bob/hello"', sub { m/file read only by owner bob/ });
+}
+
+sub test_flags {
+    return {always_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
Schedule sssd test in functional and opensuse TW job group. As this won't run in migration test so remove condition var: SSSD_389DS_FUNCTIONAL_SETUP.  Also add always_rollback=1 to clean up test.

- Related ticket: https://progress.opensuse.org/issues/89479
- Needles: no
- Verification run: 
- functional: http://10.67.17.201/tests/1684
- sssd_openldap 15sp2:  http://10.67.17.201/tests/1689
- sssd_389ds 15sp2: http://10.67.17.201/tests/1687
