### PR TITLE
Enable s390x tests for staging

### DIFF
--- a/schedule/staging/RAID1@64bit-staging.yaml
+++ b/schedule/staging/RAID1@64bit-staging.yaml
@@ -9,10 +9,12 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/welcome
-  - installation/accept_license
-  - installation/scc_registration
-  - installation/addon_products_sle
+  - installation/product_selection/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_selection/skip_module_selection
+  - installation/add_on_product/skip_install_addons
   - installation/system_role
   - installation/partitioning
   - installation/partitioning/raid_gpt

--- a/schedule/staging/RAID1@s390x-staging.yaml
+++ b/schedule/staging/RAID1@s390x-staging.yaml
@@ -1,0 +1,68 @@
+---
+name:           RAID1_s390x@s390x-staging
+description:    >
+  Test for RAID1
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_selection/skip_module_selection
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/handle_reboot
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_raid
+test_data:
+  <<: !include test_data/yast/raid/raid_disks_boot_zipl.yaml
+  mds:
+    - raid_level: 1
+      chunk_size: '64 KiB'
+      devices:
+        - vda2
+        - vdb2
+        - vdc2
+        - vdd2
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 0
+      chunk_size: '64 KiB'
+      devices:
+        - vda3
+        - vdb3
+        - vdc3
+        - vdd3
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/staging/cryptlvm_minimal_x@64bit-staging.yaml
+++ b/schedule/staging/cryptlvm_minimal_x@64bit-staging.yaml
@@ -8,19 +8,21 @@ vars:
   ENCRYPT: 1
   LVM: 1
   MAX_JOB_TIME: 14400
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
-  - installation/welcome
-  - installation/accept_license
+  - installation/setup_libyui
+  - installation/product_selection/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - installation/partitioning
   - installation/partitioning/encrypt_lvm
-  - installation/partitioning_finish
-  - installation/installer_timezone
-  - installation/user_settings
-  - installation/user_settings_root
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/change_desktop
   - installation/installation_overview

--- a/schedule/staging/cryptlvm_minimal_x@s390x-staging.yaml
+++ b/schedule/staging/cryptlvm_minimal_x@s390x-staging.yaml
@@ -1,0 +1,65 @@
+---
+name:           cryptlvm_minimal_x@s390x-staging
+description:    >
+  Combination of "cryptlvm" and "minimal_x" for 64bit and staging.
+  (crypt-)LVM installations can take longer,
+  especially on non-x86_64 architectures.
+vars:
+  ENCRYPT: 1
+  LVM: 1
+  MAX_JOB_TIME: 14400
+  SCC_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning/encrypt_lvm
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/resolve_dependency_issues
+  - installation/change_desktop
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/boot_encrypt
+  - installation/handle_reboot
+  - installation/first_boot
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - locale/keymap_or_locale
+  - console/force_scheduled_tasks
+  - console/textinfo
+  - console/hostname
+  - console/installation_snapshots
+# Disabling module till issue#98478 is resolved
+#  - console/x_vt
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - console/yast2_lan
+  - console/curl_https
+  - console/glibc_sanity
+  - console/zypper_in
+  - console/yast2_i
+  - console/yast2_bootloader
+  - console/vim
+  - console/sshd
+  - console/ssh_cleanup
+  - console/mtab
+  - console/orphaned_packages_check
+# Disabling module till issue#98556 is resolved
+#  - console/consoletest_finish

--- a/test_data/yast/raid/raid_disks_boot_zipl.yaml
+++ b/test_data/yast/raid/raid_disks_boot_zipl.yaml
@@ -1,0 +1,42 @@
+---
+disks:
+  - name: vda
+    partitions:
+      - size: 300MiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot/zipl
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdb
+    partitions:
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdc
+    partitions:
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdd
+    partitions:
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid


### PR DESCRIPTION
Enable s390x tests RAID1 and cryptlvm_minimal_x for staging

- Related ticket: https://progress.opensuse.org/issues/95751
- Verification run fail due to s390x problem: 
RAID1 - https://openqa.suse.de/tests/7094875
cryptlvm_minimal_x - https://openqa.suse.de/tests/7110931 (Disabled temporarily failing modules)
     x86_64 : https://openqa.suse.de/tests/7111254
