### PR TITLE
Public Cloud: Add --progress to rsync and timeout command before

### DIFF
--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -32,7 +32,8 @@ sub run {
         record_info('Skip download', 'Skipping download triggered by setting (QAM_PUBLICCLOUD_SKIP_DOWNLOAD = 1)');
     } else {
         assert_script_run('du -sh ~/repos');
-        assert_script_run("rsync -uva -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 1800);
+        my $timeout = 2400;
+        assert_script_run("rsync --timeout=$timeout -uvahP -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => $timeout + 10);
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");


### PR DESCRIPTION
- Related ticket: [poo#95104](https://progress.opensuse.org/issues/95104)
- Failure: [transfer_repos](https://openqa.suse.de/tests/6578724#step/transfer_repos/7)
- Verification run: http://pdostal-server.suse.cz/tests/12384#step/transfer_repos/6
