### PR TITLE
Don't attempt to run zypper-docker on Tumbleweed anymore

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1720,7 +1720,7 @@ sub load_extra_tests_docker {
     }
     loadtest "containers/docker_compose" unless (is_sle('<15') || is_sle('>=15-sp2'));
     loadtest 'containers/registry';
-    loadtest "containers/zypper_docker";
+    loadtest "containers/zypper_docker"   unless is_tumbleweed;
     loadtest "containers/rootless_podman" unless is_sle('<15-SP2');
 }
 

--- a/schedule/containers/extra_tests_textmode_containers_docker_tw.yaml
+++ b/schedule/containers/extra_tests_textmode_containers_docker_tw.yaml
@@ -1,0 +1,21 @@
+name:           extra_tests_textmode_containers_docker
+description:    >
+  Maintainer: qa-c@suse.de.
+  Extra tests about software in containers module with docker
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+schedule:
+  - '{{boot}}'
+  - boot/boot_to_desktop
+  - containers/docker
+  - containers/docker_image
+  - containers/container_diff
+  - containers/buildah_docker
+  - containers/docker_runc
+  - containers/docker_compose
+  - containers/docker_3rd_party_images
+  - containers/registry
+  - console/coredump_collect

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -25,7 +25,7 @@ use utils;
 use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
-use version_utils qw(get_os_release check_os_release);
+use version_utils qw(get_os_release check_os_release is_tumbleweed);
 
 sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
@@ -48,7 +48,7 @@ sub run {
             build_and_run_image(base => $iname, runtime => $runtime);
             if (check_os_release('suse', 'PRETTY_NAME')) {
                 test_opensuse_based_image(image => $iname, runtime => $runtime, version => $version);
-                build_with_zypper_docker(image => $iname, runtime => $runtime, version => $version);
+                build_with_zypper_docker(image => $iname, runtime => $runtime, version => $version) unless is_tumbleweed;
             }
             else {
                 exec_on_container($iname, $runtime, 'cat /etc/os-release');


### PR DESCRIPTION
It got removed from Tumbleweed.
Add new YAML schedule for extra_tests_textmode_containers_docker specific to TW
because it's not possible to exclude a module based on VERSION...

While it would be more technically correct to check for the host explicitly, there are currently no test runs with Leap hosts on Tumbleweed (which is unfortunate) and zypper-docker appears to be dead anyway. In `main_common.pm`, the version of the host isn't even easily accessible.

I'm using `unless is_tumbleweed` instead of the opposite `if is_leap || is_sle || ...` because that would turn out to be more complex and probably wrong anyway...



- Related ticket: https://progress.opensuse.org/issues/96389
- Verification run: https://openqa.opensuse.org/tests/1865782
