### PR TITLE
Rename wmp_basic_test module to wmp_check_process

### DIFF
--- a/schedule/kernel/sles4sap/setup_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/setup_hana_baremetal.yaml
@@ -30,7 +30,7 @@ conditional_schedule:
       1:
         - sles4sap/hana_install
         - sles4sap/wmp_setup
-        - sles4sap/wmp_basic_test
+        - sles4sap/wmp_check_process
   scc_deregister:
     SCC_DEREGISTER:
       1:

--- a/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node1.yaml
@@ -38,9 +38,9 @@ schedule:
   - ha/ha_cluster_init
   - sles4sap/hana_cluster
   - sles4sap/sap_suse_cluster_connector
-  - sles4sap/wmp_basic_test
+  - sles4sap/wmp_check_process
   - ha/fencing
   - boot/boot_to_desktop
   - ha/check_after_reboot
   - ha/check_logs
-  - sles4sap/wmp_basic_test
+  - sles4sap/wmp_check_process

--- a/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node2.yaml
+++ b/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node2.yaml
@@ -37,8 +37,8 @@ schedule:
   - sles4sap/wmp_setup
   - ha/ha_cluster_join
   - sles4sap/hana_cluster
-  - sles4sap/wmp_basic_test
+  - sles4sap/wmp_check_process
   - ha/fencing
   - ha/check_after_reboot
   - ha/check_logs
-  - sles4sap/wmp_basic_test
+  - sles4sap/wmp_check_process

--- a/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node1.yaml
@@ -38,9 +38,9 @@ schedule:
   - ha/ha_cluster_init
   - sles4sap/hana_cluster
   - sles4sap/sap_suse_cluster_connector
-  - sles4sap/wmp_basic_test
+  - sles4sap/wmp_check_process
   - ha/fencing
   - boot/boot_to_desktop
   - ha/check_after_reboot
   - ha/check_logs
-  - sles4sap/wmp_basic_test
+  - sles4sap/wmp_check_process

--- a/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node2.yaml
+++ b/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node2.yaml
@@ -37,8 +37,8 @@ schedule:
   - sles4sap/wmp_setup
   - ha/ha_cluster_join
   - sles4sap/hana_cluster
-  - sles4sap/wmp_basic_test
+  - sles4sap/wmp_check_process
   - ha/fencing
   - ha/check_after_reboot
   - ha/check_logs
-  - sles4sap/wmp_basic_test
+  - sles4sap/wmp_check_process

--- a/schedule/sles4sap/hana/hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/hana_cluster_node.yaml
@@ -55,15 +55,15 @@ schedule:
   - sles4sap/hana_cluster
   - sles4sap/monitoring_services
   - '{{sap_suse_cluster_connector}}'
-  - '{{wmp_basic_test}}'
+  - '{{wmp_check_process}}'
   - ha/fencing
   - '{{boot_to_desktop_node01}}'
   - ha/check_after_reboot
-  - '{{wmp_basic_test}}'
+  - '{{wmp_check_process}}'
   - ha/fencing
   - '{{boot_to_desktop_node02}}'
   - ha/check_after_reboot
-  - '{{wmp_basic_test}}'
+  - '{{wmp_check_process}}'
   - ha/check_logs
 conditional_schedule:
   cluster_setup:
@@ -88,7 +88,7 @@ conditional_schedule:
     WMP:
       1:
         - sles4sap/wmp_setup
-  wmp_basic_test:
+  wmp_check_process:
     WMP:
       1:
-        - sles4sap/wmp_basic_test
+        - sles4sap/wmp_check_process

--- a/schedule/sles4sap/qam/common/qam_hana_cluster_node.yaml
+++ b/schedule/sles4sap/qam/common/qam_hana_cluster_node.yaml
@@ -52,15 +52,15 @@ schedule:
   - '{{cluster_setup}}'
   - sles4sap/hana_cluster
   - '{{sap_suse_cluster_connector}}'
-  - '{{wmp_basic_test}}'
+  - '{{wmp_check_process}}'
   - ha/fencing
   - '{{boot_to_desktop_node01}}'
   - ha/check_after_reboot
-  - '{{wmp_basic_test}}'
+  - '{{wmp_check_process}}'
   - ha/fencing
   - '{{boot_to_desktop_node02}}'
   - ha/check_after_reboot
-  - '{{wmp_basic_test}}'
+  - '{{wmp_check_process}}'
   - ha/check_logs
 conditional_schedule:
   cluster_setup:
@@ -85,7 +85,7 @@ conditional_schedule:
     WMP:
       1:
         - sles4sap/wmp_setup
-  wmp_basic_test:
+  wmp_check_process:
     WMP:
       1:
-        - sles4sap/wmp_basic_test
+        - sles4sap/wmp_check_process

--- a/tests/sles4sap/wmp_check_process.pm
+++ b/tests/sles4sap/wmp_check_process.pm
@@ -20,7 +20,7 @@ use warnings;
 
 sub run {
     my ($self)        = @_;
-    my $testname      = 'wmp_basic_tests';
+    my $testname      = 'wmp_check_process';
     my $logdir        = '/root/wmp_logs';
     my $sapsvc        = '/usr/sap/sapservices';
     my $wmp_test_repo = get_required_var('WMP_TEST_REPO');


### PR DESCRIPTION
Updated [documentation](https://confluence.suse.com/pages/viewpage.action?spaceKey=SAP&title=WMP+Tests) on WMP tests identifies 4 main tests:

- Do SAP Processes stay in cgroup? (former Basic Tests)
- Does memory.low cause performance penalty? (former Does WMP break anything?)
- Does memory.low protect against swapping? (former Does WMP work?)
- HA Tests: Do SAP processes stay in cgroup?

As can be seen, WMP Basic Test used to refer to the test *Do SAP Processes stay in cgroup?*, but current test code for WMP in **os-autoinst-distri-opensuse** is primarily used for the scenario *HA Tests: Do SAP processes stay in cgroup?* in an HA+SAP scenario.

Moreover, the `sles4sap/wmp_basic_test` test module is just a piece in testing the *HA Tests: Do SAP processed stay in cgroup?* scenario, as the HA & SAP product configuration as well as the WMP setup is done by other test modules; `wmp_basic_test` just checks that the processes stay in the cgroup, so it makes sense to rename it to a name that better reflects its current purpose.

This PR renames the test module to `sles4sap/wmp_check_process`.

- Related ticket: https://jira.suse.com/browse/TEAM-4378
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/4151 & http://mango.qa.suse.de/tests/4152
