### PR TITLE
Fix SLE15SP4 staging project with GNOME40 upgrade

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 use utils;
 use testapi;
-use version_utils qw(is_sle is_opensuse is_tumbleweed is_vmware is_jeos);
+use version_utils qw(is_sle is_leap is_opensuse is_tumbleweed is_vmware is_jeos);
 use Carp 'croak';
 
 our @EXPORT = qw(
@@ -81,7 +81,8 @@ sub reboot_x11 {
     my ($self) = @_;
     wait_still_screen;
     if (check_var('DESKTOP', 'gnome')) {
-        if (is_tumbleweed) {
+        # For systems with GNOME 40+, use mouse click instead of 'ctrl-alt-delete'.
+        if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4')) {
             assert_and_click('reboot-power-icon');
             assert_and_click('reboot-power-menu');
             assert_and_click('reboot-click-restart');

--- a/tests/console/x_vt.pm
+++ b/tests/console/x_vt.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,15 +15,16 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_tumbleweed is_leap);
+use version_utils qw(is_tumbleweed is_leap is_sle);
 
 sub run {
+    # First, list all X processes, including user process and gdm process
+    script_run('ps -ef | grep bin/X');
     if (script_run("ps -ef | grep bin/X | egrep 'tty7|wayland'") == 1) {
-        if ((is_tumbleweed || is_leap('>=15.2')) && script_run('ps -ef | grep bin/X | grep tty2') == 0) {
-            record_soft_failure('boo#1138327');
+        if ((is_tumbleweed || is_leap('>=15.2') || is_sle('>=15-SP2')) && script_run('ps -ef | grep bin/X | grep tty2') == 0) {
+            diag('user X process runs on tty2 for systems with GNOME 3.32+, see boo#1138327');
         }
         else {
-            script_run('ps -ef | grep bin/X');
             die 'Expected tty7 used by X or wayland not found';
         }
     }


### PR DESCRIPTION
This is to fix problems in "sle-15-SP4-Online-E-Staging" on o.s.d, which includes newly introduced GNOME40 stack.

The code paths to handle GNOME40 was already added by previous Tumbleweed tests, this PR just enables them for SLE15SP4+ and Leap15.4+.

- Related ticket: https://progress.opensuse.org/issues/96875
- Needles: Created a few in osd by developer mode
- Verification run: https://openqa.suse.de/tests/6857221#step/x_vt/7 https://openqa.suse.de/tests/6857221#step/reboot_gnome/2
