### PR TITLE
security/apparmor_profile/usr_sbin_smbd: Workaround tab handling bug

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -107,7 +107,7 @@ sub samba_client_access {
 
     # Connect to samba server
     assert_and_click("nautilus-other-locations");
-    send_key_until_needlematch("nautilus-connect-to-server", 'tab', 10, 2);
+    send_key_until_needlematch("nautilus-connect-to-server", 'tab', 20, 2);
     type_string("smb://$ip");
     send_key "ret";
     wait_still_screen(2);


### PR DESCRIPTION
Apparently in Nautilus 3.34, the tab order starts from the beginning
instead of the focused button.

- Verification run: http://10.160.67.86/tests/1019