### PR TITLE
Make handle_login to take care of reaching the desktop

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -223,6 +223,9 @@ sub handle_login {
     assert_screen 'displaymanager-password-prompt';
     type_password;
     send_key 'ret';
+    assert_screen([qw(generic-desktop gnome-activities opensuse-welcome)], 60);
+    send_key('esc') if match_has_tag('gnome-activities');
+    assert_screen('generic-desktop') unless match_has_tag('generic-desktop');
 }
 
 =head2 handle_logout

--- a/tests/rt/boot_rt_kernel.pm
+++ b/tests/rt/boot_rt_kernel.pm
@@ -21,9 +21,6 @@ sub run() {
     boot_grub_item(2, 3);
     assert_screen 'displaymanager', 60;
     handle_login;
-    assert_screen 'generic-desktop';
 }
 
 1;
-
-# vim: set sw=4 et:

--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -172,8 +172,6 @@ sub run {
     assert_screen "generic-desktop";
 
     handle_relogin;
-    assert_screen "generic-desktop";
-    send_key('esc') if match_has_tag('gnome-activities');    # GNOME 40 logs in with activities opened
 
     # save session, available only for GNOME<3.34.2, see bsc#1158851
     if (is_sle('<15-sp2') || is_leap('<15.2')) {

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -76,8 +76,6 @@ sub run {
     wait_still_screen;
     handle_login($user, 1);
     handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
-    assert_screen 'generic-desktop', 60;
-    send_key 'esc' if match_has_tag('gnome-activities');
     # verify correct user is logged in
     x11_start_program('xterm');
     wait_still_screen;

--- a/tests/x11/remote_desktop/onetime_vncsession_multilogin_failed.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_multilogin_failed.pm
@@ -54,7 +54,6 @@ sub run {
     # Setup the first remote connection and minimize the vncviewer
     $self->start_vncviewer;
     handle_login;
-    assert_screen 'generic-desktop';
     send_key 'f8';
     assert_screen 'vncviewer-menu';
     send_key 'z';

--- a/tests/x11/remote_desktop/onetime_vncsession_xvnc_remmina.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_xvnc_remmina.pm
@@ -71,7 +71,6 @@ sub run {
     # Enter the full screen mode
     send_key 'z-f';
     handle_login;
-    assert_screen 'generic-desktop';
 
     # Disconnect with the remote server
     send_key 'z-f4';

--- a/tests/x11/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
@@ -51,7 +51,6 @@ sub run {
     wait_still_screen 3;
     send_key 'ret';
     handle_login;
-    assert_screen 'generic-desktop';
 
     # Launch gnome-terminal and nautilus remotely
     x11_start_program('gnome-terminal');

--- a/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
@@ -69,7 +69,6 @@ sub run {
     # First time login and configure the visibility
     $self->start_vncviewer;
     handle_login;
-    assert_screen 'generic-desktop';
     # Hold Alt key inside the vncviewer
     send_key 'f8';
     assert_screen 'vncviewer-menu';

--- a/tests/x11/start_wayland_plasma5.pm
+++ b/tests/x11/start_wayland_plasma5.pm
@@ -44,7 +44,6 @@ sub run {
     assert_and_click 'sddm_session_plasma_wayland';    # Select Plasma 5 (Wayland) session
 
     handle_login;
-    assert_screen 'generic-desktop', 60;
 
     # We're now in a wayland session, which is in a different VT
     x11_start_program('xterm');

--- a/tests/x11/user_gui_login.pm
+++ b/tests/x11/user_gui_login.pm
@@ -18,8 +18,6 @@ use x11utils 'handle_relogin';
 
 sub run {
     handle_relogin;
-    assert_screen 'generic-desktop', 90;    # x11test is checking generic-desktop in post_run_hook but after login it can take longer than 30 sec
-    send_key('esc') if match_has_tag('gnome-activities');    # GNOME 40 logs in with activities opened
 }
 
 1;


### PR DESCRIPTION
Extract the code of reaching the desktop into handle_login
Handle welcome screen in handle_login including gnome 40 activities
Remove the codes that handle assert_screen 'generic-desktop' and
gnome40 activities in specific test cases

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/738
- Verification run: 
- Test suites contain cases that invoke wait_boot_past_bootloader, handle_login and handle_relogin are verified.
- create_hdd_gnome-wayland (contains first_boot which invokes wait_boot_past_bootloader ) on TW https://openqa.opensuse.org/tests/1838019

- kde-wayland@64bit_virtio (contains first_boot which invokes wait_boot_past_bootloader and start_wayland_plasma5 which invokes handle_login) on TW https://openqa.opensuse.org/tests/1838021

- extra_tests_gome (contains multi_users_dm which invokes handle_login and vino_screensharing_available which contains handle_relogin) on TW https://openqa.opensuse.org/tests/1838016

- gnome-x11-ibus (contails ibus_installation which invokes handle_relogin) on TW  https://openqa.opensuse.org/tests/1838017

- desktopapps-gnome (contains application_starts_on_login which invokes handle_relogin) on TW: https://openqa.opensuse.org/tests/1838018
on SLE: https://openqa.suse.de/tests/6424500

- desktopapps-remote-client1 (contains onetime_vncsession_xvnc_remmina, onetime_vncsession_multilogin_failed and onetime_vncsession_xvnc_tigervnc which invokes handle_login) on SLE: https://openqa.suse.de/tests/6424524

- desktopapps-remote-client2 (contains persistent_vncsession_xvnc which invokes handle_login) on SLE: https://openqa.suse.de/tests/6424930

- test case user_gui_login only contais handle_relogin, so no verification run provided.
- test case boot_rt_kernel contains handle_login but no verification run provided.
