### PR TITLE
samba_adcli: restart network after enabling ipv6

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -110,6 +110,7 @@ sub enable_ipv6 {
     my $self = shift;
     $self->select_serial_terminal;
     assert_script_run("sysctl -w net.ipv6.conf.all.disable_ipv6=0");
+    systemctl('restart network');
     set_var('SYSCTL_IPV6_DISABLED', '0');
 }
 
@@ -185,7 +186,10 @@ sub run {
     # - smbclient //10.162.30.119/openQA as geekouser will be denied, as berhard is the owner
     # - delete the computer OU after the test is done in post_run_hook
     # - test winbind (samba?) authentication
+}
 
+sub post_run_hook {
+    my ($self) = shift;
     $self->enable_ipv6;
 }
 


### PR DESCRIPTION
Network is working but daemon like postfix does require some time
to process the ipv6 change or just restart

```
Aug 23 04:01:04.169110 susetest postfix/smtpd[29755]: fatal: parameter inet_interfaces: no local interface found for ::1
Aug 23 04:01:05.170671 susetest postfix/master[6377]: warning: process /usr/lib/postfix/bin//smtpd pid 29755 exit status 1
Aug 23 04:01:05.170682 susetest postfix/master[6377]: warning: /usr/lib/postfix/bin//smtpd: bad command startup -- throttling
Aug 23 04:02:05.230911 susetest postfix/smtpd[29765]: fatal: parameter inet_interfaces: no local interface found for ::1
Aug 23 04:02:06.232626 susetest postfix/master[6377]: warning: process /usr/lib/postfix/bin//smtpd pid 29765 exit status 1
Aug 23 04:02:06.232644 susetest postfix/master[6377]: warning: /usr/lib/postfix/bin//smtpd: bad command startup -- throttling
```
- Fail: https://openqa.suse.de/tests/6917575
- Verification run:
http://dzedro.suse.cz/tests/18984#step/samba_adcli/105
https://openqa.suse.de/tests/6922625 12 SP5
https://openqa.suse.de/tests/6922617 15 GA
https://openqa.suse.de/tests/6922620 15 SP2
https://openqa.suse.de/tests/6922621 15 SP3