### PR TITLE
Disable sporadic failing network/samba/samba_adcli in mau-extratests2

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -45,7 +45,8 @@ conditional_schedule:
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
-        - network/samba/samba_adcli
+        # https://progress.opensuse.org/issues/96512
+        # - network/samba/samba_adcli
         - '{{arch_specific}}'
       15-SP2:
         - console/osinfo_db
@@ -56,7 +57,8 @@ conditional_schedule:
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
-        - network/samba/samba_adcli
+        # https://progress.opensuse.org/issues/96512
+        # - network/samba/samba_adcli
         - '{{arch_specific}}'
       15-SP1:
         - console/osinfo_db
@@ -65,7 +67,8 @@ conditional_schedule:
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
-        - network/samba/samba_adcli
+        # https://progress.opensuse.org/issues/96512
+        # - network/samba/samba_adcli
         - '{{arch_specific}}'
       15:
         - console/osinfo_db
@@ -74,7 +77,8 @@ conditional_schedule:
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
-        - network/samba/samba_adcli
+        # https://progress.opensuse.org/issues/96512
+        # - network/samba/samba_adcli
         - '{{arch_specific}}'
       12-SP5:
         - console/osinfo_db
@@ -82,20 +86,23 @@ conditional_schedule:
         - console/valgrind
         - console/zziplib
         - console/openvswitch_ssl
-        - network/samba/samba_adcli
+        # https://progress.opensuse.org/issues/96512
+        # - network/samba/samba_adcli
         - '{{arch_specific}}'
         - '{{arch_12sp5}}'
       12-SP4:
         - console/osinfo_db
         - console/journald_fss
         - console/openvswitch_ssl
-        - network/samba/samba_adcli
+        # https://progress.opensuse.org/issues/96512
+        # - network/samba/samba_adcli
         - '{{arch_specific}}'
       12-SP3:
         - console/osinfo_db
         - console/journald_fss
         - console/openvswitch_ssl
-        - network/samba/samba_adcli
+        # https://progress.opensuse.org/issues/96512
+        # - network/samba/samba_adcli
         - '{{arch_specific}}'
       12-SP2:
         - console/journald_fss


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/96512