### PR TITLE
bootloader setup: Fix kernel parameters position for Tumbleweed

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -351,7 +351,11 @@ sub uefi_bootmenu_params {
         assert_screen "gfxpayload_changed", 10;
         # back to the entry position
         send_key "home";
-        for (1 .. 10) { send_key "down"; }
+        for (1 .. 6) { send_key "down"; }
+        # On Leap/SLE we need to move down (grub 2.04)
+        if (is_sle('<16') || is_leap('<16')) {
+            for (1 .. 4) { send_key "down"; }
+        }
     }
     else {
         if (is_microos && get_var('BOOT_HDD_IMAGE')) {


### PR DESCRIPTION
With latest Tumbleweed (due to update of grub to 2.06?), lines in grub menu have been modified, so we need to adjust the number of times we go 'down' before writing kernel args.
- Verification run: <s>https://openqa.opensuse.org/t1842140</s> https://openqa.opensuse.org/t1842265
