### PR TITLE
JeOS: Install updates before filesystem tests are executed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -578,8 +578,9 @@ sub load_jeos_tests {
         loadtest "console/suseconnect_scc";
     }
 
-    replace_opensuse_repos_tests      if is_repo_replacement_required;
-    loadtest 'console/verify_efi_mok' if get_var 'CHECK_MOK_IMPORT';
+    loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+    replace_opensuse_repos_tests              if is_repo_replacement_required;
+    loadtest 'console/verify_efi_mok'         if get_var 'CHECK_MOK_IMPORT';
 }
 
 sub installzdupstep_is_applicable {


### PR DESCRIPTION
- [missing updates in sle](https://openqa.suse.de/tests/6462929#step/btrfsmaintenance/20)
- VRs:
  * [aarch64](https://openqa.suse.de/tests/6468514#live)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64](https://openqa.suse.de/tests/6468220#)
  * [sle-15-SP2-JeOS-for-kvm-and-xen-Updates](https://openqa.suse.de/tests/6468218#)