### PR TITLE
Add missing metadata in modules

### DIFF
--- a/tests/console/check_selinux_fails.pm
+++ b/tests/console/check_selinux_fails.pm
@@ -7,7 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Package: Look for selinux fails in audit log
+# Summary: This test looks for selinux fails in audit log
+# Maintainer: Ludwig Nussel <lnussel@suse.com>
 
 use base "consoletest";
 use strict;

--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -8,6 +8,7 @@
 # without any warranty.
 
 # Summary: Enable SELinux during installation
+# Maintainer: Ludwig Nussel <lnussel@suse.com>
 
 use strict;
 use warnings;

--- a/tests/installation/partitioning/select_guided_setup.pm
+++ b/tests/installation/partitioning/select_guided_setup.pm
@@ -9,6 +9,7 @@
 
 # Summary:
 #
+# Summary: This test module selects the guided setup
 # Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 use parent 'y2_installbase';


### PR DESCRIPTION
While working on the CI extension, it was observed that in some perl modules the `Summary` and `Maintainer` areas were missing from the file header.

- Related ticket: https://progress.opensuse.org/issues/96716
- Needles: N/A
- Verification run: N/A
