### PR TITLE
PublicCloud: increase timeout for upload_logs

### DIFF
--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -56,8 +56,8 @@ sub run {
     }
 
     assert_script_run("rpm -qa > /tmp/rpm.list.txt");
-    upload_logs('/tmp/rpm.list.txt');
-    upload_logs('/var/log/zypper.log');
+    upload_logs('/tmp/rpm.list.txt',   timeout => 180, failok => 1);
+    upload_logs('/var/log/zypper.log', timeout => 180, failok => 1);
 
     assert_script_run("SUSEConnect --status-text");
     zypper_call("lr -d");


### PR DESCRIPTION
We have some performance issues from time to time when uploading
logs in Public Cloud jobs. Although it might be an infra issue,
by increasing the default timeout, we might hit less of these
problems which prevents the test to go further in execution.

