### PR TITLE
containers: add zypper -n key to work properly in pipeline

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -251,18 +251,20 @@ sub test_zypper_on_container {
     # zypper lr
     assert_script_run("$runtime run $image zypper lr -s", 120);
 
+    my $zypper_ref = 'zypper -nv ref | grep \"All repositories have been refreshed\"';
+
     if ($runtime =~ /buildah/) {
         # zypper ref
-        assert_script_run("$runtime run $image -- zypper -v ref | grep \"All repositories have been refreshed\"", 120);
+        assert_script_run("$runtime run $image -- $zypper_ref", 120);
 
         # Create new image and remove the working container
         assert_script_run("$runtime commit --rm $image refreshed", 120);
 
         # Verify the new image works
-        assert_script_run("$runtime run \$($runtime from refreshed) -- zypper -v ref | grep \"All repositories have been refreshed\" ", 120);
+        assert_script_run("$runtime run \$($runtime from refreshed) -- $zypper_ref ", 120);
     } else {
         # zypper ref
-        assert_script_run("$runtime run --name refreshed $image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
+        assert_script_run("$runtime run --name refreshed $image sh -c '$zypper_ref'", 120);
 
         # Commit the image
         assert_script_run("$runtime commit refreshed refreshed-image", 120);
@@ -271,7 +273,7 @@ sub test_zypper_on_container {
         assert_script_run("$runtime rm refreshed", 120);
 
         # Verify the image works
-        assert_script_run("$runtime run --rm refreshed-image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
+        assert_script_run("$runtime run --rm refreshed-image sh -c '$zypper_ref'", 120);
     }
     record_info "The End", "zypper test completed";
 }


### PR DESCRIPTION
Based on this output https://openqa.suse.de/tests/6363986/logfile?filename=serial_terminal.txt : 

```
podman run --name refreshed registry.suse.com/suse/sle15:15.1 sh -c 'zypper -v ref | grep "All repositories have been refreshed"'; echo 7SuKZ-$?-
Cannot read input: bad stream or EOF.
If you run zypper without a terminal, use '--non-interactive' global
option to make zypper use default answers to prompts.
Repository 'SLE-Product-SLES15-SP1-Updates for sle-15-x86_64' is invalid.
[container-suseconnect-zypp:SLE-Product-SLES15-SP1-Updates|https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/?cnay613_F446IPkZfTNwx7CCsQTr34758vAy8lt5xF6J0DNTMZuNYX50cNO31KBsf9Nm-62XVwyRFYkyqV_1FnWPRNGJzHVqY4_uzaWCUxwEE2G8EcvC1ZvaLCk6f3AduFgOJuwGWD8aRRweep5mscc] Valid metadata not found at specified URL
History:
 - Cannot read input. Bad stream or EOF.
 - Can't provide /repodata/repomd.xml

Please check if the URIs defined for this repository are pointing to a valid repository.
Skipping repository 'SLE-Product-SLES15-SP1-Updates for sle-15-x86_64' because of the above error.
Some of the repositories have not been refreshed because of an error.
```

VR : http://autobot.qa.suse.de/tests/2497#live