### PR TITLE
lib/main_common: Avoid "Use of uninitialized value in pattern match"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -694,7 +694,7 @@ sub remove_common_needles {
     unregister_needle_tags("ENV-VIDEOMODE-text") unless check_var("VIDEOMODE", "text");
     unregister_needle_tags('ENV-ARCH-s390x')     unless check_var('ARCH',      's390x');
     # Only for container tests
-    unregister_needle_tags('ENV-UBUNTU-1') unless get_var('HDD_1') =~ /ubuntu/;
+    unregister_needle_tags('ENV-UBUNTU-1') unless get_var('HDD_1', '') =~ /ubuntu/;
     if (get_var("INSTLANG") && get_var("INSTLANG") ne "en_US") {
         unregister_needle_tags("ENV-INSTLANG-en_US");
     }


### PR DESCRIPTION
Avoid a harmless warning, which however triggers printing a backtrace,
which crashes perl because one of the callers has improper stack variable
management (https://github.com/Perl/perl5/issues/15928).

Verification run: http://10.160.67.86/tests/971