### PR TITLE
Remove user_settings_root from YaST group except in extended scenario

### DIFF
--- a/schedule/yast/addon-module-ftp.yaml
+++ b/schedule/yast/addon-module-ftp.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - '{{hostname_inst}}'
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/addon-module-http.yaml
+++ b/schedule/yast/addon-module-http.yaml
@@ -18,7 +18,6 @@ schedule:
   - installation/installer_timezone
   - '{{hostname_inst}}'
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -16,7 +16,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -31,7 +31,6 @@ schedule:
   - installation/installer_timezone
   - '{{hostname_inst}}'
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -24,7 +24,6 @@ schedule:
   # Called on all, except BACKEND: s390x
   - '{{hostname_inst}}'
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/start_install

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/clone_system/clone_system_pvm.yaml
+++ b/schedule/yast/clone_system/clone_system_pvm.yaml
@@ -17,7 +17,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -26,7 +26,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
@@ -27,7 +27,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_import
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_import
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/activate_encrypted_volume.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/activate_encrypted_volume_dasd.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_dasd.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters

--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -28,7 +28,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/encryption/cryptlvm_sle_15.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -16,7 +16,6 @@ schedule:
   - installation/partitioning/edit_proposal_encrypt
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -32,7 +32,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/partitioning/new_partitioning_gpt
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -34,7 +34,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/partitioning/new_partitioning_gpt
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
@@ -18,7 +18,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/start_install

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -18,7 +18,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -18,7 +18,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/change_desktop
   - installation/installation_overview

--- a/schedule/yast/installer_extended.yaml
+++ b/schedule/yast/installer_extended.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/releasenotes
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
+  - installation/authentication/add_weak_password_for_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout
@@ -71,3 +71,5 @@ test_data:
         text: 版軟體的
   system_role:
     default: 'Text Mode'
+  root_authentication:
+    warning: 'The password is too simple:\nit is based on a dictionary word.'

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -23,7 +23,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/partitioning/resize_existing_lv
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm/lvm+resize_root.yaml
+++ b/schedule/yast/lvm/lvm+resize_root.yaml
@@ -26,7 +26,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm_multipath.yaml
+++ b/schedule/yast/lvm_multipath.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm_multipath_encrypted.yaml
+++ b/schedule/yast/lvm_multipath_encrypted.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/partitioning/setup_raid1_lvm
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/partitioning/setup_raid1_lvm
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/partitioning/setup_raid1_lvm
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/partitioning/setup_raid1_lvm
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/start_install

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -23,7 +23,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal.yaml
@@ -22,7 +22,6 @@ schedule:
   # Called on BACKEND: qemu, svirt
   - '{{hostname_inst}}'
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -18,7 +18,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/msdos/msdos.yaml
+++ b/schedule/yast/msdos/msdos.yaml
@@ -16,7 +16,6 @@ schedule:
   - installation/partitioning/msdos_partition_table
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - '{{disable_grub_timeout}}'
   - installation/start_install

--- a/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
@@ -16,7 +16,6 @@ schedule:
   - installation/partitioning/msdos_partition_table
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/start_install
   - installation/await_install

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -37,7 +37,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/nvme.yaml
+++ b/schedule/yast/nvme.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/partitioning/raid_gpt
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/partitioning/raid_gpt
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/partitioning/raid_gpt
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/partitioning/raid_gpt
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/partitioning/raid_gpt
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -25,7 +25,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - "{{edit_optional_kernel_cmd_parameters}}"

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -27,7 +27,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
@@ -29,7 +29,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -27,7 +27,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -27,7 +27,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
@@ -26,7 +26,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
@@ -27,7 +27,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -23,7 +23,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/select_patterns
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
@@ -17,7 +17,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/skip_registration/skip_registration_pvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration_pvm.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters

--- a/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
+++ b/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/yast/switch_keyboard.yaml
+++ b/schedule/yast/switch_keyboard.yaml
@@ -18,7 +18,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -18,7 +18,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/textmode/textmode@svirt-xen.yaml
+++ b/schedule/yast/textmode/textmode@svirt-xen.yaml
@@ -17,7 +17,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/start_install

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -30,7 +30,6 @@ schedule:
     - installation/partitioning_finish
     - installation/installer_timezone
     - installation/user_settings
-    - installation/user_settings_root
     - installation/resolve_dependency_issues
     - installation/installation_overview
     - "{{kernel_cmd_parameters}}"

--- a/schedule/yast/usb_install.yaml
+++ b/schedule/yast/usb_install.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/xfs/xfs.yaml
+++ b/schedule/yast/xfs/xfs.yaml
@@ -24,7 +24,6 @@ schedule:
   # Called on all, except BACKEND: s390x
   - '{{hostname_inst}}'
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/start_install

--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/edit_optional_kernel_cmd_parameters
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
@@ -23,7 +23,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_hostname/yast_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
@@ -20,7 +20,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
-  - installation/user_settings_root
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/tests/installation/licensing/verify_license_translations.pm
+++ b/tests/installation/licensing/verify_license_translations.pm
@@ -71,10 +71,15 @@ sub run {
             diag("EULA validation failed:\nExpected:\n$translation->{text}\nActual:\n$license_agreement_info->{text}\n\n");
         }
     }
-    # Assert no errors
-    assert_true(!$errors, $errors);
     # Set language back to default
     $license_agreement->select_language($default_language);
+
+    # Assert no errors
+    assert_true(!$errors, $errors);
+}
+
+sub test_flags {
+    return {fatal => 0};
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [poo#93656](https://progress.opensuse.org/issues/93656)
- Verification run: [SLE](https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23replace_user_settings_root)

Note: MUST be merged after finishing  [poo#93624](https://progress.opensuse.org/issues/93624)