### PR TITLE
Add qemu testsuite for SLEM and MicroOS

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -310,8 +310,8 @@ sub is_sle {
 Returns true if called on a transactional server
 =cut
 sub is_transactional {
-    return 1 if is_microos;
-    return check_var('SYSTEM_ROLE', 'serverro');
+    return 1 if (is_microos || is_sle_micro);
+    return check_var('SYSTEM_ROLE', 'serverro') || get_var('TRANSACTIONAL_SERVER');
 }
 
 =head2 is_sles4migration

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -92,8 +92,16 @@ sub load_installation_tests {
         load_tdup_tests             if (get_var 'TDUP');
         loadtest 'console/regproxy' if is_regproxy_required;
         load_feature_tests          if (check_var 'EXTRA', 'FEATURES');
+        load_qemu_tests()           if (check_var 'EXTRA', 'VIRTUALIZATION');
         loadtest 'shutdown/shutdown';
     }
+}
+
+sub load_qemu_tests {
+    loadtest 'qemu/info';
+    loadtest 'qemu/qemu';
+    loadtest 'qemu/kvm';
+    loadtest 'qemu/user';
 }
 
 #######################

--- a/schedule/sle-micro/virt.yaml
+++ b/schedule/sle-micro/virt.yaml
@@ -1,0 +1,37 @@
+name:           qemu_smoke_test
+description:    >
+    Maintainer: qa-c@suse.de.
+    SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+        - boot/boot_to_desktop
+      'x86_64':
+        - microos/disk_boot
+      'aarch64':
+        - microos/disk_boot
+  kvm:
+    ARCH:
+      # nested kvm is not yet implemented on ARM and kvm not supported on ppc64le
+      'x86_64':
+        - qemu/kvm
+      's390x':
+        - qemu/kvm
+  registration:
+    SCC_REGISTER:
+      'installation':
+        - console/suseconnect_scc
+  maintenance:
+    FLAVOR:
+      'MicroOS-Image-Updates':
+        - transactional/install_updates
+schedule:
+  - '{{boot}}'
+  - transactional/disable_grub
+  - '{{registration}}'
+  - '{{maintenance}}'
+  - qemu/info
+  - qemu/qemu
+  - '{{kvm}}'

--- a/tests/qemu/info.pm
+++ b/tests/qemu/info.pm
@@ -22,7 +22,7 @@ sub run {
 
     script_run 'lscpu';
     script_run 'uname -a';
-    script_run "egrep -o '(vmx|svm)' /proc/cpuinfo | sort | uniq";
+    script_run "egrep -o '(vmx|svm|sie)' /proc/cpuinfo | sort | uniq";
     script_run 'lsmod | grep kvm';
 
     if (script_run('stat /dev/kvm') != 0) {

--- a/tests/qemu/user.pm
+++ b/tests/qemu/user.pm
@@ -15,14 +15,20 @@ use warnings;
 use base "consoletest";
 use testapi;
 use utils;
-
+use transactional qw(trup_call check_reboot_changes);
+use version_utils qw(is_transactional);
 
 sub run {
     select_console 'root-console';
 
-    zypper_call 'in qemu-linux-user';
+    if (is_transactional) {
+        trup_call("pkg install qemu-linux-user");
+        check_reboot_changes;
+    } else {
+        zypper_call("in qemu-linux-user");
+    }
     # file is from https://busybox.net/downloads/binaries/1.21.1/busybox-sparc';
-    assert_script_run 'wget ' . data_url('busybox-sparc');
+    assert_script_run 'curl --remote-name ' . data_url('busybox-sparc');
     assert_script_run 'chmod +x busybox-sparc';
     assert_script_run 'qemu-sparc busybox-sparc whoami';
 }


### PR DESCRIPTION
SLEM and MicroOS should support virtualization stack due to legacy workloads, that cannot be easily containerised.

- [Virtualization tests on SLE Micro as host](https://progress.opensuse.org/issues/91809)
- VRs:
  * [microos-Tumbleweed-MicroOS-Image-x86_64-Build20210718-qemu_support@64bit](http://kepler.suse.cz/tests/6151#)
  * [slem-image](http://kepler.suse.cz/tests/6150)
  * [sle15sp3-qemu](http://kepler.suse.cz/tests/6147)
- Prerequisitites:
  * `QEMUCPU=host`
  * `EXTRA=VIRTUALIZATION` for microos/main.pm usage