### PR TITLE
Use separate log file for LibyuiClient

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -24,7 +24,9 @@ use utils qw(enter_cmd_slow type_line_svirt save_svirt_pty);
 use Utils::Backends;
 use YuiRestClient::App;
 use YuiRestClient::Wait;
+use YuiRestClient::Logger;
 use Utils::Architectures 'is_s390x';
+use bmwqemu;
 
 my $app;
 my $port;
@@ -40,6 +42,13 @@ sub get_host {
     my (%args) = @_;
     $host = init_host(%args) unless $host;
     return $host;
+}
+
+sub init_logger {
+    my $path_to_log   = 'ulogs/yui-log.txt';
+    my $yui_log_level = get_var('YUI_LOG_LEVEL', 'debug');
+    mkdir('ulogs') if (!-d 'ulogs');
+    YuiRestClient::Logger->get_instance({format => \&bmwqemu::log_format_callback, path => $path_to_log, level => $yui_log_level});
 }
 
 sub get_port {

--- a/lib/YuiRestClient/App.pm
+++ b/lib/YuiRestClient/App.pm
@@ -65,6 +65,8 @@ sub check_connection {
         host => $self->{host},
         port => $self->{port},
         path => $self->{api_version} . '/widgets');
+
+    YuiRestClient::Logger->get_instance()->debug("Check connection to the app by url: $uri");
     YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_get($uri);
             return $response->json if $response;

--- a/lib/YuiRestClient/Http/HttpClient.pm
+++ b/lib/YuiRestClient/Http/HttpClient.pm
@@ -14,6 +14,7 @@ use strict;
 use warnings;
 
 use Mojo::UserAgent;
+use YuiRestClient::Logger;
 
 my $ua = Mojo::UserAgent->new;
 
@@ -23,6 +24,7 @@ sub http_get {
     my $res = $ua->get($url)->result;
     return $res if $res->is_success;
     # Die if non OK response code
+    YuiRestClient::Logger->get_instance()->error('Widget not found by url: ' . $url);
     die $res->message . "\n" . $res->body . "\n$url";
 }
 
@@ -32,6 +34,7 @@ sub http_post {
     my $res = $ua->post($url)->result;
     return $res if $res->is_success;
     # Die if non OK response code
+    YuiRestClient::Logger->get_instance()->error('Widget not found by url: ' . $url);
     die $res->message . "\n" . $res->body . "\n$url";
 }
 

--- a/lib/YuiRestClient/Http/WidgetController.pm
+++ b/lib/YuiRestClient/Http/WidgetController.pm
@@ -13,6 +13,7 @@ package YuiRestClient::Http::WidgetController;
 use strict;
 use warnings;
 
+use YuiRestClient::Logger;
 use YuiRestClient::Wait;
 use YuiRestClient::Http::HttpClient;
 
@@ -58,6 +59,8 @@ sub find {
         params => $args
     );
 
+    YuiRestClient::Logger->get_instance()->debug('Finding widget by url: ' . $uri);
+
     YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_get($uri);
             return $response->json if $response; },
@@ -75,6 +78,8 @@ sub send_action {
         path   => $self->{api_version} . '/widgets',
         params => $args
     );
+
+    YuiRestClient::Logger->get_instance()->debug('Sending action to widget by url: ' . $uri);
 
     YuiRestClient::Wait::wait_until(object => sub {
             my $response = YuiRestClient::Http::HttpClient::http_post($uri);

--- a/lib/YuiRestClient/Logger.pm
+++ b/lib/YuiRestClient/Logger.pm
@@ -1,0 +1,61 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YuiRestClient::Logger;
+use strict;
+use warnings;
+use Term::ANSIColor;
+
+my $instance;
+
+sub get_instance {
+    my ($class, $args) = @_;
+
+    return $instance if defined $instance;
+    $instance = bless {
+        logger => Mojo::Log->new(
+            level  => $args->{level},
+            format => $args->{format},
+            path   => $args->{path})
+    }, $class;
+}
+
+sub debug {
+    my ($self, $message) = @_;
+    $instance->{logger}->append(color('white'));
+    $instance->{logger}->debug($message)->append(color('reset'));
+}
+
+sub info {
+    my ($self, $message) = @_;
+    $instance->{logger}->append(color('blue'));
+    $instance->{logger}->info($message)->append(color('reset'));
+}
+
+sub warn {
+    my ($self, $message) = @_;
+    $instance->{logger}->append(color('yellow'));
+    $instance->{logger}->warn($message)->append(color('reset'));
+}
+
+sub error {
+    my ($self, $message) = @_;
+    $instance->{logger}->append(color('bold red'));
+    $instance->{logger}->error($message)->append(color('reset'));
+}
+
+sub fatal {
+    my ($self, $message) = @_;
+    $instance->{logger}->append(color('bold red'));
+    $instance->{logger}->fatal($message)->append(color('reset'));
+}
+
+1;

--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -27,6 +27,7 @@ use File::Path 'make_path';
 use Mojo::JSON 'to_json';
 
 use YuiRestClient;
+use YuiRestClient::Logger;
 
 =head1 y2_base
 
@@ -162,4 +163,18 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
+sub pre_run_hook {
+    my $self = shift;
+
+    $self->SUPER::pre_run_hook;
+    YuiRestClient::Logger->info($autotest::current_test->{name} . " test module started") if YuiRestClient::is_libyui_rest_api;
+}
+
+sub post_run_hook {
+    my $self = shift;
+
+    $self->SUPER::post_run_hook;
+    save_screenshot;
+    YuiRestClient::Logger->info($autotest::current_test->{name} . " test module finished") if YuiRestClient::is_libyui_rest_api;
+}
 1;

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -529,13 +529,6 @@ sub save_remote_upload_y2logs {
     $self->investigate_yast2_failure();
 }
 
-sub post_run_hook {
-    my $self = shift;
-
-    $self->SUPER::post_run_hook;
-    save_screenshot;
-}
-
 sub post_fail_hook {
     my $self = shift;
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -126,7 +126,10 @@ logcurrentenv(
 );
 
 if (load_yaml_schedule) {
-    YuiRestClient::set_libyui_backend_vars if YuiRestClient::is_libyui_rest_api;
+    if (YuiRestClient::is_libyui_rest_api) {
+        YuiRestClient::set_libyui_backend_vars;
+        YuiRestClient::init_logger;
+    }
     return 1;
 }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -636,7 +636,10 @@ $testapi::distri->set_expected_serial_failures(create_list_of_serial_failures())
 $testapi::distri->set_expected_autoinst_failures(create_list_of_autoinst_failures());
 
 if (load_yaml_schedule) {
-    YuiRestClient::set_libyui_backend_vars if YuiRestClient::is_libyui_rest_api;
+    if (YuiRestClient::is_libyui_rest_api) {
+        YuiRestClient::set_libyui_backend_vars;
+        YuiRestClient::init_logger;
+    }
     return 1;
 }
 

--- a/variables.md
+++ b/variables.md
@@ -162,6 +162,7 @@ WAYLAND | boolean | false | Enables wayland tests in the system.
 XDMUSED | boolean | false | Indicates availability of xdm.
 YAML_SCHEDULE | string | | Defines yaml file containing test suite schedule.
 YAML_TEST_DATA | string | | Defines yaml file containing test data.
+YUI_LOG_LEVEL | string | debug | Allows changing log level for YuiRestClient::Logger. Available options are: debug, info, warning, error, fatal.
 YUI_PORT | integer | | Port being used for libyui REST API. See also YUI_SERVER and YUI_START_PORT.
 YUI_SERVER | string | | libyui REST API server name or ip address.
 YUI_START_PORT | integer | 39000 | Sets starting port for the libyui REST API, on qemu VNC port is then added to this port not to have conflicts.


### PR DESCRIPTION
Log LibyuiClient calls to separate from autoinst-log.txt file.

- Related ticket: https://progress.opensuse.org/issues/89485
- Verification run: https://openqa.suse.de/tests/6306983/
