### PR TITLE
Print zypper lr output via serial console

### DIFF
--- a/tests/migration/online_migration/post_migration.pm
+++ b/tests/migration/online_migration/post_migration.pm
@@ -24,7 +24,7 @@ sub run {
     select_console 'root-console';
 
     # print repos to screen and serial console after online migration
-    zypper_call('lr -u');
+    assert_script_run "zypper lr --uri | tee /dev/$serialdev";
 
     # Save output info to logfile
     my $out;


### PR DESCRIPTION
Print zypper lr output via serial console, the zypper lr output
cannot show full information in one screen. So print the information
via serical console. We can check all the information in one screen

- Related ticket: https://progress.opensuse.org/issues/93594
- Verification run: https://openqa.suse.de/tests/6265466#step/post_migration/9