### PR TITLE
[virt_autotest] fix up set_vcpus failure for fv guest on sles15sp4 xen host

### DIFF
--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -136,14 +136,16 @@ sub test_add_vcpu {
     }
     return if (is_xen_host && $guest =~ m/hvm/i);    # not supported on HVM guest
 
+    if ($sles_running_version eq '15' && $sles_running_sp eq '4' && is_xen_host && is_fv_guest($guest)) {
+        record_soft_failure('bsc#1188898 Failed to set live vcpu count on fv guest on 15-SP4 Xen host');
+        return;
+    }
+
     # Ensure guest CPU count is 2
     die "Setting vcpus failed" unless (set_vcpus($guest, 2));
     assert_script_run("ssh root\@$guest nproc | grep 2", 60);
     # Add 1 CPU
-    if ($sles_running_version eq '15' && $sles_running_sp eq '4' && is_xen_host && is_fv_guest($guest)) {
-        record_soft_failure('bsc#1188898 Failed to set live vcpu count on fv guest on 15-SP4 Xen host');
-    }
-    elsif ($sles_running_version eq '15' && $sles_running_sp eq '3' && is_xen_host && is_fv_guest($guest)) {
+    if ($sles_running_version eq '15' && $sles_running_sp eq '3' && is_xen_host && is_fv_guest($guest)) {
         record_soft_failure('bsc#1180350 Failed to set live vcpu count on fv guest on 15-SP3 Xen host');
     }
     else {


### PR DESCRIPTION
Refer to the latest OSD sles15sp4 build 29.1 results, figure out the new changes about set_vcpus failure for fv guest on sles15sp4 xen host. 
After deployed all sles12+ fv guest (e.g sles15sp4 fv guest) with 2 vcpu as the default, the try to setvcpus as 2 again to ensure deployed fv guest (e.g sles15sp4 fv guest) CPU count is 2:
$ virsh setvcpus --domain sles-15-sp4-64-fv-def-net --count 2 --live
Figure out the following error:
error: internal error: Failed to set vcpus for domain '26' with libxenlight
But, this step was successful with the sles15sp4 build26.1 - https://openqa.suse.de/tests/6888588#step/hotplugging/193

Please refer to [bsc#1188898](https://bugzilla.suse.com/show_bug.cgi?id=1188898)  for more details. 

Create this PR to workaround this set_vcpus failure for fv guest on sles15sp4 xen host

- Verification run: 
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/6986387#)
[gi-guest_sles12sp5-on-host_developing-xen](https://openqa.suse.de/tests/7030709#)
[gi-guest_sles15sp3-on-host_developing-xen](https://openqa.suse.de/tests/7030710#)
[gi-guest_developing-on-host_sles15sp3-xen](https://openqa.suse.de/tests/6990920#)