### PR TITLE
Fork xen@svirt-xen-pv schedule from before 8b895050 for 15-SP2

### DIFF
--- a/schedule/qam/QR/15-SP2/xfs@svirt-xen-pv.yaml
+++ b/schedule/qam/QR/15-SP2/xfs@svirt-xen-pv.yaml
@@ -1,0 +1,36 @@
+---
+name: xfs
+description: >
+  Installation with default parameters, except XFS being selected as filesystem
+  for the root partition. Installation is validated by successful boot and that
+  YaST does not report any issue.
+vars:
+  DESKTOP: gnome
+  FILESYSTEM: xfs
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/first_boot
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space
+  - console/validate_read_write
+test_data:
+  <<: !include test_data/yast/xfs/xfs_partition_svirt-xen.yaml


### PR DESCRIPTION
xen@svirt-xen-pv started to fail in setup_libyui on 15-SP2 QU testing. Forking the schedule for 15-SP2 and before the libyui change.

- Related ticket: https://progress.opensuse.org/issues/93754
- Verification run: https://openqa.suse.de/tests/6220775
