### PR TITLE
Increase LibyuiClient timeout for installation

### DIFF
--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -27,7 +27,7 @@ use testapi;
 use YuiRestClient;
 
 sub run {
-    my $app  = YuiRestClient::get_app(installation => 1);
+    my $app  = YuiRestClient::get_app(installation => 1, timeout => 30, interval => 1);
     my $port = $app->get_port();
     record_info('SERVER', "Used host for libyui: " . $app->get_host());
     record_info('PORT',   "Used port for libyui: " . $port);


### PR DESCRIPTION
Fixes the failure: https://openqa.suse.de/tests/6346412#step/select_product/2

- Verification run: https://openqa.suse.de/tests/6350678
