### PR TITLE
Revert sanitizing in ItemSelector

### DIFF
--- a/lib/YuiRestClient/Widget/ItemSelector.pm
+++ b/lib/YuiRestClient/Widget/ItemSelector.pm
@@ -20,6 +20,8 @@ use YuiRestClient::Sanitizer;
 
 sub select {
     my ($self, $item) = @_;
+    my $items = $self->property('items');
+    ($item) = grep { YuiRestClient::Sanitizer::sanitize($_) eq $item } map { $_->{label} } @{$items};
     return $self->action(action => YuiRestClient::Action::YUI_SELECT, value => $item);
 }
 


### PR DESCRIPTION
Revert small change unrelated with product selection, which assumed that server side was able to filter the '&' as was developed recently. Ticket to revisit this problem: https://progress.opensuse.org/issues/94835

- Related ticket: [poo#93029](https://progress.opensuse.org/issues/93029)
- Verification run: [transactional_server](https://openqa.opensuse.org/tests/1810942)
