### PR TITLE
Increase transactional update installation timeout

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -27,7 +27,7 @@ sub run {
     }
     add_test_repositories;
     record_info 'Updates', script_output('zypper lu');
-    trup_call 'up',        timeout => 300;
+    trup_call 'up',        timeout => 600;
     check_reboot_changes;
 }
 


### PR DESCRIPTION
Increase timeout for installation from 5 to 10 minutes due to test timeouts.

- Related ticket: https://progress.opensuse.org/issues/94594
- Verification run: https://openqa.suse.de/tests/6316574
