### PR TITLE
Integrate netfilter of audit test into openQA

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -115,27 +115,27 @@ sub compare_run_log {
     }
     else {
         my @lines = split(/\n/, path("$baseline_file")->slurp);
-        %baseline_results = map { $_->{name} => {id => $_->{id}, result => $_->{result}} } parse_lines(\@lines);
+        %baseline_results = map { $_->{id} => {name => $_->{name}, result => $_->{result}} } parse_lines(\@lines);
     }
 
     my $flag = 'ok';
     foreach my $current_result (@current_results) {
         my $c_id     = $current_result->{id};
         my $c_result = $current_result->{result};
-        my $key      = $current_result->{name};
-        unless ($baseline_results{$key}) {
-            my $msg = "poo#93441\nNo baseline found(defined).\n$c_id $key $c_result";
-            $flag = _parse_results_with_diff_baseline($key, $c_result, $msg, $flag);
+        my $name     = $current_result->{name};
+        unless ($baseline_results{$c_id}) {
+            my $msg = "poo#93441\nNo baseline found(defined).\n$c_id $name $c_result";
+            $flag = _parse_results_with_diff_baseline($name, $c_result, $msg, $flag);
             next;
         }
-        my $b_id     = $baseline_results{$key}->{id};
-        my $b_result = $baseline_results{$key}->{result};
+        my $b_name   = $baseline_results{$c_id}->{name};
+        my $b_result = $baseline_results{$c_id}->{result};
         if ($c_result ne $b_result) {
-            my $info = "poo#93441\nTest result is NOT same as baseline \nCurrent:  $c_id $key $c_result\nBaseline: $b_id $key $b_result";
-            $flag = _parse_results_with_diff_baseline($key, $c_result, $info, $flag);
+            my $info = "poo#93441\nTest result is NOT same as baseline \nCurrent:  $c_id $name $c_result\nBaseline: $c_id $b_name $b_result";
+            $flag = _parse_results_with_diff_baseline($name, $c_result, $info, $flag);
             next;
         }
-        record_info($key, "Test result is the same as baseline\n$c_id $key $c_result", result => 'ok');
+        record_info($name, "Test result is the same as baseline\n$c_id $name $c_result", result => 'ok');
     }
     return $flag;
 }

--- a/schedule/security/cc_netfilter.yaml
+++ b/schedule/security/cc_netfilter.yaml
@@ -1,0 +1,37 @@
+name: cc_netfilter
+description:    >
+    This is for audit_test netfilter
+schedule:
+    - boot/boot_to_desktop
+    - network/setup_multimachine
+    - security/selinux/selinux_setup
+    - security/cc/cc_selinux_setup
+    - security/cc/cc_audit_test_setup
+    - security/cc/netfilter
+test_data:
+    server:
+        first_interface:
+            netcard: eth0.0
+            mac_addr: 00:11:11:11:11:00
+            ipv4: 192.168.0.1/24
+            ipv6: fd00::1
+            route: fd00::2
+        second_interface:
+            netcard: eth0.1
+            mac_addr: 00:11:11:11:11:01
+            ipv4: 192.168.1.1/24
+            ipv6: fd00:1::1
+            route: fd00:1::2
+    client:
+        first_interface:
+            netcard: eth0.0
+            mac_addr: 00:11:11:11:11:10
+            ipv4: 192.168.0.2/24
+            ipv6: fd00::2
+            route: fd00::1
+        second_interface:
+            netcard: eth0.1
+            mac_addr: 00:11:11:11:11:11
+            ipv4: 192.168.1.2/24
+            ipv6: fd00:1::2
+            route: fd00:1::1

--- a/tests/security/cc/netfilter.pm
+++ b/tests/security/cc/netfilter.pm
@@ -1,0 +1,131 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Run 'netfilter' test case of 'audit-test' test suite
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#96540
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi 'wait_for_children';
+use audit_test qw(compare_run_log prepare_for_test upload_audit_test_logs);
+use scheduler 'get_test_suite_data';
+use Utils::Systemd qw(disable_and_stop_service);
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    zypper_call('in bridge-utils');
+
+    # Need to do 'make netconfig' to generate 'lblnet_tst_server'
+    prepare_for_test('netfilter', (make => 1, timeout => 900, make_netconfig => 1));
+
+    # Configure the network
+    my $data = get_test_suite_data();
+
+    my $role = get_required_var('ROLE');
+    foreach my $key (keys %{$data->{$role}}) {
+        my $n       = $data->{$role}->{$key};
+        my $netcard = $n->{netcard};
+        my $dev     = $netcard;
+        assert_script_run("ip link add link eth0 address $n->{mac_addr} $netcard type macvlan");
+
+        # Network Bridge setting for Target of Evaluation(TOE)
+        if ($role eq 'client' && $key eq 'second_interface') {
+            assert_script_run('brctl addbr toebr');
+            assert_script_run("brctl addif toebr $netcard");
+            assert_script_run('brctl setageing toebr 3600');
+            $dev = 'toebr';
+        }
+
+        assert_script_run("ip addr add $n->{ipv4} dev $dev");
+        assert_script_run("ip addr add $n->{ipv6} dev $dev");
+        assert_script_run("ip link set $netcard up");
+        assert_script_run('ip link set toebr up') if ($role eq 'client' && $key eq 'second_interface');
+        assert_script_run("ip -6 route add $n->{route} dev $dev");
+    }
+
+    # start lblnet_tst_server
+    my $cmd        = "$audit_test::testdir$audit_test::testfile_tar/audit-test/utils/network-server/lblnet_tst_server";
+    my $lblnet_pid = background_script_run($cmd);
+
+    my $result = 'ok';
+    if ($role eq 'server') {
+        mutex_create('NETFILTER_SERVER_READY');
+        wait_for_children;
+    } else {
+        mutex_wait('NETFILTER_SERVER_READY');
+
+        # Export the variables
+        my $client_first  = $data->{client}->{first_interface};
+        my $client_second = $data->{client}->{second_interface};
+        my $server_first  = $data->{server}->{first_interface};
+        my $server_second = $data->{server}->{second_interface};
+
+        # Deal with ipv4 address: change 192.168.0.1/24 to 192.168.0.1
+        $client_first->{ipv4}  =~ s/\/.*//g;
+        $client_second->{ipv4} =~ s/\/.*//g;
+        $server_first->{ipv4}  =~ s/\/.*//g;
+        $server_second->{ipv4} =~ s/\/.*//g;
+
+        assert_script_run("export PASSWD=$testapi::password LOCAL_DEV=$client_first->{netcard}\@eth0 LOCAL_SEC_DEV=$client_second->{netcard}\@eth0 LOCAL_SEC_MAC=$client_second->{mac_addr} LOCAL_IPV4=$client_first->{ipv4} LOCAL_IPV6=$client_first->{ipv6} LOCAL_SEC_IPV4=$client_second->{ipv4} LOCAL_SEC_IPV6=$client_second->{ipv6} LBLNET_SVR_IPV4=$server_first->{ipv4} LBLNET_SVR_IPV6=$server_first->{ipv6} SECNET_SVR_IPV4=$server_second->{ipv4} SECNET_SVR_IPV6=$server_second->{ipv6} SECNET_SVR_MAC=$server_second->{mac_addr} BRIDGE_FILTER=toebr");
+
+        run_audit_test($lblnet_pid, $cmd);
+
+        # Compare current test results with baseline
+        $result = compare_run_log('netfilter');
+    }
+
+    $self->result($result);
+}
+
+#
+# This function is only used by client.
+# When one case finishes, the port maybe hasn't been released, so we need to restart
+# `lblnet_tst_server` in case the following test case ends with ERROR.
+# So the test cases in netfilter will be run one by one.
+#
+sub run_audit_test {
+    my ($pid, $lblnet_cmd) = @_;
+    my $output = script_output('./run.bash --list');
+    my @lines  = split(/\n/, $output);
+    my @test_lists;
+    foreach (@lines) {
+        my $num;
+        if ($_ =~ /\[(\d+)\]\s+\S+/) {
+            $num = $1;
+        } else {
+            next;
+        }
+        my $cmd    = "./run.bash $num";
+        my $result = script_output($cmd, timeout => 600);
+
+        # If the port is busy, the test case will end with error, we need to restart lblnet_tst_server
+        if (index($result, 'could not setup remote test server') != -1) {
+            script_run("kill -9 $pid");
+            $pid = background_script_run($lblnet_cmd);
+            # Give more seconds for killing this process
+            sleep 3;
+            assert_script_run($cmd, timeout => 600);
+        }
+    }
+
+    # The 8th test case sometimes may end with ERROR because of the performance issue. we need to run it again
+    assert_script_run('./run.bash 8', timeout => 300) if (script_run('egrep "[8].*ERROR" rollup.log') == 0);
+    # Upload logs
+    upload_audit_test_logs();
+}
+
+1;


### PR DESCRIPTION
QE security team plans to integrate audit-test into openQA, netfilter is one test case of it.
netfilter is a multi-machine test.
    
Related: https://progress.opensuse.org/issues/96540
Verification run: https://openqa.suse.de/tests/6869802#  (client) 
                          https://openqa.suse.de/tests/6869801#  (server)
MR: https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/23