### PR TITLE
Download SUSE cacert from https instead of http for transactional

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -22,7 +22,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
     if (is_sle_micro) {
-        assert_script_run 'curl http://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt';
+        assert_script_run 'curl -k https://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt';
         assert_script_run 'update-ca-certificates -v';
     }
     add_test_repositories;


### PR DESCRIPTION
Since some days ago, http is returning 301 and therefore the
certificate doesn't get installed properly and any repo can be added.

failed test -> https://openqa.suse.de/tests/6566726#step/install_updates/26
VR: https://openqa.suse.de/tests/6571162
