### PR TITLE
Introduce TID hotfix for SecureBoot in sle12sp5

### DIFF
--- a/schedule/jeos/sle/jeos-extratest-sle12.yaml
+++ b/schedule/jeos/sle/jeos-extratest-sle12.yaml
@@ -18,10 +18,6 @@ conditional_schedule:
             'svirt-vmware65':
                 - installation/bootloader_svirt
                 - installation/bootloader_uefi
-    maintenance:
-        FLAVOR:
-            'JeOS-for-kvm-and-xen-Updates':
-                - qa_automation/patch_and_reboot
 schedule:
     - '{{bootloader}}'
     - jeos/firstrun
@@ -33,7 +29,8 @@ schedule:
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc
-    - '{{maintenance}}'
+    - jeos/efi_tid
+    - qa_automation/patch_and_reboot
     - console/zypper_lr_validate
     - console/zypper_ref
     - console/validate_packages_and_patterns

--- a/schedule/jeos/sle/jeos12sp5-main.yaml
+++ b/schedule/jeos/sle/jeos12sp5-main.yaml
@@ -1,0 +1,77 @@
+---
+description: 'Main JeOS test suite. Maintainer: qa-c@suse.de.'
+name: 'jeos-main@64bit-virtio-vga ( qemu )'
+conditional_schedule:
+    bootloader:
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+            'svirt-hyperv-uefi':
+                - installation/bootloader_hyperv
+            'svirt-hyperv':
+                - installation/bootloader_hyperv
+                - installation/bootloader_uefi
+            'svirt-vmware65':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+    efi:
+        UEFI:
+            '1':
+                - console/verify_efi_mok
+schedule:
+    - '{{bootloader}}'
+    - jeos/firstrun
+    - jeos/record_machine_id
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - jeos/grub2_gfxmode
+    - jeos/diskusage
+    - jeos/build_key
+    - console/prjconf_excluded_rpms
+    - console/journal_check
+    - microos/libzypp_config
+    - console/suseconnect_scc
+    - jeos/efi_tid
+    - qa_automation/patch_and_reboot
+    - '{{efi}}'
+    - jeos/glibc_locale
+    - console/check_network
+    - console/system_state
+    - console/consoletest_setup
+    - locale/keymap_or_locale
+    - console/apache
+    - console/dns_srv
+    - console/postgresql_server
+    - console/shibboleth
+    - console/apache_ssl
+    - console/apache_nss
+    - console/hostname
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - console/yast2_lan
+    - console/curl_https
+    - console/glibc_sanity
+    - update/zypper_up
+    - console/console_reboot
+    - console/zypper_in
+    - console/yast2_i
+    - console/yast2_bootloader
+    - console/vim
+    - console/firewall_enabled
+    - console/gpt_ptable
+    - console/kdump_disabled
+    - console/slp
+    - console/sshd_running
+    - console/sshd
+    - console/ssh_cleanup
+    - console/mtab
+    - console/mariadb_srv
+    - console/rsync
+    - console/zypper_lifecycle
+    - console/orphaned_packages_check
+    - console/consoletest_finish

--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -149,7 +149,9 @@ sub get_esp_info {
         if (!defined($drive) && $line =~ /gpt/ && $line =~ /$vbd/) {
             ($drive) = split(/:/, $line, 2);
         }
-        if (!defined($esp_part_no) && $line =~ /boot,\s?esp/) {
+        # older versions of parted used in sle12+ do not detect ESP specifically
+        # it is only labelled with "boot" flag instead of "boot, esp" as in sle15+
+        if (!defined($esp_part_no) && $line =~ /boot,\s?esp|boot/) {
             ($esp_part_no) = split(/:/, $line, 2);
         }
     }
@@ -185,7 +187,7 @@ sub run {
     # run fs check on ESP
     record_info "ESP", "Partition [$esp_details->{partition}], \nFilesystem [$esp_details->{fs}],\nMountPoint [$esp_details->{mount}]";
     assert_script_run "umount $esp_details->{mount}";
-    assert_script_run "fsck.vfat -tvV $esp_details->{partition}";
+    assert_script_run "fsck.vfat -vV $esp_details->{partition}";
     assert_script_run "mount $esp_details->{mount}";
 
     # SUT can boot from removable (firstboot of HDD, ISO, USB bootable medium) or boot entry (non-removable)

--- a/tests/jeos/efi_tid.pm
+++ b/tests/jeos/efi_tid.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: HotFix for UEFI SecureBoot issue for sle12sp5
+# Maintainer: QA-c <qa-c@suse.com>
+
+use Mojo::Base qw(opensusebasetest);
+use testapi qw(select_console assert_script_run get_var);
+use utils qw(zypper_call);
+use power_action_utils qw(power_action);
+
+sub run {
+    select_console 'root-console';
+    return unless get_var('UEFI');
+    # pbl should be aware of SecureBoot
+    assert_script_run('echo SECURE_BOOT=yes >> /etc/sysconfig/bootloader');
+    # install kernel with builtin efivars (/sys/firmware/efi/efivars/)
+    zypper_call('update kernel-default-base');
+    # boot the new kernel
+    power_action('reboot', textmode => 1);
+    shift->wait_boot(bootloader_time => get_var('BOOTLOADER_TIMEOUT', 150));
+}
+
+1;


### PR DESCRIPTION
In order to handle booting issue described in [Booting JeOS 12SP5 fails after using UEFI and applying all updates](https://bugzilla.suse.com/show_bug.cgi?id=1188852)
we need to introduce a specific test case to adjust system configuration for sle12sp5 (JeOS) only.

- Verification run: https://openqa.suse.de/tests/6865133#step/verify_efi_mok/1
