### PR TITLE
Disable grub timeout in JeOS-aarch64 after installing updates

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -47,6 +47,12 @@ sub run {
     if (is_jeos) {
         record_info('Updates', script_output('zypper lu'));
         zypper_call('up', timeout => 300);
+        if (check_var('ARCH', 'aarch64')) {
+            # Disable grub timeout for aarch64 cases so that the test doesn't stall
+            assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub");
+            assert_script_run('grub2-mkconfig -o /boot/grub2/grub.cfg');
+            record_info('GRUB', script_output('cat /etc/default/grub'));
+        }
     } else {
         fully_patch_system;
     }


### PR DESCRIPTION
Grub appears for very short time and the test stalls searching for
needles, so there is no time to match the grub screen. By disabling
the timeout we force the grub screen to stay until the needle is
found. This has been observed only in aarch64.

