### PR TITLE
[WIP] Fix sssd command line parameter

### DIFF
--- a/data/sssd-tests/krb/test.sh
+++ b/data/sssd-tests/krb/test.sh
@@ -60,7 +60,7 @@ kadmin.local -r LDAPDOM.NET -q 'modprinc +requires_preauth testuser1' &> /dev/nu
 kadmin.local -r LDAPDOM.NET -q 'modprinc +requires_preauth testuser2' &> /dev/null &&
 
 test_case 'Start SSSD'
-sssd -f -c sssd.conf || test_fatal 'Failed to start SSSD'
+sssd --logger=files  -c sssd.conf || test_fatal 'Failed to start SSSD'
 test_ok
 
 credentials_test() {

--- a/data/sssd-tests/ldap-nested-groups/test.sh
+++ b/data/sssd-tests/ldap-nested-groups/test.sh
@@ -26,7 +26,7 @@ sleep 2 &&
 ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif &> /dev/null || test_abort 'Failed to prepare LDAP server'
 
 test_case 'Start SSSD'
-sssd -f -c sssd.conf || test_fatal 'Failed to start SSSD'
+sssd --logger=files -c sssd.conf || test_fatal 'Failed to start SSSD'
 test_ok
 
 test_case 'Look up users in LDAP via SSSD'

--- a/data/sssd-tests/ldap-no-auth/test.sh
+++ b/data/sssd-tests/ldap-no-auth/test.sh
@@ -26,7 +26,7 @@ sleep 2 &&
 ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif &> /dev/null || test_abort 'Failed to prepare LDAP server'
 
 test_case 'Start SSSD'
-sssd -f -c sssd.conf || test_fatal 'Failed to start SSSD'
+sssd --logger=files -c sssd.conf || test_fatal 'Failed to start SSSD'
 test_ok
 
 test_case 'Look up users in LDAP via SSSD'

--- a/data/sssd-tests/ldap/test.sh
+++ b/data/sssd-tests/ldap/test.sh
@@ -26,7 +26,7 @@ sleep 2 &&
 ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif &> /dev/null || test_abort 'Failed to prepare LDAP server'
 
 test_case 'Start SSSD'
-sssd -f -c sssd.conf || test_fatal 'Failed to start SSSD'
+sssd --logger=files -c sssd.conf || test_fatal 'Failed to start SSSD'
 test_ok
 
 test_case 'Look up users in LDAP via SSSD'


### PR DESCRIPTION
Fixing the command line parameter of sssd from f,--debug-to-files, to --logger=files.

- Related ticket: https://progress.opensuse.org/issues/92948
- Needles: No
- Verification run: Pending
