### PR TITLE
Fix lvm_encrypt_separate_boot QAM test_data

### DIFF
--- a/test_data/qam/QR/15-SP3/encryption/lvm_encrypt_separate_boot_prep_boot.yaml
+++ b/test_data/qam/QR/15-SP3/encryption/lvm_encrypt_separate_boot_prep_boot.yaml
@@ -1,9 +1,9 @@
 disks:
   - name: vda
     partitions:
-      - size: 2MiB
+      - size: 8MiB
         role: raw-volume
-        id: bios-boot
+        id: prep-boot
       - size: 500MiB
         role: operating-system
         formatting_options:


### PR DESCRIPTION
After commit 601b2ed37e , the partitioning test_data where changed for ppc and 64bit as well. The two archs need separate test data in order for the new_partitioning_gpt to work properly.
 
- Related ticket: https://progress.opensuse.org/issues/96842
- Verification runs:
64bit: http://falafel.suse.cz/tests/524
ppc: https://openqa.suse.de/tests/6869561 
