### PR TITLE
Install ltp repository for lp15.{2,3}_x86_64

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -212,7 +212,7 @@ sub add_ltp_repo {
 
         # ltp for leap15.2 is available only x86_64
         # ltp for leap15.3+ is missing only s390x
-        if (is_leap('=15.2') && is_x86_64 || is_leap('15.3+') && !is_s390x) {
+        if ((is_leap('=15.2') && is_x86_64) || (is_leap('15.3+') && !is_s390x)) {
             $repo = sprintf("Leap_%s", get_var('VERSION'));
         } elsif (is_tumbleweed) {
             $repo = "Tumbleweed";


### PR DESCRIPTION
Pull correct LTP package for Leap15.{2,3} (x86_64) from `https://download.opensuse.org/repositories/benchmark:/ltp:/devel/`.

`jeos-ltp-commands` test suite setup in o3 test suite table.

```
BOOT_HDD_IMAGE=1
DESKTOP=textmode
INSTALL_LTP=from_repo
KERNEL_BASE=1
LTP_COMMAND_EXCLUDE=tar01_sh|logrotate_sh|unzip01_sh|df01_.*_sh|sysctl01_sh|mkfs01.*_sh|which01_sh|insmod01_sh
LTP_COMMAND_FILE=commands
LTP_TIMEOUT=7200
```

- [[qac] test fails in install_ltp: Does not handle Leap](https://progress.opensuse.org/issues/92071)
- VRs:
  * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build31.509-jeos-ltp-commands@64bit_virtio-2G](http://kepler.suse.cz/tests/6034#)
  * [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.136-jeos-ltp-commands@64bit_virtio-2G](http://kepler.suse.cz/tests/6035#)
