### PR TITLE
microos/journal_check: Handle boot marker

### DIFF
--- a/tests/microos/journal_check.pm
+++ b/tests/microos/journal_check.pm
@@ -46,6 +46,7 @@ sub run {
         bsc_1182961         => 'could not read from \'/sys/module/pcc_cpufreq/initstate\': No such device',
         bsc_1184970         => '.*rpc\.statd.*Failed to stat \/var\/lib\/nfs\/sm: No such file or directory',
         bsc_000000_FEATURE  => 'health-checker/fail.sh check" failed|Machine didn\'t come up correct, do a rollback',
+        bsc_000001_FEATURE  => '-- Boot\\s+\\w+\\s+--',
     };
     my $master_pattern = "(" . join('|', map { "$_" } values %$bug_pattern) . ")";
 


### PR DESCRIPTION
With systemd v248, "journalctl -p err" shows markers to separate boots from
each other, e.g. "-- Boot 67793553d52544e995e43c1ce540535c --".

Verification run: https://openqa.opensuse.org/tests/1813037