### PR TITLE
Remove unneeded host_configuration for rhel

### DIFF
--- a/schedule/containers/sle_image_on_res.yaml
+++ b/schedule/containers/sle_image_on_res.yaml
@@ -3,5 +3,4 @@ description:  |
   Run sle container on SLES Expanded Support (RHEL)
 schedule:
   - boot/boot_to_desktop
-  - containers/host_configuration
   - containers/podman_image


### PR DESCRIPTION
We have fix for this in the code but we seems that we can avoid this
module in scheduling anyway.


- Related ticket: https://progress.opensuse.org/issues/96116
- Verification run: sle-15-SP3-Container-Image-Updates-x86_64-Build17.5.23-sle-15-SP3_image_on_res_8.2_host@64bit -> https://openqa.suse.de/t6656866
