### PR TITLE
Remove ctdb module from rolling_upgrade test in QAM

### DIFF
--- a/schedule/ha/qam/common/qam_migration_rolling_upgrade.yaml
+++ b/schedule/ha/qam/common/qam_migration_rolling_upgrade.yaml
@@ -89,7 +89,6 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
   - ha/haproxy
   - ha/await_upgrade_or_update
   - migration/version_switch_upgrade_target


### PR DESCRIPTION
HA Rolling Upgrade tests in QAM currently schedule the `ctdb` test module on the cluster nodes jobs, but `ctdb` requires, besides the cluster nodes a client job. Since `ctdb` is also tested in other jobs (check other schedules in this repo), this commit removes the module from the rolling upgrade test.

- Related ticket: https://jira.suse.com/browse/TEAM-4527
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/6500162, https://openqa.suse.de/tests/6500163, https://openqa.suse.de/tests/6500164
