### PR TITLE
Switch to guided setup for remaining yast test_suites

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetupController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetupController.pm
@@ -71,7 +71,7 @@ sub setup_disks_to_use {
 }
 
 sub setup_partitioning_scheme {
-    my ($self, $args) = @_;
+    my ($self) = @_;
     $self->get_partitioning_scheme_page()->press_next();
 }
 

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -27,8 +27,7 @@ schedule:
   - installation/partitioning/warning/prep_small
   - installation/partitioning/warning/zipl_small
   - installation/partitioning/warning/rootfs_small
-  - installation/partitioning_filesystem
-  - installation/partitioning_finish
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - '{{hostname_inst}}'
   - installation/user_settings

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -27,8 +27,7 @@ schedule:
   - installation/partitioning/warning/prep_small
   - installation/partitioning/warning/zipl_small
   - installation/partitioning/warning/rootfs_small
-  - installation/partitioning_filesystem
-  - installation/partitioning_finish
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/resolve_dependency_issues

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -6,17 +6,19 @@ description:    >
 vars:
   FILESYSTEM: ext4
   FORMAT_DASD: pre_install
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/disk_activation
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_filesystem
-  - installation/partitioning_finish
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root

--- a/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
@@ -7,18 +7,19 @@ description: >
 vars:
   DESKTOP: gnome
   FILESYSTEM: xfs
+  YUI_REST_API: 1
 schedule:
   - installation/isosize
-  - installation/bootloader_svirt
-  - installation/bootloader
+  - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_filesystem
-  - installation/partitioning_finish
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root

--- a/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
@@ -7,17 +7,19 @@ description: >
 vars:
   DESKTOP: gnome
   FILESYSTEM: xfs
+  YUI_REST_API: 1
 schedule:
   - installation/isosize
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_filesystem
-  - installation/partitioning_finish
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root

--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -9,16 +9,18 @@ vars:
   FILESYSTEM: xfs
   DESKTOP: textmode
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
+  - installation/setup_libyui
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_filesystem
-  - installation/partitioning_finish
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup
+  - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root

--- a/test_data/yast/ext4/ext4_s390x-disk-activation.yaml
+++ b/test_data/yast/ext4/ext4_s390x-disk-activation.yaml
@@ -1,4 +1,7 @@
 ---
+guided_partitioning:
+  filesystem_options:
+    root_filesystem_type: ext4
 disks:
   - name: dasda
     table_type: dasd

--- a/test_data/yast/xfs/xfs_partition_spvm.yaml
+++ b/test_data/yast/xfs/xfs_partition_spvm.yaml
@@ -1,33 +1,24 @@
 ---
+guided_partitioning:
+  filesystem_options:
+    root_filesystem_type: xfs
 disks:
   - name: sda
     table_type: gpt
     allowed_unpartitioned: 0.00GB
     partitions:
       - name: sda2
-        role: operating-system
-        partition_type: primary
         formatting_options:
-          should_format: 1
           filesystem: xfs
         mounting_options:
-          should_mount: 1
           mount_point: /
       - name: sda3
-        role: data
-        partition_type: primary
         formatting_options:
-          should_format: 1
           filesystem: xfs
         mounting_options:
-          should_mount: 1
           mount_point: /home
       - name: sda4
-        role: swap
-        partition_type: primary
         formatting_options:
-          should_format: 1
           filesystem: swap
         mounting_options:
-          should_mount: 1
           mount_point: SWAP

--- a/test_data/yast/xfs/xfs_partition_svirt-xen.yaml
+++ b/test_data/yast/xfs/xfs_partition_svirt-xen.yaml
@@ -1,33 +1,24 @@
 ---
+guided_partitioning:
+  filesystem_options:
+    root_filesystem_type: xfs
 disks:
   - name: xvdb
     table_type: gpt
     allowed_unpartitioned: 0.00GB
     partitions:
       - name: xvdb2
-        role: operating-system
-        partition_type: primary
         formatting_options:
-          should_format: 1
           filesystem: xfs
         mounting_options:
-          should_mount: 1
           mount_point: /
       - name: xvdb3
-        role: data
-        partition_type: primary
         formatting_options:
-          should_format: 1
           filesystem: xfs
         mounting_options:
-          should_mount: 1
           mount_point: /home
       - name: xvdb4
-        role: swap
-        partition_type: primary
         formatting_options:
-          should_format: 1
           filesystem: swap
         mounting_options:
-          should_mount: 1
           mount_point: SWAP

--- a/tests/installation/partitioning/guided_setup.pm
+++ b/tests/installation/partitioning/guided_setup.pm
@@ -21,7 +21,7 @@ sub run {
     my $guided_setup = $testapi::distri->get_guided_partitioner();
     # Select disks to use, if multiple disks are available
     $guided_setup->setup_disks_to_use(@{$test_data->{disks}}) if $test_data->{disks};
-    $guided_setup->setup_partitioning_scheme($test_data->{partitioning_scheme});
+    $guided_setup->setup_partitioning_scheme();
     $guided_setup->setup_filesystem_options($test_data->{filesystem_options});
 }
 


### PR DESCRIPTION
Some tests are still using partitioning_filesystem.pm . This PR is aiming to switch to guided_setup and libyui as the rest of the installation tests in yast job group.
- Related ticket: https://progress.opensuse.org/issues/xyz
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=sofiasyria%2Fos-autoinst-distri-opensuse%23guided
