### PR TITLE
Add test modules for timezone page using LibyuiClient

### DIFF
--- a/lib/Installation/ClockAndTimeZone/ClockAndTimeZoneController.pm
+++ b/lib/Installation/ClockAndTimeZone/ClockAndTimeZoneController.pm
@@ -44,9 +44,4 @@ sub collect_current_clock_and_time_zone_info {
         hw_clock_set_to_UTC => $self->get_clock_and_time_zone_page()->is_hw_clock_set_to_UTC()};
 }
 
-sub proceed_with_current_configuration {
-    my ($self) = @_;
-    $self->get_clock_and_time_zone_page()->press_next();
-}
-
 1;

--- a/lib/Installation/ClockAndTimeZone/ClockAndTimeZonePage.pm
+++ b/lib/Installation/ClockAndTimeZone/ClockAndTimeZonePage.pm
@@ -24,7 +24,6 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{btn_next}     = $self->{app}->button({id => 'next'});
     $self->{cb_region}    = $self->{app}->combobox({id => 'region'});
     $self->{cb_time_zone} = $self->{app}->combobox({id => 'timezone'});
     $self->{chb_hw_clock} = $self->{app}->checkbox({id => 'hwclock'});
@@ -49,11 +48,6 @@ sub is_hw_clock_set_to_UTC {
 sub is_shown {
     my ($self) = @_;
     return $self->{cb_time_zone}->exist();
-}
-
-sub press_next {
-    my ($self) = @_;
-    return $self->{btn_next}->click();
 }
 
 1;

--- a/schedule/yast/addon-module-ftp.yaml
+++ b/schedule/yast/addon-module-ftp.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/system_role/validate_default_role
   - installation/system_role/select_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/addon-module-http.yaml
+++ b/schedule/yast/addon-module-http.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/partitioning/warning/zipl_small
   - installation/partitioning/warning/rootfs_small
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_opensuse.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/partitioning/warning/zipl_small
   - installation/partitioning/warning/rootfs_small
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/btrfs/btrfs_opensuse.yaml
+++ b/schedule/yast/btrfs/btrfs_opensuse.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   # Called on all, except BACKEND: s390x
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/clone_system/clone_system_pvm.yaml
+++ b/schedule/yast/clone_system/clone_system_pvm.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_ignore_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_ignore_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_reuse_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/user_import
   - installation/authentication/root_simple_pwd

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_reuse_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/user_import
   - installation/authentication/root_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/activate_encrypted_volume.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_reuse_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/encryption/activate_encrypted_volume_dasd.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_dasd.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_reuse_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_reuse_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_no_lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/crypt_no_lvm_opensuse.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_opensuse.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_no_lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_no_lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_ignore_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm_ignore_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/encryption/cryptlvm_opensuse.yaml
+++ b/schedule/yast/encryption/cryptlvm_opensuse.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/cryptlvm_sle_15.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/edit_proposal_encrypt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_opensuse.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_opensuse.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/encryption/lvm_full_encrypt_opensuse.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_opensuse.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/ext3/ext3_textmode-opensuse.yaml
+++ b/schedule/yast/ext3/ext3_textmode-opensuse.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/ext4/ex4_textmode-opensuse.yaml
+++ b/schedule/yast/ext4/ex4_textmode-opensuse.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/ext4/ext4_opensuse.yaml
+++ b/schedule/yast/ext4/ext4_opensuse.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/yast_firstboot/firstboot_language_and_keyboard
   - installation/yast_firstboot/firstboot_welcome
   - installation/yast_firstboot/firstboot_license_agreement
-  - installation/yast_firstboot/firstboot_time_and_date
+  - installation/clock_and_timezone/validate_timezone_configuration
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/firstboot_user_simple_pwd
   - installation/authentication/root_simple_pwd
   - installation/yast_firstboot/firstboot_customer_center

--- a/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
+++ b/schedule/yast/firstboot/autoyast_y2_firstboot_opensuse.yaml
@@ -17,7 +17,8 @@ schedule:
   - installation/yast_firstboot/firstboot_language_and_keyboard
   - installation/yast_firstboot/firstboot_welcome
   - installation/yast_firstboot/firstboot_license_agreement
-  - installation/yast_firstboot/firstboot_time_and_date
+  - installation/clock_and_timezone/validate_timezone_configuration
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/enable_autologin
   - installation/authentication/firstboot_user_simple_pwd
   - installation/authentication/root_simple_pwd

--- a/schedule/yast/firstboot/yast2_firstboot.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/yast_firstboot/firstboot_language_and_keyboard
   - installation/yast_firstboot/firstboot_welcome
   - installation/yast_firstboot/firstboot_license_agreement
-  - installation/yast_firstboot/firstboot_time_and_date
+  - installation/clock_and_timezone/validate_timezone_configuration
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/firstboot_user_simple_pwd
   - installation/authentication/root_simple_pwd
   - installation/yast_firstboot/firstboot_customer_center

--- a/schedule/yast/firstboot/yast2_firstboot_opensuse.yaml
+++ b/schedule/yast/firstboot/yast2_firstboot_opensuse.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/yast_firstboot/firstboot_language_and_keyboard
   - installation/yast_firstboot/firstboot_welcome
   - installation/yast_firstboot/firstboot_license_agreement
-  - installation/yast_firstboot/firstboot_time_and_date
+  - installation/clock_and_timezone/validate_timezone_configuration
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/enable_autologin
   - installation/authentication/firstboot_user_simple_pwd
   - installation/authentication/root_simple_pwd

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/gpt_opensuse.yaml
+++ b/schedule/yast/gpt_opensuse.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/system_role/select_role
   - installation/partitioning/accept_proposed_layout
   - installation/releasenotes
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/authentication/root_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/installer_extended/installer_extended_opensuse.yaml
+++ b/schedule/yast/installer_extended/installer_extended_opensuse.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/user_settings
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/partitioning
   - installation/partitioning_iscsi
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/lvm_ignore_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/lvm_ignore_existing
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/lvm_no_separate_home
   - installation/partitioning/resize_existing_lv
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/lvm/lvm+resize_root.yaml
+++ b/schedule/yast/lvm/lvm+resize_root.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/partitioning/lvm_no_separate_home
   - installation/partitioning_resize_root
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/lvm/lvm_opensuse.yaml
+++ b/schedule/yast/lvm/lvm_opensuse.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/system_role/validate_default_role
   - installation/system_role/select_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/lvm/lvm_thin_provisioning_opensuse.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning_opensuse.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/system_role/validate_default_role
   - installation/system_role/select_role
   - installation/partitioning/new_partitioning_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/lvm_multipath.yaml
+++ b/schedule/yast/lvm_multipath.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/lvm_no_separate_home
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/lvm_multipath_encrypted.yaml
+++ b/schedule/yast/lvm_multipath_encrypted.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/encrypt_lvm
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/system_role/validate_default_role
   - installation/system_role/select_role
   - installation/partitioning/setup_raid1_lvm
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/setup_raid1_lvm
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/setup_raid1_lvm
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/setup_raid1_lvm
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/setup_raid1_lvm
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   # Called on BACKEND: qemu, svirt
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root

--- a/schedule/yast/minimalx_zvm.yaml
+++ b/schedule/yast/minimalx_zvm.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/logpackages
   - installation/system_role/select_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/select_patterns

--- a/schedule/yast/modify_existing_partition_opensuse.yaml
+++ b/schedule/yast/modify_existing_partition_opensuse.yaml
@@ -12,7 +12,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/modify_existing_partition
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/modify_existing_partition
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/msdos/msdos.yaml
+++ b/schedule/yast/msdos/msdos.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/msdos_partition_table
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/msdos_partition_table
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/nvme.yaml
+++ b/schedule/yast/nvme.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/nvme_opensuse.yaml
+++ b/schedule/yast/nvme_opensuse.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/raid/raid0_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid0_opensuse_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid10_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid10_opensuse_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid1_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid1_opensuse_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid5_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid5_opensuse_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/releasenotes_origin
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/remote_ssh/remote_ssh_controller_sle15.yaml
+++ b/schedule/yast/remote_ssh/remote_ssh_controller_sle15.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues

--- a/schedule/yast/remote_vnc/remote_vnc_controller.yaml
+++ b/schedule/yast/remote_vnc/remote_vnc_controller.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/user_settings
   - installation/user_settings_root
   - installation/installation_overview

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/select_disk/select_disk_opensuse.yaml
+++ b/schedule/yast/select_disk/select_disk_opensuse.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/system_role
   - installation/partitioning/no_separate_home
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/select_patterns

--- a/schedule/yast/separate_usr_partition.yaml
+++ b/schedule/yast/separate_usr_partition.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/separate_usr_partition
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root

--- a/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/addon_products_sle
   - installation/releasenotes_origin
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/skip_registration/skip_registration_pvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration_pvm.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
+++ b/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/ssh-x.yaml
+++ b/schedule/yast/ssh-x.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/user_settings
   - installation/user_settings_root
   - installation/select_patterns

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/system_role/validate_default_role
   - installation/system_role/select_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/textmode/textmode@svirt-xen.yaml
+++ b/schedule/yast/textmode/textmode@svirt-xen.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/system_role/validate_default_role
   - installation/system_role/select_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -27,7 +27,7 @@ schedule:
     - installation/system_role/validate_default_role
     - installation/system_role/select_role
     - installation/partitioning/accept_proposed_layout
-    - installation/installer_timezone
+    - installation/clock_and_timezone/accept_timezone_configuration
     - installation/authentication/use_same_password_for_root
     - installation/authentication/default_user_simple_pwd
     - installation/resolve_dependency_issues

--- a/schedule/yast/transactional_server/create_hdd_transactional_server_opensuse.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server_opensuse.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/system_role/validate_default_role
   - installation/system_role/select_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/transactional_server/transactional_server_opensuse.yaml
+++ b/schedule/yast/transactional_server/transactional_server_opensuse.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/system_role/validate_default_role
   - installation/system_role/select_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview

--- a/schedule/yast/usb_install.yaml
+++ b/schedule/yast/usb_install.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/xfs/xfs.yaml
+++ b/schedule/yast/xfs/xfs.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   # Called on all, except BACKEND: s390x
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root

--- a/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/xfs/xfs_opensuse.yaml
+++ b/schedule/yast/xfs/xfs_opensuse.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/schedule/yast/xfs/xfs_textmode-opensuse.yaml
+++ b/schedule/yast/xfs/xfs_textmode-opensuse.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/yast_hostname/yast_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_opensuse.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_opensuse.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/logpackages
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd

--- a/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout
-  - installation/installer_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview

--- a/tests/installation/clock_and_timezone/accept_timezone_configuration.pm
+++ b/tests/installation/clock_and_timezone/accept_timezone_configuration.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Accept current timezone configuration
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    $testapi::distri->get_clock_and_time_zone()->get_clock_and_time_zone_page();
+    $testapi::distri->get_navigation()->proceed_next_screen();
+}
+
+1;

--- a/tests/installation/clock_and_timezone/validate_timezone_configuration.pm
+++ b/tests/installation/clock_and_timezone/validate_timezone_configuration.pm
@@ -7,24 +7,24 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Handles Time and Date dialog in YaST Firstboot Configuration.
-#
+# Summary: Collects all the info about current Timezone configuration
+# and validates it against the one provided by test_data.
 # Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
 
-use base 'y2_firstboot_basetest';
+use base 'y2_installbase';
 use strict;
 use warnings;
 use scheduler 'get_test_suite_data';
 use cfg_files_utils;
 
 sub run {
-    my $test_data           = get_test_suite_data()->{time_and_date};
+    my $test_data = get_test_suite_data()->{time_and_date};
+
     my $clock_and_time_zone = $testapi::distri->get_clock_and_time_zone();
     compare_settings({
             expected      => $test_data,
             current       => $clock_and_time_zone->collect_current_clock_and_time_zone_info(),
             suppress_info => 1});
-    $clock_and_time_zone->proceed_with_current_configuration();
 }
 
 1;


### PR DESCRIPTION
The PR adds the appropriate test modules for Clock And Timezone Page and updates YAML schedule files accordingly.

- Related ticket: https://progress.opensuse.org/issues/94889
- Verification runs: 
   - openSUSE: https://openqa.opensuse.org/tests/1847869
   - SLE: https://openqa.suse.de/tests/6486078