### PR TITLE
Containers: skip tests that are not supported on certain versions

### DIFF
--- a/schedule/containers/engines_and_tools.yaml
+++ b/schedule/containers/engines_and_tools.yaml
@@ -6,24 +6,45 @@ description:    >
 conditional_schedule:
   boot:
     ARCH:
-      's390x':
+      s390x:
         - installation/bootloader_start
   validate_btrfs:
     ARCH:
       x86_64:
         - containers/validate_btrfs
+  runc:
+    ARCH:
+      x86_64:
+        - containers/docker_runc
+      s390x:
+        - containers/docker_runc
+  supported:
+    HOST_VERSION:
+      15-SP3:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/rootless_podman
+      15-SP2:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/rootless_podman
+      15-SP1:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/rootless_podman
+
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
-  - containers/podman
-  - containers/buildah_podman
   - containers/docker
-  - containers/buildah_docker
-  - containers/docker_runc
+  - '{{runc}}'
+  - '{{supported}}'
   - containers/docker_compose
   - containers/zypper_docker
   - containers/containers_3rd_party
   - containers/registry
   - console/coredump_collect
-  - containers/rootless_podman
   - '{{validate_btrfs}}'


### PR DESCRIPTION
VRs:
- 12-SP3: [before](https://openqa.suse.de/tests/6292056) -> [after](https://openqa.suse.de/tests/6294177)
- 12-SP4: [before](https://openqa.suse.de/tests/6292157) -> [after](https://openqa.suse.de/tests/6294175)
- 12-SP5: [before](https://openqa.suse.de/tests/6292247) -> [after](https://openqa.suse.de/tests/6294174)
- 15: [before](https://openqa.suse.de/tests/6292408) -> [after](https://openqa.suse.de/tests/6294171)