### PR TITLE
openssl-nodejs retry logic

### DIFF
--- a/data/console/test_openssl_nodejs.sh
+++ b/data/console/test_openssl_nodejs.sh
@@ -8,13 +8,24 @@ test_result_wrapper(){
 
   local NODE="/usr/bin/node$VERSION"
   local OUTPUT="/tmp/test_output"
+  local RESULT=0;
 
-  # Run the test (using common and custom flags if present) and save the output
-  echo "Running $NODE_FULL_VERSION $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]}$FILE"
-  set +e
-  $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]} $FILE &> $OUTPUT
-  RESULT=$?
-  set -e
+  # Try same test 3 times before giving up
+  local i=0;
+  while [ $i -le 2 ]
+  do
+    # Run the test (using common and custom flags if present) and save the output
+    echo "Running $NODE_FULL_VERSION $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]}$FILE - Try #$i"
+    set +e
+    $NODE $GLOBAL_FLAGS ${node_flags[$VERSION $FILE]} $FILE &> $OUTPUT
+    RESULT=$?
+    set -e
+    if [ $RESULT -eq 0 ]; then
+      break
+    fi
+    echo "Did not work out this time."
+    ((i++))
+  done
 
   # If test failed, keep track of failure and print out its output
   if [ $RESULT -ne 0 ]; then

--- a/data/console/test_openssl_nodejs.sh
+++ b/data/console/test_openssl_nodejs.sh
@@ -24,7 +24,7 @@ test_result_wrapper(){
       break
     fi
     echo "Did not work out this time."
-    ((i++))
+    ((i+=1))
   done
 
   # If test failed, keep track of failure and print out its output


### PR DESCRIPTION
openssl-nodejs retry logic to reduce risk of sporadic failures


- Related ticket: https://progress.opensuse.org/issues/95875
- Needles: none
- Verification run: https://openqa.suse.de/tests/6612363
