### PR TITLE
Modify the import gpg untrusted key to trust/cancel

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -212,11 +212,11 @@ If yes, import the key, otherwise don't.
 sub handle_untrusted_gpg_key {
     if (match_has_tag('import-known-untrusted-gpg-key')) {
         record_info('Import', 'Known untrusted gpg key is imported');
-        wait_screen_change { send_key 'alt-y' };    # import
+        wait_screen_change { send_key 'alt-t' };    # import
     }
     else {
         record_info('Cancel import', 'Untrusted gpg key is NOT imported');
-        wait_screen_change { send_key 'alt-n' };    # cancel
+        wait_screen_change { send_key 'alt-c' };    # cancel
     }
 }
 


### PR DESCRIPTION
The choice for importing the gpg untrusted key is Trust and Cancel,
so modify the code here.

- Related ticket: https://progress.opensuse.org/issues/94219
- Verification run: https://openqa.nue.suse.com/tests/6313675#step/register_system/89
