### PR TITLE
Add "audit-remote-libvirt" into openQA

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -56,7 +56,17 @@ sub run_testcase {
     # Export MODE
     assert_script_run("export MODE=$audit_test::mode");
 
-    assert_script_run('./run.bash', timeout => $args{timeout});
+    # Test case 'audit-remote-libvirt' does not generate any logs
+    if ($testcase eq 'audit-remote-libvirt') {
+        # Note: the outputs of run.bash can not be saved to "./$file" so save to "../$file"
+        script_run("./run.bash 1>../$current_file 2>&1", timeout => $args{timeout});
+        assert_script_run("mv ../$current_file $current_file");
+        assert_script_run("cat $current_file");
+        assert_script_run("cp $current_file ./rollup.log");
+    }
+    else {
+        assert_script_run('./run.bash', timeout => $args{timeout});
+    }
 
     # Upload logs
     upload_logs("$current_file");

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2417,7 +2417,7 @@ sub load_security_tests_selinux {
     loadtest "security/selinux/chcat";
 }
 
-sub load_security_tests_cc {
+sub load_security_tests_cc_audit_test {
     # Setup environment for cc testing: 'audit-test' test suite setup
     # Such as: download code branch; install needed packages
     loadtest 'security/cc/cc_audit_test_setup';
@@ -2439,6 +2439,14 @@ sub load_security_tests_cc {
     loadtest 'security/cc/misc';
 }
 
+sub load_security_tests_cc_audit_remote {
+    # Setup environment for cc testing: 'audit-test' test suite setup
+    # Such as: download code branch; install needed packages
+    loadtest 'security/cc/cc_audit_test_setup';
+
+    # Run test cases of 'audit-test' test suite which do NOT need SELinux env
+    loadtest 'security/cc/audit_remote_libvirt';
+}
 
 sub load_security_tests_mok_enroll {
     loadtest "security/mokutil_sign";
@@ -2631,7 +2639,8 @@ sub load_security_tests {
       swtpm
       grub_auth
       lynis
-      cc
+      cc_audit_test
+      cc_audit_remote
     );
 
     # Check SECURITY_TEST and call the load functions iteratively.

--- a/tests/security/cc/audit_remote_libvirt.pm
+++ b/tests/security/cc/audit_remote_libvirt.pm
@@ -1,0 +1,66 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'audit-remote-libvirt' test case of 'audit-test' test suite
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#96531
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test qw(run_testcase compare_run_log);
+
+sub run {
+    my ($self) = shift;
+
+    my $image_path = '/var/lib/libvirt/images';
+    select_console 'root-console';
+
+    # Install the required packages for libvirt environment setup,
+    zypper_call("in qemu libvirt virt-install virt-manager");
+
+    # Start libvirtd daemon and start the default libvirt network
+    assert_script_run("systemctl start libvirtd");
+    assert_script_run("virsh net-start default");
+    assert_script_run("systemctl is-active libvirtd");
+    assert_script_run("virsh net-list | grep default | grep active");
+
+    # Download the pre-installed guest images and sample xml files
+    my $vm_name      = 'vm-swtpm-legacy';
+    my $hdd_1        = get_required_var('HDD_1');
+    my $legacy_image = 'swtpm_legacy@64bit.qcow2';
+    assert_script_run("wget -c -P $image_path " . autoinst_url("/assets/hdd/$hdd_1"), 900);
+    assert_script_run("mv $image_path/$hdd_1 $image_path/$legacy_image");
+    assert_script_run("wget --quiet " . data_url("swtpm/swtpm_legacy.xml") . " -P $image_path");
+
+    # Define the guest vm and start it
+    assert_script_run("cd $image_path");
+    assert_script_run('virsh define swtpm_legacy.xml');
+    assert_script_run("virsh start $vm_name");
+
+    # Export AUDIT_TEST_REMOTE_VM
+    assert_script_run("export AUDIT_TEST_REMOTE_VM=$vm_name");
+    # Export AUGROK
+    assert_script_run("export AUGROK=$audit_test::testdir$audit_test::testfile_tar/audit-test/utils/augrok");
+
+    # Run test case
+    run_testcase('audit-remote-libvirt', make => 0, timeout => 120);
+
+    # Compare current test results with baseline
+    my $result = compare_run_log('audit_remote_libvirt');
+    $self->result($result);
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Add "audit-remote-libvirt" of "audit-test" into openQA

- Related ticket: https://progress.opensuse.org/issues/96531
- Needles: NA
- MR: https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/22
- Verification run: https://openqa.suse.de/tests/6820236 (pass)
