### PR TITLE
SLE15-SP4 product does not include python2 module

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -99,8 +99,10 @@ sub run {
 
     script_run('zypper lr | tee /tmp/zypperlr.txt');
 
+    # Need make sure the system is registered then check modules
+    my $output = script_output 'SUSEConnect -s';
     # Check the expected addons before migration
-    if (check_var('VERSION', get_required_var('ORIGIN_SYSTEM_VERSION')) && !get_var("MEDIA_UPGRADE")) {
+    if (check_var('VERSION', get_required_var('ORIGIN_SYSTEM_VERSION')) && ($output !~ /Not Registered/)) {
         my $addons = get_var('SCC_ADDONS', "");
         $addons =~ s/ltss,?//g;
         check_addons($addons);
@@ -111,11 +113,10 @@ sub run {
     if (check_var('VERSION', get_required_var('UPGRADE_TARGET_VERSION'))) {
         check_milestone_version;
         my $myaddons = get_var('SCC_ADDONS', "");
-        $myaddons .= ",base,serverapp"                             if (is_sle('15+')                                   && check_var('SLE_PRODUCT', 'sles'));
-        $myaddons .= ",base,desktop,we,python2"                    if (is_sle('15+')                                   && check_var('SLE_PRODUCT', 'sled'));
-        $myaddons .= ",base,serverapp,desktop,dev,lgm,python2,wsm" if (is_sle('<15', get_var('ORIGIN_SYSTEM_VERSION')) && is_sle('15+'));
-        $myaddons .= ",python2"                                    if (is_sle('=15', get_var('ORIGIN_SYSTEM_VERSION')) && is_sle('15+'));
-        $myaddons .= ",base,serverapp,desktop,dev,lgm,python2,wsm,phub" if (is_leap_migration);
+        $myaddons .= ",base,serverapp"                          if (is_sle('15+') && check_var('SLE_PRODUCT', 'sles'));
+        $myaddons .= ",base,desktop,we"                         if (is_sle('15+') && check_var('SLE_PRODUCT', 'sled'));
+        $myaddons .= ",base,serverapp,desktop,dev,lgm,wsm"      if (is_sle('<15', get_var('ORIGIN_SYSTEM_VERSION')) && is_sle('15+'));
+        $myaddons .= ",base,serverapp,desktop,dev,lgm,wsm,phub" if (is_leap_migration);
 
         # After upgrade, system doesn't include ltss extension
         $myaddons =~ s/ltss,?//g;


### PR DESCRIPTION
Need remove python2 module check since python2 has already been dropped
 on SLE15SP4, need make sure the system is registered then check the
system modules

- Related ticket: https://progress.opensuse.org/issues/96037
- Verification run: 
12sp5 http://openqa.suse.de/t6605751
15sp1 zdup http://openqa.suse.de/t6616938
15GA http://openqa.suse.de/t6616939
15sp2 http://openqa.suse.de/t6617049