### PR TITLE
desktop_mainmenu: press <super> on GNOME

### DIFF
--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -27,7 +27,7 @@ sub run {
         # or Super_L or Windows key
         x11_start_program('lxpanelctl menu', target_match => 'test-desktop_mainmenu-1');
     }
-    elsif (check_var("DESKTOP", "xfce") && !is_leap("<15.3")) {
+    elsif ((check_var("DESKTOP", "gnome") || check_var("DESKTOP", "xfce")) && !is_leap("<15.3")) {
         send_key "super";
     }
     elsif (check_var("DESKTOP", "xfce")) {


### PR DESCRIPTION
With GNOME 41, the legacy keyboard shortcut <ALT>-<F1> to open the app launcher (coming from GNOME 2 times) is being eliminated (legacy keyboard shortcuts cleaned up, users can still define this as their go-to key if they wish to)

For openQA, though, we should use the default key-binding, which happens to be <super>

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t1894735
