### PR TITLE
Remove unneeded update repo tests from Leap 15.3 maintenance runs

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -18,8 +18,8 @@ conditional_schedule:
             x86_64:
                 - console/yast2_lan_device_settings
     update_repos:
-        DISTRI:
-            opensuse:
+        VERSION:
+            'Tumbleweed':
                 - update/zypper_clear_repos
                 - console/zypper_ar
                 - console/zypper_ref


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/94859
- Needles: N/A
- Verification run: [Leap 15.3](http://10.161.229.247/tests/2054#step/zypper_ref/6) | [Tumbleweed](http://10.161.229.247/tests/2055#step/zypper_ref#1/6)
