### PR TITLE
Increase trup_call timeout

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -143,7 +143,7 @@ sub rpmver {
 # Optionally skip exit status check in case immediate reboot is expected
 sub trup_call {
     my ($cmd, %args) = @_;
-    $args{timeout}   //= 90;
+    $args{timeout}   //= 180;
     $args{exit_code} //= 0;
 
     # Always wait for rollback.service to be finished before triggering manually transactional-update


### PR DESCRIPTION
For pvm, transactional_update module fails as trup_call command takes longer. Increasing the timeout helps to avoid this type of failure.
- Related ticket: https://progress.opensuse.org/issues/91842
- Verification run: https://openqa.suse.de/tests/6978397
