### PR TITLE
Enable FIPS testing for JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2170,8 +2170,9 @@ sub load_applicationstests {
 
 sub load_security_console_prepare {
     loadtest "console/consoletest_setup";
-    loadtest "security/test_repo_setup" if (get_var("SECURITY_TEST") =~ /^crypt_/);
+    loadtest "security/test_repo_setup" if (get_var("SECURITY_TEST") =~ /^crypt_/ && !is_opensuse);
     loadtest "fips/fips_setup"          if (get_var("FIPS_ENABLED"));
+    loadtest "console/openssl_alpn";
 }
 
 # The function name load_security_tests_crypt_* is to avoid confusing
@@ -2194,11 +2195,9 @@ sub load_security_tests_crypt_core {
     loadtest "fips/openssl/openssl_tlsv1_3";
     loadtest "fips/openssl/openssl_pubkey_rsa";
     loadtest "fips/openssl/openssl_pubkey_dsa";
-    loadtest "console/openssl_alpn";
-
     loadtest "fips/openssh/openssh_fips" if get_var("FIPS_ENABLED");
     loadtest "console/sshd";
-    loadtest "console/ssh_pubkey";
+    loadtest "console/ssh_pubkey" unless is_jeos;
     loadtest "console/ssh_cleanup";
 }
 

--- a/schedule/jeos/sle/fips.yaml
+++ b/schedule/jeos/sle/fips.yaml
@@ -1,0 +1,45 @@
+---
+description: 'Test suite verifies functionality of FIPS'
+name: 'jeos-fips'
+conditional_schedule:
+    bootloader:
+        MACHINE:
+            svirt-xen-pv:
+                - installation/bootloader_svirt
+            svirt-xen-hvm:
+                - installation/bootloader_svirt
+            svirt-hyperv-uefi:
+                - installation/bootloader_hyperv
+            svirt-hyperv:
+                - installation/bootloader_hyperv
+            svirt-vmware65:
+                - installation/bootloader_svirt
+    maintenance:
+        FLAVOR:
+            'JeOS-for-kvm-and-xen-Updates':
+                - qa_automation/patch_and_reboot
+schedule:
+    - '{{bootloader}}'
+    - installation/bootloader_uefi
+    - jeos/firstrun
+    - console/force_scheduled_tasks
+    - jeos/grub2_gfxmode
+    - console/suseconnect_scc
+    - '{{maintenance}}'
+    - console/consoletest_setup
+    - fips/fips_setup
+    - console/openssl_alpn
+    - fips/openssl/openssl_fips_alglist
+    - fips/openssl/openssl_fips_hash
+    - fips/openssl/openssl_fips_cipher
+    - fips/openssl/dirmngr_setup
+    - fips/openssl/dirmngr_daemon
+    - fips/gnutls/gnutls_base_check
+    - fips/gnutls/gnutls_server
+    - fips/gnutls/gnutls_client
+    - fips/openssl/openssl_tlsv1_3
+    - fips/openssl/openssl_pubkey_rsa
+    - fips/openssl/openssl_pubkey_dsa
+    - fips/openssh/openssh_fips
+    - console/sshd
+    - console/ssh_cleanup

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -75,6 +75,7 @@ sub run {
 
     # Workaround to resolve console switch issue
     select_console 'root-console';
+    assert_script_run q(grep '^1$' /proc/sys/crypto/fips_enabled);
 }
 
 sub test_flags {

--- a/tests/fips/gnutls/gnutls_server.pm
+++ b/tests/fips/gnutls/gnutls_server.pm
@@ -23,9 +23,11 @@ use base "consoletest";
 use testapi;
 use strict;
 use warnings;
+use utils qw(zypper_call);
 
 sub run {
     select_console "root-console";
+    zypper_call 'in gnutls';
 
     # Create test folder
     my $test_dir = "gnutls";

--- a/tests/fips/openssh/openssh_fips.pm
+++ b/tests/fips/openssh/openssh_fips.pm
@@ -25,7 +25,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
-use version_utils 'is_sle';
+use version_utils qw(is_sle);
 
 sub run {
     select_console 'root-console';
@@ -34,13 +34,14 @@ sub run {
     my $current_ver = script_output("rpm -q --qf '%{version}\n' openssh");
 
     # openssh update to 8.3 in SLE15 SP3
-    if (is_sle('>=15-sp3') && ($current_ver ge 8.3)) {
+    if (!is_sle('<15-sp3') && ($current_ver ge 8.3)) {
         record_info("openssh version", "Current openssh package version: $current_ver");
     }
     else {
         record_soft_failure("jsc#SLE-16308: openssh version outdate, openssh version need to be updated over to 8.3+ in SLE15 SP3");
     }
 
+    zypper_call('in expect') if script_run('rpm -q expect');
     # Verify MD5 is disabled in fips mode, no need to login
     validate_script_output
       'expect -c "spawn ssh -v -o StrictHostKeyChecking=no localhost; expect -re \[Pp\]assword; send badpass\n; exit 0"',

--- a/tests/fips/openssl/dirmngr_daemon.pm
+++ b/tests/fips/openssl/dirmngr_daemon.pm
@@ -32,7 +32,8 @@ sub dirmngr_daemon {
     my $myca_dir = "/home/linux/myca";
 
     # Create dirmngr required testing folder
-    assert_script_run('mkdir -p /etc/dirmngr/trusted-certs');
+    assert_script_run("mkdir -p /etc/dirmngr/");
+    assert_script_run("mkdir -p /etc/gnupg/trusted-certs");
     assert_script_run('mkdir -p /var/{run,log}/dirmngr /var/cache/dirmngr/crls.d /var/lib/dirmngr/extra-certs');
 
     # Create an empty ldapservers.conf
@@ -42,17 +43,20 @@ sub dirmngr_daemon {
     assert_script_run("echo 'log-file /var/log/dirmngr/dirmngr.log' > /etc/dirmngr/dirmngr.conf");
 
     # Copy trusted CA certificates to /etc/dirmngr/trusted-certs
-    assert_script_run("cp $myca_dir/ca/root-ca.crt.der /etc/dirmngr/trusted-certs");
+    assert_script_run("cp $myca_dir/ca/root-ca.crt.der /etc/gnupg/trusted-certs");
 
-    # Start dirmngr as daemon
-    validate_script_output("dirmngr --daemon --disable-ldap", sub { m/DIRMNGR_INFO=.*DIRMNGR_INFO;/ });
+    # Start dirmngr as daemon, Disable ldap, Load CRL
+    assert_script_run("dirmngr --daemon --disable-ldap --load-crl $myca_dir/crl/root-ca.crl.der");
 
-    # Load CRL
-    assert_script_run("dirmngr-client --load-crl $myca_dir/crl/root-ca.crl.der");
+    # part of softfailure https://dev.gnupg.org/T5531
+    assert_script_run("openssl x509 -inform der -outform pem -text -in $myca_dir/certs/test2.crt.der -out $myca_dir/certs/test2.crt.pem");
+    assert_script_run("openssl x509 -inform der -outform pem -text -in $myca_dir/certs/test1.crt.der -out $myca_dir/certs/test1.crt.pem");
 
     # Verify certificate ( test2.crt.der certificate is valid)
     if (script_run("dirmngr-client --validate $myca_dir/certs/test2.crt.der 2>&1 | tee -a /tmp/cert2.out") == 0) {
         assert_script_run("grep -o \'dirmngr-client: certificate is valid\' /tmp/cert2.out");
+    } elsif (script_run("dirmngr-client --validate $myca_dir/certs/test2.crt.pem 2>&1 | tee -a /tmp/cert2.out") == 0) {
+        record_soft_failure 'Maniphest#T5531: dirmngr --validate broken for DER encoded files';
     }
     else {
         die "dirmngr-client did not exit with return 0";
@@ -61,6 +65,8 @@ sub dirmngr_daemon {
     # Verify certificate ( test1.crt.der certificate is revoked)
     if (script_run("dirmngr-client --validate $myca_dir/certs/test1.crt.der 2>&1 | tee -a /tmp/cert1.out") == 1) {
         assert_script_run("grep -o \'dirmngr-client: validation of certificate failed: Certificate revoked\' /tmp/cert1.out");
+    } elsif (script_run("dirmngr-client --validate $myca_dir/certs/test1.crt.pem 2>&1 | tee -a /tmp/cert2.out") == 1) {
+        record_soft_failure 'Maniphest#T5531: dirmngr --validate broken for DER encoded files';
     }
     else {
         die "dirmngr-client did not exit with return 1";

--- a/tests/fips/openssl/dirmngr_setup.pm
+++ b/tests/fips/openssl/dirmngr_setup.pm
@@ -53,10 +53,10 @@ sub dirmngr_setup {
     assert_script_run 'echo 01 > ca/root-ca/db/root-ca.crl.srl';
 
     # Use expect for openssl Interactive mode
-    zypper_call("--no-refresh in expect");
+    zypper_call("--no-refresh in expect dirmngr");
 
     # Create and download the root-ca.conf file
-    assert_script_run "wget --quiet " . data_url('openssl/root-ca/root-ca.conf') . " -O $ca_cfg";
+    assert_script_run "curl --silent " . data_url('openssl/root-ca/root-ca.conf') . " --output $ca_cfg";
 
     # Create root ca certificate
     # assert_script_run("openssl req -new -config $ca_cfg -out $ca_csr -keyout $ca_key");

--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -23,6 +23,7 @@ use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
+    zypper_call 'in openssl';
 
     # Seperate the diffrent openssl command usage between SLE12 and SLE15
     if (is_sle('<15')) {

--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -24,6 +24,7 @@ use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
+    zypper_call 'in openssl';
 
     my $enc_passwd = "pass1234";
     my $hash_alg   = "sha256";
@@ -51,7 +52,7 @@ sub run {
     for my $cipher (@invalid_cipher) {
         validate_script_output
           "openssl enc -$cipher -e -pbkdf2 -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 || true",
-          sub { m/disabled for fips|disabled for FIPS|unknown option|Unknown cipher/ };
+          sub { m/disabled for fips|disabled for FIPS|unknown option|Unknown cipher|enc: Unrecognized flag/ };
     }
 
     script_run 'cd - && rm -rf fips-test';

--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -23,9 +23,11 @@ use base "consoletest";
 use testapi;
 use strict;
 use warnings;
+use utils qw(zypper_call);
 
 sub run {
     select_console 'root-console';
+    zypper_call 'in openssl';
 
     my $tmp_file = "/tmp/hello.txt";
 


### PR DESCRIPTION
Enable FIPS testing when `FIPS_ENABLED=1` is set for `main.pm`
conditional schedule.
Execute testcases that are grouped under `SECURITY_TEST=crypt_core`
identifier.
`sshd` and `ssh_pubkey` seem to significant overlap in their test
objects. In order to reduce duplicates, I have opened a [ticket](https://progress.opensuse.org/issues/96170) for
security team with request to merge both test cases.

- [[jeos] Add fips test](https://progress.opensuse.org/issues/95452)
- VRs:
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20210807](http://kepler.suse.cz/tests/6419#step/fips_setup/1)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20210810-1](http://kepler.suse.cz/tests/6424#step/fips_setup/1)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-QR-x86_64-Build3.1](http://kepler.suse.cz/tests/6421#step/fips_setup/1)
  * [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.3](http://kepler.suse.cz/tests/6423#step/fips_setup/1)