### PR TITLE
Add idu, ids addons' fullname to registration file

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -818,6 +818,8 @@ sub get_addon_fullname {
         tsm       => 'sle-module-transactional-server',
         espos     => 'ESPOS',
         nvidia    => 'sle-module-NVIDIA-compute',
+        idu       => is_sle('15+') ? 'IBM-POWER-Tools'         : 'IBM-DLPAR-utils',
+        ids       => is_sle('15+') ? 'IBM-POWER-Adv-Toolchain' : 'IBM-DLPAR-SDK',
     );
     return $product_list{"$addon"};
 }


### PR DESCRIPTION
For idu, ids addons, we will need get their fullname to check installed
addons

- Related ticket:https://progress.opensuse.org/issues/96040
- Verification run: 
  sles12 case: https://openqa.suse.de/tests/6855634
  sles15 case: https://openqa.suse.de/tests/6867709#step/check_system_info/4