### PR TITLE
Move microos/journal_check to console/journal_check

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -572,7 +572,7 @@ sub load_jeos_tests {
         loadtest "jeos/build_key";
         loadtest "console/prjconf_excluded_rpms";
     }
-    loadtest "microos/journal_check";
+    loadtest "console/journal_check";
     loadtest "microos/libzypp_config";
     if (is_sle) {
         loadtest "console/suseconnect_scc";

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -54,7 +54,7 @@ sub load_feature_tests {
     loadtest 'microos/services_enabled';
     load_transactional_role_tests;
     loadtest 'microos/cockpit_service' unless is_staging;
-    loadtest 'microos/journal_check';
+    loadtest 'console/journal_check';
     if (check_var 'SYSTEM_ROLE', 'kubeadm') {
         loadtest 'console/kubeadm';
     }

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -35,7 +35,7 @@ schedule:
     - jeos/diskusage
     - jeos/build_key
     - console/prjconf_excluded_rpms
-    - microos/journal_check
+    - console/journal_check
     - microos/libzypp_config
     - console/suseconnect_scc
     - '{{maintenance}}'

--- a/schedule/sle-micro/autoyast.yaml
+++ b/schedule/sle-micro/autoyast.yaml
@@ -25,5 +25,5 @@ schedule:
   - transactional/transactional_update
   - transactional/rebootmgr
   - transactional/health_check
-  - microos/journal_check
+  - console/journal_check
   - shutdown/shutdown

--- a/schedule/sle-micro/dvd.yaml
+++ b/schedule/sle-micro/dvd.yaml
@@ -46,5 +46,5 @@ schedule:
   - transactional/transactional_update
   - transactional/rebootmgr
   - transactional/health_check
-  - microos/journal_check
+  - console/journal_check
   - shutdown/shutdown

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -36,5 +36,5 @@ schedule:
   - transactional/transactional_update
   - transactional/rebootmgr
   - transactional/health_check
-  - microos/journal_check
+  - console/journal_check
   - shutdown/shutdown

--- a/schedule/sle-micro/remote_ssh_target.yaml
+++ b/schedule/sle-micro/remote_ssh_target.yaml
@@ -14,5 +14,5 @@ schedule:
   - microos/libzypp_config
   - microos/one_line_checks
   - microos/services_enabled
-  - microos/journal_check
+  - console/journal_check
   - shutdown/shutdown

--- a/tests/console/journal_check.pm
+++ b/tests/console/journal_check.pm
@@ -7,14 +7,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Basic MicroOS journal tests
+# Summary: Basic journal tests
 # Maintainer: qa-c team <qa-c@suse.de>
 
 use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use microos;
 use version_utils 'is_opensuse';
 use Mojo::JSON qw(decode_json);
 


### PR DESCRIPTION
It's no longer MicroOS specific and also used outside of MicroOS.

Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12869

Verification run: https://openqa.opensuse.org/tests/1832636