### PR TITLE
SLE Micro: add module to disable grub timeout

### DIFF
--- a/schedule/sle-micro/containers.yaml
+++ b/schedule/sle-micro/containers.yaml
@@ -13,6 +13,7 @@ conditional_schedule:
         - transactional/install_updates
 schedule:
   - microos/disk_boot
+  - transactional/disable_grub
   - '{{registration}}'
   - '{{maintenance}}'
   - microos/toolbox


### PR DESCRIPTION
For some reason, this module wasn't executed for containers schedule,
it should follow the same as the image schedule.

VR: https://openqa.suse.de/tests/6399589
