### PR TITLE
Clean openVPN test up

### DIFF
--- a/data/openvpn/ca_client.conf
+++ b/data/openvpn/ca_client.conf
@@ -1,0 +1,10 @@
+dev tap
+remote 10.0.2.101 1194
+tls-client
+remote-cert-tls server
+
+ca ca.crt
+cert client.crt
+key client.key
+
+pull

--- a/data/openvpn/ca_server.conf
+++ b/data/openvpn/ca_server.conf
@@ -1,0 +1,11 @@
+dev tap
+mode server
+tls-server
+
+cert pki/issued/server.crt
+key pki/private/server.key
+ca pki/ca.crt
+dh pki/dh.pem
+
+ifconfig 10.8.0.1 255.255.255.0
+client-config-dir ccd

--- a/data/openvpn/static_client.conf
+++ b/data/openvpn/static_client.conf
@@ -1,0 +1,4 @@
+remote 10.0.2.101
+dev tun
+ifconfig 10.8.0.2 10.8.0.1
+secret /etc/openvpn/static.key

--- a/data/openvpn/static_server.conf
+++ b/data/openvpn/static_server.conf
@@ -1,0 +1,3 @@
+dev tun
+ifconfig 10.8.0.1 10.8.0.2
+secret /etc/openvpn/static.key

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1033,25 +1033,6 @@ else {
         loadtest 'console/microcode_update';
         return 1;
     }
-    elsif (get_var("QAM_OPENVPN")) {
-        set_var('INSTALLONLY', 1);
-        if (check_var('HOSTNAME', 'server')) {
-            barrier_create('OPENVPN_STATIC_START',    2);
-            barrier_create('OPENVPN_STATIC_STARTED',  2);
-            barrier_create('OPENVPN_STATIC_FINISHED', 2);
-            barrier_create('OPENVPN_CA_START',        2);
-            barrier_create('OPENVPN_CA_STARTED',      2);
-            barrier_create('OPENVPN_CA_FINISHED',     2);
-        }
-        boot_hdd_image;
-        loadtest 'network/setup_multimachine';
-        if (check_var('HOSTNAME', 'server')) {
-            loadtest "network/openvpn_server";
-        }
-        else {
-            loadtest "network/openvpn_client";
-        }
-    }
     elsif (get_var("NFSSERVER") || get_var("NFSCLIENT")) {
         set_var('INSTALLONLY', 1);
         boot_hdd_image;

--- a/schedule/functional/openvpn.yaml
+++ b/schedule/functional/openvpn.yaml
@@ -1,0 +1,15 @@
+name: openVPN
+description: >
+  Maintainer: pdostal.
+  openVPN test
+conditional_schedule:
+  openvpn:
+    HOSTNAME:
+      'server':
+        - network/openvpn_server
+      'client':
+        - network/openvpn_client
+schedule:
+  - boot/boot_to_desktop
+  - network/setup_multimachine
+  - '{{openvpn}}'

--- a/tests/network/openvpn_client.pm
+++ b/tests/network/openvpn_client.pm
@@ -20,12 +20,15 @@ use testapi;
 use lockapi;
 use y2_module_guitest;
 use mm_network;
-use utils qw(systemctl zypper_call exec_and_insert_password);
+use utils qw(systemctl zypper_call exec_and_insert_password script_retry);
 use strict;
 use warnings;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    mutex_wait 'barrier_setup_done';
+    barrier_wait 'SETUP_DONE';
+    $self->select_serial_terminal;
 
     # Install openvpn
     zypper_call('in openvpn');
@@ -33,17 +36,24 @@ sub run {
 
     # Wait for static key and write the client config
     mutex_wait 'OPENVPN_STATIC_KEY';
+
+    # Download the client config
+    assert_script_run("curl -o static.conf " . data_url("openvpn/static_client.conf"));
+
+    # Download key from the server
     exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/static.key /etc/openvpn/static.key");
     assert_script_run("cat /etc/openvpn/static.key");
-    assert_script_run(qq(echo "remote 10.0.2.101
-dev tun
-ifconfig 10.8.0.2 10.8.0.1
-secret /etc/openvpn/static.key" > static.conf));
 
     # Start the client when also server is ready and test the connection
-    barrier_wait 'OPENVPN_STATIC_START';
     systemctl('start openvpn@static');
     systemctl('status openvpn@static -l');
+
+    # Make sure the tunnel has been established
+    script_retry('journalctl --no-pager -u openvpn@static | grep "Initialization Sequence Completed"', delay => 15, retry => 12);
+
+    # Test that the interface is present
+    assert_script_run('ip a s tun0');
+    assert_script_run('ip a s tun0 | grep "10\.8\.0\.2"');
 
     # Test the connection when both client and server are rady
     barrier_wait 'OPENVPN_STATIC_STARTED';
@@ -55,26 +65,25 @@ secret /etc/openvpn/static.key" > static.conf));
 
     # Download keys and certificates when they are on the server available
     mutex_wait 'OPENVPN_CA_KEYS';
+
+    # Write the client config
+    assert_script_run("curl -o ca.conf " . data_url("openvpn/ca_client.conf"));
+
+    # Download key from the server
     exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/pki/ca.crt /etc/openvpn/ca.crt");
     exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/pki/issued/client.crt /etc/openvpn/client.crt");
     exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/pki/private/client.key /etc/openvpn/client.key");
 
-    # Write the client config
-    assert_script_run(qq(echo "dev tap
-remote 10.0.2.101 1194
-tls-client
-remote-cert-tls server
-
-ca ca.crt
-cert client.crt
-key client.key
-
-pull" > ca.conf));
-
     # Start the client when also server is ready and test the connection
-    barrier_wait 'OPENVPN_CA_START';
     systemctl('start openvpn@ca');
     systemctl('status openvpn@ca -l');
+
+    # Make sure the tunnel has been established
+    script_retry('journalctl --no-pager -u openvpn@ca | grep "Initialization Sequence Completed"', delay => 15, retry => 12);
+
+    # Test that the interface is present
+    assert_script_run("ip a s tap0");
+    assert_script_run('ip a s tap0 | grep "10\.8\.0\.2"');
 
     barrier_wait 'OPENVPN_CA_STARTED';
     assert_script_run("ping -c5 -W1 -I tap0 10.8.0.1");

--- a/tests/network/openvpn_server.pm
+++ b/tests/network/openvpn_server.pm
@@ -21,30 +21,44 @@ use lockapi;
 use y2_module_guitest;
 use mm_network;
 use mmapi 'wait_for_children';
-use utils qw(systemctl zypper_call exec_and_insert_password);
+use utils qw(systemctl zypper_call exec_and_insert_password script_retry);
+use version_utils 'is_opensuse';
 use repo_tools 'add_qa_head_repo';
 use strict;
 use warnings;
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    barrier_create 'SETUP_DONE', 2;
+    barrier_create('OPENVPN_STATIC_STARTED',  2);
+    barrier_create('OPENVPN_STATIC_FINISHED', 2);
+    barrier_create('OPENVPN_CA_STARTED',      2);
+    barrier_create('OPENVPN_CA_FINISHED',     2);
+    mutex_create 'barrier_setup_done';
+    barrier_wait 'SETUP_DONE';
+    $self->select_serial_terminal;
 
     # Install openvpn, generate static key
-    add_qa_head_repo;
+    add_qa_head_repo unless is_opensuse();
     zypper_call('in openvpn easy-rsa');
+    zypper_call("install openssl") if (script_run("which openssl") != 0);
     assert_script_run('cd /etc/openvpn');
     assert_script_run('openvpn --genkey --secret static.key');
     mutex_create 'OPENVPN_STATIC_KEY';
 
-    # Write the server config
-    assert_script_run(qq(echo "dev tun
-ifconfig 10.8.0.1 10.8.0.2
-secret /etc/openvpn/static.key" > static.conf));
+    # Download the server config
+    assert_script_run("curl -o static.conf " . data_url("openvpn/static_server.conf"));
 
     # Start the server
     systemctl('start openvpn@static');
     systemctl('status openvpn@static -l');
-    barrier_wait 'OPENVPN_STATIC_START';
+
+    # Make sure the tunnel has been established
+    script_retry('journalctl --no-pager -u openvpn@static | grep "Initialization Sequence Completed"', delay => 15, retry => 12);
+
+    # Test that the interface is present
+    assert_script_run("ip a s tun0");
+    assert_script_run('ip a s tun0 | grep "10\.8\.0\.1"');
 
     # Test the connection when also the client is ready
     barrier_wait 'OPENVPN_STATIC_STARTED';
@@ -64,18 +78,8 @@ secret /etc/openvpn/static.key" > static.conf));
     assert_script_run("echo 'yes' | easyrsa sign-req client client", 120);
     mutex_create 'OPENVPN_CA_KEYS';
 
-    # Write the server config
-    assert_script_run(qq(echo "dev tap
-mode server
-tls-server
-
-cert pki/issued/server.crt
-key pki/private/server.key
-ca pki/ca.crt
-dh pki/dh.pem
-
-ifconfig 10.8.0.1 255.255.255.0
-client-config-dir ccd" > ca.conf));
+    # Download the server config
+    assert_script_run("curl -o ca.conf " . data_url("openvpn/ca_server.conf"));
 
     # Create the client config directory and the file for client
     assert_script_run("mkdir ccd");
@@ -84,7 +88,13 @@ client-config-dir ccd" > ca.conf));
     # Start the server
     systemctl('start openvpn@ca');
     systemctl('status openvpn@ca -l');
-    barrier_wait 'OPENVPN_CA_START';
+
+    # Make sure the tunnel has been established
+    script_retry('journalctl --no-pager -u openvpn@ca | grep "Initialization Sequence Completed"', delay => 15, retry => 12);
+
+    # Test that the interface is present
+    assert_script_run("ip a s tap0");
+    assert_script_run('ip a s tap0 | grep "10\.8\.0\.1"');
 
     # Test the connection when also the client is ready
     barrier_wait 'OPENVPN_CA_STARTED';
@@ -93,6 +103,8 @@ client-config-dir ccd" > ca.conf));
     # Stop the server when also client is done
     barrier_wait 'OPENVPN_CA_FINISHED';
     systemctl('stop openvpn@ca');
+
+    wait_for_children();
 }
 
 1;

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -16,8 +16,8 @@ use warnings;
 use testapi;
 use lockapi;
 use mm_network 'setup_static_mm_network';
-use utils 'zypper_call';
-use Utils::Systemd 'disable_and_stop_service';
+use utils qw(zypper_call permit_root_ssh);
+use Utils::Systemd qw(disable_and_stop_service systemctl);
 use version_utils qw(is_sle is_opensuse);
 
 sub is_networkmanager {
@@ -60,7 +60,7 @@ sub run {
             assert_script_run "nmcli connection up '$nm_id'";
         }
         else {
-            assert_script_run 'systemctl restart  wicked';
+            systemctl("restart wicked");
         }
     }
 
@@ -68,6 +68,11 @@ sub run {
     assert_script_run "hostnamectl set-hostname $hostname";
     assert_script_run "hostnamectl status|grep $hostname";
     assert_script_run "hostname|grep $hostname";
+
+    # Make sure that PermitRootLogin is set to yes
+    # This is needed only when the new SSH config directory exists
+    # See: poo#93850
+    permit_root_ssh();
 }
 
 1;


### PR DESCRIPTION
This test cleans the openVPN test modules and their scheduling, it:
 * Removes useless multimachine barriers
 * Moves barriers definition from main.pm to openvpn_server.pm
   (with the YAML-compatibility workaround)
 * Prevents the `scp` being too fast after barrier is released
 * Repeatedly checks that the VPN connection has been established
 * Checks that the VPN interface exists and has the desired IP
 * Use serial terminal instead of graphical console
 * Moves multiline configs from test modules to separate files
 * Moves scheduling from main.pm to YAML
 * Make it work for openSUSE
   (install openssl if needed and do not install qa_head_repo)

There is SSH login problem on Tumbleweed being fixed in #12747

- Related ticket: [poo#91623](https://progress.opensuse.org/issues/91623)
- Verification run: [SLE15](http://pdostal-server.suse.cz/tests/12156) [Tumbleweed](http://pdostal-server.suse.cz/tests/12174)
