### PR TITLE
microos/journal_check: Handle TW Stagings as Tumbleweed

### DIFF
--- a/tests/microos/journal_check.pm
+++ b/tests/microos/journal_check.pm
@@ -24,6 +24,9 @@ sub parse_bug_refs {
     my $tested_version = get_required_var('VERSION');
     my %bp;
 
+    # Treat staging projects like the full product
+    $tested_version = 'Tumbleweed' if (is_opensuse && $tested_version =~ /^Staging:/);
+
     my $data;
     {
         open(my $fh_json, '<', $bug_file) or die "Can't open \"$bug_file\": $!\n";


### PR DESCRIPTION
The staging projects are effectively Tumbleweed as well, so just treat it the
same.

Failure: https://openqa.opensuse.org/tests/1832567#step/journal_check/20
Verification run: https://openqa.opensuse.org/tests/1832635