### PR TITLE
Only softfail bsc#1189534 for sle 15-SP2

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -74,7 +74,7 @@ sub run {
     my $fips_enabled = script_output('cat /proc/sys/crypto/fips_enabled', proceed_on_failure => 1) eq '1';
 
     # If restarting sshd service is not successful and fips is enabled, we have encountered bsc#1189534
-    if (($ret != 0) && ($fips_enabled)) {
+    if (($ret != 0) && $fips_enabled && is_sle("=15-SP2")) {
         record_soft_failure("bsc#1189534");
         return;
     }


### PR DESCRIPTION
Softfailing sshd service not being able to start in a system with FIPS enabled should be limited to sle 15-SP2 for which bsc#1189534 has been reported.
For all other versions the test should still fail, not least because it is a pattern specific issue.

- Related ticket: https://progress.opensuse.org/issues/97016
- Needles: No needles
- Verification run: [sle 15-sp2 no fips](http://angmar.suse.de/tests/3762) | [sle 15-sp2 with fips](http://angmar.suse.de/tests/3763) | [sle 15-sp3 with fips](http://angmar.suse.de/tests/3764)
