### PR TITLE
Fix aiodio init for modified LTP

### DIFF
--- a/tests/kernel/create_junkfile_ltp.pm
+++ b/tests/kernel/create_junkfile_ltp.pm
@@ -20,15 +20,18 @@ sub run {
     my $pdir   = '$TMPDIR/aiodio.$$';
     my $dir    = '$TMPDIR/aiodio';
 
-    assert_script_run("mkdir -p $pdir/junkdir $dir");
+    assert_script_run("mkdir -p $pdir/junkdir $dir/junkdir");
     assert_script_run("dd if=/dev/urandom of=$pdir/junkfile oflag=sync bs=1M count=26");
+    assert_script_run("dd if=$pdir/junkfile of=$dir/junkfile oflag=sync bs=1M count=26");
     upload_logs("$pdir/junkfile", failok => 1);
     for my $f (['f', '8K'], ['1', '4K'], ['2', '1K'], ['3', '512']) {
         assert_script_run("dd if=$pdir/junkfile of=$pdir/ff$f->[0] bs=$f->[1] conv=block,sync");
+        assert_script_run("dd if=$pdir/junkfile of=$dir/ff$f->[0] bs=$f->[1] conv=block,sync");
     }
     for my $f ([2, '2K'], [3, '1K'], [4, '512'], [5, '4K']) {
         assert_script_run("dd if=$pdir/junkfile of=$dir/file$f->[0] bs=$f->[1] conv=block,sync");
     }
+    assert_script_run("touch " . join(" ", map { "$dir/junkfile$_" } (1 .. 9)));
 }
 
 sub test_flags {


### PR DESCRIPTION
QEM tests use modified LTP with slightly different junkfile structure. Create this structure in dedicated test module to avoid bogus failures after VM snapshot reload.

- Related ticket: https://progress.opensuse.org/issues/97040
- Needles: N/A
- Verification runs:
  - SLE-12SP3 x86_64:
    - ltp_aiodio_part1: https://openqa.suse.de/tests/6885649
    - ltp_aiodio_part3: https://openqa.suse.de/tests/6885650
    - ltp_aiodio_part4: https://openqa.suse.de/tests/6885651
    - ltp_aiodio_part1 without `ADPREP*` modules: https://openqa.suse.de/tests/6885821
  - SLE-15SP3 ppc64le
    - ltp_aiodio_part1: https://openqa.suse.de/tests/6885812
    - ltp_aiodio_part3: https://openqa.suse.de/tests/6885813
    - ltp_aiodio_part4: https://openqa.suse.de/tests/6885814
    - ltp_aiodio_part3 without `ADPREP*` modules: https://openqa.suse.de/tests/6885815
  - SLE-15SP4 aarch64 (vanilla LTP)
    - ltp_aiodio_part1: https://openqa.suse.de/tests/6885817
    - ltp_aiodio_part3: https://openqa.suse.de/tests/6885816
    - ltp_aiodio_part4: https://openqa.suse.de/tests/6885809

Note: verification runs without `ADPREP*` modules simulate disk state after snapshot reload. ltp_aiodio_part1 using the old `create_junkfile_ltp` without `ADPREP*` modules will fail like this: https://openqa.suse.de/tests/6885653