### PR TITLE
Extend AutoYaST file(s) preparation for Rules and Classes 

### DIFF
--- a/data/autoyast_sle15/rule-based_example/classes/default
+++ b/data/autoyast_sle15/rule-based_example/classes/default
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <classes config:type="list">
+    <class>
+      <class_name>general</class_name>
+      <configuration>users.xml</configuration>
+    </class>
+    <class>
+      <class_name>general</class_name>
+      <configuration>software.xml</configuration>
+    </class>
+    <class>
+      <class_name>swap</class_name>
+      <configuration>bigswap.xml</configuration>
+      <dont_merge config:type="list">
+        <element>partition</element>
+      </dont_merge>
+    </class>
+    <class>
+      <class_name>swap</class_name>
+      <configuration>smallswap.xml</configuration>
+      <dont_merge config:type="list">
+        <element>partition</element>
+      </dont_merge>
+    </class>
+  </classes>
+</profile>

--- a/data/autoyast_sle15/rule-based_example/classes/general/registration.xml
+++ b/data/autoyast_sle15/rule-based_example/classes/general/registration.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
+</profile>

--- a/data/autoyast_sle15/rule-based_example/classes/general/software.xml
+++ b/data/autoyast_sle15/rule-based_example/classes/general/software.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <software>
+    <install_recommended config:type="boolean">false</install_recommended>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+    <packages config:type="list">
+      <package>apache2</package>
+    </packages>
+  </software>
+</profile>

--- a/data/autoyast_sle15/rule-based_example/classes/general/users.xml
+++ b/data/autoyast_sle15/rule-based_example/classes/general/users.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_sle15/rule-based_example/classes/swap/bigswap.xml
+++ b/data/autoyast_sle15/rule-based_example/classes/swap/bigswap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <partitioning config:type="list">
+    <drive>
+      <partitions config:type="list">
+        <partition>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>swap</mount>
+          <size>2000mb</size>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
+</profile>

--- a/data/autoyast_sle15/rule-based_example/classes/swap/smallswap.xml
+++ b/data/autoyast_sle15/rule-based_example/classes/swap/smallswap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <partitioning config:type="list">
+    <drive>
+      <partitions config:type="list">
+        <partition>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>swap</mount>
+          <size>1000mb</size>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
+</profile>

--- a/data/autoyast_sle15/rule-based_example/profile_a.xml
+++ b/data/autoyast_sle15/rule-based_example/profile_a.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+    </bootloader>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+    <networking>
+      <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <partitioning config:type="list">
+    <drive>
+      <device>/dev/sda</device>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+	  <mountby config:type="symbol">uuid</mountby>
+          <size>70%</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+	  <filesystem config:type="symbol">xfs</filesystem>
+          <mount>/home</mount>
+          <mountby config:type="symbol">uuid</mountby>
+	  <size>max</size>
+        </partition>
+      </partitions>
+    </drive>
+    </partitioning>
+        <classes config:type="list">
+      <class>
+        <class_name>general</class_name>
+        <configuration>users.xml</configuration>
+      </class>
+      <class>
+        <class_name>general</class_name>
+        <configuration>software.xml</configuration>
+      </class>
+      <class>
+        <class_name>general</class_name>
+        <configuration>registration.xml</configuration>
+      </class>
+      <class>
+        <class_name>swap</class_name>
+        <configuration>bigswap.xml</configuration>
+        <dont_merge config:type="list">
+          <element>partition</element>
+        </dont_merge>
+      </class>
+    </classes>
+</profile>

--- a/data/autoyast_sle15/rule-based_example/profile_b.xml
+++ b/data/autoyast_sle15/rule-based_example/profile_b.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+    </bootloader>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+    <networking>
+      <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <size>70%</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <mount>/home</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <size>max</size>
+        </partition>
+      </partitions>
+    </drive>
+    </partitioning>
+    <classes config:type="list">
+      <class>
+        <class_name>general</class_name>
+        <configuration>users.xml</configuration>
+      </class>
+      <class>
+        <class_name>general</class_name>
+        <configuration>software.xml</configuration>
+      </class>
+      <class>
+        <class_name>general</class_name>
+        <configuration>registration.xml</configuration>
+      </class>
+      <class>
+        <class_name>swap</class_name>
+        <configuration>smallswap.xml</configuration>
+        <dont_merge config:type="list">
+          <element>partition</element>
+        </dont_merge>
+      </class>      
+    </classes>
+</profile>

--- a/data/autoyast_sle15/rule-based_example/rules/rules.xml
+++ b/data/autoyast_sle15/rule-based_example/rules/rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<autoinstall xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <rules config:type="list">
+    <rule>
+      <disksize>
+        <match>/dev/sda 19000</match>
+        <match_type>greater</match_type>
+      </disksize>
+      <result>
+        <profile>profile_a.xml</profile>
+        <continue config:type="boolean">false</continue>
+      </result>
+    </rule>
+    <rule>
+      <disksize>
+        <match>/dev/vda 10000-19000</match>
+        <match_type>range</match_type>
+      </disksize>
+      <result>
+        <profile>profile_b.xml</profile>
+        <continue config:type="boolean">false</continue>
+      </result>
+    </rule>
+  </rules>
+</autoinstall>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -786,6 +786,7 @@ Map version names
 Get IP address from system variables
 Get values from SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_URL ARCH LOADER_TYPE
 Modify profile with obtained values
+Return new path in case of using AutoYaST templates
 
  $path is the path of the AutoYaST profile or one of the xml files when
  using rules and classes.
@@ -805,6 +806,7 @@ sub prepare_ay_file {
     $profile = adjust_network_conf($profile);
     $profile = expand_variables($profile);
     upload_profile(profile => $profile, path => $path);
+    return $path;
 }
 
 1;

--- a/schedule/yast/autoyast/autoyast_rules_and_classes.yaml
+++ b/schedule/yast/autoyast/autoyast_rules_and_classes.yaml
@@ -1,0 +1,27 @@
+---
+name: autoyast_rules_and_classes
+description: >
+  For future testing of AutoYaST rules and classes
+schedule:
+  - autoyast/prepare_rules_and_classes
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - update/zypper_up
+  - console/zypper_in
+  - console/zypper_log
+  - console/orphaned_packages_check
+  - autoyast/verify_cloned_profile

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -27,7 +27,8 @@ sub run {
     $ay_path = detect_profile_directory(profile => $profile, path => $ay_path);
 
     # expand/map variables in the xml file processed
-    prepare_ay_file($ay_path);
+    # AutoYaST path is updated in case of using templates
+    $ay_path = prepare_ay_file($ay_path);
 
     # set AutoYaST path as URL
     set_var('AUTOYAST', autoinst_url . "/files/$ay_path");

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -7,13 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Expand variables in the autoyast profiles and make it accessible for SUT
-#
-# - Get profile from autoyast template
-# - Map version names
-# - Get IP address from system variables
-# - Get values from SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_URL ARCH LOADER_TYPE
-# - Modify profile with obtained values and upload new autoyast profile
+# Summary: Prepare AutoYaST xml profile by expanding variables
+# before installation and setting correct URL for the installer.
 # Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 use strict;
@@ -22,29 +17,20 @@ use base "opensusebasetest";
 use testapi;
 use autoyast qw(
   detect_profile_directory
-  expand_template
-  expand_version
-  adjust_network_conf
-  expand_variables
-  upload_profile);
+  prepare_ay_file);
 
 sub run {
-    my $path = get_required_var('AUTOYAST');
-    # Get file from data directory
-    my $profile = get_test_data($path);
+    my $ay_path = get_required_var('AUTOYAST');
 
-    $path    = detect_profile_directory(profile => $profile, path => $path);
-    $profile = get_test_data($path);
-    die "Empty profile" unless $profile;
+    # get file from data directory and guess path if needed
+    my $profile = get_test_data($ay_path);
+    $ay_path = detect_profile_directory(profile => $profile, path => $ay_path);
 
-    # if profile is a template, expand and rename
-    $profile = expand_template($profile) if $path =~ s/^(.*\.xml)\.ep$/$1/;
-    die $profile                         if $profile->isa('Mojo::Exception');
+    # expand/map variables in the xml file processed
+    prepare_ay_file($ay_path);
 
-    $profile = expand_version($profile);
-    $profile = adjust_network_conf($profile);
-    $profile = expand_variables($profile);
-    upload_profile(profile => $profile, path => $path);
+    # set AutoYaST path as URL
+    set_var('AUTOYAST', autoinst_url . "/files/$ay_path");
 }
 
 sub test_flags {

--- a/tests/autoyast/prepare_rules_and_classes.pm
+++ b/tests/autoyast/prepare_rules_and_classes.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Prepare AutoYaST xml files when using rules and clases
+# by expanding variables before installation and setting correct URL
+# for the installer.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use autoyast qw(
+  get_test_data_files
+  prepare_ay_file);
+
+sub run {
+    my $ay_path = get_required_var('AUTOYAST');
+
+    die 'Please, in order to use AutoYaST rules and classes, AUTOYAST setting ' .
+      'should point to a folder ending with `/`,' .
+      'i.e.: AUTOYAST=autoyast_sle15/rule-based_example/' unless $ay_path =~ /\/$/;
+
+    # read list of files from some folder in data/
+    my $files = get_test_data_files($ay_path);
+
+    # expand/map variables for each xml file processed
+    prepare_ay_file($_) for (@$files);
+
+    # set AutoYaST path as URL
+    set_var('AUTOYAST', autoinst_url . "/files/$ay_path");
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -15,7 +15,7 @@ ADDONURL_*      | string    |               | Define url for the addons list def
 ASSERT_BSC1122804 | boolean | false | In some scenarios it is necessary to check if the mistyped full name still happens.
 ASSERT_Y2LOGS   | boolean   | false         | If set to true, we will parse YaST logs after installation and fail test suite in case unknown errors were detected.
 AUTOCONF        | boolean   | false         | Toggle automatic configuration
-AUTOYAST        | string    |               | Full url to the AY profile or relative path if in [data directory of os-autoinst-distri-opensuse repo](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data). If value starts with `aytests/`, these profiles are provided by suport server, source code is available in [aytests repo](https://github.com/yast/aytests-tests)
+AUTOYAST        | string    |               | Full url to the AY profile or relative path if in [data directory of os-autoinst-distri-opensuse repo](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data). If value starts with `aytests/`, these profiles are provided by suport server, source code is available in [aytests repo](https://github.com/yast/aytests-tests). If value is a folder ending in `/` rules and classes will be used.
 AUTOYAST_PREPARE_PROFILE | boolean | false | Enable variable expansion in the autoyast profile.
 AUTOYAST_VERIFY_TIMEOUT  | boolean | false | Enable validation of pop-up windows timeout.
 AY_EXPAND_VARS | string | | Commas separated list of variable names to be expanded in the provided autoyast profile. For example: REPO_SLE_MODULE_BASESYSTEM,DESKTOP,... Provided variables will replace `{{VAR}}` in the profile with the value of given variable. See also `AUTOYAST_PREPARE_PROFILE`.


### PR DESCRIPTION
- Related ticket: [poo#95392](https://progress.opensuse.org/issues/95392)
- Verification run: [autoyast_mini + qam-allpatterns + ilesystem_autoyast_withouthome](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23expand_prepare_profile)
