### PR TITLE
Add "crypto", "fail-safe" of "audit-test" to openQA

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -43,7 +43,8 @@ our $current_file  = 'run.log';
 our $baseline_file = 'baseline_run.log';
 
 # Run the specific test case
-# input: $testcase - test case name (the actual test case name in 'audit-test' test suite, etc)
+# input: $testcase - test case name (the actual test case name is in corresponding 'audit-test' test suite,
+# e.g. "kvm", 'audit-tools', 'syscalls')
 sub run_testcase {
     my ($testcase, %args) = @_;
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2424,7 +2424,9 @@ sub load_security_tests_cc {
 
     # Run test cases of 'audit-test' test suite which do NOT need SELinux env
     loadtest 'security/cc/audit_tools';
+    loadtest 'security/cc/fail_safe';
 
+    # Some audit tests must be run in selinux enabled mode. so load selinux setup here
     # Setup environment for cc testing: SELinux setup
     # Such as: set up SELinux with permissive mode and specific policy type
     loadtest 'security/selinux/selinux_setup';
@@ -2432,6 +2434,7 @@ sub load_security_tests_cc {
 
     # Run test cases of 'audit-test' test suite which do need SELinux env
     # Please add these test cases here: poo#93441
+    loadtest 'security/cc/crypto';
 }
 
 

--- a/tests/security/cc/cc_audit_test_setup.pm
+++ b/tests/security/cc/cc_audit_test_setup.pm
@@ -45,7 +45,7 @@ sub run {
     assert_script_run('sed -i \'/\[Unit\]/aStartLimitIntervalSec=0\' /usr/lib/systemd/system/auditd.service');
     assert_script_run('systemctl daemon-reload');
 
-    # modify audit rules
+    # Modify audit rules
     assert_script_run('sed -i \'s/-a task,never/#&/\' /etc/audit/rules.d/audit.rules');
     assert_script_run('systemctl restart auditd.service');
 

--- a/tests/security/cc/crypto.pm
+++ b/tests/security/cc/crypto.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'crypto' test case of 'audit-test' test suite
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#95485
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # Install certification-sles-eal4: needed by test case `crypto`
+    zypper_call('in certification-sles-eal4');
+
+    # Export MODE
+    assert_script_run("export MODE=$audit_test::mode");
+
+    # Run test case
+    run_testcase('crypto', make => 1, timeout => 900);
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('crypto');
+    $self->result($result);
+}
+
+1;

--- a/tests/security/cc/fail_safe.pm
+++ b/tests/security/cc/fail_safe.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'fail-safe' test case of 'audit-test' test suite
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#95125
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # Run test case
+    run_testcase('fail-safe', make => 1, timeout => 300);
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('fail_safe');
+    $self->result($result);
+}
+
+1;


### PR DESCRIPTION
Add "crypto", "fail-safe" of "audit-test" to openQA

poo#95125 - [sle][security][sle15sp4][CC] automation: integrate "fail-safe" into openQA
poo#95485 - [sle][security][sle15sp4][CC] automation: integrate "crypto" into openQA
Related MR was merged: https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/15

- Related ticket: 
  https://progress.opensuse.org/issues/95485
  https://progress.opensuse.org/issues/95125
- Needles: NA
- Verification run: https://openqa.suse.de/tests/6532912 (all passed)
