### PR TITLE
WIP: Skip download_repos on Staging-Images runs

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -22,7 +22,7 @@ use utils;
 use version_utils;
 use publiccloud::ssh_interactive;
 
-our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand is_ec2 is_azure is_gce);
+our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand is_ec2 is_azure is_gce is_staging_image);
 
 # Select console on the test host, if force is set, the interactive session will
 # be destroyed. If called in TUNNELED environment, this function die.
@@ -82,6 +82,11 @@ sub is_azure() {
 # Check if we are on an GCP test run
 sub is_gce() {
     return is_publiccloud && check_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
+}
+
+# Check if we are a Staging images test run
+sub is_staging_image() {
+    return (get_required_var('FLAVOR') =~ '.*-Staging-Images');
 }
 
 1;

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -18,7 +18,7 @@ use warnings;
 use testapi;
 use strict;
 use utils;
-use publiccloud::utils "select_host_console";
+use publiccloud::utils qw(select_host_console is_staging_image);
 
 sub run {
     my ($self, $args) = @_;
@@ -30,6 +30,8 @@ sub run {
     # Trigger to skip the download to speed up verification runs
     if (get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD') == 1) {
         record_info('Skip download', 'Skipping download triggered by setting (QAM_PUBLICCLOUD_SKIP_DOWNLOAD = 1)');
+    } elsif (is_staging_image()) {
+        record_info('Skip download', 'Skipping download triggered by FLAVOR');
     } else {
         assert_script_run('du -sh ~/repos');
         assert_script_run("rsync -uva -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);

--- a/tests/virtualization/universal/patch_and_reboot.pm
+++ b/tests/virtualization/universal/patch_and_reboot.pm
@@ -40,12 +40,15 @@ sub run {
     add_test_repositories;
     fully_patch_system;
 
+    # useful for debugging
+    script_run("virsh list --all | grep -v Domain-0");
+
     # Check that all guests are still running
     script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
 
     if (is_xen_host) {
         # Shut all guests down so the reboot will be easier
-        assert_script_run "virsh shutdown $_" foreach (keys %virt_autotest::common::guests);
+        script_run "virsh shutdown $_" foreach (keys %virt_autotest::common::guests);
         script_retry "virsh list --all | grep -v Domain-0 | grep running", delay => 3, retry => 30, expect => 1;
     }
 


### PR DESCRIPTION
On Staged image test runs the step of downloading maintenance updates should be skipped.


- Related ticket: https://progress.opensuse.org/issues/94144
- Verification run: http://duck-norris.qam.suse.de/tests/6619 (cancelled after successful setup)
