### PR TITLE
Retry ping to make test more resilient

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -63,7 +63,7 @@ sub check_guest_ip {
         my $gi_guest = script_output("$syslog_cmd | grep $mac_guest | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"");
         assert_script_run "echo '$gi_guest $guest # virtualization' >> /etc/hosts";
         script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 60) if ($guest =~ m/sles-11/i);
-        assert_script_run "ping -c3 $guest";
+        die "Ping $guest failed !" if (script_retry("ping -c5 $guest", delay => 30, retry => 6, timeout => 60) ne 0);
     }
 }
 
@@ -95,7 +95,7 @@ sub save_guest_ip {
         my $gi_guest = script_output("$syslog_cmd | grep $mac_guest | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"");
         assert_script_run "echo '$gi_guest $guest # virtualization' >> /etc/hosts";
         script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 60) if ($guest =~ m/sles-11/i);
-        assert_script_run "ping -c3 $guest";
+        die "Ping $guest failed !" if (script_retry("ping -c5 $guest", delay => 30, retry => 6, timeout => 60) ne 0);
     }
 }
 


### PR DESCRIPTION
* **This** fix is introduced because of sr-iov test failure.
* **Use** script_retry instead of assert_script_run to ping guest in order to make test more resilient and can be back to shape
if unexpected or extreme situations happen during test run.
* **Verification run:**
  * [kvm uefi guest with sr-iov test](https://openqa.suse.de/tests/6158316)
  * [xen uefi guest with sr-iov test](https://openqa.suse.de/tests/6164541)
