### PR TITLE
Allow root to login using password

### DIFF
--- a/tests/security/389ds/tls_389ds_server.pm
+++ b/tests/security/389ds/tls_389ds_server.pm
@@ -17,7 +17,7 @@
 #          This test module covers the server setup processes
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#88513, poo#92410, tc#1768672
+# Tags: poo#88513, poo#92410, poo#93832, tc#1768672
 
 use base 'consoletest';
 use testapi;
@@ -107,6 +107,8 @@ sub run {
     # Set the ldap_uri with LDAP over SSL (LDAPS) Certificate
     assert_script_run("sed -i 's/^ldap_uri =.*\$/ldap_uri = ldaps:\\/\\/$local_name.example.com/' /tmp/sssd.conf");
 
+    # Permit ssh/scp from client as root
+    permit_root_ssh();
     mutex_create("389DS_READY");
 
     # Finish job

--- a/tests/security/create_swtpm_hdd/build_hdd.pm
+++ b/tests/security/create_swtpm_hdd/build_hdd.pm
@@ -19,13 +19,13 @@
 #          at the same time, install some required packages.
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81256, tc#1768671
+# Tags: poo#81256, tc#1768671, poo#93835
 
 use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use utils 'zypper_call';
+use utils qw(zypper_call permit_root_ssh);
 use power_action_utils 'power_action';
 
 sub run {
@@ -48,6 +48,9 @@ sub run {
     my $nic_name       = script_output("ls /etc/sysconfig/network | grep ifcfg- | grep -v lo | awk -F '-' '{print \$2}'");
     assert_script_run("wget --quiet " . data_url("swtpm/70-persistent-net.rules") . " -O $udev_rule_file");
     assert_script_run("sed -i 's/NAME=\"\"/ NAME=\"$nic_name\"/' $udev_rule_file");
+
+    # Permit ssh login as root
+    permit_root_ssh();
 
     # Power down the vm
     power_action('poweroff');


### PR DESCRIPTION
Due to bsc#1173067, openssh now no longer allows RootLogin
using password auth on Tumbleweed, the latest Leap 16 will sync
with Tumbleweed as well.

So fix the logic here, I didn't test Leap and SLES for now, will check the code once sles15sp4 is out.

- Related ticket: https://progress.opensuse.org/issues/93832
                          https://progress.opensuse.org/issues/93835
- Needles: n/a
- Verification run: https://openqa.opensuse.org/tests/1787735 (389-ds server)
                            https://openqa.opensuse.org/tests/1787736 (389-ds client)
                            https://openqa.opensuse.org/tests/1787686 (swtpm-create-hdd)
                            https://openqa.opensuse.org/tests/1787687 (swtpm-verify)