### PR TITLE
Reschedule samba_adcli

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -45,8 +45,7 @@ conditional_schedule:
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
-        # https://progress.opensuse.org/issues/96512
-        # - network/samba/samba_adcli
+        - network/samba/samba_adcli
         - '{{arch_specific}}'
       15-SP2:
         - console/osinfo_db
@@ -57,8 +56,7 @@ conditional_schedule:
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
-        # https://progress.opensuse.org/issues/96512
-        # - network/samba/samba_adcli
+        - network/samba/samba_adcli
         - '{{arch_specific}}'
       15-SP1:
         - console/osinfo_db
@@ -67,8 +65,7 @@ conditional_schedule:
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
-        # https://progress.opensuse.org/issues/96512
-        # - network/samba/samba_adcli
+        - network/samba/samba_adcli
         - '{{arch_specific}}'
       15:
         - console/osinfo_db
@@ -77,8 +74,7 @@ conditional_schedule:
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
-        # https://progress.opensuse.org/issues/96512
-        # - network/samba/samba_adcli
+        - network/samba/samba_adcli
         - '{{arch_specific}}'
       12-SP5:
         - console/osinfo_db
@@ -86,23 +82,20 @@ conditional_schedule:
         - console/valgrind
         - console/zziplib
         - console/openvswitch_ssl
-        # https://progress.opensuse.org/issues/96512
-        # - network/samba/samba_adcli
+        - network/samba/samba_adcli
         - '{{arch_specific}}'
         - '{{arch_12sp5}}'
       12-SP4:
         - console/osinfo_db
         - console/journald_fss
         - console/openvswitch_ssl
-        # https://progress.opensuse.org/issues/96512
-        # - network/samba/samba_adcli
+        - network/samba/samba_adcli
         - '{{arch_specific}}'
       12-SP3:
         - console/osinfo_db
         - console/journald_fss
         - console/openvswitch_ssl
-        # https://progress.opensuse.org/issues/96512
-        # - network/samba/samba_adcli
+        - network/samba/samba_adcli
         - '{{arch_specific}}'
       12-SP2:
         - console/journald_fss


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/96992
- Needles: No needles
- Verification runs:
[sle 15-SP3 aarch64](https://openqa.suse.de/tests/6893935#step/samba_adcli/150) | [sle 15-SP3 s390x](https://openqa.suse.de/tests/6893936#step/samba_adcli/172) | [sle 15-SP2 x86_64](https://openqa.suse.de/tests/6895276#step/samba_adcli/150) | [sle 15-SP2 s390x](https://openqa.suse.de/tests/6895278#step/samba_adcli/177) | [sle 15-SP2 aarch64](https://openqa.suse.de/tests/6895277#step/samba_adcli/181) | [sle 15-SP1 aarch64](https://openqa.suse.de/tests/6895483#step/samba_adcli/182) | [sle 15-SP1 s390x](https://openqa.suse.de/tests/6895506#) | [sle 15-SP1 x86_64](https://openqa.suse.de/tests/6895507#step/samba_adcli/228) | [sle 15 aarch64](https://openqa.suse.de/tests/6897257#step/samba_adcli/92) | [sle 15 s390x](https://openqa.suse.de/tests/6896055#step/samba_adcli/124) | [sle 15 x86_64](https://openqa.suse.de/tests/6896056#step/samba_adcli/56) | [sle 12-SP5 s390x](https://openqa.suse.de/tests/6896152#step/samba_adcli/59) | [sle 12-SP5 x86_64](https://openqa.suse.de/tests/6896149#step/samba_adcli/119) | [sle 12-SP4 x86_64](https://openqa.suse.de/tests/6897262#step/samba_adcli/146) | [sle 12-SP4 s390x](https://openqa.suse.de/tests/6897260#step/samba_adcli/118) | [sle 12-SP3 x86_64](https://openqa.suse.de/tests/6897258#step/samba_adcli/56)
