### PR TITLE
Public Cloud: Add debug output and wait longer when entering tunneled console

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -839,7 +839,8 @@ sub activate_console {
     }
     if (get_var('TUNNELED') && $name !~ /tunnel/) {
         die "Console '$console' activated in TUNNEL mode activated but tunnel(s) are not yet initialized, use the 'tunnel' console and call 'setup_ssh_tunnels' first" unless get_var('_SSH_TUNNELS_INITIALIZED');
-        $self->script_run('ssh -t sut', 0);
+        # The verbose output is visible only at the tunnel-console - it doesn't interfere with tests as it isn't piped to /dev/sshserial
+        $self->script_run('ssh -vt sut', 0);
         ensure_user($user) unless (get_var('PUBLIC_CLOUD'));
     }
     set_var('CONSOLE_JUST_ACTIVATED', 1);

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -33,14 +33,16 @@ sub run {
     # first activation hook in susedistribution:activate_console()
     if ($setup_console !~ /tunnel/) {
         select_console($setup_console);
-        script_run('ssh -t sut', timeout => 0);
+        # The verbose output is visible only at the tunnel-console -
+        #   it doesn't interfere with tests as it isn't piped to /dev/sshserial
+        script_run('ssh -vt sut', timeout => 0);
     }
 
     die("expect ssh serial") unless (get_var('SERIALDEV') =~ /ssh/);
 
     # Verify most important consoles
     select_console('root-console');
-    assert_script_run('test -e /dev/' . get_var('SERIALDEV'));
+    assert_script_run('test -e /dev/' . get_var('SERIALDEV'), 180);
     assert_script_run('test $(id -un) == "root"');
 
     select_console('user-console');


### PR DESCRIPTION
The `test` command has now longer timeout so the `ssh` has some time to establish.
The `ssh` has the verbose (`-v` flag) so we get more details when establishing the console.

- Related error: https://openqa.suse.de/tests/6924828#step/ssh_interactive_start/14
- Verification run: http://pdostal-server.suse.cz/tests/12461#step/ssh_interactive_start/13
