### PR TITLE
Exclude registration on QEM test runs

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -54,7 +54,8 @@ sub run {
 
     select_host_console();
 
-    if (get_var('PUBLIC_CLOUD_QAM')) {
+    my $qam = get_var('PUBLIC_CLOUD_QAM', 0);
+    if ($qam) {
         $instance = $self->{my_instance} = $args->{my_instance};
         $provider = $self->{provider}    = $args->{my_provider};    # required for cleanup
     } else {
@@ -69,7 +70,7 @@ sub run {
     assert_script_run('chmod +x restart_instance.sh');
     assert_script_run('chmod +x log_instance.sh');
 
-    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . get_required_var('SCC_REGCODE'), timeout => 600) if is_byos();
+    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . get_required_var('SCC_REGCODE'), timeout => 600) if (is_byos() && !$qam);
 
     # in repo with LTP rpm is internal we need to manually upload package to VM
     if (get_var('LTP_RPM_MANUAL_UPLOAD')) {


### PR DESCRIPTION
Maintenance test runs don't need to be registered when running ltp.

Forgotten fix for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12762

- Verification run: http://duck-norris.qam.suse.de/tests/6644 (test times out, important steps however succeed)
