### PR TITLE
Remove multipath-tools when switching kernel on SLE-15SP3

### DIFF
--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -24,6 +24,7 @@ sub remove_kernel_packages {
         push @packages, qw(kernel-xen kernel-xen-devel);
     }
 
+    push @packages, "multipath-tools" if is_sle('>=15-SP3');
     zypper_call('-n rm ' . join(' ', @packages), exitcode => [0, 104]);
 
     return @packages;


### PR DESCRIPTION
multipath-tools package is interfering with LTP testing of alternative kernels like kernel-azure and kernel-default-base. Uninstall it during kernel switch.

- Related ticket: https://progress.opensuse.org/issues/93674
- Needles: N/A
- Verification run: 
  - SLE-15SP3 aarch64 kernel-default-base: https://openqa.suse.de/tests/6345940
  - SLE-15SP3 ppc64le kernel-default-base: https://openqa.suse.de/tests/6345941
  - SLE-15SP3 s390x kernel-default-base: https://openqa.suse.de/tests/6345942
  - SLE-15SP3 x86_64 kernel-default-base: https://openqa.suse.de/tests/6345946
  - SLE-15SP3 kernel-azure: https://openqa.suse.de/tests/6345980
  - SLE-15SP2 KOTD: https://openqa.suse.de/tests/6345975
