### PR TITLE
Fix wrong definition of args in typing API

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -438,7 +438,7 @@ Typing a string with C<SLOW_TYPING_SPEED> to avoid losing keys.
 sub type_string_slow {
     my ($string) = @_;
 
-    type_string $string, SLOW_TYPING_SPEED;
+    type_string $string, max_interval => SLOW_TYPING_SPEED;
 }
 
 =head2 type_string_very_slow
@@ -462,7 +462,7 @@ also scaled by C<TIMEOUT_SCALE> which we do not need here.
 sub type_string_very_slow {
     my ($string) = @_;
 
-    type_string $string, VERY_SLOW_TYPING_SPEED;
+    type_string $string, max_interval => VERY_SLOW_TYPING_SPEED;
 
     if (get_var('WINTER_IS_THERE')) {
         sleep 3;
@@ -482,7 +482,7 @@ Enter a command with C<SLOW_TYPING_SPEED> to avoid losing keys.
 sub enter_cmd_slow {
     my ($cmd) = @_;
 
-    enter_cmd $cmd, SLOW_TYPING_SPEED;
+    enter_cmd $cmd, max_interval => SLOW_TYPING_SPEED;
 }
 
 =head2 enter_cmd_very_slow
@@ -496,7 +496,7 @@ C<type_string_very_slow>.
 sub enter_cmd_very_slow {
     my ($cmd) = @_;
 
-    enter_cmd $cmd, VERY_SLOW_TYPING_SPEED;
+    enter_cmd $cmd, max_interval => VERY_SLOW_TYPING_SPEED;
     wait_still_screen(1, 3);
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/88452
- Fails: https://openqa.suse.de/tests/6602223 https://openqa.suse.de/tests/6601217
```
Odd number of elements in hash assignment at /usr/lib/os-autoinst/testapi.pm line 1450.
	testapi::type_string(10, "lf", 1, 13) called at /usr/lib/os-autoinst/testapi.pm line 1523
	testapi::enter_cmd(10, 13) called at sle/lib/utils.pm line 485
	utils::enter_cmd_slow(10) called at sle/tests/console/yast2_ftp.pm line 160
	yast2_ftp::run(yast2_ftp=HASH(0x5606e136ee30)) called at /usr/lib/os-autoinst/basetest.pm line 356
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 350
	basetest::runtest(yast2_ftp=HASH(0x5606e136ee30)) called at /usr/lib/os-autoinst/autotest.pm line 374
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 374
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 242
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 242
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 298
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x5606e2364a38)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x5606e2364a38), CODE(0x5606e1b62c50)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 477
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x5606e2364a38)) called at /usr/lib/os-autoinst/autotest.pm line 300
	autotest::start_process() called at /usr/bin/isotovideo line 274
```

type_string does not require it (`if (@_ == 1) {    # backward compat`) but I already changed it, keep it consistent.

- Verification run:
http://dzedro.suse.cz/tests/18745
http://dzedro.suse.cz/tests/18746
http://dzedro.suse.cz/tests/18749