### PR TITLE
Remove build_container_image() as duplicate of build_and_run_image()

### DIFF
--- a/data/containers/Dockerfile
+++ b/data/containers/Dockerfile
@@ -13,5 +13,8 @@ COPY index.html .
 # tell the port number the container should expose
 EXPOSE 5000
 
+# Set experimental variable
+ENV WORLD_VAR Arda
+
 # run the command
 ENTRYPOINT ["/usr/sbin/start_apache2", "-DFOREGROUND", "-k", "start"]

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -25,36 +25,9 @@ use version;
 use containers::utils;
 use containers::common 'test_container_image';
 
-our @EXPORT = qw(build_container_image build_with_zypper_docker build_with_sle2docker
+our @EXPORT = qw(build_with_zypper_docker build_with_sle2docker
   test_opensuse_based_image exec_on_container ensure_container_rpm_updates build_and_run_image
   test_zypper_on_container verify_userid_on_container test_3rd_party_image upload_3rd_party_images_logs);
-
-# Build any container image using a basic Dockerfile. Not applicable for buildah builds
-sub build_container_image {
-    my %args    = @_;
-    my $image   = $args{image};
-    my $runtime = $args{runtime};
-
-    die 'Argument $image not provided!'   unless $image;
-    die 'Argument $runtime not provided!' unless $runtime;
-
-    my $dir = "~/sle_base_image/docker_build";
-
-    record_info("Building $image", "Building $image using $runtime");
-
-    assert_script_run("mkdir -p $dir");
-    assert_script_run("cd $dir");
-
-    # Create basic Dockerfile
-    assert_script_run("echo -e 'FROM $image\\nENV WORLD_VAR Arda' > Dockerfile");
-
-    # Build the image
-    assert_script_run("$runtime build -t dockerfile_derived .");
-    assert_script_run("cd");
-
-    assert_script_run("$runtime run --entrypoint 'printenv' dockerfile_derived WORLD_VAR | grep Arda");
-    assert_script_run("$runtime images");
-}
 
 =head2 build_and_run_image
 
@@ -78,7 +51,7 @@ sub build_and_run_image {
     die "You must define the runtime!"    unless $runtime;
     die "You must define the Dockerfile!" unless $dockerfile;
 
-    my $dir = "/root/containerapp";
+    my $dir = "~/containerapp";
 
     # Setup the environment
     prepare_img("$dir", $dockerfile, $base);

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -241,9 +241,16 @@ sub run_img {
     my $runtime = shift;
     die "You must define the runtime!" unless $runtime;
 
+    # Test that we can execute programs in the container and test container's variables
+    assert_script_run("$runtime run --entrypoint 'printenv' myapp WORLD_VAR | grep Arda");
+
+    # Run the container with port 80 exported as port 8888
     assert_script_run("$runtime run -dit -p 8888:80 myapp");
-    sleep 5;
-    assert_script_run("$runtime ps -a");
+
+    # Make sure our container is running
+    script_retry("$runtime ps -a | grep myapp", delay => 5, retry => 3);
+
+    # Test that the exported port is reachable
     script_retry('curl http://localhost:8888/ | grep "The test shall pass"', delay => 5, retry => 6);
 
     # Clean up

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -45,7 +45,7 @@ sub run {
             record_info "IMAGE", "Testing image: $iname";
             test_container_image(image => $iname, runtime => $runtime);
             test_rpm_db_backend(image => $iname, runtime => $runtime);
-            build_container_image(image => $iname, runtime => $runtime);
+            build_and_run_image(base => $iname, runtime => $runtime);
             if (check_os_release('suse', 'PRETTY_NAME')) {
                 test_opensuse_based_image(image => $iname, runtime => $runtime, version => $version);
                 build_with_zypper_docker(image => $iname, runtime => $runtime, version => $version);

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -36,7 +36,7 @@ sub run {
             record_info "IMAGE", "Testing image: $iname";
             test_container_image(image => $iname, runtime => $runtime);
             test_rpm_db_backend(image => $iname, runtime => $runtime);
-            build_container_image(image => $iname, runtime => $runtime);
+            build_and_run_image(base => $iname, runtime => $runtime);
             if (check_os_release('suse', 'PRETTY_NAME')) {
                 test_opensuse_based_image(image => $iname, runtime => $runtime, version => $version);
             }

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -54,7 +54,7 @@ sub run {
     assert_script_run "$runtime images -a";
     for my $iname (@{$released_images}) {
         test_container_image(image => $iname, runtime => $runtime);
-        build_container_image(image => $iname, runtime => $runtime);
+        build_and_run_image(base => $iname, runtime => $runtime);
         test_zypper_on_container($runtime, $iname);
         verify_userid_on_container($runtime, $iname, $subuid_start);
     }


### PR DESCRIPTION
In my opinion `build_container_image()` is just simplier copy of `build_and_run_image()` and the only difference is that:
 * In `build_container_image()` we set environment variable and then run `printenv` to check for it.
 * In `build_and_run_image()` we run the image with an exposed port which we then try to connect to.

I removed `build_container_image()` and move both the environment variable check to `build_and_run_image()`.

- Verification run: [engines_and_tools_docker](http://pdostal-server.suse.cz/tests/12285) [engines_and_tools_podman](http://pdostal-server.suse.cz/tests/12286) [sle_image_on_sle_host_podman](http://pdostal-server.suse.cz/tests/12288) [sle_image_on_sle_host_docker](http://pdostal-server.suse.cz/tests/12287) [extra_tests_textmode_containers](http://pdostal-server.suse.cz/tests/12284)
