### PR TITLE
Use mouse to login gdm if username is not highlighted.

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -19,6 +19,7 @@ use LWP::Simple;
 use Config::Tiny;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
+use x11utils 'select_user_gnome';
 use POSIX 'strftime';
 use mm_network;
 
@@ -30,16 +31,13 @@ sub post_run_hook {
 
 sub dm_login {
     assert_screen('displaymanager', 60);
-    # The keyboard focus was losing in gdm of SLE15 bgo#657996
-    mouse_set(520, 350) if is_sle('15+');
-    send_key('ret');
+    select_user_gnome;
     assert_screen('originUser-login-dm');
     type_password;
 }
 
 # logout and switch window-manager
 sub switch_wm {
-    mouse_set(1000, 30);
     assert_and_click "system-indicator";
     assert_and_click "user-logout-sector";
     assert_and_click "logout-system";

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -290,7 +290,6 @@ sub select_user_gnome {
     assert_screen [qw(displaymanager-user-selected displaymanager-user-notselected dm-nousers)];
     if (match_has_tag('displaymanager-user-notselected')) {
         assert_and_click "displaymanager-$myuser";
-        record_soft_failure 'bsc#1086425- user account not selected by default, have to use mouse to login';
     }
     elsif (match_has_tag('displaymanager-user-selected')) {
         send_key 'ret';


### PR DESCRIPTION
And remove the softfailure.
Upstream has changed the design of gdm, although the first
username in gdm is highlighted after boot, it is not always
like that under other circumstance.  So when the username
is not highlighted, use 'assert_and_click'.

Also update `dm_login` a bit to avoid using hard-coded value and remove outdated comment.

- Related ticket: https://progress.opensuse.org/issues/64947
- Needles: None
- Verification run:
 Tumbleweed: https://openqa.opensuse.org/tests/1865638
 SLE15SP4: https://openqa.suse.de/tests/6631109#step/gdm_session_switch/26
