### PR TITLE
Deregister the dropped modules before migration

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -32,7 +32,7 @@ our @EXPORT = qw(
   setup_sle
   setup_migration
   register_system_in_textmode
-  remove_ltss
+  deregister_dropped_modules
   disable_installation_repos
   record_disk_info
   check_rollback_system
@@ -104,19 +104,33 @@ sub register_system_in_textmode {
 
 # Remove LTSS product and manually remove its relevant package before migration
 # Also remove ltss from SCC_ADDONS setting for registration in upgrade target
-sub remove_ltss {
-    if (get_var('SCC_ADDONS', '') =~ /ltss/) {
-        my $scc_addons = get_var_array('SCC_ADDONS');
-        record_info 'remove ltss', 'got all updates from ltss channel, now remove ltss and drop it from SCC_ADDONS before migration';
-        if (check_var('SLE_PRODUCT', 'hpc')) {
-            remove_suseconnect_product('SLE_HPC-LTSS');
-        } elsif (is_sle('15+') && check_var('SLE_PRODUCT', 'sles')) {
-            remove_suseconnect_product('SLES-LTSS');
-        } else {
-            zypper_call 'rm -t product SLES-LTSS';
-            zypper_call 'rm sles-ltss-release-POOL';
+# Besides LTSS, some modules will be dropped in the migration target product,
+# need to remove these modules before migration, add the dropped modules to the
+# setting of DROPPED_MODULES.
+sub deregister_dropped_modules {
+    if ((get_var('DROPPED_MODULES')) || (get_var('SCC_ADDONS', '') =~ /ltss/)) {
+        my $droplist = get_var('DROPPED_MODULES', '');
+        $droplist .= ',ltss' if (get_var('SCC_ADDONS', '') =~ /ltss/);
+        my $droplist_array = get_var_array($droplist);
+        my @names          = grep { defined $_ && $_ } split(/,/, $droplist);
+        foreach my $name (@names) {
+            if ($name =~ /ltss/) {
+                record_info 'remove ltss', 'got all updates from ltss channel, now remove ltss and drop it from SCC_ADDONS before migration';
+                if (check_var('SLE_PRODUCT', 'hpc')) {
+                    remove_suseconnect_product('SLE_HPC-LTSS');
+                } elsif (is_sle('15+') && check_var('SLE_PRODUCT', 'sles')) {
+                    remove_suseconnect_product('SLES-LTSS');
+                } else {
+                    zypper_call 'rm -t product SLES-LTSS';
+                    zypper_call 'rm sles-ltss-release-POOL';
+                }
+            }
+            else {
+                record_info "remove $name", 'some modules are dropped in target product, now remove them and drop them from SCC_ADDONS before migration';
+                remove_suseconnect_product(get_addon_fullname($name));
+            }
+            set_var('SCC_ADDONS', join(',', grep { $_ ne $name } @$droplist_array));
         }
-        set_var('SCC_ADDONS', join(',', grep { $_ ne 'ltss' } @$scc_addons));
     }
 }
 

--- a/tests/migration/online_migration/minimal_patch.pm
+++ b/tests/migration/online_migration/minimal_patch.pm
@@ -22,7 +22,7 @@ sub run {
     select_console 'root-console';
     disable_installation_repos;
     minimal_patch_system(version_variable => 'HDDVERSION');
-    remove_ltss;
+    deregister_dropped_modules;
 }
 
 sub test_flags {

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -30,7 +30,7 @@ sub run {
     add_test_repositories;
     fully_patch_system;
     install_patterns() if (get_var('PATTERNS'));
-    remove_ltss;
+    deregister_dropped_modules;
     power_action('reboot', keepconsole => 1, textmode => 1);
     reconnect_mgmt_console if is_pvm;
 

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -91,7 +91,7 @@ sub patching_sle {
     remove_test_repositories;
 
     #migration with LTSS is not possible, remove it before upgrade
-    remove_ltss;
+    deregister_dropped_modules;
 
     if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ || get_var('KEEP_REGISTERED')) {
         # The system is registered.


### PR DESCRIPTION
Some modules are dropped in the target product, need to deregister them before migration.
- Related ticket: https://progress.opensuse.org/issues/96131
- Verification run: 
https://openqa.nue.suse.com/tests/6998792#step/zypper_patch/10 (online; pscc; remove python2, ltss; sles)
https://openqa.nue.suse.com/tests/6998793#step/patch_sle/103 (offline; pscc; remove ltss; sles)
https://openqa.nue.suse.com/tests/6988926#step/patch_sle/159 (offline; pscc; remove python2; sles)
https://openqa.nue.suse.com/tests/6988927#step/zypper_patch/10 (online; pscc; remove python2; sles)
https://openqa.nue.suse.com/tests/6987551#step/zypper_patch/10 (online; pscc; remove ltss, python2; hpc)
https://openqa.nue.suse.com/tests/6987552#step/patch_sle/161 (offline; pscc, remove ltss, python2; hpc)
https://openqa.nue.suse.com/tests/6998794#step/patch_sle/171 (offline; media; remove ltss, python2, we; sles)