### PR TITLE
MicroOS: allow failure for "audit -a" command

### DIFF
--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -36,7 +36,7 @@ sub run {
     assert_script_run('selinuxenabled');
     record_info('SELinux',       script_output('sestatus'));
     record_info('Audit report',  script_output('aureport'));
-    record_info('Audit denials', script_output('aureport -a'));
+    record_info('Audit denials', script_output('aureport -a', proceed_on_failure => 1));
     upload_logs($audit_log);
 }
 


### PR DESCRIPTION
audit -a returns !=0 if no events are found and the script_output fails the test.

- Failure: https://openqa.opensuse.org/tests/1865228#step/enable_selinux/33
- Verification run: https://openqa.opensuse.org/tests/1866577#live
