### PR TITLE
Schedule samba_adcli in mau-extratests2

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -96,6 +96,9 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/mutt
+        - network/samba/samba_adcli
+      aarch64:
+        - network/samba/samba_adcli
   arch_12sp5:
     ARCH:
       x86_64:


### PR DESCRIPTION
Scheduling the samba_adcli module for all archs except for s390
more about the s390 failure can be seen in poo#95611

- Related ticket: https://progress.opensuse.org/issues/91950
- Needles: No needles
- Verification runs for 15-SP3:  [x86_64](https://openqa.suse.de/tests/6538715#details) | [s390](https://openqa.suse.de/tests/6538744#)(samba_adcli not scheduled, as intended) | [aarch64](https://openqa.suse.de/tests/6538745#details)
