### PR TITLE
Don't depend on suseconnect package to check if SUSEConnect is installed

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -39,7 +39,7 @@ sub run {
 
 
     $self->select_serial_terminal;
-    die 'SUSEConnect package is not pre-installed!' if script_run 'rpm -q SUSEConnect';
+    die 'SUSEConnect package is not pre-installed!' if script_run 'command -v SUSEConnect';
     if ((is_jeos || is_sle_micro) && script_run(q(SUSEConnect --status-text | grep -i 'not registered'))) {
         die 'System has been already registered!';
     }


### PR DESCRIPTION
SLE Micro is starting to introduce suseconnect-ng package, so this
check fails even though SUSEConnect command works.
This change relies on the command instead of the package. If the
command fails, we make sure any of the packages is installed.

Failed test: https://openqa.suse.de/tests/6485324
Fix: http://openqa.suse.de/t6486067