### PR TITLE
container: Use serial terminal for image test modules

### DIFF
--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -28,7 +28,9 @@ use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release is_tumbleweed);
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal();
+
     my ($running_version, $sp, $host_distri) = get_os_release;
     my $runtime = "docker";
 

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -21,9 +21,12 @@ use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
 
 sub run {
-    select_console "root-console";
+    my $self = shift;
+    $self->select_serial_terminal();
+
     my ($running_version, $sp, $host_distri) = get_os_release;
     my $runtime = "podman";
+
     install_podman_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => $runtime);
 


### PR DESCRIPTION
Simple exchange `root-console` with `$self->select_serial_console()`
reduce the execution time on s390 from 1h8m to 21m.

- Verification run: 
  - https://openqa.suse.de/tests/6898866 (s390 with serial_terminal) => 21m

Compared with this https://openqa.suse.de/tests/6893576 using `root-console` it takes 1h8m.


