### PR TITLE
x11/gnomecase/application_starts_on_login: Get out of activities view

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -173,6 +173,7 @@ sub run {
 
     handle_relogin;
     assert_screen "generic-desktop";
+    send_key('esc') if match_has_tag('gnome-activities');    # GNOME 40 logs in with activities opened
 
     # save session, available only for GNOME<3.34.2, see bsc#1158851
     if (is_sle('<15-sp2') || is_leap('<15.2')) {


### PR DESCRIPTION
The test logs out and in again, but leaves GNOME in activities view. That
confuses later tests.

The better solution would be https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12715#discussion_r660385332, but that might take a while so just address this particular failure for now.

- Related ticket: https://progress.opensuse.org/issues/93159
- Verification run: https://openqa.opensuse.org/tests/1831068
