### PR TITLE
Update code to fix desktopapps-gnome failures on GNOME40

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -86,6 +86,7 @@ sub change_pwd {
 
 sub add_user {
     assert_and_click "add-user";
+    assert_screen("before-input-username-test");
     type_string $newUser;
     assert_screen("input-username-test");
     assert_and_click "set-password-option";

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -980,4 +980,23 @@ sub libreoffice_start_program {
     }
 }
 
+sub start_gnome_tweak_tool {
+    my @gnome_tweak_matches = qw(gnome-tweaks gnome-tweak-tool command-not-found);
+
+    send_key "esc";
+    x11_start_program('gnome-tweaks', target_match => \@gnome_tweak_matches);
+
+    if (match_has_tag('command-not-found')) {
+        # GNOME Tweak tool was renamed to GNOME Tweaks during 3.28 dev branch
+        # As the new name yielded a 'command-not-found', start as old command
+        send_key 'esc';
+        x11_start_program('gnome-tweak-tool');
+    }
+
+    if (check_screen('gnome-tweak-extensions-moved')) {
+        # GNOME 40 moved extensions out of tweak tool, pops a warning
+        assert_and_click('gnome-tweak-extensions-moved');
+    }
+}
+
 1;

--- a/tests/x11/gnome_tweak_tool.pm
+++ b/tests/x11/gnome_tweak_tool.pm
@@ -21,20 +21,9 @@ use warnings;
 use testapi;
 
 sub run {
-    my @gnome_tweak_matches = qw(gnome-tweaks gnome-tweak-tool command-not-found gnome-tweak-extensions-moved);
+    my ($self) = shift;
+    $self->start_gnome_tweak_tool;
 
-    mouse_hide(1);
-    x11_start_program('gnome-tweaks', target_match => \@gnome_tweak_matches);
-    if (match_has_tag('command-not-found')) {
-        # GNOME Tweak tool was renamed to GNOME Tweaks during 3.28 dev branch
-        # As the new name yielded a 'command-not-found', start as old command
-        send_key 'esc';
-        x11_start_program('gnome-tweak-tool');
-    }
-    if (match_has_tag('gnome-tweak-extensions-moved')) {
-        # GNOME 40 moved extensions out of tweak tool, pops a warning
-        assert_and_click('gnome-tweak-extensions-moved');
-    }
     assert_and_click "gnome-tweak-tool-fonts";
     assert_screen "gnome-tweak-tool-fonts-dialog";
     send_key "alt-f4";

--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2020 SUSE LLC
+# Copyright © 2016-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -46,21 +46,9 @@ use version_utils qw(is_leap is_opensuse is_sle is_tumbleweed);
 use x11utils qw(handle_relogin turn_off_gnome_screensaver);
 
 sub tweak_startupapp_menu {
-    my ($self) = @_;
-    if (!is_sle('<15-sp2') && !is_leap('<15.2')) {
-        x11_start_program 'gnome-tweaks';
-    }
-    elsif (is_sle('15+')) {
-        # tweak-tool entry is not in gnome-control-center of SLE15;
-        x11_start_program 'gnome-tweak-tool';
-    }
-    else {
-        $self->start_gnome_settings;
-        type_string "tweak";
-        assert_screen "settings-tweak-selected";
-        send_key "ret";
-    }
-    assert_screen "tweak-tool";
+    my ($self) = shift;
+
+    $self->start_gnome_tweak_tool;
     # increase the default timeout - the switching can be slow
     send_key_until_needlematch "tweak-startapp", "down", 10, 2;
 }
@@ -171,10 +159,8 @@ sub run {
         click_lastmatch;
         assert_screen 'xterm';
     }
-    send_key "alt-f4";
-    wait_still_screen;
-    send_key "ret";
-    wait_still_screen;
+    send_key "esc";
+    assert_and_click "xterm-close-window";
     assert_screen "generic-desktop";
 
     #remove xterm from startup application

--- a/tests/x11/gnomecase/nautilus_cut_file.pm
+++ b/tests/x11/gnomecase/nautilus_cut_file.pm
@@ -28,10 +28,9 @@ sub run {
     x11_start_program('nautilus');
     x11_start_program("touch newfile", valid => 0);
 
-    send_key_until_needlematch 'nautilus-newfile-matched', 'right', 15;
+    assert_and_click "nautilus-newfile-matched";
     send_key "ctrl-x";
-    send_key_until_needlematch 'nautilus-Downloads-matched', 'left', 5;
-    send_key "ret";
+    assert_and_dclick "nautilus-Downloads-matched";
     # paste to ~/Downloads
     send_key "ctrl-v";
     # assure file moved, no matter file is highlighted or not


### PR DESCRIPTION
Update code to fix desktopapps-gnome failures on GNOME40
Verification runs on TW and SLE are provided
The code change and newly added needles won't cause side effect on the previous passed gnome-tweak-tool 

- Related ticket: https://progress.opensuse.org/issues/93159
- Needles: 
> TW: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/728
> SLE15SP3: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1539
- Verification runs: 
> TW: http://10.163.42.54/tests/1781
> SLE15SP3: http://10.163.42.54/tests/1780
