### PR TITLE
Add reset_console to test_users_locale sub when is not sle15

### DIFF
--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -96,7 +96,7 @@ sub test_users_locale {
 
     ($ldd_help_string_expected eq $ldd_help_string_updated) or die "Unexpected locale settings, glibc test strings are not the same!\n";
     enter_cmd("exit");
-
+    reset_consoles if is_sle('<15');
     return $ldd_help_string_updated;
 }
 


### PR DESCRIPTION
`glibc_locale.pm` was not written with sle12 in mind. When we scheduled
sle12sp5 we had an unexpected misbehavior with the console. Specifically
it makes `curl_https` break. The later switch to user console which left
dirty from `glibc_locale` as it exits when `is_sle('<15')`. When it is sle15
runs `test_users_locale` sub for a second time and then it resets the console
before exits.

With this patch we reset the consoles before the modules is completed even for
sle12


- Related ticket: https://progress.opensuse.org/issues/95410
Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x\

- sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20210823-1-jeos-main@64bit-virtio-vga -> https://openqa.suse.de/t6916040
- sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20210823-1-jeos-main@64bit-virtio-vga -> https://openqa.suse.de/t6916041
- opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20210820-jeos@64bit_virtio -> https://openqa.opensuse.org/t1882998
- opensuse-15.3-JeOS-for-AArch64-aarch64-Build9.175-jeos@USBboot_aarch64 -> https://openqa.opensuse.org/t1883157


