### PR TITLE
Revert is_tumbleweed from is_storage_ng

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -376,7 +376,7 @@ sub is_staging {
 Returns true if storage_ng is used
 =cut
 sub is_storage_ng {
-    return get_var('STORAGE_NG') || is_sle('15+') || is_tumbleweed;
+    return get_var('STORAGE_NG') || is_sle('15+');
 }
 
 =head2 is_upgrade


### PR DESCRIPTION
This condition was added by me recently and even if makes sense, doesn't get along well with the 'monster' code that we have in `is_boot_encrypted`. We will improve that part in the future, for now, this change will fix Leap upgrades and adding setting FULL_LVM_ENCRYPT to encryptlvm in TW should allow correct booting using current module.

- Related ticket: [poo#94904](https://progress.opensuse.org/issues/94904)
- Verification run: [cryptlvm + upgrade_Leap_42.3_cryptlvm](https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_encrypt_scenarios_o3)
