### PR TITLE
Containers: fix profile for s390x

### DIFF
--- a/data/autoyast_containers.xml.ep
+++ b/data/autoyast_containers.xml.ep
@@ -65,9 +65,8 @@
     <loader_type>grub2</loader_type>
     % }
   </bootloader>
-  % if ($check_var->('ARCH', 's390x') {
   <networking>
-    % if ($check_var->('ARCH', 's390x') {
+    % if ($check_var->('ARCH', 's390x')) {
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>


### PR DESCRIPTION
Fixing wrong syntax created in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12704