### PR TITLE
Handle both cases of "Yes/Trust" for unknown repo cert

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -212,11 +212,11 @@ If yes, import the key, otherwise don't.
 sub handle_untrusted_gpg_key {
     if (match_has_tag('import-known-untrusted-gpg-key')) {
         record_info('Import', 'Known untrusted gpg key is imported');
-        wait_screen_change { send_key 'alt-t' };    # import
+        wait_screen_change { send_key 'alt-t'; send_key 'alt-y' };    # import/yes, depending on variant
     }
     else {
         record_info('Cancel import', 'Untrusted gpg key is NOT imported');
-        wait_screen_change { send_key 'alt-c' };    # cancel
+        wait_screen_change { send_key 'alt-c'; send_key 'spc' };      # cancel/no, depending on variant
     }
 }
 


### PR DESCRIPTION
Depending on content in the repositories sometimes it is needed to
confirm the unknown repo certificates, e.g. for NVidia, with "Yes",
sometimes it is "Trust", so try both variant key presses in rapid
succession, expecting that the second key press is not accepted
elsewhere on the same screen.

Verification:
```
MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12781 https://openqa.suse.de/tests/6320443
```

* [sle-15-SP2-Server-DVD-Updates-x86_64-Build20210624-1-qam-textmode+sle15@64bit](https://openqa.suse.de/t6322930)


Related progress issue: https://progress.opensuse.org/issues/94534