### PR TITLE
Remove testdata and wget-ipv6 from publiccloud

### DIFF
--- a/schedule/publiccloud/mau-extratests-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-publiccloud.yml
@@ -12,7 +12,6 @@ schedule:
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview
   - console/system_prepare
-  - console/prepare_test_data
   - console/consoletest_setup
   - console/check_os_release
   - console/cleanup_qam_testrepos
@@ -28,7 +27,6 @@ schedule:
   - console/gdb
   - console/sysctl
   - console/sysstat
-  - console/wget_ipv6
   - console/gpg
   - console/shells
   - console/sudo


### PR DESCRIPTION
The test run prepare-testdata is obsolete and needs to be removed.
The wget-ipv6 test does not make sense to run in publiccloud, where IPv6 is not available.

- Related ticket: https://progress.opensuse.org/issues/96194
