### PR TITLE
Refactor get_suse_container_urls using data structure for each distri

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -52,7 +52,7 @@ sub get_opensuse_registry_prefix {
     }
 }
 
-our %registries = (
+our %images_uri = (
     sle => {
         '12-SP3' => {
             released => sub { 'registry.suse.com/suse/sles12sp3' },
@@ -234,7 +234,7 @@ our %registries = (
 
 sub supports_image_arch {
     my ($distri, $version, $arch) = @_;
-    (grep { $_ eq $arch } @{$registries{$distri}{$version}{available_arch}}) ? 1 : 0;
+    (grep { $_ eq $arch } @{$images_uri{$distri}{$version}{available_arch}}) ? 1 : 0;
 }
 
 # Returns a tuple of image urls and their matching released "stable" counterpart.
@@ -250,8 +250,8 @@ sub get_suse_container_urls {
     my @released_images = ();
 
     if (supports_image_arch($args{distri}, $args{version}, $args{arch})) {
-        push @untested_images, $registries{$args{distri}}{$args{version}}{totest}->($args{arch});
-        push @released_images, $registries{$args{distri}}{$args{version}}{released}->($args{arch});
+        push @untested_images, $images_uri{$args{distri}}{$args{version}}{totest}->($args{arch});
+        push @released_images, $images_uri{$args{distri}}{$args{version}}{released}->($args{arch});
     } else {
         die("Unknown combination of distro/arch.");
     }

--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Database for URLs of container images to be tested
-# Maintainer: Fabian Vogt <fvogt@suse.com>
+# Maintainer: Fabian Vogt <fvogt@suse.com>, qa-c team <qa-c@suse.de>
 
 package containers::urls;
 
@@ -52,64 +52,207 @@ sub get_opensuse_registry_prefix {
     }
 }
 
+our %registries = (
+    sle => {
+        '12-SP3' => {
+            released => sub { 'registry.suse.com/suse/sles12sp3' },
+            totest   => sub {
+                'registry.suse.de/suse/sle-12-sp3/docker/update/cr/totest/images/suse/sles12sp3';
+            },
+            available_arch => ['x86_64', 'ppc64le', 's390x']
+        },
+        '12-SP4' => {
+            released => sub { 'registry.suse.com/suse/sles12sp4' },
+            totest   => sub {
+                'registry.suse.de/suse/sle-12-sp4/docker/update/cr/totest/images/suse/sles12sp4';
+            },
+            available_arch => ['x86_64', 'ppc64le', 's390x']
+        },
+        '12-SP5' => {
+            released => sub { 'registry.suse.com/suse/sles12sp5' },
+            totest   => sub {
+                'registry.suse.de/suse/sle-12-sp5/docker/update/cr/totest/images/suse/sles12sp5';
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
+        '15' => {
+            released => sub { 'registry.suse.com/suse/sle15:15.0' },
+            totest   => sub {
+                'registry.suse.de/suse/sle-15/update/cr/totest/images/suse/sle15:15.0';
+            },
+            available_arch => ['x86_64', 'ppc64le', 's390x']
+        },
+        '15-SP1' => {
+            released => sub { 'registry.suse.com/suse/sle15:15.1' },
+            totest   => sub {
+                'registry.suse.de/suse/sle-15-sp1/update/cr/totest/images/suse/sle15:15.1';
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
+        '15-SP2' => {
+            released => sub { 'registry.suse.com/suse/sle15:15.2' },
+            totest   => sub {
+                'registry.suse.de/suse/sle-15-sp2/update/cr/totest/images/suse/sle15:15.2';
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
+        '15-SP3' => {
+            released => sub { 'registry.suse.com/suse/sle15:15.3' },
+            totest   => sub {
+                'registry.suse.de/suse/sle-15-sp3/update/cr/totest/images/suse/sle15:15.3';
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
+        '15-SP4' => {
+            released => sub { },
+            totest   => sub {
+                'registry.suse.de/suse/sle-15-sp4/ga/test/images/suse/sle15:15.4 ';
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        }
+    },
+    opensuse => {
+        Tumbleweed => {
+            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
+            totest   => sub {
+                'registry.opensuse.org/' . get_opensuse_registry_prefix . 'opensuse/tumbleweed';
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+        },
+        '15.0' => {
+            released => sub { 'registry.opensuse.org/opensuse/leap:15.0' },
+            totest   => sub {
+                'registry.opensuse.org/opensuse/leap/15.0/images/totest/images/opensuse/leap:15.0';
+            },
+            available_arch => ['x86_64']
+        },
+        '15.1' => {
+            released => sub { 'registry.opensuse.org/opensuse/leap:15.1' },
+            totest   => sub {
+                my $arch = shift;
+                if ($arch eq 'x86_64') {
+                    'registry.opensuse.org/opensuse/leap/15.1/images/totest/containers/opensuse/leap:15.1';
+                } elsif ($arch eq 'arm') {
+                    'registry.opensuse.org/opensuse/leap/15.1/arm/images/totest/containers/opensuse/leap:15.1';
+                }
+            },
+            available_arch => ['x86_64', 'arm']
+        },
+        '15.2' => {
+            released => sub { 'registry.opensuse.org/opensuse/leap:15.2' },
+            totest   => sub {
+                my $arch = shift;
+                if ($arch eq 'x86_64') {
+                    'registry.opensuse.org/opensuse/leap/15.2/images/totest/containers/opensuse/leap:15.2';
+                } elsif ($arch eq 'arm') {
+                    'registry.opensuse.org/opensuse/leap/15.2/arm/images/totest/containers/opensuse/leap:15.2';
+                }
+            },
+            available_arch => ['x86_64', 'arm']
+        },
+        '15.3' => {
+            released => sub { 'registry.opensuse.org/opensuse/leap:15.3' },
+            totest   => sub {
+                my $arch = shift;
+                if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
+                    'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3';
+                } elsif ($arch eq 'arm') {
+                    'registry.opensuse.org/opensuse/leap/15.3/arm/images/totest/containers/opensuse/leap:15.3';
+                }
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+        }
+    },
+    'sle-micro' => {
+        '15' => {
+            released       => sub { 'registry.suse.com/suse/sle15:15.0' },
+            totest         => sub { },
+            available_arch => ['x86_64', 'ppc64le', 's390x']
+        },
+        '15-SP1' => {
+            released       => sub { 'registry.suse.com/suse/sle15:15.1' },
+            totest         => sub { },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
+        '15-SP2' => {
+            released       => sub { 'registry.suse.com/suse/sle15:15.2' },
+            totest         => sub { },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
+        '15-SP3' => {
+            released       => sub { 'registry.suse.com/suse/sle15:15.3' },
+            totest         => sub { },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        }
+    },
+    microos => {
+        Tumbleweed => {
+            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
+            totest   => sub {
+                'registry.opensuse.org/' . get_opensuse_registry_prefix . 'opensuse/tumbleweed';
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+        },
+        '15.1' => {
+            released => sub { 'registry.opensuse.org/opensuse/leap:15.1' },
+            totest   => sub {
+                my $arch = shift;
+                if ($arch eq 'x86_64') {
+                    'registry.opensuse.org/opensuse/leap/15.1/images/totest/containers/opensuse/leap:15.1';
+                } elsif (grep { $_ eq $arch } qw/aarch64 arm/) {
+                    'registry.opensuse.org/opensuse/leap/15.1/arm/images/totest/containers/opensuse/leap:15.1';
+                }
+            },
+            available_arch => ['x86_64', 'aarch64', 'arm']
+        },
+        '15.2' => {
+            released => sub { 'registry.opensuse.org/opensuse/leap:15.2' },
+            totest   => sub {
+                my $arch = shift;
+                if ($arch eq 'x86_64') {
+                    'registry.opensuse.org/opensuse/leap/15.2/images/totest/containers/opensuse/leap:15.2';
+                } elsif (grep { $_ eq $arch } qw/aarch64 arm/) {
+                    'registry.opensuse.org/opensuse/leap/15.2/arm/images/totest/containers/opensuse/leap:15.2';
+                }
+            },
+            available_arch => ['x86_64', 'aarch64', 'arm']
+        },
+        '15.3' => {
+            released => sub { 'registry.opensuse.org/opensuse/leap:15.3' },
+            totest   => sub {
+                my $arch = shift;
+                if ($arch eq 'x86_64') {
+                    'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3';
+                } elsif (grep { $_ eq $arch } qw/aarch64 arm/) {
+                    'registry.opensuse.org/opensuse/leap/15.3/arm/images/totest/containers/opensuse/leap:15.3';
+                }
+            },
+            available_arch => ['x86_64', 'aarch64', 'arm']
+        }
+    }
+);
+
+sub supports_image_arch {
+    my ($distri, $version, $arch) = @_;
+    (grep { $_ eq $arch } @{$registries{$distri}{$version}{available_arch}}) ? 1 : 0;
+}
+
 # Returns a tuple of image urls and their matching released "stable" counterpart.
 # If empty, no images available.
 sub get_suse_container_urls {
-    my $version    = shift // get_required_var('VERSION');
-    my $dotversion = $version =~ s/-SP/./r;                    # 15 -> 15, 15-SP1 -> 15.1
-    $dotversion = "${dotversion}.0" if $dotversion !~ /\./;    # 15 -> 15.0
-
+    my %args = (
+        version => get_required_var('VERSION'),
+        arch    => get_required_var('ARCH'),
+        distri  => get_required_var('DISTRI'),
+        @_
+    );
     my @untested_images = ();
     my @released_images = ();
-    if (is_sle(">=12-sp3", $version) && is_sle('<15', $version)) {
-        my $lowerversion  = lc $version;
-        my $nodashversion = $version =~ s/-sp/sp/ir;
-        # No aarch64 image
-        if (!is_aarch64) {
-            push @untested_images, "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/totest/images/suse/sles${nodashversion}";
-            push @released_images, "registry.suse.com/suse/sles${nodashversion}";
-        }
-    }
-    elsif (is_sle(">=15", $version) && is_released) {
-        my $lowerversion = lc $version;
-        # Location for maintenance builds
-        push @untested_images, "registry.suse.de/suse/sle-${lowerversion}/update/cr/totest/images/suse/sle15:${dotversion}";
-        push @released_images, "registry.suse.com/suse/sle15:${dotversion}";
-    }
-    elsif (is_sle(">=15-sp4", $version)) {
-        my $lowerversion = lc $version;
-        # Location for GA builds
-        push @untested_images, "registry.suse.de/suse/sle-${lowerversion}/ga/test/images/suse/sle15:${dotversion}";
-        push @released_images, "registry.suse.com/suse/sle15:${dotversion}";
-    }
-    elsif (is_sle_micro) {
-        # Untested images are not validated in SLE Micro, so leave it empty
-        push @released_images, "registry.suse.com/suse/sle15:${dotversion}";
-    }
-    elsif (is_tumbleweed || is_microos("Tumbleweed")) {
-        push @untested_images, "registry.opensuse.org/" . get_opensuse_registry_prefix . "opensuse/tumbleweed";
-        push @released_images, "registry.opensuse.org/opensuse/tumbleweed";
-    }
-    elsif (is_leap(">=15.3")) {
-        # All archs in the same location
-        push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
-        push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
-    }
-    elsif ((is_leap(">15.0") || is_microos(">15.0")) && is_x86_64) {
-        push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
-        push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
-    }
-    elsif ((is_leap(">15.0") || is_microos(">15.0")) && (is_aarch64 || is_arm)) {
-        push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/arm/images/totest/containers/opensuse/leap:${version}";
-        push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
-    }
-    elsif (is_leap(">15.0") && is_ppc64le) {
-        # No image set up yet :-(
-    }
-    elsif (is_sle("<=12-sp2", $version)) {
-        # No images for old SLE
-    }
-    else {
+
+    if (supports_image_arch($args{distri}, $args{version}, $args{arch})) {
+        push @untested_images, $registries{$args{distri}}{$args{version}}{totest}->($args{arch});
+        push @released_images, $registries{$args{distri}}{$args{version}}{released}->($args{arch});
+    } else {
         die("Unknown combination of distro/arch.");
     }
 
@@ -143,3 +286,5 @@ sub get_3rd_party_images {
 
     return (\@images);
 }
+
+1;

--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -34,7 +34,7 @@ sub run {
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
     for my $version (split(/,/, $versions)) {
-        my ($untested_images, $released_images) = get_suse_container_urls($version);
+        my ($untested_images, $released_images) = get_suse_container_urls(version => $version);
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
         for my $iname (@{$images_to_test}) {
             record_info "IMAGE", "Testing image: $iname";

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -34,7 +34,7 @@ sub run {
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
     for my $version (split(/,/, $versions)) {
-        my ($untested_images, $released_images) = get_suse_container_urls($version);
+        my ($untested_images, $released_images) = get_suse_container_urls(version => $version);
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
         for my $iname (@{$images_to_test}) {
             record_info "IMAGE", "Testing image: $iname";

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -42,7 +42,7 @@ sub run {
     my $versions   = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
     my $dockerfile = $host_distri !~ m/^(sle|opensuse)/i ? 'Dockerfile.python3' : 'Dockerfile';
     for my $version (split(/,/, $versions)) {
-        my ($untested_images, $released_images) = get_suse_container_urls($version);
+        my ($untested_images, $released_images) = get_suse_container_urls(version => $version);
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
         for my $iname (@{$images_to_test}) {
             record_info "IMAGE", "Testing image: $iname";

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -34,7 +34,7 @@ sub run {
     my $versions   = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
     my $dockerfile = $host_distri !~ m/^(sle|opensuse)/i ? 'Dockerfile.python3' : 'Dockerfile';
     for my $version (split(/,/, $versions)) {
-        my ($untested_images, $released_images) = get_suse_container_urls($version);
+        my ($untested_images, $released_images) = get_suse_container_urls(version => $version);
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
         for my $iname (@{$images_to_test}) {
             record_info "IMAGE", "Testing image: $iname";


### PR DESCRIPTION
I have approach this problem organizing the data into a hash. The data
structure can hold information explicitly, so it is more ease to handle.

Each <distri><version> hold three information
- released_registry
- totest_registry
- available_arch

I use anonumous functions for `registries` to provide flexibility. For instance
you can choose the different registry based on aarch. or it is possible to
modify the sub to return an array in the future.

I tried to group some of the versions as they provide commonalities but regular
hash accept scalar as a key.


- Related ticket: https://progress.opensuse.org/issues/97232
Verification run:
- https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313141&distri=sle&version=15-SP4
- https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%2313141
- https://openqa.suse.de/tests/overview?version=5.1&distri=sle-micro&build=b10n1k%2Fos-autoinst-distri-opensuse%2313141
- https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313141&version=5.0&distri=sle-micro
- https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.3&build=b10n1k%2Fos-autoinst-distri-opensuse%2313141
- https://openqa.opensuse.org/tests/overview?version=Tumbleweed&build=b10n1k%2Fos-autoinst-distri-opensuse%2313141&distri=microos
- https://openqa.opensuse.org/tests/overview?version=15.2&distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2313141