### PR TITLE
Unschedule pidgin tests from SLE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2038,7 +2038,7 @@ sub load_x11_message {
         }
         loadtest "x11/groupwise/groupwise" if is_sle || is_tumbleweed;
     }
-    if (get_var("DESKTOP") =~ /kde|gnome/ && is_sle || is_tumbleweed) {
+    if (get_var("DESKTOP") =~ /kde|gnome/ && is_tumbleweed) {
         loadtest "x11/pidgin/prep_pidgin";
         loadtest "x11/pidgin/pidgin_IRC";
         loadtest "x11/pidgin/clean_pidgin";


### PR DESCRIPTION
Unschedule pidgin tests from SLE, not included outside of PackageHub other than SLE <=12, and not included in current test runs there either.

- Related ticket: https://progress.opensuse.org/issues/94177
- Verification run: https://openqa.suse.de/tests/6288743

