### PR TITLE
Add TID test case for 12sp5 JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -576,6 +576,7 @@ sub load_jeos_tests {
     loadtest "microos/libzypp_config";
     if (is_sle) {
         loadtest "console/suseconnect_scc";
+        loadtest "jeos/efi_tid" if (get_var('UEFI') && is_sle('=12-sp5'));
     }
 
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;


### PR DESCRIPTION
Main.pm-like schedule has missed TID test case for JeOS sle12sp5.

- VRs:
    * [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20210901-1-jeos-filesystem@uefi-virtio-vga](http://kepler.suse.cz/tests/6726#step/patch_and_reboot/1)
    * [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20210901-1-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/6723#step/patch_and_reboot/1)
