### PR TITLE
Remove unstable tests from Staging test runs

### DIFF
--- a/schedule/staging/gnome@64bit-staging.yaml
+++ b/schedule/staging/gnome@64bit-staging.yaml
@@ -59,8 +59,6 @@ schedule:
   - x11/gnome_control_center
   - x11/gnome_terminal
   - x11/gedit
-  - x11/firefox
-  - x11/yast2_snapper
   - x11/glxgears
   - x11/nautilus
   - x11/desktop_mainmenu


### PR DESCRIPTION
https://progress.opensuse.org/issues/98135

- Related ticket: https://progress.opensuse.org/issues/98135
- Needles: None
- Verification run: (None. First, this commit only changes schedule yaml file; second, the original test is unable to rerun due to asset file being removed.)