### PR TITLE
switch_to_wicked: ensure wicked is installed prior to switching

### DIFF
--- a/tests/console/switch_to_wicked.pm
+++ b/tests/console/switch_to_wicked.pm
@@ -18,8 +18,9 @@ use testapi;
 
 sub run {
     my ($self) = shift;
-    select_console 'root-console';
     return unless is_network_manager_default;
+    ensure_installed 'wicked';
+    select_console 'root-console';
     $self->use_wicked_network_manager;
 }
 


### PR DESCRIPTION
    Due to a long standing issue, wicked had always been selected for installation,
    even when the role to be installed was NetworkManager based.
    
    This forced dependency has been corrected, which in turn means that a system
    installed using a role based on NetworkManager (desktop roles) need to
    install wicked before they can enable the service

- Related ticket: https://progress.opensuse.org/issues/94108
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1791562
