### PR TITLE
Softfail wbinfo failures

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -154,14 +154,19 @@ sub run {
     }
 
     systemctl('restart nscd');
+
     #Verify users and groups  from AD
-    if (script_run("wbinfo -u | grep foursixnine") != 0) {
+    my $wbinfo_ret = 0;
+    $wbinfo_ret += script_run "wbinfo -u | grep foursixnine";
+    $wbinfo_ret += script_run "wbinfo -g | grep dnsupdateproxy";
+    $wbinfo_ret += script_run "wbinfo -D geeko.com";
+    $wbinfo_ret += script_run "wbinfo -i geekouser\@geeko.com";
+    $wbinfo_ret += script_run "wbinfo -i Administrator\@geeko.com";
+
+    # If any of the wbinfo commands did not return successfully, softfail
+    if ($wbinfo_ret != 0) {
         record_soft_failure('poo#96513');
     }
-    assert_script_run "wbinfo -g | grep dnsupdateproxy";
-    assert_script_run "wbinfo -D geeko.com";
-    assert_script_run "wbinfo -i geekouser\@geeko.com";
-    assert_script_run "wbinfo -i Administrator\@geeko.com";
 
     if (script_run("expect -c 'spawn ssh -l geekouser\@geeko.com localhost -t;expect sword:;send Nots3cr3t\\n;expect geekouser>;send exit\\n;interact'") != 0) {
         record_soft_failure('poo#96512');
@@ -170,7 +175,10 @@ sub run {
     # poo#91950 (update machine password with adcli --add-samba-data option)
     update_password() unless is_sle('=15');    # sle 15 does not support the `--add-samba-data` option
 
-    assert_script_run "echo Nots3cr3t  | net ads leave --domain geeko.com -U Administrator -i";
+    if ((script_run "echo Nots3cr3t  | net ads leave --domain geeko.com -U Administrator -i") != 0) {
+        record_soft_failure('poo#96986');
+        return;
+    }
 
     # For futher extensions
     # - Mount //GEEKO


### PR DESCRIPTION
`wbinfo` test failures need to be softfailed until fixed.

- Related ticket: https://progress.opensuse.org/issues/96992
- Needles: No needles
- Verification runs:
[sle 15-SP3 aarch64](https://openqa.suse.de/tests/6893935#step/samba_adcli/150) | [sle 15-SP3 s390x](https://openqa.suse.de/tests/6893936#step/samba_adcli/172) | [sle 15-SP2 x86_64](https://openqa.suse.de/tests/6895276#step/samba_adcli/150) | [sle 15-SP2 s390x](https://openqa.suse.de/tests/6895278#step/samba_adcli/177) | [sle 15-SP2 aarch64](https://openqa.suse.de/tests/6895277#step/samba_adcli/181) | [sle 15-SP1 aarch64](https://openqa.suse.de/tests/6895483#step/samba_adcli/182) | [sle 15-SP1 s390x](https://openqa.suse.de/tests/6895506#) | [sle 15-SP1 x86_64](https://openqa.suse.de/tests/6895507#step/samba_adcli/228) | [sle 15 aarch64](https://openqa.suse.de/tests/6897257#step/samba_adcli/92) | [sle 15 s390x](https://openqa.suse.de/tests/6896055#step/samba_adcli/124) | [sle 15 x86_64](https://openqa.suse.de/tests/6896056#step/samba_adcli/56) | [sle 12-SP5 s390x](https://openqa.suse.de/tests/6896152#step/samba_adcli/59) | [sle 12-SP5 x86_64](https://openqa.suse.de/tests/6896149#step/samba_adcli/119) | [sle 12-SP4 x86_64](https://openqa.suse.de/tests/6897262#step/samba_adcli/146) | [sle 12-SP4 s390x](https://openqa.suse.de/tests/6897260#step/samba_adcli/118) | [sle 12-SP3 x86_64](https://openqa.suse.de/tests/6897258#step/samba_adcli/56)