### PR TITLE
Ignore orphan kernel symlink in livepatch tests

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -30,7 +30,11 @@ sub check_kernel_package {
     my $kernel_name = shift;
 
     script_run('ls -1 /boot/vmlinu[xz]*');
-    my $packs = script_output('rpm -qf --qf "%{NAME}\n" /boot/vmlinu[xz]*');
+    # Only check versioned kernels in livepatch tests. Some old kernel
+    # packages install /boot/vmlinux symlink but don't set package ownership.
+    my $glob  = get_var('KGRAFT', 0) ? '-*' : '*';
+    my $cmd   = 'rpm -qf --qf "%{NAME}\n" /boot/vmlinu[xz]' . $glob;
+    my $packs = script_output($cmd);
 
     for my $packname (split /\s+/, $packs) {
         die "Unexpected kernel package $packname is installed, test may boot the wrong kernel"

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -29,8 +29,8 @@ use Utils::Backends 'use_ssh_serial_console';
 sub check_kernel_package {
     my $kernel_name = shift;
 
-    script_run('ls -1 /boot/vmlinux*');
-    my $packs = script_output('rpm -qf --qf "%{NAME}\n" /boot/vmlinux*');
+    script_run('ls -1 /boot/vmlinu[xz]*');
+    my $packs = script_output('rpm -qf --qf "%{NAME}\n" /boot/vmlinu[xz]*');
 
     for my $packname (split /\s+/, $packs) {
         die "Unexpected kernel package $packname is installed, test may boot the wrong kernel"


### PR DESCRIPTION
A few older kernel packages create `/boot/vmlinux` or `/boot/vmlinuz` symlink but fail to set package ownership for it. This packaging mistake causes the check for unexpected kernel packages to fail and blocks livepatch testing. Since there's nothing we can do about these already released packages, ignore the symlink altogether in livepatch tests and only check it in new kernel updates.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - SLE-15SP1 livepatch: https://openqa.suse.de/tests/6583334
  - SLE-15SP2 livepatch: https://openqa.suse.de/tests/6583337
  - SLE-15SP2 KOTD: https://openqa.suse.de/tests/6583339
  - SLE-15SP2 kernel-rt: https://openqa.suse.de/tests/6583341