### PR TITLE
Add test_metadata in ci check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test-spec:
 	tools/update_spec --check
 
 .PHONY: test-static
-test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax test-code-style
+test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax test-code-style test-metadata
 
 .PHONY: test
 ifeq ($(TESTS),compile)

--- a/tools/check_metadata
+++ b/tools/check_metadata
@@ -4,6 +4,7 @@ success=1
 for file in $files; do
     grep -q '# Summary: .\+' $file || (echo "Missing '# Summary: <multi line summary of test>'" in $file && exit 1) || success=0
     grep -q '# Maintainer: .\+@.\+' $file || (echo "Missing '# Maintainer: <email address>'" in $file && exit 1) || success=0
+    grep -q '# Copyright .\+' $file || (echo "Missing Copyright © <year> SUSE LLC" in $file && exit 1) || success=0
 done
 [ $success = 1 ] && echo "SUCCESS" && exit 0
 exit 1


### PR DESCRIPTION
It checks that the Copyright, Summary and Maintainer fields in the file header of the tests are added.

- Related ticket: https://progress.opensuse.org/issues/96716
- Needles: N/A
- Verification run: N/A
