### PR TITLE
Remove tests from the areas that they fail

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -30,8 +30,6 @@ schedule:
   - console/aaa_base
   - console/gd
   - console/systemtap
-  - console/openvswitch_ssl
-  - console/journald_fss
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:
@@ -44,31 +42,46 @@ conditional_schedule:
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
+        - console/journald_fss
+        - console/openvswitch_ssl
         - '{{arch_specific}}'
       15-SP1:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
+        - console/journald_fss
+        - console/openvswitch_ssl
         - '{{arch_specific}}'
       15:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
+        - console/journald_fss
+        - console/openvswitch_ssl
         - '{{arch_specific}}'
       12-SP5:
         - console/osinfo_db
         - console/libgcrypt
         - console/valgrind
         - console/zziplib
+        - console/openvswitch_ssl
         - '{{arch_specific}}'
+        - '{{arch_12sp5}}'
       12-SP4:
         - console/osinfo_db
+        - console/journald_fss
+        - console/openvswitch_ssl
         - '{{arch_specific}}'
       12-SP3:
         - console/osinfo_db
+        - console/journald_fss
+        - console/openvswitch_ssl
         - '{{arch_specific}}'
+      12-SP2:
+        - console/journald_fss
+        - console/vsftpd
   arch_specific:
     ARCH:
       x86_64:
@@ -76,4 +89,10 @@ conditional_schedule:
         - console/vsftpd
       aarch64:
         - console/vsftpd
+  arch_12sp5:
+    ARCH:
+      x86_64:
+        - console/journald_fss
+      aarch64:
+        - console/journald_fss
 ...


### PR DESCRIPTION
* opevnswitch_ssl fails in SLE12SP2(x86_64), because of bug :
https://bugzilla.suse.com/show_bug.cgi?id=1186718
https://openqa.suse.de/tests/6152266#step/openvswitch_ssl/7
remove it from schedule

* journald_fss fails in SLE12SP5(s390x) sporadically
https://openqa.suse.de/tests/6143653#step/journald_fss/20
https://openqa.suse.de/tests/6156831#step/journald_fss/19

remove it from schedule

- Related ticket: https://progress.opensuse.org/issues/91193
- Needles: N/A
- Verification run: 
s390x : [15sp2](https://openqa.suse.de/tests/6158547) | [15sp1](https://openqa.suse.de/tests/6158550) | [15](https://openqa.suse.de/tests/6158555) | [12sp5](https://openqa.suse.de/tests/6158558) | [12sp4](https://openqa.suse.de/tests/6158560)
x86_64 : [15sp2](https://openqa.suse.de/tests/6158742) | [15sp1](https://openqa.suse.de/tests/6158744) | [15](https://openqa.suse.de/tests/6158746) | [12sp5](https://openqa.suse.de/tests/6158992) | [12sp4](https://openqa.suse.de/tests/6158749) | [12sp3](https://openqa.suse.de/tests/6158750) | [12sp2](https://openqa.suse.de/tests/6158942)
aarch64 : [15sp2](https://openqa.suse.de/tests/6158547) | [15sp1](https://openqa.suse.de/tests/6158550) | [15](https://openqa.suse.de/tests/6158745) | [12sp5](https://openqa.suse.de/tests/6158993) 
