### PR TITLE
containers: Simplify 'zypper ref' calls

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -258,17 +258,15 @@ sub test_zypper_on_container {
     assert_script_run("$runtime run $image zypper lr -s", 120);
 
     if ($runtime =~ /buildah/) {
-        # zypper ref
-        assert_script_run("$runtime run $image -- zypper -v ref | grep \"All repositories have been refreshed\"", 120);
+        assert_script_run("$runtime run $image -- zypper -nv ref", 120);
 
         # Create new image and remove the working container
         assert_script_run("$runtime commit --rm $image refreshed", 120);
 
         # Verify the new image works
-        assert_script_run("$runtime run \$($runtime from refreshed) -- zypper -v ref | grep \"All repositories have been refreshed\" ", 120);
+        assert_script_run("$runtime run \$($runtime from refreshed) -- zypper -nv ref", 120);
     } else {
-        # zypper ref
-        assert_script_run("$runtime run --name refreshed $image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
+        assert_script_run("$runtime run --name refreshed $image sh -c 'zypper -nv ref'", 120);
 
         # Commit the image
         assert_script_run("$runtime commit refreshed refreshed-image", 120);
@@ -277,7 +275,7 @@ sub test_zypper_on_container {
         assert_script_run("$runtime rm refreshed", 120);
 
         # Verify the image works
-        assert_script_run("$runtime run --rm refreshed-image sh -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
+        assert_script_run("$runtime run --rm refreshed-image sh -c 'zypper -nv ref'", 120);
     }
     record_info "The End", "zypper test completed";
 }


### PR DESCRIPTION
'zypper ref' correctly returns a zero exit code for success only if
repositories can be successfully refreshed. So there is no need to grep
the output. Also this prevents some problems which ask for the
non-interactive mode anyway.

Related progress issue: https://progress.opensuse.org/issues/95311