### PR TITLE
Public Cloud: Fix 15-SP3 GCE wait_for_ssh()

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -219,7 +219,7 @@ sub wait_for_ssh
 
     # Check ssh command
     while ((my $duration = time() - $start_time) < $args{timeout}) {
-        return $duration if ($self->run_ssh_command(cmd => 'sudo journalctl -b | grep -E "Reached target (Cloud-init|Default)"', proceed_on_failure => 1, quiet => 1, username => $args{username}) =~ m/Reached target.*/);
+        return $duration if ($self->run_ssh_command(cmd => 'sudo journalctl -b | grep -E "Reached target (Cloud-init|Default|Main User Target)"', proceed_on_failure => 1, quiet => 1, username => $args{username}) =~ m/Reached target.*/);
         sleep 1;
     }
 


### PR DESCRIPTION
In `wait_for_ssh()` we are checking that the system already fully booted. This is fixing the `journalctl -b | grep` expression.
 
- Related ticket: [poo#94330](https://progress.opensuse.org/issues/94330)
- Verification run: [15-SP3-GCE-BYOS-Updates](http://pdostal-server.suse.cz/tests/12292#)
