### PR TITLE
Integrate test case 'filter' of audit test into openQA

### DIFF
--- a/schedule/security/cc_filter.yaml
+++ b/schedule/security/cc_filter.yaml
@@ -1,0 +1,7 @@
+name: cc_filter
+description:    >
+    This is for audit_test filter
+schedule:
+    - boot/boot_to_desktop
+    - security/cc/cc_audit_test_setup
+    - security/cc/filter

--- a/tests/security/cc/filter.pm
+++ b/tests/security/cc/filter.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'filter' test case of 'audit-test' test suite
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#95464
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    run_testcase('filter', (make => 1));
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('filter');
+    $self->result($result);
+}
+
+1;


### PR DESCRIPTION
QE security plan to integrate all test cases under `CC audit test`
into openQA. 'filter' is one of these.

Related: https://progress.opensuse.org/issues/95464
Verification run: https://openqa.suse.de/tests/6490980#

