### PR TITLE
Unschedule zypper_lr_validate from SLE15+ runs

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1556,7 +1556,7 @@ sub load_extra_tests_desktop {
 sub load_extra_tests_zypper {
     # Add non-oss and debug repos for o3 and remove other by default (skipped, if already done)
     replace_opensuse_repos_tests if is_repo_replacement_required;
-    loadtest "console/zypper_lr_validate";
+    loadtest "console/zypper_lr_validate" unless is_sle '15+';
     loadtest "console/zypper_ref";
     unless (is_jeos) {
         loadtest "console/zypper_info";


### PR DESCRIPTION
Unschedule the module from SLE15+ runs, till it is adapted for these SLE versions.

- Related ticket: https://progress.opensuse.org/issues/66451
- Needles: N/A
- Verification run: [SLE15SP3](http://10.161.229.247/tests/2099)
