### PR TITLE
Change toolchain lifecycle, gcc9 is EOS

### DIFF
--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -29,7 +29,7 @@ sub run {
         gcc6  => 'Now',
         gcc7  => 'Now',
         gcc8  => 'Now',
-        gcc9  => '2021-05',
+        gcc9  => 'Now',
         gcc10 => '2024-10',
     );
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/93186
- Verification run: https://openqa.suse.de/tests/6397356