### PR TITLE
Ignore bsc#1126272 in journal_check for SLE Micro and MicroOS

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -68,7 +68,7 @@
             "sle-micro": [ "5.0", "5.1" ],
             "microos":  ["Tumbleweed"]
         },
-        "type": "bug"
+        "type": "ignore"
     },
     "bsc#1022525|bsc#1177461": {
         "description": ".*rpcbind.*cannot(.*open file.*rpcbind.xdr.*|.*open file.*portmap.xdr.*|.*save any registration.*)",


### PR DESCRIPTION
The bug has been reported as Won't fix and it appears on different
products besides MicroOS.

