### PR TITLE
Add missing permissions to Apache AppArmor profile

### DIFF
--- a/data/apparmor/usr.sbin.httpd-prefork
+++ b/data/apparmor/usr.sbin.httpd-prefork
@@ -1,10 +1,11 @@
 # Last Modified: Thu Mar 21 15:39:34 2019
 #include <tunables/global>
 
-/usr/sbin/httpd-prefork {
+/usr/sbin/httpd-prefork flags=(attach_disconnected) {
   #include <abstractions/apache2-common>
   #include <abstractions/base>
   #include <abstractions/php5>
+  #include <abstractions/openssl>
 
   capability kill,
   capability net_admin,
@@ -32,6 +33,7 @@
   /etc/php7/conf.d/xmlreader.ini r,
   /etc/php7/conf.d/xmlwriter.ini r,
   /run/httpd.pid rw,
+  /run/httpd.pid.?????? rw,
   /usr/lib{,32,64}/** mr,
   /usr/lib{,32,64}/apache2*/** mr,
   /var/log/apache2/** rw,

--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -146,10 +146,7 @@ sub get_named_profile {
     my ($self, $profile_name) = @_;
 
     # Recalculate profile name in case
-    $profile_name = script_output("grep ' {\$' /etc/apparmor.d/$profile_name | sed 's/ {//' | head -1");
-    if ($profile_name =~ m/profile /) {
-        $profile_name = script_output("echo $profile_name | cut -d ' ' -f2");
-    }
+    $profile_name = script_output("/sbin/apparmor_parser -N /etc/apparmor.d/$profile_name | head -1");
     return $profile_name;
 }
 


### PR DESCRIPTION
This will make the apache2_changehat tests green again.

See https://bugzilla.opensuse.org/show_bug.cgi?id=1188295 for details
why each of the added permissions are needed.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1188295 
- Needles: no change needed
- Verification run: https://openqa.opensuse.org/tests/1843415