### PR TITLE
Provide test_data for validate_blockdevices test

### DIFF
--- a/test_data/yast/xfs/xfs_partition_opensuse.yaml
+++ b/test_data/yast/xfs/xfs_partition_opensuse.yaml
@@ -1,0 +1,22 @@
+---
+disks:
+  - name: vda
+    table_type: gpt
+    allowed_unpartitioned: 0.00GB
+    partitions:
+      - name: vda2
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: xfs
+        mounting_options:
+          should_mount: 1
+          mount_point: /
+      - name: vda3
+        role: swap
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1
+          mount_point: SWAP


### PR DESCRIPTION
- on openSUSE the validate_blockdevices test seems to just check for
  the prompt of the root shell.
- this file provides the default disk layout, so that the
  validate_blockdevices test can check against it
- You need to provide this file as YAML_TEST_DATA setting

- Related ticket: https://progress.opensuse.org/issues/97142
- Verification run: https://openqa.opensuse.org/tests/1880239
