### PR TITLE
Check rootless podman failures related and skip test

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -30,6 +30,7 @@ use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
+    $self->select_serial_terminal;
     my ($untested_images, $released_images) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
     my $runtime = "podman";
@@ -50,8 +51,8 @@ sub run {
     ensure_serialdev_permissions;
     select_console "user-console";
 
-    # smoke test
-    assert_script_run "$runtime images -a";
+    return if softfail_and_skip_on_bsc1182874();
+
     for my $iname (@{$released_images}) {
         test_container_image(image => $iname, runtime => $runtime);
         build_and_run_image(base => $iname, runtime => $runtime);
@@ -59,6 +60,14 @@ sub run {
         verify_userid_on_container($runtime, $iname, $subuid_start);
     }
     clean_container_host(runtime => $runtime);
+}
+
+sub softfail_and_skip_on_bsc1182874 {
+    if (script_run("podman run alpine", timeout => 120) != 0) {
+        record_soft_failure "bsc#1182874 - container fails to run in rootless mode";
+        return 1;
+    }
+    return 0;
 }
 
 sub get_user_subuid {


### PR DESCRIPTION
When podman encounter problem related to the rootless mode.
A single `podman image` will write a failure in the logs.
If this is found the test is skipped raising a soft_fail linked to
https://bugzilla.suse.com/show_bug.cgi?id=1182874

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/95003
- Verification run: http://aquarius.suse.cz/tests/6303#

check latest {
sle-15-SP1-Server-DVD-Updates-x86_64-Build20210702-1-engines_and_tools_podman@64bit -> https://openqa.suse.de/t6367858
sle-15-SP2-Server-DVD-Updates-x86_64-Build20210702-1-engines_and_tools_podman@64bit -> https://openqa.suse.de/t6367859
sle-15-SP3-Server-DVD-Updates-x86_64-Build20210702-1-engines_and_tools_podman@64bit -> https://openqa.suse.de/t6367860
opensuse-Tumbleweed-DVD-x86_64-Build20210701-extra_tests_textmode_podman_containers@64bit -> https://openqa.opensuse.org/t1818457
}