### PR TITLE
boot_ltp: Take framebuffer console screenshot after boot

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -40,6 +40,11 @@ sub run {
     }
 
     $self->select_serial_terminal;
+
+    # Debug code for poo#81142
+    script_run('gzip -9 </dev/fb0 >framebuffer.dat.gz');
+    upload_logs('framebuffer.dat.gz', failok => 1);
+
     assert_secureboot_status(1) if (get_var('SECUREBOOT'));
 
     log_versions;


### PR DESCRIPTION
This is debug code for [poo#81142](https://progress.opensuse.org/issues/81142). It'll gzip the contents of console framebuffer and upload them to OpenQA.

The framebuffer contains raw pixel data of what the kernel thinks the screen output should look like. The raw screenshot will not rule out a display device driver bug in the kernel but it will tell us whether the bug is in the higher level console rendering code.

- Related ticket: https://progress.opensuse.org/issues/81142
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/6784854
