### PR TITLE
online_repos: handle network-not-configured case - poo#87719

### DIFF
--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -57,6 +57,19 @@ sub run {
     my @needles = qw(online-repos-popup before-role-selection inst-networksettings partitioning-edit-proposal-button inst-instmode network-not-configured list-of-online-repositories);
     assert_screen(\@needles, timeout => 60);
 
+    if (match_has_tag('network-not-configured')) {
+        # On slow workers the network may be unconfigured - poo#87719
+        send_key("alt-i");                                       # Edit button
+        assert_screen('static-ip-address-set');
+        send_key("alt-y");                                       # Select Dynamic address
+        assert_screen('dynamic-ip-address-set');
+        send_key $cmd{next};                                     # Next
+        assert_screen('inst-networksettings');
+        send_key $cmd{next};                                     # Next
+        @needles = grep { !/inst-networksettings/ } @needles;    # Do not match the previous screen
+        assert_screen(\@needles, timeout => 60);                 # Check the screen again with network up and running
+    }
+
     # Do nothing if pop-up is not found
     return unless match_has_tag('online-repos-popup');
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/87719
- Needles: 
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/efc76f00ead8326650d59f13eeefe67ca051bc09
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/f42e7734be6facf8bed3363dc4c72c76c753c211
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/9c2ba012f9453ff9ca3bf1956e0c84a7088284a2
- Verification run: https://openqa.opensuse.org/tests/1851295#step/online_repos/6 (passed)
