### PR TITLE
console/firewalld: Adjust to chain name changes in firewalld 1.0.0

### DIFF
--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -16,7 +16,7 @@ use warnings;
 use base "consoletest";
 use testapi;
 use utils qw(systemctl zypper_call);
-use version_utils qw(is_sle is_leap is_tumbleweed);
+use version_utils qw(is_sle is_leap);
 
 sub uses_iptables {
     return is_sle('<15-SP3') || is_leap('<15.3');
@@ -42,7 +42,11 @@ sub check_rules {
     else {
         assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 25");
         assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 110");
-        assert_script_run("nft list chain inet firewalld filter_FWDI_public | grep icmp");
+        if (is_leap("<16") || is_sle("<16")) {
+            assert_script_run("nft list chain inet firewalld filter_FWDI_public | grep icmp");
+        } else {
+            assert_script_run("nft list chain inet firewalld filter_FWD_public | grep icmp");
+        }
         assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 2000-3000");
     }
 }
@@ -69,7 +73,11 @@ sub test_temporary_rules {
     }
     else {
         assert_script_run("nft list chain inet firewalld filter_IN_public_allow | wc -l > /tmp/nr_in_public.txt");
-        assert_script_run("nft list chain inet firewalld filter_FWDI_public | wc -l > /tmp/nr_fwdi_public.txt");
+        if (is_leap("<16") || is_sle("<16")) {
+            assert_script_run("nft list chain inet firewalld filter_FWDI_public | wc -l > /tmp/nr_fwdi_public.txt");
+        } else {
+            assert_script_run("nft list chain inet firewalld filter_FWD_public | wc -l > /tmp/nr_fwd_public.txt");
+        }
     }
 
     assert_script_run("firewall-cmd --zone=public --add-port=25/tcp");
@@ -87,7 +95,11 @@ sub test_temporary_rules {
     }
     else {
         assert_script_run("test `nft list chain inet firewalld filter_IN_public_allow | wc -l` -eq `cat /tmp/nr_in_public.txt`");
-        assert_script_run("test `nft list chain inet firewalld filter_FWDI_public | wc -l` -eq `cat /tmp/nr_fwdi_public.txt`");
+        if (is_leap("<16") || is_sle("<16")) {
+            assert_script_run("test `nft list chain inet firewalld filter_FWDI_public | wc -l` -eq `cat /tmp/nr_fwdi_public.txt`");
+        } else {
+            assert_script_run("test `nft list chain inet firewalld filter_FWD_public | wc -l` -eq `cat /tmp/nr_fwd_public.txt`");
+        }
     }
 }
 
@@ -100,7 +112,11 @@ sub test_permanent_rules {
     }
     else {
         assert_script_run("nft list chain inet firewalld filter_IN_public_allow | wc -l > /tmp/nr_in_public.txt");
-        assert_script_run("nft list chain inet firewalld filter_FWDI_public | wc -l > /tmp/nr_fwdi_public.txt");
+        if (is_leap("<16") || is_sle("<16")) {
+            assert_script_run("nft list chain inet firewalld filter_FWDI_public | wc -l > /tmp/nr_fwdi_public.txt");
+        } else {
+            assert_script_run("nft list chain inet firewalld filter_FWD_public | wc -l > /tmp/nr_fwd_public.txt");
+        }
     }
 
     assert_script_run("firewall-cmd --zone=public --permanent --add-port=25/tcp");
@@ -124,7 +140,11 @@ sub test_permanent_rules {
     }
     else {
         assert_script_run("test `nft list chain inet firewalld filter_IN_public_allow | wc -l` -eq `cat /tmp/nr_in_public.txt`");
-        assert_script_run("test `nft list chain inet firewalld filter_FWDI_public | wc -l` -eq `cat /tmp/nr_fwdi_public.txt`");
+        if (is_leap("<16") || is_sle("<16")) {
+            assert_script_run("test `nft list chain inet firewalld filter_FWDI_public | wc -l` -eq `cat /tmp/nr_fwdi_public.txt`");
+        } else {
+            assert_script_run("test `nft list chain inet firewalld filter_FWD_public | wc -l` -eq `cat /tmp/nr_fwd_public.txt`");
+        }
     }
 
 }

--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -144,10 +144,12 @@ sub test_masquerading {
     if (uses_iptables) {
         assert_script_run("iptables -t nat -L PRE_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_pre.txt");
         assert_script_run("iptables -t nat -L POST_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l > /tmp/nr_rules_nat_post.txt");
-    }
-    else {
+    } elsif (is_leap("<16") || is_sle("<16")) {
         assert_script_run("nft list chain ip firewalld nat_PRE_public_allow | wc -l > /tmp/nr_rules_nat_pre.txt");
         assert_script_run("nft list chain ip firewalld nat_POST_public_allow | wc -l > /tmp/nr_rules_nat_post.txt");
+    } else {
+        assert_script_run("nft list chain inet firewalld nat_PRE_public_allow | wc -l > /tmp/nr_rules_nat_pre.txt");
+        assert_script_run("nft list chain inet firewalld nat_POST_public_allow | wc -l > /tmp/nr_rules_nat_post.txt");
     }
 
     assert_script_run("firewall-cmd --zone=public --add-masquerade");
@@ -156,10 +158,12 @@ sub test_masquerading {
     if (uses_iptables) {
         assert_script_run("iptables -t nat -L PRE_public_allow | grep 'to::22'");
         assert_script_run("iptables -t nat -L POST_public_allow | grep MASQUERADE");
-    }
-    else {
+    } elsif (is_leap("<16") || is_sle("<16")) {
         assert_script_run("nft list chain ip firewalld nat_PRE_public_allow | grep 'redirect to :22'");
         assert_script_run("nft list chain ip firewalld nat_POST_public_allow | grep masquerade");
+    } else {
+        assert_script_run("nft list chain inet firewalld nat_PRE_public_allow | grep 'redirect to :22'");
+        assert_script_run("nft list chain inet firewalld nat_POST_public_allow | grep masquerade");
     }
 
     # Reload default configuration
@@ -168,10 +172,12 @@ sub test_masquerading {
     if (uses_iptables) {
         assert_script_run("test `iptables -t nat -L PRE_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_nat_pre.txt`");
         assert_script_run("test `iptables -t nat -L POST_public_allow --line-numbers | sed '/^num\\|^\$\\|^Chain/d' | wc -l` -eq `cat /tmp/nr_rules_nat_post.txt`");
-    }
-    else {
+    } elsif (is_leap("<16") || is_sle("<16")) {
         assert_script_run("test `nft list chain ip firewalld nat_PRE_public_allow | wc -l` -eq `cat /tmp/nr_rules_nat_pre.txt`");
         assert_script_run("test `nft list chain ip firewalld nat_POST_public_allow | wc -l` -eq `cat /tmp/nr_rules_nat_post.txt`");
+    } else {
+        assert_script_run("test `nft list chain inet firewalld nat_PRE_public_allow | wc -l` -eq `cat /tmp/nr_rules_nat_pre.txt`");
+        assert_script_run("test `nft list chain inet firewalld nat_POST_public_allow | wc -l` -eq `cat /tmp/nr_rules_nat_post.txt`");
     }
 }
 


### PR DESCRIPTION
FWDI got renamed to just FWD, FWDO got dropped:
https://github.com/firewalld/firewalld/commit/736173c9eb571a84610106dfafa78a59bcad9f0d

nat rules moved from ip to inet as well:
https://github.com/firewalld/firewalld/commit/9d9a1a88b53ade7d0358f0f43200a08300c8d887

Verification run: https://openqa.opensuse.org/tests/1878927
