### PR TITLE
Add i/o APIC to vagrant

### DIFF
--- a/data/virtualization/Vagrantfile
+++ b/data/virtualization/Vagrantfile
@@ -40,6 +40,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |virtbox, override|
     virtbox.memory = 2048
     virtbox.cpus = 4
+    virtbox.customize ["modifyvm", :id, "--ioapic", "on"]
     ip_config(override, "virtualbox")
   end
 

--- a/lib/vagrant.pm
+++ b/lib/vagrant.pm
@@ -5,7 +5,7 @@ use warnings;
 use utils;
 
 our @ISA    = qw(Exporter);
-our @EXPORT = qw(setup_vagrant_libvirt setup_vagrant_virtualbox);
+our @EXPORT = qw(setup_vagrant_libvirt setup_vagrant_virtualbox run_vagrant_cmd);
 
 # - install vagrant and vagrant-libvirt
 # - launch the required daemons
@@ -26,4 +26,14 @@ sub setup_vagrant_virtualbox {
     systemctl("start vboxdrv");
     systemctl("start vboxautostart-service");
     assert_script_run("usermod -a -G vboxusers bernhard");
+}
+
+sub run_vagrant_cmd {
+    my ($cmd, %args) = @_;
+
+    my $logfile = 'vagrant_cmd.log';
+    my $ret     = script_run("VAGRANT_LOG=DEBUG vagrant $cmd 2> $logfile", %args);
+    return undef if $ret == 0;
+    upload_logs($logfile);
+    die "'vagrant $cmd' failed with $ret";
 }

--- a/tests/virtualization/vagrant/add_box_libvirt.pm
+++ b/tests/virtualization/vagrant/add_box_libvirt.pm
@@ -37,13 +37,13 @@ sub run() {
     assert_script_run('echo "test" > testfile');
 
     # Available from https://app.vagrantup.com/opensuse
-    assert_script_run("vagrant init opensuse/Tumbleweed." . get_required_var('ARCH'));
+    run_vagrant_cmd('init opensuse/Tumbleweed.' . get_required_var('ARCH'));
 
-    assert_script_run('vagrant up', timeout => 1200);
+    run_vagrant_cmd('up', timeout => 1200);
 
-    assert_script_run('vagrant ssh -c "[ $(cat testfile) = \"test\" ]"');
-    assert_script_run('vagrant halt');
-    assert_script_run('vagrant destroy -f');
+    run_vagrant_cmd('ssh -c "[ $(cat testfile) = \"test\" ]"');
+    run_vagrant_cmd('halt');
+    run_vagrant_cmd('destroy -f');
 
     assert_script_run('rm -rf Vagrantfile testfile .vagrant');
 }

--- a/tests/virtualization/vagrant/add_box_virtualbox.pm
+++ b/tests/virtualization/vagrant/add_box_virtualbox.pm
@@ -30,12 +30,12 @@ sub run() {
     select_console('user-console');
     assert_script_run('echo "test" > testfile');
 
-    assert_script_run('vagrant init centos/7');
-    assert_script_run('vagrant up --provider virtualbox', timeout => 1200);
+    run_vagrant_cmd('init centos/7');
+    run_vagrant_cmd('up --provider virtualbox', timeout => 1200);
 
-    assert_script_run('vagrant ssh -c "[ $(cat testfile) = \"test\" ]"');
-    assert_script_run('vagrant halt');
-    assert_script_run('vagrant destroy -f');
+    run_vagrant_cmd('ssh -c "[ $(cat testfile) = \"test\" ]"');
+    run_vagrant_cmd('halt');
+    run_vagrant_cmd('destroy -f');
 
     assert_script_run('rm -rf Vagrantfile testfile .vagrant');
 }

--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -31,13 +31,13 @@ sub run_test_per_provider {
     my $boxname = "$version-$provider";
 
     # Test the box *only*: bring it up and destroy it immediately afterwards
-    assert_script_run("vagrant up $boxname --provider $provider", timeout => 1200);
+    run_vagrant_cmd("up $boxname --provider $provider", timeout => 1200);
 
     # test if the box survives a reboot
-    assert_script_run("vagrant halt");
-    assert_script_run("vagrant up $boxname", timeout => 1200);
+    run_vagrant_cmd('halt');
+    run_vagrant_cmd("up $boxname", timeout => 1200);
 
-    assert_script_run("vagrant destroy -f $boxname");
+    run_vagrant_cmd("destroy -f $boxname");
 }
 
 sub run() {
@@ -104,7 +104,7 @@ sub run() {
     # cleanup after all the tests ran
     foreach my $provider (@providers) {
         my $boxname = "$boxes{$provider}";
-        assert_script_run("vagrant box remove --force --provider $provider ../$boxname");
+        run_vagrant_cmd("box remove --force --provider $provider ../$boxname");
         assert_script_run("rm ../$boxname");
     }
 

--- a/tests/virtualization/vagrant/sshfs.pm
+++ b/tests/virtualization/vagrant/sshfs.pm
@@ -42,18 +42,18 @@ sub run() {
     #
     assert_script_run('echo "Foo" > testfile');
 
-    assert_script_run('vagrant init opensuse/Tumbleweed.' . get_required_var('ARCH'));
+    run_vagrant_cmd('init opensuse/Tumbleweed.' . get_required_var('ARCH'));
 
     assert_script_run('sed -i \'s/# config\.vm\.synced_folder .*$/config\.vm\.synced_folder "\.", "\/vagrant", type: "sshfs"/\' Vagrantfile');
 
-    assert_script_run('vagrant up', timeout => 1200);
+    run_vagrant_cmd('up', timeout => 1200);
 
     assert_script_run('[[ $(vagrant ssh -- cat /vagrant/testfile) = "Foo" ]]');
     assert_script_run('vagrant ssh -- "echo \"Bar\" > /vagrant/testfile"');
     assert_script_run('[[ $(cat testfile) = "Bar" ]]');
 
-    assert_script_run('vagrant halt');
-    assert_script_run('vagrant destroy -f');
+    run_vagrant_cmd('halt');
+    run_vagrant_cmd('destroy -f');
     assert_script_run('rm -rf Vagrantfile testfile .vagrant');
 
     #


### PR DESCRIPTION
This PR force enables I/O APIC for virtualbox vagrant boxes: this allows them to actually leverage multiple CPU cores (for some reason that is disabled when running them in qemu). This change greatly improves performance and reduced the flakyness of the vagrant jenkins pipeline.

Additionally, I've added a wrapper for invoking vagrant commands that will set the logging level to DEBUG and upload the log on failure.

- Related ticket: n/a
- Needles: n/a
- Verification run: ~~https://openqa.opensuse.org/tests/1814840 (note that this one contains a monkey patch provided by https://build.opensuse.org/request/show/903367)~~ https://openqa.opensuse.org/tests/1828297
