### PR TITLE
Schedule vsftpd in s390x maintenance runs

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -30,6 +30,7 @@ schedule:
   - console/aaa_base
   - console/gd
   - console/systemtap
+  - console/vsftpd
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:
@@ -81,14 +82,10 @@ conditional_schedule:
         - '{{arch_specific}}'
       12-SP2:
         - console/journald_fss
-        - console/vsftpd
   arch_specific:
     ARCH:
       x86_64:
         - console/mutt
-        - console/vsftpd
-      aarch64:
-        - console/vsftpd
   arch_12sp5:
     ARCH:
       x86_64:


### PR DESCRIPTION
When this [PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12919) is merged, vsftpd can be also scheduled for s390x architecture in maintenance runs.

- Related ticket: https://progress.opensuse.org/issues/93270
- Needles: N/A
- Verification run: SLES [15SP3](https://openqa.suse.de/tests/6506800#step/vsftpd/31) | [15SP2](https://openqa.suse.de/tests/6506801#step/vsftpd/31) | [15SP1](https://openqa.suse.de/tests/6506802#step/vsftpd/31) | [15](https://openqa.suse.de/tests/6506803#step/vsftpd/31) | [12SP5](https://openqa.suse.de/tests/6506804#step/vsftpd/31) | [12SP4](https://openqa.suse.de/tests/6506805#step/vsftpd/31)
