### PR TITLE
NM_wpa2_enterprise: give NM 300s to restart

### DIFF
--- a/tests/x11/network/NM_wpa2_enterprise.pm
+++ b/tests/x11/network/NM_wpa2_enterprise.pm
@@ -21,6 +21,8 @@ use utils;
 sub run {
     my $self = shift;
 
+    # sleep 300s, validate claim https://bugzilla.opensuse.org/show_bug.cgi?id=1176553#c1
+    sleep 300;
     $self->connect_to_network;
     $self->enter_NM_credentials;
     $self->handle_polkit_root_auth;


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
