### PR TITLE
kernel: Switch kexec test to select_serial_terminal

### DIFF
--- a/tests/kernel/kernel_kexec.pm
+++ b/tests/kernel/kernel_kexec.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright (C) 2017-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 
 # Package: kexec-tools systemd
 # Summary:  [qa_automation] kexec testsuite
-# Maintainer: Nathan Zhao <jtzhao@suse.com>
+# Maintainer: QE Kernel <kernel-qa@suse.de>
 
 use base "opensusebasetest";
 use strict;
@@ -25,7 +25,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    select_console('root-console');
+    $self->select_serial_terminal;
     # clear console to prevent linux-login to match before reboot
     clear_console;
     # Copy kernel image and rename it
@@ -50,8 +50,8 @@ sub run {
     # don't use built-in systemctl api, see poo#31180
     script_run("systemctl kexec", 0);
     reset_consoles;
-    assert_screen('linux-login', 300);
-    select_console('root-console');
+    $self->wait_boot_past_bootloader;
+    $self->select_serial_terminal;
     # Check kernel cmdline parameter
     my $result = script_output("cat /proc/cmdline", 120);
     print "Checking kernel boot parameter...\nCurrent:  $result\nExpected: $cmdline\n";


### PR DESCRIPTION
Fix poo#97004: Use select_serial_terminal instead of root console to
make test more robust. Test maintainer was updated.

- Related ticket: https://progress.opensuse.org/issues/97004
- Needles: none
- Verification run: 
15-SP4 x86_64: https://openqa.suse.de/tests/6882461
15-SP4 aarch64: https://openqa.suse.de/tests/6882466
15-SP4 ppc64le: https://openqa.suse.de/tests/6882467
15-SP3 x86_64: https://openqa.suse.de/tests/6882463
15-SP2 x86_64: https://openqa.suse.de/tests/6882480
15 x86_64: https://openqa.suse.de/tests/6882544
12-SP5 x86_64: https://openqa.suse.de/tests/6882647
12-SP4 x86_64: https://openqa.suse.de/t6882548

