### PR TITLE
Containers: Separate engines_and_tools.yaml by architecture

### DIFF
--- a/schedule/containers/engines_and_tools-aarch64.yaml
+++ b/schedule/containers/engines_and_tools-aarch64.yaml
@@ -1,0 +1,37 @@
+name:           engines_and_tools-aarch64
+description:    >
+  Maintainer: qa-c@suse.de.
+  This schedule is focused on testing the related container packages and features,
+  but not the official container images from SUSE and openSUSE.
+conditional_schedule:
+  supported:
+    HOST_VERSION:
+      15-SP3:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/podman_3rd_party_images
+        - containers/rootless_podman
+        - containers/registry
+      15-SP2:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/podman_3rd_party_images
+        - containers/rootless_podman
+        - containers/registry
+      15-SP1:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/podman_3rd_party_images
+        - containers/rootless_podman
+
+schedule:
+  - boot/boot_to_desktop
+  - containers/docker
+  - containers/docker_3rd_party_images
+  - '{{supported}}'
+  - containers/docker_compose
+  - containers/zypper_docker
+  - console/coredump_collect

--- a/schedule/containers/engines_and_tools-s390x.yaml
+++ b/schedule/containers/engines_and_tools-s390x.yaml
@@ -1,23 +1,9 @@
-name:           extra_tests_textmode_containers
+name:           engines_and_tools-s390x
 description:    >
   Maintainer: qa-c@suse.de.
   This schedule is focused on testing the related container packages and features,
   but not the official container images from SUSE and openSUSE.
 conditional_schedule:
-  boot:
-    ARCH:
-      s390x:
-        - installation/bootloader_start
-  validate_btrfs:
-    ARCH:
-      x86_64:
-        - containers/validate_btrfs
-  runc:
-    ARCH:
-      x86_64:
-        - containers/docker_runc
-      s390x:
-        - containers/docker_runc
   supported:
     HOST_VERSION:
       15-SP3:
@@ -39,14 +25,13 @@ conditional_schedule:
         - containers/rootless_podman
         - containers/podman_3rd_party_images
 schedule:
-  - '{{boot}}'
+  - installation/bootloader_start
   - boot/boot_to_desktop
   - containers/docker
-  - '{{runc}}'
+  - containers/docker_runc
+  - containers/docker_3rd_party_images
   - '{{supported}}'
   - containers/docker_compose
   - containers/zypper_docker
-  - containers/docker_3rd_party_images
   - containers/registry
   - console/coredump_collect
-  - '{{validate_btrfs}}'

--- a/schedule/containers/engines_and_tools-x86_64.yaml
+++ b/schedule/containers/engines_and_tools-x86_64.yaml
@@ -1,0 +1,38 @@
+name:           engines_and_tools-x86_64
+description:    >
+  Maintainer: qa-c@suse.de.
+  This schedule is focused on testing the related container packages and features,
+  but not the official container images from SUSE and openSUSE.
+conditional_schedule:
+  supported:
+    HOST_VERSION:
+      15-SP3:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/podman_3rd_party_images
+        - containers/rootless_podman
+      15-SP2:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/podman_3rd_party_images
+        - containers/rootless_podman
+      15-SP1:
+        - containers/podman
+        - containers/buildah_podman
+        - containers/buildah_docker
+        - containers/podman_3rd_party_images
+        - containers/rootless_podman
+
+schedule:
+  - boot/boot_to_desktop
+  - containers/docker
+  - containers/docker_runc
+  - containers/docker_3rd_party_images
+  - '{{supported}}'
+  - containers/docker_compose
+  - containers/zypper_docker
+  - containers/registry
+  - console/coredump_collect
+  - containers/validate_btrfs


### PR DESCRIPTION
To make the containers YAML more readable let's separate it by `ARCH`.

- [qac-openqa-yaml!296](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/296)
- Verification run: TBD
