### PR TITLE
Enable selinux for SLEM 5.1+ container testing

### DIFF
--- a/schedule/sle-micro/containers.yaml
+++ b/schedule/sle-micro/containers.yaml
@@ -20,11 +20,16 @@ conditional_schedule:
     FLAVOR:
       'MicroOS-Image-Updates':
         - transactional/install_updates
+  selinux:
+    ENABLE_SELINUX:
+      '1':
+        - transactional/enable_selinux
 schedule:
   - '{{boot}}'
   - transactional/host_config
   - '{{registration}}'
   - '{{maintenance}}'
+  - '{{selinux}}'
   - microos/toolbox
   - containers/podman_3rd_party_images
   - containers/podman


### PR DESCRIPTION
- [Job Group Update](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/397)
- VR: http://kepler.suse.cz/tests/6732
- https://progress.opensuse.org/issues/97823
