### PR TITLE
Add license agreement checking for yast2_migration

### DIFF
--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -97,6 +97,12 @@ sub yast2_migration_handle_conflicts_text {
     }
 }
 
+sub yast2_migration_handle_license_agreement {
+    wait_screen_change { send_key "alt-a" };
+    assert_screen 'yast2_migration-license-agreenment-accepted', 60;
+    send_key "alt-n";
+}
+
 sub run {
     my $self = shift;
 
@@ -220,10 +226,16 @@ sub run {
             send_key 'alt-t';
         }
     }
-    assert_screen ['yast2-migration-installupdate', 'yast2-migration-proposal'], 700;
-    if (match_has_tag 'yast2-migration-installupdate') {
+    assert_screen [qw(yast2-migration-installupdate yast2_migration-license-agreement)], 300;
+    if (match_has_tag 'yast2-migration-installupdate', 150) {    # Not all cases have install update message.
         send_key 'alt-y';
+        assert_screen 'yast2_migration-license-agreement', 60;
+        yast2_migration_handle_license_agreement;
     }
+    if (match_has_tag 'yast2_migration-license-agreement', 150) {
+        yast2_migration_handle_license_agreement;
+    }
+    assert_screen 'yast2-migration-proposal', 60;
     if (yast2_migration_gnome_x11) {
         yast2_migration_handle_conflicts_x11($self);
     }


### PR DESCRIPTION
Add license agreement checking for yast2 migration cases. Based on bsc#1185808, license agreement is not printed when doing yast2 migration, now the bug has been fixed, we should add the license agreement checking and accept the license to the automation testing.

- Related ticket: https://progress.opensuse.org/issues/92620
- Verification run: 
https://openqa.suse.de/tests/6464530#step/yast2_migration/8 (sles s390x textmode)
https://openqa.suse.de/tests/6464552#step/yast2_migration/19 (sles x86_64 gnome)
https://openqa.suse.de/tests/6464536#step/yast2_migration/19 (sled x86_64 gnome)
https://openqa.suse.de/tests/6464537#step/yast2_migration/7 (hpc x86_64 textmode)
https://openqa.suse.de/tests/6464532#step/yast2_migration/20 (leap to sle x86_64 gnome)