### PR TITLE
Fix kdump_and_crash power_action to boot into non-textmode

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -292,7 +292,7 @@ sub configure_service {
     }
 
     # restart to activate kdump
-    power_action('reboot', keepconsole => is_pvm);
+    power_action('reboot', textmode => 1, keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
     $self->wait_boot(bootloader_time => 300);
 


### PR DESCRIPTION
If we set DESKTOP to non-textmode, it will need to click the reboot
button and issue a password for the power_action 'reboot'. We just
need the textmode to reboot it fast and easy to make the configure
take effect.

Related ticket: https://progress.opensuse.org/issues/97529

Needles: N/A

Verification run:
https://openqa.nue.suse.com/tests/6954676
https://openqa.nue.suse.com/tests/6963411
https://openqa.nue.suse.com/tests/6963844

regression:
https://openqa.nue.suse.com/tests/7028201
https://openqa.nue.suse.com/tests/7028203