### PR TITLE
Add -p for mkdir to easily re-run the tests

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -350,7 +350,7 @@ sub copy_media {
     # First copy media
     my $mnt_path   = '/mnt';
     my $media_path = "$mnt_path/" . get_required_var('ARCH');
-    assert_script_run "mkdir $target";
+    assert_script_run "mkdir -p $target";
     assert_script_run "mount -t $proto -o ro $path $mnt_path";
     $media_path = $mnt_path if script_run "[[ -d $media_path ]]";    # Check if specific ARCH subdir exists
     assert_script_run "cp -ax $media_path/. $target/", $nettout;


### PR DESCRIPTION
If not added we see the following:
Test died: command 'mkdir /sapinst' failed at /usr/lib/os-autoinst/testapi.pm line 963
testapi::_handle_script_run_ret(1, "mkdir /sapinst", "timeout", 90, "fail_message", "", "quiet", undef) called at /usr/lib/os-autoinst/testapi.pm line 1001
testapi::assert_script_run("mkdir /sapinst") called at sle/lib/sles4sap.pm line 353

- Verification run: ....running.... https://openqa.suse.de/tests/6607473
