### PR TITLE
xfstests: update log file name for more readable

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -47,7 +47,7 @@ sub upload_subdirs {
     for my $subdir (split(/\n/, $output)) {
         my $tarball = "$subdir.tar.xz";
         assert_script_run("ll; tar cJf $tarball -C $dir " . basename($subdir), $timeout);
-        upload_logs($tarball, timeout => $timeout, log_name => basename($dir));
+        upload_logs($tarball, timeout => $timeout);
     }
 }
 
@@ -64,7 +64,7 @@ sub run {
 
     # Finalize status log and upload it
     log_end($STATUS_LOG);
-    upload_logs($STATUS_LOG, timeout => 60, log_name => "test");
+    upload_logs($STATUS_LOG, timeout => 60, log_name => $STATUS_LOG);
 
     # Upload test logs
     upload_subdirs($LOG_DIR, 1200);


### PR DESCRIPTION
log => generate_report-<filesystem>.tar.xz
test => status.log

- Related ticket: https://progress.opensuse.org/issues/97559
- Needles: N/A
- Verification run: http://10.67.133.102/tests/365#downloads
