### PR TITLE
Remove SF "Error waiting for loop object"

### DIFF
--- a/tests/console/udisks2.pm
+++ b/tests/console/udisks2.pm
@@ -62,9 +62,7 @@ sub run {
     assert_script_run "mkisofs -o udisk_test.iso udisk_test/";
     my $udloop_output = script_output("udisksctl loop-setup -r -f udisk_test.iso 2>&1", proceed_on_failure => 1);
 
-    if ($udloop_output =~ /^Error\ssetting\sup\sloop\sdevice.*Timed\sout\swaiting\sfor\sobject$/) {
-        record_soft_failure "boo#1177419  [Build 20201003] udisks2ctl randomly fails to set up loop device for /root/udisk_test.iso";
-    } elsif ($udloop_output =~ "Mapped") {
+    if ($udloop_output =~ "Mapped") {
         assert_script_run "losetup -j /root/udisk_test.iso | grep loop";
     } else {
         die "Missing mapping info. Expected: Mapped value \nGot: /$udloop_output/";


### PR DESCRIPTION
- [[qac][JeOS] softfail udisksctl times out while configuring loop device](https://progress.opensuse.org/issues/73087)
- [closed report](https://bugzilla.opensuse.org/show_bug.cgi?id=1177419)

