### PR TITLE
Add workanound for slow posgresql start on ARM/ppc64le

### DIFF
--- a/tests/console/php7_postgresql.pm
+++ b/tests/console/php7_postgresql.pm
@@ -51,6 +51,8 @@ sub run {
     zypper_call 'in php7-pgsql postgresql*-contrib sudo unzip';
 
     # start postgresql service
+    # with workaround for poo#88439
+    assert_script_run '/usr/share/postgresql/postgresql-script start && /usr/share/postgresql/postgresql-script stop';
     systemctl 'start postgresql';
 
     # setup database


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/p88439

