### PR TITLE
Set the filesystem on root partition to test different filesystem

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,15 +22,18 @@ use partition_setup qw(%partition_roles is_storage_ng_newui);
 
 sub run {
     assert_screen 'partitioning-edit-proposal-button', 40;
-    if (check_var('PARTITION_EDIT', 'ext4_btrfs')) {
+    # We need to test on different filesystems on root partition
+    # and do not care the filesystem on home partition.
+    my $my_filesys = get_var('PARTITION_EDIT');
+    if ($my_filesys) {
         send_key 'alt-g';
         send_key 'alt-n';
         send_key 'down';
         send_key 'alt-f';
-        type_string 'ext4';
+        type_string $my_filesys;
         send_key 'alt-i';
         send_key 'b';
-        assert_screen 'partitioning-ext4_root-btrfs_home';
+        assert_screen "partitioning-" . $my_filesys . "_root";
         send_key 'alt-n';
     }
 


### PR DESCRIPTION
We'd like to test on different file system such as ext4,xfs besides the default btrfs on root partition.

Related ticket: https://progress.opensuse.org/issues/93600
Needles: Already merged in OSD.
Verification run:
  x86_64:
  https://openqa.nue.suse.com/tests/6506809#step/partitioning/2 - ext4
  http://openqa.nue.suse.com/tests/6506810#step/partitioning/2 - xfs
  later will support more verification log on other Arches.