### PR TITLE
Unify publiccloud variables

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -29,12 +29,15 @@ sub get_repo_status {
 
 sub run {
     my ($self, $args) = @_;
-
     select_host_console();    # select console on the host, not the PC instance
 
+    # Skip maintenance updates. This is useful for debug runs
+    # Note: QAM_PUBLICCLOUD_SKIP_DOWNLOAD is left for backwards compatability and will be removed in the future
+    my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD', 0));
+
     # Trigger to skip the download to speed up verification runs
-    if (get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD') == 1) {
-        record_info('Skip download', 'Skipping download triggered by setting (QAM_PUBLICCLOUD_SKIP_DOWNLOAD = 1)');
+    if ($skip_mu) {
+        record_info('Skip download', 'Skipping maintenance update download (triggered by setting)');
     } else {
         # Skip if we already downloaded the repos
         if (get_repo_status() == 1) {

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -22,14 +22,14 @@ use publiccloud::utils "select_host_console";
 
 sub run {
     my ($self, $args) = @_;
-
-    my @addons = split(/,/, get_var('SCC_ADDONS', ''));
-
     select_host_console();    # select console on the host, not the PC instance
 
+    my @addons  = split(/,/, get_var('SCC_ADDONS', ''));
+    my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD', 0));
+
     # Trigger to skip the download to speed up verification runs
-    if (get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD') == 1) {
-        record_info('Skip download', 'Skipping download triggered by setting (QAM_PUBLICCLOUD_SKIP_DOWNLOAD = 1)');
+    if ($skip_mu) {
+        record_info('Skip download', 'Skipping maintenance update download (triggered by setting)');
     } else {
         assert_script_run('du -sh ~/repos');
         my $timeout = 2400;


### PR DESCRIPTION
In an attempt to get rid of the old QAM variables, this PR introduced a
new unified `PUBLIC_CLOUD_` variable to skip usage of the maintenance
updates.

The old `QAM_PUBLICCLOUD_SKIP_DOWNLOAD` variable will be removed once we
are convinced that it is not used anymore.

- Verification run: http://duck-norris.qam.suse.de/tests/6808 and http://duck-norris.qam.suse.de/t6814
