### PR TITLE
SLE Micro: install updates before enabling SELinux

### DIFF
--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -23,8 +23,8 @@ schedule:
   - microos/disk_boot
   - transactional/disable_grub
   - '{{registration}}'
-  - '{{selinux}}'
   - '{{maintenance}}'
+  - '{{selinux}}'
   - '{{k3s}}'
   - microos/networking
   - microos/libzypp_config


### PR DESCRIPTION
There is a bug that we will always hit if we enable SELinux before we install updates, where there is an update that contains
a fix for such bug.

VR: https://openqa.suse.de/tests/6400407 (see previous runs for the error)
