### PR TITLE
Schedule ghostscript test module to Tumbleweed

### DIFF
--- a/schedule/functional/extra_tests_misc.yaml
+++ b/schedule/functional/extra_tests_misc.yaml
@@ -9,6 +9,7 @@ conditional_schedule:
             opensuse:
                 - console/ndctl
                 - console/openvswitch_ssl
+                - x11/ghostscript
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop


### PR DESCRIPTION
see https://progress.opensuse.org/issues/56003
verification:
http://10.160.64.152/tests/3291#step/ghostscript/37
