### PR TITLE
publiccloud::run_ltp Use LTP::WhiteList utils to evaluate failures

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -1,4 +1,4 @@
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,7 +28,14 @@ use Mojo::UserAgent;
 use Mojo::JSON;
 use Mojo::File 'path';
 
-our @EXPORT = qw(download_whitelist override_known_failures is_test_disabled);
+our @EXPORT = qw(
+  download_whitelist
+  find_whitelist_testsuite
+  find_whitelist_entry
+  override_known_failures
+  is_test_disabled
+  list_skipped_tests
+);
 
 sub download_whitelist {
     my $path = get_var('LTP_KNOWN_ISSUES');
@@ -38,6 +45,7 @@ sub download_whitelist {
     unless ($res->is_success) {
         record_info("File not downloaded!", $res->message, result => 'softfail');
         set_var('LTP_KNOWN_ISSUES', undef);
+        return;
     }
     my $basename = $path =~ s#.*/([^/]+)#$1#r;
     save_tmp_file($basename, $res->body);
@@ -49,31 +57,21 @@ sub download_whitelist {
 sub find_whitelist_entry {
     my ($env, $suite, $test) = @_;
 
-    my $path = get_var('LTP_KNOWN_ISSUES');
-    return undef unless defined($path);
-
-    my $content = path($path)->slurp;
-    my $issues  = Mojo::JSON::decode_json($content);
-    return undef unless $issues;
-    return undef unless exists $issues->{$suite};
+    $suite = find_whitelist_testsuite($suite);
+    return undef unless ($suite);
 
     my @issues;
-    if (ref($issues->{$suite}) eq 'ARRAY') {
-        @issues = @{$issues->{$suite}};
+    if (ref($suite) eq 'ARRAY') {
+        @issues = @{$suite};
     }
     else {
         $test =~ s/_postun$//g if check_var('KGRAFT', 1) && check_var('UNINSTALL_INCIDENT', 1);
-        return undef unless exists $issues->{$suite}->{$test};
-        @issues = @{$issues->{$suite}->{$test}};
+        return undef unless exists $suite->{$test};
+        @issues = @{$suite->{$test}};
     }
 
-  ISSUE:
     foreach my $cond (@issues) {
-        foreach my $filter (qw(product ltp_version revision arch kernel backend retval flavor)) {
-            next ISSUE if exists $cond->{$filter} and $env->{$filter} !~ m/$cond->{$filter}/;
-        }
-
-        return $cond;
+        return $cond if (whitelist_entry_match($cond, $env));
     }
 
     return undef;
@@ -81,12 +79,29 @@ sub find_whitelist_entry {
 
 sub override_known_failures {
     my ($self, $env, $suite, $test) = @_;
-    my $entry = find_whitelist_entry($env, $suite, $test);
+    my $entry;
+
+    if ($env->{retval} && ref($env->{retval}) eq 'ARRAY') {
+        my %local_env = %$env;
+
+        my @retvals = grep { $_ ne 0 } @{$env->{retval}};
+        # if all retvals are zero, we might catch one of the `retval=>'^0$'` filters.
+        @retvals = (0) unless (@retvals);
+
+        for my $retval (@retvals) {
+            my $tmp = find_whitelist_entry({%$env, retval => $retval}, $suite, $test);
+            return 0 unless ($tmp);
+            $entry //= $tmp;
+        }
+    } else {
+        $entry = find_whitelist_entry($env, $suite, $test);
+    }
 
     return 0 unless defined($entry);
-    bmwqemu::diag("Failure in LTP:$suite:$test is known, overriding to softfail");
+    my $msg = "Failure in LTP:$suite:$test is known, overriding to softfail";
+    bmwqemu::diag($msg);
     $self->{result} = 'softfail';
-    $self->record_soft_failure_result($entry->{message}) if exists $entry->{message};
+    $self->record_soft_failure_result(join("\n", $msg, ($entry->{message} // ())));
     return 1;
 }
 
@@ -95,6 +110,45 @@ sub is_test_disabled {
 
     return 1 if defined($entry) && exists $entry->{skip} && $entry->{skip};
     return 0;
+}
+
+sub find_whitelist_testsuite {
+    my ($suite) = @_;
+
+    my $path = get_var('LTP_KNOWN_ISSUES');
+    return undef unless defined($path) and -e $path;
+
+    my $content = path($path)->slurp;
+    my $issues  = Mojo::JSON::decode_json($content);
+    return undef unless $issues;
+    return $issues->{$suite};
+}
+
+sub list_skipped_tests {
+    my ($env, $suite) = @_;
+    my @skipped_tests;
+    $suite = find_whitelist_testsuite($suite);
+    return @skipped_tests unless ($suite);
+    return @skipped_tests if (ref($suite) eq 'ARRAY');
+
+    for my $test (keys(%$suite)) {
+        my @entrys = grep { $_->{skip} && whitelist_entry_match($_, $env) } @{$suite->{$test}};
+        push @skipped_tests, $test if @entrys;
+    }
+    return @skipped_tests;
+}
+
+sub whitelist_entry_match
+{
+    my ($entry, $env) = @_;
+    my @attributes = qw(product ltp_version revision arch kernel backend retval flavor);
+
+    foreach my $attr (@attributes) {
+        next         unless defined $entry->{$attr};
+        return undef unless defined $env->{$attr};
+        return undef if ($env->{$attr} !~ m/$entry->{$attr}/);
+    }
+    return $entry;
 }
 
 1;

--- a/t/07_ltp_whitelist.t
+++ b/t/07_ltp_whitelist.t
@@ -1,0 +1,133 @@
+use Mojo::Base -strict;
+
+use Mojo::File;
+use Mojo::JSON;
+use Test::More;
+use Test::MockModule;
+use Test::Warnings;
+use Test::MockObject;
+use LTP::WhiteList qw(override_known_failures);
+use testapi;
+
+
+subtest 'whitelist_entry_match' => sub {
+
+    my $entry = {
+        product => '^sle:15-SP[23]$'
+    };
+    my $env = {
+        foo     => 'something',
+        product => 'sle:15-SP3'
+    };
+
+    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), $entry, "Product match regex");
+
+    $entry->{arch} = '^x86_64$';
+    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), undef, "Missing field in ltp-environment, doesn't match the entry");
+
+    $env->{arch} = 'foo';
+    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), undef, "Different value in ltp-environment, doesn't match the entry");
+
+    $env->{arch} = 'x86_64';
+    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), $entry, "Multiple values need match");
+
+    $env->{flavor} = 'EC2-HVM';
+    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), $entry, "Entry match with less attributes");
+
+    for my $attr (qw(product ltp_version revision arch kernel backend retval flavor)) {
+        $entry = {$attr => '^incredible_value$'};
+        $env   = {$attr => "incredible_value"};
+        is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), $entry, "Check match attribute $attr");
+    }
+
+};
+
+
+subtest override_known_failures => sub {
+    set_var(LTP_KNOWN_ISSUES => 'test_known_issues.json');
+    my $self = Test::MockObject->new();
+    my $msg;
+    $self->mock('record_soft_failure_result' => sub { shift; $msg = shift });
+    $self->{result} = 'not_set';
+
+    my $known_issues_json = {
+        testsuite_01 => {
+            test_01 => [
+                {
+                    product => '^sle:15',
+                    retval  => '^2$',
+                    message => 'overwrite result 2'
+                },
+                {
+                    product => '^sle:12',
+                    message => 'overwrite for product sle:12',
+                    skip    => 1
+                },
+                {
+                    product => '^sle:11',
+                    message => 'overwrite ZERO result',
+                    retval  => '^0$'
+                },
+                {
+                    product => '^sle:11',
+                    message => 'overwrite TWO result',
+                    retval  => '^2$'
+                }
+            ],
+        }
+    };
+
+    Mojo::File::path('test_known_issues.json')->spurt(Mojo::JSON::encode_json($known_issues_json));
+
+    my $env = {product => 'sle:15', retval => 0};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Check override_known_failures doesn't override");
+
+    $env = {product => 'sle:15', retval => 2};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures single retval");
+
+    $env = {product => 'sle:15', retval => [0, 2]};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures retval array");
+
+    $env = {product => 'sle:15', retval => [0, 2, 3]};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Check override_known_failures don't override on new error");
+
+
+    $env = {product => 'sle:12', retval => 0};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override with retval=0");
+
+    $env = {product => 'sle:12', retval => [0]};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override with retval=0");
+
+    $env = {product => 'sle:12', retval => 1};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override");
+
+    $env = {product => 'sle:12', retval => [1]};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override");
+
+
+    $msg = undef;
+    $env = {product => 'sle:11', retval => 0};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check for zero result");
+    like($msg, qr/ZERO/, 'Check softrecord_message contains correct entry message ZERO');
+
+    $msg = undef;
+    $env = {product => 'sle:11', retval => [0, 0, 0]};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check for zero result, if all are zero");
+    like($msg, qr/ZERO/, 'Check softrecord_message contains correct entry message ZERO');
+
+    delete $self->{result};
+    $msg = undef;
+    $env = {product => 'sle:11', retval => [0, 0, 2, 0]};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Ignore zero and softfail");
+    like($msg, qr/TWO/, 'Check softrecord_message contains correct entry message TWO');
+    is($self->{result}, 'softfail', 'Result was patched to `softfail`');
+
+    $env = {product => 'sle:11', retval => [0, 0, 1, 0]};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Ignore zero and fail");
+
+    $env = {product => 'sle:11', retval => [0, 2, 1, 0]};
+    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Ignore zero and fail [2]");
+
+};
+
+done_testing;


### PR DESCRIPTION
Use LTP::WhiteList utility to evaluate failures.
Also extend skipped ltp test.


- Related ticket: https://progress.opensuse.org/issues/92470
- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/8261 (whit LTP_KNOWN_ISSUES set)
  - ~http://cfconrad-vm.qa.suse.de/t8262 (without known issues)~
  - http://cfconrad-vm.qa.suse.de/tests/8263 (without known issues)

