### PR TITLE
Unified guest installation installer

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -600,10 +600,10 @@ sub load_yast2_registration_tests {
 }
 
 sub load_virt_guest_install_tests {
-    if (get_var("VIRT_UEFI_GUEST_INSTALL")) {
-        loadtest "virt_autotest/uefi_guest_installation";
+    if (get_var("VIRT_UNIFIED_GUEST_INSTALL")) {
+        loadtest "virt_autotest/unified_guest_installation";
         loadtest "virt_autotest/set_config_as_glue";
-        loadtest "virt_autotest/uefi_guest_verification";
+        loadtest "virt_autotest/uefi_guest_verification" if get_var("VIRT_UEFI_GUEST_INSTALL");
     }
     else {
         loadtest "virt_autotest/guest_installation_run";

--- a/tests/virt_autotest/unified_guest_installation.pm
+++ b/tests/virt_autotest/unified_guest_installation.pm
@@ -7,15 +7,15 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 #
-# Summary: This module supports concurrent multiple uefi virtual machine
-# installations with vm names and profiles obtained from UEFI_GUEST_LIST
-# and UEFI_GUEST_PROFILES respectively. There is no restriction on vm names
-# to be used, so any desired vm names can be given to UEFI_GUEST_LIST=
+# Summary: This module supports concurrent multiple virtual machines
+# installations with vm names and profiles obtained from UNIFIED_GUEST_LIST
+# and UNIFIED_GUEST_PROFILES respectively. There is no restriction on vm names
+# to be used, so any desired vm names can be given to UNIFIED_GUEST_LIST=
 # "vm_name_1,vm_name_2,vm_name_3". Similary,any vm profile names can be
-# given to UEFI_GUEST_PROFILES,as long as there are corresponding profile
+# given to UNIFIED_GUEST_PROFILES,as long as there are corresponding profile
 # files in data/virt_autotest/guest_params_xml_files folder, for example,
 # there should be profile file called vm_profile_1.xml,vm_profile_2.xml
-# and vm_profile_3.xml in the folder if UEFI_GUEST_PROFILES="vm_profile_1,
+# and vm_profile_3.xml in the folder if UNIFIED_GUEST_PROFILES="vm_profile_1,
 # vm_profile_2,vm_profile_3".Then vm_name_1 will be created and installed
 # using vm_profile_1 and so on by calling:
 # generate_guest_instances,
@@ -35,7 +35,7 @@
 # about subroutines in base module being called.
 #
 # Maintainer: Wayne Chen <wchen@suse.com>
-package uefi_guest_installation;
+package unified_guest_installation;
 
 use base 'concurrent_guest_installations';
 use strict;
@@ -47,8 +47,8 @@ sub run {
     my $self = shift;
 
     $self->reveal_myself;
-    my @guest_names    = split(/,/, get_required_var('UEFI_GUEST_LIST'));
-    my @guest_profiles = split(/,/, get_required_var('UEFI_GUEST_PROFILES'));
+    my @guest_names    = split(/,/, get_required_var('UNIFIED_GUEST_LIST'));
+    my @guest_profiles = split(/,/, get_required_var('UNIFIED_GUEST_PROFILES'));
     croak("Guest names and profiles must be given to create, configure and install guests.") if ((scalar(@guest_names) eq 0) or (scalar(@guest_profiles) eq 0));
     $self->concurrent_guest_installations_run(\@guest_names, \@guest_profiles);
     return $self;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -722,7 +722,7 @@ sub cleanup_host_and_guest_logs {
     #Clean dhcpd and named services up explicity
     if (get_var('VIRT_AUTOTEST')) {
         script_run("brctl addbr br123;brctl setfd br123 0;ip addr add 192.168.123.1/24 dev br123;ip link set br123 up");
-        if (!get_var('VIRT_UEFI_GUEST_INSTALL')) {
+        if (!get_var('VIRT_UNIFIED_GUEST_INSTALL')) {
             my @control_operation = ('restart');
             virt_autotest::utils::manage_system_service('dhcpd', \@control_operation);
             virt_autotest::utils::manage_system_service('named', \@control_operation);

--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -228,7 +228,7 @@ sub run_test {
     my ($self) = @_;
     my ($sles_running_version, $sles_running_sp) = get_os_release;
 
-    if ($sles_running_version eq '15' && get_var("VIRT_AUTOTEST") && !get_var("VIRT_UEFI_GUEST_INSTALL")) {
+    if ($sles_running_version eq '15' && get_var("VIRT_AUTOTEST") && !get_var("VIRT_UNIFIED_GUEST_INSTALL")) {
         record_info("DNS Setup", "SLE 15+ host may have more strict rules on dhcp assigned ip conflict prevention, so guest ip may change");
         my $dns_bash_script_url = data_url("virt_autotest/setup_dns_service.sh");
         script_output("curl -s -o ~/setup_dns_service.sh $dns_bash_script_url", 180, type_command => 0, proceed_on_failure => 0);


### PR DESCRIPTION
* **Rename** uefi_guest_installation.pm to unified_guest_installation.pm because it is really an unified guest installation installer instead of can only be used with uefi guest installation.
* **Rename** UEFI_GUEST_LIST and UEFI_GUEST_PROFILES to UNIFIED_GUEST_LIST and UNIFIED_GUEST_PROFILES to also indicate that these two arguments can be used with any kind of guest.
* **Introduce** VIRT_UNIFIED_GUEST_INSTALL to indicate that the new module virt_autotest/unified_guest_installation is preferred other than legacy one.
* **VIRT_UEFI_GUEST_INSTALL** is kept to indicate that the installed guest is uefi guest so uefi_guest_verification needs to be called to verify it.
* **Replace** the old "VIRT_UEFI_GUEST_INSTALL" in tests/virt_autotest/virt_utils.pm and tests/virtualization/universal/hotplugging.pm to "VIRT_UNIFIED_GUEST_INSTALL" because integrated dhcp/dns is being used in new guest installation module instead of manipulating them separately."VIRT_UNIFIED_GUEST_INSTALL" is the one to be used here.

* **Verification runs:**
  * [oracle linux 6 with features](http://10.67.129.106/tests/1495)
  * [oracle linux 8 uefi guest with features](http://10.67.129.106/tests/1521)