### PR TITLE
NFS: initial cthon04 testsuite and put pynfs in the same folder

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -74,10 +74,10 @@ our @EXPORT = qw(
   load_jeos_tests
   load_kernel_baremetal_tests
   load_kernel_tests
+  load_nfs_tests
   load_nfv_master_tests
   load_nfv_trafficgen_tests
   load_public_cloud_patterns_validation_tests
-  load_pynfs_tests
   load_transactional_role_tests
   load_reboot_tests
   load_rescuecd_tests
@@ -3270,10 +3270,10 @@ sub load_kernel_baremetal_tests {
     loadtest "kernel/build_git_kernel" if get_var('KERNEL_GIT_TREE');
 }
 
-sub load_pynfs_tests {
-    loadtest "pynfs/install";
-    loadtest "pynfs/run";
-    loadtest "pynfs/generate_report";
+sub load_nfs_tests {
+    loadtest "nfs/install";
+    loadtest "nfs/run";
+    loadtest "nfs/generate_report";
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -271,9 +271,9 @@ if (is_kernel_test()) {
 elsif (get_var('NFV')) {
     load_nfv_tests();
 }
-elsif (get_var("PYNFS")) {
+elsif (get_var("PYNFS") || get_var("CTHON04")) {
     loadtest "boot/boot_to_desktop";
-    load_pynfs_tests;
+    load_nfs_tests;
 }
 elsif (get_var("REGRESSION")) {
     load_common_x11;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -781,9 +781,9 @@ elsif (get_var("BTRFS_PROGS")) {
     loadtest "btrfs-progs/run";
     loadtest "btrfs-progs/generate_report";
 }
-elsif (get_var("PYNFS")) {
+elsif (get_var("PYNFS") || get_var("CTHON04")) {
     prepare_target;
-    load_pynfs_tests;
+    load_nfs_tests;
 }
 elsif (get_var("BTRFSMAINTENANCE")) {
     prepare_target;

--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -18,7 +18,7 @@ use File::Basename;
 use testapi;
 use upload_system_log;
 
-sub upload_log {
+sub upload_pynfs_log {
     my $self   = shift;
     my $folder = get_required_var('PYNFS');
 
@@ -38,11 +38,47 @@ sub upload_log {
     }
 }
 
+sub upload_cthon04_log {
+    my $self = shift;
+    assert_script_run('cd ~/cthon04');
+    if (script_output("grep 'All tests completed' ./result* | wc -l") =~ '4') {
+        record_info('All tests completed');
+    }
+    else {
+        $self->result("fail");
+        record_info("Test fail: Not all test completed");
+    }
+    if (script_output("grep ' ok.' ./result_basic_test.txt | wc -l") =~ '9') {
+        record_info('Basic test pass');
+    }
+    else {
+        $self->result("fail");
+        record_info('Basic test failed');
+    }
+    if (script_output("egrep ' ok|success' ./result_special_test.txt | wc -l") =~ '7') {
+        record_info('Special test pass');
+    }
+    else {
+        $self->result("fail");
+        record_info('Special test failed');
+    }
+    if (script_run("grep 'Congratulations, you passed the locking tests!' ./result_lock_test.txt")) {
+        $self->result("fail");
+        record_info('Lock test failed');
+    }
+    upload_logs('result_*', failok => 1);
+}
+
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    $self->upload_log();
+    if (get_var("PYNFS")) {
+        $self->upload_pynfs_log();
+    }
+    elsif (get_var("CTHON04")) {
+        $self->upload_cthon04_log();
+    }
     upload_system_logs();
 }
 

--- a/tests/nfs/run.pm
+++ b/tests/nfs/run.pm
@@ -20,7 +20,7 @@ use testapi;
 use utils;
 use power_action_utils 'power_action';
 
-sub server_test_all {
+sub pynfs_server_test_all {
     my $self   = shift;
     my $folder = get_required_var('PYNFS');
 
@@ -32,15 +32,24 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    script_run('cd ~/pynfs');
-    server_test_all;
+    if (get_var("PYNFS")) {
+        script_run('cd ~/pynfs');
+        pynfs_server_test_all;
+    }
+    elsif (get_var("CTHON04")) {
+        script_run('cd ~/cthon04');
+        script_run('./runtests -b -t /exportdir | tee result_basic_test.txt');
+        script_run('./runtests -g -t /exportdir | tee result_general_test.txt');
+        script_run('./runtests -s -t /exportdir | tee result_special_test.txt');
+        script_run('./runtests -l -t /exportdir | tee result_lock_test.txt');
+    }
 }
 
 1;
 
 =head1 Configuration
 
-=head2 Example configuration for SLE:
+=head2 Example PYNFS configuration for SLE:
 
 BOOT_HDD_IMAGE=1
 DESKTOP=textmode
@@ -60,5 +69,18 @@ will accept.
 
 If not set, then the default clone action will be performed, which probably
 means the latest master branch will be used.
+
+=head2 Example CTHON04 configuration for SLE:
+
+BOOT_HDD_IMAGE=1
+DESKTOP=textmode
+HDD_1=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2
+CTHON04=1
+UEFI_PFLASH_VARS=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed-uefi-vars.qcow2
+START_AFTER_TEST=create_hdd_minimal_base+sdk
+
+=head2 CTHON04_GIT_URL
+
+Similar PYNFS_GIT_URL, it overrides the official cthon04 repository URL.
 
 =cut


### PR DESCRIPTION
This PR mainly initial cthon04 testsuite, and consider more NFS tests will involve, then make some change in previous NFS test - pynfs, move them in a new test folder. Details:
1. Initial cthon04 test, add it into NFS tests
2. Put previous pynfs in the same folder, and reuse its code
3. Remove folder /pynfs and use /nfs

- Related ticket: https://progress.opensuse.org/issues/93396
- Verification run: 
http://10.67.133.102/tests/327
And this PR doesn't change anything to run pynfs: http://10.67.133.102/tests/323 http://10.67.133.102/tests/324