### PR TITLE
Fix wrong condition in firstrun

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -76,7 +76,7 @@ sub run {
     mouse_hide;
     # kiwi-templates-JeOS images (sle, opensuse x86_64 only) are build w/o translations
     # jeos-firstboot >= 0.0+git20200827.e920a15 locale warning dialog has been removed
-    if (is_sle('15+') && (is_sle('<15-sp3') || (is_leap('<15.3') && is_x86_64))) {
+    if ((is_sle('15+') && is_sle('<15-sp3')) || (is_leap('<15.3') && is_x86_64)) {
         assert_screen 'jeos-lang-notice', 300;
         # Without this 'ret' sometimes won't get to the dialog
         wait_still_screen;


### PR DESCRIPTION
The parenthesis were wrong here.
What was intended was to assert `jeos-lang-notice` when:
- sle is bigger than 12
- or leap is smaller than 15.3+x86


- Related ticket: https://progress.opensuse.org/issues/95410
- Verification run: 

[leap](http://aquarius.suse.cz/tests/6692)
[tw](http://aquarius.suse.cz/tests/6693)
[sle12](http://aquarius.suse.cz/tests/6694)
sle-15-SP2-JeOS-for-kvm-and-xen-Updates-x86_64-Build20210809-1-jeos-extratest@uefi-virtio-vga -> https://openqa.suse.de/t6783983
 sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20210809-1-jeos-extratest@uefi-virtio-vga -> https://openqa.suse.de/t6783985
opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.161-jeos@64bit_virtio-2G -> https://openqa.opensuse.org/t1871854
