### PR TITLE
pynfs: Proper server setup

### DIFF
--- a/tests/pynfs/generate_report.pm
+++ b/tests/pynfs/generate_report.pm
@@ -29,7 +29,7 @@ sub upload_log {
     script_run('../showresults.py result-raw.txt > result-analysis.txt');
     upload_logs('result-analysis.txt', failok => 1);
 
-    script_run('grep -A 2 FAILURE result-analysis.txt | grep -v PASS > result-fail.txt');
+    script_run('../showresults.py --hidepass result-raw.txt > result-fail.txt');
     upload_logs('result-fail.txt', failok => 1);
 
     if (script_run('[ -s result-fail.txt ]') == 0) {

--- a/tests/pynfs/install.pm
+++ b/tests/pynfs/install.pm
@@ -45,7 +45,10 @@ sub install_pynfs {
 }
 
 sub setup_nfs_server {
-    assert_script_run('mkdir -p /exportdir && echo \'/exportdir *(rw,no_root_squash,insecure)\' >/etc/exports && systemctl restart nfs-server');
+    assert_script_run('mkdir -p /exportdir && echo \'/exportdir *(rw,no_root_squash,insecure)\' >> /etc/exports');
+    assert_script_run('echo "NFSD_V4_GRACE=15" >> /etc/sysconfig/nfs && echo "NFSD_V4_LEASE=15" >> /etc/sysconfig/nfs');
+    assert_script_run('echo "options lockd nlm_grace_period=15" >> /etc/modprobe.d/lockd.conf && echo "options lockd nlm_timeout=5" >> /etc/modprobe.d/lockd.conf');
+    assert_script_run('systemctl enable nfs-server.service && systemctl restart nfs-server');
 }
 
 sub run {

--- a/tests/pynfs/run.pm
+++ b/tests/pynfs/run.pm
@@ -25,7 +25,7 @@ sub server_test_all {
     my $folder = get_required_var('PYNFS');
 
     assert_script_run("cd ./$folder");
-    script_run('./testserver.py --outfile result-raw.txt --maketree localhost:/exportdir all', 3600);
+    script_run('./testserver.py -v --rundeps --hidepass --outfile result-raw.txt --maketree localhost:/exportdir all', 3600);
 }
 
 sub run {


### PR DESCRIPTION
This PR enhance server setup part
1. Correct lockd options
2. Shorter NFSD_V4 wait time to make test faster
3. Correct run script arvg, add "-v --rundeps --hidepass" in runtime
4. Use --hidepass instead of using grep in generate log

- Related ticket: https://progress.opensuse.org/issues/93396
- Verification run: 
Before:
v4.0(takes 42:38 minutes): http://10.67.133.102/tests/307#step/generate_report/30 
v4.1(takes 10:48 minutes): http://10.67.133.102/tests/308#step/generate_report/30

After:
v4.0(takes 37:46 minutes): http://10.67.133.102/tests/311#step/generate_report/30
v4.1(takes 09:43 minutes): http://10.67.133.102/tests/312#step/generate_report/30