### PR TITLE
Move "SUSEMIRROR" check over from os-autoinst

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -749,6 +749,12 @@ sub check_env {
             die sprintf("%s must be one of %s\n", $k, join(',', @{$valueranges{$k}}));
         }
     }
+
+    my $mirror = get_var('SUSEMIRROR');
+    if ($mirror && $mirror =~ s{^(\w+)://}{}) {    # strip & check proto
+        set_var('SUSEMIRROR', $mirror);
+        die "only http mirror URLs are currently supported but found '$1'." if $1 ne "http";
+    }
 }
 
 sub unregister_needle_tags {


### PR DESCRIPTION
Within os-autoinst we would like to remove the very test distribution
specific check for SUSEMIRROR so instead we should move it here.

Verification job:
* [opensuse-Tumbleweed-Rescue-CD-x86_64-Build20210619-mediacheck@64bit](https://openqa.opensuse.org/t1797618)