### PR TITLE
Public Cloud: Increase timeout in transfer_repos and instance_overview

### DIFF
--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -59,7 +59,7 @@ sub run {
     upload_logs('/tmp/rpm.list.txt',   timeout => 180, failok => 1);
     upload_logs('/var/log/zypper.log', timeout => 180, failok => 1);
 
-    assert_script_run("SUSEConnect --status-text");
+    assert_script_run("SUSEConnect --status-text", 90);
     zypper_call("lr -d");
 }
 

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -32,7 +32,7 @@ sub run {
         record_info('Skip download', 'Skipping download triggered by setting (QAM_PUBLICCLOUD_SKIP_DOWNLOAD = 1)');
     } else {
         assert_script_run('du -sh ~/repos');
-        assert_script_run("rsync -uva -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
+        assert_script_run("rsync -uva -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 1800);
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");


### PR DESCRIPTION
As we run tests across different locations the transfer of maintenance updates may take longer.
Also the SUSEConnect command may take more than 30 seconds.

- Tricket: https://progress.opensuse.org/issues/95104
- Failure transfer_repos: https://openqa.suse.de/tests/6380175
- Failure instance_overview: https://openqa.suse.de/tests/6380239
