### PR TITLE
Fix multi_users_dm.pm issues

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -77,6 +77,7 @@ sub run {
     handle_login($user, 1);
     handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
     assert_screen 'generic-desktop', 60;
+    send_key 'esc' if match_has_tag('gnome-activities');
     # verify correct user is logged in
     x11_start_program('xterm');
     wait_still_screen;
@@ -84,7 +85,8 @@ sub run {
     assert_script_sudo "grep $user /tmp/whoami.log";
     # logout user
     handle_logout;
-    wait_still_screen;
+    # Wait some more seconds before selecting root-console, as it fails sporadically in aarch64
+    wait_still_screen 10;
 
     # restore previous config
     select_console 'root-console';


### PR DESCRIPTION
1. For the related ticket: https://progress.opensuse.org/issues/92095 
Workaround for gnome desktop unfocused when user re logs in. As a result , xterm gets unfocused (in extra_tests_gnome TW ppc64le) , after calling the `x11_start_program('xterm')` and as a result the `enter_cmd` gets redirected to gnome search. 
When trying to click on the white area of xterm, xterm still seems to be unfocused : https://openqa.opensuse.org/tests/1791584#step/multi_users_dm/25

2. The test fails sporadically in aarch64 : https://openqa.opensuse.org/tests/1796800#step/multi_users_dm/34. It is not a matter of re-needling, but a matter of some extra seconds before `select_console 'root-console';`. For this reason `wait_still_screen 10;` has been added.

Related ticket: https://progress.opensuse.org/issues/92095 
- Needles:  N/A 
- Verification runs : 
TW : [ppc64le](https://openqa.opensuse.org/tests/1801779#step/multi_users_dm/41) | [aarch64](https://openqa.opensuse.org/tests/1801837#step/multi_users_dm/45) | [x86_64](https://openqa.opensuse.org/tests/1801830#step/multi_users_dm/45) 
Leap : [ppc64le](https://openqa.opensuse.org/tests/1802428#step/multi_users_dm/45)
