### PR TITLE
LTP: Use uname -r for kernel version checks

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -243,10 +243,8 @@ sub schedule_tests {
         harness     => 'SUSE OpenQA',
         ltp_version => ''
     };
+
     my $ver_linux_out = script_output("cat /tmp/ver_linux_before.txt");
-    if ($ver_linux_out =~ qr'^Linux\s+(.*?)\s*$'m) {
-        $environment->{kernel} = $1;
-    }
     if ($ver_linux_out =~ qr'^Linux C Library\s*>?\s*(.*?)\s*$'m) {
         $environment->{libc} = $1;
     }
@@ -255,6 +253,7 @@ sub schedule_tests {
     }
 
     my $file = get_ltp_version_file();
+    $environment->{kernel}      = script_output('uname -r');
     $environment->{ltp_version} = script_output("touch $file; cat $file");
     record_info("LTP version", $environment->{ltp_version});
 


### PR DESCRIPTION
LTP currently uses `uname -a` as the kernel version for conditional softfail checks. But this string contains too much useless noise:

    susetest 4.4.180-195.ga25f9fb-default #1 SMP Fri Jun 4 09:07:08 UTC 2021 (a25f9fb) x86_64 x86_64 x86_64 GNU/Linux

Use `uname -r` to simplify the softfail checks: `4.4.180-195.ga25f9fb-default`

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/6351701#step/boot_ltp/114
