### PR TITLE
autoyast.xml: Change <product> to Leap for LEAP != 15.2

### DIFF
--- a/data/autoyast_opensuse/autoyast_wicked_x86_64.xml.ep
+++ b/data/autoyast_opensuse/autoyast_wicked_x86_64.xml.ep
@@ -26,7 +26,7 @@
   <software>
     <install_recommended config:type="boolean">true</install_recommended>
     <products config:type="list">
-        <product>openSUSE</product>
+        <product><%= $get_var->('VERSION') =~ /^Tumbleweed|15\.2$/ ? 'openSUSE' : 'Leap' %></product>
     </products>
     <patterns config:type="list">
       <pattern>base</pattern>


### PR DESCRIPTION
For Tumbleweed and Leap_15.2 the product must be `openSUSE` but since
Leap_15.3 the <product> is `Leap`.


- Verification run: 
 -  http://openqa.wicked.suse.de/tests/11563 Leap15.3
 - http://openqa.wicked.suse.de/tests/11562 Leap15.2
 - http://openqa.wicked.suse.de/tests/11564 Tumbleweed
