### PR TITLE
Adjust validate_btrfs module to use a single opensuse image

### DIFF
--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -101,10 +101,10 @@ sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
     install_docker_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => 'docker');
-    my $docker    = containers::runtime->new(runtime => 'docker');
-    my $btrfs_dev = '/var/lib/docker';
-    my ($untested_images, $released_images) = get_suse_container_urls();
-    _sanity_test_btrfs($docker, $btrfs_dev, $released_images->[0]);
+    my $docker         = containers::runtime->new(runtime => 'docker');
+    my $btrfs_dev      = '/var/lib/docker';
+    my $images_to_test = 'registry.opensuse.org/opensuse/leap:15';
+    _sanity_test_btrfs($docker, $btrfs_dev, $images_to_test);
     _test_btrfs_thin_partitioning($docker, $btrfs_dev);
     _test_btrfs_device_mgmt($docker, $btrfs_dev);
     _test_btrfs_balancing($btrfs_dev);


### PR DESCRIPTION
`engines_and_tools_docker` tries to fetch an image from *registry.suse.com*
which doesnt exist at the moment. However when the module runs against sle15sp4
(latest jobgroup) it should use the images from the internal repo.

The solution proposed by @jlausuch is to pick up some openSUSE image as the test
    is always running against the host-based tests to test the btrfs storage feature
    of docker.

- Related ticket: https://progress.opensuse.org/issues/96383
- Verification run: TBD - no totest sp4 yet