### PR TITLE
x11/gnomecase/gnome_default_applications: Handle non SLE properly

### DIFF
--- a/tests/x11/gnomecase/gnome_default_applications.pm
+++ b/tests/x11/gnomecase/gnome_default_applications.pm
@@ -97,18 +97,18 @@ sub open_default_apps {
 sub check_default_apps {
     my @apps = @_;
 
-    my $default    = 1;
-    my $returnCode = 1;
-    my @message    = ();
+    my $default     = 1;
+    my $application = "";
+    my @message     = ();
     for my $app (@apps) {
         if (is_sle('<15')) {
-            $returnCode = script_run("[ '$app->[1]' == \$(gvfs-mime --query '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+            $application = script_output("gvfs-mime --query '$app->[0]' | awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//'");
         }
         else {
-            $returnCode = script_run("[ '$app->[1]' == \$(gio mime '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+            $application = script_output("gio mime '$app->[0]' | awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//'");
         }
-        if ($returnCode) {
-            push @message, "The mimetype $app->[0] should open with $app->[1]";
+        if ($application ne $app->[1]) {
+            push @message, "The mimetype $app->[0] should open with $app->[1], but opens with $application";
             $default = 0;
         }
     }

--- a/tests/x11/gnomecase/gnome_default_applications.pm
+++ b/tests/x11/gnomecase/gnome_default_applications.pm
@@ -101,11 +101,11 @@ sub check_default_apps {
     my $returnCode = 1;
     my @message    = ();
     for my $app (@apps) {
-        if (is_sle('15+')) {
-            $returnCode = script_run("[ '$app->[1]' == \$(gio mime '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+        if (is_sle('<15')) {
+            $returnCode = script_run("[ '$app->[1]' == \$(gvfs-mime --query '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
         }
         else {
-            $returnCode = script_run("[ '$app->[1]' == \$(gvfs-mime --query '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+            $returnCode = script_run("[ '$app->[1]' == \$(gio mime '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
         }
         if ($returnCode) {
             push @message, "The mimetype $app->[0] should open with $app->[1]";


### PR DESCRIPTION
Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12858.

openSUSE doesn't match "is_sle('15+')", so ended up in the wrong case.
Fix this by explicitly checking for SLE < 15 instead.

Even though all calls to `gvfs-mime` failed, it only softfailed, which is not ideal.

I added another commit which allows showing of the actual value as opposed to just the expected one.

Verification run: https://openqa.opensuse.org/tests/1831134