### PR TITLE
Add underscore to PUBLICCLOUD_ prefix and move the QAM_ behind that prefix

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -559,14 +559,14 @@ Wrapper around C<<$self->vault_api()>> to get retry capability.
 sub vault_api {
     my ($self, $path, %args) = @_;
     my $ret;
-    my $tries = get_var('PUBLICCLOUD_VAULT_TRIES', 3);
+    my $tries = get_var('PUBLIC_CLOUD_VAULT_TRIES', 3);
 
     while ($tries-- > 0) {
         eval {
             $ret = $self->__vault_api($path, %args);
         };
         return $ret unless ($@);
-        sleep get_var('PUBLICCLOUD_VAULT_TIMEOUT', 60);
+        sleep get_var('PUBLIC_CLOUD_VAULT_TIMEOUT', 60);
     }
     die("Maximum number of Vault request retries exceeded. Check Vault Server is up and running");
 }

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -79,7 +79,7 @@ sub run {
         }
         # Failsafe: Fail if there are no test repositories, otherwise we have the wrong template link
         my $count             = scalar @repos;
-        my $check_empty_repos = get_var('QAM_PUBLICCLOUD_IGNORE_EMPTY_REPO', 0) == 0;
+        my $check_empty_repos = get_var('PUBLIC_CLOUD_IGNORE_EMPTY_REPO', 0) == 0;
         die "No test repositories" if ($check_empty_repos && $count == 0);
 
         my $size = script_output("du -hs ~/repos");

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -32,8 +32,7 @@ sub run {
     select_host_console();    # select console on the host, not the PC instance
 
     # Skip maintenance updates. This is useful for debug runs
-    # Note: QAM_PUBLICCLOUD_SKIP_DOWNLOAD is left for backwards compatability and will be removed in the future
-    my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD', 0));
+    my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);
 
     # Trigger to skip the download to speed up verification runs
     if ($skip_mu) {

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -25,7 +25,7 @@ sub run {
     select_host_console();    # select console on the host, not the PC instance
 
     my @addons  = split(/,/, get_var('SCC_ADDONS', ''));
-    my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', get_var('QAM_PUBLICCLOUD_SKIP_DOWNLOAD', 0));
+    my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);
 
     # Trigger to skip the download to speed up verification runs
     if ($skip_mu) {


### PR DESCRIPTION
- Related ticket: [poo#97742](https://progress.opensuse.org/issues/97742)
- Dependency: [qac-openqa-yaml!401](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/401)

In detail:
 * Rename `PUBLICCLOUD_VAULT_TRIES` to `PUBLIC_CLOUD_VAULT_TRIES`
 * Rename `PUBLICCLOUD_VAULT_TIMEOUT` to `PUBLIC_CLOUD_VAULT_TIMEOUT`
 * Rename `QAM_PUBLICCLOUD_IGNORE_EMPTY_REPO` to `PUBLIC_CLOUD_IGNORE_EMPTY_REPO`
 * Remove `QAM_PUBLICCLOUD_SKIP_DOWNLOAD`
