### PR TITLE
firefox_html5: Wait after pressing agree for pop-up to disappear

### DIFF
--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -33,6 +33,7 @@ sub run {
             wait_still_screen(2);
             send_key_until_needlematch('firefox-accept-youtube-cookies-agree', 'tab', 7, 1);
             assert_and_click('firefox-accept-youtube-cookies-agree');
+            wait_still_screen(2);
             next;
         }
         elsif (match_has_tag('firefox-youtube-signin')) {

--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -43,7 +43,7 @@ sub run {
         }
         last;
     }
-    send_key_until_needlematch('firefox-testvideo', 'spc', 5, 5);
+    send_key_until_needlematch('firefox-testvideo', 'spc', 15, 5);
     $self->exit_firefox;
 }
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/96368
- Verification run: http://dzedro.suse.cz/tests/18795 http://dzedro.suse.cz/tests/18802 http://dzedro.suse.cz/tests/18803 http://dzedro.suse.cz/tests/18804 https://openqa.suse.de/tests/6646805
