### PR TITLE
Fix kdump debug repo issue

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -252,7 +252,7 @@ sub do_kdump {
 
 #
 # Install debug kernel and use yast2 kdump to enable kdump service.
-# we use $args{test_type} to distingush  migration or function check.
+# we use $args{test_type} to distingush migration from function check.
 #
 # For migration test we just do activate kdump. migration test do
 # not need to run prepare_for_kdump function because it can't get
@@ -274,7 +274,7 @@ sub configure_service {
         }
     }
 
-    prepare_for_kdump($args{test_type});
+    prepare_for_kdump(%args);
     if ($args{yast_interface} eq 'cli') {
         activate_kdump_cli;
     } else {


### PR DESCRIPTION
In kdump's configure_service fucntion, we should pass a hash key/value to
function prepare_for_kdump, not just a scalar string.

- Related ticket: https://progress.opensuse.org/issues/94681
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/6346113
   https://openqa.nue.suse.com/tests/6350633
   https://openqa.nue.suse.com/tests/6350628

  regression with kdump_and_crash
  https://openqa.nue.suse.com/tests/6350633

