### PR TITLE
Increase login timeout in gnome

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -231,7 +231,7 @@ sub handle_login {
     assert_screen 'displaymanager-password-prompt';
     type_password;
     send_key 'ret';
-    assert_screen([qw(generic-desktop gnome-activities opensuse-welcome)], 60);
+    assert_screen([qw(generic-desktop gnome-activities opensuse-welcome)], 180);
     if (match_has_tag('gnome-activities')) {
         send_key('esc');
         assert_screen([qw(generic-desktop opensuse-welcome)]);


### PR DESCRIPTION
Allow more time to detect successful login in gnome to address
  timeouts on aarch64


- Related ticket: https://progress.opensuse.org/issues/95759
- Needles: no needles
- Verification run: https://openqa.suse.de/tests/overview?build=mgrifalconi-investigation-slowboot
