### PR TITLE
[virt_autotest] add bsc1188898 as soft failure for hotplugging test

### DIFF
--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -140,7 +140,10 @@ sub test_add_vcpu {
     die "Setting vcpus failed" unless (set_vcpus($guest, 2));
     assert_script_run("ssh root\@$guest nproc | grep 2", 60);
     # Add 1 CPU
-    if ($sles_running_version eq '15' && $sles_running_sp eq '3' && is_xen_host && is_fv_guest($guest)) {
+    if ($sles_running_version eq '15' && $sles_running_sp eq '4' && is_xen_host && is_fv_guest($guest)) {
+        record_soft_failure('bsc#1188898 Failed to set live vcpu count on fv guest on 15-SP4 Xen host');
+    }
+    elsif ($sles_running_version eq '15' && $sles_running_sp eq '3' && is_xen_host && is_fv_guest($guest)) {
         record_soft_failure('bsc#1180350 Failed to set live vcpu count on fv guest on 15-SP3 Xen host');
     }
     else {


### PR DESCRIPTION
For now, figure out the new product issue as bsc1188898 block osd hotplugging test on sles15sp4 xen host. 
So, add bsc1188898 as soft failure for hotplugging test (Add a virtual CPU to the given guest) on sles15sp4 xen server. 
Also, had confirmed bsc#1180350 does still reproduce on sles15sp3 xen server with sles15sp4 fv guest.
So, keep bsc#1180350 as soft failure for hotplugging test (Add a virtual CPU to the given guest) on sles15sp3 xen server. 

- Verification run: 
[gi-guest_sles12sp5-on-host_developing-xen](https://openqa.suse.de/tests/6655365#)
[gi-guest_sles15sp3-on-host_developing-xen](https://openqa.suse.de/tests/6655366#)
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/6655367#)
[gi-guest_developing-on-host_sles15sp3-xen](https://openqa.suse.de/tests/6655368#)