### PR TITLE
Fix declarative schedule documentation

### DIFF
--- a/declarative-schedule-doc.md
+++ b/declarative-schedule-doc.md
@@ -86,6 +86,7 @@ There are a few exceptions:
   - `HDD_1`: if added, openQA will not publish the image in openQA WebUI due to it depends on os-autoinst.
   - `START_AFTER_TEST`: if added, openQA will not link dependencies on the corresponding tab in openQA WebUI due to it depends on os-autoinst.
 -   `UEFI_PFLASH_VARS`: if added, openQA will not publish in UI
+- `QEMUCPUS` and `QEMURAM`: openQA cannot set these from the declarative yaml schedule and will use the defaults instead
 
 #### conditional_schedule
 Depending on different values of an environmental variable we can schedule different set of modules.

--- a/schedule/vagrant.yaml
+++ b/schedule/vagrant.yaml
@@ -3,8 +3,6 @@ description:    >
     Tests for vagrant, vagrant plugins and the official vagrant boxes
 vars:
     QEMUCPU: host
-    QEMURAM: 4096
-    QEMUCPUS: 4
 schedule:
     - '{{boot_to_desktop}}'
     - '{{add_box_virtualbox}}'


### PR DESCRIPTION
The documentation does not mention that you cannot set `QEMUCPUS` and `QEMURAM` from the declarative yaml schedule.

Since the setting is pointless, I've also removed it from `vagrant.yaml`. 

cc @schlad `schedule/storage/blktests.yaml` sets `QEMUCPUS`, you might want to move this to the yaml job template.