### PR TITLE
Fix qdevice/qnetd tests for diskless sbd scenario

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -124,6 +124,8 @@ sub run {
         barrier_create("QNETD_TESTS_DONE_$cluster_name",       $num_nodes + 1);
         barrier_create("SPLIT_BRAIN_TEST_READY_$cluster_name", $num_nodes + 1);
         barrier_create("SPLIT_BRAIN_TEST_DONE_$cluster_name",  $num_nodes + 1);
+        barrier_create("QNETD_STONITH_DISABLED_$cluster_name", $num_nodes + 1);
+        barrier_create("DISKLESS_SBD_QDEVICE_$cluster_name",   $num_nodes);
 
         # PRIORITY_FENCING_DELAY barriers
         barrier_create("PRIORITY_FENCING_CONF_$cluster_name", $num_nodes);

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -78,7 +78,11 @@ sub run {
         systemctl 'restart pacemaker', timeout => $default_timeout;
     }
     systemctl 'list-units | grep iscsi', timeout => $default_timeout;
-    systemctl 'status pacemaker',        timeout => $default_timeout;
+    if (get_var('USE_DISKLESS_SBD') and check_var('QDEVICE_TEST_ROLE', 'client')) {
+        assert_script_run 'crm cluster restart';
+        record_soft_failure 'bsc#1189398 - Node reboots too fast in DISKLESS SBD with QDEVICE';
+    }
+    systemctl 'status pacemaker', timeout => $default_timeout;
 
     # Wait for resources to be started
     if (is_sles4sap) {


### PR DESCRIPTION
HA qdevice/qnetd test modules are currently working on block device backed sbd scenarios with no issues, however when using diskless sbd, the test fails due to several issues:

1. When adding a qdevice in block device backed sbd scenarios, the changes take effect automatically by reloading the cluster configuration without a need to restart the cluster.

2. When adding a qdevice in diskless sbd scenarios, for changes to take effect the cluster requires a restart. Bootstrap scripts will do this automatically, but not when there are resources already configured in the cluster, such as the one added by the `ha/qnetd` test module.

Due to this, it is necessary to restart the cluster services in both nodes after adding back the qdevice in the diskless sbd scenario. This PR adds code and barriers to sync the nodes and do this.

Additionally, after fencing the node in the diskless sbd with qdevice scenario, the cluster is not coming back online due to bsc#1189398. This PR also adds a workaround for this issue, and a soft failure referencing the bug.

- Related ticket: https://jira.suse.com/browse/TEAM-2108 & https://bugzilla.suse.com/show_bug.cgi?id=1189398
- Needles: N/A
- Verification run (diskless sbd scenario): [node 1](http://mango.qa.suse.de/tests/4347), [node 2](http://mango.qa.suse.de/tests/4348), [qnetd server](http://mango.qa.suse.de/tests/4349), [support server](http://mango.qa.suse.de/tests/4346)
- Verification run (block device backed sbd scenario - regression tests): [node 1](http://mango.qa.suse.de/tests/4351), [node 2](http://mango.qa.suse.de/tests/4352), [qnetd server](http://mango.qa.suse.de/tests/4353), [support server](http://mango.qa.suse.de/tests/4350)
