### PR TITLE
Add gcc-jit coverage to the valgrind test suite

### DIFF
--- a/data/gcc/gcc-jit.c
+++ b/data/gcc/gcc-jit.c
@@ -1,0 +1,113 @@
+/* Usage example for libgccjit.so
+   Copyright (C) 2014-2021 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3, or (at your option)
+any later version.
+
+GCC is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <libgccjit.h>
+
+
+void
+create_code (gcc_jit_context *ctxt)
+{
+  /* Let's try to inject the equivalent of:
+
+      int square (int i)
+      {
+        return i * i;
+      }
+  */
+  gcc_jit_type *int_type =
+    gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_INT);
+  gcc_jit_param *param_i =
+    gcc_jit_context_new_param (ctxt, NULL, int_type, "i");
+  gcc_jit_function *func =
+    gcc_jit_context_new_function (ctxt, NULL,
+                                  GCC_JIT_FUNCTION_EXPORTED,
+                                  int_type,
+                                  "square",
+                                  1, &param_i,
+                                  0);
+
+  gcc_jit_block *block = gcc_jit_function_new_block (func, NULL);
+
+  gcc_jit_rvalue *expr =
+    gcc_jit_context_new_binary_op (
+      ctxt, NULL,
+      GCC_JIT_BINARY_OP_MULT, int_type,
+      gcc_jit_param_as_rvalue (param_i),
+      gcc_jit_param_as_rvalue (param_i));
+
+   gcc_jit_block_end_with_return (block, NULL, expr);
+}
+
+int
+main (int argc, char **argv)
+{
+  gcc_jit_context *ctxt = NULL;
+  gcc_jit_result *result = NULL;
+
+  /* Get a "context" object for working with the library.  */
+  ctxt = gcc_jit_context_acquire ();
+  if (!ctxt)
+    {
+      fprintf (stderr, "NULL ctxt");
+      goto error;
+    }
+
+  /* Set some options on the context.
+     Let's see the code being generated, in assembler form.  */
+  gcc_jit_context_set_bool_option (
+    ctxt,
+    GCC_JIT_BOOL_OPTION_DUMP_GENERATED_CODE,
+    0);
+
+  /* Populate the context.  */
+  create_code (ctxt);
+
+  /* Compile the code.  */
+  result = gcc_jit_context_compile (ctxt);
+  if (!result)
+    {
+      fprintf (stderr, "NULL result");
+      goto error;
+    }
+
+  /* We're done with the context; we can release it: */
+  gcc_jit_context_release (ctxt);
+  ctxt = NULL;
+
+  /* Extract the generated code from "result".  */
+  void *fn_ptr = gcc_jit_result_get_code (result, "square");
+  if (!fn_ptr)
+     {
+       fprintf (stderr, "NULL fn_ptr");
+       goto error;
+     }
+
+  typedef int (*fn_type) (int);
+  fn_type square = (fn_type)fn_ptr;
+  printf ("result: %d\n", square (5));
+
+ error:
+  if (ctxt)
+    gcc_jit_context_release (ctxt);
+  if (result)
+    gcc_jit_result_release (result);
+  return 0;
+}

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1681,6 +1681,7 @@ sub load_extra_tests_console {
     loadtest 'console/osinfo_db' if (is_sle('12-SP3+') && !is_jeos);
     loadtest 'console/libgcrypt' if ((is_sle(">=12-SP4") && (check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk'))) || is_opensuse);
     loadtest "console/gd";
+    loadtest 'console/gcc'               unless is_sle('<=12-SP3');
     loadtest 'console/valgrind'          unless is_sle('<=12-SP3');
     loadtest 'console/sssd_samba'        unless (is_sle("<15") || is_sle(">=15-sp2") || is_leap('>=15.2') || is_tumbleweed);
     loadtest 'console/wpa_supplicant'    unless (!is_x86_64    || is_sle('<15') || is_leap('<15.1') || is_jeos || is_public_cloud);

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -50,6 +50,7 @@ conditional_schedule:
                 - console/libgpiod
                 - console/libgcrypt
                 - console/gd
+                - console/gcc
                 - console/valgrind
                 - console/wpa_supplicant
                 - appgeo/gdal

--- a/tests/console/gcc.pm
+++ b/tests/console/gcc.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Package: gcc
+# Summary: additional gcc tests
+# - gcc-jit test according to https://gcc.gnu.org/onlinedocs/jit/intro/tutorial02.html
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils qw(is_tumbleweed);
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    ## Note: Because this test currently only includes the gcc-jit test, the module is scheduled on Tumbleweed only
+    ## When extending the test, consider scheduling it on SLES/Leap as well.
+
+    # Test gccjit (tumbleweed only, because it's a very new feature)
+    # See https://bugzilla.opensuse.org/show_bug.cgi?id=1185529 for the reason behind this test
+    # and https://gcc.gnu.org/onlinedocs/jit/intro/tutorial02.html for the test template.
+    if (is_tumbleweed) {
+        zypper_call 'in gcc libgccjit0 libgccjit0-devel-gcc11';
+        assert_script_run 'curl -v -o gcc-jit.c ' . data_url('gcc/gcc-jit.c');
+        assert_script_run 'gcc gcc-jit.c -o gcc-jit -lgccjit';
+        validate_script_output './gcc-jit', sub { m/result: 25/ };
+    }
+}
+
+sub post_run_hook {
+    my $self = shift;
+    script_run("rm -f gcc-jit.c gcc-jit");
+    $self->SUPER::post_run_hook;
+}
+
+1;


### PR DESCRIPTION
On request adding coverage to the gcc-jit compiler within the valgrind test suite.
This test will run on openSUSE Tumbleweed only, as the feature is quiet new and not applicable yet to SLES.

- Related ticket: https://progress.opensuse.org/issues/94928
- Verification run: [Tumbleweed](http://duck-norris.qam.suse.de/tests/6687) | [Tumbleweed Schedule](http://duck-norris.qam.suse.de/tests/6677)
