### PR TITLE
g40 activities

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -81,8 +81,6 @@ sub test_terminal {
     my ($self, $name) = @_;
     mouse_hide(1);
     x11_start_program($name);
-    # GNOME40 sometimes gets its activities mode incorrectly triggered by x11_start_program
-    send_key 'esc' if (check_var("DESKTOP", "gnome") && check_screen "$name-activities");
     $self->enter_test_text($name, cmd => 1);
     assert_screen "test-$name-1";
     send_key 'alt-f4';

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -77,6 +77,7 @@ sub run {
     handle_login($user, 1);
     handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
     assert_screen 'generic-desktop', 60;
+    send_key('esc') if match_has_tag('gnome-activities');    # GNOME 40 logs in with activities opened
     # verify correct user is logged in
     x11_start_program('xterm');
     wait_still_screen;


### PR DESCRIPTION
The workaround was placed in a too generic place, assuming that every app could accidentally end up in the activities view.

in fact, it's 'just' after login where activities is shown - and we can just handle that in a controlled way

GNOME TW: https://openqa.opensuse.org/tests/1788815
Plasma TW: https://openqa.opensuse.org/tests/1788816
