### PR TITLE
SLE Micro: use list of container images to be tested

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -82,11 +82,8 @@ sub get_suse_container_urls {
         push @released_images, "registry.suse.com/suse/sle15:${dotversion}";
     }
     elsif (is_sle_micro) {
-        push @untested_images,
-          "registry.suse.com/suse/sle15:15.0",
-          "registry.suse.com/suse/sle15:15.1",
-          "registry.suse.com/suse/sle15:15.2",
-          "registry.suse.com/suse/sle15:15.3";
+        # Untested images are not validated in SLE Micro, so leave it empty
+        push @released_images, "registry.suse.com/suse/sle15:${dotversion}";
     }
     elsif (is_tumbleweed || is_microos("Tumbleweed")) {
         push @untested_images, "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";


### PR DESCRIPTION
We use hard-coded list of images in SLE Micro container tests.
Also, the list that is filled is wrong, it should be stable_images.
To be aligned with the other conditions, let's just let the test
select which images to test using the variable CONTAINER_IMAGE_VERSIONS