### PR TITLE
Install cacert on 15sp4

### DIFF
--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -30,7 +30,7 @@ sub run {
     install_docker_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => 'docker');
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
-
+    install_ca_certs();
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
     for my $version (split(/,/, $versions)) {

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -30,7 +30,7 @@ sub run {
     install_podman_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => 'podman');
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
-
+    install_ca_certs();
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
     for my $version (split(/,/, $versions)) {


### PR DESCRIPTION
15sp4 build is missing cacert.
buildah complains about the certification.
    
```
    Error initializing source docker://registry.suse.de/suse/sle-15-sp4/update/cr/totest/images/suse/sle15:15.4: error pinging docker registry registry.suse.de: Get "https://registry.suse.de/v2/": x509: certificate signed by unknown authority
```
    
 as a workaround i install the required ca manually for buildah_docker


- Verification run: https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313184&distri=sle&version=15-SP4
(Notice: Error is different for another reason but there is a softfail)