### PR TITLE
Do not fail when fips_enabled file does not exist

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -71,7 +71,7 @@ sub run {
 
     # Restart sshd and check it's status
     my $ret          = systemctl('restart sshd', ignore_failure => 1);
-    my $fips_enabled = script_output('cat /proc/sys/crypto/fips_enabled') eq '1';
+    my $fips_enabled = script_output('cat /proc/sys/crypto/fips_enabled', proceed_on_failure => 1) eq '1';
 
     # If restarting sshd service is not successful and fips is enabled, we have encountered bsc#1189534
     if (($ret != 0) && ($fips_enabled)) {


### PR DESCRIPTION
File `/proc/sys/crypto/fips_enabled` does not exist in some systems.
Do not fail when getting it's content while it does not exist.

- Related ticket: https://progress.opensuse.org/issues/97187
- Needles: No needles
- Verification run: pending
