### PR TITLE
firefox_html5: Press tab until agree is visible & click

### DIFF
--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -31,12 +31,8 @@ sub run {
         if (match_has_tag('firefox-accept-youtube-cookies')) {
             # get to the accept button with tab and space
             wait_still_screen(2);
-            send_key('tab');
-            wait_still_screen(2);
-            send_key('spc');
-            wait_still_screen(2);
+            send_key_until_needlematch('firefox-accept-youtube-cookies-agree', 'tab', 7, 1);
             assert_and_click('firefox-accept-youtube-cookies-agree');
-            wait_still_screen(2);
             next;
         }
         elsif (match_has_tag('firefox-youtube-signin')) {


### PR DESCRIPTION
pgdn can't be pressed because it will scroll page behind not the popup,
tabbing until button is visible works fine

- Related ticket: https://progress.opensuse.org/issues/96368
- Verification run:
http://dzedro.suse.cz/tests/18786
https://openqa.suse.de/tests/6642380