### PR TITLE
Containers: disable firewall by default

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -16,6 +16,7 @@
 use Mojo::Base qw(consoletest);
 use testapi;
 use utils;
+use Utils::Systemd qw(disable_and_stop_service);
 use version_utils qw(check_os_release is_sle);
 
 sub run {
@@ -26,6 +27,7 @@ sub run {
         $interface = script_output q@ip r s default 0.0.0.0/0 | awk '{printf $5}'@;
         validate_script_output "ip a s '$interface'", sub { m/((\d{1,3}\.){3}\d{1,3}\/\d{1,2})/ };
         ensure_ca_certificates_suse_installed();
+        disable_and_stop_service(opensusebasetest::firewall, ignore_failure => 1);
     }
     else {
         assert_script_run "dhclient -v";


### PR DESCRIPTION
In some versions, we have firewall running and in some others firewall
is disabled. This way we make sure we start the test with the same
conditions for all the cases.

The reason to choose disabled is to avoid some further configuration
of iptables to allow containers contact the public network ([bsc#1187176](https://bugzilla.suse.com/show_bug.cgi?id=1187176))
Since container tests are not targeting network testing, it makes
sense to run the general tests with additional network setup.
What we can do in the other hand is to create a new test case where
we test container networking with firewall enabled.


