### PR TITLE
Schedule ntp_client.pm in aggregate test repo

### DIFF
--- a/schedule/qam/common/qam-security-fips.yml
+++ b/schedule/qam/common/qam-security-fips.yml
@@ -22,3 +22,11 @@ schedule:
 - fips/curl_fips_rc4_seed
 - fips/mozilla_nss/apache_nssfips
 - fips/mozilla_nss/firefox_nss
+- '{{version_specific}}'
+conditional_schedule:
+    version_specific:
+        VERSION:
+            15-SP3:
+            - console/ntp_client
+            15-SP2:
+            - console/ntp_client


### PR DESCRIPTION
This module was unscheduled some months ago, because of [bug]( https://bugzilla.suse.com/show_bug.cgi?id=1173760) in chronyd. As the issue is now solved, they can be scheduled again in osd. It is scheduled only in SLES 15SP3 and 15SP2, because of the following reasons:
1. [Bug](https://bugzilla.suse.com/show_bug.cgi?id=1188981) detected in SLE15SP1 and SLE15
2. Chrony doesn't exist in SLE12 versions, so the [test](https://progress.opensuse.org/issues/96462) has to be adapted.

- Related ticket: https://progress.opensuse.org/issues/89392
- Needles: N/A
- Verification run: SLES [15-SP2](https://openqa.suse.de/tests/6631556#step/ntp_client/54) | [15-SP3](https://openqa.suse.de/tests/6631573#step/ntp_client/54)
