### PR TITLE
Schedule test modules to debug poo#88273

### DIFF
--- a/schedule/ha/qam/12-SP3/ha_rolling_update_node01.yaml
+++ b/schedule/ha/qam/12-SP3/ha_rolling_update_node01.yaml
@@ -3,9 +3,12 @@ description:    >
   Test a rolling update in a two nodes cluster
   Further info about the test suite
 schedule:
+  - info/show_hdd_info
   - boot/boot_to_desktop
   - migration/online_migration/register_system
   - update/zypper_up
+  - info/show_hdd_info
+  - console/check_boot_files
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare

--- a/schedule/ha/qam/12-SP3/ha_rolling_update_node02.yaml
+++ b/schedule/ha/qam/12-SP3/ha_rolling_update_node02.yaml
@@ -3,9 +3,12 @@ description:    >
   Test a rolling update in a two nodes cluster
   Further info about the test suite
 schedule:
+  - info/show_hdd_info
   - boot/boot_to_desktop
   - migration/online_migration/register_system
   - update/zypper_up
+  - info/show_hdd_info
+  - console/check_boot_files
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare

--- a/tests/console/check_boot_files.pm
+++ b/tests/console/check_boot_files.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: display checksums for contents of /boot files.
+#          It focuses on vmlinu*, initrd*, config*, symvers* and sysctl*
+#          files in /boot
+# Maintainer: Alvaro Carvajal <acarvajal@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    my $checksums = script_output "md5sum /boot/vmlinu* /boot/initrd* /boot/config* /boot/symvers* /boot/sysctl*";
+    record_info "/boot checksums", $checksums;
+}
+
+1;

--- a/tests/info/show_hdd_info.pm
+++ b/tests/info/show_hdd_info.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify source disks attached to the test and record a
+#          checksum of the files.
+# Maintainer: Alvaro Carvajal <acarvajal@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use data_integrity_utils qw(get_image_digest);
+
+sub run {
+    my $self     = shift;
+    my $numdisks = get_var('NUMDISKS', 1);
+
+    for my $i (1 .. $numdisks) {
+        my $disk    = get_var("HDD_$i");
+        my $overlay = "raid/hd" . ($i - 1) . "-overlay0";
+        if ($disk) {
+            my $size     = $disk ? -s $disk : 0;
+            my $digest   = get_image_digest($disk);
+            my $ovdigest = get_image_digest($overlay);
+            record_info "HDD_$i Info", "Name: [$disk]\nSize: [$size]\nDigest: [$digest]\nOverlay Digest: [$ovdigest]";
+            diag "HDD_$i Info: Name=[$disk], Size=[$size], Digest=[$digest], Overlay Digest=[$ovdigest]";
+        }
+        else {
+            record_info "HDD_$i Info", "Empty HDD_$i setting";
+            diag "HDD_$i Info: empty HDD_$i setting";
+        }
+    }
+}
+
+1;


### PR DESCRIPTION
The ticket https://progress.opensuse.org/issues/88273 describes a frequent test failure on the QAM TestRepo 12-SP3 HA rolling update tests that requires more investigation.

This PR is adding 2 modules to check some assets' integrity both in the worker and in SUT to verify if changes to these files could explain the frequent issues.

The issue itself can be described as follows: 2 MM jobs are started from the same qcow2 image in the same job group, to eventually configure them as an HA cluster; before any HA configuration is done, both SUT boot from the qcow2, are registered to SCC with `migration/register_system` and updated with `update/zypper_up`; then both SUT are rebooted. and even though by this time both tests should be identical, one of them is seen successfully booting, while the other shows an `Invalid Magic Number` error in grub while booting and fails the test, failing the whole MM job: https://openqa.suse.de/tests/6323075#step/console_reboot/4

Issue is frequent enough in openqa.suse.de to be a concern (https://openqa.suse.de/tests/6323075#next_previous), but cloning the job into our development environment shows the test always passing: http://mango.qa.suse.de/tests/4140#next_previous

Tests were moved from openqaworker10 to openqaworker9 as an initial attempt to fix/gather more details on the failure, but this has not changed the outcome in openqa.suse.de, which is why these changes are now being submitted.

- Related ticket: https://jira.suse.com/browse/TEAM-4330 & https://progress.opensuse.org/issues/88273
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/4143 & http://mango.qa.suse.de/tests/4144
