### PR TITLE
Unschedule prepare_ test modules from public cloud

### DIFF
--- a/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
@@ -20,9 +20,6 @@ schedule:
   - publiccloud/patch_and_reboot
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview
-  - console/system_prepare
-  - console/prepare_test_data
-  - console/consoletest_setup
   - '{{podman}}'
   - containers/docker
   - containers/docker_runc

--- a/schedule/publiccloud/mau-extratests-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-publiccloud.yml
@@ -11,8 +11,6 @@ schedule:
   - publiccloud/patch_and_reboot
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview
-  - console/system_prepare
-  - console/consoletest_setup
   - console/check_os_release
   - console/cleanup_qam_testrepos
   - console/openvswitch


### PR DESCRIPTION
Unschedule modules `system_prepare`, `prepare_test_data` and `consoletest_setup` as they are not needed.

- Ticked: https://progress.opensuse.org/issues/97208
- Verification run: [GCE12.4BYOS@consoletests](http://pdostal-server.suse.cz/tests/12452) [EC212.5@consoletests](http://pdostal-server.suse.cz/tests/12453) [AZURE15.3@containers](http://pdostal-server.suse.cz/tests/12450)
