### PR TITLE
Adjust network/uefi tests to make them more resilient

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -397,6 +397,11 @@ sub shutdown_guests {
 sub wait_guests_shutdown {
     my $retries = shift // 240;
     # Note: Domain-0 is for xen only, but it does not hurt to exclude this also in kvm runs.
+    # Firstly wait for guest shutdown for a while, turn it off forcibly using "virsh destroy" if timed-out.
+    # Then wait for guest shutdown again with default "die => 1".
+    if (script_retry("! virsh list | grep -v Domain-0 | grep running", delay => 1, retry => $retries, die => 0) ne '0') {
+        script_run("virsh destroy $_") foreach (keys %virt_autotest::common::guests);
+    }
     script_retry("! virsh list | grep -v Domain-0 | grep running", delay => 1, retry => $retries);
 }
 

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -86,7 +86,7 @@ sub save_guest_ip {
     my $name = $args{name};
 
     # If we don't know guest's address or the address is wrong so the guest is not responding to ICMP
-    if (script_run("grep $guest /etc/hosts") != 0 || script_retry("ping -c3 $guest", delay => 6, retry => 30) != 0) {
+    if (script_run("grep $guest /etc/hosts") != 0 || script_retry("ping -c3 $guest", delay => 6, retry => 30, die => 0) != 0) {
         script_run "sed -i '/ $guest /d' /etc/hosts";
         assert_script_run "virsh domiflist $guest";
         my $mac_guest  = script_output("virsh domiflist $guest | grep $name | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"");


### PR DESCRIPTION
* **Shutdown** guest forcibly if they can not become shutoff timely in wait_guests_shutdown function in lib/virt_autotest/utils.pm.

* **save_guest_ip** function should not die by default after ssh connection checking in lib/virt_autotest/virtual_network_utils.pm.

* **For** sles host earlier than 15, power management features are not supported together with uefi by virt-manager(earlier than 3.0.0).

* **For** sles 12-sp5 kvm guest on sles 15-sp4 host, only suspend to memory power management is supported.

* **Verification runs:**
  * [oracle linux on 15sp4 kvm pass](https://openqa.suse.de/tests/6960049)
  * [uefi 15sp4 on 15sp4 kvm pass](https://openqa.suse.de/tests/6960047)
  * [uefi 15sp4 on 15sp4 xen pass](https://openqa.suse.de/tests/6960048)
  * [uefi 15sp3 on 15sp4 kvm pass](https://openqa.suse.de/tests/6959484)
  * [uefi 15sp3 on 15sp4 xen pass](https://openqa.suse.de/tests/6960985)
  * [uefi 12sp5 on 15sp4 kvm pass](https://openqa.suse.de/tests/6962462)
  * [uefi 12sp5 on 15sp4 xen pass](https://openqa.suse.de/tests/6961385)
  * [uefi 15sp4 on 15sp3 kvm pass](https://openqa.suse.de/tests/6960986)
  * [uefi 15sp4 on 15sp3 xen pass](https://openqa.suse.de/tests/6960987)
  * [uefi 15sp4 on 12sp5 kvm pass](https://openqa.suse.de/tests/6960988)
  * [uefi 12sp5 on 15sp4 kvm fail](https://openqa.suse.de/tests/6944153)
  * [uefi 12sp5 on 15sp4 xen fail](https://openqa.suse.de/tests/6939562)