### PR TITLE
Fix adcli tests on s390x

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -31,6 +31,7 @@ schedule:
   - console/gd
   - console/systemtap
   - console/vsftpd
+  - network/samba/samba_adcli
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:
@@ -96,9 +97,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/mutt
-        - network/samba/samba_adcli
-      aarch64:
-        - network/samba/samba_adcli
   arch_12sp5:
     ARCH:
       x86_64:

--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -147,10 +147,16 @@ sub run {
     # - Mount //GEEKO
     # - smbclient //10.162.30.119/openQA as geekouser will be denied, as berhard is the owner
     # - delete the computer OU after the test is done in post_run_hook
-    # - add the post_fail_hook to upload all relevant logs
     # - test winbind (samba?) authentication
 
 }
 
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->SUPER::post_fail_hook;
+    $self->select_serial_terminal;
+    script_run 'tar Jcvf samba_adcli.tar.xz /etc/sssd /var/log/samba /var/log/sssd /var/log/krb5';
+    upload_logs('./samba_adcli.tar.xz');
+}
 
 1;

--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -18,6 +18,7 @@ use base "consoletest";
 use testapi;
 use utils;
 use version_utils 'is_sle';
+use Utils::Architectures;
 
 my $AD_hostname = 'win2019dcadprovider.phobos.qa.suse.de';
 my $AD_ip       = '10.162.30.119';
@@ -95,10 +96,17 @@ sub update_password {
     }
 }
 
+sub disable_ipv6 {
+    my $self = shift;
+    $self->select_serial_terminal;
+    assert_script_run("sysctl -w net.ipv6.conf.all.disable_ipv6=1");
+}
+
 sub run {
     my $self = shift;
     # select_console 'root-console';
     $self->select_serial_terminal;
+    $self->disable_ipv6 if is_s390x;
     samba_sssd_install;
 
     #Join the Active Directory

--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -100,6 +100,14 @@ sub disable_ipv6 {
     my $self = shift;
     $self->select_serial_terminal;
     assert_script_run("sysctl -w net.ipv6.conf.all.disable_ipv6=1");
+    set_var('SYSCTL_IPV6_DISABLED', '1');
+}
+
+sub enable_ipv6 {
+    my $self = shift;
+    $self->select_serial_terminal;
+    assert_script_run("sysctl -w net.ipv6.conf.all.disable_ipv6=0");
+    set_var('SYSCTL_IPV6_DISABLED', '0');
 }
 
 sub run {
@@ -157,6 +165,7 @@ sub run {
     # - delete the computer OU after the test is done in post_run_hook
     # - test winbind (samba?) authentication
 
+    $self->enable_ipv6 if is_s390x;
 }
 
 sub post_fail_hook {
@@ -165,6 +174,7 @@ sub post_fail_hook {
     $self->select_serial_terminal;
     script_run 'tar Jcvf samba_adcli.tar.xz /etc/sssd /var/log/samba /var/log/sssd /var/log/krb5';
     upload_logs('./samba_adcli.tar.xz');
+    $self->enable_ipv6 if is_s390x;
 }
 
 1;

--- a/variables.md
+++ b/variables.md
@@ -142,6 +142,7 @@ SPECIFIC_DISK | boolean | false | Enables installation/partitioning_olddisk test
 SPLITUSR | boolean | false | Enables `installation/partitioning_splitusr` test module.
 SUSEMIRROR | string | | Mirror url of the installation medium.
 SYSAUTHTEST | boolean | false | Enable system authentication test (`sysauth/sssd`)
+SYSCTL_IPV6_DISABLED | boolean | undef | Set automatically in samba_adcli tests when ipv6 is disabled
 TEST | string | | Name of the test suite.
 TEST_CONTEXT | string | | Defines the class name to be used as the context instance of the test. This is used in the scheduler to pass the `run_args` into the loadtest function. If it is not given it will be undef.
 TOGGLEHOME | boolean | false | Changes the state of partitioning to have or not to have separate home partition in the proposal.


### PR DESCRIPTION
Fixes [poo#96611](https://progress.opensuse.org/issues/95611), basically we're disabling ipv6 on s390 only to enable it  after the test back again. See 
https://progress.opensuse.org/issues/72169#note-58 for follow up, as this is likely a potential problem (be it infrastructure, configuration or an actual bug).

samba_adcli: Disable ipv6 on s390
samba_adcli: Export relevant logs on failure

VR: https://openqa.suse.de/tests/6596238