### PR TITLE
rt: Add schedule for system preparation with internal repositories

### DIFF
--- a/schedule/rt/sle15/create_hdd_rt.yaml
+++ b/schedule/rt/sle15/create_hdd_rt.yaml
@@ -1,0 +1,41 @@
+---
+name: create_hdd_rt
+description:    >
+    Prepare image with internal RT repositories.
+vars:
+    SYSTEM_ROLE: minimal
+    DESKTOP: textmode
+    SCC_ADDONS: sdk
+schedule:
+    - installation/isosize
+    - installation/bootloader
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/grub_test
+    - installation/first_boot
+    - console/system_prepare
+    - console/check_network
+    - console/system_state
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - rt/add_repositories
+    - console/install_rt_kernel
+    - locale/keymap_or_locale
+    - console/force_scheduled_tasks
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/rt/sle15/prepare_baremetal_rt.yaml
+++ b/schedule/rt/sle15/prepare_baremetal_rt.yaml
@@ -1,0 +1,38 @@
+name:          prepare_baremetal_rt
+description:    >
+    Installation schedule to prepare bare metal for RT using IPXE.
+vars:
+    SYSTEM_ROLE: minimal
+    DESKTOP: textmode
+    SCC_ADDONS: sdk
+schedule:
+    - installation/ipxe_install
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_firstdisk
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_graphics
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/handle_reboot
+    - installation/first_boot
+    - console/hostname
+    - console/system_prepare
+    - rt/add_repositories
+    - console/install_rt_kernel
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/tests/rt/add_repositories.pm
+++ b/tests/rt/add_repositories.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Add RT repositories for kernel installation.
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils qw(zypper_ar);
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    # Add repositories if they are requested
+    zypper_ar(get_var('REPO_RT_IMAGES'),   name => 'repo_rt_images')   if get_var('REPO_RT_IMAGES');
+    zypper_ar(get_var('REPO_RT_STANDARD'), name => 'repo_rt_standard') if get_var('REPO_RT_STANDARD');
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+=head1 Notes
+
+=head2 REPO_RT_IMAGES
+http://download.suse.de/ibs/SUSE:/SLE-15-SP3:/Update:/Products:/SLERT/images/repo/SLE-15-SP3-Module-RT-POOL-x86_64-Media1/
+
+=head2 REPO_RT_STANDARD
+http://download.suse.de/ibs/SUSE:/SLE-15-SP3:/Update:/Products:/SLERT/standard/
+
+=cut


### PR DESCRIPTION
Fix poo#94543: We need to add additional internal repositories for
unreleased RT product. New schedules will prepare hdd and baremetal
for textmode testing.

- Related ticket: https://progress.opensuse.org/issues/94543
- Needles: none
- Verification run: 
qemu: http://10.100.12.105/tests/834
baremetal: http://openqa.suse.de/tests/6617409