### PR TITLE
Containers: poo#95042 podman build times out - increase it

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -64,10 +64,10 @@ sub build_and_run_image {
     assert_script_run("cd $dir");
     if (!$buildah) {
         # At least on publiccloud, this image pull can take long and occasinally fails due to network issues
-        assert_script_run("$runtime build -t myapp BuildTest", timeout => 300);
+        assert_script_run("$runtime build -t myapp BuildTest", timeout => 600);
         assert_script_run("$runtime images | grep myapp");
     } else {
-        assert_script_run("buildah bud -t myapp BuildTest", timeout => 300);
+        assert_script_run("buildah bud -t myapp BuildTest", timeout => 600);
         assert_script_run("buildah images | grep myapp");
     }
     assert_script_run("cd");


### PR DESCRIPTION
As we have Dockerfile which is installing apache2 it may take more than 5 minutes to build it.
This increases the timeout to 10 minutes which should be enough.

- Related ticket: [poo#95042](https://openqa.suse.de/tests/6367474#step/docker/267)