### PR TITLE
Remove required SCC_REGCODE variable for OnDemand

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -49,7 +49,6 @@ sub run {
     my ($self, $args) = @_;
     my $arch     = check_var('PUBLIC_CLOUD_ARCH', 'arm64') ? 'aarch64' : 'x86_64';
     my $ltp_repo = get_var('LTP_REPO', 'https://download.opensuse.org/repositories/benchmark:/ltp:/devel/' . generate_version("_") . '/');
-    my $REG_CODE = get_required_var('SCC_REGCODE');
     my $provider;
     my $instance;
 
@@ -70,7 +69,7 @@ sub run {
     assert_script_run('chmod +x restart_instance.sh');
     assert_script_run('chmod +x log_instance.sh');
 
-    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . $REG_CODE, timeout => 600) if is_byos();
+    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . get_required_var('SCC_REGCODE'), timeout => 600) if is_byos();
 
     # in repo with LTP rpm is internal we need to manually upload package to VM
     if (get_var('LTP_RPM_MANUAL_UPLOAD')) {


### PR DESCRIPTION
OnDemand images don't need to register. This commits removes the requirement for the `SCC_REGCODE` variable in the run_ltp test there.

- Verification run: [15-SP2-EC2-BYOS](http://duck-norris.qam.suse.de/t6637) | [15-SP2-GCE](http://duck-norris.qam.suse.de/t6639) (OnDemand)
