### PR TITLE
rpcbind service need to add rpcbind.socket to make rpcbind service works

### DIFF
--- a/lib/services/rpcbind.pm
+++ b/lib/services/rpcbind.pm
@@ -39,28 +39,28 @@ sub config_service {
 }
 
 sub enable_service {
-    common_service_action('rpcbind',   $service_type, 'enable');
-    common_service_action($nfs_server, $service_type, 'enable');
+    common_service_action('rpcbind.socket', $service_type, 'enable');
+    common_service_action($nfs_server,      $service_type, 'enable');
 }
 
 sub start_service {
-    common_service_action('rpcbind',   $service_type, 'start');
-    common_service_action($nfs_server, $service_type, 'start');
+    common_service_action('rpcbind.socket', $service_type, 'start');
+    common_service_action($nfs_server,      $service_type, 'start');
 }
 
 sub stop_service {
-    common_service_action('rpcbind',   $service_type, 'stop');
-    common_service_action($nfs_server, $service_type, 'stop');
+    common_service_action($nfs_server,       $service_type, 'stop');
+    common_service_action('rpcbind.service', $service_type, 'stop');
 }
 
 sub check_enabled {
-    common_service_action('rpcbind',   $service_type, 'is-enabled');
-    common_service_action($nfs_server, $service_type, 'is-enabled');
+    common_service_action('rpcbind.socket', $service_type, 'is-enabled');
+    common_service_action($nfs_server,      $service_type, 'is-enabled');
 }
 
 sub check_service {
-    common_service_action('rpcbind', $service_type, 'is-enabled');
-    common_service_action('rpcbind', $service_type, 'is-active');
+    common_service_action('rpcbind.socket', $service_type, 'is-enabled');
+    common_service_action('rpcbind.socket', $service_type, 'is-active');
 }
 
 sub check_function {


### PR DESCRIPTION
In SP3, rpcbind.service is socket activated, so we'd enable and check
rpcbind.socket instead of checking rpcbind.service. The command of
"systemctl is-active rpcbind" checks both of rpcbind.socket and
rpcbing.service.

- Related ticket: https://progress.opensuse.org/issues/92812
- Needles: N/A
- Verification run: 
    https://openqa.nue.suse.com/tests/6332326#step/check_upgraded_service/5
    https://openqa.nue.suse.com/tests/6342799#step/check_upgraded_service/5
    latest run:
    https://openqa.nue.suse.com/tests/6358676#step/check_upgraded_service/7