### PR TITLE
JeOS: fix schedule for fips test case

### DIFF
--- a/schedule/jeos/sle/fips.yaml
+++ b/schedule/jeos/sle/fips.yaml
@@ -8,8 +8,10 @@ conditional_schedule:
                 - installation/bootloader_svirt
             svirt-xen-hvm:
                 - installation/bootloader_svirt
+                - installation/bootloader_uefi
             svirt-hyperv-uefi:
                 - installation/bootloader_hyperv
+                - installation/bootloader_uefi
             svirt-hyperv:
                 - installation/bootloader_hyperv
             svirt-vmware65:
@@ -20,7 +22,6 @@ conditional_schedule:
                 - qa_automation/patch_and_reboot
 schedule:
     - '{{bootloader}}'
-    - installation/bootloader_uefi
     - jeos/firstrun
     - console/force_scheduled_tasks
     - jeos/grub2_gfxmode


### PR DESCRIPTION
bootloader_uefi was executed for all the cases. It should be
only executed in specific machine types.

