### PR TITLE
WIP Rename check_resume to hibernation_disabled

### DIFF
--- a/tests/console/hibernation_enabled.pm
+++ b/tests/console/hibernation_enabled.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that "resume=" kernel parameter is present in the list of default parameters.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+    assert_script_run("grep 'resume=' /proc/cmdline", fail_message => "resume parameter not found in /proc/cmdline");
+}
+
+1;


### PR DESCRIPTION
Related to https://progress.opensuse.org/issues/96098

Failing scenario: https://openqa.suse.de/tests/6950236

According to https://bugzilla.suse.com/show_bug.cgi?id=1188731

    Hibernation is proposed by default in x86_64
    Hibernation is NOT proposed for any other architecture

Instead on unschedule test for x86_64 we should rename this negative test and probably create a positive one for x86_64.
Please, consider other products, as the check is present for SLE-15-SP1.
Suggestion: try to avoid test data and just be explicit with the check hardcoded in the test module.