### PR TITLE
wicked-wlan: Skip t12_ssid_format if wicked version <0.6.66

### DIFF
--- a/tests/wicked/wlan/sut/t12_ssid_format.pm
+++ b/tests/wicked/wlan/sut/t12_ssid_format.pm
@@ -87,6 +87,8 @@ sub run {
     my $WAIT_SECONDS = get_var("WICKED_WAIT_SECONDS", 70);
 
     $self->select_serial_terminal;
+    return if ($self->skip_by_wicked_version());
+
     $self->setup_ref();
 
     # Start hostapd


### PR DESCRIPTION
I forgot to call `$self->skip_by_wicked_version()` on this module.

This is a fix for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13027

- Related ticket: https://progress.opensuse.org/issues/96977

- Verification run: http://cfconrad-vm.qa.suse.de/tests/8269
