### PR TITLE
Prevent rogue RMT servers to show up in unexpected selection dialogs

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -733,6 +733,9 @@ sub select_addons_in_textmode {
 sub registration_bootloader_cmdline {
     # https://www.suse.com/documentation/smt11/book_yep/data/smt_client_parameters.html
     # SCC_URL=https://smt.example.com
+    # prevent rogue RMT servers to show up in unexpected selection dialogs
+    # https://progress.opensuse.org/issues/94696
+    set_var('SCC_URL', 'https://scc.suse.com') unless get_var('SCC_URL');
     my $cmdline = '';
     if (my $url = get_var('SMT_URL') || get_var('SCC_URL')) {
         $cmdline .= " regurl=$url";


### PR DESCRIPTION
In case any RMT server shows up in the same network as where openQA
tests are running if no registration server is forced then a selection
dialog shows up which is unexpected by tests. This can be prevented by
forcing the REG_URL to be on the default SUSE server.

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12789 https://openqa.suse.de/tests/6325524
```

sle-15-SP3-Desktop-DVD-Updates-x86_64-Build20210625-1-qam-regression-installation-SLED@64bit -> https://openqa.suse.de/tests/6329021


Related progress issue: https://progress.opensuse.org/issues/94696