### PR TITLE
Fix ai_ml tests: armnn and tvm

### DIFF
--- a/tests/ai_ml/tvm.pm
+++ b/tests/ai_ml/tvm.pm
@@ -22,7 +22,7 @@ sub run {
 
     $self->select_serial_terminal;
 
-    zypper_call 'in python3-tvm tvmc python3-onnx python3-Pillow python3-pytest python3-tornado gcc-c++';
+    zypper_call 'in python3-tvm tvmc python3-onnx python3-Pillow python3-pytest python3-tornado gcc-c++ tensorflow2';
 
     select_console 'user-console';
     record_info('AutoTVM');


### PR DESCRIPTION
- Verification run:  https://openqa.opensuse.org/t1773616

`tvm` still fails because tensorflow2 build failed in OBS for aarch64.