### PR TITLE
xfstests: Add xfstests basic tests in o3

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -329,6 +329,21 @@ elsif (get_var('VIRT_AUTOTEST')) {
     loadtest "virtualization/universal/hotplugging"             if get_var('ENABLE_HOTPLUGGING');
     loadtest "virtualization/universal/storage"                 if get_var('ENABLE_STORAGE');
 }
+elsif (get_var('XFSTESTS')) {
+    prepare_target();
+    if (check_var('XFSTESTS', 'installation')) {
+        loadtest 'xfstests/install';
+        unless (get_var('NO_KDUMP')) {
+            loadtest 'xfstests/enable_kdump';
+        }
+        loadtest 'shutdown/shutdown';
+    }
+    else {
+        loadtest 'xfstests/partition';
+        loadtest 'xfstests/run';
+        loadtest 'xfstests/generate_report';
+    }
+}
 else {
     if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {
         load_boot_tests();


### PR DESCRIPTION
Add xfstests basic tests into o3.
- Modify opensuse/main.pm to goto xfstests test path
- Modify xfstests/install.pm to use obs for non-sle test
- Correct test path for xfstests in non-sle test, because default install path not the same


- Verification run: 
create_hdd_xfstests:             http://10.67.133.102/tests/360
xfstests_btrfs-btrfs-001-050: http://10.67.133.102/tests/361