### PR TITLE
Add kdump_and_crash module to the regression test for migration

### DIFF
--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -94,6 +94,7 @@ conditional_schedule:
         - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
+        - console/kdump_and_crash
         - console/consoletest_finish
       2:
         - console/supportutils

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -78,6 +78,7 @@ conditional_schedule:
         - console/ssh_cleanup
         - console/mtab
         - console/orphaned_packages_check
+        - console/kdump_and_crash
         - console/consoletest_finish
       2:
         - console/supportutils

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -92,6 +92,7 @@ conditional_schedule:
         - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
+        - console/kdump_and_crash
         - console/consoletest_finish
       2:
         - console/supportutils

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -84,6 +84,7 @@ conditional_schedule:
         - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
+        - console/kdump_and_crash
         - console/consoletest_finish
       2:
         - console/supportutils

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -79,6 +79,7 @@ conditional_schedule:
         - console/ssh_cleanup
         - console/mtab
         - console/orphaned_packages_check
+        - console/kdump_and_crash
         - console/consoletest_finish
       2:
         - console/supportutils

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -72,6 +72,7 @@ conditional_schedule:
         - console/ssh_cleanup
         - console/mtab
         - console/orphaned_packages_check
+        - console/kdump_and_crash
         - console/consoletest_finish
       2:
         - console/check_upgraded_service

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -89,6 +89,7 @@ conditional_schedule:
         - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
+        - console/kdump_and_crash
         - console/consoletest_finish
 
       2:

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -78,6 +78,7 @@ conditional_schedule:
         - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
+        - console/kdump_and_crash
         - console/consoletest_finish
 
       2:


### PR DESCRIPTION
We'd add kdump_and_crash module to the regression for more test
coverage after the migration.

 
- Related ticket: https://progress.opensuse.org/issues/93492
- Needles: N/A
- Verification run:  
                             https://openqa.nue.suse.com/tests/6424949 
                             https://openqa.nue.suse.com/tests/6425070 
                             https://openqa.nue.suse.com/tests/6426390
                             https://openqa.nue.suse.com/tests/6443199