### PR TITLE
Increase reconnect_mgmt_console timeout for ay installation

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -330,7 +330,7 @@ sub run {
 
     # Cannot verify second stage properly on s390x, so reconnect to already installed system
     if (check_var('ARCH', 's390x')) {
-        reconnect_mgmt_console(timeout => 500, grub_timeout => 180);
+        reconnect_mgmt_console(timeout => 700, grub_timeout => 180);
         return;
     }
     # For powerVM need to switch to mgmt console to handle the reboot properly


### PR DESCRIPTION
autoyast_reinstall fails often for s390x, due to reconnection taking too long.

VRs: https://openqa.suse.de/tests/6455416#next_previous