### PR TITLE
Extend the tomcat test with apache2-mod_jk

### DIFF
--- a/lib/Tomcat/JspTest.pm
+++ b/lib/Tomcat/JspTest.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Test the tomcat JSP examples
-# Maintainer: George Gkioulis <ggkioulis@suse.com>
+# Maintainer: QE Core <qe-core@suse.de>
 
 package Tomcat::JspTest;
 use base "x11test";
@@ -17,30 +17,39 @@ use warnings;
 use testapi;
 use utils;
 use Tomcat::Utils;
+use version_utils 'is_sle';
 
 # allow a 60 second timeout for asserting needles
 use constant TIMEOUT => 60;
 
 # test all JSP examples
 sub test_all_examples() {
-    my ($self) = shift;
+    my ($self, $mod_jk) = @_;
 
     # array with example test function and number of tabs required to select the example
     # shuffle example is skipped
-    my @jsp_examples = ([\&basic_arithmetics, 2], [\&basic_comparisons, 4], [\&implicit_objects, 4], [\&functions, 4], [\&composite_expressions, 4], [\&hello_world_tag, 4], [\&repeat_simple_tag, 4], [\&book_tag, 4], [\&tag_file, 4], [\&panel_tag, 4], [\&display_product, 4], [\&xhtml_basic, 4], [\&attribute_body, 8], [\&dynamic_attributes, 8], [\&jsp_configuration, 4], [\&number_guess, 4], [\&date, 4], [\&snoop, 4], [\&error, 4], [\&carts, 4], [\&checkbox, 4], [\&color, 4], [\&calendar, 4], [\&include, 4], [\&forward, 4], [\&plugin, 4], [\&servlet_jsp, 4], [\&simple_tag, 4], [\&jsp_xml, 4], [\&if, 4], [\&foreach, 4], [\&choose, 4], [\&form, 4]);
+    my @jsp_examples = ([\&basic_arithmetics, 2], [\&basic_comparisons, 4], [\&implicit_objects, 4], [\&functions, 4], [\&composite_expressions, 4], [\&hello_world_tag, 4]);
+    if (!$mod_jk) {
+        push(@jsp_examples, ([\&repeat_simple_tag, 4], [\&book_tag, 4], [\&tag_file, 4], [\&panel_tag, 4], [\&display_product, 4], [\&xhtml_basic, 4], [\&attribute_body, 8], [\&dynamic_attributes, 8], [\&jsp_configuration, 4], [\&number_guess, 4], [\&date, 4], [\&snoop, 4], [\&error, 4], [\&carts, 4], [\&checkbox, 4], [\&color, 4], [\&calendar, 4], [\&include, 4], [\&forward, 4], [\&plugin, 4], [\&servlet_jsp, 4], [\&simple_tag, 4], [\&jsp_xml, 4], [\&if, 4], [\&foreach, 4], [\&choose, 4], [\&form, 4]));
+    }
 
     # access the tomcat jsp examples page
-    $self->firefox_open_url('localhost:8080/examples/jsp');
+    if ($mod_jk) {
+        $self->firefox_open_url('localhost/examples/jsp');
+    } else {
+        $self->firefox_open_url('localhost:8080/examples/jsp');
+    }
     send_key_until_needlematch('tomcat-jsp-examples', 'ret');
 
     # Navigate with keyboard to each example and test it
     for my $i (0 .. $#jsp_examples) {
         Tomcat::Utils->browse_with_keyboard('tomcat-jsp-fallback', $jsp_examples[$i][0], $jsp_examples[$i][1]);
     }
-
     # test xhtml svg example
-    $self->firefox_open_url('localhost:8080/examples/jsp/jsp2/jspx/textRotate.jspx?name=testing');
-    send_key_until_needlematch('tomcat-xhtml-svg', 'ret');
+    if (!$mod_jk) {
+        $self->firefox_open_url('localhost:8080/examples/jsp/jsp2/jspx/textRotate.jspx?name=testing');
+        send_key_until_needlematch('tomcat-xhtml-svg', 'ret');
+    }
 }
 
 

--- a/lib/Tomcat/ModjkTest.pm
+++ b/lib/Tomcat/ModjkTest.pm
@@ -1,0 +1,108 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Provide the functionality for apache2 apache2-mod_jk installation
+# and configuration to tests regarding interaction between tomcat and apache2
+# via apache2-mod_jk package
+# Maintainer: QE Core <qe-core@suse.de>
+
+package Tomcat::ModjkTest;
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+use registration;
+
+# install and configure apache2, apache2-mod_jk and verify the interaction between apache2 and tomcat
+# via the package apache2-mod_jk
+sub mod_jk_setup() {
+    my $self = shift;
+    $self->select_serial_terminal();
+
+    record_info('install and configure apache2 and apache2-mod_jk connector Setup');
+    zypper_call('in apache2 apache2-mod_jk');
+
+    $self->conn_apache2_tomcat();
+    $self->load_jk_module();
+}
+
+# Connection from apache2 to tomcat: Functionality test
+sub func_conn_apache2_tomcat() {
+    my $self = shift;
+    $self->select_serial_terminal();
+    systemctl('stop apache2');
+    systemctl('stop tomcat');
+    assert_script_run(
+        "echo  \"\$(cat <<EOF
+JkMount /*       ajp13
+JkMount /*.jsp   ajp13
+JkMount /*.xhtml ajp13
+EOF
+        )\"  >> /etc/apache2/conf.d/jk.conf", timeout => 180
+    );
+    systemctl('start apache2');
+    systemctl('status apache2');
+
+    systemctl('start tomcat');
+    systemctl('status tomcat');
+}
+
+# Connection from apache2 to tomcat: tomcat part and apache2 part
+sub conn_apache2_tomcat() {
+    systemctl('stop tomcat');
+
+    # Define an AJP 1.3 Connector on IPv6 localhost port 8009
+    my $ajp_connector = qq(    <Connector protocol="AJP/1.3" address="::1" port="8009" redirectPort="8443" \/>);
+    assert_script_run qq(sed -i '/<\!-- Define an AJP 1.3 Connector on port 8009 -->/ a $ajp_connector\' /etc/tomcat/server.xml);
+
+    # Define a worker "ajp13" which listens behind the above AJP 1.3 Connector address and port
+    assert_script_run('cp /usr/share/doc/packages/apache2-mod_jk/workers.properties /etc/tomcat/workers.properties');
+    assert_script_run(
+        "echo \"\$(cat <<EOF
+worker.list=ajp13
+worker.ajp13.reference=worker.template
+worker.ajp13.host=localhost
+worker.ajp13.port=8009
+EOF
+        )\" >> /etc/tomcat/workers.properties", timeout => 180
+    );
+
+    # Connection from apache2 to tomcat: apache2 part
+    systemctl('stop apache2');
+    assert_script_run('cp -ai /usr/share/doc/packages/apache2-mod_jk/jk.conf /etc/apache2/conf.d');
+    if (is_sle('=15') or is_sle('<12-sp4')) {
+        # apache2-mod_jk package includes jk.conf is required to specify valid JkShmFile and Aliases.
+        record_soft_failure 'boo#1167896 included jk.conf broken';
+        assert_script_run(
+            "echo \"\$(cat <<EOF
+JkShmFile /var/log/tomcat/jk-runtime-status
+EOF
+        )\" >> /etc/apache2/conf.d/jk.conf", timeout => 180
+        );
+        assert_script_run("sed -i 's|servlets-examples|examples/servlets|g' /etc/apache2/conf.d/jk.conf");
+        assert_script_run("sed -i 's|jsp-examples|examples/jsp|g' /etc/apache2/conf.d/jk.conf");
+    }
+}
+
+# Include mod_jk into the apache2 list of modules to load
+sub load_jk_module() {
+    assert_script_run('cp -a /etc/sysconfig/apache2 sysconfig.apache2-1-no.jk');
+    # Configure inclusion of mod_jk into apache2 service
+    assert_script_run('a2enmod jk');
+    if ((script_run 'diff sysconfig.apache2-1-no.jk /etc/sysconfig/apache2') != 1) {
+        die "failed to appended jk to the APACHE_MODULES line";
+    }
+    systemctl('start apache2');
+    validate_script_output("apachectl -M | grep jk_module",                        sub { ".*jk_module.*" });
+    validate_script_output("grep mod_jk /etc/apache2/sysconfig.d/loadmodule.conf", sub { "LoadModule jk_module.*" });
+}
+
+1;

--- a/lib/Tomcat/ServletTest.pm
+++ b/lib/Tomcat/ServletTest.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Test the tomcat Servlet examples
-# Maintainer: George Gkioulis <ggkioulis@suse.com>
+# Maintainer: QE Core <qe-core@suse.de>
 
 package Tomcat::ServletTest;
 use base "x11test";
@@ -24,14 +24,21 @@ use constant TIMEOUT => 60;
 
 # test all Servlet examples
 sub test_all_examples() {
-    my ($self) = shift;
+    my ($self, $mod_jk) = @_;
 
     # array with example test function and number of tabs required to select the example
     # the two servlet 4.0 examples are skipped
-    my @servlet_examples = ([\&hello, 2], [\&request_information, 4], [\&request_header, 4], [\&request_parameters, 4], [\&cookies, 4], [\&sessions, 4], [\&async0, 3], [\&async1, 1], [\&async2, 1], [\&async3, 1], [\&stocksticker, 1], [\&byte_counter, is_sle('<12-sp4') ? 2 : 1], [\&number_writer, 1]);
+    my @servlet_examples = ([\&hello, 2], [\&request_information, 4], [\&request_header, 4], [\&request_parameters, 4], [\&cookies, 4], [\&sessions, 4]);
+    if (!$mod_jk) {
+        push(@servlet_examples, [\&async0, 3], [\&async1, 1], [\&async2, 1], [\&async3, 1], [\&stocksticker, 1], [\&byte_counter, is_sle('<12-sp4') ? 2 : 1], [\&number_writer, 1]);
+    }
 
     # access the tomcat servlets examples page
-    $self->firefox_open_url('localhost:8080/examples/servlets');
+    if ($mod_jk) {
+        $self->firefox_open_url('localhost/examples/servlets');
+    } else {
+        $self->firefox_open_url('localhost:8080/examples/servlets');
+    }
     send_key_until_needlematch('tomcat-servlet-examples-page', 'ret');
 
     # Navigate with keyboard to each example and test it
@@ -39,7 +46,6 @@ sub test_all_examples() {
         Tomcat::Utils->browse_with_keyboard('tomcat-servlet-fallback', $servlet_examples[$i][0], $servlet_examples[$i][1]);
     }
 }
-
 
 # test hello example
 sub hello() {

--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,8 +9,7 @@
 
 # Summary: Provide functionality for tomcat installation and configuration,
 # accessing the tomcat manager page, and browsing tomcat examples using keyboard.
-# Maintainer: George Gkioulis <ggkioulis@suse.com>
-
+# Maintainer: QE Core <qe-core@suse.de>
 
 package Tomcat::Utils;
 use base "x11test";
@@ -34,7 +33,6 @@ sub browse_with_keyboard {
     send_key('ctrl-tab');
 
     $test_func->();
-
     send_key('ctrl-w');
 }
 

--- a/tests/x11/tomcat.pm
+++ b/tests/x11/tomcat.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -12,7 +12,9 @@
 # * install and configure tomcat
 # * access tomcat manager web page
 # * test all Servlet, JSP and WebSocket examples
-# Maintainer: George Gkioulis <ggkioulis@suse.com>
+# * install apache2-mod_jk
+# * test the interaction between tomcat and apache2 via apache2-mod_jk
+# Maintainer: QE Core <qe-core@suse.de>
 
 use base "x11test";
 use strict;
@@ -22,20 +24,19 @@ use Tomcat::ServletTest;
 use Tomcat::JspTest;
 use Tomcat::WebSocketsTest;
 use Tomcat::Utils;
+use Tomcat::ModjkTest;
 use utils;
+use version_utils 'is_sle';
 use x11utils 'ensure_unlocked_desktop';
 
 sub run() {
-    my ($self) = shift;
 
+    my ($self) = shift;
     # install and configure tomcat in console
     Tomcat::Utils->tomcat_setup();
 
     # switch to desktop
-    if (!check_var('DESKTOP', 'textmode')) {
-        select_console('x11', await_console => 0);
-        ensure_unlocked_desktop;
-    }
+    $self->switch_to_desktop();
 
     # start firefox
     $self->start_firefox_with_profile();
@@ -62,6 +63,69 @@ sub run() {
     my $websocket_test = Tomcat::WebSocketsTest->new();
     $websocket_test->test_all_examples();
 
+    # Close firefox
+    $self->close_firefox();
+    assert_screen('generic-desktop');
+
+    # Install and configure apache2 and apache2-mod_jk connector
+    Tomcat::ModjkTest->mod_jk_setup();
+    $self->switch_to_desktop();
+
+    # start firefox
+    $self->start_firefox_with_profile();
+    $self->firefox_open_url('http://localhost/examples/servlets');
+    send_key_until_needlematch('tomcat-servlet-examples-page', 'ret');
+
+    $self->firefox_open_url('http://localhost/examples/jsp');
+    send_key_until_needlematch('tomcat-jsp-examples', 'ret');
+    $self->close_firefox();
+
+    $self->select_serial_terminal();
+    systemctl('start tomcat');
+
+    my $with_modjk = 1;
+    $self->switch_to_desktop();
+    # start firefox
+    $self->start_firefox_with_profile();
+    record_info('Servlet Testing');
+    $servlet_test->test_all_examples($with_modjk);
+
+    record_info('JSP Testing');
+    $jsp_test->test_all_examples($with_modjk);
+
+    $self->close_firefox();
+
+    $self->select_serial_terminal();
+    # Connection from apache2 to tomcat: Functionality test
+    Tomcat::ModjkTest->func_conn_apache2_tomcat();
+
+    # switch to desktop
+    $self->switch_to_desktop();
+
+    # start firefox
+    $self->start_firefox_with_profile();
+
+    $self->firefox_open_url('http://localhost');
+    send_key_until_needlematch('tomcat-succesfully-installed', 'ret');
+
+    $self->firefox_open_url('http://localhost:8080');
+    send_key_until_needlematch('tomcat-succesfully-installed', 'ret');
+
+    $self->close_firefox();
+    assert_screen('generic-desktop');
+
+}
+
+sub switch_to_desktop {
+
+    # switch to desktop
+    if (!check_var('DESKTOP', 'textmode')) {
+        select_console('x11', await_console => 0);
+        ensure_unlocked_desktop;
+    }
+}
+
+sub close_firefox {
 
     # close firefox
     send_key('alt-f4');
@@ -73,8 +137,6 @@ sub run() {
     send_key('ret');
     type_string_slow 'killall xterm';
     send_key('ret');
-
-    assert_screen('generic-desktop');
 }
 
 1;


### PR DESCRIPTION
- Summary: Extend the existing tomcat test
   install apache2, apache2-mod_jk packages
   configure and test the connection from apache2 to tomcat
   test the interaction between apache2 and tomcat via apache2-mod_jk 

- Related ticket:https://progress.opensuse.org/issues/91643
- Needles: 
       - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1550
       - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/741
- Verification run: 
   Tumbleweed  -  http://10.161.229.147/tests/1055#step/tomcat/203
   SLE 15 SP1   -  http://10.161.229.147/tests/1057#step/tomcat/199
   SLE 15 SP2   -  http://10.161.229.147/tests/1062#step/tomcat/198
   SLE 15 SP3   -  http://10.161.229.147/tests/1053#step/tomcat/200
   SLE 15           -  http://10.161.229.147/tests/1052#step/tomcat/198
   SLE 12 SP2   -  http://10.161.229.147/tests/1064#step/tomcat/199
   SLE 12 SP3   -    http://10.161.229.147/tests/1058#step/tomcat/199
   SLE 12 SP4   -   http://10.161.229.147/tests/1056#step/tomcat/200 
   
- Latest Verification run:
  Tumbleweed -  http://10.161.229.147/tests/1149#step/tomcat/201
  SLE 15 SP1 - http://10.161.229.147/tests/1139#step/tomcat/198
  SLE 15 SP2 - http://10.161.229.147/tests/1140#step/tomcat/198
  SLE 15 SP3 - http://10.161.229.147/tests/1141#step/tomcat/200
  SLE 15 - http://10.161.229.147/tests/1138#step/tomcat/200
  SLE 12 SP2 -  http://10.161.229.147/tests/1148#step/tomcat/198
  SLE 12 SP3 - http://10.161.229.147/tests/1103#step/tomcat/197
  SLE 12 SP4 - http://10.161.229.147/tests/1102#step/tomcat/195
  SLE 12 SP5 - http://10.161.229.147/tests/1101#step/tomcat/199
 