### PR TITLE
Add mce-inject module at beginning of the test

### DIFF
--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -30,8 +30,6 @@ use testapi;
 use utils;
 
 sub inject_error {
-    # load kernel module
-    assert_script_run('modprobe mce-inject');
     # Inject some software errors
     script_run('echo 0x9c00410000080f2b > /sys/kernel/debug/mce-inject/status');
     script_run('echo d5a099a9 > /sys/kernel/debug/mce-inject/addr');
@@ -42,6 +40,9 @@ sub inject_error {
 
 sub run {
     my $self = shift;
+
+    # load kernel module
+    assert_script_run('modprobe mce-inject');
 
     zypper_call('in rasdaemon');
 


### PR DESCRIPTION
MCE event is not recorded after injection, not sure why does that happen.
Add mce-inject module at beginnig of test, to make sure it's loaded when
injecting errors.

- Related ticket: https://progress.opensuse.org/issues/95126
- Verification run:
http://dzedro.suse.cz/tests/18668 15 SP2
http://dzedro.suse.cz/tests/18671 15 SP1
http://dzedro.suse.cz/tests/18670 15
https://openqa.suse.de/tests/6533663 15 SP2