### PR TITLE
Add correct hotkey for SLES for SAP Applications QR Medium

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -71,6 +71,7 @@ sub get_product_shortcuts {
             sled => 'x',
             sles4sap => is_ppc64le() ? 'i'
             : (is_sle('15-SP2+') && is_x86_64() && !is_quarterly_iso()) ? 't'
+            : (is_sle('15-SP3+') && is_x86_64()) ? 't'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',
             rt  => is_x86_64() ? 't' : undef


### PR DESCRIPTION
Add correct hotkey for SLES for SAP Applications QR Medium

- Failing test: https://openqa.suse.de/tests/6590629#step/welcome/5
- Related ticket: https://progress.opensuse.org/issues/96206
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/4190
