### PR TITLE
Fork disk ext4 s390x schedule and data to be 15-SP2 QU compatible.

### DIFF
--- a/schedule/qam/QR/15-SP2/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/qam/QR/15-SP2/ext4@yast-s390x-disk-activation.yaml
@@ -1,0 +1,35 @@
+---
+name:           ext4@yast-s390x-disk-activation
+description:    >
+  Test for ext4 filesystem.
+  Requires disk activation and grub is not displayed due to console reconnection.
+vars:
+  FILESYSTEM: ext4
+  FORMAT_DASD: pre_install
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/disk_activation
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/handle_reboot
+  - installation/first_boot
+  - console/validate_partition_table_via_parted
+  - console/validate_blockdevices
+test_data:
+  <<: !include test_data/qam/QR/ext4_s390x-disk-activation.yaml

--- a/test_data/qam/QR/ext4_s390x-disk-activation.yaml
+++ b/test_data/qam/QR/ext4_s390x-disk-activation.yaml
@@ -1,0 +1,16 @@
+---
+disks:
+  - name: dasda
+    table_type: dasd
+    partitions:
+      - name: dasda1
+        formatting_options:
+          filesystem: ext4
+        mounting_options:
+          should_mount: 1
+          mount_point: /
+      - name: dasda2
+        formatting_options:
+          filesystem: swap
+        mounting_options:
+          mount_point: SWAP


### PR DESCRIPTION
Try using the schedule and data that worked with previous QU build 15 days ago.

- Related ticket: https://progress.opensuse.org/issues/93895
Before this: fails in bootloader_start: https://openqa.suse.de/tests/6230395
After this: fails only later https://openqa.suse.de/tests/6251034#
