### PR TITLE
Add missing mau-extratests in sle15sp3

### DIFF
--- a/schedule/qam/common/mau-extratests-phub.yaml
+++ b/schedule/qam/common/mau-extratests-phub.yaml
@@ -14,6 +14,8 @@ schedule:
 conditional_schedule:
   version_specific:
     VERSION:
+      15-SP3:
+        - '{{sle15_x86_64}}'
       15-SP2:
         - '{{sle15_x86_64}}'
       15-SP1:

--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -38,6 +38,10 @@ schedule:
 conditional_schedule:
   version_specific:
     VERSION:
+      15-SP3:
+        - console/openssl_nodejs
+        - console/golang
+        - '{{arch_specific}}'
       15-SP2:
         - console/openssl_nodejs
         - console/golang

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -36,6 +36,16 @@ schedule:
 conditional_schedule:
   version_specific:
     VERSION:
+      15-SP3:
+        - console/osinfo_db
+        - console/ovn
+        - console/firewalld
+        - console/libgcrypt
+        - console/valgrind
+        - console/zziplib
+        - console/journald_fss
+        - console/openvswitch_ssl
+        - '{{arch_specific}}'
       15-SP2:
         - console/osinfo_db
         - console/ovn


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/95798
- Needles: N/A
- Verification run: 
SLE 15SP3
mau-extratests1 [x86_64](https://openqa.suse.de/tests/6521838) | [s390x](https://openqa.suse.de/tests/6521059) | [aarch64](https://openqa.suse.de/tests/6523008)
mau-extratests2 [x86_64](https://openqa.suse.de/tests/6521054) | [s390x](https://openqa.suse.de/tests/6521055) | [aarch64](https://openqa.suse.de/tests/6522601)
mau-extratests-phub [x86_64](https://openqa.suse.de/tests/6521061) | [s390x](https://openqa.suse.de/tests/6521062) | [aarch64](https://openqa.suse.de/tests/6522603)
