### PR TITLE
Change parent module for yast2_network_use_nm

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1460,7 +1460,7 @@ sub show_tasks_in_blocked_state {
         send_key 'alt-sysrq-t';
         send_key 'alt-sysrq-w';
         # info will be sent to serial tty
-        wait_serial(qr/sysrq\s*:\s+show\s+blocked\s+state/i, 1);
+        wait_serial(qr/sysrq\s*:\s+show\s+blocked\s+state/i);
         send_key 'ret';    # ensure clean shell prompt
     }
 }

--- a/tests/x11/network/yast2_network_use_nm.pm
+++ b/tests/x11/network/yast2_network_use_nm.pm
@@ -12,8 +12,7 @@
 # Maintainer: Nick Singer <nsinger@suse.de>
 # Tags: poo#20306
 
-use base 'x11test';
-use y2_module_guitest 'launch_yast2_module_x11';
+use base 'y2_module_guitest';
 use y2_base;
 use strict;
 use warnings;
@@ -54,13 +53,6 @@ sub configure_system {
         record_soft_failure 'boo#1049097';
         assert_and_click 'yast2_network-error_dialog';
     }
-}
-
-sub post_fail_hook {
-    my ($self) = @_;
-    select_console 'log-console';
-    y2_base::save_upload_y2logs($self);
-    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
The commit changes parent module to y2_module_guitest, so that the test
will be able to reuse post_fail_hook from parent packages.

Also, this adds consistency, as all yast2 module GUI tests are inherited
from y2_module_guitest package.

- Related ticket: https://progress.opensuse.org/issues/91761
- Verification run: https://openqa.opensuse.org/tests/1786720
Example of failed run, when y2logs are collected: https://openqa.opensuse.org/tests/1789964