### PR TITLE
Fix condition which assigns the proper dockerfile template

### DIFF
--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -38,7 +38,7 @@ sub run {
 
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
     my $versions   = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
-    my $dockerfile = ($host_distri ne 'suse') ? 'Dockerfile.python3' : 'Dockerfile';
+    my $dockerfile = $host_distri !~ m/^(sle|opensuse)/i ? 'Dockerfile.python3' : 'Dockerfile';
     for my $version (split(/,/, $versions)) {
         my ($untested_images, $released_images) = get_suse_container_urls($version);
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -28,9 +28,8 @@ sub run {
     allow_selected_insecure_registries(runtime => $runtime);
 
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
-    my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
-
-    my $dockerfile = ($host_distri ne 'suse') ? 'Dockerfile.python3' : 'Dockerfile';
+    my $versions   = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
+    my $dockerfile = $host_distri !~ m/^(sle|opensuse)/i ? 'Dockerfile.python3' : 'Dockerfile';
     for my $version (split(/,/, $versions)) {
         my ($untested_images, $released_images) = get_suse_container_urls($version);
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;


### PR DESCRIPTION
With the condition as it was before the `$dockerfile` variable was always
assigned to the one that uses the python image. That may not make the tests
fail but it was not the expected behavior.

The `dockerfile.python3` should be used only for the hosts which do not support
`container-suseconnect-zypp`. Use `dockerfile.python3` to workaround wherever we
cant perform apache installation as it happens in `Dockerfile`.

- Related ticket: https://progress.opensuse.org/issues/95786
Verification run: 
https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313104&version=15-SP3&distri=sle
- [sle](https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313104&distri=sle&version=15-SP2)
- [tw](https://openqa.opensuse.org/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313104&distri=opensuse&version=Tumbleweed)