### PR TITLE
Revert "Improve stability of ssh tunnel tests"

### DIFF
--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -40,16 +40,16 @@ sub run {
 
     # Verify most important consoles
     select_console('root-console');
-    script_retry('test -e /dev/' . get_var('SERIALDEV'), timeout => 120, retry => 3, delay => 30);
-    script_retry('test $(id -un) == "root"',             timeout => 120, retry => 3, delay => 30);
+    assert_script_run('test -e /dev/' . get_var('SERIALDEV'));
+    assert_script_run('test $(id -un) == "root"');
 
     select_console('user-console');
-    script_retry('test -e /dev/' . get_var('SERIALDEV'),           timeout => 120, retry => 3, delay => 30);
-    script_retry('test $(id -un) == "' . $testapi::username . '"', timeout => 120, retry => 3, delay => 30);
+    assert_script_run('test -e /dev/' . get_var('SERIALDEV'));
+    assert_script_run('test $(id -un) == "' . $testapi::username . '"');
 
     $self->select_serial_terminal();
-    script_retry('test -e /dev/' . get_var('SERIALDEV'), timeout => 120, retry => 3, delay => 30);
-    script_retry('test $(id -un) == "root"',             timeout => 120, retry => 3, delay => 30);
+    assert_script_run('test -e /dev/' . get_var('SERIALDEV'));
+    assert_script_run('test $(id -un) == "root"');
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#12633

The intended effect of reestablishing the ssh serial tunnel in case of connection loss does not occur, so those changes are more harmful than useful. We need to fix the issue elsewhere.

Reverting the previous PR.

Verification run: http://duck-norris.qam.suse.de/t6588