### PR TITLE
Add softfail for  boo#1176553  on Networkmanager  connect dialog

### DIFF
--- a/tests/x11/network/NM_wpa2_enterprise.pm
+++ b/tests/x11/network/NM_wpa2_enterprise.pm
@@ -22,6 +22,12 @@ sub run {
     my $self = shift;
 
     $self->connect_to_network;
+    if (check_screen("gnome_widget-connect-click", 5)) {
+        record_soft_failure 'boo#1176553';
+        assert_and_click("gnome_widget-network_cancel");
+        return 1;
+
+    }
     $self->enter_NM_credentials;
     $self->handle_polkit_root_auth;
 


### PR DESCRIPTION
Add soft fail in the test NM_WPA2_enterprise when the connect button is clicked in Tumbleweed build, as the test is failing due to issue https://bugzilla.opensuse.org/show_bug.cgi?id=1176553.  Same test is working fine in LEAP.  

- Related ticket: https://progress.opensuse.org/issues/93644
- Needles: yes
  https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/727
- Verification run: 
    LEAP - http://10.161.229.147/tests/734#step/NM_wpa2_enterprise/1
    Tumbleweed : http://10.161.229.147/tests/733#step/NM_wpa2_enterprise/1

