### PR TITLE
AY deployed slem5.1 had misconfigured kdump

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro.xml
+++ b/data/autoyast_sle15/autoyast_sle-micro.xml
@@ -32,6 +32,14 @@
       <pattern>microos-selinux</pattern>
     </patterns>
   </software>
+  <kdump>
+  <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+  <crash_kernel>191M</crash_kernel>
+  <general>
+    <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+    <KDUMP_DUMPLEVEL>1</KDUMP_DUMPLEVEL>
+  </general>
+</kdump>
   <users config:type="list">
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>


### PR DESCRIPTION
Our autoyast profile had no kdump configuration, but kdump service has
been enabled by default.

Error reported by `journal_check`:

```
Aug 16 13:56:50.743930 s390kvm085 load.sh[1166]: Please reserve memory by passing"crashkernel=X@Y" parameter to kernel
```

- [test fails in journal_check - kdump service fails](https://progress.opensuse.org/issues/96953)
- VR:
    - [sle-micro_autoyast@s390x-kvm-sle12 (crashkernel=256M-:64M)](http://kepler.suse.cz/tests/6463#)
    - [sle-micro_autoyast@s390x-kvm-sle12 (crashkernel=191M)](http://kepler.suse.cz/tests/6464#)
