### PR TITLE
Fix autoyast profile for rules and classes example

### DIFF
--- a/data/autoyast_sle15/rule-based_example/classes/default
+++ b/data/autoyast_sle15/rule-based_example/classes/default
@@ -11,6 +11,10 @@
       <configuration>software.xml</configuration>
     </class>
     <class>
+      <class_name>general</class_name>
+      <configuration>registration.xml</configuration>
+    </class>
+    <class>
       <class_name>swap</class_name>
       <configuration>bigswap.xml</configuration>
       <dont_merge config:type="list">

--- a/data/autoyast_sle15/rule-based_example/classes/general/software.xml
+++ b/data/autoyast_sle15/rule-based_example/classes/general/software.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <software>
-    <install_recommended config:type="boolean">false</install_recommended>
     <products config:type="list">
       <product>SLES</product>
     </products>

--- a/data/autoyast_sle15/rule-based_example/profile_a.xml
+++ b/data/autoyast_sle15/rule-based_example/profile_a.xml
@@ -62,7 +62,7 @@
       </partitions>
     </drive>
     </partitioning>
-        <classes config:type="list">
+    <classes config:type="list">
       <class>
         <class_name>general</class_name>
         <configuration>users.xml</configuration>


### PR DESCRIPTION
Fixing the autoyast example for rules and classes, so that graphical version of grub is available after first boot.

- Related ticket: https://progress.opensuse.org/issues/95506
- Verification run: http://falafel.suse.cz/tests/522
