### PR TITLE
Update size string when creating KVM backing image file 

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1000,7 +1000,6 @@ sub zkvm_add_disk {
 
                 enter_cmd("# copying image ($basename)...");
                 if (my $size = get_var("HDDSIZEGB_$di")) {
-                    $size .= "G";
                     $svirt->add_disk({file => $hdd_path, backingfile => 1, dev_id => $dev_id, size => $size});
                 } else {
                     $svirt->add_disk({file => $hdd_path, backingfile => 1, dev_id => $dev_id});

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1007,7 +1007,7 @@ sub zkvm_add_disk {
             } else {
                 # Create a new image, most likely it can be image for installation
                 # or additional optional drive for further testing
-                my $size = sprintf("%dG", get_var("HDDSIZEGB_$di", get_var('HDDSIZEGB', 4)));
+                my $size = sprintf("%d", get_var("HDDSIZEGB_$di", get_var('HDDSIZEGB', 4)));
                 $svirt->add_disk({size => $size, create => 1, dev_id => $dev_id});
             }
         }

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -139,6 +139,7 @@ sub run {
         if (my $full_hdd = get_var('HDD_' . $n)) {
             my $hdd     = basename($full_hdd);
             my $hddpath = search_image_on_svirt_host($svirt, $hdd, $hdddir);
+            $size_i = get_var("HDDSIZEGB_$n") if get_var("HDDSIZEGB_$n");
             if ($hddpath =~ m/vmdk\.xz$/) {
                 my $nfs_ro = $hddpath;
                 $hddpath = "$vmware_openqa_datastore/$hdd" =~ s/vmdk\.xz/vmdk/r;
@@ -154,7 +155,8 @@ sub run {
                 {
                     backingfile => 1,
                     dev_id      => $dev_id,
-                    file        => $hddpath
+                    file        => $hddpath,
+                    size        => $size_i
                 });
         }
         else {
@@ -162,7 +164,7 @@ sub run {
                 {
                     create => 1,
                     dev_id => $dev_id,
-                    size   => $size_i . 'G'
+                    size   => $size_i
                 });
         }
         $dev_id = chr((ord $dev_id) + 1);    # return next letter in alphabet


### PR DESCRIPTION
SLEM z/KVM failures [sle-micro-5.1-MicroOS-Image-s390x-Build46.1_10.9-sle-micro_update@s390x-kvm-sle12](https://openqa.suse.de/tests/6645372) and [sle-micro-5.1-MicroOS-Image-s390x-Build46.1_10.9-sle-micro_qemu@s390x-kvm-sle12](https://openqa.suse.de/tests/6645371) occur due to wrong string size parameter in the caller.

```
[2021-08-04T09:10:59.446 CEST] [debug] [run_ssh_cmd(qemu-img create '/var/lib/libvirt/images/openQA-SUT-2a.img' -f qcow2 -b '/var/lib/libvirt/images//SUSE-MicroOS.s390x-5.1.0-Default-kvm-Build10.9.qcow2' 30GG)] stderr:
  qemu-img: Invalid image size specified! You may use k, M, G, T, P or E suffixes for
  qemu-img: kilobytes, megabytes, gigabytes, terabytes, petabytes and exabytes.
```

VRs:
- [sle-micro-5.1-MicroOS-Image-s390x-Build46.1_10.9-sle-micro_qemu@s390x-kvm-sle12](http://kepler.suse.cz/tests/6277#step/boot_to_desktop/1)
- [sle-micro-5.1-MicroOS-Image-s390x-Build46.1_10.9-sle-micro_update@s390x-kvm-sle12](http://kepler.suse.cz/tests/6278#)
