### PR TITLE
Add cleanup function to the service check

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -62,10 +62,11 @@ our %srv_check_results = (
 
 our $default_services = {
     users => {
-        srv_pkg_name       => 'users',
-        srv_proc_name      => 'users',
-        support_ver        => $support_ver_ge12,
-        service_check_func => \&services::users::full_users_check
+        srv_pkg_name         => 'users',
+        srv_proc_name        => 'users',
+        support_ver          => $support_ver_ge12,
+        service_check_func   => \&services::users::full_users_check,
+        service_cleanup_func => \&services::users::users_cleanup
     },
     hpcpackage_remain => {
         srv_pkg_name       => 'hpcpackage_remain',
@@ -249,6 +250,8 @@ sub install_services {
         my $service_type  = 'SystemV';
         next unless _is_applicable($srv_pkg_name);
         record_info($srv_pkg_name, "service check before migration");
+        # We assume this service $service->{$s} passed at install_service
+        $service->{$s}->{before_migration} = 'PASS';
         eval {
             if (is_sle($support_ver, get_var('ORIGIN_SYSTEM_VERSION'))) {
                 if (check_var('ORIGIN_SYSTEM_VERSION', '11-SP4')) {
@@ -270,10 +273,14 @@ sub install_services {
             }
         };
         if ($@) {
+            # This service $service->{$s} failed at install_service
+            $service->{$s}->{before_migration} = 'FAIL';
+            if (exists $service->{$s}->{service_cleanup_func}) {
+                $service->{$s}->{service_cleanup_func}->(%{$service->{$s}}, service_type => $service_type, stage => 'before');
+            }
             record_info($srv_pkg_name, "failed reason: $@", result => 'fail');
-            $srv_check_results{'before_migration'} = 'FAIL' if $srv_check_results{'before_migration'} eq 'PASS';
+            $srv_check_results{'before_migration'} = 'FAIL';
         }
-
     }
 }
 
@@ -291,7 +298,7 @@ sub check_services {
         my $srv_proc_name = $service->{$s}->{srv_proc_name};
         my $support_ver   = $service->{$s}->{support_ver};
         my $service_type  = 'Systemd';
-        next unless _is_applicable($srv_pkg_name);
+        next unless (($service->{$s}->{before_migration} eq 'PASS') && _is_applicable($srv_pkg_name));
         record_info($srv_pkg_name, "service check after migration");
         eval {
             if (is_sle($support_ver, get_var('ORIGIN_SYSTEM_VERSION'))) {
@@ -305,8 +312,11 @@ sub check_services {
             }
         };
         if ($@) {
+            if (exists $service->{$s}->{service_cleanup_func}) {
+                $service->{$s}->{service_cleanup_func}->(%{$service->{$s}}, service_type => $service_type, stage => 'after');
+            }
             record_info($srv_pkg_name, "failed reason: $@", result => 'fail');
-            $srv_check_results{'after_migration'} = 'FAIL' if $srv_check_results{'after_migration'} eq 'PASS';
+            $srv_check_results{'after_migration'} = 'FAIL';
         }
     }
 }

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -193,4 +193,16 @@ sub full_users_check {
     }
 }
 
+# Cleanup for exceptions during before and after migration
+sub users_cleanup {
+    my (%hash) = @_;
+    my $stage = $hash{stage};
+    select_console "root-console";
+    if ($stage eq 'before') {
+        script_run("pkill -KILL -u $newUser");
+        script_run("userdel -r $newUser");
+    }
+    reset_consoles;
+}
+
 1;


### PR DESCRIPTION
In the service check, We need to add the cleanup mechanism for all
services. Like the function check, all modules should have a cleanup
function once the function check failed in the install_service module.
And once one service failed in install_service, We don't need to check
it again in the check_upgraded_service module.

- Related ticket: https://progress.opensuse.org/issues/93528
- Needles: N/A
- Verification run:  
   https://openqa.nue.suse.com/tests/6313710#step/install_service/44
   https://openqa.nue.suse.com/tests/6250561
   https://openqa.nue.suse.com/tests/6251736
   https://openqa.nue.suse.com/tests/6250819
   https://openqa.nue.suse.com/tests/6251966
  
use users service to fail to check the check_upgraded_service
https://openqa.nue.suse.com/tests/6443213#step/check_upgraded_service/1
  regression:
   https://openqa.nue.suse.com/tests/6381342
   https://openqa.nue.suse.com/tests/6463981