### PR TITLE
Fix yast2_gui_opensuse schedule

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_opensuse.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_opensuse.yaml
@@ -1,33 +1,38 @@
 ---
 name:           yast2_gui
 description:    >
-    Test for yast2 UI, GUI only.
-    Running on created gnome images which provides both text console for ncurses UI tests as well
-    as the gnome environment for the GUI tests.
+  Test for yast2 UI, GUI only.
+  Running on created gnome images which provides both text console for ncurses UI tests as well
+  as the gnome environment for the GUI tests.
 vars:
-    BOOTFROM: c
-    HDDSIZEGB: 20
-    SOFTFAIL_BSC1063638: 1
-    VALIDATE_ETC_HOSTS: 1
-    YUI_REST_API: 1
+  BOOTFROM: c
+  HDDSIZEGB: 20
+  SOFTFAIL_BSC1063638: 1
+  VALIDATE_ETC_HOSTS: 1
+  YUI_REST_API: 1
 schedule:
-    - boot/boot_to_desktop
-    - console/prepare_test_data
-    - console/consoletest_setup
-    - console/hostname
-    - console/setup_libyui_running_system
-    - yast2_gui/yast2_system_settings
-    - yast2_gui/yast2_control_center
-    - x11/yast2_lan_restart
-    - yast2_gui/yast2_bootloader
-    - yast2_gui/bootloader/bootcode_options
-    - yast2_gui/yast2_datetime
-    - yast2_gui/yast2_firewall
-    - yast2_gui/yast2_hostnames
-    - yast2_gui/yast2_lang
-    - yast2_gui/yast2_network_settings
-    - yast2_gui/yast2_software_management
-    - yast2_gui/yast2_users
-    - yast2_gui/yast2_security
+  - boot/boot_to_desktop
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/hostname
+  - console/setup_libyui_running_system
+  - yast2_gui/yast2_system_settings
+  - yast2_gui/yast2_control_center
+  - x11/yast2_lan_restart
+  - yast2_gui/yast2_bootloader
+  - "{{bootcode_options}}"
+  - yast2_gui/yast2_datetime
+  - yast2_gui/yast2_firewall
+  - yast2_gui/yast2_hostnames
+  - yast2_gui/yast2_lang
+  - yast2_gui/yast2_network_settings
+  - yast2_gui/yast2_software_management
+  - yast2_gui/yast2_users
+  - yast2_gui/yast2_security
+conditional_schedule:
+  bootcode_options:
+    ARCH:
+      x86_64:
+        - yast2_gui/bootloader/bootcode_options
 test_data:
-    <<: !include test_data/yast/yast2_gui.yaml
+  <<: !include test_data/yast/yast2_gui.yaml


### PR DESCRIPTION
- Related ticket: [poo#93630](https://progress.opensuse.org/issues/93630)
- Verification run: [yast2_gui](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_schedule_aarch_yast2_gui_o3&version=Tumbleweed)
