### PR TITLE
Fix change_password and snapper_rollback failure

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -47,13 +47,7 @@ sub logout_and_login {
     my $test_user = $login_user // $username;
     my $test_pw   = $login_pw   // $newpwd;
     handle_logout;
-    send_key_until_needlematch 'displaymanager', 'esc', 9, 10;
-    mouse_hide();
-    wait_still_screen;
-    assert_and_click "displaymanager-$test_user";
-    assert_screen 'displaymanager-password-prompt', no_wait => 1;
-    type_password "$test_pw\n";
-    assert_screen 'generic-desktop', 120;
+    handle_login($test_user, 0, $test_pw);
 }
 
 sub switch_user {

--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -19,11 +19,12 @@ use migration 'check_rollback_system';
 use power_action_utils 'power_action';
 use Utils::Backends 'is_pvm';
 use version_utils;
+use x11utils 'handle_gnome_activities';
 
 sub run {
     my ($self) = @_;
     if ((is_leap_migration || is_opensuse) && (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'kde'))) {
-        assert_screen 'generic-desktop', 90;
+        handle_gnome_activities;
     }
     else {
         assert_screen [qw(linux-login displaymanager)], 300;


### PR DESCRIPTION
Update handle_login in x11utils.pm to allow user defined password
Update logout_and_login in users.pm to use handle_login
Update snapper_rollback.pm to handle gnome-activities

- Related ticket: https://progress.opensuse.org/issues/95789
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/c64c3d618b377f6286dbbfc02e9cfc1507afe155
- Verification run: 
- desktopapps-gnome (include application_starts_on_login and change_password) https://openqa.opensuse.org/tests/1852854
- system_performance (include snapper_rollback) https://openqa.opensuse.org/tests/1852865
