### PR TITLE
container: Fix version string validation in test_opensuse_based_image()

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -152,8 +152,9 @@ sub test_opensuse_based_image {
     my $image   = $args{image};
     my $runtime = $args{runtime};
 
-    my $distri  = $args{distri}  //= get_required_var("DISTRI");
-    my $version = $args{version} //= get_required_var("VERSION");
+    my $distri  = $args{distri}  // get_required_var("DISTRI");
+    my $version = $args{version} // get_required_var("VERSION");
+    my $beta    = $args{beta}    // get_var('BETA', 0);
 
     die 'Argument $image not provided!'   unless $image;
     die 'Argument $runtime not provided!' unless $runtime;
@@ -174,7 +175,7 @@ sub test_opensuse_based_image {
     if ($image_id =~ 'sles') {
         if ($host_id =~ 'sles') {
             my $pretty_version = $version =~ s/-SP/ SP/r;
-            my $betaversion    = get_var('BETA') ? '\s\([^)]+\)' : '';
+            my $betaversion    = $beta ? '\s\([^)]+\)' : '';
             record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
             if ($runtime =~ /buildah/) {
                 validate_script_output("$runtime run $image grep PRETTY_NAME /etc/os-release | cut -d= -f2",

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -48,7 +48,8 @@ sub run {
             test_rpm_db_backend(image => $iname, runtime => $runtime);
             build_and_run_image(base => $iname, runtime => $runtime, dockerfile => $dockerfile);
             if (check_os_release('suse', 'PRETTY_NAME')) {
-                test_opensuse_based_image(image => $iname, runtime => $runtime, version => $version);
+                my $beta = $version eq get_var('VERSION') ? get_var('BETA', 0) : 0;
+                test_opensuse_based_image(image => $iname, runtime => $runtime, version => $version, beta => $beta);
                 build_with_zypper_docker(image => $iname, runtime => $runtime, version => $version) unless is_tumbleweed;
             }
             else {

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -40,7 +40,8 @@ sub run {
             test_rpm_db_backend(image => $iname, runtime => $runtime);
             build_and_run_image(base => $iname, runtime => $runtime, dockerfile => $dockerfile);
             if (check_os_release('suse', 'PRETTY_NAME')) {
-                test_opensuse_based_image(image => $iname, runtime => $runtime, version => $version);
+                my $beta = $version eq get_var('VERSION') ? get_var(BETA => 0) : 0;
+                test_opensuse_based_image(image => $iname, runtime => $runtime, version => $version, beta => $beta);
             }
             else {
                 exec_on_container($iname, $runtime, 'cat /etc/os-release');


### PR DESCRIPTION
We use openQA `BETA` variable to determine if a beta Version string is
available or not. But this function is also used to verify containers
running on a host. So it doesn't belong to the `BETA` varialbe of the
test.

- Ticked:  https://progress.opensuse.org/issues/97223
- Verification run: TBD
