### PR TITLE
Add test scenario for PC-AMD-SEV

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -123,6 +123,7 @@ sub img_proof {
 sub terraform_apply {
     my ($self, %args) = @_;
     $args{project} //= $self->project_id;
+    $args{confidential_compute} = get_var("PUBLIC_CLOUD_CONFIDENTIAL_VM", 0);
     return $self->SUPER::terraform_apply(%args);
 }
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -369,6 +369,7 @@ sub terraform_apply {
         $cmd .= "-var 'region=" . $self->region . "' ";
         $cmd .= "-var 'name=" . $name . "' ";
         $cmd .= "-var 'project=" . $args{project} . "' " if $args{project};
+        $cmd .= "-var 'enable_confidential_vm=true' "    if $args{confidential_compute};
         $cmd .= sprintf(q(-var 'tags={"openqa_ttl":"%d"}' ), get_var('MAX_JOB_TIME', 7200) + get_var('PUBLIC_CLOUD_TTL_OFFSET', 300));
         if ($args{use_extra_disk}) {
             $cmd .= "-var 'create-extra-disk=true' ";

--- a/schedule/publiccloud/smoketest.yml
+++ b/schedule/publiccloud/smoketest.yml
@@ -1,0 +1,16 @@
+---
+name: publiccloud-smoketest
+description: |
+  Basic smoketests on public cloud instances
+schedule:
+  - boot/boot_to_desktop
+  - publiccloud/download_repos
+  - publiccloud/ssh_interactive_init
+  - publiccloud/register_system
+  - publiccloud/transfer_repos
+  - publiccloud/patch_and_reboot
+  - publiccloud/ssh_interactive_start
+  - publiccloud/instance_overview
+  - publiccloud/smoketest
+  - publiccloud/sev
+  - publiccloud/ssh_interactive_end

--- a/tests/publiccloud/sev.pm
+++ b/tests/publiccloud/sev.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test AMD-SEV
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+#use version_utils qw(is_sle is_opensuse is_leap is_tumbleweed);
+#use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Skip this test run, unless defined to run
+    unless (get_var("PUBLIC_CLOUD_CONFIDENTIAL_VM", 0)) {
+        record_info("Skipping test", "PUBLIC_CLOUD_CONFIDENTIAL_VM is not set");
+        return;
+    }
+
+    # Ensure we are running with activated AMD Memory encryption
+    script_run('dmesg | grep SEV | head');
+    assert_script_run('dmesg | grep SEV | grep "AMD Memory Encryption Features active"', fail_message => "AMD-SEV not active on this instance");
+}
+
+1;

--- a/tests/publiccloud/smoketest.pm
+++ b/tests/publiccloud/smoketest.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run basic smoketest on publiccloud test instance
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Check if systemd completed sucessfully
+    assert_script_run 'journalctl -b | grep "Reached target Basic System"';
+    # Additional basic commands to verify the instance is healthy
+    validate_script_output('echo "ping"', sub { m/ping/ });
+    assert_script_run 'uname -a';
+}
+
+1;


### PR DESCRIPTION
Adding a test scenario for running a smoke test on the AMD-SEV secured
publiccloud instances. Also introduce the `smoketest` test scenario, which can be used for basic smoketest on more non-standard machine types.

- Related ticket: https://progress.opensuse.org/issues/94634
- Verification run: 15-SP3 [GCE AMD-SEV](http://duck-norris.qam.suse.de/tests/6843) | [GCE default](http://duck-norris.qam.suse.de/tests/6844)
