### PR TITLE
Add schedule for staging-images

### DIFF
--- a/schedule/publiccloud/staging_images/mau-extratests-docker-publiccloud.yml
+++ b/schedule/publiccloud/staging_images/mau-extratests-docker-publiccloud.yml
@@ -1,0 +1,27 @@
+---
+name: mau-extratests-docker-publiccloud
+description: |
+  Run mau-extratests-docker on public cloud instances
+conditional_schedule:
+  podman:
+    VERSION:
+      15-SP1:
+        - containers/podman
+      15-SP2:
+        - containers/podman
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/ssh_interactive_init
+  - publiccloud/register_system
+  - publiccloud/ssh_interactive_start
+  - publiccloud/instance_overview
+  - console/system_prepare
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - '{{podman}}'
+  - containers/docker
+  - containers/docker_runc
+  - containers/containers_3rd_party
+  - containers/registry
+  - containers/zypper_docker
+  - publiccloud/ssh_interactive_end

--- a/schedule/publiccloud/staging_images/mau-extratests-publiccloud.yml
+++ b/schedule/publiccloud/staging_images/mau-extratests-publiccloud.yml
@@ -1,0 +1,44 @@
+---
+name: mau-extratests-publiccloud
+description: |
+  Run mau-extratests on public cloud instances
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/ssh_interactive_init
+  - publiccloud/register_system
+  - publiccloud/ssh_interactive_start
+  - publiccloud/instance_overview
+  - console/system_prepare
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/cleanup_qam_testrepos
+  - console/openvswitch
+  - console/sshd
+  - console/rpm
+  - console/command_not_found
+  - console/openssl_alpn
+  - console/cron
+  - console/syslog
+  - console/mta
+  - console/check_default_network_manager
+  - console/gdb
+  - console/sysctl
+  - console/sysstat
+  - console/wget_ipv6
+  - console/gpg
+  - console/shells
+  - console/sudo
+  - console/supportutils
+  - console/journalctl
+  - console/quota
+  - console/rpcbind
+  - console/timezone
+  - console/procps
+  - console/suse_module_tools
+  - console/firewalld
+  - console/aaa_base
+  - console/osinfo_db
+  - console/libgcrypt
+  - console/valgrind
+  - publiccloud/ssh_interactive_end

--- a/schedule/publiccloud/staging_images/publiccloud_upload_img.yml
+++ b/schedule/publiccloud/staging_images/publiccloud_upload_img.yml
@@ -1,0 +1,8 @@
+---
+name: publiccloud_upload_img
+description: |
+  Upload a public-cloud image to the CSP. How the image gets uploaded depends on
+  the CSP. If the image already exists, the upload gets skipped.Maintainer: cfamullaconrad@suse.com
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/upload_image


### PR DESCRIPTION
Add yaml schedules for staging image test runs

- Related ticket: https://progress.opensuse.org/issues/94144
- Related: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/295
- Verification run: http://duck-norris.qam.suse.de/tests/6633 (failing elsewhere, the affected part succeeds)
