### PR TITLE
Add check for @/home subvolume on opensuse

### DIFF
--- a/schedule/yast/btrfs/btrfs_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs_opensuse.yaml
@@ -28,6 +28,7 @@ schedule:
   - installation/first_boot
   - console/validate_no_cow_attribute
   - console/verify_no_separate_home
+  - console/validate_subvolumes
 test_data:
   device: vda
   table_type: gpt
@@ -42,3 +43,6 @@ test_data:
       - /opt
     no_cow:
       - /var
+  validate_subvolumes:
+    - subvolume: home
+      mount_point: /


### PR DESCRIPTION
Validate that separate subvolume is created and mounted.

- Related ticket: https://progress.opensuse.org/issues/88969
- Verification runs:
   - TW: https://openqa.opensuse.org/tests/1804735
   - TW: https://openqa.opensuse.org/tests/1804737
   - Leap: https://openqa.opensuse.org/tests/1804738

After merge, we need to add the following to [openSUSE Leap 15](https://openqa.opensuse.org/admin/job_templates/50) Job Group settings:
```
    - btrfs:
        settings:
          HDDSIZEGB: '40'
          YAML_SCHEDULE: schedule/yast/btrfs/btrfs_opensuse.yaml
        testsuite: null
```

