### PR TITLE
Increase timeout for libyui to 60 seconds

### DIFF
--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -27,7 +27,7 @@ use testapi;
 use YuiRestClient;
 
 sub run {
-    my $app  = YuiRestClient::get_app(installation => 1, timeout => 30, interval => 1);
+    my $app  = YuiRestClient::get_app(installation => 1, timeout => 60, interval => 1);
     my $port = $app->get_port();
     record_info('SERVER', "Used host for libyui: " . $app->get_host());
     record_info('PORT',   "Used port for libyui: " . $port);


### PR DESCRIPTION
For aarch64 seems that 30 seconds is not enough.

- Related ticket: [poo#93029](https://progress.opensuse.org/issues/93029)
- Verification run: 
