### PR TITLE
Add a basic smoke test for k3s package

### DIFF
--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -15,12 +15,17 @@ conditional_schedule:
     ENABLE_SELINUX:
       '1':
         - transactional/enable_selinux
+  k3s:
+    SLE_MICRO_K3S:
+      '1':
+        - containers/k3s_cli_check
 schedule:
   - microos/disk_boot
   - transactional/disable_grub
   - '{{registration}}'
   - '{{selinux}}'
   - '{{maintenance}}'
+  - '{{k3s}}'
   - microos/networking
   - microos/libzypp_config
   - microos/image_checks

--- a/tests/containers/k3s_cli_check.pm
+++ b/tests/containers/k3s_cli_check.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: k3s
+# Summary: Smoke test for k3s CLI
+#          This module assumes kubectl and k3s is already installed.
+# Maintainer: qa-c@suse.de
+
+use base "consoletest";
+use testapi;
+use version_utils 'is_sle_micro';
+use strict;
+use warnings;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    record_info('kubectl', script_output('kubectl'));
+    record_info('k3s',     script_output('k3s'));
+    record_info('version', script_output('k3s -v'));
+    assert_script_run('k3s server --help');
+    assert_script_run('k3s server --help');
+    assert_script_run('k3s agent --help');
+    assert_script_run('k3s kubectl --help');
+    assert_script_run('k3s crictl --help');
+    assert_script_run('k3s etcd-snapshot --help');
+}
+
+1;


### PR DESCRIPTION
SLE Micro 5.1 has a new image with k3s package in it. This test is
just checking that the package is pre-installed and basic help
commands working.

- Related ticket: https://progress.opensuse.org/issues/94261
- VR: https://openqa.suse.de/tests/6300850 ([bsc#1187540](https://bugzilla.suse.com/show_bug.cgi?id=1187540) found)