### PR TITLE
Containers: update host config for RES8

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -31,7 +31,7 @@ sub run {
     }
     else {
         assert_script_run "dhclient -v";
-        $interface = script_output q@ip r s default | awk '{printf $5}'@;
+        $interface = script_output q@ip r s default | head -1 | awk '{printf $5}'@;
         validate_script_output "ip a s '$interface'", sub { m/((\d{1,3}\.){3}\d{1,3}\/\d{1,2})/ };
         assert_script_run "curl http://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/ssl/certs/SUSE_Trust_Root.crt" if is_sle();
         # Stop unattended-upgrades on Ubuntu hosts to prevent interference from automatic updates


### PR DESCRIPTION
For some reason, `ip r s default` shows 2 "default" routes which are similar.
With this, we make sure we don't get the interface twice.
Before, the script output was "ens4ens4", with this small fix is "ens4" only.

- Related ticket: https://progress.opensuse.org/issues/94183
- Verification run: http://fromm.arch.suse.de/tests/1751#step/podman_image/27
