### PR TITLE
MicroOS: add k3s CLI test for openSUSE MicroOS

### DIFF
--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -47,6 +47,7 @@ sub load_tdup_tests {
 
 sub load_feature_tests {
     # Feature tests for Micro OS operating system
+    loadtest 'containers/k3s_cli_check' if get_required_var('FLAVOR') =~ /-k3s/;
     loadtest 'microos/libzypp_config';
     loadtest 'microos/image_checks' if is_image_flavor;
     loadtest 'microos/one_line_checks';


### PR DESCRIPTION
VR: https://openqa.opensuse.org/tests/1831267 with expected bug [bsc#1187540](https://bugzilla.suse.com/show_bug.cgi?id=1187540)