### PR TITLE
evolution: New third party password had to be generated

### DIFF
--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -28,7 +28,7 @@ use version_utils qw(is_sle is_tumbleweed);
 sub run {
     my $self        = shift;
     my $mail_box    = 'nooops_test3@aim.com';
-    my $mail_passwd = 'opensuse';
+    my $mail_passwd = 'hkiworexcmmeqmzt';
 
     mouse_hide(1);
     x11_start_program('xterm -e "gsettings set org.gnome.desktop.session idle-delay 0"', valid => 0);


### PR DESCRIPTION
New login password is same as password for third party login/IMAP

- Related ticket: https://progress.opensuse.org/issues/67408
- Verification run:
http://dzedro.suse.cz/tests/18873
http://dzedro.suse.cz/tests/18874
https://openqa.suse.de/tests/6882719
https://openqa.suse.de/tests/6882720