### PR TITLE
Fix curl_https defect from #12947

### DIFF
--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -209,6 +209,7 @@ sub run {
     select_console('root-console');
     ensure_serialdev_permissions;
     (test_users_locale($rc_lc_reverted, $test_data_lang{$lang_ref}) eq $original_glibc_string) or die "Locale has changed after reboot!\n";
+    reset_consoles;
 }
 
 1;


### PR DESCRIPTION
Revert a change on glibc_locale which breaks curl_https in o3.
Change should have been removed on #12947

- Related ticket: https://progress.opensuse.org/issues/95410
- Verification run: https://openqa.opensuse.org/tests/1870284
