### PR TITLE
Public Cloud: Add temporal debug output to wait_for_ssh()

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -225,6 +225,9 @@ sub wait_for_ssh
         sleep 1;
     }
 
+    # Debug output: We have ocasional error in 'journalctl -b' - see poo#96464 - this will be removed soon.
+    $self->run_ssh_command(cmd => 'sudo journalctl -b', proceed_on_failure => 1, username => $args{username});
+
     unless ($args{proceed_on_failure}) {
         my $error_msg;
         if ($check_port) {


### PR DESCRIPTION
- Related ticket: [poo#96464](https://progress.opensuse.org/issues/96464)
- Verification run: [publiccloud_ltp_cve@12-SP4-GCE-BYOS-Updates](http://pdostal-server.suse.cz/tests/12430)
