### PR TITLE
Fix create_hdd_gnome_libyui schedule

### DIFF
--- a/schedule/yast/create_hdd_gnome_libyui.yaml
+++ b/schedule/yast/create_hdd_gnome_libyui.yaml
@@ -16,8 +16,8 @@ schedule:
   - '{{upload_assets}}'
 conditional_schedule:
   bootloader:
-    ARCH:
-      s390x:
+    BACKEND:
+      svirt:
         - installation/bootloader_start
   upload_assets:
     ARCH:


### PR DESCRIPTION
Test fails for xen, because it's missing bootloader_start

Verification run: https://openqa.suse.de/tests/7013728
