### PR TITLE
Fix gnome-x11-ibus failure

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -999,4 +999,32 @@ sub start_gnome_tweak_tool {
     }
 }
 
+# Since GNOME 40 or later, the 'Input Sources' is no longer in the 'Region & Language' panel
+# The 'Input Sources' is in the gnome-control-center 'Keyboard' panel now
+# Navigate to the 'Keyboard' panel first and then add the input source that to be tested
+sub add_input_resource {
+    my ($self, $tag) = @_;
+
+    # send_key 'super';
+    # wait_still_screen;
+    x11_start_program "gnome-control-center keyboard", target_match => "gnome-control-center-keyboard";
+
+    # assert_screen 'g-c-c-keyboard-input-source';
+    assert_and_click 'ibus-input-source-add';
+    assert_and_click 'ibus-input-language-list';
+    type_string $tag;
+
+    assert_and_click "ibus-input-$tag";
+    if ($tag eq "japanese") {
+        assert_and_dclick 'ibus-input-japanese-kkc';
+    } elsif ($tag eq "chinese") {
+        assert_and_dclick 'ibus-input-chinese-pinyin';
+    } elsif ($tag eq "korean") {
+        assert_and_dclick 'ibus-input-korean-hangul';
+    }
+    assert_screen "ibus-input-added-$tag";
+    send_key 'alt-f4';
+    assert_screen 'generic-desktop';
+}
+
 1;

--- a/tests/x11/ibus/ibus_clean.pm
+++ b/tests/x11/ibus/ibus_clean.pm
@@ -9,7 +9,7 @@
 # without any warranty.
 
 # Summary: other ibus tests
-# Maintainer: Gao Zhiyuan <zgao@suse.com>
+# Maintainer: Grace Wang <grace.wang@suse.com>
 
 use base "x11test";
 use strict;
@@ -17,16 +17,11 @@ use warnings;
 use testapi;
 use utils;
 
-sub remove_cn {
-    assert_and_click 'ibus-input-added-cn';
-}
-
-sub remove_jp {
-    assert_and_click 'ibus-input-added-jp';
-}
-
-sub remove_kr {
-    assert_and_click 'ibus-input-added-kr';
+sub remove_input_source {
+    for my $tag (qw(chinese japanese korean)) {
+        assert_and_click "ibus-input-added-$tag";
+        assert_and_click "ibus-remove-input-source";
+    }
 }
 
 sub run {
@@ -36,18 +31,11 @@ sub run {
     assert_and_click 'ibus-indicator';
     send_key 'esc';
 
-    send_key 'super';
-    wait_still_screen;
-    type_string_slow ' region & language';
-    wait_still_screen;
-    send_key 'ret';
+    x11_start_program "gnome-control-center keyboard", target_match => "g-c-c-keyboard-before-clean";
 
-    assert_screen 'ibus-region-language';
-    remove_cn;
-    remove_jp;
-    remove_kr;
+    remove_input_source;
 
-    assert_screen 'ibus-region-language-empty';
+    assert_screen 'ibus-input-source-default';
     send_key 'alt-f4';
 }
 

--- a/tests/x11/ibus/ibus_test_cn.pm
+++ b/tests/x11/ibus/ibus_test_cn.pm
@@ -10,32 +10,13 @@
 
 # Package: gedit ibus
 # Summary: test ibus chinese input
-# Maintainer: Gao Zhiyuan <zgao@suse.com>
+# Maintainer: Grace Wang <grace.wang@suse.com>
 
 use base "x11test";
 use strict;
 use warnings;
 use testapi;
 use utils;
-
-sub ibus_enable_source_cn {
-    send_key 'super';
-    wait_still_screen;
-    type_string_slow ' region & language';
-    wait_still_screen(3);
-    send_key 'ret';
-
-    assert_screen 'ibus-region-language';
-    assert_and_click 'ibus-input-source-options';
-    assert_and_click 'ibus-input-language-list';
-    type_string 'chinese';
-
-    assert_and_click 'ibus-input-chinese';
-    assert_and_dclick 'ibus-input-chinese-pinyin';
-    assert_screen 'ibus-input-added-cn';
-    send_key 'alt-f4';
-    assert_screen 'generic-desktop';
-}
 
 sub test_cn {
     x11_start_program('gedit');
@@ -62,8 +43,8 @@ sub run {
     my ($self) = @_;
 
     assert_screen "generic-desktop";
-    # enable Chinese input sources
-    ibus_enable_source_cn;
+    # add Chinese input source
+    $self->add_input_resource("chinese");
 
     # open gedit and test chinese
     test_cn;

--- a/tests/x11/ibus/ibus_test_jp.pm
+++ b/tests/x11/ibus/ibus_test_jp.pm
@@ -10,32 +10,13 @@
 
 # Package: gedit ibus
 # Summary: setup and test ibus japanese input
-# Maintainer: Gao Zhiyuan <zgao@suse.com>
+# Maintainer: Grace Wang <grace.wang@suse.com>
 
 use base "x11test";
 use strict;
 use warnings;
 use testapi;
 use utils;
-
-sub ibus_enable_source_jp {
-    send_key 'super';
-    wait_still_screen;
-    type_string_slow ' region & language';
-    wait_still_screen(3);
-    send_key 'ret';
-
-    assert_screen 'ibus-region-language';
-    assert_and_click 'ibus-input-source-options';
-    assert_and_click 'ibus-input-language-list';
-    type_string 'japanese';
-
-    assert_and_click 'ibus-input-japanese';
-    assert_and_dclick 'ibus-input-japanese-kkc';
-    assert_screen 'ibus-input-added-jp';
-    send_key 'alt-f4';
-    assert_screen 'generic-desktop';
-}
 
 sub test_jp {
     x11_start_program('gedit');
@@ -62,8 +43,8 @@ sub run {
 
     assert_screen "generic-desktop";
 
-    # enable Japanses input sources
-    ibus_enable_source_jp;
+    # add Japanses input source
+    $self->add_input_resource("japanese");
 
     # open gedit and test chinese
     test_jp;

--- a/tests/x11/ibus/ibus_test_kr.pm
+++ b/tests/x11/ibus/ibus_test_kr.pm
@@ -10,32 +10,13 @@
 
 # Package: gedit ibus
 # Summary: ibus enable and test korean language
-# Maintainer: Gao Zhiyuan <zgao@suse.com>
+# Maintainer: Grace Wang <grace.wang@suse.com>
 
 use base "x11test";
 use strict;
 use warnings;
 use testapi;
 use utils;
-
-sub ibus_enable_source_kr {
-    send_key 'super';
-    type_string_slow ' region & language';
-    wait_still_screen(3);
-    send_key 'ret';
-
-
-    assert_screen 'ibus-region-language';
-    assert_and_click 'ibus-input-source-options';
-    assert_and_click 'ibus-input-language-list';
-    type_string 'korean';
-
-    assert_and_click 'ibus-input-korean';
-    assert_and_dclick 'ibus-input-korean-hangul';
-    assert_screen 'ibus-input-added-kr';
-    send_key 'alt-f4';
-    assert_screen 'generic-desktop';
-}
 
 sub test_kr {
     x11_start_program('gedit');
@@ -64,8 +45,8 @@ sub run {
     my ($self) = @_;
 
     assert_screen "generic-desktop";
-    # enable Korean input sources
-    ibus_enable_source_kr;
+    # add Korean input source
+    $self->add_input_resource("korean");
 
     # open gedit and test korean
     test_kr;


### PR DESCRIPTION
GNOME40: input sources are now under 'keyboard'
Extract add_input_resource into x11test.pm
Update ibus_test_cn/kr/jp.pm to use add_input_resource
Simplify remove_input_source in ibus_clean.pm
Update ibus_clean.pm to use the new location of the input source

- Related ticket: https://progress.opensuse.org/issues/95120
- Needles: already added when debugging on o3
- Verification run: https://openqa.opensuse.org/tests/1865693