### PR TITLE
Fix host_configuration module against rhel

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Setup system which will host containers
-# - setup networking via dhclient
+# - setup networking via dhclient when is needed
 # - make sure that ca certifications were installed
 # - import SUSE CA certificates
 # Maintainer: qa-c team <qa-c@suse.de>
@@ -30,7 +30,8 @@ sub run {
         disable_and_stop_service(opensusebasetest::firewall, ignore_failure => 1);
     }
     else {
-        assert_script_run "dhclient -v";
+        # Re-running dhclient on RHEL is confusing the routing tables
+        assert_script_run "dhclient -v" unless get_var("HDD_1") =~ /rhel/;
         $interface = script_output q@ip r s default | head -1 | awk '{printf $5}'@;
         validate_script_output "ip a s '$interface'", sub { m/((\d{1,3}\.){3}\d{1,3}\/\d{1,2})/ };
         assert_script_run "curl http://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/ssl/certs/SUSE_Trust_Root.crt" if is_sle();


### PR DESCRIPTION
Running dhclient on all-good networking of the rhel image is messing
with the route table.

Running dhclient shouldnt cause any problem on an already configured route table
IIRC and is propably distro specific issue and it can ignored for now and workaround
exclude the execution when HDD is rhel image.

Maybe it would be nice to have an self-agnostic method here and run config
commands when it is needed.


- Related ticket: https://progress.opensuse.org/issues/96116
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2313025
