### PR TITLE
Wait before checking screen at pxe grub boot

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -178,6 +178,7 @@ sub run {
 
         # Proceed if the 'installation' console is ready
         # otherwise the 'sol' console may be just freezed
+        wait_still_screen(stilltime => 180, timeout => 185);
         if (check_screen(\@tags, $ssh_vnc_wait_time)) {
             save_screenshot;
             sleep 2;
@@ -185,13 +186,13 @@ sub run {
                 my $image_name = eval { check_var("INSTALL_TO_OTHERS", 1) ? get_var("REPO_0_TO_INSTALL") : get_var("REPO_0") };
                 my $args       = "initrd auto/openqa/repo/${image_name}/boot/${arch}/initrd";
                 $args = "initrd /mnt/openqa/repo/${image_name}/boot/${arch}/initrd" if (!is_orthos_machine);
-                wait_still_screen 5;
-                type_string $args;
+                type_string_slow $args;
                 send_key 'ret';
                 #Detect orthos-grub-boot-initrd and qa-net-grub-boot-initrd for aarch64 in orthos and openQA networks respectively
+                wait_still_screen(stilltime => 480, timeout => 485);
                 assert_screen [qw(orthos-grub-boot-initrd qa-net-grub-boot-initrd)], $ssh_vnc_wait_time;
                 $args = "boot";
-                type_string $args;
+                type_string_slow $args;
                 send_key "ret";
                 assert_screen $ssh_vnc_tag, $ssh_vnc_wait_time;
             }


### PR DESCRIPTION
* **Due** to the unique mechanism that is being used by openQA needle matching program, even partially same areas in one needle [can not be matched as expected](https://openqa.suse.de/tests/6640290#step/boot_from_pxe/8). The smaller one can be found inside the bigger one if the content of the former happens to be subset of the latter, especially when the former and the latter do not appear on the screen at the same time.
* **And** it is very difficult to control the search area by "area margin", so the optimal way is to delay the needle matching by waiting for the the screen to stop change and, at the same time, linux and initrd are already downloaded successfully. So the needles can be matched exactly as what they are. The timer used is well tuned for "linux" and "initrd" files.
* **Additionally**, use type_string_slow instead of type_string to better cope slow response issue.

* **Needles:**
  * [qa-net-grub-boot-linux-20210804](https://openqa.suse.de/tests/6645557#step/boot_from_pxe/8)
  * [qa-net-grub-boot-initrd-20210804](https://openqa.suse.de/tests/6645557#step/boot_from_pxe/10)

* **Verification runs:**
  * [qa-net-grub-boot-linux-20210804 is matched as expected](https://openqa.suse.de/tests/6645557#step/boot_from_pxe/8)
  * [qa-net-grub-boot-initrd-20210804 is matched as expected](https://openqa.suse.de/tests/6645557#step/boot_from_pxe/10)
  * [x86_64 verification run](https://openqa.suse.de/tests/6654584#step/boot_from_pxe/2)
