### PR TITLE
Remove modules_selection when we skip registration

### DIFF
--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -14,7 +14,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/raid_gpt

--- a/schedule/yast/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered.yaml
@@ -14,7 +14,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/releasenotes_origin
   - installation/system_role

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
@@ -24,7 +24,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -22,7 +22,6 @@ schedule:
   - installation/licensing/accept_license
   - installation/disk_activation
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
@@ -11,7 +11,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/releasenotes_origin
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -14,7 +14,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/skip_registration/skip_registration_pvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration_pvm.yaml
@@ -15,7 +15,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/usb_install.yaml
+++ b/schedule/yast/usb_install.yaml
@@ -14,7 +14,6 @@ schedule:
   - installation/product_selection/select_product
   - installation/licensing/accept_license
   - installation/registration/skip_registration
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout


### PR DESCRIPTION
This module is not needed in the case we skip the registration, as
the modules selection is handled by addon_products_sle if we
skip the registration (this is quite wrong, as that module is supposed
to handle addons, not modules) during earlier VRs the test was passing
anyway thanks (?) to a wrongly-tagged needle:
https://openqa.suse.de/tests/6990905#step/modules_selection/1.
 
Additional VRs:
http://waaa-amazing.suse.cz/tests/15706
http://waaa-amazing.suse.cz/tests/15707
http://waaa-amazing.suse.cz/tests/15708
http://waaa-amazing.suse.cz/tests/15709
http://waaa-amazing.suse.cz/tests/15710
