### PR TITLE
Integrate audit test 'syscalls' into openQA

### DIFF
--- a/schedule/security/cc_syscalls.yaml
+++ b/schedule/security/cc_syscalls.yaml
@@ -1,0 +1,7 @@
+name: cc_syscalls
+description:    >
+    This is for audit_test syscalls
+schedule:
+    - boot/boot_to_desktop
+    - security/cc/cc_audit_test_setup
+    - security/cc/syscalls

--- a/tests/security/cc/cc_audit_test_setup.pm
+++ b/tests/security/cc/cc_audit_test_setup.pm
@@ -41,8 +41,13 @@ sub run {
     # Install audit packages
     zypper_call('in audit audit-audispd-plugins');
 
-    # Export MODE
-    assert_script_run("export MODE=$audit_test::mode");
+    # Workaround for restarting audit service
+    assert_script_run('sed -i \'/\[Unit\]/aStartLimitIntervalSec=0\' /usr/lib/systemd/system/auditd.service');
+    assert_script_run('systemctl daemon-reload');
+
+    # modify audit rules
+    assert_script_run('sed -i \'s/-a task,never/#&/\' /etc/audit/rules.d/audit.rules');
+    assert_script_run('systemctl restart auditd.service');
 
     # Download "audit-test"
     assert_script_run("wget --no-check-certificate $audit_test::code_repo -O ${dir}${file_tar}");

--- a/tests/security/cc/syscalls.pm
+++ b/tests/security/cc/syscalls.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'syscalls' test case of 'audit-test' test suite
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#94684
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+
+sub run {
+    my ($self) = shift;
+
+    select_console "root-console";
+
+    if (my $pprofile = get_var('PPROFILE')) {
+        assert_script_run("export PPROFILE=$pprofile");
+    }
+    # Run test case
+    run_testcase('syscalls', (make => 1, timeout => 720));
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('syscalls');
+    $self->result($result);
+}
+
+sub test_flags {
+    return {no_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Integrate CC audit test `syscalls` into openQA (only run on SLE)

Relate ticket: https://progress.opensuse.org/issues/94684

Verification run:
 https://openqa.suse.de/tests/6417560 (pass)
 https://openqa.suse.de/tests/6388752 (fail)
