### PR TITLE
Move buildah and validate_btrfs on host related tests

### DIFF
--- a/schedule/containers/engines_and_tools_docker.yaml
+++ b/schedule/containers/engines_and_tools_docker.yaml
@@ -19,7 +19,7 @@ conditional_schedule:
       s390x:
         - containers/docker_runc
   supported:
-    HOST_VERSION:
+    VERSION:
       15-SP4:
         - containers/buildah_docker
       15-SP3:

--- a/schedule/containers/sle_image_on_sle_host_docker.yaml
+++ b/schedule/containers/sle_image_on_sle_host_docker.yaml
@@ -7,18 +7,9 @@ conditional_schedule:
     ARCH:
       's390x':
         - installation/bootloader_start
-  buildah_docker:
-    HOST_VERSION:
-      15-SP3:
-        - containers/buildah_docker
-      15-SP2:
-        - containers/buildah_docker
-      15-SP1:
-        - containers/buildah_docker
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/docker_image
-  - '{{buildah_docker}}'
   - containers/container_diff

--- a/schedule/containers/sle_image_on_sle_host_podman.yaml
+++ b/schedule/containers/sle_image_on_sle_host_podman.yaml
@@ -12,4 +12,3 @@ schedule:
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/podman_image
-  - containers/buildah_podman


### PR DESCRIPTION
Find and reassign some modules to the correct group and run them only in a single place.

The reason they removed from image testing jobs are:

- buildah is unlikely to find any problem on the images other than podman will find.
this is because it used by podman underneath. Buildah is more likely to find bugs against
the sut rather the images.

- validate_btrfs tests the docker storage fs feature which likely belongs to the host tests as well.

- Related ticket: https://progress.opensuse.org/issues/96383
- Verification run: 

[sle15sp3](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313021&version=15-SP3&distri=sle)
[sle15sp2](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313021&version=15-SP2&distri=sle)
[sle15sp1](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313021&version=15-SP1&distri=sle)
[sle15](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313021&version=15&distri=sle)
[sle12sp5](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=b10n1k%2Fos-autoinst-distri-opensuse%2313021)