### PR TITLE
Public Cloud: Fix maintenance repositories priority

### DIFF
--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -35,10 +35,10 @@ sub run {
         my $timeout = 2400;
         assert_script_run("rsync --timeout=$timeout -uvahP -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => $timeout + 10);
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
-        $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
+        $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar -p10 '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
 
-        $args->{my_instance}->run_ssh_command(cmd => "zypper lr");
+        $args->{my_instance}->run_ssh_command(cmd => "zypper lr -P");
     }
 }
 


### PR DESCRIPTION
The maintenance repositories have the same priority as the upstream repositories.
This pull request tries to increase the priority of maintenance repositories.

- Verification run: http://pdostal-server.suse.cz/tests/12412#step/transfer_repos/8
