### PR TITLE
console/publiccloud: Increase timeout to download data dir

### DIFF
--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -25,7 +25,7 @@ sub run {
     check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
 
     select_console 'user-console';
-    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " | cpio -id", timeout => 300;
+    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " | cpio -id", timeout => get_var('PUBLIC_CLOUD') ? 600 : 300;
     script_run "ls -al data";
 }
 


### PR DESCRIPTION
Current data/ directory size is 230M, if I create a tar.gz it gets only
reduced to 215M.
So give PUBLIC_CLOUD tests 10min to download the directory to the
running instance.

- Related ticket: https://progress.opensuse.org/issues/97208
- Verification run: https://openqa.suse.de/tests/6893493
