### PR TITLE
Containers: use untested or official container images accordingly

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -57,52 +57,52 @@ sub get_suse_container_urls {
     my $dotversion = $version =~ s/-SP/./r;                    # 15 -> 15, 15-SP1 -> 15.1
     $dotversion = "${dotversion}.0" if $dotversion !~ /\./;    # 15 -> 15.0
 
-    my @image_names  = ();
-    my @stable_names = ();
+    my @untested_images = ();
+    my @released_images = ();
     if (is_sle(">=12-sp3", $version) && is_sle('<15', $version)) {
         my $lowerversion  = lc $version;
         my $nodashversion = $version =~ s/-sp/sp/ir;
         # No aarch64 image
         if (!check_var('ARCH', 'aarch64')) {
-            push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/totest/images/suse/sles${nodashversion}";
-            push @stable_names, "registry.suse.com/suse/sles${nodashversion}";
+            push @untested_images, "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/totest/images/suse/sles${nodashversion}";
+            push @released_images, "registry.suse.com/suse/sles${nodashversion}";
         }
     }
     elsif (is_sle(">=15", $version) && is_released) {
         my $lowerversion = lc $version;
         # Location for maintenance builds
-        push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/totest/images/suse/sle15:${dotversion}";
-        push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
+        push @untested_images, "registry.suse.de/suse/sle-${lowerversion}/update/cr/totest/images/suse/sle15:${dotversion}";
+        push @released_images, "registry.suse.com/suse/sle15:${dotversion}";
     }
-    elsif (is_sle(">=15-sp3", $version)) {
+    elsif (is_sle(">=15-sp4", $version)) {
         my $lowerversion = lc $version;
         # Location for GA builds
-        push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/ga/test/images/suse/sle15:${dotversion}";
-        push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
+        push @untested_images, "registry.suse.de/suse/sle-${lowerversion}/ga/test/images/suse/sle15:${dotversion}";
+        push @released_images, "registry.suse.com/suse/sle15:${dotversion}";
     }
     elsif (is_sle_micro) {
-        push @image_names,
+        push @untested_images,
           "registry.suse.com/suse/sle15:15.0",
           "registry.suse.com/suse/sle15:15.1",
           "registry.suse.com/suse/sle15:15.2",
           "registry.suse.com/suse/sle15:15.3";
     }
     elsif (is_tumbleweed || is_microos("Tumbleweed")) {
-        push @image_names,  "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";
-        push @stable_names, "registry.opensuse.org/opensuse/tumbleweed";
+        push @untested_images, "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";
+        push @released_images, "registry.opensuse.org/opensuse/tumbleweed";
     }
     elsif (is_leap(">=15.3")) {
         # All archs in the same location
-        push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
-        push @stable_names, "registry.opensuse.org/opensuse/leap:${version}";
+        push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
+        push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
     }
     elsif ((is_leap(">15.0") || is_microos(">15.0")) && check_var('ARCH', 'x86_64')) {
-        push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
-        push @stable_names, "registry.opensuse.org/opensuse/leap:${version}";
+        push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
+        push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
     }
     elsif ((is_leap(">15.0") || is_microos(">15.0")) && (check_var('ARCH', 'aarch64') || check_var('ARCH', 'arm'))) {
-        push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/arm/images/totest/containers/opensuse/leap:${version}";
-        push @stable_names, "registry.opensuse.org/opensuse/leap:${version}";
+        push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/arm/images/totest/containers/opensuse/leap:${version}";
+        push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
     }
     elsif (is_leap(">15.0") && check_var('ARCH', 'ppc64le')) {
         # No image set up yet :-(
@@ -114,5 +114,5 @@ sub get_suse_container_urls {
         die("Unknown combination of distro/arch.");
     }
 
-    return (\@image_names, \@stable_names);
+    return (\@untested_images, \@released_images);
 }

--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -22,33 +22,37 @@ use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
-use version_utils 'is_sle';
 
 sub run {
-    my ($image_names, $stable_names) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
+
     install_buildah_when_needed($host_distri);
     install_docker_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => 'docker');
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
-    for my $iname (@{$image_names}) {
-        record_info 'testing image', $iname;
-        test_container_image(image => $iname, runtime => 'buildah');
-        if (check_os_release('suse', 'PRETTY_NAME')) {
-            # Use container which it is created in test_container_image
-            # Buildah default name is conducted by <image-name>-working-container
-            my ($prefix_img_name) = $iname =~ /([^\/:]+)(:.+)?$/;
-            test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah');
-            # Due to the steps from the test_opensuse_based_image previously,
-            # the image has been committed as refreshed
-            test_containered_app(runtime => 'docker',
-                buildah    => 1,
-                dockerfile => 'Dockerfile.suse',
-                base       => 'refreshed');
+    # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
+    my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
+    for my $version (split(/,/, $versions)) {
+        my ($untested_images, $released_images) = get_suse_container_urls($version);
+        my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
+        for my $iname (@{$images_to_test}) {
+            record_info "IMAGE", "Testing image: $iname";
+            test_container_image(image => $iname, runtime => 'buildah');
+            if (check_os_release('suse', 'PRETTY_NAME')) {
+                # Use container which it is created in test_container_image
+                # Buildah default name is conducted by <image-name>-working-container
+                my ($prefix_img_name) = $iname =~ /([^\/:]+)(:.+)?$/;
+                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah');
+                # Due to the steps from the test_opensuse_based_image previously,
+                # the image has been committed as refreshed
+                test_containered_app(runtime => 'docker',
+                    buildah    => 1,
+                    dockerfile => 'Dockerfile.suse',
+                    base       => 'refreshed');
+            }
         }
     }
-
     scc_restore_docker_image_credentials();
     clean_container_host(runtime => 'docker');
     clean_container_host(runtime => 'buildah');

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -31,15 +31,14 @@ sub run {
     allow_selected_insecure_registries(runtime => 'docker') if (is_sle());
     zypper_call("install container-diff")                   if (script_run("which container-diff") != 0);
 
-    my ($image_names, $stable_names) = get_suse_container_urls();
-
+    my ($untested_images, $released_images) = get_suse_container_urls();
     # container-diff
-    for my $i (@{$image_names}) {
-        my $image_file             = $image_names->[$i] =~ s/\/|:/-/gr;
+    for my $i (@{$untested_images}) {
+        my $image_file             = $untested_images->[$i] =~ s/\/|:/-/gr;
         my $container_diff_results = "/tmp/container-diff-$image_file.txt";
-        assert_script_run("docker pull $image_names->[$i]",  360);
-        assert_script_run("docker pull $stable_names->[$i]", 360);
-        assert_script_run("container-diff diff daemon://$image_names->[$i] daemon://$stable_names->[$i] --type=rpm --type=file --type=size > $container_diff_results", 300);
+        assert_script_run("docker pull $untested_images->[$i]", 360);
+        assert_script_run("docker pull $released_images->[$i]", 360);
+        assert_script_run("container-diff diff daemon://$untested_images->[$i] daemon://$released_images->[$i] --type=rpm --type=file --type=size > $container_diff_results", 300);
         upload_logs("$container_diff_results");
         ensure_container_rpm_updates("$container_diff_results");
     }

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -39,10 +39,10 @@ sub run {
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
 
     for my $version (split(/,/, $versions)) {
-        record_info "IMAGE", "We are testing image for $version now.";
-        my ($image_names, $stable_names) = get_suse_container_urls($version);
-
-        for my $iname (@{$image_names}) {
+        my ($untested_images, $released_images) = get_suse_container_urls($version);
+        my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
+        for my $iname (@{$images_to_test}) {
+            record_info "IMAGE", "Testing image: $iname";
             test_container_image(image => $iname, runtime => $runtime);
             test_rpm_db_backend(image => $iname, runtime => $runtime);
             build_container_image(image => $iname, runtime => $runtime);

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -30,9 +30,10 @@ sub run {
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
 
     for my $version (split(/,/, $versions)) {
-        record_info "IMAGE", "We are testing image for $version now.";
-        my ($image_names, $stable_names) = get_suse_container_urls($version);
-        for my $iname (@{$image_names}) {
+        my ($untested_images, $released_images) = get_suse_container_urls($version);
+        my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
+        for my $iname (@{$images_to_test}) {
+            record_info "IMAGE", "Testing image: $iname";
             test_container_image(image => $iname, runtime => $runtime);
             test_rpm_db_backend(image => $iname, runtime => $runtime);
             build_container_image(image => $iname, runtime => $runtime);

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -30,7 +30,7 @@ use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
-    my ($image_names, $stable_names) = get_suse_container_urls();
+    my ($untested_images, $released_images) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
     my $runtime = "podman";
 
@@ -52,7 +52,7 @@ sub run {
 
     # smoke test
     assert_script_run "$runtime images -a";
-    for my $iname (@{$image_names}) {
+    for my $iname (@{$released_images}) {
         test_container_image(image => $iname, runtime => $runtime);
         build_container_image(image => $iname, runtime => $runtime);
         test_zypper_on_container($runtime, $iname);

--- a/variables.md
+++ b/variables.md
@@ -28,6 +28,7 @@ CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test mo
 CHECK_RELEASENOTES_ORIGIN | boolean | false | Loads `installation/releasenotes_origin` test module.
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
+CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.


### PR DESCRIPTION
There are 2 scenarios:
1) SUT=Host updates
   Here we should test the host container features and use official
   stable images for that purpose.
   These tests are triggered every day as part of maintenance updates.

2) SUT=container image updates
   Here we are targetting the images that are not released yet, so
   we use an official released HOST to test the untested images.
   For these tests, we have the variable CONTAINER_IMAGE_TYPE=untested
   These tests will be triggered whenever there is a new container image
   build in :/Update:/CR:/ToTest/images/

The PR is putting this into practice and using the right arrays depending
on the situation.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/93480
