### PR TITLE
Jna/fix load qaperf twice issue

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -31,6 +31,7 @@ sub setup_environment {
     my $ver_path          = "/root";
 
     assert_script_run("wget -N -P $ver_path $ver_cfg 2>&1");
+    assert_script_run("systemctl disable qaperf.service");
     if (get_var("HANA_PERF")) {
         assert_script_run("/usr/share/qa/qaset/bin/deploy_hana_perf.sh $runid $mitigation_switch");
         assert_script_run("ls /root/qaset/deploy_hana_perf_env.done");

--- a/tests/kernel_performance/run_perf_case.pm
+++ b/tests/kernel_performance/run_perf_case.pm
@@ -41,6 +41,7 @@ sub run_one_by_one {
     }
     assert_script_run("echo \"$case\" >> /root/qaset/list");
     assert_script_run("echo \')\' >> /root/qaset/list");
+    assert_script_run("systemctl enable qaperf.service");
     for (; $i <= $repeat; $i++) {
         # clean fail.list
         script_run("rm $fail_path/$fail_list");


### PR DESCRIPTION
in hana-perf testing, we hit several times that power9 machine failed. after checking the qaset log, we found qaperf was load twice,
and between this twice load, there was runlist update. and the runlist update timeslot is uncertain between qaperf twice loading,

to fix this issue,I added" systemctl disable qaperf.service" after qa_test_automation installed,it can make sure the qaperf can not load after machine reboot.

then after runlist is updated.I add "systemctl enable qaperf.service",it can make sure the last test can bu run correctly. 

- Related ticket: https://progress.opensuse.org/issues/95770
- Needles: N/A
- Verification run:http://10.67.129.7/tests/611       http://10.67.129.7/tests/610(this case failed for this testing machine didn't have abuild.)
