### PR TITLE
Enhance launch stability of anaconda installer

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/oracle_linux_7_9_graphical_server_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/oracle_linux_7_9_graphical_server_x86_64.xml
@@ -21,7 +21,7 @@
     <guest_installation_automation>kickstart</guest_installation_automation>
     <guest_installation_automation_file>oracle_linux_7_9_graphical_server.ks</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1#inst.noverifyssl#inst.waitfornet=60#inst.geoloc=provider_hostip#inst.geoloc-use-with-ks#inst.sshd#inst.debug#inst.notmux#inst.cmdline#inst.resolution=1024x768#inst.gpt</guest_installation_extra_args>
+    <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1#inst.noverifyssl#inst.waitfornet=60#inst.geoloc=provider_hostip#inst.geoloc-use-with-ks#inst.sshd#inst.debug#inst.notmux#inst.cmdline#inst.resolution=1024x768#inst.gpt#inst.usefbx#inst.xtimeout=300</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>OracleLinux-R7-U9-Server-x86_64-dvd.iso</guest_installation_media>


### PR DESCRIPTION
* **Generally speaking,** oracle linux server can be installed successfully without hassle on sles host. But stability test (sequence of guest installations of oracle linux server on the same sles host, for example, installing oracle linux server 7 as guest ten times with the same domain name) reveals a secondary problem. 
* **The** anaconda installer for oracle linux server 7 can not be started up as normal and the corresponding installation program seems to hang for good after successive six or seven times of installation. This issue seems only happens to oracle
 linux server 7. 
* **Fortunately,** anaconda console/display options inst.usefbx and inst.xtimeout can help solve the problem straightaway.

* **Verification run:**
  * [oracle linux server 7 installation seems to hang](http://10.67.129.106/tests/1679#step/unified_guest_installation/1521)
  * [oracle linux server 7 installation succeeds even after sequence of successive ten times of installation run](http://10.67.129.106/tests/1693)
