### PR TITLE
Improve stability of patch_and_reboot

### DIFF
--- a/tests/virtualization/universal/patch_and_reboot.pm
+++ b/tests/virtualization/universal/patch_and_reboot.pm
@@ -40,12 +40,15 @@ sub run {
     add_test_repositories;
     fully_patch_system;
 
+    # useful for debugging
+    script_run("virsh list --all | grep -v Domain-0");
+
     # Check that all guests are still running
     script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
 
     if (is_xen_host) {
         # Shut all guests down so the reboot will be easier
-        assert_script_run "virsh shutdown $_" foreach (keys %virt_autotest::common::guests);
+        script_run "virsh shutdown $_" foreach (keys %virt_autotest::common::guests);
         script_retry "virsh list --all | grep -v Domain-0 | grep running", delay => 3, retry => 30, expect => 1;
     }
 


### PR DESCRIPTION
Shutdown sometimes fails because some machines are already shutting
down. Since this is an auxillary step we make this not failures.

Forgotten commit for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12647

- Verification run: http://openqa.qam.suse.cz/tests/23166#dependencies
