### PR TITLE
Revert timezone test module for offline installation

### DIFF
--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish
-  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/installer_timezone
   - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root


### PR DESCRIPTION
Offline installation currently does not support LibyuiClient, so the
test module that uses it cannot work properly.

The commit reverts the change.

- Verification run: https://openqa.suse.de/tests/6497430
