### PR TITLE
Increase timeout for kdump restart info

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -179,7 +179,7 @@ sub activate_kdump {
     if ($expect_restart_info == 1) {
         my @tags = qw(yast2-kdump-restart-info os-prober-warning);
         do {
-            assert_screen(\@tags);
+            assert_screen(\@tags, timeout => 90);
             handle_warning_install_os_prober() if match_has_tag('os-prober-warning');
         } until (match_has_tag('yast2-kdump-restart-info'));
         send_key('alt-o');


### PR DESCRIPTION
Fix poo#96702: Default timeout is not enough, it is set to 90 seconds now.

- Related ticket: https://progress.opensuse.org/issues/96702
- Needles: none
- Verification run: 
ppc64le: https://openqa.suse.de/tests/7002076
aarch64:  https://openqa.suse.de/tests/7002075
