### PR TITLE
Fix hanging run_ltp when instance restarts

### DIFF
--- a/data/publiccloud/restart_instance.sh
+++ b/data/publiccloud/restart_instance.sh
@@ -66,5 +66,8 @@ esac
 wait_for_power_off "$HOST" "$CNT"
 wait_for_power_on "$HOST" "$CNT"
 echo "Instance $INSTANCE_ID restarted";
-test -x $LOG_SCRIPT && $LOG_SCRIPT start "$PROVIDER" "$INSTANCE_ID" "$HOST" "$ZONE"
+## Not needed, because the log_instance.sh does not depend on the running instance
+## Leaving it here in case we need to revert it. If no issues arise, this can be
+## removed after some time.
+#test -x $LOG_SCRIPT && $LOG_SCRIPT start "$PROVIDER" "$INSTANCE_ID" "$HOST" "$ZONE"
 


### PR DESCRIPTION
Fixes the issue, that `runltp` freezes on an instance reboot.

The reason is that the restart script forks a helper script for getting the logs, which keeps looping in the
background and perl waits for it to terminate. The helper-script (`log_instance.sh`) is executed in the `run_ltp` test and not needed in the `restart_instance.sh` script. Consequently it appears safe to remove it from there. Removing this line fixes the "hang on reboot" issue.

- Related ticket: https://progress.opensuse.org/issues/94141
- Verification run: 
[15-SP2 Azure-BYOS ltp-syscalls](http://duck-norris.qam.suse.de/t6768) (ltp runs fine, other ltp failures unrelated to this PR)
[15-SP2 Azure-Basic ltp-cve](http://duck-norris.qam.suse.de/t6755)
[15-SP2 EC2-ARM-Updates ltp-syscalls](http://duck-norris.qam.suse.de/t6756)
[15-SP2 EC2 ltp-cve](http://duck-norris.qam.suse.de/t6757)
[15-SP2 GCE ltp-cve](http://duck-norris.qam.suse.de/t6769)
[12-SP5-Azure-Basic ltp-cve](http://duck-norris.qam.suse.de/t6759)
[12-SP5 Azure-Standard ltp-syscalls](http://duck-norris.qam.suse.de/t6760)
[12-SP5 EC2-BYOS ltp-cve](http://duck-norris.qam.suse.de/t6761)
[12-SP5 EC2-Updates ltp-syscalls](http://duck-norris.qam.suse.de/t6762)
[12-SP5 GCE-BYOS ltp-syscalls](http://duck-norris.qam.suse.de/t6763)
[12-SP5 GCE ltp-cve](http://duck-norris.qam.suse.de/t6764)

`openqa-mon -mfbc 2 http://duck-norris.qam.suse.de/tests/6754..6764`