### PR TITLE
Update bugref file for kubic and community JeOS testing

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -7,6 +7,37 @@
         },
         "type": "bug"
     },
+    "gh#OSInside/kiwi#1867": {
+        "description": "Failed to find module 'br_netfilter'",
+        "products": {
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "bug"
+    },
+    "bsc#1186742": {
+        "description": "Directory '.*.hdmi' with parent 'vc4-hdmi.*' already present",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["15.3"]
+        },
+        "type": "bug"
+    },
+    "bsc#1188237": {
+        "description": "kevent 4 may have been dropped",
+        "products": {
+            "opensuse": ["15.3"]
+        },
+        "type": "bug"
+    },
+    "bsc#1188238": {
+        "description": "BCM: Reset failed \\(-110\\)|hci0: command .* tx timeout",
+        "products": {
+            "opensuse": ["15.3"]
+        },
+        "type": "bug"
+    },
     "bsc#1022527": {
         "description": ".*wickedd.*ni_process_reap.*blocking waitpid.*",
         "products": {
@@ -25,10 +56,11 @@
         },
         "type": "bug"
     },
-    "bsc#1022525": {
+    "bsc#1022525|bsc#1177461": {
         "description": ".*rpcbind.*cannot(.*open file.*rpcbind.xdr.*|.*open file.*portmap.xdr.*|.*save any registration.*)",
         "products": {
-            "sle-micro": [ "5.0", "5.1" ]
+            "sle-micro": [ "5.0", "5.1" ],
+            "microos":  ["Tumbleweed"]
         },
         "type": "bug"
     },
@@ -187,6 +219,16 @@
     },
     "chrony": {
         "description": "chronyd.*Received KoD RATE from|System clock wrong by.*, adjustment started|System clock was stepped by.*",
+        "products": {
+            "sle-micro": [ "5.0", "5.1" ],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"],
+            "microos":  ["Tumbleweed"],
+            "sle": ["15-SP2", "15-SP3"]
+        },
+        "type": "ignore"
+    },
+    "ssh-connection-close-by-remote": {
+        "description": "error: kex_exchange_identification: Connection closed by remote host",
         "products": {
             "sle-micro": [ "5.0", "5.1" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],


### PR DESCRIPTION
- [[qac][jeos] test fails in journal_check: SSH errors in RPi generalhw testing](https://progress.opensuse.org/issues/95284)
- VRs:
  * [microos-Tumbleweed-MicroOS-Image-Kubic-kubeadm-x86_64-Build20210707-kubeadm@64bit-2G](http://kepler.suse.cz/tests/5904#)
  * [opensuse-15.3-JeOS-for-RPi-aarch64](https://openqa.opensuse.org/tests/1833323#step/journal_check/9)
  * [opensuse-15.3-JeOS-for-RPi-aarch64](https://openqa.opensuse.org/tests/1833322)