### PR TITLE
lib/x11test: test_terminal: Don't apply GNOME workaround elsewhere

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -82,7 +82,7 @@ sub test_terminal {
     mouse_hide(1);
     x11_start_program($name);
     # GNOME40 sometimes gets its activities mode incorrectly triggered by x11_start_program
-    send_key 'esc' if check_screen "$name-activities";
+    send_key 'esc' if (check_var("DESKTOP", "gnome") && check_screen "$name-activities");
     $self->enter_test_text($name, cmd => 1);
     assert_screen "test-$name-1";
     send_key 'alt-f4';


### PR DESCRIPTION
Outside of GNOME, the check_screen is not needed and just wastes time.

Verification runs:

GNOME TW: https://openqa.opensuse.org/tests/1781537
Plasma TW: https://openqa.opensuse.org/tests/1781532