### PR TITLE
Use update_install_start in QAM HA & SAP jobs

### DIFF
--- a/schedule/ha/qam/common/qam_incident_install.yaml
+++ b/schedule/ha/qam/common/qam_incident_install.yaml
@@ -11,7 +11,7 @@ vars:
 schedule:
   - '{{bootloader_zkvm}}'
   - boot/boot_to_desktop
-  - qam-updinstall/update_install_mr
+  - qam-updinstall/update_install_start
 conditional_schedule:
   bootloader_zkvm:
     BACKEND:

--- a/schedule/sles4sap/qam/common/qam_incident_install.yaml
+++ b/schedule/sles4sap/qam/common/qam_incident_install.yaml
@@ -15,4 +15,4 @@ vars:
   INSTALLTEST: '1'
 schedule:
   - boot/boot_to_desktop
-  - qam-updinstall/update_install_mr
+  - qam-updinstall/update_install_start

--- a/tests/qam-updinstall/update_install_start.pm
+++ b/tests/qam-updinstall/update_install_start.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Temporary solution to combine qam-updinstall/update_install
+# and qam-updinstall/update_install_mr to conditionally load one or
+# the other from a YAML schedule depending on the value of BUILD.
+# Maintainer: Alvaro Carvajal <acarvajal@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+
+sub run {
+    my $self = shift;
+    if (get_required_var('BUILD') =~ /^MR:/) {
+        record_info("Maintenance Request Build", "Scheduling qam-updinstall/update_install_mr");
+        autotest::loadtest("tests/qam-updinstall/update_install_mr.pm");
+    }
+    else {
+        record_info("update_install", "Scheduling qam-updinstall/update_install");
+        autotest::loadtest("tests/qam-updinstall/update_install.pm");
+    }
+}
+
+1;


### PR DESCRIPTION
YAML schedules for `qam_incident_install` in HA & SAP QAM job groups are using the test module `qam-updinstall/update_install_mr` in all scenarios for Incidents Install testing, but this contradicts the original purpose of `qam-updinstall/update_install_mr`; as shown in the original [commit](https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/e7b9207d55f3a2fa49c6ccdc345263edd1bee8b7#diff-cf3053ed58fc1e7a87340267c87d752c2ae8427f7c614545070f51988ed2bed8R899-R904), this module is intended to be used only on jobs which were triggered by Maintenance Request builds.
    
Since there is not easy way to handle this via conditional scheduling in the YAML schedule using the BUILD setting, this PR introduces the `qam-updinstall/update_install_start` module to load the appropriate test module depending on the value of the BUILD setting, and replaces `update_install_mr` with `update_install_start` in the HA & SAP QAM job schedules.

- Related ticket: N/A
- Needles: N/A
- Verification runs: [non MR build](http://mango.qa.suse.de/tests/4088), [MR build](http://mango.qa.suse.de/tests/4090)
- Verification runs on different architectures using `qam-updinstall/update_install`: [aarch64](https://openqa.suse.de/t6212786), [ppc64le](https://openqa.suse.de/t6212787), [s390x](https://openqa.suse.de/t6212788), [x86_64](https://openqa.suse.de/t6212789)
- Verification runs on different architectures using `qam-updinstall/update_install_start`:  [aarch64](https://openqa.suse.de/t6215227), [ppc64le](https://openqa.suse.de/t6215228), [s390x](https://openqa.suse.de/t6215229), [x86_64](https://openqa.suse.de/t6215230)
