### PR TITLE
Containers: schedule buildah tests only in 1 place

### DIFF
--- a/schedule/containers/engines_and_tools_docker.yaml
+++ b/schedule/containers/engines_and_tools_docker.yaml
@@ -18,16 +18,6 @@ conditional_schedule:
         - containers/docker_runc
       s390x:
         - containers/docker_runc
-  supported:
-    HOST_VERSION:
-      15-SP4:
-        - containers/buildah_docker
-      15-SP3:
-        - containers/buildah_docker
-      15-SP2:
-        - containers/buildah_docker
-      15-SP1:
-        - containers/buildah_docker
   package_hub_dependent:
     FLAVOR:
       Server-DVD-Updates:
@@ -42,7 +32,6 @@ schedule:
   - boot/boot_to_desktop
   - containers/docker
   - '{{runc}}'
-  - '{{supported}}'
   - containers/zypper_docker
   - containers/docker_3rd_party_images
   - '{{package_hub_dependent}}'

--- a/schedule/containers/engines_and_tools_podman.yaml
+++ b/schedule/containers/engines_and_tools_podman.yaml
@@ -12,7 +12,6 @@ schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/podman
-  - containers/buildah_podman
   - containers/rootless_podman
   - containers/podman_3rd_party_images
   - console/coredump_collect

--- a/schedule/containers/sle_image_on_sle_host_docker.yaml
+++ b/schedule/containers/sle_image_on_sle_host_docker.yaml
@@ -9,6 +9,8 @@ conditional_schedule:
         - installation/bootloader_start
   buildah_docker:
     HOST_VERSION:
+      15-SP4:
+        - containers/buildah_docker
       15-SP3:
         - containers/buildah_docker
       15-SP2:


### PR DESCRIPTION
For some reason we were scheduling buildah tests in
engines and tools and also in sle image on sle host.
Let's just run it in single place.

- Related ticket:  https://progress.opensuse.org/issues/95626
