### PR TITLE
 Unset `_EXPECT_EFI_MOK_MANAGER` before selecting console

### DIFF
--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -247,8 +247,8 @@ sub run {
 }
 
 sub post_fail_hook {
-    select_console('root-console');
     set_var('_EXPECT_EFI_MOK_MANAGER', 0);
+    select_console('log-console');
 
     upload_logs(GRUB_DEFAULT,        log_name => 'etc_default_grub.txt');
     upload_logs(GRUB_CFG,            log_name => 'grub.cfg');


### PR DESCRIPTION
Failure as [during reboot](https://openqa.suse.de/tests/6790389#step/verify_efi_mok/120)
prevents accessing another console in the post fail hook subroutine.
Therefore the test case has to unset expected MOK Manager variable as
first action.