### PR TITLE
Add RT product installation workaround for not released product

### DIFF
--- a/schedule/rt/sle15/rt-product-textmode.yaml
+++ b/schedule/rt/sle15/rt-product-textmode.yaml
@@ -1,9 +1,12 @@
 ---
 description: 'GUI installation of RT product without gnome pattern.'
 name: 'rt-product-textmode@64bit ( qemu )'
+vars:
+  EXTRABOOTPARAMS: startshell=1
 schedule:
   - installation/isosize
   - installation/bootloader
+  - rt/add_product
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -22,5 +25,6 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/exit_startshell
   - installation/grub_test
   - installation/first_boot

--- a/schedule/rt/sle15/rt-product.yaml
+++ b/schedule/rt/sle15/rt-product.yaml
@@ -1,9 +1,12 @@
 ---
 description: 'The default installation of RT product in GUI. Upload the installed system for further validation testing.'
 name: 'rt-product@64bit ( qemu )'
+vars:
+  EXTRABOOTPARAMS: startshell=1
 schedule:
   - installation/isosize
   - installation/bootloader
+  - rt/add_product
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
@@ -22,6 +25,7 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
+  - installation/exit_startshell
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/tests/rt/add_product.pm
+++ b/tests/rt/add_product.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Add RT product installation workaround
+# Maintainer: QE Kernel <kernel-qa@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+
+sub run() {
+    record_soft_failure 'poo#96158 - Adding RT product to control.xml';
+    assert_screen 'startshell', 90;
+    assert_script_run 'sed -i \'/./{H;$!d} ; x ; s/\s*<\/base_product>\s*<\/base_products>/<\/base_product><base_product><display_name>SUSE Linux Enterprise Real Time 15 SP3<\/display_name><name>SLE_RT<\/name><version>15\.3<\/version><register_target>sle-15-\$arch<\/register_target><archs>x86_64<\/archs><\/base_product><\/base_products>/\' control.xml';
+    assert_script_run 'sed -i \'1d\' control.xml';
+    script_run 'exit', timeout => 0;
+}
+
+1;


### PR DESCRIPTION
We need to test RT product installation with existing SLE installation
media, which don't contain RT. It is possible todo it  with updated
control.xml configuration file of YaST installer.

- Related ticket: https://progress.opensuse.org/issues/96119
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1551
- Verification run: 
rt_product:  http://10.100.12.105/tests/811#step/add_product/1
rt_product-textmode: http://10.100.12.105/tests/810#step/add_product/1
