### PR TITLE
New btrfsmaintenance modules

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -782,6 +782,10 @@ elsif (get_var("PYNFS")) {
     prepare_target;
     load_pynfs_tests;
 }
+elsif (get_var("BTRFSMAINTENANCE")) {
+    prepare_target;
+    loadtest "btrfsmaintenance/btrfsmaintenance";
+}
 elsif (get_var("VIRT_AUTOTEST")) {
     if (get_var('REPO_0_TO_INSTALL', '')) {
         #Before host installation starts, swtich to version REPO_0_TO_INSTALL if it is set

--- a/tests/btrfsmaintenance/btrfsmaintenance.pm
+++ b/tests/btrfsmaintenance/btrfsmaintenance.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Regression test for btrfsmaintenance. poo#59211.
+#   Fixed by commit 93b0054 (Make balance, scrub, and trim mutually exclusive tasks)
+# Maintainer: An Long <lan@suse.com>
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use File::Basename;
+use testapi;
+use utils;
+use power_action_utils 'power_action';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Reinstall btrfsmaintenance pachage
+    zypper_call 'in -f btrfsmaintenance';
+
+    assert_script_run('cd /usr/share/btrfsmaintenance');
+    script_output('
+for i in $(seq 1 10)
+do
+{
+./btrfs-defrag.sh;
+./btrfs-scrub.sh;
+./btrfs-trim.sh;
+./btrfs-balance.sh;
+}&
+done
+');
+
+}
+
+1;
+


### PR DESCRIPTION
Regression test for btrfsmaintenance.

- Related ticket: https://progress.opensuse.org/issues/59211
- Needles: N/A
- Verification run: http://10.67.133.102/tests/304