### PR TITLE
Read AppArmor profile name before disabling the profile

### DIFF
--- a/lib/services/apparmor.pm
+++ b/lib/services/apparmor.pm
@@ -78,12 +78,12 @@ sub check_aa_enforce {
     my $named_profile   = "";
     systemctl('restart apparmor');
 
+    # Recalculate profile name in case
+    $named_profile = $self->get_named_profile($profile_name);
+
     validate_script_output "aa-disable $executable_name", sub {
         m/Disabling.*nscd/;
     }, timeout => 180;
-
-    # Recalculate profile name in case
-    $named_profile = $self->get_named_profile($profile_name);
 
     # Check if /usr/sbin/ntpd is really disabled
     die "$executable_name should be disabled"


### PR DESCRIPTION
After switching to `apparmor_parser -N` (instead of some broken grep and
sed magic) to read the profile name, it's no longer possible to read the
profile name of disabled profiles because apparmor_parser skips them.

Fix this by reading the profile name befe disabling the profile.

Fixes: https://progress.opensuse.org/issues/95605

- Related ticket: https://progress.opensuse.org/issues/95605
- Needles: None
- Verification run: https://openqa.opensuse.org/tests/1847334