### PR TITLE
lib/containers/common: Ignore warnings from buildah from

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -236,7 +236,8 @@ sub test_container_image {
             assert_script_run("buildah pull $image", timeout => 300);
             assert_script_run("buildah inspect --format='{{.FromImage}}' $image | grep '$image'");
         }
-        my $container = script_output("buildah from $image");
+        # Ignore stderr explicitly, script_output with serial_terminal captures that as well.
+        my $container = script_output("buildah from $image 2>/dev/null");
         record_info 'Container', qq[Testing:\nContainer "$container" based on image "$image"];
         assert_script_run("buildah run $container $smoketest");
     } else {


### PR DESCRIPTION
script_output using the serial terminal captures both stdout and stderr, but
stderr may contain some warnings which need to be ignored.

- Related ticket: https://progress.opensuse.org/issues/96753
- Verification run:
bulidah_docker: https://openqa.opensuse.org/t1873975
bulidah_podman: https://openqa.opensuse.org/t1873976
