### PR TITLE
Handle specific test checks on SLES12-SP5-JeOS

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -58,7 +58,7 @@
             "sle-micro": [ "5.0", "5.1" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
-            "sle": ["15-SP2", "15-SP3", "12-SP5"]
+            "sle": ["15-SP2", "15-SP3", "15-SP4", "12-SP5"]
         },
         "type": "feature"
     },

--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -58,7 +58,7 @@
             "sle-micro": [ "5.0", "5.1" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
-            "sle": ["15-SP2", "15-SP3"]
+            "sle": ["15-SP2", "15-SP3", "12-SP5"]
         },
         "type": "feature"
     },

--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 package btrfs_test;
 use base 'consoletest';
 use strict;
@@ -66,7 +75,7 @@ sub snapper_nodbus_restore {
     if (script_run('systemctl is-active dbus')) {
         script_run('systemctl default', 0);
         my $tty = get_root_console_tty;
-        assert_screen "tty$tty-selected";
+        assert_screen "tty$tty-selected", 60;
         reset_consoles;
         select_console 'root-console';
     }

--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 package locale;
 use base "opensusebasetest";
 
@@ -43,7 +52,7 @@ sub verify_default_keymap_textmode {
     assert_screen($tag);
     # clear line in order to add user bernhard to tty group
     # clear line to avoid possible failures in following console tests if scheduled
-    send_key("ctrl-w");
+    assert_screen_change { send_key("ctrl-u") };
 }
 
 sub notification_handler {

--- a/schedule/jeos/sle/jeos-extratest-sle12.yaml
+++ b/schedule/jeos/sle/jeos-extratest-sle12.yaml
@@ -1,0 +1,62 @@
+---
+description: |
+    'Extratest JeOS test suite against sle12'
+name: 'jeos-extratest'
+conditional_schedule:
+    bootloader:
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+            'svirt-hyperv-uefi':
+                - installation/bootloader_hyperv
+            'svirt-hyperv':
+                - installation/bootloader_hyperv
+                - installation/bootloader_uefi
+            'svirt-vmware65':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+    maintenance:
+        FLAVOR:
+            'JeOS-for-kvm-and-xen-Updates':
+                - qa_automation/patch_and_reboot
+schedule:
+    - '{{bootloader}}'
+    - jeos/firstrun
+    - console/consoletest_setup
+    - jeos/record_machine_id
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - jeos/grub2_gfxmode
+    - jeos/diskusage
+    - jeos/build_key
+    - console/suseconnect_scc
+    - '{{maintenance}}'
+    - console/zypper_lr_validate
+    - console/zypper_ref
+    - console/validate_packages_and_patterns
+    - console/zypper_extend
+    - console/check_os_release
+    - console/timezone
+    - console/ntp
+    - console/sshd
+    - console/rpm
+    - console/openssl_alpn
+    - console/syslog
+    - console/check_default_network_manager
+    - console/cups
+    - console/sysctl
+    - console/sysstat
+    - console/curl_ipv6
+    - console/wget_ipv6
+    - console/ca_certificates_mozilla
+    - console/unzip
+    - console/salt
+    - console/gpg
+    - console/rsync
+    - console/shells
+    - console/dstat
+    - console/procps
+    - console/kdump_and_crash

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -49,8 +49,8 @@ sub run {
     if (is_sle) {
         # What has been activated by default
         assert_script_run q[SUSEConnect --list-extensions | grep -e '\(Activated\)'];
-        assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'    \e\[1mServer Applications Module\')"';
-        assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'        \e\[1mWeb and Scripting Module\')"';
+        assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'    \e\[1mServer Applications Module\')"' unless is_sle('=12-sp5');
+        assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'    \e\[1mWeb and Scripting Module\')"';
     }
 
     # add modules

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2015-2018 SUSE LLC
+# Copyright © 2015-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -76,12 +76,12 @@ sub run {
     mouse_hide;
     # kiwi-templates-JeOS images (sle, opensuse x86_64 only) are build w/o translations
     # jeos-firstboot >= 0.0+git20200827.e920a15 locale warning dialog has been removed
-    if (is_sle('<15-sp3') || (is_leap('<15.3') && is_x86_64)) {
+    if (is_sle('15+') && (is_sle('<15-sp3') || (is_leap('<15.3') && is_x86_64))) {
         assert_screen 'jeos-lang-notice', 300;
         # Without this 'ret' sometimes won't get to the dialog
         wait_still_screen;
         send_key 'ret';
-    } elsif (is_opensuse && !is_x86_64) {
+    } elsif ((is_opensuse && !is_x86_64) || is_sle('=12-sp5')) {
         assert_screen 'jeos-locale', 300;
         send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 50;
         send_key 'ret';

--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -209,7 +209,6 @@ sub run {
     select_console('root-console');
     ensure_serialdev_permissions;
     (test_users_locale($rc_lc_reverted, $test_data_lang{$lang_ref}) eq $original_glibc_string) or die "Locale has changed after reboot!\n";
-    reset_consoles;
 }
 
 1;

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -369,7 +369,7 @@ sub run {
         assert_script_run('generate_lvm_runfile.sh');
     }
 
-    is_jeos && zypper_call 'in system-user-bin system-user-daemon';
+    (is_jeos && is_sle('>15')) && zypper_call 'in system-user-bin system-user-daemon';
 
     # boot_ltp will schedule the tests and shutdown_ltp if there is a command
     # file

--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018-2019 SUSE LLC
+# Copyright © 2018-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,6 @@ use strict;
 use warnings;
 use Utils::Backends 'has_ttys';
 use testapi qw(assert_screen get_var select_console);
-use utils 'ensure_serialdev_permissions';
 
 sub run {
     my ($self) = @_;
@@ -34,7 +33,7 @@ sub run {
     return $self->verify_default_keymap_textmode_non_us($keystrokes, "${expected}_keymap") if ($expected ne 'us');
     $self->verify_default_keymap_textmode($keystrokes, "${expected}_keymap");
     $self->verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'root-console');
-    ensure_serialdev_permissions;
+    # ensure_serialdev_permissions is not needed as it is executing by system_prepare
     $self->verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'user-console');
 }
 


### PR DESCRIPTION
- `Server Applications Module` is not available on SLES12-SP5-JeOS
- `Select System Local` comes before keyboard selection


- Related ticket: https://progress.opensuse.org/issues/95410
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1548
- Verification run: 
https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2312947&distri=sle&version=12-SP5

https://openqa.suse.de/tests/overview?version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2312947&distri=sle