### PR TITLE
Integrate 'trustedprograms' of audit test into openQA

### DIFF
--- a/schedule/security/cc_trustedprograms.yaml
+++ b/schedule/security/cc_trustedprograms.yaml
@@ -1,0 +1,7 @@
+name: cc_trustedprograms
+description:    >
+    This is for audit_test trustedprograms
+schedule:
+    - boot/boot_to_desktop
+    - security/cc/cc_audit_test_setup
+    - security/cc/trustedprograms

--- a/tests/security/cc/trustedprograms.pm
+++ b/tests/security/cc/trustedprograms.pm
@@ -1,0 +1,66 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'trustedprograms' test case of 'audit-test' test suite
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#95908
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+use bootloader_setup qw(add_grub_cmdline_settings);
+use power_action_utils "power_action";
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # For database testcases
+    zypper_call('in perl-Expect');
+
+    # Workaround for testcase pam01.
+    # This case will restart sshd service many times in short time,
+    # in case the test fails, we need to do workaround.
+    assert_script_run('sed -i \'/\[Unit\]/aStartLimitIntervalSec=0\' /usr/lib/systemd/system/sshd.service');
+    assert_script_run('systemctl daemon-reload');
+
+    # For the test case 'password is acceptable, but previously used' in pam01 ([37] database pam01).
+    # When we set a password which has been used previously, the operation should fail.
+    # By default, this system doesn't have this limitation, we should set common-password to support it.
+    assert_script_run('pam-config -a --pwhistory --pwhistory-remember=3');
+
+    # The tests ([8] screen_locking and [9] screen_manage) require these settings in grub file.
+    add_grub_cmdline_settings('no-scroll fbcon=scrollback:0', update_grub => 1);
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(textmode => 1);
+
+    select_console 'root-console';
+
+    run_testcase('trustedprograms', (make => 1, timeout => 900));
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('trustedprograms');
+
+    # Upload log files in tests, e.g. pam01.log
+    my $output    = script_output('ls tests | grep .log');
+    my @log_files = split(/\n/, $output);
+    upload_logs("tests/$_") for @log_files;
+
+    $self->result($result);
+}
+
+sub test_flags {
+    return {no_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
QE security plan to integrate all test cases under `CC audit test`
into openQA. 'trustedprograms' is one of them.

Related: https://progress.opensuse.org/issues/95908
Verification run: https://openqa.suse.de/tests/6605402
MR: https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/19