### PR TITLE
Add enable_autologin module for autologin@yast test

### DIFF
--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -16,6 +16,7 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
+  - installation/authentication/enable_autologin
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview


### PR DESCRIPTION
enable_autologin was not featured in autologin@yast test suite and as a result we had failure: 
https://openqa.suse.de/tests/6455395/modules/first_boot/steps/19

- Related ticket: https://progress.opensuse.org/issues/95551
- Verification run: http://falafel.suse.cz/tests/505
