### PR TITLE
Containers: install runc instead of docker-runc for Leap

### DIFF
--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -31,8 +31,7 @@ sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     my @runtimes = ();
-    push @runtimes, "docker-runc" if is_leap("<16.0");
-    push @runtimes, "runc"        if !is_sle('=15');
+    push @runtimes, "runc" if (is_leap(">15.1") or !is_sle('=15'));
 
     record_info 'Setup', 'Setup the environment';
     # runC cannot create or extract the root filesystem on its own. Use Docker to create it.


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/94054

