### PR TITLE
Containers: move validate_btrfs and rootless_podman to engines and tools test

### DIFF
--- a/schedule/containers/engines_and_tools.yaml
+++ b/schedule/containers/engines_and_tools.yaml
@@ -8,6 +8,10 @@ conditional_schedule:
     ARCH:
       's390x':
         - installation/bootloader_start
+  validate_btrfs:
+    ARCH:
+      x86_64:
+        - containers/validate_btrfs
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
@@ -22,3 +26,4 @@ schedule:
   - containers/registry
   - console/coredump_collect
   - containers/rootless_podman
+  - '{{validate_btrfs}}'

--- a/schedule/containers/sle_image_on_sle_host.yaml
+++ b/schedule/containers/sle_image_on_sle_host.yaml
@@ -7,27 +7,20 @@ conditional_schedule:
     ARCH:
       's390x':
         - installation/bootloader_start
-  validate_btrfs:
-    ARCH:
-      x86_64:
-        - containers/validate_btrfs
   podman_buildah:
     HOST_VERSION:
       15-SP3:
         - containers/podman_image
         - containers/buildah_docker
         - containers/buildah_podman
-        - containers/rootless_podman
       15-SP2:
         - containers/podman_image
         - containers/buildah_docker
         - containers/buildah_podman
-        - containers/rootless_podman
       15-SP1:
         - containers/podman_image
         - containers/buildah_docker
         - containers/buildah_podman
-        - containers/rootless_podman
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
@@ -35,4 +28,3 @@ schedule:
   - containers/docker_image
   - '{{podman_buildah}}'
   - containers/container_diff
-  - '{{validate_btrfs}}'


### PR DESCRIPTION
validate_btrfs tests the docker storage driver on the host and rootles_podman
tests a podman feature. So they are not a direct image tests but host or
package feature. It belongs to engines and tools schedule.

- Related ticket: https://progress.opensuse.org/issues/93062
