### PR TITLE
enable_selinux: wait until back to overview

### DIFF
--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -37,6 +37,9 @@ sub run {
     send_key 'ret' if $textmode;
 
     send_key $cmd{ok};
+
+    # yast needs some time to think
+    assert_screen 'installation-settings-overview-loaded';
 }
 
 1;


### PR DESCRIPTION
start_install might press alt-i too fast

- Verification run: http://tortuga.suse.de/tests/138
