### PR TITLE
Fix curl_https defect from #12947

### DIFF
--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -125,7 +125,6 @@ sub run {
     ## Check glibc locale, should be the same as in firstrun module
     my $original_glibc_string = script_output("ldd --help | grep '^" . $test_data_lang{$lang_booted_short} . "'");
     record_info('Original', $original_glibc_string);
-    enter_cmd("exit");
 
     ## Check system wide locale configuration; general notes
     # 1) Verify RC_LC_ variables defined in the file /etc/sysconfig/language


### PR DESCRIPTION
Revert a change on glibc_locale which breaks curl_https in o3.
Change should have been removed on #12947


- Related ticket: https://progress.opensuse.org/issues/95410
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
