### PR TITLE
Revert "Workaround for sles-release version mismatch"

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -294,10 +294,6 @@ sub ensure_container_rpm_updates {
             my $updated_v = version->parse("v$+{update_version}");
             my $stable_v  = version->parse("v$+{stable_version}");
             record_info("checking... $+{package}", "$+{package} $stable_v to $updated_v");
-            if ($stable_v eq 'v52.1' && $updated_v eq 'v49.1') {
-                record_soft_failure('poo#91422');
-                last;
-            }
             die "$+{package} $stable_v is not updated to $updated_v" unless ($updated_v > $stable_v);
         } elsif ($line =~ $regex2zerorpm) {
             record_info("No Update found", "no updates found between rpm versions");


### PR DESCRIPTION
This reverts commit 014f0fc7645bdc28e3a392b6e6c5ce8d9218f3b7.

- Related ticket: https://progress.opensuse.org/issues/91422
- Verification run:
https://openqa.suse.de/tests/6945617 15 SP3
https://openqa.suse.de/tests/6945616 15 SP2