### PR TITLE
Add vsftpd test to Tumbleweed

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -83,6 +83,7 @@ conditional_schedule:
             'Tumbleweed':
                 - console/parsec
                 - console/systemd_rpm_macros
+                - console/vsftpd
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop


### PR DESCRIPTION
Add vsftpd test to Tumbleweed. Test is scheduled under extra_tests_textmode test suite.

- Related ticket: https://progress.opensuse.org/issues/93321
- Needles: No
- Verification run: 
  Tumbleweed - http://10.161.229.147/tests/691#step/vsftpd/1

