### PR TITLE
wicked-wlan: Fix hostapd config for t06_wpa_eap_tls

### DIFF
--- a/tests/wicked/wlan/sut/t06_wpa_eap_tls.pm
+++ b/tests/wicked/wlan/sut/t06_wpa_eap_tls.pm
@@ -51,15 +51,15 @@ has hostapd_conf => q(
 
     ## RADIUS authentication server
     nas_identifier=the_ap
-    auth_server_shared_secret=testing123
     auth_server_addr=127.0.0.1
     auth_server_port=1812
+    auth_server_shared_secret=testing123
 );
 
 has ifcfg_wlan => sub { [
         q(
-        BOOTPROTO='dhcp'
         STARTMODE='auto'
+        BOOTPROTO='dhcp'
 
         # Global settings
         WIRELESS_AP_SCANMODE='1'


### PR DESCRIPTION
This is a fix for the early merged PR
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13027 .
I tried there the automerge button, but didn't realized that no approval
is needed.

- Verification run: http://openqa.wicked.suse.de/tests/11329
