### PR TITLE
tests/security/selinux/audit2allow: Handle systemd_config_generic_services

### DIFF
--- a/tests/security/selinux/audit2allow.pm
+++ b/tests/security/selinux/audit2allow.pm
@@ -97,7 +97,7 @@ sub run {
             .*require\ \{.*
             .*type\ .*;.*
             #=============.*==============.*
-            .*allow.*;.*/sx
+            .*(?:allow.*;|systemd_config_generic_services).*/sx
         }, 600);
 }
 


### PR DESCRIPTION
Apparently audit2allow is smart enough to use interfaces here instead of
direct allow statements. Handle that as well.

- Related ticket: https://progress.opensuse.org/issues/93405
- Verification run: https://openqa.opensuse.org/tests/1817964

CC @lilyeyes (who is not in the list of possible reviewers for some reason)