### PR TITLE
Make yast2_console_exec to use 0 timeout

### DIFF
--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -25,7 +25,7 @@ sub yast2_console_exec {
     # Kepp only the first 10 characters of a magic string plus a dash ('-')
     # and up to a three digit exit code.
     $module_name = substr($module_name, 0, 10) if is_hyperv('2012r2');
-    if (!script_run($y2_start . " echo $module_name-\$? > /dev/$serialdev", 90)) {
+    if (!script_run($y2_start . " echo $module_name-\$? > /dev/$serialdev", 0)) {
         return $module_name;
     } else {
         die "Yast2 module failed to execute!\n";


### PR DESCRIPTION
Returns back the timeout for yast2_console_exec, as recent change made tests on TW failing (e.g. https://openqa.opensuse.org/tests/1862643)

- Related ticket: https://progress.opensuse.org/issues/96435
- Verification run: https://openqa.opensuse.org/tests/1865691
