### PR TITLE
Persistent journal in community JeOS based on lp15.3

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -39,7 +39,7 @@ use constant {
 
 # by default persistent journal is set for opensuse, except of leap 15.3+
 sub has_default_persistent_journal {
-    return is_opensuse && !is_leap('>=15.3');
+    return is_opensuse && (!is_leap('15.3+') || check_var('FLAVOR', 'JeOS-for-AArch64'));
 }
 
 # If the daemon is stopped uncleanly, or if the files are found to be corrupted, they are renamed using the ".journal~" suffix


### PR DESCRIPTION
- [[opensuse][jeos] test fails in journalctl](https://progress.opensuse.org/issues/92001)
- VRs:
  * [opensuse-15.3-JeOS-for-AArch64-aarch64](https://openqa.opensuse.org/tests/1847489#step/journalctl/1)
  * [opensuse-15.3-JeOS-for-AArch64-arm](https://openqa.opensuse.org/tests/1847487#step/journal_check/12)
  * [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.137-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/6093#step/journalctl/1)
  * [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build31.509-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/6094#step/journalctl/1)