### PR TITLE
Add logs for variables parsed from yaml schedule

### DIFF
--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -35,6 +35,7 @@ my $root_project_dir = dirname(__FILE__) . '/../';
 my $include          = YAML::PP::Schema::Include->new(paths => ($root_project_dir));
 my $ypp              = YAML::PP->new(schema => ['Core', $include, 'Merge']);
 $include->yp($ypp);
+$Data::Dumper::Terse = 1;
 
 sub parse_vars {
     my ($schedule) = shift;
@@ -43,6 +44,8 @@ sub parse_vars {
         $value =~ s/%(.*?)%/get_var($1)/eg;
         $vars{$var} = $value;
     }
+    my $varlog = Dumper(\%vars);
+    diag("parse_vars (variables parsed from YAML schedule): " . $varlog);
     return %vars;
 }
 
@@ -124,10 +127,9 @@ sub parse_test_suite_data {
         $test_suite_data = {%$test_suite_data, %{$include_yaml}};
     }
     expand_test_data_vars($test_suite_data);
-    local $Data::Dumper::Terse = 1;
     my $out = Dumper($test_suite_data);
     chomp($out);
-    diag("parse_test_suite_data: $out");
+    diag("parse_test_suite_data (data parsed from YAML test_data): $out");
 }
 
 =head2 load_yaml_schedule


### PR DESCRIPTION
There are some openQA variables, parsed from yaml schedule. This commit creates logs for these particular VARS.  Also, modifies message for YAML test_data, in order to be more clear.

- Related ticket: https://progress.opensuse.org/issues/94955
- Verification run: http://falafel.suse.cz/tests/499/logfile?filename=autoinst-log.txt