### PR TITLE
Containers: adjust test cases according to the SLE version compatibility

### DIFF
--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -11,14 +11,28 @@ conditional_schedule:
     ARCH:
       x86_64:
         - containers/validate_btrfs
+  podman_buildah:
+    HOST_VERSION:
+      15-SP3:
+        - containers/podman_image
+        - containers/buildah_docker
+        - containers/buildah_podman
+        - containers/rootless_podman
+      15-SP2:
+        - containers/podman_image
+        - containers/buildah_docker
+        - containers/buildah_podman
+        - containers/rootless_podman
+      15-SP1:
+        - containers/podman_image
+        - containers/buildah_docker
+        - containers/buildah_podman
+        - containers/rootless_podman
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
-  - containers/podman_image
-  - containers/buildah_podman
-  - containers/buildah_docker
   - containers/docker_image
+  - '{{podman_buildah}}'
   - containers/container_diff
   - '{{validate_btrfs}}'
-  - containers/rootless_podman


### PR DESCRIPTION
Some packages are not available in older SLE releases
e.g. podman is not available in <=SLE-15, same for buildah

Package compatibility matrix [here](https://confluence.suse.com/display/ENGCTNRSTORY/Level+Test+Plan#LevelTestPlan-PackagesfromContainersModule)


- Related ticket: https://progress.opensuse.org/issues/93062
