### PR TITLE
RStudio: kill firefox if it hangs

### DIFF
--- a/lib/rstudio.pm
+++ b/lib/rstudio.pm
@@ -131,7 +131,7 @@ sub rstudio_run_profiler {
     type_string("profvis(expr = {sub.test1 <- system.time(for (i in 1:50000) {df[3, 2]})})");
     send_key("ret");
 
-    assert_screen("$prefix-profile_flame-graph_close");
+    assert_and_click("$prefix-profile_flame-graph_close");
 }
 
 sub rstudio_test_notebook {

--- a/tests/x11/rstudio_server.pm
+++ b/tests/x11/rstudio_server.pm
@@ -62,13 +62,17 @@ sub run() {
     # log out at last and close firefox
     assert_and_click("rstudio_server-sign-out");
     assert_screen("rstudio_server-login-username");
-    send_key('alt-f4');
 
-    # optionally click away the close all tabs window
-    assert_screen([qw(rstudio_server-firefox_quit-and-close-tabs generic-desktop)]);
-    if (match_has_tag('rstudio_server-firefox_quit-and-close-tabs')) {
-        click_lastmatch();
-        assert_screen('generic-desktop');
+    for my $i (1 .. 5) {
+        send_key('ctrl-w', wait_screen_change => 1);
+        last if defined(check_screen('generic-desktop'));
+    }
+
+    if (!defined(check_screen('generic-desktop'))) {
+        # firefox is stuck and just greys out but does not display the "close
+        # all tabs" dialog => kill it
+        record_info('Workaround', 'Firefox froze for 60s and does not want to close');
+        script_run('pkill -9 firefox');
     }
 }
 


### PR DESCRIPTION
This pull request does two things:
1. At the end of the RStudio Server tests we quit Firefox. However, Firefox will sometimes hang and won't quit, in that case we just `kill -9` it and be done with that.
2. fix a `assert_screen` to `assert_and_click` so that a the flamegraph tab is closed and the rstudio_server and rstudio_desktop tests can be run independently of each other (atm they have an implicit dependency due to the needles).

- Related ticket: https://progress.opensuse.org/issues/96593
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/743
- Verification run: https://openqa.opensuse.org/tests/1885829