### PR TITLE
Reuse microos/journal_check and microos/libzypp_config in JeOS testing

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -1,0 +1,190 @@
+{
+    "bsc#1022527": {
+        "description": ".*wickedd.*ni_process_reap.*blocking waitpid.*",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "feature"
+    },
+    "bsc#1126272": {
+        "description": "Failed unmounting \/\\S+\\.|-- Reboot --|pam_systemd.*Failed to release session",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "bug"
+    },
+    "bsc#1022525": {
+        "description": ".*rpcbind.*cannot(.*open file.*rpcbind.xdr.*|.*open file.*portmap.xdr.*|.*save any registration.*)",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ]
+        },
+        "type": "bug"
+    },
+    "bsc#1184970": {
+        "description": ".*rpc\\.statd.*Failed to open directory sm.*|.*Failed to stat \/var\/lib\/nfs\/sm: No such file or directory",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "bug"
+    },
+    "bsc#1182500": {
+        "description": "Failed to transition into init label 'system_u:system_r:init_t:s0'",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "bug"
+    },
+    "bsc#1178033": {
+        "description": "kernel: ITS@0x8080000: Unable to locate ITS domain handle",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "bug"
+    },
+    "bsc#1177695": {
+        "description": "kernel: parport_pc: `none' invalid for parameter `dma'",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ]
+        },
+        "type": "bug"
+    },
+    "bsc#1177693": {
+        "description": "kernel: intel_powerclamp: CPU does not support MWAIT",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "bug"
+    },
+    "bsc#1182961": {
+        "description": "could not read from '/sys/module/pcc_pufreq/initstate': No such device",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "bug"
+    },
+    "bsc#1177028": {
+        "description": "Started bpfilter",
+        "products": {
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "bug"
+    },
+    "bsc#1187618": {
+        "description": "systemd-vconsole-setup.service",
+        "products": {
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "bug"
+    },
+    "bsc#1187591": {
+        "description": "EFI secret key getting failed: EFI_NOT_FOUND|EFI secret key size 0 is less than 64. Please regenerate secret key",
+        "products": {
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "bug"
+    },
+    "bsc#1187613": {
+        "description": "kernel: Grant table initialized",
+        "products": {
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "bug"
+    },
+    "apci-bridge": {
+        "description": "fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge|PCI: System does not support PCI",
+        "products": {
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    },
+    "printk": {
+        "description": "kernel: printk: systemd:.*output lines suppressed due to ratelimiting",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    },
+    "boot-marker": {
+        "description": "-- Boot\\s+\\w+\\s+--",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    },
+    "vmware-cpuid": {
+        "description": "kernel: core: CPUID marked event:",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    },
+    "hyperv-timer": {
+        "description": ".*Found PM-Timer Bug on the chipset. Due to workarounds for a bug.*|.*Unstable clock detected, switching default tracing clock to \"global\".*|If you want to keep using the local clock, then add:|\"trace_clock=local\"| on the kernel command line|.*this clock source is slow. Consider trying other clock sources.*",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    },
+    "hyperv-mouse": {
+        "description": "kernel: psmouse serio1: trackpoint: failed to get extended button data, assuming 3 buttons",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    },
+    "xen-trim-btrfs-on-mechaninal-drive": {
+        "description": "kernel: BTRFS warning.*: failed to trim.*, last error -512",
+        "products": {
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    },
+    "health-check": {
+        "description": "health-checker/fail.sh check\" failed|Machine didn't come up correct, do a rollback",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "ignore"
+    },
+    "chrony": {
+        "description": "chronyd.*Received KoD RATE from|System clock wrong by.*, adjustment started|System clock was stepped by.*",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    }
+}

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -557,7 +557,6 @@ sub load_system_role_tests {
     }
 }
 sub load_jeos_tests {
-    # loadtest 'jeos/sccreg';
     if ((is_arm || is_aarch64) && is_opensuse()) {
         # Enable jeos-firstboot, due to boo#1020019
         load_boot_tests();
@@ -573,6 +572,8 @@ sub load_jeos_tests {
         loadtest "jeos/build_key";
         loadtest "console/prjconf_excluded_rpms";
     }
+    loadtest "microos/journal_check";
+    loadtest "microos/libzypp_config";
     if (is_sle) {
         loadtest "console/suseconnect_scc";
     }

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -36,6 +36,8 @@ schedule:
     - jeos/diskusage
     - jeos/build_key
     - console/prjconf_excluded_rpms
+    - microos/journal_check
+    - microos/libzypp_config
     - console/suseconnect_scc
     - '{{efi}}'
     - jeos/glibc_locale

--- a/tests/microos/journal_check.pm
+++ b/tests/microos/journal_check.pm
@@ -16,61 +16,65 @@ use warnings;
 use testapi;
 use microos;
 use version_utils 'is_opensuse';
+use Mojo::JSON qw(decode_json);
+
+sub parse_bug_refs {
+    my $res            = shift;
+    my $tested_product = get_required_var('DISTRI');
+    my $tested_version = get_required_var('VERSION');
+    my %bp;
+
+    my $bugs = decode_json($res->body);
+    foreach my $bugid (keys %$bugs) {
+        if (exists $bugs->{$bugid}->{products}->{$tested_product} && ref $bugs->{$bugid}->{products}->{$tested_product} eq ref []) {
+            foreach my $ver (@{$bugs->{$bugid}->{products}->{$tested_product}}) {
+                if ($ver eq $tested_version) {
+                    $bp{$bugid} = {%{$bugs->{$bugid}}{qw(type description)}};
+                    last;
+                }
+            }
+        } else {
+            bmwqemu::diag("Versions of a product in journal_check::bug_refs.json should be stored in an array, or the product key is missing!");
+        }
+    }
+    return !%bp ? undef : \%bp;
+}
 
 sub run {
     my $self = shift;
+    my $res  = Mojo::UserAgent->new->get(data_url('journal_check/bug_refs.json'))->result;
+    $res->is_success or die "Could not download file with bug refs";
+    my $bug_pattern = parse_bug_refs($res);
 
     $self->select_serial_terminal;
 
-    my $bug_pattern = {
-        bsc_1062349         => '.*vbd.*xenbus_dev_probe on device.*',
-        bsc_1022527_FEATURE => '.*wickedd.*ni_process_reap.*blocking waitpid.*',
-        bsc_1022524_FEATURE => '.*rpc\.statd.*Failed to open directory sm.*',
-        bsc_1022525_FEATURE => '.*rpcbind.*cannot(.*open file.*rpcbind.xdr.*|.*open file.*portmap.xdr.*|.*save any registration.*)',
-        bsc_1023818         => '.*Dev dev-disk-by.*device appeared twice with different sysfs paths.*',
-        bsc_1033792         => '.*blk_update_request.*error.*dev fd0.*sector 0.*',
-        bsc_1047923         => '.*e820: (cannot find a gap in the 32bit address range|PCI devices with unassigned 32bit BARs may break!)',
-        bsc_1058703         => '.*Specified group \'.*\' unknown.*',
-        bsc_1025217_FEATURE => '.*piix4_smbus.*SMBus (Host Controller not enabled|base address uninitialized - upgrade BIOS).*',
-        bsc_1025218_FEATURE => '.*dmi.*Firmware registration failed.*',
-        bsc_1028060_FEATURE => '.*getting etcd lock took too long, reboot canceld.*',
-        bsc_1071224         => '.*Failed to start Mask tmp.mount by default on SUSE systems.*',
-        poo_31951_FEATURE   => '.*Spectre V2 \:.*LFENCE not serializing.*',
-        bsc_1118321         => '.*update-checker-migration.timer.*(Failed to parse calendar specification|Timer unit lacks value setting).*',
-        bsc_1126272         => 'Failed unmounting \/\S+\.|-- Reboot --|pam_systemd.*Failed to release session',
-        bsc_1127339         => 'kernel: efi: EFI_MEMMAP is not enabled',
-        bsc_1177693         => 'kernel: intel_powerclamp: CPU does not support MWAIT',
-        bsc_1177695         => 'kernel: parport_pc: `none\' invalid for parameter `dma\'',
-        bsc_1178033         => 'kernel: ITS@0x8080000: Unable to locate ITS domain handle',
-        bsc_1182500         => 'Failed to transition into init label \'system_u:system_r:init_t:s0\'',
-        bsc_1182961         => 'could not read from \'/sys/module/pcc_cpufreq/initstate\': No such device',
-        bsc_1184970         => '.*rpc\.statd.*Failed to stat \/var\/lib\/nfs\/sm: No such file or directory',
-        bsc_000000_FEATURE  => 'health-checker/fail.sh check" failed|Machine didn\'t come up correct, do a rollback',
-    };
-    my $master_pattern = "(" . join('|', map { "$_" } values %$bug_pattern) . ")";
-
-    my $journal_output = script_output("journalctl --no-pager -p err -o short-precise | tail -n +2");
+    my @journal_output = split(/\n/, script_output("journalctl --no-pager -p ${\get_var('JOURNAL_LOG_LEVEL', 'err')} -o short-precise | tail -n +2"));
 
     # Find lines which matches to the pattern_bug
-    while (my ($bug, $pattern) = each %$bug_pattern) {
+    foreach my $bug (keys %$bug_pattern) {
         my $buffer = "";
-        my $result = "";
-        foreach my $line (split(/\n/, $journal_output)) {
-            $buffer .= $line . "\n" if ($line =~ /$pattern/);
+        foreach my $line (@journal_output) {
+            $buffer .= $line . "\n" if ($line =~ /$bug_pattern->{$bug}->{description}/);
         }
         if ($buffer) {
-            $result = $bug =~ 'FEATURE' ? 'ok' : 'softfail';
-            record_info $bug, $buffer, result => $result;
+            if ($bug_pattern->{$bug}->{type} eq 'feature') {
+                record_info($bug, $buffer);
+            } elsif ($bug_pattern->{$bug}->{type} eq 'ignore') {
+                bmwqemu::diag("Ignoring log message:\n$buffer\n");
+            } else {
+                record_soft_failure("$bug:\n$buffer");
+            }
         }
     }
 
     my $failed;
     # Find lines which doesn't match to the pattern_bug by using master_pattern
-    foreach my $line (split(/\n/, $journal_output)) {
-        if ($line !~ /$master_pattern/) {
-            record_info('Unknown issue', $line, result => 'fail');
-            $failed = 1;
+  OUT: foreach my $line (@journal_output) {
+        foreach my $mp (map { $bug_pattern->{$_}->{description} } keys %$bug_pattern) {
+            next OUT if ($line =~ /$mp/);
         }
+        record_info('Unknown issue', $line, result => 'fail');
+        $failed = 1;
     }
 
     # Write full journal output for reference and upload it into Uploaded Logs section in test webUI

--- a/tests/microos/libzypp_config.pm
+++ b/tests/microos/libzypp_config.pm
@@ -15,11 +15,12 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use version_utils qw(is_jeos);
 
 sub run {
     assert_script_run 'egrep -x "^solver.onlyRequires ?= ?true" /etc/zypp/zypp.conf';
     assert_script_run 'egrep -x "^rpm.install.excludedocs ?= ?yes" /etc/zypp/zypp.conf';
-    assert_script_run 'egrep -x "^multiversion ?=" /etc/zypp/zypp.conf';
+    assert_script_run sprintf('egrep -x "^multiversion ?=%s" /etc/zypp/zypp.conf', is_jeos ? ' ?provides:multiversion\(kernel\)' : '');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION


- Related ticket: [JeOS's Warnings in log](https://progress.opensuse.org/issues/93267)
- Verification runs without:
    - [microos-Tumbleweed-MicroOS-Image-Kubic-kubeadm-x86_64-Build20210613-kubeadm@64bit-2G](http://kepler.suse.cz/tests/5769#step/journal_check/116)
    - [microos-Tumbleweed-MicroOS-Image-ContainerHost-x86_64-Build20210613-container-host@64bit](http://kepler.suse.cz/tests/5768#step/journal_check/36)
    - [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20210615-jeos@uefi_virtio-2G](http://kepler.suse.cz/tests/5771#step/journal_check/23)
    - [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20210615-log-warnings@uefi_virtio-2G](http://kepler.suse.cz/tests/5772#step/journal_check/25)
    - [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build31.477-log-warnings@64bit_virtio-2G](http://kepler.suse.cz/tests/5786#step/journal_check/36)
    - [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.94-log-warnings@64bit_virtio-2G](http://kepler.suse.cz/tests/5799#step/journal_check/36)
    - [microos-Tumbleweed-MicroOS-Image-x86_64-Build20210613-microos@64bit](http://kepler.suse.cz/tests/5770#step/journal_check/36)
    - [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20210621-1-log-warnings@uefi-virtio-vga](http://kepler.suse.cz/tests/5790#step/journal_check/25)
    - [sle-15-SP2-JeOS-for-kvm-and-xen-QR-x86_64-Build15.92-log-warnings@uefi-virtio-vga](http://kepler.suse.cz/tests/5782#step/journal_check/36)
    - [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build2.36-log-warnings@svirt-xen-hvm](http://kepler.suse.cz/tests/5792#step/journal_check/13)
    - [sle-15-SP3-JeOS-for-MS-HyperV-x86_64-Build2.36-log-warnings@svirt-hyperv-uefi](http://kepler.suse.cz/tests/5766#step/journal_check/13)
    - [sle-15-SP3-JeOS-for-VMware-x86_64-Build2.36-log-warnings@svirt-vmware65](http://kepler.suse.cz/tests/5793#step/journal_check/12)
    - [sle-15-SP3-JeOS-for-MS-HyperV-x86_64-Build2.36-log-warnings@svirt-hyperv](http://kepler.suse.cz/tests/5794#)
    - [sle-15-SP3-JeOS-for-kvm-and-xen-x86_64-Build2.36-log-warnings@svirt-xen-pv](http://kepler.suse.cz/tests/5795)
    - [sle-micro-5.0-MicroOS-Image-Updates-x86_64-Build20210622-1-sle-micro_selinux@64bit](http://kepler.suse.cz/tests/5805)
    - [sle-micro-5.1-MicroOS-Image-x86_64-Build27.3_4.7-sle-micro_selinux@64bit](http://kepler.suse.cz/tests/5806)