### PR TITLE
[WIP] Use libyui-rest-api to register during installation

### DIFF
--- a/lib/Distribution/Sle/15_current.pm
+++ b/lib/Distribution/Sle/15_current.pm
@@ -23,6 +23,7 @@ use parent 'Distribution::Opensuse::Tumbleweed';
 use Installation::License::Sle::LicenseAgreementController;
 use Installation::License::Sle::Firstboot::LicenseAgreementController;
 use Installation::ProductSelection::ProductSelectionController;
+use Installation::Registration::RegistrationController;
 
 =head2 get_license_agreement
 
@@ -41,6 +42,10 @@ sub get_firstboot_license_agreement {
 
 sub get_product_selection {
     return Installation::ProductSelection::ProductSelectionController->new();
+}
+
+sub get_registration {
+    return Installation::Registration::RegistrationController->new();
 }
 
 1;

--- a/lib/Installation/Registration/RegistrationController.pm
+++ b/lib/Installation/Registration/RegistrationController.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for Registration dialog
+# when the system is already registered.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Registration::RegistrationController;
+use strict;
+use warnings;
+use Installation::Registration::RegistrationPage;
+use Installation::Warnings::ConfirmationWarning;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{RegistrationPage}    = Installation::Registration::RegistrationPage->new({app => YuiRestClient::get_app()});
+    $self->{UseUpdateReposPopup} = Installation::Warnings::ConfirmationWarning->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_registration_page {
+    my ($self) = @_;
+    die "Registration page is not displayed" unless $self->{RegistrationPage}->is_shown();
+    return $self->{RegistrationPage};
+}
+
+sub get_update_repository_popup {
+    my ($self, $expected_popup) = @_;
+    # Check that that a "yesno" popup is shown and that it contains expected text.
+    $self->{UseUpdateReposPopup}->check_text($expected_popup) if $self->{UseUpdateReposPopup}->is_shown;
+    return $self->{UseUpdateReposPopup};
+}
+
+sub register_product_with_regcode {
+    my ($self, $reg_code) = @_;
+    $self->get_registration_page->enter_reg_code($reg_code);
+    $self->get_registration_page->press_next();
+}
+
+sub enable_update_repositories {
+    my ($self, $expected_popup) = @_;
+    $self->get_update_repository_popup($expected_popup)->press_yes();
+}
+
+1;

--- a/lib/Installation/Registration/RegistrationPage.pm
+++ b/lib/Installation/Registration/RegistrationPage.pm
@@ -1,0 +1,45 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The module provides interface to act with Registration page
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Registration::RegistrationPage;
+use parent 'Installation::Navigation::NavigationBar';
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->{lbl_skip_registration} = $self->{app}->label({label => 'Skip Registration'});
+    $self->{tb_reg_code}           = $self->{app}->textbox({id => 'reg_code'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{lbl_skip_registration}->exist();
+}
+
+sub enter_reg_code {
+    my ($self, $reg_code) = @_;
+    return $self->{tb_reg_code}->set($reg_code);
+}
+
+1;

--- a/lib/Installation/Warnings/ConfirmationWarning.pm
+++ b/lib/Installation/Warnings/ConfirmationWarning.pm
@@ -14,6 +14,7 @@
 package Installation::Warnings::ConfirmationWarning;
 use strict;
 use warnings;
+use Test::Assert ':all';
 
 sub new {
     my ($class, $args) = @_;
@@ -49,6 +50,12 @@ sub press_no {
 sub text {
     my ($self) = @_;
     return $self->{lbl_warning}->text();
+}
+
+sub check_text {
+    my ($self, $expected_text) = @_;
+    assert_matches(qr/$expected_text/, $self->{lbl_warning}->text(),
+        "Unexpected text in popup");
 }
 
 1;

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/registration_regcode
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/tests/installation/registration/modules_selection.pm
+++ b/tests/installation/registration/modules_selection.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Register SCC modules.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use registration 'process_modules';
+
+sub run {
+    process_modules();
+}
+
+1;

--- a/tests/installation/registration/registration_regcode.pm
+++ b/tests/installation/registration/registration_regcode.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Register the system with scc in the installer with registration code.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi 'get_var';
+
+sub run {
+    my $reg_code = get_var('SCC_REGCODE');
+    $testapi::distri->get_registration()->register_product_with_regcode($reg_code);
+    $testapi::distri->get_registration()->enable_update_repositories('The registration server offers update repos.*');
+}
+
+1;


### PR DESCRIPTION
Related ticket https://progress.opensuse.org/issues/95476

Job Groups: YaST
Screen: Registration
Test Cases:
1 - Provide only registration code;
3 - Skip registration for Full medium.
Ticket with Test Cases: https://progress.opensuse.org/issues/94895
Task:
 Implement test modules for both test cases using Page Object Model and LibyuiClient; Split existing scc_registration module to two parts: system registration and module selection, leaving the part for module selection as is (The rewrite of module selection will be covered in another ticket);
        As the scope is only YaST Job Group for now, we cannot simply remove registration part from scc_registration, as it is used in a lot of places. So, as a possible solution, the part for module selection may be extracted to separate function and moved to registration.pm library file then used in scc_registration and in new module (something like select_extensions_and_modules), which will be used altogether with the test module for registration.
    Update schedule files with the new modules.

VRs:
[ext4_yast@64bit](http://waaa-amazing.suse.cz/tests/15630)

Other VRs to see if the changes in library work as expected:
[skip_registration+workaround_modules@64bit](http://waaa-amazing.suse.cz/tests/15629)
[gnome+proxy_SCC+allmodules@64bit](http://waaa-amazing.suse.cz/tests/15577)
[wsm+dev_tools+textmode@64bit](http://waaa-amazing.suse.cz/tests/15579)

Update to schedule files in Yast group will be done in a separate PR for clarity.
