### PR TITLE
Containers: remove enhanced base pattern from autoyast profile

### DIFF
--- a/data/autoyast_containers.xml.ep
+++ b/data/autoyast_containers.xml.ep
@@ -50,9 +50,6 @@
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
-      % if ($get_var->('VERSION') =~ /15|15-SP1|15-SP2|15-SP3/) {
-      <pattern>enhanced_base</pattern>
-      % }
     </patterns>
   </software>
   <users config:type="list">


### PR DESCRIPTION
poo#93817

It fixes problem of installing [15-SP2 on aarch64](https://openqa.suse.de/tests/6214367)
VR: https://openqa.suse.de/tests/6226810#
