### PR TITLE
Increase timeout for guest updates

### DIFF
--- a/tests/virtualization/universal/upgrade_guests.pm
+++ b/tests/virtualization/universal/upgrade_guests.pm
@@ -33,7 +33,7 @@ sub run {
         # Try update three times - this sometimes helps to prevent failures due to infrastructure problems
         assert_script_run("ssh root\@$guest 'zypper ref; (zypper -n dup || zypper -n dup || zypper -n dup)' </dev/null >/root/update_guests/$guest.txt 2>&1 & true");
     }
-    assert_script_run("wait", timeout => 1200);    # this can take some time, but wait at most 20 minutes
+    assert_script_run("wait", timeout => 2400);    # this can take some time (max 40 minutes)
 
     # Make sure there are no phantom zypper processes present anymore
     script_retry("! ssh root\@$_ ps | grep zypper", delay => 5, retry => 60) foreach (keys %virt_autotest::common::guests);


### PR DESCRIPTION
Increasing the timeout for the guest updates becomes necessary after
including 15-SP3 guests as well.

- Verification run: [15-SP3 KVM](http://openqa.qam.suse.cz/t24683) | [15-SP3 XEN](http://openqa.qam.suse.cz/t24710) | [15-SP2 KVM](http://openqa.qam.suse.cz/t24725) | [15-SP2 XEN](http://openqa.qam.suse.cz/t24794)