### PR TITLE
Integrate 'audit_trail_protection' into openQA

### DIFF
--- a/schedule/security/cc_audit_trail_protection.yaml
+++ b/schedule/security/cc_audit_trail_protection.yaml
@@ -1,0 +1,7 @@
+name: cc_audit_trail_protection
+description:    >
+    This is for audit_test audit-trail-protection
+schedule:
+    - boot/boot_to_desktop
+    - security/cc/cc_audit_test_setup
+    - security/cc/audit_trail_protection

--- a/tests/security/cc/audit_trail_protection.pm
+++ b/tests/security/cc/audit_trail_protection.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'audit-trail-protection' test case of 'audit-test' test suite
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#94447
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    run_testcase('audit-trail-protection', (make => 1));
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('audit_trail_protection');
+    $self->result($result);
+}
+
+1;


### PR DESCRIPTION
In CC test plan, we need to integrate test cases of `audit-test` into
openQA. `audit-trail-protection` is one of these test cases.

Related: https://progress.opensuse.org/issues/94447

Verify run: https://openqa.suse.de/tests/6455141#