### PR TITLE
Automation fixes for virtualization features with uefi guest

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -132,6 +132,8 @@ sub ssh_setup {
     my $dt              = DateTime->now;
     my $comment         = "openqa-" . $dt->mdy . "-" . $dt->hms('-') . get_var('NAME');
     if (script_run("[[ -s $default_ssh_key ]]") != 0) {
+        my $default_ssh_key_dir = dirname($default_ssh_key);
+        script_run("mkdir -p $default_ssh_key_dir");
         assert_script_run "ssh-keygen -t rsa -P '' -C '$comment' -f $default_ssh_key";
     }
 }

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -87,7 +87,7 @@ sub run_test {
         check_guest_module("$guest", module => "acpiphp");
         assert_script_run("virsh attach-interface $guest network vnet_routed --model $model1 --mac $mac1 --live $affecter", 60);
         #Wait for attached interface and associated information to be populated and become stable
-        die "Interface model:$model1 mac:$mac1 can not be attached to guest $guest successfully" if (script_retry("virsh domiflist $guest | grep vnet_routed | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"", delay => 20, retry => 3) ne 0);
+        die "Interface model:$model1 mac:$mac1 can not be attached to guest $guest successfully" if (script_retry("virsh domiflist $guest | grep vnet_routed | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"", delay => 30, retry => 10) ne 0);
 
         $mac2   = '00:16:3e:32:' . (int(rand(89)) + 10) . ':' . (int(rand(89)) + 10);
         $model2 = (is_xen_host) ? 'netfront' : 'virtio';
@@ -96,7 +96,7 @@ sub run_test {
         check_guest_module("$guest.clone", module => "acpiphp");
         assert_script_run("virsh attach-interface $guest.clone network vnet_routed_clone --model $model2 --mac $mac2 --live $affecter", 60);
         #Wait for attached interface and associated information to be populated and become stable
-        die "Interface model:$model2 mac:$mac2 can not be attached to guest $guest.clone successfully" if (script_retry("virsh domiflist $guest.clone | grep vnet_routed_clone | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"", delay => 20, retry => 3) ne 0);
+        die "Interface model:$model2 mac:$mac2 can not be attached to guest $guest.clone successfully" if (script_retry("virsh domiflist $guest.clone | grep vnet_routed_clone | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"", delay => 30, retry => 10) ne 0);
 
         my $net1 = is_sle('=11-sp4') ? 'br123' : 'vnet_routed';
         test_network_interface("$guest", mac => $mac1, gate => $gate1, routed => 1, target => $target1, net => $net1);

--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -207,7 +207,7 @@ sub run_test {
     my ($self) = @_;
     my ($sles_running_version, $sles_running_sp) = get_os_release;
 
-    if ($sles_running_version eq '15' && get_var("VIRT_AUTOTEST")) {
+    if ($sles_running_version eq '15' && get_var("VIRT_AUTOTEST") && !get_var("VIRT_UEFI_GUEST_INSTALL")) {
         record_info("DNS Setup", "SLE 15+ host may have more strict rules on dhcp assigned ip conflict prevention, so guest ip may change");
         my $dns_bash_script_url = data_url("virt_autotest/setup_dns_service.sh");
         script_output("curl -s -o ~/setup_dns_service.sh $dns_bash_script_url", 180, type_command => 0, proceed_on_failure => 0);


### PR DESCRIPTION
* **Create** folder that does no exist in ssh_setup function before saving ssh key
* **Retry** several times more to ensure interface is attached for libvirt_routed_virtual_network test
* **Only** call setup_dns_service.sh if test does not have VIRT_UEFI_GUEST_INSTALL set
* **Verification run:**
  * [kvm uefi guest with features](https://openqa.suse.de/tests/6152789)
  * [xen uefi guest with features](https://openqa.suse.de/tests/6152774)