### PR TITLE
Do not run the --add-samba-data testcase in sle 15

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -133,7 +133,7 @@ sub run {
     assert_script_run "expect -c 'spawn ssh -l geekouser\@geeko.com localhost -t;expect sword:;send Nots3cr3t\\n;expect geekouser>;send exit\\n;interact'";
 
     # poo#91950 (update machine password with adcli --add-samba-data option)
-    update_password();
+    update_password() unless is_sle('=15');    # sle 15 does not support the `--add-samba-data` option
 
     assert_script_run "echo Nots3cr3t  | net ads leave --domain geeko.com -U Administrator -i";
 


### PR DESCRIPTION
sle 15 fails with unrecognized option '--add-samba-data', since the --add-samba-data option is not available in adcli for this product.

- Needles: No needles
- Verification run: [before](http://angmar.suse.de/tests/3577#step/samba_adcli/108) | [after](http://angmar.suse.de/tests/3649#)
