### PR TITLE
Add missing information in test modules

### DIFF
--- a/tests/appgeo/gdal.pm
+++ b/tests/appgeo/gdal.pm
@@ -1,3 +1,7 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2021 SUSE LLC
+#
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,

--- a/tests/appgeo/qgis.pm
+++ b/tests/appgeo/qgis.pm
@@ -1,3 +1,7 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2021 SUSE LLC
+#
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,

--- a/tests/console/libgpiod.pm
+++ b/tests/console/libgpiod.pm
@@ -1,3 +1,7 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2021 SUSE LLC
+#
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
@@ -5,7 +9,7 @@
 
 # Package: libgpiod
 # Summary: Test libgpiod
-#  More information can be found on https://en.opensuse.org/openSUSE:GPIO
+# More information can be found on https://en.opensuse.org/openSUSE:GPIO
 # Maintainer: Guillaume Gardet <guillaume@opensuse.org>
 
 use base "consoletest";

--- a/tests/installation/sles4sap_wizard_nw.pm
+++ b/tests/installation/sles4sap_wizard_nw.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 # Summary: Add SLES4SAP tests
 # Maintainer: Denis Zyuzin <dzyuzin@suse.com>
 

--- a/tests/installation/sles4sap_wizard_swpm.pm
+++ b/tests/installation/sles4sap_wizard_swpm.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 # Summary: Add SLES4SAP tests
 # Maintainer: Denis Zyuzin <dzyuzin@suse.com>
 

--- a/tests/installation/sles4sap_wizard_trex.pm
+++ b/tests/installation/sles4sap_wizard_trex.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 # Summary: Add SLES4SAP tests
 # Maintainer: Denis Zyuzin <dzyuzin@suse.com>
 

--- a/tests/virt_autotest/cleanup_service.pm
+++ b/tests/virt_autotest/cleanup_service.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 # Summary: revert or cleanup the configuration files and restart services
 # Maintainer: Julie CAO <jcao@suse.com>
 package cleanup_service;

--- a/tests/virt_autotest/restore_guests.pm
+++ b/tests/virt_autotest/restore_guests.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 # Summary: make the guests(specified by test suite settings) ready(virsh define).
 # Maintainer: Julie CAO <jcao@suse.com>
 package restore_guests;

--- a/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
+++ b/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
@@ -1,3 +1,6 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/virtualization/universal/download_image.pm
+++ b/tests/virtualization/universal/download_image.pm
@@ -1,4 +1,6 @@
-#Copyright © 2019 SUSE LLC
+# SUSE's openQA tests
+
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/virtualization/universal/list_guests.pm
+++ b/tests/virtualization/universal/list_guests.pm
@@ -1,4 +1,6 @@
-#Copyright © 2019 SUSE LLC
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/virtualization/universal/windows.pm
+++ b/tests/virtualization/universal/windows.pm
@@ -1,4 +1,6 @@
-#Copyright © 2019 SUSE LLC
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/x11/awesome_menu.pm
+++ b/tests/x11/awesome_menu.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
 # Package: awesome
 # Summary: awesome window manager startup
 #    Based on "minimalx" installation.

--- a/tests/x11/awesome_xterm.pm
+++ b/tests/x11/awesome_xterm.pm
@@ -1,3 +1,12 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
 # Package: awesome
 # Summary: Test for xterm started in awesome window manager
 # Maintainer: Dominik Heidler <dheidler@suse.de>


### PR DESCRIPTION
Some of the tests miss the Copyright area in the file header.

- Related ticket: https://progress.opensuse.org/issues/96716
- Needles: N/A
- Verification run: N/A
