### PR TITLE
Integrate test case "audit-tools" of "audit-test" into openQA

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -1,0 +1,124 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Base module for audit-test test cases
+# Maintainer: llzhao <llzhao@suse.com>
+
+package audit_test;
+
+use base Exporter;
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Mojo::File 'path';
+
+our @EXPORT = qw(
+  $testdir
+  $testfile_tar
+  $baseline_file
+  $code_repo
+  $mode
+  get_testsuite_name
+  run_testcase
+  parse_testcase_log
+  compare_run_log
+);
+
+our $testdir      = '/tmp/';
+our $code_repo    = get_var('CODE_BASE', 'https://gitlab.suse.de/security/audit-test-sle15/-/archive/master/audit-test-sle15-master.tar');
+our $testfile_tar = 'audit-test-sle15-master';
+our $mode         = get_var('MODE', 64);
+
+# $current_file: current output file name; $baseline_file: baseline file name
+our $current_file  = 'run.log';
+our $baseline_file = 'baseline_run.log';
+
+# Run the specific test case
+# input: $testcase - test case name (the actual test case name in 'audit-test' test suite, etc)
+sub run_testcase {
+    my ($testcase, %args) = @_;
+
+    # Run test case
+    assert_script_run("cd ${testdir}${testfile_tar}/audit-test/${testcase}/");
+    assert_script_run('./run.bash', %args);
+
+    # Upload logs
+    upload_logs("$current_file");
+    upload_logs("$baseline_file");
+}
+
+# Parse all test cases in *.log (run.log, etc)
+# input: $file - file name
+# output: @testcase_list - test case list
+sub parse_testcase_log {
+    my ($file) = @_;
+
+    # Test case token, it is a number within []: e.g., [0], [1], [12]
+    my $s_tok         = '\[\d+\] ';
+    my @testcase_list = ();
+
+    my @lines = split(/\n/, path("$file")->slurp);
+    my $i     = 0;
+    # Parse the test cases of input file
+    for my $line (@lines) {
+        if ($line =~ /$s_tok/) {
+            push @testcase_list, "$line\n";
+            $i++;
+        }
+    }
+    record_info("T: $i", "Total \"$i\" test cases found in file \"$file\":\n @testcase_list");
+    return @testcase_list;
+}
+
+# Compare baseline testing result and current testing result
+# input: $testcase - test case name (the test module name in openQA code,
+# if test module is 'audit_tools.pm' then $testcase = audit_tools, etc)
+sub compare_run_log {
+    my ($testcase) = @_;
+    my $c_file     = "ulogs/${testcase}-${current_file}";
+    my $b_file     = "ulogs/${testcase}-${baseline_file}";
+
+    # Define Test case (name and result) list
+    my @testcase_list_current  = ();
+    my @testcase_list_baseline = ();
+    my $result                 = 'ok';
+
+    # Parse the test cases in baseline file
+    record_info('Baseline', 'Parse baseline test results');
+    @testcase_list_baseline = parse_testcase_log($b_file);
+    record_info('Current', 'Parse current test results');
+    @testcase_list_current = parse_testcase_log($c_file);
+    my $str_baseline = join('', @testcase_list_baseline);
+    my $str_current  = join('', @testcase_list_current);
+    record_info('Compare', "Compare the testing results of current file \"$c_file\" with baseline file \"$b_file\".");
+    if ($str_baseline eq $str_current) {
+        $result = 'ok';
+    }
+    else {
+        my $size = @testcase_list_baseline;
+        for (my $i = 0; $i < $size; $i++) {
+            if ($testcase_list_current[$i] !~ m/PASS/ && "$testcase_list_current[$i]" ne "$testcase_list_baseline[$i]") {
+                record_info(
+                    'Not Same',
+                    "Current testing results are not same with baseline! FYI:\n\"Baseline\"=$testcase_list_baseline[$i]\" Current\"=$testcase_list_current[$i]"
+                );
+                $result = 'fail';
+            }
+        }
+    }
+    if ($result eq 'ok') {
+        # Current run.log is the same with baseline_run.log
+        record_info('Same', 'Current testing results are the same with baseline');
+    }
+    return $result;
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2405,6 +2405,24 @@ sub load_security_tests_selinux {
     loadtest "security/selinux/chcat";
 }
 
+sub load_security_tests_cc {
+    # Setup environment for cc testing: 'audit-test' test suite setup
+    # Such as: download code branch; install needed packages
+    loadtest 'security/cc/cc_audit_test_setup';
+
+    # Run test cases of 'audit-test' test suite which do NOT need SELinux env
+    loadtest 'security/cc/audit_tools';
+
+    # Setup environment for cc testing: SELinux setup
+    # Such as: set up SELinux with permissive mode and specific policy type
+    loadtest 'security/selinux/selinux_setup';
+    loadtest 'security/cc/cc_selinux_setup';
+
+    # Run test cases of 'audit-test' test suite which do need SELinux env
+    # Please add these test cases here: poo#93441
+}
+
+
 sub load_security_tests_mok_enroll {
     loadtest "security/mokutil_sign";
 }
@@ -2596,6 +2614,7 @@ sub load_security_tests {
       swtpm
       grub_auth
       lynis
+      cc
     );
 
     # Check SECURITY_TEST and call the load functions iteratively.

--- a/tests/security/cc/audit_tools.pm
+++ b/tests/security/cc/audit_tools.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'audit-tools' test case of 'audit-test' test suite
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#94450
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # Run test case
+    run_testcase('audit-tools');
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('audit_tools');
+    $self->result($result);
+}
+
+1;

--- a/tests/security/cc/cc_audit_test_setup.pm
+++ b/tests/security/cc/cc_audit_test_setup.pm
@@ -1,0 +1,52 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Setup 'audit-test' test environment of a system with needed packages
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#93441
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use registration 'add_suseconnect_product';
+use audit_test;
+
+sub run {
+    my ($self)   = @_;
+    my $dir      = $audit_test::testdir;
+    my $file_tar = $audit_test::testfile_tar . '.tar';
+
+    select_console 'root-console';
+
+    # Add needed modules
+    add_suseconnect_product('sle-module-legacy');
+    add_suseconnect_product('sle-module-desktop-applications');
+    add_suseconnect_product('sle-module-development-tools');
+
+    # Install needed packages/paterns
+    zypper_call('in -t pattern devel_basis');
+    zypper_call('in git expect libcap-devel psmisc cryptsetup');
+
+    # Install vsftpd
+    zypper_call('in vsftpd');
+
+    # Install audit packages
+    zypper_call('in audit audit-audispd-plugins');
+
+    # Export MODE
+    assert_script_run("export MODE=$audit_test::mode");
+
+    # Download "audit-test"
+    assert_script_run("wget --no-check-certificate $audit_test::code_repo -O ${dir}${file_tar}");
+    assert_script_run("tar -xvf ${dir}${file_tar} -C ${dir}");
+}
+
+1;

--- a/tests/security/cc/cc_selinux_setup.pm
+++ b/tests/security/cc/cc_selinux_setup.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Setup 'audit-test' test environment of a system running SELinux
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#93441
+
+use base 'selinuxtest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    my $file = "$selinuxtest::dir" . "$selinuxtest::policyfile_tar" . '/data/selinux/selinux-policy-targeted-*.noarch.rpm';
+    $self->download_policy_pkgs();
+    assert_script_run("rpm -ivh --nosignature --nodeps --noplugins $file");
+
+    # Set SELINUXTYPE=targeted
+    # NOTE: 'targeted' type still has some problems (reboot failed)
+    # We use 'minimum' atm for a workaround, related poo: poo#94910
+    $self->set_sestatus('permissive', 'minimum');
+}
+
+1;

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -1,79 +1,28 @@
-# Copyright (C) 2018-2021 SUSE LLC
+# SUSE's openQA tests
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# Copyright © 2018-2021 SUSE LLC
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, see <http://www.gnu.org/licenses/>.
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 #
 # Summary: Test "sestatus" command gets the right status of a system running SELinux
 # Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#40358, tc#1682592
 
-use base 'opensusebasetest';
-use power_action_utils "power_action";
-use bootloader_setup 'add_grub_cmdline_settings';
+use base 'selinuxtest';
 use strict;
 use warnings;
 use testapi;
 use utils;
-use Utils::Backends 'is_pvm';
-use Utils::Architectures 'is_aarch64';
 
 sub run {
     my ($self) = @_;
-    my $selinux_config_file = "/etc/selinux/config";
+
     select_console "root-console";
-
-    # SELinux by default
-    validate_script_output("sestatus", sub { m/SELinux status: .*disabled/ });
-
-    # workaround for "selinux-auto-relabel" in case: auto relabel then trigger reboot
-    my $results = script_run("zypper --non-interactive se selinux-autorelabel");
-    if (!$results) {
-        assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=8/\' /etc/default/grub");
-    }
-
-    # enable SELinux in grub
-    add_grub_cmdline_settings('security=selinux selinux=1 enforcing=0', update_grub => 1);
-
-    # control (enable) the status of SELinux on the system
-    assert_script_run("sed -i -e 's/^SELINUX=/#SELINUX=/' $selinux_config_file");
-    assert_script_run("echo 'SELINUX=permissive' >> $selinux_config_file");
-
-    # set SELINUXTYPE=minimum
-    assert_script_run("sed -i -e 's/^SELINUXTYPE=/#SELINUXTYPE=/' $selinux_config_file");
-    assert_script_run("echo 'SELINUXTYPE=minimum' >> $selinux_config_file");
-    assert_script_run("systemctl enable auditd");
-
-
-    # reboot the vm and reconnect the console
-    power_action("reboot", textmode => 1);
-    reconnect_mgmt_console if is_pvm;
-    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
-    select_console "root-console";
-
-    validate_script_output(
-        "sestatus",
-        sub {
-            m/
-            SELinux\ status:\ .*enabled.*
-            SELinuxfs\ mount:\ .*\/sys\/fs\/selinux.*
-            SELinux\ root\ directory:\ .*\/etc\/selinux.*
-            Loaded\ policy\ name:\ .*minimum.*
-            Current\ mode:\ .*permissive.*
-            Mode\ from\ config\ file:\ .*permissive.*
-            Policy\ MLS\ status:\ .*enabled.*
-            Policy\ deny_unknown\ status:\ .*allowed.*
-            Max\ kernel\ policy\ version:\ .*[0-9]+.*/sx
-        });
+    $self->set_sestatus("permissive", "minimum");
 }
 
 1;


### PR DESCRIPTION
Integrate test case "audit-tools" of "audit-test" into openQA.

NOTE1:
  The "audit-test" is for CC certification testing so it is only supported on SLES.
  Same while we only focus on running on x86 now we will support other arches later.

NOTE2:
The `cc_*_setup.pm` are not very complete yet as I only added the pkgs mentioned in docs but there also some pkgs are under investigation, the `cc_*_setup.pm` is a kind of frame for future updating.

NOTE3: The related MR were merged already
  https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/1
  https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/2


- Related ticket: https://progress.opensuse.org/issues/94450
- Needles: NA
- Verification run: 
  https://openqa.suse.de/tests/6342898 
  https://openqa.suse.de/tests/6345092#step/audit_tools/15 (for a failed comparing VR on purpose)
