### PR TITLE
Buildah: Fix test_opensuse_based_image() call

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -249,6 +249,9 @@ sub test_built_img {
     sleep 5;
     assert_script_run("$runtime ps -a");
     script_retry('curl http://localhost:8888/ | grep "Networking test shall pass"', delay => 5, retry => 6);
+
+    # Clean up
+    assert_script_run("$runtime stop `$runtime ps -q`");
     assert_script_run("rm -rf /root/templates");
 }
 

--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -21,7 +21,7 @@ use utils;
 use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
-use version_utils qw(get_os_release check_os_release);
+use version_utils qw(get_os_release check_os_release is_sle);
 
 sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
@@ -43,13 +43,10 @@ sub run {
                 # Use container which it is created in test_container_image
                 # Buildah default name is conducted by <image-name>-working-container
                 my ($prefix_img_name) = $iname =~ /([^\/:]+)(:.+)?$/;
-                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah');
+                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah', version => $version);
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
-                test_containered_app(runtime => 'docker',
-                    buildah    => 1,
-                    dockerfile => 'Dockerfile.suse',
-                    base       => 'refreshed');
+                test_containered_app(runtime => 'docker', buildah => 1, dockerfile => 'Dockerfile.suse', base => 'refreshed') unless is_sle('<15', $version);
             }
         }
     }

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -21,7 +21,7 @@ use utils;
 use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
-use version_utils qw(get_os_release check_os_release);
+use version_utils qw(get_os_release check_os_release is_sle);
 
 sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
@@ -43,13 +43,10 @@ sub run {
                 # Use container which it is created in test_container_image
                 # Buildah default name is conducted by <image-name>-working-container
                 my ($prefix_img_name) = $iname =~ /([^\/:]+)(:.+)?$/;
-                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah');
+                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah', version => $version);
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
-                test_containered_app(runtime => 'podman',
-                    buildah    => 1,
-                    dockerfile => 'Dockerfile.suse',
-                    base       => 'refreshed');
+                test_containered_app(runtime => 'podman', buildah => 1, dockerfile => 'Dockerfile.suse', base => 'refreshed') unless is_sle('<15', $version);
             }
         }
     }


### PR DESCRIPTION
As we test multiple image versions on given host we need to pass the `version` parameter to the `test_opensuse_based_image()` subroutine.

- Related ticket: 
- Verification run: [SLE15 host with SLE15* images](http://pdostal-server.suse.cz/tests/12185) [SLE15 host with both SLE15* and SLE12* images](http://pdostal-server.suse.cz/tests/12188)
