### PR TITLE
Schedules podman_3rd_party_images only for supported sle versions

### DIFF
--- a/schedule/containers/engines_and_tools.yaml
+++ b/schedule/containers/engines_and_tools.yaml
@@ -25,17 +25,19 @@ conditional_schedule:
         - containers/buildah_podman
         - containers/buildah_docker
         - containers/rootless_podman
+        - containers/podman_3rd_party_images
       15-SP2:
         - containers/podman
         - containers/buildah_podman
         - containers/buildah_docker
         - containers/rootless_podman
+        - containers/podman_3rd_party_images
       15-SP1:
         - containers/podman
         - containers/buildah_podman
         - containers/buildah_docker
         - containers/rootless_podman
-
+        - containers/podman_3rd_party_images
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
@@ -45,7 +47,6 @@ schedule:
   - containers/docker_compose
   - containers/zypper_docker
   - containers/docker_3rd_party_images
-  - containers/podman_3rd_party_images
   - containers/registry
   - console/coredump_collect
   - '{{validate_btrfs}}'


### PR DESCRIPTION
A small adjustment in the scheduling moving the podman derived module
of 3rd_party_images into the conditional section.
This indents to fix some of the current issues for the groups which failing
due to run unsuppoerted container runtime.



- Related ticket: https://progress.opensuse.org/issues/90086

