### PR TITLE
console/force_scheduled_tasks: Avoid masking active units

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -56,8 +56,9 @@ sub run {
     if (script_run('ls -a /etc/cron.{hourly,daily,weekly,monthly}') == 0) {
         assert_script_run('find /etc/cron.{hourly,daily,weekly,monthly} -type f -executable -exec echo cron job: {} \; -exec {} \;', 1000);
     }
-    my $systemd_tasks_cmd = 'echo "Triggering systemd timed service $i" && systemctl start $i';
-    $systemd_tasks_cmd .= ' && systemctl mask $i.{service,timer}' unless get_var('SOFTFAIL_BSC1063638');
+    my $systemd_tasks_cmd = 'echo "Triggering systemd timed service $i"';
+    $systemd_tasks_cmd .= ' && systemctl stop $i.timer && systemctl mask $i.timer' unless get_var('SOFTFAIL_BSC1063638');
+    $systemd_tasks_cmd .= ' && systemctl start $i';
     assert_script_run(
 'for i in $(systemctl list-units --type=timer --state=active --no-legend | sed -e \'s/\(\S\+\)\.timer\s.*/\1/\'); do ' . $systemd_tasks_cmd . '; done', 1000);
     record_soft_failure 'bsc#1063638 - review I/O scheduling parameters of btrfsmaintenance' if (time - $before) > 60 && get_var('SOFTFAIL_BSC1063638');


### PR DESCRIPTION
Masking units which are currently running results in error messages such as:
```
backup-rpmdb.timer: Unit to trigger vanished.
backup-rpmdb.timer: Failed with result 'resources'.
```

Avoid them by stopping the .timer, then masking it and only then starting
the .service. The .service units shouldn't need to be masked anyway.

Verification run: https://openqa.opensuse.org/tests/1797750