### PR TITLE
Only test midori on Leap < 16

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1262,7 +1262,8 @@ sub load_x11tests {
         loadtest "x11/chromium";
     }
     if (xfcestep_is_applicable()) {
-        loadtest "x11/midori" unless (is_staging || is_livesystem);
+        # Midori got dropped from TW
+        loadtest "x11/midori" unless (is_staging || is_livesystem || !is_leap("<16"));
         loadtest "x11/ristretto";
     }
     if (gnomestep_is_applicable()) {


### PR DESCRIPTION
It got dropped from Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/93402
- Verification run: https://openqa.opensuse.org/tests/1764829
