### PR TITLE
Fix YAML schedule for remote_ssh_controller and splitusr

### DIFF
--- a/schedule/yast/remote_ssh_controller.yaml
+++ b/schedule/yast/remote_ssh_controller.yaml
@@ -13,8 +13,7 @@ schedule:
  - installation/partitioning
  - installation/partitioning_finish
  - installation/installer_timezone
- - installation/authentication/use_same_password_for_root
- - installation/authentication/default_user_simple_pwd
+ - installation/user_settings
  - installation/installation_overview
  - installation/disable_grub_timeout
  - installation/start_install

--- a/schedule/yast/separate_usr_partition.yaml
+++ b/schedule/yast/separate_usr_partition.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/partitioning
   - installation/partitioning/separate_usr_partition
   - installation/installer_timezone
-  - installation/authentication/use_same_password_for_root
+  - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview


### PR DESCRIPTION
Fixes failures on opensuse that were introduced by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12831

- Verification runs: 
   - remote_ssh_controller: reverted the changes, so it should work as before. On remote machines we do not have libyui setup yet.
   - splitusr: https://openqa.opensuse.org/tests/1821233