### PR TITLE
SLE Micro: add migration test from 5.0 to 5.1

### DIFF
--- a/schedule/sle-micro/migration.yaml
+++ b/schedule/sle-micro/migration.yaml
@@ -1,0 +1,19 @@
+name:           sle_micro_containers
+description:    >
+    Maintainer: qa-c@suse.de.
+    SUSE Linux Enterprise Micro tests
+schedule:
+  - microos/disk_boot
+  - transactional/disable_grub
+  - console/suseconnect_scc
+  - transactional/install_updates
+  - migration/online_migration/zypper_migration
+  - microos/networking
+  - microos/libzypp_config
+  - microos/image_checks
+  - microos/one_line_checks
+  - microos/services_enabled
+  - microos/cockpit_service
+  - microos/toolbox
+  - console/journal_check
+  - shutdown/shutdown


### PR DESCRIPTION
Reuse existing zypper_migration test and adapting zypper commands
to transactional server equivalent.

- Related ticket: https://progress.opensuse.org/issues/95383
- Verification run:  https://openqa.suse.de/tests/6512108
