### PR TITLE
Replace check_var(ARCH) and check_var(BACKEND) function calls

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -22,6 +22,7 @@ use base Exporter;
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
 use autotest;
 use LTP::WhiteList qw(download_whitelist is_test_disabled);
 use LTP::TestInfo 'testinfo';
@@ -313,7 +314,7 @@ sub parse_runtest_file {
 
         #Command format is "<name> <command> [<args>...] [#<comment>]"
         if ($line =~ /^\s* ([\w-]+) \s+ (\S.+) #?/gx) {
-            next if (check_var('BACKEND', 'svirt') && ($1 eq 'dnsmasq' || $1 eq 'dhcpd'));    # poo#33850
+            next if (is_svirt && ($1 eq 'dnsmasq' || $1 eq 'dhcpd'));    # poo#33850
             my $test  = {name => $1 . $suffix, command => $2};
             my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
             if ($test->{name} =~ m/$cmd_pattern/ && !($test->{name} =~ m/$cmd_exclude/)) {

--- a/lib/Mitigation.pm
+++ b/lib/Mitigation.pm
@@ -59,7 +59,7 @@ use warnings;
 use base "consoletest";
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends;
 use bootloader_setup qw(grub_mkconfig change_grub_config add_grub_cmdline_settings remove_grub_cmdline_settings grep_grub_settings set_framebuffer_resolution set_extrabootparams_grub_conf);
 use ipmi_backend_utils;
 use power_action_utils 'power_action';
@@ -84,7 +84,7 @@ C<$timeout> in seconds.
 =cut
 sub reboot_and_wait {
     my ($self, $timeout) = @_;
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         power_action('reboot', textmode => 1, keepconsole => 1);
         switch_from_ssh_to_sol_console(reset_console_flag => 'on');
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
@@ -281,7 +281,7 @@ sub check_cpu_flags {
     assert_script_run('cat /proc/cpuinfo');
     foreach my $flag (@{$self->{cpuflags}}) {
         my $ret = script_run('cat /proc/cpuinfo | grep "^flags.*' . $flag . '.*"');
-        if (get_var('MACHINE', '') =~ /NO-IBRS$/ && check_var('BACKEND', 'qemu')) {
+        if (get_var('MACHINE', '') =~ /NO-IBRS$/ && is_qemu) {
             if ($ret ne 0) {
                 record_info("NOT PASSTHROUGH", "Host didn't pass flags into this VM.");
                 return;
@@ -569,7 +569,7 @@ sub do_test {
     if (!check_var('TEST', 'MITIGATIONS') && !check_var('TEST', 'KVM_GUEST_MITIGATIONS')) {
         #If it is qemu vm and didn't passthrough cpu flags
         #Meltdown doesn't matter CPU flags
-        if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/ && check_var('BACKEND', 'qemu') && !(get_var('TEST') =~ /MELTDOWN/)) {
+        if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/ && is_qemu && !(get_var('TEST') =~ /MELTDOWN/)) {
             record_info('NO-IBRS machine', "This is a QEMU VM and didn't passthrough CPU flags.");
             record_info('INFO',            "Check status of mitigations as like OFF.");
             $self->check_sysfs("off");

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -25,7 +25,7 @@ use Utils::Backends;
 use YuiRestClient::App;
 use YuiRestClient::Wait;
 use YuiRestClient::Logger;
-use Utils::Architectures 'is_s390x';
+use Utils::Architectures;
 use bmwqemu;
 
 my $app;
@@ -113,7 +113,7 @@ sub init_host {
                 return $+{ip} if ($ip =~ $ip_regexp);
         });
     };
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         $host = 'localhost';
     } elsif (is_pvm || is_ipmi) {
         $host = get_var('SUT_IP');
@@ -151,7 +151,7 @@ sub is_libyui_rest_api {
 
 sub set_libyui_backend_vars {
     my $yuiport = get_port();
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         # On qemu we connect to the worker using port forwarding
         set_var('NICTYPE_USER_OPTIONS', join(' ', grep($_, (
                         get_var('NICTYPE_USER_OPTIONS'),

--- a/lib/bootbasetest.pm
+++ b/lib/bootbasetest.pm
@@ -1,5 +1,6 @@
 package bootbasetest;
 use testapi;
+use Utils::Backends;
 use base 'opensusebasetest';
 use strict;
 use warnings;
@@ -13,7 +14,7 @@ sub post_fail_hook {
 
     # if we found a shell, we do not need the memory dump
     if (!(match_has_tag('emergency-shell') or match_has_tag('emergency-mode'))) {
-        if (check_var('BACKEND', 'qemu')) {
+        if (is_qemu) {
             select_console 'root-console';
             diag 'Save memory dump to debug bootup problems, e.g. for bsc#1005313';
             save_memory_dump;

--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -18,6 +18,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_microos is_sle_micro is_released);
 
 our @EXPORT = qw(
@@ -29,19 +30,19 @@ our @EXPORT = qw(
 # Returns a string which should be prepended to every pull from registry.opensuse.org.
 sub get_opensuse_registry_prefix {
     # Can't use is_tumbleweed as that would also return true for stagings
-    if (check_var("VERSION", "Tumbleweed") && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
+    if (check_var("VERSION", "Tumbleweed") && (is_i586 || is_x86_64)) {
         return "opensuse/factory/totest/containers/";
     }
-    elsif (check_var("VERSION", "Tumbleweed") && (check_var('ARCH', 'aarch64') || check_var('ARCH', 'arm'))) {
+    elsif (check_var("VERSION", "Tumbleweed") && (is_aarch64 || is_arm)) {
         return "opensuse/factory/arm/totest/containers/";
     }
-    elsif (check_var("VERSION", "Tumbleweed") && check_var('ARCH', 'ppc64le')) {
+    elsif (check_var("VERSION", "Tumbleweed") && is_ppc64le) {
         return "opensuse/factory/powerpc/totest/containers/";
     }
-    elsif (check_var("VERSION", "Tumbleweed") && check_var('ARCH', 's390x')) {
+    elsif (check_var("VERSION", "Tumbleweed") && is_s390x) {
         return "opensuse/factory/zsystems/totest/containers/";
     }
-    elsif (get_var("VERSION") =~ /^Staging:(?<letter>.)$/ && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
+    elsif (get_var("VERSION") =~ /^Staging:(?<letter>.)$/ && (is_i586 || is_x86_64)) {
         # Tumbleweed letter staging
         my $lowercaseletter = lc $+{letter};
         return "opensuse/factory/staging/${lowercaseletter}/images/";
@@ -64,7 +65,7 @@ sub get_suse_container_urls {
         my $lowerversion  = lc $version;
         my $nodashversion = $version =~ s/-sp/sp/ir;
         # No aarch64 image
-        if (!check_var('ARCH', 'aarch64')) {
+        if (!is_aarch64) {
             push @untested_images, "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/totest/images/suse/sles${nodashversion}";
             push @released_images, "registry.suse.com/suse/sles${nodashversion}";
         }
@@ -94,15 +95,15 @@ sub get_suse_container_urls {
         push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
         push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
     }
-    elsif ((is_leap(">15.0") || is_microos(">15.0")) && check_var('ARCH', 'x86_64')) {
+    elsif ((is_leap(">15.0") || is_microos(">15.0")) && is_x86_64) {
         push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
         push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
     }
-    elsif ((is_leap(">15.0") || is_microos(">15.0")) && (check_var('ARCH', 'aarch64') || check_var('ARCH', 'arm'))) {
+    elsif ((is_leap(">15.0") || is_microos(">15.0")) && (is_aarch64 || is_arm)) {
         push @untested_images, "registry.opensuse.org/opensuse/leap/${version}/arm/images/totest/containers/opensuse/leap:${version}";
         push @released_images, "registry.opensuse.org/opensuse/leap:${version}";
     }
-    elsif (is_leap(">15.0") && check_var('ARCH', 'ppc64le')) {
+    elsif (is_leap(">15.0") && is_ppc64le) {
         # No image set up yet :-(
     }
     elsif (is_sle("<=12-sp2", $version)) {
@@ -128,17 +129,17 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi8/ubi-init");
 
     # poo#72124 Ubuntu image (occasionally) fails on s390x
-    push @images, "$ex_reg/library/ubuntu" unless check_var('ARCH', 's390x');
+    push @images, "$ex_reg/library/ubuntu" unless is_s390x;
 
     # Missing centos container image for s390x.
-    push @images, "$ex_reg/library/centos" unless check_var('ARCH', 's390x');
+    push @images, "$ex_reg/library/centos" unless is_s390x;
 
     # RedHat UBI7 images are not built for aarch64
     push @images, (
         "registry.access.redhat.com/ubi7/ubi",
         "registry.access.redhat.com/ubi7/ubi-minimal",
         "registry.access.redhat.com/ubi7/ubi-init"
-    ) unless (check_var('ARCH', 'aarch64') or check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
+    ) unless (is_aarch64 or check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
 
     return (\@images);
 }

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -17,6 +17,7 @@ use Exporter;
 
 use base "consoletest";
 use testapi;
+use Utils::Architectures;
 use utils;
 use strict;
 use warnings;
@@ -117,7 +118,7 @@ sub basic_container_tests {
     #   - https://store.docker.com/images/hello-world
     assert_script_run("$runtime image pull $hello_world", timeout => 300);
     #   - pull image of last released version of openSUSE Leap
-    if (!check_var('ARCH', 's390x')) {
+    if (!is_s390x) {
         assert_script_run("$runtime image pull $leap", timeout => 600);
     } else {
         record_soft_failure("bsc#1171672 Missing Leap:latest container image for s390x");
@@ -136,7 +137,7 @@ sub basic_container_tests {
     #   - all local images
     my $local_images_list = script_output("$runtime image ls");
     die("$runtime image $tumbleweed not found") unless ($local_images_list =~ /opensuse\/tumbleweed\s*latest/);
-    die("$runtime image $leap not found") if (!check_var('ARCH', 's390x') && !$local_images_list =~ /opensuse\/leap\s*latest/);
+    die("$runtime image $leap not found") if (!is_s390x && !$local_images_list =~ /opensuse\/leap\s*latest/);
 
     # Containers can be spawned
     #   - using 'run'

--- a/lib/data_integrity_utils.pm
+++ b/lib/data_integrity_utils.pm
@@ -22,6 +22,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
 use File::Basename;
 use Digest::file 'digest_file_hex';
 use version_utils qw(is_vmware);
@@ -40,7 +41,7 @@ sub get_image_digest {
     my ($image_path) = shift;
 
     my $digest;
-    if (check_var('BACKEND', 'svirt')) {
+    if (is_svirt) {
         $digest = console('svirt')->get_cmd_output("sha256sum $image_path", {domain => is_vmware() ? 'sshVMwareServer' : undef});
         # On Hyper-V the hash starts with '\'
         my $start = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 1 : 0;

--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -7,6 +7,7 @@ use strict;
 use warnings;
 use opensusebasetest qw(handle_uefi_boot_disk_workaround);
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils qw(is_sle is_livecd);
 use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
@@ -37,7 +38,7 @@ sub grub_test {
     stop_grub_timeout;
     boot_into_snapshot                                               if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');
-    if ((check_var('ARCH', 'aarch64') && is_sle && get_var('PLYMOUTH_DEBUG'))
+    if ((is_aarch64 && is_sle && get_var('PLYMOUTH_DEBUG'))
         || get_var('GRUB_KERNEL_OPTION_APPEND'))
     {
         bug_workaround_bsc1005313() unless get_var("BOOT_TO_SNAPSHOT");
@@ -68,7 +69,7 @@ sub handle_installer_medium_bootup {
     send_key 'ret';
 
     # use firmware boot manager of aarch64 to boot upgraded system
-    'opensusebasetest'->handle_uefi_boot_disk_workaround() if (check_var('ARCH', 'aarch64'));
+    'opensusebasetest'->handle_uefi_boot_disk_workaround() if (is_aarch64);
 }
 
 sub bug_workaround_bsc1005313 {

--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -15,6 +15,7 @@ use parent Exporter;
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use version_utils 'is_sle';
 use utils 'type_string_slow';
 
@@ -29,7 +30,7 @@ sub type_password_and_verification {
 sub await_password_check {
     # PW too easy (cracklib)
     # bsc#937012 is resolved in > SLE 12, skip if VERSION=12
-    return if (is_sle('=12') && check_var('ARCH', 's390x'));
+    return if (is_sle('=12') && is_s390x);
     assert_screen('inst-userpasswdtoosimple', (check_var('BACKEND', 'pvm_hmc')) ? 60 : 30);
     send_key 'ret';
 

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -14,8 +14,8 @@ use warnings;
 use testapi;
 use utils;
 use registration;
-use Utils::Backends qw(is_pvm is_xen_pv is_ipmi);
-use Utils::Architectures qw(is_ppc64le is_aarch64 is_x86_64);
+use Utils::Backends;
+use Utils::Architectures;
 use power_action_utils 'power_action';
 use version_utils qw(is_sle is_jeos is_leap is_tumbleweed is_opensuse);
 use utils 'ensure_serialdev_permissions';
@@ -219,7 +219,7 @@ sub deactivate_kdump_cli {
 sub activate_kdump_without_yast {
     # activate kdump by grub, need a reboot to start kdump
     my $cmd = "";
-    if (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'aarch64')) {
+    if (is_ppc64le || is_aarch64) {
         $cmd = "if [ -e /etc/default/grub ]; then sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT/ s/\"\$/ crashkernel=256M \"/' /etc/default/grub; fi";
     }
     else {
@@ -297,7 +297,7 @@ sub configure_service {
     $self->wait_boot(bootloader_time => 300);
 
     select_console 'root-console';
-    if (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'ppc64')) {
+    if (is_ppc64le || check_var('ARCH', 'ppc64')) {
         if (script_run('kver=$(uname -r); kconfig="/boot/config-$kver"; [ -f $kconfig ] && grep ^CONFIG_RELOCATABLE $kconfig')) {
             record_soft_failure 'poo#49466 -- No kdump if no CONFIG_RELOCATABLE in kernel config';
             return 1;

--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -20,6 +20,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use main_common;
 use version_utils;
 
@@ -61,7 +62,7 @@ sub create_list_of_serial_failures {
     push @$serial_failures, {type => 'soft', message => 'rogue workqueue lockup bsc#1126782', pattern => quotemeta 'BUG: workqueue lockup'};
 
     # Detect bsc#1093797 on aarch64
-    if (is_sle('=12-SP4') && check_var('ARCH', 'aarch64')) {
+    if (is_sle('=12-SP4') && is_aarch64) {
         push @$serial_failures, {type => 'hard', message => 'bsc#1093797', pattern => quotemeta 'Internal error: Oops: 96000006'};
     }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -20,9 +20,9 @@ use containers::urls 'get_suse_container_urls';
 use autotest;
 use utils;
 use wicked::TestContext;
-use Utils::Architectures ':ARCH';
+use Utils::Architectures;
 use version_utils qw(:VERSION :BACKEND :SCENARIO);
-use Utils::Backends qw(is_remote_backend is_hyperv is_hyperv_in_gui is_svirt_except_s390x is_pvm);
+use Utils::Backends;
 use data_integrity_utils 'verify_checksum';
 use bmwqemu ();
 use lockapi 'barrier_create';
@@ -129,7 +129,7 @@ sub init_main {
     check_env();
     # We need to check image only for qemu backend, for svirt we validate image
     # after it is copied to the hypervisor host.
-    if (check_var('BACKEND', 'qemu') && data_integrity_is_applicable()) {
+    if (is_qemu && data_integrity_is_applicable()) {
         my $errors = verify_checksum();
         set_var('CHECKSUM_FAILED', $errors) if $errors;
     }
@@ -370,7 +370,7 @@ sub load_svirt_boot_tests {
 }
 
 sub load_svirt_vm_setup_tests {
-    return unless check_var('BACKEND', 'svirt');
+    return unless is_svirt;
     set_bridged_networking;
     if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
         # Loading bootloader_hyperv here when UPGRADE is on (i.e. offline migration is underway)
@@ -390,7 +390,7 @@ sub load_boot_tests {
     if (get_var("ISO_MAXSIZE") && (!is_remote_backend() || is_svirt_except_s390x())) {
         loadtest "installation/isosize";
     }
-    if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
+    if ((get_var("UEFI") || is_jeos()) && !is_svirt) {
         loadtest "installation/data_integrity" if data_integrity_is_applicable;
         loadtest "installation/bootloader_uefi";
     }
@@ -424,7 +424,7 @@ sub load_reboot_tests {
         # test makes no sense on s390 because grub2 can't be captured
         if (!(is_s390x or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
             # exclude this scenario for autoyast test with switched keyboard layaout. also exclude on ipmi as installation/first_boot will call wait_grub
-            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT') || get_var('KEEP_GRUB_TIMEOUT') || check_var('BACKEND', 'ipmi');
+            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT') || get_var('KEEP_GRUB_TIMEOUT') || is_ipmi;
             if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
                 loadtest "installation/boot_into_snapshot";
             }
@@ -432,7 +432,7 @@ sub load_reboot_tests {
         if (get_var('ENCRYPT')) {
             loadtest "installation/boot_encrypt";
             # reconnect after installation/boot_encrypt
-            if (check_var('ARCH', 's390x')) {
+            if (is_s390x) {
                 loadtest "boot/reconnect_mgmt_console";
             }
         }
@@ -598,7 +598,7 @@ sub snapper_is_applicable {
 }
 
 sub chromestep_is_applicable {
-    return is_opensuse && (check_var('ARCH', 'i586') || is_x86_64);
+    return is_opensuse && (is_i586 || is_x86_64);
 }
 
 sub chromiumstep_is_applicable {
@@ -645,10 +645,10 @@ sub libreoffice_is_applicable {
     # for opensuse libreoffice package has ExclusiveArch:  aarch64 %{ix86} x86_64
     # do not know for SLE (so assume built for all)
     return 1 if (!is_opensuse);
-    return (check_var('ARCH', 'x86_64')
-          || check_var('ARCH', 'i686')
-          || check_var('ARCH', 'i586')
-          || check_var('ARCH', 'aarch64'));
+    return (is_x86_64
+          || is_i686
+          || is_i586
+          || is_aarch64);
 }
 
 sub need_clear_repos {
@@ -694,7 +694,7 @@ sub remove_common_needles {
     remove_desktop_needles("textmode");
 
     unregister_needle_tags("ENV-VIDEOMODE-text") unless check_var("VIDEOMODE", "text");
-    unregister_needle_tags('ENV-ARCH-s390x')     unless check_var('ARCH',      's390x');
+    unregister_needle_tags('ENV-ARCH-s390x')     unless is_s390x;
     # Only for container tests
     unregister_needle_tags('ENV-UBUNTU-1') unless get_var('HDD_1', '') =~ /ubuntu/;
     if (get_var("INSTLANG") && get_var("INSTLANG") ne "en_US") {
@@ -780,7 +780,7 @@ sub load_bootloader_s390x {
 sub boot_hdd_image {
     # On JeOS we don't need to load any test to boot, but to keep main.pm sane just return.
     is_jeos() ? return 1 : get_required_var('BOOT_HDD_IMAGE');
-    if (check_var('BACKEND', 'svirt')) {
+    if (is_svirt) {
         if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
             loadtest 'installation/bootloader_hyperv';
         }
@@ -825,7 +825,7 @@ sub load_inst_tests {
     if (get_var('WITHISCSI')) {
         loadtest "installation/disk_activation_iscsi";
     }
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         if (check_var('BACKEND', 's390x')) {
             loadtest "installation/disk_activation";
         }
@@ -947,7 +947,7 @@ sub load_inst_tests {
     # functionality needs to be covered by other backends
     # Skip release notes test on sle 15 if have addons
     if (get_var('CHECK_RELEASENOTES') &&
-        is_sle && !check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') &&
+        is_sle && !check_var('BACKEND', 'generalhw') && !is_ipmi &&
         !(is_sle('15+') && get_var('ADDONURL'))) {
         loadtest "installation/releasenotes";
     }
@@ -1017,7 +1017,7 @@ sub load_inst_tests {
         # SELinux relabel reboots, so grub needs to timeout
         set_var('KEEP_GRUB_TIMEOUT', 1) if check_var('VIRSH_VMM_TYPE', 'linux') || get_var('SELINUX');
         loadtest "installation/disable_grub_timeout" unless get_var('KEEP_GRUB_TIMEOUT');
-        if (check_var('VIDEOMODE', 'text') && check_var('BACKEND', 'ipmi')) {
+        if (check_var('VIDEOMODE', 'text') && is_ipmi) {
             loadtest "installation/disable_grub_graphics";
         }
         loadtest "installation/enable_selinux" if get_var('SELINUX');
@@ -1047,7 +1047,7 @@ sub load_inst_tests {
 }
 
 sub load_console_server_tests {
-    if (check_var('BACKEND', 'qemu') && !is_jeos) {
+    if (is_qemu && !is_jeos) {
         # The NFS test expects the IP to be 10.0.2.15
         loadtest "console/yast2_nfs_server";
     }
@@ -1175,8 +1175,8 @@ sub load_consoletests {
         loadtest "console/salt";
     }
     if (!is_staging && (is_x86_64
-            || check_var('ARCH', 'i686')
-            || check_var('ARCH', 'i586')))
+            || is_i686
+            || is_i586))
     {
         loadtest "console/glibc_sanity";
     }
@@ -1265,7 +1265,7 @@ sub load_x11tests {
         loadtest "x11/gedit";
     }
     loadtest "x11/firefox";
-    if (is_opensuse && !get_var("OFW") && check_var('BACKEND', 'qemu') && !check_var('FLAVOR', 'Rescue-CD') && !is_kde_live) {
+    if (is_opensuse && !get_var("OFW") && is_qemu && !check_var('FLAVOR', 'Rescue-CD') && !is_kde_live) {
         loadtest "x11/firefox_audio";
     }
     if (chromiumstep_is_applicable() && !(is_staging() || is_livesystem)) {
@@ -1588,7 +1588,7 @@ sub load_extra_tests_opensuse {
     loadtest "console/znc";
     loadtest "console/weechat";
     loadtest "console/nano";
-    loadtest "console/steamcmd" if (check_var('ARCH', 'i586') || is_x86_64);
+    loadtest "console/steamcmd" if (is_i586 || is_x86_64);
     loadtest "console/libqca2";
 }
 
@@ -1615,7 +1615,7 @@ sub load_extra_tests_console {
     loadtest 'console/slp';
     loadtest 'console/pkcon';
     # Audio device is not supported on ppc64le, s390x, JeOS, Public Cloud and Xen PV
-    if (!get_var('PUBLIC_CLOUD') && !get_var("OFW") && !is_jeos && !check_var('VIRSH_VMM_FAMILY', 'xen') && !check_var('ARCH', 's390x')) {
+    if (!get_var('PUBLIC_CLOUD') && !get_var("OFW") && !is_jeos && !check_var('VIRSH_VMM_FAMILY', 'xen') && !is_s390x) {
         loadtest "console/aplay";
         loadtest "console/soundtouch" if is_opensuse || (is_sle('12-sp4+') && is_sle('<15'));
         # wavpack is available only sle12sp4 onwards
@@ -1757,7 +1757,7 @@ sub load_extra_tests {
 }
 
 sub load_rollback_tests {
-    return if check_var('ARCH', 's390x');
+    return if is_s390x;
     # On Xen PV we don't have GRUB.
     # For continuous migration test from SLE11SP4, the filesystem is 'ext3' and btrfs snapshot is not supported.
     # For HPC migration test with 'management server' role, the filesystem is 'xfs', btrfs snapshot is not supported.
@@ -1882,7 +1882,7 @@ sub load_extra_tests_udev {
 sub load_nfv_master_tests {
     loadtest "nfv/prepare_env";
     loadtest "nfv/run_performance_tests";
-    loadtest "nfv/run_integration_tests" if (check_var('BACKEND', 'qemu'));
+    loadtest "nfv/run_integration_tests" if (is_qemu);
 }
 
 sub load_nfv_trafficgen_tests {
@@ -2026,7 +2026,7 @@ sub load_x11_webbrowser {
     loadtest "x11/firefox/firefox_emaillink";
     loadtest "x11/firefox/firefox_plugins";
     loadtest "x11/firefox/firefox_extcontent";
-    if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
+    if (!get_var("OFW") && is_qemu) {
         loadtest "x11/firefox_audio";
     }
 }
@@ -2546,10 +2546,10 @@ sub load_vt_perf_tests {
     }
 }
 sub load_mitigation_tests {
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         loadtest "virt_autotest/login_console";
     }
-    elsif (check_var('BACKEND', 'qemu')) {
+    elsif (is_qemu) {
         boot_hdd_image;
         loadtest "console/system_prepare";
         loadtest "console/consoletest_setup";
@@ -2675,7 +2675,7 @@ sub load_create_hdd_tests {
     # install SES packages and deepsea testsuites
     load_system_prepare_tests;
     load_shutdown_tests;
-    if (check_var('BACKEND', 'svirt')) {
+    if (is_svirt) {
         if (is_hyperv) {
             loadtest 'shutdown/hyperv_upload_assets';
         }
@@ -3136,7 +3136,7 @@ sub load_ha_cluster_tests {
     loadtest 'ha/fencing';
 
     # Node1 will be fenced, so we have to wait for it to boot. On svirt load only boot_to_desktop
-    check_var('BACKEND', 'svirt') ? loadtest 'boot/boot_to_desktop' : boot_hdd_image if !get_var('HA_CLUSTER_JOIN');
+    is_svirt ? loadtest 'boot/boot_to_desktop' : boot_hdd_image if !get_var('HA_CLUSTER_JOIN');
 
     # Show HA cluster status *after* fencing test
     loadtest 'ha/check_after_reboot';

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -22,7 +22,7 @@ use testapi qw(check_var get_required_var get_var);
 use utils;
 use main_common qw(boot_hdd_image load_bootloader_s390x load_kernel_baremetal_tests);
 use 5.018;
-use Utils::Backends 'is_pvm';
+use Utils::Backends;
 use version_utils 'is_opensuse';
 use LTP::utils qw(loadtest_kernel shutdown_ltp);
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
@@ -113,7 +113,7 @@ sub load_kernel_tests {
         loadtest_kernel 'numa_irqbalance';
     }
 
-    if (check_var('BACKEND', 'svirt') && get_var('PUBLISH_HDD_1')) {
+    if (is_svirt && get_var('PUBLISH_HDD_1')) {
         loadtest_kernel '../shutdown/svirt_upload_assets';
     }
 }

--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -22,6 +22,7 @@ use strict;
 use warnings;
 
 use testapi;
+use Utils::Architectures;
 use utils;
 use zypper;
 use registration;
@@ -125,7 +126,7 @@ sub remove_ltss {
 # Other archs: use local DVDs as installation repos
 # https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-online.html#sec-upgrade-online-zypper
 sub disable_installation_repos {
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         zypper_call "mr -d `zypper lr -u | awk '/ftp:.*?openqa.suse.de|10.160.0.100/ {print \$1}'`";
     }
     else {

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use utils;
 use testapi;
+use Utils::Architectures;
 use version_utils qw(is_sle is_leap is_opensuse is_tumbleweed is_vmware is_jeos);
 use Carp 'croak';
 
@@ -51,7 +52,7 @@ sub prepare_system_shutdown {
     # kill the ssh connection before triggering reboot
     console('root-ssh')->kill_ssh if get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/;
 
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         if (check_var('BACKEND', 's390x')) {
             # kill serial ssh connection (if it exists)
             eval { console('iucvconn')->kill_ssh unless get_var('BOOT_EXISTING_S390', ''); };
@@ -367,7 +368,7 @@ sub assert_shutdown_and_restore_system {
         reset_consoles;
         my $svirt = console('svirt');
         # Set disk as a primary boot device
-        if (check_var('ARCH', 's390x') or get_var('NETBOOT')) {
+        if (is_s390x or get_var('NETBOOT')) {
             $svirt->change_domain_element(os        => initrd  => undef);
             $svirt->change_domain_element(os        => kernel  => undef);
             $svirt->change_domain_element(os        => cmdline => undef);
@@ -404,7 +405,7 @@ Example:
 =cut
 sub assert_shutdown_with_soft_timeout {
     my ($args) = @_;
-    $args->{timeout}      //= check_var('ARCH', 's390x') ? 600 : get_var('DEBUG_SHUTDOWN') ? 180 : 60;
+    $args->{timeout}      //= is_s390x ? 600 : get_var('DEBUG_SHUTDOWN') ? 180 : 60;
     $args->{soft_timeout} //= 0;
     $args->{bugref}       //= "No bugref specified";
     if ($args->{soft_timeout}) {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -20,6 +20,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key script_retry);
 use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro);
 use constant ADDONS_COUNT => 50;
@@ -732,7 +733,7 @@ sub yast_scc_registration {
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => $client_module, yast2_opts => $args{yast2_opts});
     # For Aarch64 if the worker run with heavy loads, it will
     # timeout in nearly 120 seconds. So we set it to 150.
-    assert_screen('scc-registration', timeout => (check_var('ARCH', 'aarch64')) ? 150 : 90,);
+    assert_screen('scc-registration', timeout => (is_aarch64) ? 150 : 90,);
     fill_in_registration_data;
     wait_serial("$module_name-0", 150) || die "yast scc failed";
     # To check repos validity after registration, call 'validate_repos' as needed

--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -10,6 +10,7 @@ package serial_terminal;
 use 5.018;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use autotest;
 use base 'Exporter';
@@ -61,7 +62,7 @@ sub prepare_serial_console {
     # poo#18860 Enable console on hvc0 on SLES < 12-SP2
     # poo#44699 Enable console on hvc1 to fix login issues on ppc64le
     if (!check_var('VIRTIO_CONSOLE', 0)) {
-        if (is_sle('<12-SP2') && !check_var('ARCH', 's390x')) {
+        if (is_sle('<12-SP2') && !is_s390x) {
             add_serial_console('hvc0');
         }
         elsif (get_var('OFW')) {

--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -20,6 +20,7 @@ package service_check;
 
 use Exporter 'import';
 use testapi;
+use Utils::Architectures;
 use utils;
 use base 'opensusebasetest';
 use strict;
@@ -206,7 +207,7 @@ service package name.
 
 sub _is_applicable {
     my ($srv_pkg_name) = @_;
-    if ($srv_pkg_name eq 'kdump' && check_var('ARCH', 's390x')) {
+    if ($srv_pkg_name eq 'kdump' && is_s390x) {
         # workaround for bsc#116300 on s390x
         record_soft_failure 'bsc#1163000 - System does not come back after crash on s390x';
         return 0;
@@ -241,7 +242,7 @@ sub install_services {
     assert_script_run('echo export LMOD_SH_DBG_ON=1 >> /etc/bash.bashrc.local');
     # On ppc64le, sometime the console font will be distorted into pseudo graphics characters.
     # we need to reset the console font. As it impacted all the console services, added this command to bashrc file
-    assert_script_run('echo /usr/lib/systemd/systemd-vconsole-setup >> /etc/bash.bashrc.local') if check_var('ARCH', 'ppc64le');
+    assert_script_run('echo /usr/lib/systemd/systemd-vconsole-setup >> /etc/bash.bashrc.local') if is_ppc64le;
     assert_script_run '. /etc/bash.bashrc.local';
     foreach my $s (sort keys %$service) {
         my $srv_pkg_name  = $service->{$s}->{srv_pkg_name};

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -23,6 +23,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use power_action_utils 'reboot_x11';
 use version_utils;
@@ -144,7 +145,7 @@ sub full_users_check {
     }
     # reset consoles before select x11 console will make the connect operation
     # more stable on s390x
-    reset_consoles             if check_var('ARCH',    's390x');
+    reset_consoles             if is_s390x;
     turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     select_console 'x11', await_console => 0;
     wait_still_screen 5;
@@ -158,7 +159,7 @@ sub full_users_check {
         # verify changed password work well in the following scenario:
         # workaround the lock screen will cause vnc lost connection issue on
         # SLE15+ on s390x for bsc#1182958.
-        if ((check_var('ARCH', 's390x')) && is_sle('15+')) {
+        if ((is_s390x) && is_sle('15+')) {
             record_soft_failure("bsc#1182958, openQA test fails in install_service - gdm crashed after lock screen on s390x");
         }
         else {
@@ -175,7 +176,7 @@ sub full_users_check {
         # switch to new added user then switch back
         # it's not supported to switch user on s390x VM with vnc connection,
         # so we have to change this test to logout and login new user.
-        if (check_var('ARCH', 's390x')) {
+        if (is_s390x) {
             logout_and_login($newUser, $pwd4newUser);
         }
         else {

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -22,7 +22,7 @@ use isotovideo;
 use ipmi_backend_utils;
 use x11utils qw(ensure_unlocked_desktop);
 use power_action_utils qw(power_action);
-use Utils::Backends qw(use_ssh_serial_console);
+use Utils::Backends;
 use registration qw(add_suseconnect_product);
 use version_utils qw(is_sle);
 use utils qw(zypper_call);
@@ -212,7 +212,7 @@ Returns the total memory configured in SUT.
 =cut
 
 sub get_total_mem {
-    return get_required_var('QEMURAM') if (check_var('BACKEND', 'qemu'));
+    return get_required_var('QEMURAM') if (is_qemu);
     my $mem = script_output q@grep ^MemTotal /proc/meminfo | awk '{print $2}'@;
     $mem /= 1024;
     return $mem;
@@ -694,7 +694,7 @@ Restart the SUT and reconnect to the console right after.
 sub reboot {
     my ($self) = @_;
 
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         power_action('reboot', textmode => 1, keepconsole => 1);
         switch_from_ssh_to_sol_console;
         $self->wait_boot(textmode => 1, nologin => get_var('NOAUTOLOGIN', '0'));

--- a/lib/systemd_testsuite_test.pm
+++ b/lib/systemd_testsuite_test.pm
@@ -18,6 +18,8 @@ use strict;
 use warnings;
 use known_bugs;
 use testapi;
+use Utils::Backends;
+use Utils::Architectures;
 use power_action_utils 'power_action';
 use utils 'zypper_call';
 use version_utils qw(is_opensuse is_sle is_tumbleweed);
@@ -67,10 +69,10 @@ sub testsuiteinstall {
         change_grub_config('=.*', '=9', 'GRUB_TIMEOUT');
         grub_mkconfig;
         wait_screen_change { enter_cmd "shutdown -r now" };
-        if (check_var('ARCH', 's390x')) {
+        if (is_s390x) {
             $self->wait_boot(bootloader_time => 180);
         } else {
-            $self->handle_uefi_boot_disk_workaround if (check_var('ARCH', 'aarch64'));
+            $self->handle_uefi_boot_disk_workaround if (is_aarch64);
             wait_still_screen 10;
             send_key 'ret';
             wait_serial('Welcome to', 300) || die "System did not boot in 300 seconds.";
@@ -103,13 +105,13 @@ sub testsuiteprepare {
 
         assert_script_run 'ls -l /etc/systemd/system/testsuite.service';
         #virtual machines do a vm reset instead of reboot
-        if (!check_var('BACKEND', 'qemu') || ($option eq 'needreboot')) {
+        if (!is_qemu || ($option eq 'needreboot')) {
             wait_screen_change { enter_cmd "shutdown -r now" };
-            if (check_var('ARCH', 's390x')) {
+            if (is_s390x) {
                 $self->wait_boot(bootloader_time => 180);
             }
             else {
-                $self->handle_uefi_boot_disk_workaround if (check_var('ARCH', 'aarch64'));
+                $self->handle_uefi_boot_disk_workaround if (is_aarch64);
                 wait_serial('Welcome to', 300) || die "System did not boot in 300 seconds.";
             }
             wait_still_screen 10;

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -24,7 +24,7 @@ use power_action_utils 'power_action';
 use version_utils qw(is_opensuse is_microos is_sle_micro is_sle);
 use utils 'reconnect_mgmt_console';
 use Utils::Backends 'is_pvm';
-use Utils::Architectures qw(is_s390x);
+use Utils::Architectures;
 
 our @EXPORT = qw(
   process_reboot

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -22,8 +22,8 @@ use warnings;
 use testapi qw(check_var get_var set_var script_output);
 use version 'is_lax';
 use Carp 'croak';
-use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_svirt_except_s390x);
-use Utils::Architectures 'is_s390x';
+use Utils::Backends;
+use Utils::Architectures;
 
 use constant {
     VERSION => [
@@ -485,7 +485,7 @@ On microos, leap 15.1+, TW we have it instead of desktop selection screen
 =cut
 sub is_using_system_role {
     return is_sle('>=12-SP2') && is_sle('<15')
-      && check_var('ARCH', 'x86_64')
+      && is_x86_64
       && is_server()
       && (!is_sles4sap()         || is_sles4sap_standard())
       && (install_this_version() || install_to_other_at_least('12-SP2'))
@@ -567,7 +567,7 @@ sub has_license_to_accept {
 Returns true if the SUT uses qa net hardware
 =cut
 sub uses_qa_net_hardware {
-    return !check_var("IPXE", "1") && check_var("BACKEND", "ipmi") || check_var("BACKEND", "generalhw");
+    return !check_var("IPXE", "1") && is_ipmi || check_var("BACKEND", "generalhw");
 }
 
 =head2 get_os_release

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -33,7 +33,7 @@ use DateTime;
 use NetAddr::IP;
 use Net::IP qw(:PROC);
 use File::Basename;
-use Utils::Architectures 'is_s390x';
+use Utils::Architectures;
 
 our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest is_guest_ballooned is_xen_host is_kvm_host
   check_host check_guest print_cmd_output_to_file ssh_setup ssh_copy_id create_guest import_guest install_default_packages

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -25,6 +25,7 @@ use version_utils 'check_version';
 
 use strict;
 use warnings;
+use Utils::Architectures;
 
 use constant WICKED_DATA_DIR => '/tmp/wicked/data';
 
@@ -733,7 +734,7 @@ sub pre_run_hook {
     wait_serial($coninfo, undef, 0, no_regex => 1);
     send_key 'ret';
     if ($self->{name} eq 'before_test' && get_var('VIRTIO_CONSOLE_NUM', 1) > 1) {
-        my $serial_terminal = check_var('ARCH', 'ppc64le') ? 'hvc2' : 'hvc1';
+        my $serial_terminal = is_ppc64le ? 'hvc2' : 'hvc1';
         add_serial_console($serial_terminal);
     }
     if ($self->{name} ne 'before_test' && get_var('WICKED_TCPDUMP')) {

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -23,7 +23,7 @@ use warnings;
 use testapi;
 use version_utils qw(is_sle is_leap);
 use utils 'assert_and_click_until_screen_change';
-use Utils::Architectures 'is_aarch64';
+use Utils::Architectures;
 
 our @EXPORT = qw(
   desktop_runner_hotkey

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 
 use testapi;
+use Utils::Architectures;
 
 use version_utils qw(is_microos is_sle);
 use y2_logs_helper 'get_available_compression';
@@ -371,7 +372,7 @@ sub use_ifconfig {
 }
 
 sub get_ip_address {
-    return if (get_var('NET') || check_var('ARCH', 's390x'));
+    return if (get_var('NET') || is_s390x);
     return if (get_var('NOLOGS'));
 
     # avoid known issue in FIPS mode: bsc#985969

--- a/tests/autoyast/console.pm
+++ b/tests/autoyast/console.pm
@@ -22,10 +22,11 @@ use strict;
 use warnings;
 use base 'y2_installbase';
 use testapi;
+use Utils::Backends;
 
 sub run {
     my ($self) = @_;
-    $self->wait_boot if check_var('BACKEND', 'ipmi');
+    $self->wait_boot if is_ipmi;
     select_console 'root-console';
 }
 

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 use base 'y2_installbase';
 use testapi;
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends;
 
 sub run {
     my $self = shift;
@@ -33,7 +33,7 @@ sub run {
 
     # TODO: is_remote_backend could be a better fit here, but not
     # too sure if it would make sense for svirt or s390 for example
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         #use console based on ssh to avoid unstable ipmi
         use_ssh_serial_console;
     }

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -20,8 +20,8 @@ use testapi;
 use bootloader_setup qw(bootmenu_default_params specific_bootmenu_params prepare_disks);
 use registration 'registration_bootloader_cmdline';
 use utils qw(type_string_slow enter_cmd_slow);
-use Utils::Backends 'is_remote_backend';
-use Utils::Architectures qw(is_aarch64 is_orthos_machine is_supported_suse_domain);
+use Utils::Backends;
+use Utils::Architectures;
 use version_utils 'is_upgrade';
 
 sub run {
@@ -29,14 +29,14 @@ sub run {
     my $arch      = get_var('ARCH');
     my $interface = get_var('SUT_NETDEVICE', 'eth0');
     # In autoyast tests we need to wait until pxe is available
-    if (get_var('AUTOYAST') && get_var('DELAYED_START') && !check_var('BACKEND', 'ipmi')) {
+    if (get_var('AUTOYAST') && get_var('DELAYED_START') && !is_ipmi) {
         mutex_lock('pxe');
         mutex_unlock('pxe');
         resume_vm();
     }
 
-    if (check_var('BACKEND', 'ipmi')) {
-        if (is_remote_backend && check_var('ARCH', 'aarch64') && get_var('IPMI_HW') eq 'thunderx') {
+    if (is_ipmi) {
+        if (is_remote_backend && is_aarch64 && get_var('IPMI_HW') eq 'thunderx') {
             select_console 'sol', await_console => 1;
             send_key 'ret';
             ipmi_backend_utils::ipmitool 'chassis power reset';
@@ -51,7 +51,7 @@ sub run {
     assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600);
 
     # boot bare-metal/IPMI machine
-    if (check_var('BACKEND', 'ipmi') && get_var('BOOT_IPMI_SYSTEM')) {
+    if (is_ipmi && get_var('BOOT_IPMI_SYSTEM')) {
         send_key 'ret';
         assert_screen 'linux-login', 100;
         return 1;
@@ -101,7 +101,7 @@ sub run {
         }
 
         #IPMI Backend
-        $image_path .= "?device=$interface " if (check_var('BACKEND', 'ipmi') && !get_var('SUT_NETDEVICE_SKIPPED'));
+        $image_path .= "?device=$interface " if (is_ipmi && !get_var('SUT_NETDEVICE_SKIPPED'));
     }
     elsif (match_has_tag('prague-pxe-menu')) {
         send_key_until_needlematch 'qa-net-boot', 'esc', 8, 3;
@@ -111,8 +111,8 @@ sub run {
             send_key 'tab';
         }
         else {
-            my $device  = (check_var('BACKEND', 'ipmi') && !get_var('SUT_NETDEVICE_SKIPPED')) ? "?device=$interface" : '';
-            my $release = get_var('BETA')                                                     ? 'LATEST'             : 'GM';
+            my $device  = (is_ipmi && !get_var('SUT_NETDEVICE_SKIPPED')) ? "?device=$interface" : '';
+            my $release = get_var('BETA')                                ? 'LATEST'             : 'GM';
             $image_name = get_var('ISO') =~ s/(.*\/)?(.*)-DVD-${arch}-.*\.iso/$2-$release/r;
             $image_name = get_var('PXE_PRODUCT_NAME') if get_var('PXE_PRODUCT_NAME');
             $image_path = "/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/linux ";
@@ -125,7 +125,7 @@ sub run {
         send_key "down";
         send_key "tab";
     }
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         $image_path .= " ipv6.disable=1 "         if get_var('LINUX_BOOT_IPV6_DISABLE');
         $image_path .= " ifcfg=$interface=dhcp4 " if (!get_var('NETWORK_INIT_PARAM') && !get_var('SUT_NETDEVICE_SKIPPED'));
         $image_path .= ' plymouth.enable=0 ';
@@ -134,7 +134,7 @@ sub run {
     type_string_slow ${image_path} . " ";
     bootmenu_default_params(pxe => 1, baud_rate => '115200');
 
-    if (check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) {
+    if (is_ipmi && !get_var('AUTOYAST')) {
         if (check_var('VIDEOMODE', 'text')) {
             $cmdline .= 'ssh=1 ';    # trigger ssh-text installation
         }
@@ -163,14 +163,14 @@ sub run {
 
     # try to avoid blue screen issue on osd ipmi tests
     # local test passes, if validated on osd, will switch on to all ipmi tests
-    if (check_var('BACKEND', 'ipmi') && check_var('VIDEOMODE', 'text') && check_var('VIRT_AUTOTEST', 1)) {
+    if (is_ipmi && check_var('VIDEOMODE', 'text') && check_var('VIRT_AUTOTEST', 1)) {
         type_string_slow(" vt.color=0x07 ");
     }
 
     send_key 'ret';
     save_screenshot;
 
-    if (check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) {
+    if (is_ipmi && !get_var('AUTOYAST')) {
         my $ssh_vnc_wait_time = 420;
         my $ssh_vnc_tag       = eval { check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc' } . '-server-started';
         #Detect orthos-grub-boot-linux and qa-net-grub-boot-linux for aarch64 in orthos and openQA networks respectively
@@ -215,7 +215,7 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
 
-    if (check_var('BACKEND', 'ipmi') && check_var('VIDEOMODE', 'text')) {
+    if (is_ipmi && check_var('VIDEOMODE', 'text')) {
         select_console 'log-console';
         save_screenshot;
         script_run "save_y2logs /tmp/y2logs_clone.tar.bz2";

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -18,7 +18,8 @@ use base 'bootbasetest';
 use strict;
 use warnings;
 use testapi;
-use Utils::Backends qw(is_pvm is_ipmi);
+use Utils::Architectures;
+use Utils::Backends;
 use version_utils qw(is_upgrade is_sles4sap is_sle);
 
 sub run {
@@ -37,7 +38,7 @@ sub run {
     $timeout += 60 if get_var('ENCRYPT');
     # For bsc#1180313, can't stop wicked during reboot make system need more time
     # to wait bootloader, add additional 60s when ARCH is ppc64le.
-    if (check_var('ARCH', 'ppc64le') && is_sle && get_required_var('FLAVOR') =~ /Migration/ && get_var('ZDUP') && check_var('HDDVERSION', '15-SP1')) {
+    if (is_ppc64le && is_sle && get_required_var('FLAVOR') =~ /Migration/ && get_var('ZDUP') && check_var('HDDVERSION', '15-SP1')) {
         record_soft_failure 'Bug 1180313 - [Build 114.1] openQA test fails in boot_to_desktop#1 - failed to stop wicked during system reboot after online migration from SLES15SP1 to SLES15SP3';
         $timeout += 60;
     }

--- a/tests/console/check_network.pm
+++ b/tests/console/check_network.pm
@@ -15,14 +15,14 @@
 
 use base "consoletest";
 use testapi;
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends;
 use strict;
 use warnings;
 
 sub run {
     # let's see how it looks at the beginning
     save_screenshot;
-    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    is_ipmi ? use_ssh_serial_console : select_console 'root-console';
 
     # https://fate.suse.com/320347 https://bugzilla.suse.com/show_bug.cgi?id=988157
     if (check_var('NETWORK_INIT_PARAM', 'ifcfg=eth0=dhcp')) {

--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -22,6 +22,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils;
 use registration;
@@ -95,7 +96,7 @@ sub check_buildid {
 
 sub run {
     select_console('root-console');
-    assert_script_run('setterm -blank 0') unless (check_var('ARCH', 's390x'));
+    assert_script_run('setterm -blank 0') unless (is_s390x);
 
     script_run('zypper lr | tee /tmp/zypperlr.txt');
 

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -23,6 +23,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils qw(is_jeos is_opensuse is_sle);
 
@@ -62,7 +63,7 @@ sub run {
 
     # clamd takes a lot of memory at startup so a swap partition is needed on JeOS
     # But openSUSE aarch64 JeOS has already a swap and BTRFS does not support swapfile
-    if (is_jeos && !(is_opensuse && check_var('ARCH', 'aarch64'))) {
+    if (is_jeos && !(is_opensuse && is_aarch64)) {
         assert_script_run("mkdir -p /var/lib/swap");
         assert_script_run("dd if=/dev/zero of=/var/lib/swap/swapfile bs=1M count=512");
         assert_script_run("mkswap /var/lib/swap/swapfile");
@@ -116,7 +117,7 @@ sub run {
 }
 
 sub post_run_hook {
-    assert_script_run("swapoff /var/lib/swap/swapfile") if is_jeos && !(is_opensuse && check_var('ARCH', 'aarch64'));
+    assert_script_run("swapoff /var/lib/swap/swapfile") if is_jeos && !(is_opensuse && is_aarch64);
     systemctl('stop clamd', timeout => 500);
     systemctl('stop freshclam');
 }

--- a/tests/console/console_reboot.pm
+++ b/tests/console/console_reboot.pm
@@ -14,6 +14,7 @@
 
 use base "consoletest";
 use testapi;
+use Utils::Architectures;
 use utils;
 use power_action_utils 'power_action';
 use strict;
@@ -22,7 +23,7 @@ use warnings;
 sub run {
     my ($self) = @_;
     power_action('reboot', textmode => 1);
-    if (check_var('ARCH', 'aarch64')) {
+    if (is_aarch64) {
         $self->wait_boot(bootloader_time => 300);
     }
     else {

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -21,6 +21,7 @@
 
 use base "opensusebasetest";
 use testapi;
+use Utils::Architectures;
 use utils;
 use strict;
 use warnings;
@@ -39,7 +40,7 @@ sub run {
     # On s390x sometimes the vnc will still be there and the next select_console
     # will create another vnc. This will make the OpenQA have 2 vnc sessions at
     # the same time. We'd cleanup the previous one and setup the new one.
-    assert_script_run 'pkill Xvnc ||:' if !check_var('DESKTOP', 'textmode') && check_var('ARCH', 's390x');
+    assert_script_run 'pkill Xvnc ||:' if !check_var('DESKTOP', 'textmode') && is_s390x;
     # logout root (and later user) so they don't block logout
     # in KDE
     enter_cmd "exit";

--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -18,6 +18,7 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
+use Utils::Architectures;
 use utils qw(is_bridged_networking systemctl zypper_call);
 
 sub run {
@@ -37,9 +38,9 @@ sub run {
 
     # verify dns server responds to anything
     if (script_run 'host localhost. localhost') {
-        record_soft_failure 'bsc#1064438: "bind" cannot resolve localhost'         if check_var('ARCH', 's390x');
+        record_soft_failure 'bsc#1064438: "bind" cannot resolve localhost'         if is_s390x;
         record_info 'Skip the entire test on bridged networks (e.g. Xen, Hyper-V)' if (is_bridged_networking);
-        return                                                                     if (is_bridged_networking || check_var('ARCH', 's390x'));
+        return                                                                     if (is_bridged_networking || is_s390x);
         die "Command 'host localhost localhost' failed, cannot resolv localhost";
     }
 }

--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils "is_upgrade";
-use Utils::Architectures 'is_ppc64le';
+use Utils::Architectures;
 
 sub run {
     my ($self) = @_;

--- a/tests/console/glibc_sanity.pm
+++ b/tests/console/glibc_sanity.pm
@@ -22,19 +22,20 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils 'zypper_call';
 
 sub run {
     select_console 'root-console';
 
     my $libcstr = 'GNU C Library';
-    if (check_var('ARCH', 'x86_64')) {
+    if (is_x86_64) {
         # On Tumbleweed we still support 32-bit x86
         zypper_call 'in -C libc.so.6';
         assert_script_run "/lib/libc.so.6 | tee /dev/$serialdev | grep --color '$libcstr'";
         assert_script_run '/lib/libc.so.6 | grep --color "i686-suse-linux"';
     }
-    if (check_var('ARCH', 'x86_64') || check_var('ARCH', 'aarch64')) {
+    if (is_x86_64 || is_aarch64) {
         zypper_call 'in -C "libc.so.6()(64bit)"';
         assert_script_run "/lib64/libc.so.6 | tee /dev/$serialdev | grep --color '$libcstr'";
         assert_script_run '/lib64/libc.so.6 | grep --color "' . get_var('ARCH') . '-suse-linux"';

--- a/tests/console/glibc_tunables.pm
+++ b/tests/console/glibc_tunables.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
-use Utils::Architectures 'is_aarch64';
+use Utils::Architectures;
 
 sub run {
     select_console 'root-console';

--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -27,6 +27,8 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
+use Utils::Architectures;
 use utils;
 use version_utils 'is_sle';
 
@@ -143,7 +145,7 @@ sub run {
     select_console 'root-console';
 
     # increase entropy for key generation for s390x on svirt backend
-    if (check_var('ARCH', 's390x') && (is_sle('15+') && (check_var('BACKEND', 'svirt')))) {
+    if (is_s390x && (is_sle('15+') && (is_svirt))) {
         zypper_call('in haveged');
         systemctl('start haveged');
     }

--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -28,7 +28,7 @@ use testapi;
 use utils qw(zypper_call script_retry systemctl);
 use version_utils qw(is_opensuse is_tumbleweed is_sle is_public_cloud is_leap);
 use Utils::Backends qw(is_hyperv);
-use Utils::Architectures qw(is_s390x);
+use Utils::Architectures;
 use power_action_utils qw(power_action);
 use constant {
     PERSISTENT_LOG_DIR => '/var/log/journal',

--- a/tests/console/libgpiod.pm
+++ b/tests/console/libgpiod.pm
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use Utils::Architectures qw(is_aarch64 is_arm);
+use Utils::Architectures;
 use version_utils qw(is_sle is_leap);
 
 sub run {

--- a/tests/console/lvm.pm
+++ b/tests/console/lvm.pm
@@ -39,6 +39,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use version_utils;
 use utils 'zypper_call';
 use btrfs_test 'set_playground_disk';
@@ -47,7 +48,7 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         # bring dasd online
         # exit status 0 -> everything ok
         # exit status 8 -> unformatted but still usable (e.g. from previous testrun)

--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -17,12 +17,12 @@
 use base "consoletest";
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends;
 use strict;
 use warnings;
 
 sub run {
-    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    is_ipmi ? use_ssh_serial_console : select_console 'root-console';
 
     select_console 'user-console';
     assert_script_run "curl -L -v -f " . autoinst_url('/data') . " | cpio -id", timeout => 300;

--- a/tests/console/shells.pm
+++ b/tests/console/shells.pm
@@ -26,6 +26,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils 'zypper_call';
 use version_utils 'is_leap';
 
@@ -33,10 +34,10 @@ sub run() {
     select_console 'root-console';
     my @packages = qw(tcsh zsh);
     # ksh does not build for Leap 15.x on aarch64, so, skip it
-    push @packages, qw(ksh) unless (is_leap('15.0+') and check_var('ARCH', 'aarch64'));
+    push @packages, qw(ksh) unless (is_leap('15.0+') and is_aarch64);
     zypper_call("in @packages");
     select_console 'user-console';
-    assert_script_run 'ksh -c "print hello" | grep hello' unless (is_leap('15.0+') and check_var('ARCH', 'aarch64'));
+    assert_script_run 'ksh -c "print hello" | grep hello' unless (is_leap('15.0+') and is_aarch64);
     assert_script_run 'tcsh -c "printf \'hello\n\'" | grep hello';
     assert_script_run 'csh -c "printf \'hello\n\'" | grep hello';
     assert_script_run 'zsh -c "echo hello" | grep hello';

--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -13,6 +13,7 @@
 
 use base 'consoletest';
 use testapi;
+use Utils::Architectures;
 use utils;
 use strict;
 use warnings;
@@ -42,7 +43,7 @@ sub rollback_and_reboot {
     assert_script_run("snapper rollback $rollback_id");
     assert_script_run("snapper list");
     power_action('reboot');
-    if (check_var('ARCH', 'aarch64')) {
+    if (is_aarch64) {
         $self->wait_boot(bootloader_time => 300);
     }
     else {

--- a/tests/console/sysstat.pm
+++ b/tests/console/sysstat.pm
@@ -19,7 +19,7 @@
 
 use base 'consoletest';
 use utils qw(zypper_call systemctl);
-use Utils::Architectures 'is_arm';
+use Utils::Architectures;
 use version_utils qw(is_sle is_leap is_opensuse);
 use strict;
 use warnings;

--- a/tests/console/system_state.pm
+++ b/tests/console/system_state.pm
@@ -25,13 +25,13 @@
 use base "consoletest";
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends;
 use strict;
 use warnings;
 
 sub run {
     my ($self) = shift;
-    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    is_ipmi ? use_ssh_serial_console : select_console 'root-console';
     script_run "mkdir /tmp/system_state";
     script_run "ps axf > /tmp/system_state/psaxf.log";
     script_run "cat /proc/loadavg > /tmp/system_state/loadavg_consoletest_setup.txt";

--- a/tests/console/systemd_nspawn.pm
+++ b/tests/console/systemd_nspawn.pm
@@ -13,6 +13,7 @@
 
 use base 'opensusebasetest';
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils;
 use strict;
@@ -83,7 +84,7 @@ sub run {
     assert_script_run 'wget -O oci_testbundle.tgz ' . data_url('oci_testbundle.tgz');
     assert_script_run 'tar xf oci_testbundle.tgz';
     assert_script_run 'ls -l oci_testbundle';
-    if (!check_var('ARCH', 'x86_64')) {
+    if (!is_x86_64) {
         # our bundle is x86_64 but is essentially only busybox
         # so we'll simply replace the binary with one of the right arch
         zypper_call 'in busybox-static';

--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -14,6 +14,7 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
+use Utils::Architectures;
 use version_utils 'is_sle';
 use Test::Assert ':all';
 
@@ -76,7 +77,7 @@ my (
 );
 # Prepare test data depending on specific architecture/product
 sub prepare_test_data {
-    if (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'ppc64')) {
+    if (is_ppc64le || check_var('ARCH', 'ppc64')) {
         @partitioning = (
             $raid_partitions_3_arrays, $hard_disks, $linux_raid_member_3_arrays,
             $ext4_boot,
@@ -87,7 +88,7 @@ sub prepare_test_data {
         $num_raid_arrays = @raid_arrays;
         @raid            = (($raid_level, $raid0, $raid1), @raid_detail);
     }
-    elsif (check_var('ARCH', 'aarch64')) {
+    elsif (is_aarch64) {
         @partitioning = @partitioning = (
             $raid_partitions_2_arrays, $hard_disks, $linux_raid_member_2_arrays,
             $vfat_efi,
@@ -95,7 +96,7 @@ sub prepare_test_data {
         );
         @raid = (($raid_level, $raid0), @raid_detail);
     }
-    elsif (check_var('ARCH', 'x86_64') && is_sle('<15')) {
+    elsif (is_x86_64 && is_sle('<15')) {
         @partitioning = (
             $btrfs,      $ext4_boot, $swap,
             $hard_disks, $linux_raid_member_3_arrays,

--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -15,7 +15,7 @@ use Mojo::Base 'opensusebasetest';
 use testapi;
 use utils qw(zypper_call is_efi_boot);
 use version_utils qw(is_leap is_opensuse is_sle is_jeos);
-use Utils::Architectures qw(is_x86_64 is_aarch64);
+use Utils::Architectures;
 use jeos qw(reboot_image set_grub_gfxmode);
 use registration qw(add_suseconnect_product remove_suseconnect_product);
 use main_common qw(is_updates_tests);

--- a/tests/console/vim.pm
+++ b/tests/console/vim.pm
@@ -22,13 +22,14 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use version_utils qw(is_jeos is_opensuse);
 
 sub run {
     select_console 'root-console';
     assert_script_run 'rpm -qi --whatprovides vim_client';
     # vim-data package must not be present on JeOS (except on aarch64 openSUSE)
-    assert_script_run('! rpm -qi vim-data') if (is_jeos() && !(check_var('ARCH', 'aarch64') && is_opensuse()));
+    assert_script_run('! rpm -qi vim-data') if (is_jeos() && !(is_aarch64 && is_opensuse()));
     enter_cmd "vim /etc/passwd";
     my $jeos = is_jeos() ? '-jeos' : '';
     assert_screen "vim-showing-passwd$jeos";

--- a/tests/console/vsftpd.pm
+++ b/tests/console/vsftpd.pm
@@ -29,7 +29,7 @@ use testapi;
 use strict;
 use warnings;
 use utils 'zypper_call';
-use Utils::Architectures 'is_s390x';
+use Utils::Architectures;
 
 sub run {
     my $self = shift;

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -20,6 +20,7 @@ use strict;
 use base 'y2_module_consoletest';
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use Utils::Backends 'is_hyperv';
 
@@ -39,7 +40,7 @@ sub run {
     # OK => Close
     send_key "alt-o";
     # Our Hyper-V host & aarch64 is slow when initrd is being re-generated
-    my $timeout = (is_hyperv || check_var('ARCH', 'aarch64')) ? 600 : 200;
+    my $timeout = (is_hyperv || is_aarch64) ? 600 : 200;
     assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], $timeout);
     if (match_has_tag('yast2_bootloader-missing_package')) {
         wait_screen_change { send_key 'alt-i'; };

--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -20,6 +20,7 @@ use strict;
 use base 'y2_module_consoletest';
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
 use y2lan_restart_common;
@@ -37,7 +38,7 @@ sub run {
     script_run('ip a');
     script_run('ls -alF /etc/sysconfig/network/');
     save_screenshot;
-    unless (check_var("ARCH", "s390x")) {
+    unless (is_s390x) {
         my $opened = open_yast2_lan();
         wait_still_screen;
         if ($opened eq "Controlled by network manager") {

--- a/tests/console/zypper_extend.pm
+++ b/tests/console/zypper_extend.pm
@@ -50,6 +50,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils qw(zypper_call);
 use version_utils qw(is_sle is_leap is_jeos is_tumbleweed);
 
@@ -181,7 +182,7 @@ sub run {
     #Enter zypper shell and run the lr command | echo lr
     assert_script_run('echo lr |zypper shell');
 
-    if (check_var('ARCH', 'x86_64') && !is_jeos && (is_sle('>=15-SP3') || is_leap('>=15.3') || is_tumbleweed())) {
+    if (is_x86_64 && !is_jeos && (is_sle('>=15-SP3') || is_leap('>=15.3') || is_tumbleweed())) {
         # - It is enough to test it on x86_64.
         # - MariaDB-server provides MariaDB
         # - mariadb provides mariadb

--- a/tests/console/zypper_lr_validate.pm
+++ b/tests/console/zypper_lr_validate.pm
@@ -19,6 +19,8 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
+use Utils::Architectures;
 use utils;
 use version_utils 'is_sle';
 
@@ -152,9 +154,9 @@ sub validate_repos_sle {
     # verified in such a scenario.
     if (!(get_var('ONLINE_MIGRATION') || get_var('ZDUP'))) {
         # This is where we verify base product repos for SLES, SLED, and HA
-        my $uri = check_var('ARCH', 's390x') ? "ftp://" : "$cd:///";
+        my $uri = is_s390x ? "ftp://" : "$cd:///";
         if (check_var('FLAVOR', 'Server-DVD')) {
-            if (check_var("BACKEND", "ipmi") || check_var("BACKEND", "generalhw")) {
+            if (is_ipmi || check_var("BACKEND", "generalhw")) {
                 $uri = "http[s]*://.*suse";
             }
             elsif (get_var('USBBOOT') && is_sle('12-SP3+')) {
@@ -296,7 +298,7 @@ sub validate_repos_sle {
     # s390x can't use dvd media, only works with network repo
     if (get_var('ZDUP')) {
         my $uri;
-        if (get_var('TEST') =~ m{zdup_offline} and !check_var('ARCH', 's390x')) {
+        if (get_var('TEST') =~ m{zdup_offline} and !is_s390x) {
             $uri = "$dvd:///";
         }
         else {

--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -20,6 +20,7 @@
 
 use base "consoletest";
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils 'get_os_release';
 use strict;
@@ -40,7 +41,7 @@ sub run {
     my $testing_image = 'registry.opensuse.org/opensuse/leap';
 
     # Leap container image is missing in s390x
-    if ((check_var('ARCH', 's390x')) && ($testing_image =~ /leap/)) {
+    if ((is_s390x) && ($testing_image =~ /leap/)) {
         record_soft_failure("bsc#1171672 Missing Leap:latest container image for s390x");
         return 0;
     } else {

--- a/tests/cpu_bugs/l1tf.pm
+++ b/tests/cpu_bugs/l1tf.pm
@@ -17,6 +17,7 @@ use base "consoletest";
 use bootloader_setup;
 use strict;
 use testapi;
+use Utils::Backends;
 use utils;
 use power_action_utils 'power_action';
 
@@ -53,7 +54,7 @@ our %mitigations_list =
 
 sub run {
     my $self = shift;
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         record_info('softfail', "QEMU needn't run this testcase");
         return;
     }

--- a/tests/cpu_bugs/mds.pm
+++ b/tests/cpu_bugs/mds.pm
@@ -17,6 +17,7 @@ use base "consoletest";
 use bootloader_setup;
 use strict;
 use testapi;
+use Utils::Backends;
 use utils;
 use power_action_utils 'power_action';
 
@@ -58,7 +59,7 @@ sub smt_status_qemu {
 }
 
 sub run {
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         smt_status_qemu();
     }
     my $obj = Mitigation->new(\%mitigations_list);

--- a/tests/cpu_bugs/mds_taa.pm
+++ b/tests/cpu_bugs/mds_taa.pm
@@ -17,6 +17,7 @@ use base "consoletest";
 use bootloader_setup;
 use strict;
 use testapi;
+use Utils::Backends;
 use utils;
 use power_action_utils 'power_action';
 
@@ -92,7 +93,7 @@ sub run {
 
     if ($taa_vul_ret and $mds_vul_ret) {
         record_info("Both TAA and MDS", "Testing will continue.");
-        if (check_var('BACKEND', 'qemu')) {
+        if (is_qemu) {
             update_list_for_qemu();
         }
         my $mds_taa_obj = Mitigation->new(\%mds_taa_list);

--- a/tests/cpu_bugs/mitigations.pm
+++ b/tests/cpu_bugs/mitigations.pm
@@ -15,6 +15,7 @@ use warnings;
 use base "consoletest";
 use bootloader_setup;
 use testapi;
+use Utils::Backends;
 use utils;
 use power_action_utils 'power_action';
 use Data::Dumper;
@@ -66,7 +67,7 @@ sub run {
         my $current_list;
 
         #UPDATE list for QEMU first
-        if (check_var('BACKEND', 'qemu')) {
+        if (is_qemu) {
             mds::smt_status_qemu();
             taa::update_list_for_qemu();
         }
@@ -129,7 +130,7 @@ sub run {
                     $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Full generic retpoline,.*IBPB: conditional, IBRS_FW*";
                 }
             }
-            if (check_var('BACKEND', 'qemu')) {
+            if (is_qemu) {
                 #spectre_v2
                 if ($item eq 'spectre_v2') {
                     $mitigations_list{sysfs}->{auto}->{'spectre_v2'}         =~ s/STIBP: conditional/STIBP: disabled/g;
@@ -186,7 +187,7 @@ sub run {
     }
 
     #Handle itlb_multihit
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         if (get_var('MACHINE', '') =~ /passthrough/) {
             record_info("itlb_multihit Not affected", "itlb_multihit is not affected on qemu passthrough");
             $mitigations_list{sysfs}->{auto}->{'itlb_multihit'}         = "Not affected";

--- a/tests/cpu_bugs/spectre_v2.pm
+++ b/tests/cpu_bugs/spectre_v2.pm
@@ -18,6 +18,7 @@ use bootloader_setup;
 use ipmi_backend_utils;
 use power_action_utils 'power_action';
 use testapi;
+use Utils::Backends;
 use utils;
 
 use Mitigation;
@@ -50,7 +51,7 @@ our %mitigations_list =
   );
 sub run {
     my $obj = Mitigation->new(\%mitigations_list);
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         if (get_var('MACHINE', '') =~ /NO-IBRS$/) {
             $obj->check_cpu_flags();
             return;

--- a/tests/cpu_bugs/spectre_v2_user.pm
+++ b/tests/cpu_bugs/spectre_v2_user.pm
@@ -17,6 +17,7 @@ use base "consoletest";
 use bootloader_setup;
 use strict;
 use testapi;
+use Utils::Backends;
 use utils;
 use power_action_utils 'power_action';
 
@@ -51,7 +52,7 @@ our %mitigations_list =
   );
 
 sub run {
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         $mitigations_list{cpuflags} = ['ibpb'];
         $mitigations_list{sysfs}->{on}           =~ s/STIBP: forced/STIBP: disabled/g;
         $mitigations_list{sysfs}->{prctl}        =~ s/STIBP: conditional/STIBP: disabled/g;

--- a/tests/cpu_bugs/taa.pm
+++ b/tests/cpu_bugs/taa.pm
@@ -17,6 +17,7 @@ use base "Mitigation";
 use bootloader_setup;
 use ipmi_backend_utils;
 use testapi;
+use Utils::Backends;
 use utils;
 
 our $mitigations_list =
@@ -68,7 +69,7 @@ sub update_list_for_qemu {
 
 sub run {
     my ($self) = shift;
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         update_list_for_qemu();
     }
     my $obj = taa->new($mitigations_list);

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use Utils::Architectures 'is_aarch64';
+use Utils::Architectures;
 
 sub quit_firefox {
     send_key "alt-f4";

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -15,6 +15,7 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use lockapi;
 use hacluster;
 use version_utils qw(is_sles4sap);
@@ -27,7 +28,7 @@ sub run {
     # In ppc64le and aarch64, workers are slower
     my $timeout_scale = get_var('TIMEOUT_SCALE', 2);
     $timeout_scale = 2 if ($timeout_scale < 2);
-    set_var('TIMEOUT_SCALE', $timeout_scale) unless (check_var('ARCH', 'x86_64'));
+    set_var('TIMEOUT_SCALE', $timeout_scale) unless (is_x86_64);
 
     # Check cluster state *after* reboot
     barrier_wait("CHECK_AFTER_REBOOT_BEGIN_${cluster_name}_NODE${node_index}");

--- a/tests/ha/pacemaker_cts_regression.pm
+++ b/tests/ha/pacemaker_cts_regression.pm
@@ -15,6 +15,7 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils 'zypper_call';
 use hacluster;
 
@@ -26,7 +27,7 @@ sub run {
 
     # Some of the tests take longer to complete in aarch64.
     # This increases the timeout in that ARCH
-    $timeout *= 2 if check_var('ARCH', 'aarch64');
+    $timeout *= 2 if is_aarch64;
 
     zypper_call 'in pacemaker-cts';
 

--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -27,6 +27,7 @@ use base 'hpcbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 
 sub inject_error {
@@ -42,7 +43,7 @@ sub run {
     my $self = shift;
 
     # load kernel module
-    assert_script_run('modprobe mce-inject') if (check_var('ARCH', 'x86_64') && check_var('VERSION', '15-SP2'));
+    assert_script_run('modprobe mce-inject') if (is_x86_64 && check_var('VERSION', '15-SP2'));
 
     zypper_call('in rasdaemon');
 
@@ -79,7 +80,7 @@ sub run {
         && $empty_error_output =~ /PCIe AER errors/ && $empty_error_output =~ /No MCE errors/);
 
     # x86_64 check: Validating output of 'ras-mc-ctl --errors' after MCE error is injected
-    if (check_var('ARCH', 'x86_64') && check_var('VERSION', '15-SP2')) {
+    if (is_x86_64 && check_var('VERSION', '15-SP2')) {
         inject_error();
         my $error_output = script_output('ras-mc-ctl --errors');
         record_info('INFO', $error_output);

--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -49,7 +49,7 @@ use testapi;
 use lockapi;
 use mmapi;
 use utils;
-use Utils::Architectures 'is_arm';
+use Utils::Architectures;
 use version_utils qw(:VERSION :BACKEND is_sle is_leap is_sle_micro);
 use ipmi_backend_utils;
 
@@ -93,7 +93,7 @@ sub _set_timeout {
     ${$timeout} = 3600 if (check_var('VIRSH_VMM_FAMILY', 'vmware'));
 
     # aarch64 can be particularily slow depending on the hardware
-    ${$timeout} *= 2 if check_var('ARCH', 'aarch64') && get_var('MAX_JOB_TIME');
+    ${$timeout} *= 2 if is_aarch64 && get_var('MAX_JOB_TIME');
     # PPC HMC (Power9) performs very slow in general
     ${$timeout} *= 2 if check_var('BACKEND', 'pvm_hmc') && get_var('MAX_JOB_TIME');
     # encryption, LVM and RAID makes it even slower
@@ -124,7 +124,7 @@ sub run {
         # _timeout() adjusts the $timeout because upgrades are slower;
     }
     # on s390 we might need to install additional packages depending on the installation method
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         ssh_password_possibility();
         push(@tags, 'additional-packages');
     }
@@ -220,7 +220,7 @@ sub run {
     }
 
     # Stop reboot countdown where necessary for e.g. uploading logs
-    unless (check_var('REBOOT_TIMEOUT', 0) || get_var("REMOTE_CONTROLLER") || is_microos || (is_sle('=11-sp4') && check_var('ARCH', 's390x') && check_var('BACKEND', 's390x'))) {
+    unless (check_var('REBOOT_TIMEOUT', 0) || get_var("REMOTE_CONTROLLER") || is_microos || (is_sle('=11-sp4') && is_s390x && check_var('BACKEND', 's390x'))) {
         # Depending on the used backend the initial key press to stop the
         # countdown might not be evaluated correctly or in time. In these
         # cases we keep hitting the keys until the countdown stops.

--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -18,6 +18,7 @@ use strict;
 use warnings FATAL => 'all';
 use base "installbasetest";
 use testapi;
+use Utils::Backends;
 use utils;
 use bootloader;
 use bootloader_uefi;
@@ -52,7 +53,7 @@ sub run {
             return;
         }
     }
-    if (check_var('BACKEND', 'svirt') && is_x86_64()) {
+    if (is_svirt && is_x86_64()) {
         set_bridged_networking();
         if (is_hyperv()) {
             record_info('bootloader_hyperv');
@@ -68,7 +69,7 @@ sub run {
     }
     # Load regular bootloader for all qemu backends and for x84_86 systems,
     # except Xen PV as id does not have VNC (bsc#961638).
-    if (check_var('BACKEND', 'qemu') || (check_var('BACKEND', 'svirt') && !(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')))) {
+    if (is_qemu || (is_svirt && !(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')))) {
         if (get_var('UEFI')) {
             unless (get_var('BOOT_HDD_IMAGE')) {
                 record_info('bootloader_uefi');

--- a/tests/installation/data_integrity.pm
+++ b/tests/installation/data_integrity.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use data_integrity_utils 'verify_checksum';
-use Utils::Backends 'is_svirt_except_s390x';
+use Utils::Backends;
 
 sub run {
     # If variable is set, we only inform about it

--- a/tests/installation/handle_reboot.pm
+++ b/tests/installation/handle_reboot.pm
@@ -18,7 +18,8 @@ use strict;
 use warnings;
 use grub_utils qw(grub_test);
 use testapi;
-use Utils::Backends 'is_remote_backend';
+use Utils::Architectures;
+use Utils::Backends;
 use utils qw(reconnect_mgmt_console);
 
 sub run {
@@ -27,7 +28,7 @@ sub run {
         reconnect_mgmt_console();
     }
 
-    unless (check_var('ARCH', 's390x') || check_var('BACKEND', 'ipmi')) {
+    unless (is_s390x || is_ipmi) {
         record_info 'Handle GRUB';
         grub_test();
     }

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -20,7 +20,7 @@ use bmwqemu;
 use ipmi_backend_utils;
 use version_utils 'is_upgrade';
 use bootloader_setup 'prepare_disks';
-use Utils::Architectures qw(is_aarch64);
+use Utils::Architectures;
 
 use HTTP::Tiny;
 use IPC::Run;

--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -25,7 +25,7 @@ use version_utils "is_upgrade";
 use strict;
 use warnings;
 use x11utils 'turn_off_kde_screensaver';
-use Utils::Architectures qw(is_aarch64);
+use Utils::Architectures;
 
 sub send_key_and_wait {
     my ($key, $wait_time) = @_;

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -24,6 +24,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use lockapi;
 use utils;
 use Utils::Backends 'use_ssh_serial_console';
@@ -51,7 +52,7 @@ sub run {
             set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));
             set_serial_console_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE', 'kvm'));
             adjust_for_ipmi_xen('/mnt')                 if (get_var('REGRESSION') && (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')));
-            set_pxe_efiboot('/mnt')                     if check_var('ARCH', 'aarch64');
+            set_pxe_efiboot('/mnt')                     if is_aarch64;
         }
     }
     else {

--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -15,6 +15,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
 use version_utils qw(is_storage_ng is_sle);
 use partition_setup 'select_first_hard_disk';
 
@@ -24,7 +25,7 @@ sub run {
     wait_screen_change { send_key $cmd{guidedsetup} };
     # Process disk selection if screen is shown. Is relevant for ipmi only as have
     # multiple disks attached there which might contain previous installation
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         assert_screen([qw(select-hard-disks partition-scheme)]);
         select_first_hard_disk if match_has_tag 'select-hard-disks';
     }

--- a/tests/installation/partitioning_smalldisk_storageng.pm
+++ b/tests/installation/partitioning_smalldisk_storageng.pm
@@ -16,6 +16,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
 use version_utils qw(is_storage_ng);
 use partition_setup qw(take_first_disk);
 
@@ -86,7 +87,7 @@ sub run {
 
     assert_screen [qw(existing-partitions partition-scheme)];
     if (match_has_tag 'existing-partitions') {
-        if (check_var('BACKEND', 'ipmi') && !check_var('VIDEOMODE', 'text')) {
+        if (is_ipmi && !check_var('VIDEOMODE', 'text')) {
             send_key_until_needlematch("remove-menu", "tab");
             while (check_screen('remove-menu', 3)) {
                 send_key 'spc';

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -23,6 +23,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use partition_setup qw(create_new_partition_table addpart addboot);
 use version_utils qw(is_opensuse is_storage_ng);
 
@@ -35,16 +36,16 @@ sub process_warning {
 
 sub process_missing_special_partitions {
     # Have missing boot/zipl partition warning only in storage_ng
-    if (is_storage_ng && check_var('ARCH', 's390x')) {    # s390x needs /boot/zipl on ext partition
+    if (is_storage_ng && is_s390x) {    # s390x needs /boot/zipl on ext partition
         process_warning(warning => 'no-boot-zipl', key => 'alt-n');
     }
-    elsif (check_var('ARCH', 'ppc64le')) {                # ppc64le needs PReP /boot
+    elsif (is_ppc64le) {                # ppc64le needs PReP /boot
         process_warning(warning => 'no-prep-boot', key => 'alt-n');
     }
     elsif (get_var('UEFI')) {
         process_warning(warning => 'no-efi-boot', key => 'alt-n');
     }
-    elsif (is_storage_ng() && check_var('ARCH', 'x86_64')) {
+    elsif (is_storage_ng() && is_x86_64) {
         # Storage-ng has GPT by defaut, so warn about missing bios-boot partition for legacy boot, which is only on x86_64
         process_warning(warning => 'no-bios-boot', key => 'alt-n');
     }
@@ -126,13 +127,13 @@ sub run {
             process_warning(warning => 'no-swap', key => 'alt-n');
         }
         else {
-            if (!check_var('ARCH', 'ppc64le')) {
+            if (!is_ppc64le) {
                 record_info('Test: Snapshots + small root', 'Enable snapshots for undersized root partition');
                 process_warning(warning => 'too-small-for-snapshots', key => 'alt-n');
             }
             record_info('Test: No boot', "Missing boot partition for " . get_var('ARCH'));
             process_missing_special_partitions;
-            if (check_var('ARCH', 'ppc64le')) {
+            if (is_ppc64le) {
                 record_info('Test: Snapshots + small root', 'Enable snapshots for undersized root partition');
                 process_warning(warning => 'too-small-for-snapshots', key => 'alt-n');
             }

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -15,6 +15,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use version_utils qw(is_sle is_microos);
 
 sub run {
@@ -74,7 +75,7 @@ sub run {
     # no relnotes for ltss in QAM_MINIMAL
     push @no_relnotes, qw(ltss) if get_var('QAM_MINIMAL');
     # no HA-GEO release-notes for s390x on SLE12-SP1 GM media, see bsc#1033504
-    if (check_var('ARCH', 's390x') and check_var('BASE_VERSION', '12-SP1')) {
+    if (is_s390x and check_var('BASE_VERSION', '12-SP1')) {
         push @no_relnotes, qw(geo);
     }
     if (@addons) {

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -21,8 +21,8 @@
 use strict;
 use warnings;
 use base "installbasetest";
-use Utils::Backends qw(is_svirt is_ssh_installation);
-use Utils::Architectures qw(is_s390x);
+use Utils::Backends;
+use Utils::Architectures;
 use testapi;
 use YuiRestClient;
 

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use lockapi;
 use testapi;
+use Utils::Architectures;
 use mmapi;
 use version_utils qw(is_sle is_upgrade);
 
@@ -108,7 +109,7 @@ sub run {
         && !get_var("NICEVIDEO")
         && !get_var("UPGRADE")
         && !check_var('VIDEOMODE', 'text')
-        && (!is_sle('=11-sp4') || !check_var('ARCH', 's390x') || !check_var('BACKEND', 's390x')))
+        && (!is_sle('=11-sp4') || !is_s390x || !check_var('BACKEND', 's390x')))
     {
         my $counter = 20;
         while ($counter--) {

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -17,6 +17,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use version_utils qw(is_sle is_opensuse is_microos is_sle_micro);
 
 my %role_hotkey = (
@@ -73,10 +74,10 @@ sub assert_system_role {
 }
 
 sub run {
-    if (is_sle('=12-SP5') && !check_var('ARCH', 'x86_64')) {
+    if (is_sle('=12-SP5') && !is_x86_64) {
         record_info("Skip screen", "System Role screen is displayed only for x86_64 in SLE-12-SP5 due to it has more than one role available");
     }
-    elsif (check_var('ARCH', 'aarch64') && is_sle('>=12-SP3') && is_sle('<15')) {
+    elsif (is_aarch64 && is_sle('>=12-SP3') && is_sle('<15')) {
         record_info("Skip screen", "System Role screen is  not displayed on aarch64 between 12SP3 and 12SP5");
     }
     else {

--- a/tests/installation/system_workarounds.pm
+++ b/tests/installation/system_workarounds.pm
@@ -13,13 +13,14 @@
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use base 'opensusebasetest';
 
 sub run {
     select_console('root-console');
 
     # boo#1105302 - Disable kernel watchdog on aarch64 (for running system and for next boot)
-    if (check_var('ARCH', 'aarch64')) {
+    if (is_aarch64) {
         record_info('boo#1105302', "Disable kernel watchdog to avoid test failures due to 'watchdog: BUG: soft lockup - CPU#0 stuck for XXs!'");
         assert_script_run('echo 0 > /proc/sys/kernel/watchdog_thresh');
         assert_script_run('echo "kernel.watchdog_thresh = 0" > /etc/sysctl.d/watchdog.conf');

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -114,7 +114,7 @@ sub run {
     while ($iterations++ < scalar(@welcome_tags)) {
         # See poo#19832, sometimes manage to match same tag twice and test fails due to broken sequence
         wait_still_screen 5;
-        my $timeout = check_var('ARCH', 'aarch64') ? '1000' : '500';
+        my $timeout = is_aarch64 ? '1000' : '500';
         assert_screen(\@welcome_tags, $timeout);
         # Normal exit condition
         if ((match_has_tag 'inst-betawarning') || (match_has_tag 'inst-welcome') || (match_has_tag 'inst-welcome-no-product-list')) {

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils qw(is_sle is_tumbleweed is_leap is_opensuse);
-use Utils::Architectures qw(is_aarch64 is_x86_64);
+use Utils::Architectures;
 use Utils::Backends 'is_hyperv';
 use jeos qw(expect_mount_by_uuid);
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);

--- a/tests/jeos/flash_rpi_firmware_workaround.pm
+++ b/tests/jeos/flash_rpi_firmware_workaround.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use Utils::Architectures 'is_aarch64';
+use Utils::Architectures;
 
 sub run {
     my ($self) = @_;

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -16,6 +16,7 @@ use 5.018;
 use warnings;
 use base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use LTP::utils;
 use version_utils 'is_jeos';
 use utils 'assert_secureboot_status';
@@ -25,7 +26,7 @@ sub run {
     my $cmd_file = get_var('LTP_COMMAND_FILE') || '';
 
     # Use standard boot for ipmi backend with IPXE
-    if (check_var('BACKEND', 'ipmi') && !get_var('IPXE_CONSOLE')) {
+    if (is_ipmi && !get_var('IPXE_CONSOLE')) {
         record_info('INFO', 'IPMI boot');
         select_console 'sol', await_console => 0;
         assert_screen('linux-login', 1800);

--- a/tests/kernel/install_klp_product.pm
+++ b/tests/kernel/install_klp_product.pm
@@ -20,7 +20,7 @@ use testapi;
 use utils;
 use klp;
 use power_action_utils 'power_action';
-use Utils::Architectures qw(is_s390x);
+use Utils::Architectures;
 use Utils::Backends qw(is_pvm);
 
 sub do_reboot {

--- a/tests/kernel/install_kotd.pm
+++ b/tests/kernel/install_kotd.pm
@@ -15,6 +15,7 @@ use 5.018;
 use warnings;
 use base "opensusebasetest";
 use testapi;
+use Utils::Backends;
 use utils;
 use kernel;
 use power_action_utils 'power_action';
@@ -23,7 +24,7 @@ sub run {
     my $self = shift;
     $self->wait_boot;
     # Use root-console for KOTD installation on svirt instead of root-sut-serial poo#54275
-    check_var('BACKEND', 'svirt') ? select_console('root-console') : $self->select_serial_terminal;
+    is_svirt ? select_console('root-console') : $self->select_serial_terminal;
     # Get url of kotd/kmp repositories
     my $kotd_repo = get_required_var('KOTD_REPO');
     my $kmp_repo  = get_var('KMP_REPO');

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -24,7 +24,7 @@ use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
 use upload_system_log;
 use version_utils qw(is_jeos is_opensuse is_released is_sle is_leap is_tumbleweed);
-use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x is_x86_64);
+use Utils::Architectures;
 use Utils::Systemd qw(systemctl disable_and_stop_service);
 use LTP::utils;
 

--- a/tests/kernel/mellanox_config.pm
+++ b/tests/kernel/mellanox_config.pm
@@ -19,6 +19,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
 use utils;
 use ipmi_backend_utils;
 use power_action_utils 'power_action';
@@ -38,7 +39,7 @@ sub run {
 
     # right now, this code will only do something reasonable if we
     # run on a baremetal machine (and thus on IPMI backend)
-    return unless check_var('BACKEND', 'ipmi');
+    return unless is_ipmi;
 
     $self->select_serial_terminal;
 

--- a/tests/kernel/mellanox_ofed.pm
+++ b/tests/kernel/mellanox_ofed.pm
@@ -20,6 +20,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
 use utils;
 use version_utils 'is_sle';
 
@@ -46,7 +47,7 @@ sub run {
     assert_script_run("wget $ofed_url");
     assert_script_run("tar -xvf $ofed_file_tgz");
     assert_script_run("cd $ofed_dir");
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         record_info('INFO', 'OFED install');
         assert_script_run("./mlnxofedinstall --skip-distro-check --add-kernel-support --with-mft --with-mstflint --dpdk --upstream-libs", timeout => 2000);
         assert_script_run("modprobe -rv rpcrdma");

--- a/tests/kernel/pressure_stall_information.pm
+++ b/tests/kernel/pressure_stall_information.pm
@@ -16,7 +16,7 @@ use warnings;
 use testapi;
 use power_action_utils 'power_action';
 use bootloader_setup 'add_grub_cmdline_settings';
-use Utils::Architectures 'is_s390x';
+use Utils::Architectures;
 
 sub boot {
     my $self = shift;

--- a/tests/kernel/proc_sys_dump.pm
+++ b/tests/kernel/proc_sys_dump.pm
@@ -21,7 +21,7 @@ use testapi qw(is_serial_terminal :DEFAULT);
 use utils;
 use serial_terminal;
 require bmwqemu;
-use Utils::Architectures 'is_aarch64';
+use Utils::Architectures;
 
 sub run {
     my ($self)         = @_;

--- a/tests/kernel/tuned.pm
+++ b/tests/kernel/tuned.pm
@@ -16,6 +16,7 @@ use base 'consoletest';
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
 use utils;
 use version_utils qw(is_sle is_tumbleweed);
 
@@ -41,7 +42,7 @@ sub run {
     # Check status
     systemctl 'status tuned';
     # Set virtual-guest profile for QEMU backends and throughput-performance for the rest
-    tuned_set_profile(check_var('BACKEND', 'qemu') ? 'virtual-guest' : 'throughput-performance');
+    tuned_set_profile(is_qemu ? 'virtual-guest' : 'throughput-performance');
     # Stop tuned daemon
     systemctl 'stop tuned';
     # Delete and ignore logs from first run without proper profile set

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -24,7 +24,7 @@ use kernel 'remove_kernel_packages';
 use klp;
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends;
 
 sub check_kernel_package {
     my $kernel_name = shift;
@@ -388,7 +388,7 @@ sub install_kotd {
 sub boot_to_console {
     my ($self) = @_;
 
-    select_console('sol', await_console => 0) if check_var('BACKEND', 'ipmi');
+    select_console('sol', await_console => 0) if is_ipmi;
     $self->wait_boot;
     $self->select_serial_terminal;
 }
@@ -396,7 +396,7 @@ sub boot_to_console {
 sub run {
     my $self = shift;
 
-    if (check_var('BACKEND', 'ipmi') && get_var('LTP_BAREMETAL')) {
+    if (is_ipmi && get_var('LTP_BAREMETAL')) {
         # System is already booted after installation, just switch terminal
         $self->select_serial_terminal;
     } else {

--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -17,6 +17,7 @@ use strict;
 use warnings;
 use utils;
 use testapi;
+use Utils::Architectures;
 use repo_tools 'add_qa_head_repo';
 
 sub install_pkg {
@@ -83,7 +84,7 @@ sub run {
     }
     install_pkg;
     setup_environment;
-    if (check_var('ARCH', 'ppc64le')) {
+    if (is_ppc64le) {
         power_action('reboot', keepconsole => 1, textmode => 1);
     } else {
         power_action('poweroff', keepconsole => 1, textmode => 1);

--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -15,6 +15,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use migration;
 use version_utils 'is_sle';
@@ -59,7 +60,7 @@ sub run {
     # solve conflict during online migration with live patching addon
     remove_kgraft_patch if is_sle('<15');
     # create btrfs subvolume for aarch64 before migration
-    create_btrfs_subvolume() if (check_var('ARCH', 'aarch64'));
+    create_btrfs_subvolume() if (is_aarch64);
 }
 
 sub test_flags {

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -15,6 +15,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils;
 use power_action_utils 'power_action';
@@ -221,7 +222,7 @@ sub run {
     if (get_var('SMT_URL') =~ /smt/) {
         assert_screen 'import-untrusted-gpg-key', 60;
         send_key 'alt-t';
-        if ((check_var('ARCH', 'x86_64')) && (!(is_leap_migration)) || (check_var('ARCH', 'aarch64'))) {
+        if ((is_x86_64) && (!(is_leap_migration)) || (is_aarch64)) {
             assert_screen 'import-untrusted-gpg-key-nvidia', 300;
             send_key 'alt-t';
         }

--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -17,6 +17,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use Utils::Backends 'is_pvm';
 
@@ -32,13 +33,13 @@ sub run {
     # Aarch64 need BOOT_HDD_IMAGE=1 to keep the correct flow to boot from disk for x11/reboot_gnome.
     # but in Aarch64 zdup migration we need to set it to 0, this will make it boot from hard disk.
     if (get_var('UPGRADE') || get_var('AUTOUPGRADE')) {
-        set_var('BOOT_HDD_IMAGE', 0) unless (check_var('ARCH', 'aarch64') && !check_var('ZDUP', '1'));
+        set_var('BOOT_HDD_IMAGE', 0) unless (is_aarch64 && !check_var('ZDUP', '1'));
     }
     assert_script_run "sync", 300;
     enter_cmd "reboot";
 
     # After remove -f for reboot, we need wait more time for boot menu and avoid exception during reboot caused delay to boot up.
-    assert_screen('inst-bootmenu', 300) unless (check_var('ARCH', 's390x') || is_pvm);
+    assert_screen('inst-bootmenu', 300) unless (is_s390x || is_pvm);
 }
 
 1;

--- a/tests/nfv/prepare_env.pm
+++ b/tests/nfv/prepare_env.pm
@@ -21,6 +21,7 @@
 
 use base "opensusebasetest";
 use testapi;
+use Utils::Backends;
 use strict;
 use warnings;
 use utils;
@@ -102,7 +103,7 @@ sub run {
     record_info("INFO", "Wait for mutex NFV_TRAFFICGEN_READY");
     mutex_wait('NFV_TRAFFICGEN_READY', $child_id);
 
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         # Generate ssh keypair and ssh-copy-id to the Traffic generator machine
         record_info("INFO", "Grant SSH access to trafficgen machine $trafficgen_ip");
         assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ~/.ssh/id_rsa');

--- a/tests/nfv/run_performance_tests.pm
+++ b/tests/nfv/run_performance_tests.pm
@@ -12,6 +12,7 @@
 
 use base "opensusebasetest";
 use testapi;
+use Utils::Backends;
 use strict;
 use warnings;
 use lockapi;
@@ -26,9 +27,9 @@ sub run_test {
     my $cmd      = "./vsperf --conf-file=/root/vswitchperf/conf/10_custom.conf --vswitch $vswitch $test";
     record_info("INFO", "Running test case $testname");
     record_info("INFO", "Command to run: $cmd");
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         assert_script_run($cmd, timeout => 60 * 60 * 1.5);
-    } elsif (check_var('BACKEND', 'qemu')) {
+    } elsif (is_qemu) {
         record_info("INFO", "Skip test as this is a virtual environment. Generate dummy results instead.");
         assert_script_run("mkdir -p $results_dir/results_dummy");
         assert_script_run("curl " . data_url('nfv/result_0_dummy.csv') . " -o $results_dir/results_dummy/result_0_dummy.csv");

--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -13,6 +13,7 @@
 
 use base "opensusebasetest";
 use testapi;
+use Utils::Backends;
 use strict;
 use warnings;
 use utils;
@@ -44,7 +45,7 @@ sub run {
     assert_script_run("sed -i 's/PORT_1/$PORT_2/' -i $trex_conf");
     assert_script_run("cat $trex_conf");
 
-    if (check_var('BACKEND', 'ipmi')) {
+    if (is_ipmi) {
         record_info("INFO", "Bring Mellanox interfaces up");
         assert_script_run("ip link set dev eth2 up");
         assert_script_run("ip link set dev eth3 up");

--- a/tests/nfv/trex_runner.pm
+++ b/tests/nfv/trex_runner.pm
@@ -13,6 +13,7 @@
 
 use base "opensusebasetest";
 use testapi;
+use Utils::Backends;
 use strict;
 use warnings;
 use utils;
@@ -26,7 +27,7 @@ sub run {
 
     record_info("INFO", "Start TREX in background");
     script_run("cd /tmp/trex-core");
-    enter_cmd("nohup bash /tmp/trex-core/t-rex-64 -i &") if (check_var('BACKEND', 'ipmi'));
+    enter_cmd("nohup bash /tmp/trex-core/t-rex-64 -i &") if (is_ipmi);
 
     record_info("INFO", "Wait for NFV tests to be completed. Waiting for Mutex NFV_TESTING_DONE");
     mutex_wait('NFV_TESTING_DONE');

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -25,6 +25,7 @@ use strict;
 use warnings;
 use utils;
 use testapi;
+use Utils::Architectures;
 use qam;
 use Utils::Backends 'use_ssh_serial_console';
 use power_action_utils qw(power_action);
@@ -47,7 +48,7 @@ sub run {
     if (is_jeos) {
         record_info('Updates', script_output('zypper lu'));
         zypper_call('up', timeout => 300);
-        if (check_var('ARCH', 'aarch64')) {
+        if (is_aarch64) {
             # Disable grub timeout for aarch64 cases so that the test doesn't stall
             assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub");
             assert_script_run('grub2-mkconfig -o /boot/grub2/grub.cfg');

--- a/tests/qemu/kvm.pm
+++ b/tests/qemu/kvm.pm
@@ -14,17 +14,18 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
+use Utils::Architectures;
 use utils;
 
 
 sub run {
     select_console 'root-console';
 
-    if (check_var('ARCH', 'x86_64')) {
+    if (is_x86_64) {
         enter_cmd "qemu-system-x86_64 -nographic -enable-kvm";
         assert_screen 'qemu-no-bootable-device', 60;
     }
-    elsif (check_var('ARCH', 'ppc64le')) {
+    elsif (is_ppc64le) {
         enter_cmd "qemu-system-ppc64 -nographic -enable-kvm";
         assert_screen ['qemu-open-firmware-ready', 'qemu-does-not-support-1tib-segments', 'qemu-ppc64-no-trans-mem'], 60;
         if (match_has_tag 'qemu-does-not-support-1tib-segments') {
@@ -38,11 +39,11 @@ sub run {
             assert_screen 'qemu-open-firmware-ready', 60;
         }
     }
-    elsif (check_var('ARCH', 's390x')) {
+    elsif (is_s390x) {
         enter_cmd "qemu-system-s390x -nographic -enable-kvm -kernel /boot/image -initrd /boot/initrd";
         assert_screen 'qemu-reached-target-basic-system', 60;
     }
-    elsif (check_var('ARCH', 'aarch64')) {
+    elsif (is_aarch64) {
         enter_cmd "qemu-system-aarch64 -M virt,usb=off,gic-version=host -cpu host -enable-kvm -nographic -pflash flash0.img -pflash flash1.img";
         assert_screen 'qemu-uefi-shell', 600;
     }

--- a/tests/qemu/qemu.pm
+++ b/tests/qemu/qemu.pm
@@ -14,9 +14,10 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
+use Utils::Backends;
 use utils;
 use transactional qw(trup_call check_reboot_changes);
-use Utils::Architectures qw(is_x86_64 is_ppc64le is_s390x is_aarch64);
+use Utils::Architectures;
 use version_utils qw(is_sle_micro is_transactional);
 
 # 'patterns-microos-kvm_host' is required for SUMA client use case

--- a/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
+++ b/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
@@ -23,11 +23,12 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 
 sub run {
     # check the kernel configuration file to make sure the parameter is there
-    if (!check_var('ARCH', 's390x')) {
+    if (!is_s390x) {
         validate_script_output "cat /boot/config-`uname -r`|grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
     }
     else {

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -23,7 +23,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
-use Utils::Architectures 'is_x86_64';
+use Utils::Architectures;
 
 sub run {
     select_console "root-console";

--- a/tests/security/test_repo_setup.pm
+++ b/tests/security/test_repo_setup.pm
@@ -21,6 +21,7 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils "is_sle";
 use registration qw(cleanup_registration register_product add_suseconnect_product);
@@ -56,7 +57,7 @@ sub run {
             register_product;
 
             # WE addon registration (according to the conditions)
-            if (get_var("SECTEST_REQUIRE_WE") && check_var("ARCH", "x86_64")) {
+            if (get_var("SECTEST_REQUIRE_WE") && is_x86_64) {
                 # Register Desktop module as a dependency
                 add_suseconnect_product('sle-module-desktop-applications');
 
@@ -89,11 +90,11 @@ sub run {
 
     repo_cleanup;
 
-    if (!check_var('ARCH', 's390x')) {
+    if (!is_s390x) {
         # Add all available ISO images can be found
         my $sr_out = script_output("cd /dev && ls -1 sr* && cd", proceed_on_failure => 1);
         if ($sr_out =~ /No such file/) {
-            die "DVD images not found!" if (!check_var('ARCH', 'x86_64'));
+            die "DVD images not found!" if (!is_x86_64);
         } else {
             foreach my $sr (split("\n", $sr_out)) {
                 zypper_call("ar dvd:///?devices=/dev/$sr $sr");

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -25,7 +25,7 @@ use testapi;
 use serial_terminal 'prepare_serial_console';
 use utils;
 use version_utils;
-use Utils::Backends qw(is_qemu is_image_backend);
+use Utils::Backends;
 
 sub run {
     select_console('root-console');

--- a/tests/shutdown/grub_set_bootargs.pm
+++ b/tests/shutdown/grub_set_bootargs.pm
@@ -21,6 +21,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 
 sub run {
     select_console('root-console');
@@ -38,7 +39,7 @@ sub run {
 
     # Slow type for 12-SP2 aarch64 image creation test to try to avoid filling up the key event queue
     for my $cmd (@cmds) {
-        if (check_var('ARCH', 'aarch64') && check_var('VERSION', '12-SP2')) {
+        if (is_aarch64 && check_var('VERSION', '12-SP2')) {
             enter_cmd $cmd . " ; echo cmd-\$? > /dev/$testapi::serialdev", wait_screen_change => 1;
             wait_serial "cmd-0";
         }

--- a/tests/sles4sap/forkbomb.pm
+++ b/tests/sles4sap/forkbomb.pm
@@ -13,6 +13,7 @@
 
 use base "sles4sap";
 use testapi;
+use Utils::Backends;
 use strict;
 use warnings;
 
@@ -21,7 +22,7 @@ sub run {
 
     # NOTE: Do not call this function on the qemu backend
     # The first forkbomb can create 3 times as many processes as the second due to unknown bug
-    return if check_var('BACKEND', 'qemu');
+    return if is_qemu;
 
     $self->select_serial_terminal;
 

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -14,7 +14,7 @@
 use base "sles4sap";
 use testapi;
 use version_utils qw(is_staging is_sle is_upgrade);
-use Utils::Architectures 'is_x86_64';
+use Utils::Architectures;
 use Utils::Systemd 'systemctl';
 use strict;
 use warnings;

--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -12,6 +12,7 @@
 
 use base "sles4sap";
 use testapi;
+use Utils::Backends;
 use utils;
 use version_utils 'is_sle';
 use Utils::Architectures;
@@ -52,7 +53,7 @@ sub setup {
     assert_script_run "sed -i.bak '/^@/,\$d' /etc/security/limits.conf";
     script_run "mv /etc/systemd/logind.conf.d/sap.conf{,.bak}" unless check_var('DESKTOP', 'textmode');
     assert_script_run 'saptune daemon start';
-    if (check_var('BACKEND', 'qemu')) {
+    if (is_qemu) {
         # Ignore disk_elevator on VM's
         assert_script_run "sed -ri '/:scripts\\/disk_elevator/s/^/#/' \$(fgrep -rl :scripts/disk_elevator Pattern/)";
         # Skip nr_requests on VM's. Fix bsc#1177888
@@ -362,7 +363,7 @@ sub test_solutions {
 sub test_ppc64le {
     my ($self) = @_;
 
-    die "This test cannot be run on QEMU" if (check_var('BACKEND', 'qemu'));
+    die "This test cannot be run on QEMU" if (is_qemu);
     my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
 
     assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Power_1";
@@ -435,7 +436,7 @@ sub run {
         $self->test_note($test) if ($test ne "1805750");
         $self->test_override($test);
     } elsif ($test =~ m/^(x86_64|ppc64le)$/) {
-        $self->test_x86_64     if (check_var('BACKEND', 'ipmi'));
+        $self->test_x86_64     if (is_ipmi);
         $self->test_ppc64le    if is_ppc64le();
         $self->test_bsc1152598 if is_sle('>12-SP3');
     } elsif ($test eq "delete_rename") {

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -39,6 +39,7 @@ use warnings;
 use base 'basetest';
 use lockapi;
 use testapi;
+use Utils::Architectures;
 use utils;
 use mm_network;
 use mm_tests;
@@ -585,7 +586,7 @@ sub run {
     if (exists $server_roles{pxe}) {
         # PXE server cannot be configured on other ARCH than x86_64
         # because 'syslinux' package only exists on it
-        die "PXE server is only supported on x86_64 architecture" unless check_var('ARCH', 'x86_64');
+        die "PXE server is only supported on x86_64 architecture" unless is_x86_64;
         setup_dhcp_server((exists $server_roles{dns}), 1);
         setup_pxe_server();
         setup_tftp_server();

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -13,6 +13,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use version_utils qw(is_sle is_desktop_installed is_upgrade is_sles4sap);
 use migration;
@@ -85,7 +86,7 @@ sub patching_sle {
     install_salt_packages() if (check_var_array('SCC_ADDONS', 'asmm'));
 
     # create btrfs subvolume for aarch64
-    create_btrfs_subvolume() if (check_var('ARCH', 'aarch64'));
+    create_btrfs_subvolume() if (is_aarch64);
 
     # Remove test repos after system being patched
     remove_test_repositories;

--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -14,11 +14,12 @@ use base "virt_autotest_base";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use virt_utils;
 
 sub get_script_run {
     my $pre_test_cmd = "";
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
     }
     else {
@@ -69,7 +70,7 @@ sub run {
 
     # Add option to keep guest after successful installation
     # Only for x86_64 now
-    if (check_var('ARCH', 'x86_64')) {
+    if (is_x86_64) {
         assert_script_run("sed -i 's/vm-install.sh/vm-install\.sh -g -k /' /usr/share/qa/qa_test_virtualization/installos");
         assert_script_run("sed -i 's/virt-install.sh/virt-install\.sh -u /' /usr/share/qa/qa_test_virtualization/virt_installos");
         assert_script_run('cat /usr/share/qa/qa_test_virtualization/installos | grep vm-install');
@@ -85,7 +86,7 @@ sub run {
 
     my $upload_guest_assets_flag = 'no';
     # Only enable UPLOAD_GUEST_ASSETS for x86_64 now
-    if (check_var('UPLOAD_GUEST_ASSETS', '1') && check_var('ARCH', 'x86_64')) {
+    if (check_var('UPLOAD_GUEST_ASSETS', '1') && is_x86_64) {
         $upload_guest_assets_flag = 'yes';
     }
 

--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -13,6 +13,7 @@
 use base "host_upgrade_base";
 #use virt_utils qw(set_serialdev);
 use testapi;
+use Utils::Architectures;
 use strict;
 use warnings;
 use virt_utils;
@@ -32,7 +33,7 @@ sub post_execute_script_configuration {
     my $self = shift;
 
     #online upgrade actually
-    if (is_remote_backend && check_var('ARCH', 'aarch64') && is_installed_equal_upgrade_major_release) {
+    if (is_remote_backend && is_aarch64 && is_installed_equal_upgrade_major_release) {
         set_serial_console_on_vh('', '', 'kvm');
         set_pxe_efiboot('');
     }

--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -17,7 +17,7 @@ use utils "zypper_call";
 use virt_utils;
 use strict;
 use warnings;
-use Utils::Architectures qw(is_x86_64 is_aarch64);
+use Utils::Architectures;
 use version_utils 'is_sle';
 
 sub get_script_run {

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -15,6 +15,7 @@ use warnings;
 use base "virt_autotest_base";
 use virt_autotest::utils;
 use testapi;
+use Utils::Architectures;
 use virt_utils;
 use utils;
 use Utils::Backends 'is_remote_backend';
@@ -29,7 +30,7 @@ sub install_package {
         set_var('QA_HEAD_REPO', $qa_server_repo);
         bmwqemu::save_vars();
     }
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         lpar_cmd("zypper --non-interactive rr server-repo");
         lpar_cmd("zypper --non-interactive --no-gpg-checks ar -f '$qa_server_repo' server-repo");
     }
@@ -57,7 +58,7 @@ sub install_package {
     }
 
     if ($dependency_repo) {
-        if (check_var('ARCH', 's390x')) {
+        if (is_s390x) {
             lpar_cmd("zypper --non-interactive --no-gpg-checks ar -f ${dependency_repo} dependency_repo");
             lpar_cmd("zypper --non-interactive --gpg-auto-import-keys ref");
             lpar_cmd("zypper --non-interactive in $dependency_rpms");
@@ -72,13 +73,13 @@ sub install_package {
     }
 
     ###Install KVM role patterns for aarch64 virtualization host
-    if (is_remote_backend && check_var('ARCH', 'aarch64')) {
+    if (is_remote_backend && is_aarch64) {
         zypper_call("--gpg-auto-import-keys ref",         timeout => 180);
         zypper_call("in -t pattern kvm_server kvm_tools", timeout => 300);
     }
 
     #install qa_lib_virtauto
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         lpar_cmd("zypper --non-interactive --gpg-auto-import-keys ref");
         my $pkg_lib_data = "qa_lib_virtauto-data";
         my $cmd          = "rpm -q $pkg_lib_data";

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use File::Basename;
 use testapi;
+use Utils::Architectures;
 use Utils::Backends qw(use_ssh_serial_console is_remote_backend set_ssh_console_timeout);
 use ipmi_backend_utils;
 use virt_autotest::utils qw(is_xen_host);
@@ -38,7 +39,7 @@ sub login_to_console {
     $timeout //= 5;
     $counter //= 240;
 
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         #Switch to s390x lpar console
         reset_consoles;
         my $svirt = select_console('svirt', await_console => 0);
@@ -47,7 +48,7 @@ sub login_to_console {
 
     reset_consoles;
     reset_consoles;
-    if (is_remote_backend && check_var('ARCH', 'aarch64') && get_var('IPMI_HW') eq 'thunderx') {
+    if (is_remote_backend && is_aarch64 && get_var('IPMI_HW') eq 'thunderx') {
         select_console 'sol', await_console => 1;
         send_key 'ret';
         ipmi_backend_utils::ipmitool 'chassis power reset';
@@ -146,7 +147,7 @@ sub login_to_console {
     }
 
     # Set ssh console timeout for thunderx machine
-    set_ssh_console_timeout_before_use if (is_remote_backend && check_var('ARCH', 'aarch64') && get_var('IPMI_HW') eq 'thunderx');
+    set_ssh_console_timeout_before_use if (is_remote_backend && is_aarch64 && get_var('IPMI_HW') eq 'thunderx');
     # use console based on ssh to avoid unstable ipmi
     use_ssh_serial_console;
 

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -26,7 +26,7 @@ sub reboot_and_wait_up {
     my $self           = shift;
     my $reboot_timeout = shift;
 
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         record_info('INFO', 'Reboot LPAR');
         #Reboot s390x lpar
         power_action('reboot', observe => 1, keepconsole => 1);

--- a/tests/virt_autotest/reboot_and_wait_up_normal.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal.pm
@@ -13,6 +13,7 @@
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use base "reboot_and_wait_up";
 use virt_utils 'is_installed_equal_upgrade_major_release';
 use Utils::Backends 'is_remote_backend';
@@ -23,7 +24,7 @@ sub run {
     my $timeout = 180;
 
     #online upgrade actually
-    return if (is_remote_backend && check_var('ARCH', 'aarch64') && (is_installed_equal_upgrade_major_release || get_var("VIRT_PRJ1_GUEST_INSTALL") || get_var("VIRT_PRJ4_GUEST_UPGRADE")));
+    return if (is_remote_backend && is_aarch64 && (is_installed_equal_upgrade_major_release || get_var("VIRT_PRJ1_GUEST_INSTALL") || get_var("VIRT_PRJ4_GUEST_UPGRADE")));
     $self->reboot_and_wait_up($timeout);
 }
 

--- a/tests/virt_autotest/setup_kvm_serial_console.pm
+++ b/tests/virt_autotest/setup_kvm_serial_console.pm
@@ -13,6 +13,7 @@
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use base "virt_autotest_base";
 use virt_utils 'is_installed_equal_upgrade_major_release';
 use Utils::Backends 'is_remote_backend';
@@ -20,12 +21,12 @@ use ipmi_backend_utils;
 
 sub run {
     #online upgrade actually
-    if (is_remote_backend && check_var('ARCH', 'aarch64') && is_installed_equal_upgrade_major_release) {
+    if (is_remote_backend && is_aarch64 && is_installed_equal_upgrade_major_release) {
         return;
     }
     else {
         set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));
-        set_pxe_efiboot('')                     if check_var('ARCH', 'aarch64');
+        set_pxe_efiboot('')                     if is_aarch64;
     }
 }
 

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -34,7 +34,7 @@ sub update_package {
     }
 
     $update_pkg_cmd = $update_pkg_cmd . " 2>&1 | tee /tmp/update_virt_rpms.log ";
-    if (check_var('ARCH', 's390x')) {
+    if (is_s390x) {
         lpar_cmd("$update_pkg_cmd");
         upload_asset "/tmp/update_virt_rpms.log", 1, 1;
     }

--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 use vagrant;
 use File::Basename;
-use Utils::Architectures 'is_x86_64';
+use Utils::Architectures;
 
 sub run_test_per_provider {
     my ($version, $provider) = @_;

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -15,6 +15,7 @@ use base 'y2_module_guitest';
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 
 sub run {
@@ -28,7 +29,7 @@ sub run {
     }
     y2_module_guitest::launch_yast2_module_x11('virtualization');
     # select everything
-    if (check_var('ARCH', 'x86_64')) {
+    if (is_x86_64) {
         send_key 'alt-x';    # XEN Server, only available on x86_64: bsc#1088175
         send_key 'alt-e';    # Xen tools
     }

--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -16,6 +16,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 
 sub install_google_repo_key {
@@ -36,7 +37,7 @@ sub preserve_privacy_of_non_human_openqa_workers {
 }
 
 sub run {
-    my $arch       = check_var('ARCH', 'i586') ? 'i386' : 'x86_64';
+    my $arch       = is_i586 ? 'i386' : 'x86_64';
     my $chrome_url = "https://dl.google.com/linux/direct/google-chrome-stable_current_$arch.rpm";
     select_console('x11');
     mouse_hide;

--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use Utils::Architectures 'is_aarch64';
+use Utils::Architectures;
 
 sub run {
     mouse_hide();

--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -41,7 +41,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use Utils::Architectures 'is_aarch64';
+use Utils::Architectures;
 use version_utils qw(is_leap is_opensuse is_sle is_tumbleweed);
 use x11utils qw(handle_relogin turn_off_gnome_screensaver);
 

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 
 use testapi;
+use Utils::Architectures;
 use utils 'workaround_type_encrypted_passphrase';
 use power_action_utils 'power_action';
 use version_utils 'is_sle12_hdd_in_upgrade';
@@ -43,7 +44,7 @@ sub run {
     # increases
     return if select_bootmenu_option(300) == 3;
     # set uefi bootmenu parameters properly for aarch64, such like gfxpayload and so on
-    if (check_var('ARCH', 'aarch64')) {
+    if (is_aarch64) {
         uefi_bootmenu_params;
     }
     bootmenu_default_params;
@@ -58,7 +59,7 @@ sub run {
     }
     else {
         # boot
-        my $key = get_var('OFW') || check_var('ARCH', 'aarch64') ? 'ctrl-x' : 'ret';
+        my $key = get_var('OFW') || is_aarch64 ? 'ctrl-x' : 'ret';
         send_key $key;
     }
 

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -17,6 +17,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use power_action_utils 'power_action';
 use utils 'is_boot_encrypted';
 
@@ -24,13 +25,13 @@ sub run {
     my ($self) = @_;
     # 'keepconsole => 1' is workaround for bsc#1044072
     # Poo#80184, it's not suitable to keep console for s390x after reboot.
-    power_action('reboot', keepconsole => (check_var('ARCH', 's390x')) ? 0 : 1);
+    power_action('reboot', keepconsole => (is_s390x) ? 0 : 1);
 
     # In 88388900d2dfe267230972c6905b3cc18fb288cf the wait timeout was
     # bumped, due to tianocore being a bit slower, this brings this module
     # in sync
     # 12/2019: Increasing from 400 to 600 since more seems to be required.
-    my $bootloader_timeout = (is_boot_encrypted || check_var('ARCH', 'aarch64')) ? 600 : 300;
+    my $bootloader_timeout = (is_boot_encrypted || is_aarch64) ? 600 : 300;
 
     $self->wait_boot(bootloader_time => $bootloader_timeout);
 }

--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -18,6 +18,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 use utils;
 use power_action_utils 'power_action';
 
@@ -28,7 +29,7 @@ sub run {
     # Reboot the system when x11 launch fail to Workaround the Switch Console error
     # (s390x limitation) s390x does not support snapshot to rollback the lastgood snapshot
     # This workaround can avoid the blocked test fail from the last case
-    if (check_var('ARCH', 's390x') && check_var('FIPS_ENABLED', 1) && !get_var("FIPS_ENV_MODE")) {
+    if (is_s390x && check_var('FIPS_ENABLED', 1) && !get_var("FIPS_ENV_MODE")) {
         power_action('reboot', textmode => 1);
         $self->wait_boot(bootloader_time => 200);
     }

--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -28,7 +28,7 @@ use warnings;
 use testapi;
 use y2lan_restart_common qw(initialize_y2lan open_network_settings close_network_settings check_network_status);
 use version_utils 'is_sle';
-use Utils::Architectures 'is_s390x';
+use Utils::Architectures;
 
 sub check_bsc1111483 {
     return 0 unless match_has_tag('yast2_lan_device_bsc1111483');


### PR DESCRIPTION
We have function calls **check_var('ARCH', '') and check_var('BACKEND','')** in most of the perl modules.
Replace function calls with already defined functions(in the lib/Utils/Architectures.pm and lib/Utils/Backends.pm) to improve the readability or its structure.

- Related ticket: https://progress.opensuse.org/issues/97097
- Needles: No
- Verification run: 
     https://openqa.suse.de/tests/6990965
     https://openqa.suse.de/tests/7029725#
                      
