### PR TITLE
SLE Micro: increase timeout to install maintenance updates

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -27,7 +27,7 @@ sub run {
     }
     add_test_repositories;
     record_info 'Updates', script_output('zypper lu');
-    trup_call 'up';
+    trup_call 'up',        timeout => 300;
     check_reboot_changes;
 }
 


### PR DESCRIPTION
Due to big amount of updates, the time to install them in the image flavor increases. This is the test where it has been failing during latest runs: https://openqa.suse.de/tests/6157780#step/install_updates/47

VR: https://openqa.suse.de/tests/6160543