### PR TITLE
Fix openSUSE Leap 15.3 Backports

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -298,7 +298,7 @@ sub replace_opensuse_repos_tests {
 sub is_updates_tests {
     my $flavor = get_required_var('FLAVOR');
     # Incidents might be also Incidents-Gnome or Incidents-Kernel
-    return $flavor =~ /-Updates$/ || $flavor =~ /-Incidents/;
+    return $flavor =~ /-Updates$/ || $flavor =~ /-Incidents/ || $flavor =~ /~Backports/;
 }
 
 sub is_updates_test_repo {


### PR DESCRIPTION
Add Backports flavor as a condition in function `is_updates_tests`, as all tests fail in Leap 15.3 Backports in `zypper_patch` module

- Related ticket: https://progress.opensuse.org/issues/94810
- Needles: N/A
- Verification run: pending
