### PR TITLE
Containers: schedule PackageHub related tests only if BETA=1

### DIFF
--- a/schedule/containers/engines_and_tools_docker.yaml
+++ b/schedule/containers/engines_and_tools_docker.yaml
@@ -20,21 +20,31 @@ conditional_schedule:
         - containers/docker_runc
   supported:
     HOST_VERSION:
+      15-SP4:
+        - containers/buildah_docker
       15-SP3:
         - containers/buildah_docker
       15-SP2:
         - containers/buildah_docker
       15-SP1:
         - containers/buildah_docker
+  package_hub_dependent:
+    FLAVOR:
+      Server-DVD-Updates:
+        - containers/docker_compose
+        - containers/registry
+    BETA:
+      0:
+        - containers/docker_compose
+        - containers/registry
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/docker
   - '{{runc}}'
   - '{{supported}}'
-  - containers/docker_compose
   - containers/zypper_docker
   - containers/docker_3rd_party_images
-  - containers/registry
+  - '{{package_hub_dependent}}'
   - console/coredump_collect
   - '{{validate_btrfs}}'

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -69,9 +69,6 @@ sub run {
     $self->select_serial_terminal;
     my ($running_version, $sp, $host_distri) = get_os_release;
 
-    # Package Hub is not enabled on 15-SP3 yet.
-    return if is_sle '=15-SP3';
-
     # Install and check that it's running
     add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1) if is_sle(">=15");
     zypper_call 'se -v docker-distribution-registry';


### PR DESCRIPTION
We started QA for 15-SP4 but PackageHub is not available until Beta
phase, so we should stop running the tests that need PH available.

- Related ticket:  https://progress.opensuse.org/issues/95626
