### PR TITLE
Handle os-prober yast warning and install package

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -129,6 +129,12 @@ sub handle_warning_not_supported {
     }
 }
 
+sub handle_warning_install_os_prober {
+    send_key('alt-i');
+    wait_still_screen;
+    wait_screen_change { send_key 'alt-n' };
+}
+
 # use yast2 kdump to enable the kdump service
 sub activate_kdump {
     # restart info will appear only when change has been done
@@ -171,7 +177,11 @@ sub activate_kdump {
     }
     send_key('alt-o');
     if ($expect_restart_info == 1) {
-        assert_screen('yast2-kdump-restart-info', 200);
+        my @tags = qw(yast2-kdump-restart-info os-prober-warning);
+        do {
+            assert_screen(\@tags);
+            handle_warning_install_os_prober() if match_has_tag('os-prober-warning');
+        } until (match_has_tag('yast2-kdump-restart-info'));
         send_key('alt-o');
     }
     wait_serial("$module_name-0", 240) || die "'yast2 kdump' didn't finish";


### PR DESCRIPTION
`kdump_and_crash` modules fails as the yast warns that `os-prober`
needs to be installed. handle this using needling and continue with installation.


- Related ticket: https://progress.opensuse.org/issues/95326
- Needles: grub2-TW-virtio-20210713 kdump_and_crash-os-prober-warning-20210713
- Verification run: https://openqa.opensuse.org/tests/overview?version=Tumbleweed&distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2312885
