### PR TITLE
Permit ssh root login and pubkey access for Tumbleweed

### DIFF
--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
@@ -174,5 +174,29 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is not default installed in TW -->
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>
 

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
@@ -174,5 +174,30 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is not default installed in TW -->
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>
 

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
@@ -174,5 +174,29 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is not default installed in TW -->
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>
 

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -792,7 +792,7 @@ sub config_guest_network_bridge_device {
                 #NIC in openSUSE TW guest is unable to get the IP from its network configration file with 'wicked ifup' or 'ifup'
                 #Not sure if it is a bug yet. This is just a temporary solution.
                 my $_bridge_ipaddr = script_output("grep IPADDR $_bridge_device_config_file | cut -d \"'\" -f2");
-                script_retry("brctl addbr $_bridge_device && ip addr add $_bridge_ipaddr dev $_bridge_device && ip link set $_bridge_device up", retry => 3, die => 0);
+                script_retry("ip link add $_bridge_device type bridge && ip addr add $_bridge_ipaddr dev $_bridge_device && ip link set $_bridge_device up", retry => 3, die => 0);
             }
             else {
                 script_retry("wicked ifup $_bridge_device_config_file $_bridge_device", retry => 3, die => 0);

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -99,6 +99,7 @@ our @EXPORT = qw(
   assert_secureboot_status
   susefirewall2_to_firewalld
   permit_root_ssh
+  permit_root_ssh_in_sol
 );
 
 =head1 SYNOPSIS
@@ -2030,6 +2031,22 @@ sub permit_root_ssh {
         assert_script_run("echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf");
         assert_script_run("systemctl restart sshd");
     }
+}
+
+=head2 permit_root_ssh_in_sol
+    permit_root_ssh_in_sol();
+
+for ipmi backend, PermitRootLogin has to be set in sol console
+however, assert_script_run and script_run is not stable in sole console
+enter_cmd or type_string are acceptable
+
+=cut
+
+sub permit_root_ssh_in_sol {
+    my $sshd_config_file = shift;
+
+    $sshd_config_file //= "/etc/ssh/sshd_config";
+    enter_cmd("[ `grep \"^PermitRootLogin *yes\" $sshd_config_file | wc -l` -gt 0 ] || (echo 'PermitRootLogin yes' >>$sshd_config_file; systemctl restart sshd)");
 }
 
 1;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -41,9 +41,9 @@ sub enable_debug_logging {
     #log filter is set to store component logs with different levels.
     my $libvirtd_conf_file = "/etc/libvirt/libvirtd.conf";
     if (!script_run "ls $libvirtd_conf_file") {
-        script_run "sed -i '/log_level *=/{h;s/^[# ]*log_level *= *[0-9].*\$/log_level = 1/};\${x;/^\$/{s//log_level = 1/;H};x}' $libvirtd_conf_file";
-        script_run "sed -i '/log_outputs *=/{h;s%^[# ]*log_outputs *=.*[0-9].*\$%log_outputs=\"1:file:/var/log/libvirt/libvirtd.log\"%};\${x;/^\$/{s%%log_outputs=\"1:file:/var/log/libvirt/libvirtd.log\"%;H};x}' $libvirtd_conf_file";
-        script_run "sed -i '/log_filters *=/{h;s%^[# ]*log_filters *=.*[0-9].*\$%log_filters=\"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%};\${x;/^\$/{s%%log_filters=\"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%;H};x}' $libvirtd_conf_file";
+        script_run "sed -i '/^[# ]*log_level *=/{h;s/^[# ]*log_level *= *[0-9].*\$/log_level = 1/};\${x;/^\$/{s//log_level = 1/;H};x}' $libvirtd_conf_file";
+        script_run "sed -i '/^[# ]*log_outputs *=/{h;s%^[# ]*log_outputs *=.*[0-9].*\$%log_outputs=\"1:file:/var/log/libvirt/libvirtd.log\"%};\${x;/^\$/{s%%log_outputs=\"1:file:/var/log/libvirt/libvirtd.log\"%;H};x}' $libvirtd_conf_file";
+        script_run "sed -i '/^[# ]*log_filters *=/{h;s%^[# ]*log_filters *=.*[0-9].*\$%log_filters=\"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%};\${x;/^\$/{s%%log_filters=\"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%;H};x}' $libvirtd_conf_file";
         script_run "grep -e log_level -e log_outputs -e log_filters $libvirtd_conf_file";
     }
     save_screenshot;
@@ -51,7 +51,7 @@ sub enable_debug_logging {
     # enable journal log with prvious reboot
     my $journald_conf_file = "/etc/systemd/journald.conf";
     if (!script_run "ls $journald_conf_file") {
-        script_run "sed -i '/Storage *=/{h;s/^[# ]*Storage *=.*\$/Storage=persistent/};\${x;/^\$/{s//Storage=persistent/;H};x}' $journald_conf_file";
+        script_run "sed -i '/^[# ]*Storage *=/{h;s/^[# ]*Storage *=.*\$/Storage=persistent/};\${x;/^\$/{s//Storage=persistent/;H};x}' $journald_conf_file";
         script_run "grep Storage $journald_conf_file";
         script_run 'systemctl restart systemd-journald';
     }


### PR DESCRIPTION
sshd default configuration was changed since a TW snapshot(between 20210521 and 20210727). Root user login, password login and authentic keys login have not been allowed by default any more. This PR is to modify the sshd configuration as soon as the SLE is installed as ssh is the primary way we interact with the system.

- permit root login to host via sol console
- permit root login and authentic keys login to guest via autoyast
- minor improvement
  --use 'ip link' instead 'brctl'(no extra package has to be installed)
  --remove workaround for libvirtd.service as the issue is fixed

- Related ticket: https://progress.opensuse.org/issues/96374
- needles: [sol-console-wait-typing-ret](http://10.67.129.51/tests/2580#step/switch_to_ssh_and_install_hypervisor/2)
- Verification run: 
[TW kvm guest installation](http://10.67.129.51/tests/2566)
[TW XEN guest installation](http://10.67.129.51/tests/2580)
[SLE 12sp5 xen fv guest installation](https://openqa.nue.suse.com/tests/6828263)

@alice-suse @guoxuguang @waynechen55 @nanzhg 
