### PR TITLE
SLE Micro: add basic check for Cockpit service

### DIFF
--- a/schedule/sle-micro/autoyast.yaml
+++ b/schedule/sle-micro/autoyast.yaml
@@ -20,6 +20,7 @@ schedule:
   - microos/libzypp_config
   - microos/one_line_checks
   - microos/services_enabled
+  - microos/cockpit_check
   - transactional/filesystem_ro
   - transactional/transactional_update
   - transactional/rebootmgr

--- a/schedule/sle-micro/dvd.yaml
+++ b/schedule/sle-micro/dvd.yaml
@@ -28,6 +28,7 @@ schedule:
   - microos/libzypp_config
   - microos/one_line_checks
   - microos/services_enabled
+  - microos/cockpit_check
   - transactional/filesystem_ro
   - transactional/transactional_update
   - transactional/rebootmgr

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -26,6 +26,7 @@ schedule:
   - microos/image_checks
   - microos/one_line_checks
   - microos/services_enabled
+  - microos/cockpit_check
   - transactional/filesystem_ro
   - transactional/transactional_update
   - transactional/rebootmgr

--- a/tests/microos/cockpit_check.pm
+++ b/tests/microos/cockpit_check.pm
@@ -1,0 +1,58 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Basic check for cockpit service
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use transactional;
+use utils qw(systemctl);
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'root-console';
+
+    # Install cockpit if needed, this is needed for DVD flavor where
+    # Cockpit pattern is not selected during install
+    if (script_run('rpm -q cockpit') != 0) {
+        record_info('TEST', 'Installing Cockpit...');
+        trup_call('pkg install cockpit');
+        check_reboot_changes;
+    }
+
+    record_info('Cockpit', script_output('rpm -qi cockpit'));
+
+    # Enable cockpit
+    #   By enabling the socket, the service shall remain inactive. We can either
+    #   start the service manually or wait to have an http request where it will
+    #   be activated automatically
+    record_info('TEST', "Cockpit is active and accessible on http://localhost:9090");
+    systemctl('enable --now cockpit.socket');
+    systemctl('is-enabled cockpit.socket');
+    systemctl('is-active cockpit.service', expect_false => 1);
+    assert_script_run('curl http://localhost:9090', fail_message => 'Cannot fetch index page');
+    assert_script_run('lsof -i :9090',              fail_message => 'Port 9090 is not opened!');
+    systemctl('is-active cockpit.service');
+
+
+    # Cockpit should survive a reboot. After reboot cockpit.socket should be
+    # enabled, but the service is not active, we need to do a request as before
+    record_info('TEST', 'Cockpit survices a reboot');
+    process_reboot(trigger => 1);
+    systemctl('is-enabled cockpit.socket');
+    assert_script_run('curl http://localhost:9090', fail_message => 'Cannot fetch index page');
+    systemctl('is-active cockpit.service');
+
+}
+
+1;


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/93438
VRs: [link](https://openqa.suse.de/tests/overview?version=5.1&distri=sle-micro&build=jlausuch%2Fos-autoinst-distri-opensuse%23sle_micro_cockpit_check)