### PR TITLE
Decrease lower limit for download repos

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -85,9 +85,9 @@ sub run {
         assert_script_run("echo 'Download completed' >> ~/repos/qem_download_status.txt");
         upload_logs('/tmp/repos.list.txt');
         upload_logs('qem_download_status.txt');
-        # Failsafe 2: Ensure the repos are not empty (i.e. size >= 1 MB)
+        # Failsafe 2: Ensure the repos are not empty (i.e. size >= 100 kB)
         $size = script_output('du -s ~/repos | awk \'{print$1}\'');
-        die "Empty test repositories" if ($check_empty_repos && $size < 1000);
+        die "Empty test repositories" if ($check_empty_repos && $size < 100);
     }
     # The maintenance *.repo files all point to download.suse.de, but we are using dist.suse.de, so we need to rename the directory
     assert_script_run("if [ -d ~/repos/dist.suse.de ]; then mv ~/repos/dist.suse.de ~/repos/download.suse.de; fi");


### PR DESCRIPTION
Decreate the lower limit below which the downloading of the test
repositories is considered as empty. This is necessary because on LTSS
test runs with only 1 issue, the current limit is too high and causes
false positives.

- Related ticket: https://progress.opensuse.org/issues/94868
