### PR TITLE
Avoid operations on Domain-0

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -343,7 +343,7 @@ sub clean_up_all_guests {
     my $self = shift;
 
     $self->reveal_myself;
-    my @_guests_to_clean_up = split(/\n/, script_output("virsh list --all --name", proceed_on_failure => 1));
+    my @_guests_to_clean_up = split(/\n/, script_output("virsh list --all --name | grep -v Domain-0", proceed_on_failure => 1));
     if (scalar(@_guests_to_clean_up) gt 0) {
         diag("Going to clean up all guests on $self->{host_name}");
         foreach (@_guests_to_clean_up) {


### PR DESCRIPTION
* **Although** destroy and undefine operations on Domain-0 are not supported and will do no harm to system, it would be better to exclude it from vm list to avoid unexpected situations.
* **Verification run:**
  * [kvm test](http://10.67.129.106/tests/1323#step/uefi_guest_installation/26)
  * [xen test](http://10.67.129.106/tests/1324#step/uefi_guest_installation/40)
