### PR TITLE
Install guestfs-tools to use libguestfs command

### DIFF
--- a/data/virt_autotest/fetch_logs_from_guest.sh
+++ b/data/virt_autotest/fetch_logs_from_guest.sh
@@ -272,8 +272,8 @@ guest_hash_index=0
 dhcpd_lease_file="/var/lib/dhcp/db/dhcpd.leases"
 
 #Install necessary packages
-echo -e "Install necessary packages. zypper install -y sshpass nmap xmlstarlet libguestfs*" | tee -a ${fetch_logs_from_guest_log}
-zypper install -y sshpass nmap xmlstarlet libguestfs* | tee -a ${fetch_logs_from_guest_log}
+echo -e "Install necessary packages. zypper install -y sshpass nmap xmlstarlet libguestfs* guestfs-tools" | tee -a ${fetch_logs_from_guest_log}
+zypper install -y sshpass nmap xmlstarlet libguestfs* guestfs-tools | tee -a ${fetch_logs_from_guest_log}
 
 #Establish reachable networks and hosts database on host
 subnets_in_route=`ip route show all | awk '{print $1}' | grep -v default`


### PR DESCRIPTION
* **It** seems that there is package dependency change, so guestfs-tools will not be installed automatically together with libguestfs0.
* **In** order to be able to use libguestfs command, install guestfs-tools manually in fetch_logs_from_guest.sh.
* **Verification run**:
  * [Verification run](http://10.67.129.106/tests/1330#step/uefi_guest_installation/621)
