### PR TITLE
Modify schedule in yast group for scc registration

### DIFF
--- a/schedule/yast/addon-module-ftp.yaml
+++ b/schedule/yast/addon-module-ftp.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role/validate_default_role
   - installation/system_role/select_role

--- a/schedule/yast/addon-module-http.yaml
+++ b/schedule/yast/addon-module-http.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -10,7 +10,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/warning/no_root

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/licensing/accept_license
   # Called only on BACKEND: s390x
   - '{{disk_activation}}'
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/disk_activation
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/clone_system/clone_system_pvm.yaml
+++ b/schedule/yast/clone_system/clone_system_pvm.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/dud_addon
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/activate_encrypted_volume
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/activate_encrypted_volume
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/activate_encrypted_volume
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/activate_encrypted_volume
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/encryption/activate_encrypted_volume.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/activate_encrypted_volume
   - console/validate_encrypted_volume_activation
   - installation/addon_products_sle

--- a/schedule/yast/encryption/activate_encrypted_volume_dasd.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_dasd.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/disk_activation
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/activate_encrypted_volume
   - console/validate_encrypted_volume_activation
   - installation/addon_products_sle

--- a/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/activate_encrypted_volume
   - console/validate_encrypted_volume_activation
   - installation/addon_products_sle

--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/encrypt_no_lvm

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -21,7 +21,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/encrypt_no_lvm

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/cancel_encrypted_volume
   - console/validate_encrypted_partition_not_activated
   - installation/addon_products_sle

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/cancel_encrypted_volume
   - console/validate_encrypted_partition_not_activated
   - installation/addon_products_sle

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -17,7 +17,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/iscsi_configuration
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/encrypt_lvm

--- a/schedule/yast/encryption/cryptlvm_sle_15.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/encrypt_lvm

--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -17,7 +17,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/encrypt_lvm

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -10,7 +10,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/edit_proposal_encrypt

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -25,7 +25,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -27,7 +27,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/disk_activation
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/setup_libyui
   - installation/welcome
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -22,7 +22,8 @@ schedule:
   - installation/licensing/verify_license_translations
   - installation/licensing/verify_license_has_to_be_accepted
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role/validate_default_role
   - installation/system_role/select_role

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/iscsi_configuration
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/cancel_encrypted_volume
   - console/validate_encrypted_partition_not_activated
   - installation/addon_products_sle

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/system_probing/cancel_encrypted_volume
   - console/validate_encrypted_partition_not_activated
   - installation/addon_products_sle

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/lvm_no_separate_home

--- a/schedule/yast/lvm/lvm+resize_root.yaml
+++ b/schedule/yast/lvm/lvm+resize_root.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/lvm_no_separate_home

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/lvm

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -17,7 +17,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/lvm

--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role/validate_default_role
   - installation/system_role/select_role

--- a/schedule/yast/lvm_multipath.yaml
+++ b/schedule/yast/lvm_multipath.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/multipath
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/lvm_multipath_encrypted.yaml
+++ b/schedule/yast/lvm_multipath_encrypted.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/multipath
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/setup_raid1_lvm

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/setup_raid1_lvm

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/setup_raid1_lvm

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/setup_raid1_lvm

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -17,7 +17,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/disk_activation
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/modify_existing_partition

--- a/schedule/yast/msdos/msdos.yaml
+++ b/schedule/yast/msdos/msdos.yaml
@@ -10,7 +10,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/msdos_partition_table

--- a/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
@@ -10,7 +10,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/msdos_partition_table

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -29,7 +29,8 @@ schedule:
   - '{{multipath_on_full_medium}}'
   # for some odd reason multipath is on different positions
   # in the installation depending on the medium
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - '{{multipath_on_online_medium}}'
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/nvme.yaml
+++ b/schedule/yast/nvme.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/releasenotes_origin
   - installation/system_role

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -17,7 +17,8 @@ schedule:
   - installation/setup_libyui
   - installation/welcome
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -20,7 +20,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
@@ -23,7 +23,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -21,7 +21,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/disk_activation
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -20,7 +20,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
@@ -20,7 +20,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
@@ -20,7 +20,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -12,7 +12,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/no_separate_home

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -17,7 +17,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
@@ -10,7 +10,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/releasenotes_origin
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/skip_registration/skip_registration_pvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration_pvm.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
+++ b/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -11,7 +11,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - '{{disk_activation}}'
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role/validate_default_role
   - installation/system_role/select_role

--- a/schedule/yast/textmode/textmode@svirt-xen.yaml
+++ b/schedule/yast/textmode/textmode@svirt-xen.yaml
@@ -10,7 +10,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role/validate_default_role
   - installation/system_role/select_role

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -18,7 +18,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -23,7 +23,8 @@ schedule:
     - installation/validate_beta_popup
     - installation/product_selection/select_product
     - installation/licensing/accept_license
-    - installation/scc_registration
+    - installation/registration/register_via_scc
+    - installation/registration/modules_selection
     - installation/addon_products_sle
     - installation/system_role/validate_default_role
     - installation/system_role/select_role

--- a/schedule/yast/usb_install.yaml
+++ b/schedule/yast/usb_install.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/skip_registration
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/xfs/xfs.yaml
+++ b/schedule/yast/xfs/xfs.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/licensing/accept_license
   # Called only on BACKEND: s390x
   - '{{disk_activation}}'
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/select_guided_setup

--- a/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
@@ -16,7 +16,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/yast_hostname/yast_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname.yaml
@@ -13,7 +13,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/validate_no_self_update
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -15,7 +15,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/validate_self_update
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/validate_beta_popup
   - installation/product_selection/select_product
   - installation/licensing/accept_license
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -14,7 +14,8 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/disk_activation
-  - installation/scc_registration
+  - installation/registration/register_via_scc
+  - installation/registration/modules_selection
   - installation/multipath
   - installation/addon_products_sle
   - installation/system_role


### PR DESCRIPTION
Modify schedule in yast group for scc registration
    
Related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13134
and ticket https://progress.opensuse.org/issues/95476

Vrs on various tests suites/archs:

**yast_no_self_update**
aarch64 https://openqa.suse.de/tests/6988946
hmc https://openqa.suse.de/tests/6990273
zkvm https://openqa.suse.de/tests/6990273
64bit https://openqa.suse.de/tests/6990296

**textmode**
aarch64 https://openqa.suse.de/tests/6990863
ppc64le https://openqa.suse.de/tests/6990423
hmc https://openqa.suse.de/tests/6990426
spvm https://openqa.suse.de/tests/6990428
zvm https://openqa.suse.de/tests/6990429
svirt-xen-hvm https://openqa.suse.de/tests/6990431

msdos@svirt-hyperv2016 https://openqa.suse.de/tests/6990833
minimal+base_yast@svirt-hyperv-uefi https://openqa.suse.de/tests/6990847

**skip_registration**
aarch64 https://openqa.suse.de/tests/6990905
ppc64le https://openqa.suse.de/tests/6949025








