### PR TITLE
Add schedule for RAID0 in QAM job group

### DIFF
--- a/schedule/qam/15-SP2/raid/raid0_gpt_prep_boot.yaml
+++ b/schedule/qam/15-SP2/raid/raid0_gpt_prep_boot.yaml
@@ -1,0 +1,86 @@
+name:           RAID0_gpt_prep_boot
+description:    >
+  Configure RAID 0 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates PReP boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 0.
+vars:
+  RAIDLEVEL: 0
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_md_raid
+  - console/validate_raid
+test_data:
+  <<: !include test_data/yast/raid/raid_disks_prep_boot.yaml
+  mds:
+    - raid_level: 0
+      name: md0
+      chunk_size: 64
+      device_selection_step: 3
+      devices:
+        - vda2
+        - vdb2
+        - vdc2
+        - vdd2
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 1
+      name: md1
+      chunk_size: 64
+      device_selection_step: 2
+      devices:
+        - vda3
+        - vdb3
+        - vdc3
+        - vdd3
+      partition:
+        role: data
+        formatting_options:
+          should_format: 1
+          filesystem: ext4
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot'
+    - raid_level: 0
+      name: md2
+      chunk_size: 64
+      device_selection_step: 1
+      devices:
+        - vda4
+        - vdb4
+        - vdc4
+        - vdd4
+      partition:
+        role: swap
+        formatting_options:
+          should_format: 1
+        filesystem: swap
+        mounting_options:
+          should_mount: 1


### PR DESCRIPTION
The PR fixes RAID0@ppc64le test failure in the last QR updates.

- Related failure: https://openqa.suse.de/tests/6209919
**- MR for Job Group Settings:** https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/139
- Verification runs: 
   - https://openqa.suse.de/tests/6225717
   - https://openqa.suse.de/tests/6225718

**For reviewers:** Please, do not forget to merge [Job Group settings](https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/139) to make the solution work. Thank you. 
