### PR TITLE
console/steamcmd: Work around steam download bug

### DIFF
--- a/tests/console/steamcmd.pm
+++ b/tests/console/steamcmd.pm
@@ -26,6 +26,11 @@ sub run {
     # see https://github.com/ValveSoftware/steam-for-linux/issues/4341
     my $allow_exit_codes = [qw(0 6 7 8)];
     my $ret = script_run '/usr/bin/steamcmd +login anonymous +app_update 90 validate +quit', 1200;
+    if ($ret == 8) {
+        # Steam bug: HL needs multiple download attempts:
+        # https://developer.valvesoftware.com/wiki/SteamCMD#Downloading_an_app
+        $ret = script_run '/usr/bin/steamcmd +login anonymous +app_update 90 validate +quit', 1200;
+    }
     die "'steamcmd' failed with exit code $ret" unless (grep { $_ == $ret } @$allow_exit_codes);
     assert_script_run 'test -f Steam/steamapps/common/Half-Life/hlds_run';
 }


### PR DESCRIPTION
It's documented that Half-Life needs multiple download attempts until it's
complete.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1187019
- Verification run: https://openqa.opensuse.org/tests/1831189