### PR TITLE
JeOS: move suse connect module before updating the system

### DIFF
--- a/schedule/jeos/sle/jeos-extratest.yaml
+++ b/schedule/jeos/sle/jeos-extratest.yaml
@@ -28,11 +28,11 @@ schedule:
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
-    - '{{maintenance}}'
     - jeos/grub2_gfxmode
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc
+    - '{{maintenance}}'
     - console/zypper_lr_validate
     - console/zypper_ref
     - console/validate_packages_and_patterns

--- a/schedule/jeos/sle/jeos-ltp.yaml
+++ b/schedule/jeos/sle/jeos-ltp.yaml
@@ -11,10 +11,10 @@ schedule:
   - jeos/record_machine_id
   - console/system_prepare
   - console/force_scheduled_tasks
-  - '{{maintenance}}'
   - jeos/grub2_gfxmode
   - jeos/diskusage
   - jeos/build_key
   - console/suseconnect_scc
+  - '{{maintenance}}'
   - console/consoletest_setup
   - kernel/install_ltp

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -31,12 +31,12 @@ schedule:
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
-    - '{{maintenance}}'
     - jeos/grub2_gfxmode
     - jeos/diskusage
     - jeos/build_key
     - console/prjconf_excluded_rpms
     - console/suseconnect_scc
+    - '{{maintenance}}'
     - '{{efi}}'
     - jeos/glibc_locale
     - console/check_network


### PR DESCRIPTION
We need to first register the system to get all the repositories
before we update the system.

- Related ticket: https://progress.opensuse.org/issues/95138
- VR: https://openqa.suse.de/tests/6383891
