### PR TITLE
console/ovs_server.pm: Don't fail if /etc/keys/ already exists

### DIFF
--- a/tests/console/ovs_client.pm
+++ b/tests/console/ovs_client.pm
@@ -74,7 +74,7 @@ sub run {
 
     assert_script_run("ovs-vsctl del-br br-ipsec");
     add_bridge("$client_vpn");
-    assert_script_run("mkdir $dir && cd $dir");
+    assert_script_run("mkdir -p $dir && cd $dir");
 
     # Set IPsec tunnel using self-signed certificate
     # Generate self-signed certificate

--- a/tests/console/ovs_server.pm
+++ b/tests/console/ovs_server.pm
@@ -87,7 +87,7 @@ sub run {
 
     assert_script_run("ovs-vsctl del-br br-ipsec");
     add_bridge("$server_vpn");
-    assert_script_run("mkdir $dir && cd $dir");
+    assert_script_run("mkdir -p $dir && cd $dir");
 
     # Setup IPsec tunnel using self-signed certificate
     # Generate self-signed certificate


### PR DESCRIPTION
It's created by the "keyutils" package meanwhile.

- Related ticket: https://progress.opensuse.org/issues/96641
- Verification run:
ovs-server: https://openqa.opensuse.org/tests/1872772
ovs-client: https://openqa.opensuse.org/tests/1872773

I had to clone the `ovs-client` job with `--skip-chained-deps --parental-inheritance` to get `CASEDIR` and `_GROUP` set properly.