### PR TITLE
Delete python2 moudle, as sles15sp4 doesn't include it

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -109,14 +109,14 @@ sub remove_ltss {
         my $scc_addons = get_var_array('SCC_ADDONS');
         record_info 'remove ltss', 'got all updates from ltss channel, now remove ltss and drop it from SCC_ADDONS before migration';
         if (check_var('SLE_PRODUCT', 'hpc')) {
-            remove_suseconnect_product('SLE_HPC-LTSS');
+              remove_suseconnect_product('SLE_HPC-LTSS');
         } elsif (is_sle('15+') && check_var('SLE_PRODUCT', 'sles')) {
             remove_suseconnect_product('SLES-LTSS');
         } else {
             zypper_call 'rm -t product SLES-LTSS';
             zypper_call 'rm sles-ltss-release-POOL';
         }
-        set_var('SCC_ADDONS', join(',', grep { $_ ne 'ltss' } @$scc_addons));
+      set_var('SCC_ADDONS', join(',', grep { $_ ne 'ltss' } @$scc_addons));
     }
 }
 

--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -59,7 +59,7 @@ sub check_upgraded_addons {
     $addonls //= get_var('SCC_ADDONS');
     $addonls =~ s/ltss,?//g;
     # Check auto-select modules after migration base is <15 and upgrade system is 15+
-    $addonls = $addonls . ",base,desktop,sdk,lgm,python2,serverapp,wsm" if (is_sle('<15', get_var('HDDVERSION')) and is_sle('15+', get_var('VERSION')));
+    $addonls = $addonls . ",base,desktop,sdk,lgm,serverapp,wsm" if (is_sle('<15', get_var('HDDVERSION')) and is_sle('15+', get_var('VERSION')));
     check_registered_addons($addonls);
 }
 

--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -118,8 +118,6 @@ sub run {
         $myaddons .= ",base,serverapp,desktop,dev,lgm,wsm"      if (is_sle('<15', get_var('ORIGIN_SYSTEM_VERSION')) && is_sle('15+'));
         $myaddons .= ",base,serverapp,desktop,dev,lgm,wsm,phub" if (is_leap_migration);
 
-        # After upgrade, system doesn't include ltss extension
-        $myaddons =~ s/ltss,?//g;
         # For hpc, system doesn't include legacy module
         $myaddons =~ s/lgm,?//g if (get_var("SCC_ADDONS", "") =~ /hpcm/);
         check_addons($myaddons);

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -54,11 +54,8 @@ sub run {
             add_suseconnect_product(get_addon_fullname('base'),    undef, undef, undef,                             300, 1);
             add_suseconnect_product(get_addon_fullname('desktop'), undef, undef, undef,                             300, 1);
             add_suseconnect_product(get_addon_fullname('we'),      undef, undef, "-r " . get_var('SCC_REGCODE_WE'), 300, 1);
-            add_suseconnect_product(get_addon_fullname('python2'), undef, undef, undef,                             300, 1);
         }
         my $myaddons = get_var('SCC_ADDONS');
-        # After media upgrade, system don't include ltss extension
-        $myaddons =~ s/ltss,?//g;
         if ($myaddons ne '') {
             register_addons_cmd($myaddons);
         }

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -68,9 +68,6 @@ sub handle_all_packages_medium {
         push @addons, $i if !grep(/^$i$/, @addons);
     }
 
-    # Add python2 module, refer to https://jira.suse.de/browse/SLE-3167
-    push @addons, 'python2' if get_var('MEDIA_UPGRADE') && is_sle('<=15', get_var('HDDVERSION')) && is_sle('>15') && !check_var('SLE_PRODUCT', 'rt');
-
     # Record the addons to be enabled for debugging
     record_info 'Extension and Module Selection', join(' ', @addons);
     # Enable the extentions or modules


### PR DESCRIPTION
Delete python2 test code, as sles15sp4 doesn't include this module

- Related ticket: https://progress.opensuse.org/issues/97352
                         https://progress.opensuse.org/issues/97211
- Verification run: https://openqa.suse.de/tests/6963116
                        http://openqa.suse.de/t6962987
