### PR TITLE
Increase timeout for reboot after patching

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -57,7 +57,7 @@ sub run {
 
     # DESKTOP can be gnome, but patch is happening in shell, thus always force reboot in shell
     power_action('reboot', textmode => 1);
-    $self->wait_boot(bootloader_time => 150);
+    $self->wait_boot(bootloader_time => get_var('BOOTLOADER_TIMEOUT', 150));
 }
 
 sub test_flags {


### PR DESCRIPTION
Some aarch64 jobs need more time to reboot and get the login prompt.