### PR TITLE
Increase robusness of guest running step

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -402,12 +402,7 @@ sub wait_guests_shutdown {
 
 # Start all guests and wait until they are online
 sub start_guests {
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        if (script_run("virsh list | grep '$guest' | grep running") != 0) {
-            assert_script_run("virsh start '$guest'");
-            script_retry("virsh list | grep '$guest' | grep running", delay => 5, retry => 10);
-        }
-    }
+    script_run("virsh start '$_'") foreach (keys %virt_autotest::common::guests);
     wait_guest_online($_) foreach (keys %virt_autotest::common::guests);
 }
 

--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -685,7 +685,7 @@ sub powercycle {
     if (!check_screen 'virt-manager_notrunning', 120) {
         assert_and_click 'virt-manager_shutdown_menu';
         assert_and_click 'virt-manager_shutdown_item';
-        # There migh me 'Are you sure' dialog window
+        # There might be a 'Are you sure' dialog window
         if (check_screen "virt-manager_shutdown_sure", 2) {
             assert_and_click "virt-manager_shutdown_sure";
         }


### PR DESCRIPTION
Ensure all guests are running and skip this unnecessary check.

- Related ticket: quickfix
- Verification run: http://openqa.qam.suse.cz/tests/23788
