### PR TITLE
Allow enabling SELinux during installation

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1006,11 +1006,13 @@ sub load_inst_tests {
         loadtest "installation/resolve_dependency_issues" unless get_var("DEPENDENCY_RESOLVER_FLAG");
         loadtest "installation/installation_overview";
         # On Xen PV we don't have GRUB on VNC
-        set_var('KEEP_GRUB_TIMEOUT', 1) if check_var('VIRSH_VMM_TYPE', 'linux');
+        # SELinux relabel reboots, so grub needs to timeout
+        set_var('KEEP_GRUB_TIMEOUT', 1) if check_var('VIRSH_VMM_TYPE', 'linux') || get_var('SELINUX');
         loadtest "installation/disable_grub_timeout" unless get_var('KEEP_GRUB_TIMEOUT');
         if (check_var('VIDEOMODE', 'text') && check_var('BACKEND', 'ipmi')) {
             loadtest "installation/disable_grub_graphics";
         }
+        loadtest "installation/enable_selinux" if get_var('SELINUX');
 
         if (check_var("UPGRADE", "LOW_SPACE")) {
             loadtest "installation/disk_space_release";
@@ -2613,6 +2615,7 @@ sub load_system_prepare_tests {
     loadtest 'console/hostname' unless is_bridged_networking;
     loadtest 'console/install_rt_kernel' if check_var('SLE_PRODUCT', 'SLERT');
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
+    loadtest 'console/check_selinux_fails' if get_var('SELINUX');
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests          if is_repo_replacement_required;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');

--- a/tests/console/check_selinux_fails.pm
+++ b/tests/console/check_selinux_fails.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: Look for selinux fails in audit log
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+
+    script_run "ausearch -ts boot -m avc | tee /root/selinux_audit_logs.txt";
+
+    upload_logs "/root/selinux_audit_logs.txt";
+
+    assert_script_run "! grep denied /root/selinux_audit_logs.txt";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Enable SELinux during installation
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+
+sub run {
+    my $textmode = check_var('VIDEOMODE', 'text');
+    # Verify Installation Settings overview is displayed as starting point
+    assert_screen "installation-settings-overview-loaded";
+
+    if ($textmode) {
+        # Select section booting on Installation Settings overview on text mode
+        send_key $cmd{change};
+        assert_screen 'inst-overview-options';
+        send_key 'alt-e';
+    }
+    else {
+        # Select section booting on Installation Settings overview (video mode)
+        send_key_until_needlematch 'security-section-selected', 'tab';
+        send_key 'ret';
+    }
+
+    send_key 'alt-m';
+    send_key_until_needlematch 'security-selinux-enforcing', 'down';
+    send_key 'ret' if $textmode;
+
+    send_key $cmd{ok};
+}
+
+1;


### PR DESCRIPTION
With the setting SELINUX=1 the installation will activate SELinux in
enforcing mode. An additional console test checks for SELinux messages
in the audit log. The test fails if there are any complaints.

- Verification runs (obviously they fail as the policy in Factory is not complete yet)
  http://tortuga.suse.de/tests/130
  http://tortuga.suse.de/tests/131
  http://tortuga.suse.de/tests/132
