### PR TITLE
Adapt check_resume to new implemented logic

### DIFF
--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -38,12 +38,22 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks
-  - console/check_resume
+  - '{{validate_hibernation}}'
   - console/validate_product_installed_SLES
   - console/validate_no_cow_attribute
   # On all the backends except s390x, /home is located on a separate partition
   - '{{validate_home_partition}}'
 conditional_schedule:
+  validate_hibernation:
+    ARCH:
+      aarch64:
+        - console/hibernation_disabled
+      ppc64le:
+        - console/hibernation_disabled
+      s390x:
+        - console/hibernation_disabled
+      x86_64:
+        - console/hibernation_enabled
   isosize:
     BACKEND:
       qemu:

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks
-  - console/check_resume
+  - console/hibernation_enabled
   - console/validate_product_installed_SLES
   - console/validate_no_cow_attribute
   - console/verify_separate_home

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks
-  - console/check_resume
+  - console/hibernation_disabled
   - console/validate_product_installed_SLES
   - console/validate_no_cow_attribute
   - console/verify_no_separate_home

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - console/force_scheduled_tasks
-  - console/check_resume
+  - console/hibernation_disabled
   - console/validate_product_installed_SLES
   - console/verify_separate_home
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -38,7 +38,6 @@ schedule:
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
-  - console/check_resume
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -38,7 +38,6 @@ schedule:
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
-  - console/check_resume
   - console/hostname
   - console/system_prepare
   - console/force_scheduled_tasks

--- a/tests/console/hibernation_disabled.pm
+++ b/tests/console/hibernation_disabled.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that "resume=" kernel parameter is absent in the list of default parameters.
+# This kernel parameter enables hibernation, it is not supported for all backends.
+# See https://bugzilla.suse.com/show_bug.cgi?id=1188731
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+    assert_script_run("grep -v 'resume=' /proc/cmdline", fail_message => "resume parameter found in /proc/cmdline");
+}
+
+1;

--- a/tests/console/hibernation_enabled.pm
+++ b/tests/console/hibernation_enabled.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2020-2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that "resume=" kernel parameter is present in the list of default parameters.
+# This kernel parameter enables hibernation, it is not supported for all backends.
+# See https://bugzilla.suse.com/show_bug.cgi?id=1188731
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+    assert_script_run("grep 'resume=' /proc/cmdline", fail_message => "resume parameter not found in /proc/cmdline");
+}
+
+1;


### PR DESCRIPTION
Failing scenario: https://openqa.suse.de/tests/6950236

According to https://bugzilla.suse.com/show_bug.cgi?id=1188731

    Hibernation is proposed by default in x86_64
    Hibernation is NOT proposed for any other architecture

Instead on unschedule test for x86_64 we should rename this negative test and probably create a positive one for x86_64.
Please, consider other products, as the check is present for SLE-15-SP1.
Suggestion: try to avoid test data and just be explicit with the check hardcoded in the test module.

VRs: https://openqa.suse.de/tests/overview?build=JRivrain%2Fos-autoinst-distri-opensuse%2313167

