### PR TITLE
Skip 'onlyRequires' and 'excludedocs' checks for community JeOS

### DIFF
--- a/tests/microos/libzypp_config.pm
+++ b/tests/microos/libzypp_config.pm
@@ -18,8 +18,10 @@ use testapi;
 use version_utils qw(is_jeos);
 
 sub run {
-    assert_script_run 'egrep -x "^solver.onlyRequires ?= ?true" /etc/zypp/zypp.conf';
-    assert_script_run 'egrep -x "^rpm.install.excludedocs ?= ?yes" /etc/zypp/zypp.conf';
+    unless (check_var('FLAVOR', 'JeOS-for-AArch64') || check_var('FLAVOR', 'JeOS-for-RPi')) {
+        assert_script_run 'egrep -x "^solver.onlyRequires ?= ?true" /etc/zypp/zypp.conf';
+        assert_script_run 'egrep -x "^rpm.install.excludedocs ?= ?yes" /etc/zypp/zypp.conf';
+    }
     assert_script_run sprintf('egrep -x "^multiversion ?=%s" /etc/zypp/zypp.conf', is_jeos ? ' ?provides:multiversion\(kernel\)' : '');
 }
 


### PR DESCRIPTION
- failure in [opensuse-15.3-JeOS-for-AArch64-aarch64-Build9.126-jeos-filesystem@USBboot_aarch64](https://openqa.opensuse.org/tests/1832686#step/libzypp_config/5)

There are only 3 differences from the default state `solver.dupAllowVendorChange, multiversion, multiversion.kernels`
and only multiversion check is being implemented as of now.

- VRs:
  * [opensuse-15.3-JeOS-for-AArch64-aarch64](https://openqa.opensuse.org/tests/1832741#step/libzypp_config/3)
  * [opensuse-15.3-JeOS-for-RPi-aarch64](https://openqa.opensuse.org/tests/1832751#step/libzypp_config/3)