### PR TITLE
Make unified guest installation base module more rigorous

### DIFF
--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -97,7 +97,7 @@ sub install_guest_instances {
         else {
             $guest_instances{$_}->guest_installation_run(@_);
         }
-        if ($guest_instances{$_}->{guest_autoconsole} eq '') {
+        if ($guest_instances{$_}->has_noautoconsole_for_sure) {
             assert_screen('text-logged-in-root');
             $guest_instances{$_}->do_attach_guest_installation_screen_without_session;
         }

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -92,11 +92,10 @@ our %guest_params = (
     'guest_network_others' => '', #virt-install --netowrk=bridge=[guest_network_device],mac=[guest_macaddr],[guest_network_others]
                                   #(Also can be used with other network type)
     'guest_macaddr'        => '', #virt-install --network=bridge=[guest_network_device],mac=[guest_macaddr] (Also can be used with other network type)
-    'guest_netaddr'        => '', #This indicates the subnet to which guest will be connected. It takes the form ip_address/subnet_mask_length and
-        #defaults to 192.168.123.255/24, not virt-install argument. If 'host-default' is given, this indicates guest will use host network
-        #and host bridge device that already exists and are connected directly to default gateway, for example, br0. If br0 or any other
-        #host bridge devices already conneced to host network that do not exist, [guest_network_device] wil be configured to connect to host
-        #network and used for guest configuration.
+    'guest_netaddr' => '', #This indicates the subnet to which guest will be connected. It takes the form ip_address/subnet_mask_length and defaults to 192.168.123.255/24,
+                           #not virt-install argument. If 'host-default' is given, this indicates guest will use host network and host bridge device that already exists
+                           #and are connected directly to default gateway, for example, br0. If br0 or any other host bridge devices already conneced to host network that
+                           #do not exist, [guest_network_device] wil be configured to connect to host network and used for guest configuration.
     'guest_ipaddr'           => '',    #virt-install --extra-args "ip=[guest_ipaddr]" if it is a static ip address, otherwise it is not virt-install argument.
                                        #It stores the final guest ip address obtained from ip discovery
     'guest_ipaddr_static'    => '',    #This indicates whether guest uses static ip address(true or false), not virt-install argument
@@ -139,45 +138,50 @@ our %guest_params = (
     'guest_autostart'        => '',    #TODO            #virt-install --[guest_autostart(autostart or empty)]
     'guest_transient'        => '',    #TODO            #virt-install --[guest_transient(transient or empty)]
     'guest_destroy_on_exit'  => '',    #TODO            #virt-install --[guest_destroy_on_exit(true or false)]
-    'guest_autoconsole'      => '',    #virt-install --autoconsole [guest_autoconsole(text or graphical)] or virt-install --noautoconsole if empty
+    'guest_autoconsole'      => '',    #virt-install --autoconsole [guest_autoconsole(text or graphical or none)] or empty.
+                                       #For virt-manager earlier than 3.0.0, this option does not exist and should be left empty.
+    'guest_noautoconsole'    => '',    #virt-install --noautoconsole if true.This option should only be given 'true', 'false' or empty.
     'guest_noreboot'         => '',    #TODO            #virt-install --[guest_noreboot(true or false)]
-    'guest_default_target'   => '',    #This indicates whether guest os default target(multi-user, graphical or others), not virt-install argument
-        #The following parameters end with 'options' are derived from above parameters. They contains options and corresponding values
-        #which are passed to virt-install command line directly to perform guest installations.
-    'guest_virt_options'                => '',    #[guest_virt_options] = "--connect [host_hypervisor_uri] --virt-type [host_virt_type] --[guest_virt_type]"
-    'guest_platform_options'            => '',    #[guest_platform_options] = "--arch [guest_arch] --machine [guest_machine_type]"
-    'guest_name_options'                => '',    #[guest_name_options] = "--name [guest_name]"
-    'guest_memory_options'              => '',    #[guest_memory_options] = "--memory [guest_memory]"
-    'guest_vcpus_options'               => '',    #[guest_vcpus_options] = "--vcpus [guest_vcpus]"
-    'guest_cpumodel_options'            => '',    #[guest_cpumodel_options] = "--cpu [guest_cpumodel]"
-    'guest_metadata_options'            => '',    #[guest_metadata_options] = "--metadata [guest_metadata]"
-    'guest_xpath_options'               => '',    #[guest_xpath_options] = [guest_xpath_options] . "--xml $_ " foreach ([@guest_xpath])
+    'guest_default_target'   => '',    #This indicates whether guest os default target(multi-user, graphical or others), not virt-install argument.
+                                       #The following parameters end with 'options' are derived from above parameters. They contains options and
+                                       #corresponding values which are passed to virt-install command line directly to perform guest installations.
+    'guest_virt_options'     => '',    #[guest_virt_options] = "--connect [host_hypervisor_uri] --virt-type [host_virt_type] --[guest_virt_type]"
+    'guest_platform_options' => '',    #[guest_platform_options] = "--arch [guest_arch] --machine [guest_machine_type]"
+    'guest_name_options'     => '',    #[guest_name_options] = "--name [guest_name]"
+    'guest_memory_options'   => '',    #[guest_memory_options] = "--memory [guest_memory]"
+    'guest_vcpus_options'    => '',    #[guest_vcpus_options] = "--vcpus [guest_vcpus]"
+    'guest_cpumodel_options' => '',    #[guest_cpumodel_options] = "--cpu [guest_cpumodel]"
+    'guest_metadata_options' => '',    #[guest_metadata_options] = "--metadata [guest_metadata]"
+    'guest_xpath_options'    => '',    #[guest_xpath_options] = [guest_xpath_options] . "--xml $_ " foreach ([@guest_xpath])
     'guest_installation_method_options' => '', #[guest_installation_method_options] = "--location [guest_installation_media] --install [guest_installation_fine_grained]
                                                #--autoconsole [guest_autoconsole] or --noautoconsole" or
                                                #"--[guest_installation_method] [guest_installation_media],[guest_installation_method_others]"
     'guest_installation_extra_args_options' => '', #[guest_installation_extra_args_options] = "[guest_installation_extra_args_options] . --extra-args $_ foreach
         #[@guest_installation_extra_args] --extra-args ip=[guest_ipaddr(if static)] [guest_installation_automation_options]"
     'guest_installation_automation_options' => '', #[guest_installation_automation_options] = "--extra-args [autoyast|inst.ks][ks]=[guest_installation_automation_file]"
-    'guest_boot_options'               => '',      #[guest_boot_options} = "--boot [guest_boot_settings]"
-    'guest_os_variant_options'         => '',      #[guest_os_variant_options] = "--os-variant [guest_os_variant]"
-    'guest_storage_options'            => '',      #[guest_storage_options] = "--disk path=[guest_storage_path],size=[guest_storage_size],
-                                                   #format=[guest_storage_format],[guest_storage_others]"
-    'guest_network_selection_options'  => '',      #[guest_network_selection_options] = "--network=bridge=[guest_network_device],mac=[guest_macaddr]"
-    'guest_graphics_and_video_options' => '',      #[guest_graphics_and_video_options] = "--video [guest_video] --graphics [guest_graphics]"
-    'guest_serial_options'             => '',      #[guest_serial_options] = "--serial [guest_serial]"
-    'guest_console_options'            => '',      #[guest_console_options] = "--console [guest_console]"
-    'guest_features_options'           => '',      #[guest_features_options] = "--features [guest_features]"
-    'guest_power_management_options'   => '',      #[guest_power_management_options] = "--pm [guest_power_management]"
-    'guest_events_options'             => '',      #[guest_events_options] = "--events [guest_events]"
-    'guest_qemu_command_options'       => '',      #[guest_qemu_command_options] = "--qemu-commandline [guest_qemu_command]"
-    'virt_install_command_line'        => '',      #This is the complete virt-install command line which is composed of above parameters end with 'options'
-    'virt_install_command_line_dryrun' => '',      #This is [virt_install_command_line] appended with --dry-run
-    'host_ipaddr'                      => '',      #This is get_required_var('SUT_IP')
-    'host_name'                        => '',      #This is script_output('hostname')
-    'host_domain_name'                 => '',      #This is script_output('dnsdomainname')
-                                                   #The following five parameters are detailed guest os information,not virt-install arguments
-    'guest_log_folder'                 => '',      #Log folder for individual guest [common_log_folder]/[guest_name]
-    'guest_installation_result'        => '',      #PASSED,FAILED,TIMEOUT,UNKNOWN or others
+    'guest_boot_options'                => '',   #[guest_boot_options} = "--boot [guest_boot_settings]"
+    'guest_os_variant_options'          => '',   #[guest_os_variant_options] = "--os-variant [guest_os_variant]"
+    'guest_storage_options'             => '',   #[guest_storage_options] = "--disk path=[guest_storage_path],size=[guest_storage_size],
+                                                 #format=[guest_storage_format],[guest_storage_others]"
+    'guest_network_selection_options'   => '',   #[guest_network_selection_options] = "--network=bridge=[guest_network_device],mac=[guest_macaddr]"
+    'guest_graphics_and_video_options'  => '',   #[guest_graphics_and_video_options] = "--video [guest_video] --graphics [guest_graphics]"
+    'guest_serial_options'              => '',   #[guest_serial_options] = "--serial [guest_serial]"
+    'guest_console_options'             => '',   #[guest_console_options] = "--console [guest_console]"
+    'guest_features_options'            => '',   #[guest_features_options] = "--features [guest_features]"
+    'guest_power_management_options'    => '',   #[guest_power_management_options] = "--pm [guest_power_management]"
+    'guest_events_options'              => '',   #[guest_events_options] = "--events [guest_events]"
+    'guest_qemu_command_options'        => '',   #[guest_qemu_command_options] = "--qemu-commandline [guest_qemu_command]"
+    'virt_install_command_line'         => '',   #This is the complete virt-install command line which is composed of above parameters end with 'options'
+    'virt_install_command_line_dryrun'  => '',   #This is [virt_install_command_line] appended with --dry-run
+    'host_ipaddr'                       => '',   #This is get_required_var('SUT_IP')
+    'host_name'                         => '',   #This is script_output('hostname')
+    'host_domain_name'                  => '',   #This is script_output('dnsdomainname')
+                                                 #The following five parameters are detailed guest os information,not virt-install arguments
+    'guest_log_folder'                  => '',   #Log folder for individual guest [common_log_folder]/[guest_name]
+    'guest_installation_result'         => '',   #PASSED,FAILED,TIMEOUT,UNKNOWN or others
+    'guest_installation_session_config' => '',   #Absolute path of screen command config file that will be used in screen -c [guest_installation_session_config]
+                                                 #to start guest installation session. The content of the config file includes content of global /etc/screenrc
+                                                 #and logfile="absolute path of guest installation log file".
     'guest_installation_session' => '', #Guest installation process started by "screen -t [guest_name] [virt_install_command_line]. It is in the form of 3401.pts-1.vh017
     'guest_installation_session_command' => '', #If there is no [guest_installation_session] or [guest_installation_session] is terminated, start or re-connect to
         #guest installation screen using [guest_installation_session_command] = screen -t [guest_name] virsh console --force [guest_name]
@@ -383,7 +387,7 @@ sub prepare_guest_environment {
     $self->{guest_log_folder} = $common_log_folder . '/' . $self->{guest_name};
     script_run("rm -f -r $self->{guest_log_folder}");
     assert_script_run("mkdir -p $self->{guest_log_folder}");
-    script_run("sed -i -r '/^.*$self->{guest_name}.*\$/d' /etc/hosts");
+    script_run("sed -i -r \'/^.*$self->{guest_name}.*\$/d\' /etc/hosts");
     return $self;
 }
 
@@ -834,7 +838,7 @@ sub config_guest_network_bridge_services {
     my $_detect_signature = script_output("cat /etc/sysconfig/network/config | grep \"#Modified by guest_installation_and_configuration_base module\"", proceed_on_failure => 1);
     if (!($_detect_signature =~ /#Modified by guest_installation_and_configuration_base module/im)) {
         assert_script_run("cp /etc/sysconfig/network/config /etc/sysconfig/network/config_backup");
-        assert_script_run("sed -ri 's/^NETCONFIG_DNS_POLICY.*\$/NETCONFIG_DNS_POLICY=\"\"/g' /etc/sysconfig/network/config");
+        assert_script_run("sed -ri \'s/^NETCONFIG_DNS_POLICY.*\$/NETCONFIG_DNS_POLICY=\"\"/g\' /etc/sysconfig/network/config");
         assert_script_run("echo \'#Modified by guest_installation_and_configuration_base module\' >> /etc/sysconfig/network/config");
     }
     record_info("Content of /etc/sysconfig/network/config", script_output("cat /etc/sysconfig/network/config", proceed_on_failure => 1));
@@ -855,14 +859,16 @@ sub config_guest_network_bridge_services {
     my $_dnsmasq_log = "$common_log_folder/dnsmasq_listen_address_$_guest_network_ipaddr_gw_transformed" . '_log';
     my $_dnsmasq_command = "/usr/sbin/dnsmasq --bind-dynamic --listen-address=$_guest_network_ipaddr_gw --bogus-priv --domain-needed --expand-hosts --dhcp-range=$_guest_network_ipaddr_start,$_guest_network_ipaddr_end,$_guest_network_mask,8h --interface=$_guest_network_device --dhcp-authoritative --no-negcache --dhcp-option=option:router,$_guest_network_ipaddr_gw --log-queries --local=/$self->{guest_domain_name}/ --domain=$self->{guest_domain_name} --log-dhcp --dhcp-fqdn --dhcp-sequential-ip --dhcp-client-update --dns-loop-detect --no-daemon --server=/$self->{guest_domain_name}/$_guest_network_ipaddr_gw --server=/$_guest_network_ipaddr_rev/$_guest_network_ipaddr_gw";
     my $_retry_counter = 5;
-    while (($_retry_counter gt 0) and (script_output("pgrep -i -f \"$_dnsmasq_command\"", proceed_on_failure => 1) eq '')) {
+    #Use grep instead of pgrep to avoid that the latter's case-insensitive search option might not be supported by some obsolete operating systems.
+    while (($_retry_counter gt 0) and (script_output("ps ax | grep -i \"$_dnsmasq_command\" | grep -v grep | awk \'{print \$1}\'", proceed_on_failure => 1) eq '')) {
         script_run("((nohup $_dnsmasq_command  &>$_dnsmasq_log) &)");
         save_screenshot;
         send_key('ret');
         save_screenshot;
         $_retry_counter--;
     }
-    if (script_output("pgrep -i -f \"$_dnsmasq_command\"", proceed_on_failure => 1) eq '') {
+    #Use grep instead of pgrep to avoid that the latter's case-insensitive search option might not be supported by some obsolete operating systems.
+    if (script_output("ps ax | grep -i \"$_dnsmasq_command\" | grep -v grep | awk \'{print \$1}\'", proceed_on_failure => 1) eq '') {
         record_info("DHCP and DNS services can not start.Mark guest $self->{guest_name} installation as FAILED", "The command used is ((nohup $_dnsmasq_command  &>$_dnsmasq_log) &)");
         $self->record_guest_installation_result('FAILED');
     }
@@ -900,6 +906,8 @@ LANG=POSIX
 SHELL=/bin/bash
 PWD=/root
 iptables-save > $self->{guest_log_folder}/iptables_before_modification_by_$self->{guest_name}
+systemctl stop SuSEFirewall2
+systemctl disable SuSEFirewall2
 systemctl stop firewalld
 systemctl disable firewalld
 systemctl stop apparmor
@@ -948,7 +956,8 @@ sub config_guest_installation_method {
     }
     $self->{guest_installation_method_options} = $self->{guest_installation_method_options} . ($self->{guest_installation_method_others} ne '' ? ",$self->{guest_installation_method_others}" : '') if ($self->{guest_installation_method_others} ne '');
     $self->{guest_installation_method_options} = $self->{guest_installation_method_options} . ($self->{guest_installation_fine_grained} ne '' ? " --install $self->{guest_installation_fine_grained}" : '') if ($self->{guest_installation_fine_grained} ne '');
-    $self->{guest_installation_method_options} = $self->{guest_installation_method_options} . ($self->{guest_autoconsole} ne '' ? " --autoconsole $self->{guest_autoconsole}" : ' --noautoconsole');
+    $self->{guest_installation_method_options} = $self->{guest_installation_method_options} . " --autoconsole $self->{guest_autoconsole}" if ($self->{guest_autoconsole} ne '');
+    $self->{guest_installation_method_options} = $self->{guest_installation_method_options} . " --noautoconsole" if ($self->{guest_noautoconsole} eq 'true');
     return $self;
 }
 
@@ -1068,7 +1077,7 @@ sub config_guest_installation_automation {
             $_guest_installation_media_extension_url =~ s/\//PLACEHOLDER/img;
             assert_script_run("sed -ri \'s/##$_##/$_guest_installation_media_extension_url/g;\' $self->{guest_installation_automation_file}");
         }
-        assert_script_run("sed -ri 's/PLACEHOLDER/\\\//g;' $self->{guest_installation_automation_file}");
+        assert_script_run("sed -ri \'s/PLACEHOLDER/\\\//g;\' $self->{guest_installation_automation_file}");
     }
 
     if (!((script_run("[[ -f /root/.ssh/id_rsa.pub ]] && [[ -f /root/.ssh/id_rsa.pub.bak ]]") eq 0) and (script_run("cmp /root/.ssh/id_rsa.pub /root/.ssh/id_rsa.pub.bak") eq 0))) {
@@ -1099,14 +1108,16 @@ sub config_guest_installation_automation {
 
     my $_http_server_command = "python3 -m http.server 8666 --bind $self->{host_ipaddr}";
     my $_retry_counter       = 5;
-    while (($_retry_counter gt 0) and (script_output("pgrep -i -f \"$_http_server_command\"", proceed_on_failure => 1) eq '')) {
+    #Use grep instead of pgrep to avoid that the latter's case-insensitive search option might not be supported by some obsolete operating systems.
+    while (($_retry_counter gt 0) and (script_output("ps ax | grep -i \"$_http_server_command\" | grep -v grep | awk \'{print \$1}\'", proceed_on_failure => 1) eq '')) {
         script_run("cd $common_log_folder && ((nohup $_http_server_command &>$common_log_folder/http_server_log) &) && cd ~");
         save_screenshot;
         send_key("ret");
         save_screenshot;
         $_retry_counter--;
     }
-    if (script_output("pgrep -i -f \"$_http_server_command\"", proceed_on_failure => 1) eq '') {
+    #Use grep instead of pgrep to avoid that the latter's case-insensitive search option might not be supported by some obsolete operating systems.
+    if (script_output("ps ax | grep -i \"$_http_server_command\" | grep -v grep | awk \'{print \$1}\'", proceed_on_failure => 1) eq '') {
         record_info("HTTP server can not start and serve unattended installation file.Mark guest $self->{guest_name} installation as FAILED", "The command used is ((nohup $_http_server_command &>$common_log_folder/http_server_log) &)");
         $self->record_guest_installation_result('FAILED');
         return $self;
@@ -1219,7 +1230,13 @@ sub start_guest_installation {
     script_run("set +o pipefail");
     save_screenshot;
     record_info("Guest $self->{guest_name} installation dry run succeeded", "Going to install by using $self->{virt_install_command_line}");
-    type_string("screen -t $self->{guest_name} -L -Logfile $_guest_installation_log $self->{virt_install_command_line}\n", timeout => 600 / get_var('TIMEOUT_SCALE', 1));
+    #Use "screen" in the most compatible way, screen -t "title (window's name)" -c "screen configuration file" -L(turn on output logging) "command to run".
+    #The -Logfile option is only supported by more recent operating systems.
+    $self->{guest_installation_session_config} = script_output("cd ~;pwd") . '/' . $self->{guest_name} . '_installation_screen_config';
+    script_run("rm -f -r $self->{guest_installation_session_config};touch $self->{guest_installation_session_config};chmod 777 $self->{guest_installation_session_config}");
+    script_run("cat /etc/screenrc > $self->{guest_installation_session_config};sed -in \'/^logfile .*\$/d\' $self->{guest_installation_session_config}");
+    script_run("echo \"logfile $_guest_installation_log\" >> $self->{guest_installation_session_config}");
+    type_string("screen -t $self->{guest_name} -L -c $self->{guest_installation_session_config} $self->{virt_install_command_line}\n", timeout => 600 / get_var('TIMEOUT_SCALE', 1));
     record_info("Guest $self->{guest_name} installation started", "The virt-install command line is $self->{virt_install_command_line}");
     return $self;
 }
@@ -1234,7 +1251,8 @@ sub get_guest_installation_session {
         return $self;
     }
     my $installation_tty = script_output("tty | awk -F\"/\" 'BEGIN { OFS=\"-\" } {print \$3,\$4}\'", proceed_on_failure => 1);
-    my $installation_pid = script_output("pgrep -i -f \"SCREEN -t $self->{guest_name}\"",            proceed_on_failure => 1);
+    #Use grep instead of pgrep to avoid that the latter's case-insensitive search option might not be supported by some obsolete operating systems.
+    my $installation_pid = script_output("ps ax | grep -i \"SCREEN -t $self->{guest_name}\" | grep -v grep | awk \'{print \$1}\'", proceed_on_failure => 1);
     $self->{guest_installation_session} = ($installation_pid eq '' ? '' : $installation_pid . ".$installation_tty." . $self->{host_name});
     record_info("Guest $self->{guest_name} installation screen process info", "$self->{guest_name} $self->{guest_installation_session}");
     return $self;
@@ -1325,8 +1343,8 @@ sub monitor_guest_installation {
     }
     elsif (match_has_tag('text-logged-in-root')) {
         save_screenshot;
-        if ($self->{guest_autoconsole} eq '') {
-            record_info("Can not monitor and obtain guest $self->{guest_name} installation progress", "Installation screen process $self->{guest_installation_session} is not attached currently or already terminated on reboot/shutoff after installation finished or at certain stage");
+        if (!($self->has_autoconsole_for_sure)) {
+            record_info("Can not monitor and obtain guest $self->{guest_name} installation progress", "Installation screen process $self->{guest_installation_session} is not attached currently or already terminated on reboot/shutoff after installation finished or at certain stage or guest $self->{guest_name} has no autoconsole");
         }
         else {
             record_info("Can not monitor and obtain guest $self->{guest_name} installation progress", "Installation screen process $self->{guest_installation_session} is not attached currently");
@@ -1380,11 +1398,11 @@ sub attach_guest_installation_screen {
     save_screenshot;
     record_info("Attaching $self->{guest_name} installation screen process $self->{guest_installation_session}", "Trying hard");
     if (($self->{guest_installation_attached} eq 'false') or ($self->{guest_installation_attached} eq '')) {
-        if (($self->{guest_installation_session} eq '') and ($self->{guest_autoconsole} eq '')) {
-            record_info("Guest $self->{guest_name} has no autoconsole and installation screen process $self->{guest_installation_session} may terminate on reboot/shutoff after installation finishes or at certain stage", "Reconnect by using screen -t $self->{guest_name} virsh console $self->{guest_name}");
+        if (($self->{guest_installation_session} eq '') and (!($self->has_autoconsole_for_sure))) {
+            record_info("Guest $self->{guest_name} has no autoconsole or installation screen process $self->{guest_installation_session} may terminate on reboot/shutoff after installation finishes or at certain stage", "Reconnect by using screen -t $self->{guest_name} virsh console $self->{guest_name}");
             $self->do_attach_guest_installation_screen_without_session;
         }
-        elsif (($self->{guest_installation_session} eq '') and ($self->{guest_autoconsole} ne '')) {
+        elsif (($self->{guest_installation_session} eq '') and ($self->has_autoconsole_for_sure)) {
             record_info("Guest $self->{guest_name} has autoconsole but no installation screen session info to attach", "Trying to get installation screen session info");
             $self->get_guest_installation_session;
             if ($self->{guest_installation_session} eq '') {
@@ -1418,8 +1436,8 @@ sub do_attach_guest_installation_screen {
         record_info("Attached $self->{guest_name} installation screen process $self->{guest_installation_session} successfully", "Well done !");
     }
     else {
-        if ($self->{guest_autoconsole} eq '') {
-            record_info("Guest $self->{guest_name} has no autoconsole and installation screen process $self->{guest_installation_session} may terminate on reboot/shutoff after installaton finishes or at certain stage", "Reconnect by using screen -t $self->{guest_name} virsh console $self->{guest_name}");
+        if (!($self->has_autoconsole_for_sure)) {
+            record_info("Guest $self->{guest_name} has no autoconsole or installation screen process $self->{guest_installation_session} may terminate on reboot/shutoff after installaton finishes or at certain stage", "Reconnect by using screen -t $self->{guest_name} virsh console $self->{guest_name}");
         }
         else {
             record_info("Failed to attach $self->{guest_name} installation screen process $self->{guest_installation_session}", "Bad luck ! Try to re-connect by using screen -t $self->{guest_name} virsh console $self->{guest_name}");
@@ -1474,7 +1492,12 @@ sub do_attach_guest_installation_screen_without_session {
             my $_attach_timestamp = localtime();
             $_attach_timestamp =~ s/ |:/_/g;
             my $_guest_installation_log = "$common_log_folder/$self->{guest_name}/$self->{guest_name}" . "_installation_log_" . $_attach_timestamp;
-            $self->{guest_installation_session_command} = "screen -t $self->{guest_name} -L -Logfile $_guest_installation_log virsh console --force $self->{guest_name}";
+            $self->{guest_installation_session_config} = script_output("cd ~;pwd") . '/' . $self->{guest_name} . '_installation_screen_config' if ($self->{guest_installation_session_config} eq '');
+            script_run("> $self->{guest_installation_session_config};cat /etc/screenrc > $self->{guest_installation_session_config};sed -in \'/^logfile .*\$/d\' $self->{guest_installation_session_config}");
+            script_run("echo \"logfile $_guest_installation_log\" >> $self->{guest_installation_session_config}");
+         #Use "screen" in the most compatible way, screen -t "title (window's name)" -c "screen configuration file" -L(turn on output logging) "command to run".
+         #The -Logfile option is only supported by more recent operating systems.
+            $self->{guest_installation_session_command} = "screen -t $self->{guest_name} -L -c $self->{guest_installation_session_config} virsh console --force $self->{guest_name}";
             wait_screen_change {
                 type_string("$self->{guest_installation_session_command}\n");
             };
@@ -1567,6 +1590,24 @@ sub do_detach_guest_installation_screen {
     }
     $self->{guest_installation_attached} = 'false';
     return $self;
+}
+
+#Return true if guest has [guest_autoconsole] and [guest_noautoconsole] that are not equal to 'none', 'true' or empty which indicates guest definitely has autoconsole.
+#Empty value may indicate there is autoconsole or the opposite which depends on detailed configuration of guest.
+sub has_autoconsole_for_sure {
+    my $self = shift;
+
+    $self->reveal_myself;
+    return (($self->{guest_autoconsole} ne 'none') and ($self->{guest_autoconsole} ne '') and ($self->{guest_noautoconsole} ne 'true') and ($self->{guest_noautoconsole} ne ''));
+}
+
+#Return true if guest has [guest_autoconsole] or [guest_noautoconsole] that are equal to 'none' or 'true' which indicates guest definitely has no autoconsole.
+#Empty value may indicate there is autoconsole or the opposite which depends on detailed configuration of guest.
+sub has_noautoconsole_for_sure {
+    my $self = shift;
+
+    $self->reveal_myself;
+    return (($self->{guest_autoconsole} eq 'none') or ($self->{guest_noautoconsole} eq 'true'));
 }
 
 #Record final guest installation result in [guest_installation_result] and set [stop_run] and [stop_timestamp].


### PR DESCRIPTION
* **Introduce** guest_noautoconsole parameter to better handle console settings together with guest_autoconsole and virt-manager earlier than 3.0.0. If they have empty values, there will be no --autoconsole and --noautoconsole options in the final virt-install command line just like how they are really used by end user.
* **Introduce** guest_installation_session_config parameter to store absolute path of guest screen session config file that is used in command "screen -c". This is the more common and compatible way to use "screen" because "-Logfile" option might be available on old operating systems.
* **Use** "grep -i" to query running process to avoid unsupported options or arguments on old operating systems caused by "pgrep -i" command.
* **Stop** SuSEFirewall2 as well besides firewalld.
* **Introduce** and use new functions has_autoconsole_for_sure and has_noautoconsole_for_sure to better deal with conditional judgements that are based on values of parameters guest_autoconsole and guest_noautoconsole.

* **Verification runs:**
  * [oracle linux on 15sp4 kvm pass](https://openqa.suse.de/tests/6960049)
  * [uefi 15sp4 on 15sp4 kvm pass](https://openqa.suse.de/tests/6960047)
  * [uefi 15sp4 on 15sp4 xen pass](https://openqa.suse.de/tests/6960048)
  * [uefi 15sp3 on 15sp4 kvm pass](https://openqa.suse.de/tests/6959484)
  * [uefi 15sp3 on 15sp4 xen pass](https://openqa.suse.de/tests/6960985)
  * [uefi 12sp5 on 15sp4 kvm pass](https://openqa.suse.de/tests/6962462)
  * [uefi 12sp5 on 15sp4 xen pass](https://openqa.suse.de/tests/6961385)
  * [uefi 15sp4 on 15sp3 kvm pass](https://openqa.suse.de/tests/6960986)
  * [uefi 15sp4 on 15sp3 xen pass](https://openqa.suse.de/tests/6960987)
  * [uefi 15sp4 on 12sp5 kvm pass](https://openqa.suse.de/tests/6960988)
  * [uefi 12sp5 on 15sp4 kvm fail](https://openqa.suse.de/tests/6944153)
  * [uefi 12sp5 on 15sp4 xen fail](https://openqa.suse.de/tests/6939562)