### PR TITLE
Improve test stability in patch_and_reboot test module

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -219,7 +219,7 @@ sub wait_for_ssh
 
     # Check ssh command
     while ((my $duration = time() - $start_time) < $args{timeout}) {
-        return $duration if ($self->run_ssh_command(cmd => 'echo test', proceed_on_failure => 1, quiet => 1, username => $args{username}) eq 'test');
+        return $duration if ($self->run_ssh_command(cmd => 'sudo journalctl -b | grep -E "Reached target (Cloud-init|Default)"', proceed_on_failure => 1, quiet => 1, username => $args{username}) =~ m/Reached target.*/);
         sleep 1;
     }
 


### PR DESCRIPTION
As the system reboots we wait for the SSH being available. But sometimes the SSH appears and then disappears for a while before being stable.

- Ticket: [poo#93695](https://progress.opensuse.org/issues/93695)
- Verification run: [sle-15-SP3-EC2-ARM-Updates](http://pdostal-server.suse.cz/tests/11986), [sle-12-SP5-AZURE-Basic-gen2-Updates](http://pdostal-server.suse.cz/tests/11994), [sle-12-SP4-AZURE-BYOS-Updates](http://pdostal-server.suse.cz/tests/11988), [sle-15-SP2-GCE-Updates](http://pdostal-server.suse.cz/tests/11990)

Proving log:
```
# nc -vz -w 1 35.159.24.121 22; echo Z9Dn2-$?-
Connection to 35.159.24.121 22 port [tcp/ssh] succeeded!
Z9Dn2-0-
# cat > /tmp/scriptPLsuv.sh << 'EOT_PLsuv'; echo PLsuv-$?-
> timeout 90 ssh  -i '/root/.ssh/id_rsa' "ec2-user@35.159.24.121" -- 'echo test'
> EOT_PLsuv
PLsuv-0-
# echo PLsuv; bash -oe pipefail /tmp/scriptPLsuv.sh ; echo SCRIPT_FINISHEDPLsuv-$?-
PLsuv
test
SCRIPT_FINISHEDPLsuv-0-
# timeout 90 ssh  -i '/root/.ssh/id_rsa' "ec2-user@35.159.24.121" -- 'sudo journalctl -b | grep -E "Reached target (Cloud-init|Default)"' >/dev/ttyS0 2>&1; echo gqKYr-$?-
gqKYr-1-
# Jun 09 05:19:43 ip-172-31-46-221 systemd[1]: Reached target Cloud-init target.
timeout 90 ssh  -i '/root/.ssh/id_rsa' "ec2-user@35.159.24.121" -- 'sudo journalctl -b | grep -E "Reached target (Cloud-init|Default)"' >/dev/ttyS0 2>&1; echo gqKYr-$?-
gqKYr-0-
```