### PR TITLE
Remove failing traceroute

### DIFF
--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -48,12 +48,12 @@ sub run {
     assert_script_run("cat /etc/hosts");
     assert_script_run("cat /etc/resolv.conf");
 
-    if (script_run("zypper -n in traceroute bzip2") == 8) {
+    # Install bzip2 to check for bsc#1165915
+    if (script_run("zypper -n in bzip2") == 8) {
         record_soft_failure('bsc#1165915');
         assert_script_run('update-ca-certificates');
-        zypper_call("in traceroute bzip2");
+        zypper_call("in bzip2");
     }
-    assert_script_run("traceroute -I gate.suse.cz", 90);
 
     assert_script_run("rpm -qa > /tmp/rpm.list.txt");
     upload_logs('/tmp/rpm.list.txt');


### PR DESCRIPTION
Remove unnecessary failing traceroute test from publiccloud instance_overview.

- Related ticket: https://progress.opensuse.org/issues/94144
- Verification run: http://duck-norris.qam.suse.de/t6661 | http://duck-norris.qam.suse.de/t6662