### PR TITLE
console/regproxy: Start update-ca-certificates through systemd

### DIFF
--- a/tests/console/regproxy.pm
+++ b/tests/console/regproxy.pm
@@ -34,7 +34,8 @@ sub run {
     assert_script_run('echo "PREFIX=' . $opensuse_prefix . '" > /etc/regproxy.conf');
     assert_script_run('systemctl daemon-reload && systemctl enable --now regproxy.service');
     # Install the MITM cert
-    assert_script_run('ln -s $PWD/regproxy-cert.pem /etc/pki/trust/anchors && update-ca-certificates');
+    assert_script_run('ln -s $PWD/regproxy-cert.pem /etc/pki/trust/anchors');
+    systemctl('start ca-certificates');
     assert_script_run('popd');
 
     # Redirect to localhost


### PR DESCRIPTION
The copy of the file already triggers update-ca-certificates.path, which
starts update-ca-certificates.service. Starting update-ca-certificates manually
as well can lead to conflicts. Simply start the service manually to ensure that
it completed.

- Verification run: https://openqa.opensuse.org/tests/1813114
