### PR TITLE
yast2_system_settings: Simplify xterm and grep calls

### DIFF
--- a/tests/yast2_gui/yast2_system_settings.pm
+++ b/tests/yast2_gui/yast2_system_settings.pm
@@ -36,8 +36,8 @@ sub validate_sysrq_config {
     record_info("Validate sysrq", "Validate that sysrq is $expected_status in configuration files");
     my %config_value = (disabled => 0, enabled => 1);
     x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');
-    validate_script_output("cat /proc/sys/kernel/sysrq",                  sub { m/^$config_value{$expected_status}/ });
-    validate_script_output("cat /etc/sysctl.d/70-yast.conf | grep sysrq", sub { m/$config_value{$expected_status}$/ });
+    validate_script_output("cat /proc/sys/kernel/sysrq",            sub { m/^$config_value{$expected_status}/ });
+    validate_script_output('grep sysrq /etc/sysctl.d/70-yast.conf', sub { m/$config_value{$expected_status}$/ });
     close_xterm();
 }
 

--- a/tests/yast2_gui/yast2_system_settings.pm
+++ b/tests/yast2_gui/yast2_system_settings.pm
@@ -35,9 +35,9 @@ sub validate_sysrq_config {
     my $expected_status = shift;
     record_info("Validate sysrq", "Validate that sysrq is $expected_status in configuration files");
     my %config_value = (disabled => 0, enabled => 1);
-    x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');
-    validate_script_output("cat /proc/sys/kernel/sysrq",            sub { m/^$config_value{$expected_status}/ });
-    validate_script_output('grep sysrq /etc/sysctl.d/70-yast.conf', sub { m/$config_value{$expected_status}$/ });
+    x11_start_program('xterm');
+    assert_script_run "grep '^$config_value{$expected_status}' /proc/sys/kernel/sysrq";
+    assert_script_run "grep 'sysrq.*$config_value{$expected_status}$' /etc/sysctl.d/70-yast.conf";
     close_xterm();
 }
 


### PR DESCRIPTION
As observed in
https://openqa.opensuse.org/tests/1887939#step/yast2_system_settings/43
an openQA test ran into a problem after running `validate_script_output`
within an xterm session. X11 applications seem to be more prone to
mistyping characters so we should be careful to type less. This might
help in the future to reduce mistyping failures in this test module. A
next step could be to use the "root-console" or a proper serial
terminal.