### PR TITLE
lib/containers/container_images: Fix typo which caused wrong code to run

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -66,7 +66,7 @@ sub build_and_run_image {
         # At least on publiccloud, this image pull can take long and occasinally fails due to network issues
         assert_script_run("$runtime build -t myapp BuildTest", timeout => 300);
         assert_script_run("$runtime images | grep myapp");
-    } ele {
+    } else {
         assert_script_run("buildah bud -t myapp BuildTest", timeout => 300);
         assert_script_run("buildah images | grep myapp");
     }


### PR DESCRIPTION
The `ele` block was always run, so it tried to run buildah even when testing
podman.

I really wonder how this didn't result in a test failure or just a warning during runtime.

Example of a failed test run: https://openqa.opensuse.org/tests/1813394

Verification run: https://openqa.opensuse.org/tests/1813522
