### PR TITLE
Re-schedule pidgin tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2032,31 +2032,6 @@ sub load_x11_webbrowser {
     }
 }
 
-sub load_x11_message {
-    if (check_var("DESKTOP", "gnome")) {
-        loadtest "x11/empathy/empathy_irc"       if is_sle("<15");
-        loadtest "x11/evolution/evolution_smoke" if is_sle || is_tumbleweed;
-        loadtest "x11/evolution/evolution_prepare_servers";
-        if (is_sle || is_tumbleweed) {
-            loadtest "x11/evolution/evolution_mail_imap";
-            loadtest "x11/evolution/evolution_mail_pop";
-            loadtest "x11/evolution/evolution_timezone_setup";
-            loadtest "x11/evolution/evolution_meeting_imap";
-            loadtest "x11/evolution/evolution_meeting_pop";
-        }
-        if (!is_pre_15 && (!is_server() || we_is_applicable())) {
-            loadtest "x11/thunderbird/thunderbird_install";
-            loadtest "x11/thunderbird/thunderbird_imap";
-            loadtest "x11/thunderbird/thunderbird_pop";
-        }
-        loadtest "x11/groupwise/groupwise" if is_sle || is_tumbleweed;
-    }
-    if (get_var("DESKTOP") =~ /kde|gnome/ && is_tumbleweed) {
-        loadtest "x11/pidgin/prep_pidgin";
-        loadtest "x11/pidgin/pidgin_IRC";
-        loadtest "x11/pidgin/clean_pidgin";
-    }
-}
 
 sub load_x11_remote {
     # load onetime vncsession testing
@@ -2126,11 +2101,6 @@ sub load_common_x11 {
         loadtest "boot/boot_to_desktop";
         loadtest "x11/window_system";
         load_x11_webbrowser();
-    }
-    elsif (check_var("REGRESSION", "message")) {
-        loadtest "boot/boot_to_desktop";
-        loadtest "x11/window_system";
-        load_x11_message();
     }
     elsif (check_var('REGRESSION', 'remote')) {
         if (check_var("REMOTE_DESKTOP_TYPE", "win_client") || check_var('REMOTE_DESKTOP_TYPE', "win_server")) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1133,15 +1133,6 @@ else {
             loadtest 'network/config_services';
             loadtest 'support_server/wait_children';
         }
-        else {
-            loadtest 'x11/window_system';
-            loadtest 'x11/evolution/evolution_smoke';
-            loadtest 'x11/evolution/evolution_mail_imap';
-            loadtest 'x11/evolution/evolution_mail_pop';
-            loadtest 'x11/evolution/evolution_timezone_setup';
-            loadtest 'x11/evolution/evolution_meeting_imap';
-            loadtest 'x11/evolution/evolution_meeting_pop';
-        }
     }
     elsif (get_var('UPGRADE_ON_ZVM')) {
         # Set origin and target version

--- a/schedule/functional/message.yaml
+++ b/schedule/functional/message.yaml
@@ -1,0 +1,35 @@
+---
+name: message
+description: >
+    Maintainer: zluo
+    desktop message test modules, can be used by qam regression,
+    sled desktop and openSUSE
+conditional_schedule:
+    opensuse_tests:
+        DISTRI:
+            opensuse:
+                - x11/empathy/empathy_irc
+                - x11/pidgin/pidgin_IRC
+                - x11/pidgin/clean_pidgin
+    sle_tests:
+        DISTRI:
+            sle:
+                - x11/evolution/evolution_smoke
+                - x11/evolution/evolution_prepare_servers
+                - x11/evolution/evolution_mail_imap
+                - x11/evolution/evolution_mail_pop
+                - x11/evolution/evolution_timezone_setup
+                - x11/evolution/evolution_meeting_imap
+                - x11/evolution/evolution_meeting_pop
+                - x11/thunderbird/thunderbird_install
+                - x11/thunderbird/thunderbird_imap
+                - x11/thunderbird/thunderbird_pop
+                - x11/groupwise/groupwise
+                - x11/pidgin/prep_pidgin
+                - x11/pidgin/pidgin_IRC
+                - x11/pidgin/clean_pidgin
+schedule:
+    - boot/boot_to_desktop
+    - x11/window_system
+    - '{{sle_tests}}'
+    - '{{opensuse_tests}}'

--- a/tests/x11/pidgin/pidgin_IRC.pm
+++ b/tests/x11/pidgin/pidgin_IRC.pm
@@ -27,8 +27,9 @@ use testapi;
 use version_utils qw(is_sle is_tumbleweed);
 
 sub run {
-    my ($self) = @_;
+    my ($self)      = @_;
     my $CHANNELNAME = "susetesting";
+    my $SERVERNAME  = "irc.libera.chat";
     x11_start_program('pidgin');
 
     # Focus the welcome window in SLE15
@@ -47,6 +48,9 @@ sub run {
     send_key "alt-u";
     wait_still_screen 2;
     type_string "$CHANNELNAME";
+    wait_still_screen 2;
+    send_key "alt-s";
+    type_string "$SERVERNAME";
     wait_still_screen 2;
     send_key "alt-a";
 


### PR DESCRIPTION
fix pidgin-IRC and schedule it with message tests together by yaml schedule
see https://progress.opensuse.org/issues/94441
verifications:
http://10.160.64.152/tests/3322 (qam-regression-message)
http://10.160.64.152/tests/3329 (wayland-desktopapps-message)
http://10.160.64.152/tests/3330 (x11-desktopapps-message)