### PR TITLE
Add "misc", "ip+eb-tables" of "audit-test"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2425,6 +2425,7 @@ sub load_security_tests_cc {
     # Run test cases of 'audit-test' test suite which do NOT need SELinux env
     loadtest 'security/cc/audit_tools';
     loadtest 'security/cc/fail_safe';
+    loadtest 'security/cc/ip_eb_tables';
 
     # Some audit tests must be run in selinux enabled mode. so load selinux setup here
     # Setup environment for cc testing: SELinux setup
@@ -2435,6 +2436,7 @@ sub load_security_tests_cc {
     # Run test cases of 'audit-test' test suite which do need SELinux env
     # Please add these test cases here: poo#93441
     loadtest 'security/cc/crypto';
+    loadtest 'security/cc/misc';
 }
 
 

--- a/tests/security/cc/audit_tools.pm
+++ b/tests/security/cc/audit_tools.pm
@@ -31,4 +31,8 @@ sub run {
     $self->result($result);
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/security/cc/cc_audit_test_setup.pm
+++ b/tests/security/cc/cc_audit_test_setup.pm
@@ -54,4 +54,8 @@ sub run {
     assert_script_run("tar -xvf ${dir}${file_tar} -C ${dir}");
 }
 
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
 1;

--- a/tests/security/cc/cc_selinux_setup.pm
+++ b/tests/security/cc/cc_selinux_setup.pm
@@ -31,4 +31,8 @@ sub run {
     $self->set_sestatus('permissive', 'minimum');
 }
 
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
 1;

--- a/tests/security/cc/fail_safe.pm
+++ b/tests/security/cc/fail_safe.pm
@@ -31,4 +31,8 @@ sub run {
     $self->result($result);
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/security/cc/ip_eb_tables.pm
+++ b/tests/security/cc/ip_eb_tables.pm
@@ -4,12 +4,12 @@
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved. This file is offered as-is,
+# notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: Run 'crypto' test case of 'audit-test' test suite
+# Summary: Run 'ip+eb-tables' test case of 'audit-test' test suite
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#95485
+# Tags: poo#96049
 
 use base 'consoletest';
 use strict;
@@ -23,17 +23,11 @@ sub run {
 
     select_console 'root-console';
 
-    # Install certification-sles-eal4: needed by test case `crypto`
-    zypper_call('in certification-sles-eal4');
-
-    # Export MODE
-    assert_script_run("export MODE=$audit_test::mode");
-
     # Run test case
-    run_testcase('crypto', make => 1, timeout => 900);
+    run_testcase('ip+eb-tables', timeout => 300);
 
     # Compare current test results with baseline
-    my $result = compare_run_log('crypto');
+    my $result = compare_run_log('ip_eb_tables');
     $self->result($result);
 }
 

--- a/tests/security/cc/misc.pm
+++ b/tests/security/cc/misc.pm
@@ -4,12 +4,12 @@
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved. This file is offered as-is,
+# notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: Run 'crypto' test case of 'audit-test' test suite
+# Summary: Run 'misc' test case of 'audit-test' test suite
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#95485
+# Tags: poo#95488
 
 use base 'consoletest';
 use strict;
@@ -23,17 +23,11 @@ sub run {
 
     select_console 'root-console';
 
-    # Install certification-sles-eal4: needed by test case `crypto`
-    zypper_call('in certification-sles-eal4');
-
-    # Export MODE
-    assert_script_run("export MODE=$audit_test::mode");
-
     # Run test case
-    run_testcase('crypto', make => 1, timeout => 900);
+    run_testcase('misc', make => 1, timeout => 300);
 
     # Compare current test results with baseline
-    my $result = compare_run_log('crypto');
+    my $result = compare_run_log('misc');
     $self->result($result);
 }
 


### PR DESCRIPTION
Add "misc", "ip+eb-tables" of "audit-test" into openQA
poo#95488 - [sle][security][sle15sp4][CC] automation: integrate "misc" into openQA
poo#96049 - [sle][security][sle15sp4][CC] automation: integrate "ip+eb-tables" into openQA

- Related MR:
   https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/18
- Related ticket:
   https://progress.opensuse.org/issues/96049
   https://progress.opensuse.org/issues/95488
- Needles: NA
- Verification run:
   https://openqa.suse.de/tests/6632493 (the failed cases can be tracked by bsc#1188851 - [SLES15SP3][SECURITY][audit][ebtables] can not generate "type=NETFILTER_PKT" audit record)