### PR TITLE
Remove manual addition of --ioapic to the Virtualbox vagrant box

### DIFF
--- a/data/virtualization/Vagrantfile
+++ b/data/virtualization/Vagrantfile
@@ -40,7 +40,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |virtbox, override|
     virtbox.memory = 2048
     virtbox.cpus = 4
-    virtbox.customize ["modifyvm", :id, "--ioapic", "on"]
     ip_config(override, "virtualbox")
   end
 


### PR DESCRIPTION
This change is already included inside the vagrant box itself and is thus no
longer required.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1884463
