### PR TITLE
Add modules in create_hdd_gnome_libyui schedule

### DIFF
--- a/schedule/yast/create_hdd_gnome_libyui.yaml
+++ b/schedule/yast/create_hdd_gnome_libyui.yaml
@@ -10,6 +10,8 @@ schedule:
   - console/scc_cleanup_reregister
   - console/install_packages_simple
   - console/firewalld_add_port
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
   - '{{upload_assets}}'
 conditional_schedule:


### PR DESCRIPTION
There are weird failures for yast2_gui on s390x when we use NUMDISKS=2 . Adding extra modules might fix the issue.

- Verification run: https://openqa.suse.de/tests/6978420
https://openqa.suse.de/tests/6988092
