### PR TITLE
Do not uninstall multipath-tools during livepatch installation

### DIFF
--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -24,7 +24,8 @@ sub remove_kernel_packages {
         push @packages, qw(kernel-xen kernel-xen-devel);
     }
 
-    push @packages, "multipath-tools" if is_sle('>=15-SP3');
+    push @packages, "multipath-tools"
+      if is_sle('>=15-SP3') and !get_var('KGRAFT');
     zypper_call('-n rm ' . join(' ', @packages), exitcode => [0, 104]);
 
     return @packages;


### PR DESCRIPTION
multipath-tools should be uninstalled only when switching to an alternative kernel package. In livepatch tests, the installer will try to install it back with the wrong package version number.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-15SP3 ppc64le: https://openqa.suse.de/tests/6445339
  - SLE-15SP3 s390x: https://openqa.suse.de/tests/6446690
