### PR TITLE
POC: BCI test integration

### DIFF
--- a/schedule/containers/sle_image_on_sle_host_docker.yaml
+++ b/schedule/containers/sle_image_on_sle_host_docker.yaml
@@ -7,9 +7,14 @@ conditional_schedule:
     ARCH:
       's390x':
         - installation/bootloader_start
+  bci:
+    HOST_VERSION:
+      '15-SP3':
+        - containers/bci_tests
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/docker_image
+  - '{{bci}}'
   - containers/container_diff

--- a/schedule/containers/sle_image_on_sle_host_podman.yaml
+++ b/schedule/containers/sle_image_on_sle_host_podman.yaml
@@ -7,8 +7,13 @@ conditional_schedule:
     ARCH:
       's390x':
         - installation/bootloader_start
+  bci:
+    HOST_VERSION:
+      '15-SP3':
+        - containers/bci_tests
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/podman_image
+  - '{{bci}}'

--- a/tests/containers/bci_tests.pm
+++ b/tests/containers/bci_tests.pm
@@ -1,0 +1,117 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: bci-tests runner
+#   SUSE Linux Enterprise Base Container Images (SLE BCI)
+#   provides truly open, flexible and secure container images and application
+#   development tools for immediate use by developers and integrators without
+#   the lock-in imposed by alternative offerings.
+#
+#   This module is used to test BCI repository within a container.
+#
+#   It installs the required python packages and uses the existing BCI-test
+#   repository defined by BCI_TESTS_REPO. Then, it will run the different
+#   tests environments defined by BCI_TEST_ENVS.
+#   - install needed python environment
+#   - clone bci-tests repo
+#   - build project
+#   - run test for each given environment
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use XML::LibXML;
+use utils qw(systemctl zypper_call ensure_ca_certificates_suse_installed);
+use version_utils qw(get_os_release);
+use containers::common;
+use testapi;
+
+our $test_envs = get_var('BCI_TEST_ENVS', 'base,init,dotnet,python,node,go,multistage');
+
+sub parse_logs {
+    my $self = @_;
+
+    upload_logs('junit_build_serial.xml');
+    upload_logs('junit_build_parallel.xml');
+
+    # bci-tests produce separate XUnit results files for each environment.
+    # We need tp merge all together into a single xml file that will
+    # be used by OpenQA to represent the results in "External results"
+    my $dom  = XML::LibXML::Document->new('1.0', 'utf-8');
+    my $root = $dom->createElement('testsuites');
+    $dom->setDocumentElement($root);
+
+    # Dump xml contents to a location where we can access later using data_url
+    for my $env (split(/,/, $test_envs)) {
+        upload_logs('junit_' . $env . '_serial.xml');
+        my $log_file = upload_logs('junit_' . $env . '_parallel.xml');
+        my $dom      = XML::LibXML->load_xml(location => "ulogs/$log_file");
+        for my $node ($dom->findnodes('//testsuite')) {
+            # Replace default attribute name "pytest" by its env name
+            $node->{name} =~ s/pytest/$env/;
+            # Append test results to the resulting xml file
+            $root->appendChild($node);
+        }
+    }
+    $dom->toFile('result.xml', 1);
+    # Download file from host pool to the instance
+    assert_script_run('curl ' . autoinst_url('/files/result.xml') . ' -o /tmp/result.txt');
+    parse_extra_log('XUnit', '/tmp/result.txt');
+}
+
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $runtime        = get_required_var('CONTAINER_RUNTIME');
+    my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
+    my $bci_devel_repo = get_var('BCI_DEVEL_REPO');
+    my $bci_timeout    = get_var('BCI_TIMEOUT', 900);
+
+    ensure_ca_certificates_suse_installed;
+
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    if ($runtime eq 'podman') {
+        install_podman_when_needed($host_distri);
+        install_buildah_when_needed($host_distri);
+    }
+    elsif ($runtime eq 'docker') {
+        install_docker_when_needed($host_distri);
+    }
+    else {
+        die("Runtime $runtime not given or not supported");
+    }
+
+    record_info('Install', 'Install needed packages');
+    zypper_call('--quiet in git-core python39', timeout => 600);
+    assert_script_run('pip3.9 --quiet install tox pytest', timeout => 600);
+
+    record_info('Clone', 'Clone BCI tests repository');
+    assert_script_run("git clone -q --depth 1 $bci_tests_repo");
+
+    record_info('Build', 'Build bci-tests project');
+    assert_script_run('cd bci-tests');
+    assert_script_run("export CONTAINER_RUNTIME=$runtime");
+    assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;
+    assert_script_run('tox -e build', timeout => 600);
+
+    # Run the tests for each environment
+    for my $env (split(/,/, $test_envs)) {
+        record_info("Test: $env");
+        assert_script_run("tox -e $env", timeout => $bci_timeout);
+    }
+
+    $self->parse_logs();
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -21,6 +21,10 @@ AUTOYAST_VERIFY_TIMEOUT  | boolean | false | Enable validation of pop-up windows
 AY_EXPAND_VARS | string | | Commas separated list of variable names to be expanded in the provided autoyast profile. For example: REPO_SLE_MODULE_BASESYSTEM,DESKTOP,... Provided variables will replace `{{VAR}}` in the profile with the value of given variable. See also `AUTOYAST_PREPARE_PROFILE`.
 BASE_VERSION | string | | |
 BETA | boolean | false | Enables checks and processing of beta warnings. Defines current stage of the product under test.
+BCI_DEVEL_REPO | string | | This parameter is given to the bci-tests to inject a different SLE_BCI repository url to the container image instead of the default one. Used by `bci_tests.pm`.
+BCI_TEST_ENVS | string | | The list of environments to be tested, e.g. `base,init,dotnet,python,node,go,multistage`. Used by `bci_tests.pm`.
+BCI_TESTS_REPO | string | | Location of the bci-tests repository to be cloned. Used by `bci_tests.pm`.
+BCI_TIMEOUT | string | | Timeout given to the command to test each environment. Used by `bci_tests.pm`.
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.
 CASEDIR | string | | Path to the directory which contains tests.
@@ -28,6 +32,7 @@ CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test mo
 CHECK_RELEASENOTES_ORIGIN | boolean | false | Loads `installation/releasenotes_origin` test module.
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
+CONTAINER_RUNTIME | string | | Container runtime to be used, e.g.  `docker`, `podman`.
 CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/94003

**NOTE**: This is a PoC, so it's tested only on 15-SP3 host as an example. However, the code is valid to be enabled on other hosts. Therefore, I created [this ticket](https://progress.opensuse.org/issues/98183) to extend the coverage to all the hosts we support. However, there are some things to be fixed in the upstream repository and the needed adaptations in this module can be done in later PRs. 