### PR TITLE
Retry terraform destroy on errors

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -448,7 +448,9 @@ sub terraform_destroy {
     else {
         assert_script_run('cd ' . TERRAFORM_DIR);
     }
-    my $ret = script_run('terraform destroy -no-color -auto-approve', get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT));
+    # Retry 3 times with considerable delay. This has been introduced due to poo#95932 (RetryableError)
+    # terraform keeps track of the allocated and destroyed resources, so its safe to run this multiple times.
+    my $ret = script_retry('terraform destroy -no-color -auto-approve', retry => 3, delay => 60, timeout => get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT), die => 0);
     unless (defined $ret) {
         if (is_serial_terminal()) {
             type_string(qq(\c\\));    # Send QUIT signal

--- a/lib/publiccloud/ssh_interactive_init.pm
+++ b/lib/publiccloud/ssh_interactive_init.pm
@@ -27,7 +27,7 @@ use testapi;
 sub post_fail_hook {
     select_host_console(force => 1);
     assert_script_run('cd /root/terraform');
-    script_run('terraform destroy -no-color -auto-approve', 240);
+    script_retry('terraform destroy -no-color -auto-approve', retry => 3, delay => 60, timeout => get_var('TERRAFORM_TIMEOUT', 240), die => 0);
 }
 
 sub test_flags {


### PR DESCRIPTION
Retry failed terraform destroy commands to account for an
RetryableError.

- Related ticket: https://progress.opensuse.org/issues/95932
- Verification run: [15-SP3 Azure imgproof](http://duck-norris.qam.suse.de/t6948) | [15-SP3 Azure-BYOS-gen2 consoletests](http://duck-norris.qam.suse.de/t6949) | [15-SP3 EC2-ARM containers](http://duck-norris.qam.suse.de/t6950) | [15-SP3 GCE consoletests](http://duck-norris.qam.suse.de/t6951)
