### PR TITLE
Create br0 after host installation and fix network interface names

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -254,7 +254,7 @@ sub restart_network {
 
 sub restore_guests {
     return if get_var('INCIDENT_ID');    # QAM does not recreate guests every time
-    my $get_vm_hostnames   = "virsh list  --all | grep sles | awk \'{print \$2}\'";
+    my $get_vm_hostnames   = "virsh list --all | grep -e sles -e opensuse | awk \'{print \$2}\'";
     my $vm_hostnames       = script_output($get_vm_hostnames, 30, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
     foreach (@vm_hostnames_array)

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -635,7 +635,7 @@ sub check_guest_disk_type {
 sub recreate_guests {
     my $based_guest_dir = shift;
     return if get_var('INCIDENT_ID');    # QAM does not recreate guests every time
-    my $get_vm_hostnames   = "virsh list  --all | grep sles | awk \'{print \$2}\'";
+    my $get_vm_hostnames   = "virsh list  --all | grep -e sles -e opensuse | awk \'{print \$2}\'";
     my $vm_hostnames       = script_output($get_vm_hostnames, 30, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
     foreach (@vm_hostnames_array)


### PR DESCRIPTION
- create br0 just after host installation as it is not default installed
- support opensuse as guest name
- allow more network interface names with udev naming scheme in virtual network tests


- Related ticket: https://progress.opensuse.org/issues/96374
- Verification run: 
[TW kvm](http://10.67.129.51/tests/2607)
[TW xen](http://10.67.129.51/tests/2608)
[SLE kvm](https://openqa.nue.suse.com/tests/6935263)

@alice-suse @xguo @waynechen55 @nanzhg   Could you help review?
