### PR TITLE
Add AMD-SEV conditional schedule

### DIFF
--- a/schedule/publiccloud/smoketest.yml
+++ b/schedule/publiccloud/smoketest.yml
@@ -2,6 +2,11 @@
 name: publiccloud-smoketest
 description: |
   Basic smoketests on public cloud instances
+conditional_schedule:
+  sev:
+    PUBLIC_CLOUD_CONFIDENTIAL_VM:
+      '1':
+        - publiccloud/sev
 schedule:
   - boot/boot_to_desktop
   - publiccloud/download_repos
@@ -12,5 +17,5 @@ schedule:
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview
   - publiccloud/smoketest
-  - publiccloud/sev
+  - '{{sev}}'
   - publiccloud/ssh_interactive_end


### PR DESCRIPTION
Schedule the AMD-SEV test only on confidential compute instances.

- Related ticket: https://progress.opensuse.org/issues/95557
- Verification runs
* [15-SP3 GCE smoketest](https://duck-norris.qam.suse.de/tests/7157) (not included as expected)
* [15-SP3 GCE smoketest@gce_n2d_standard_2](https://duck-norris.qam.suse.de/tests/7158) (not included as expected)
* [15-SP3 GCE smoketest@gce_n2d_standard_2_confidential](https://duck-norris.qam.suse.de/tests/7159) (included as expected)
