### PR TITLE
Integrate 'libpam' of audit test into openQA

### DIFF
--- a/schedule/security/cc_libpam.yaml
+++ b/schedule/security/cc_libpam.yaml
@@ -1,0 +1,8 @@
+name: cc_libpam
+description:    >
+    This is for audit_test libpam
+schedule:
+    - boot/boot_to_desktop
+    - security/selinux/selinux_setup
+    - security/cc/cc_audit_test_setup
+    - security/cc/libpam

--- a/tests/security/cc/libpam.pm
+++ b/tests/security/cc/libpam.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'libpam' test case of 'audit-test' test suite
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#95911
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # PASSWD is needed by test case 'ssh04'
+    script_run("export PASSWD=$testapi::password");
+
+    run_testcase('libpam', (make => 1, timeout => 900));
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('libpam');
+    $self->result($result);
+}
+
+1;


### PR DESCRIPTION
QE security plan to integrate all test cases under CC audit test
into openQA. 'libpam' is one of them.

Related: https://progress.opensuse.org/issues/95911
Verify run: https://openqa.suse.de/tests/6631568#
MR: https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/21

