### PR TITLE
Remove gdb and valgrind from pc staging images run

### DIFF
--- a/schedule/publiccloud/staging_images/mau-extratests-publiccloud.yml
+++ b/schedule/publiccloud/staging_images/mau-extratests-publiccloud.yml
@@ -22,7 +22,6 @@ schedule:
   - console/syslog
   - console/mta
   - console/check_default_network_manager
-  - console/gdb
   - console/sysctl
   - console/sysstat
   - console/wget_ipv6
@@ -40,5 +39,4 @@ schedule:
   - console/aaa_base
   - console/osinfo_db
   - console/libgcrypt
-  - console/valgrind
   - publiccloud/ssh_interactive_end


### PR DESCRIPTION
Remove gdb and valgrind from the publiccloud staging images test runs
because they are tested elsewhere.

- Related ticket: https://progress.opensuse.org/issues/94144

No verification run, because we would need to run `trigger-public-cloud`. Impact will be evaluated tomorrow morning.