### PR TITLE
WIP: Replace modules_selection by libyui modules in YaST group

### DIFF
--- a/schedule/yast/addon-module-ftp.yaml
+++ b/schedule/yast/addon-module-ftp.yaml
@@ -12,7 +12,6 @@ schedule:
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role/validate_default_role
   - installation/system_role/select_role

--- a/schedule/yast/addon-module-http.yaml
+++ b/schedule/yast/addon-module-http.yaml
@@ -12,7 +12,6 @@ schedule:
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -11,7 +11,7 @@ schedule:
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/registration/modules_selection
+  - installation/module_selection/select_module_desktop
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/registration/modules_selection
+  - installation/module_selection/select_module_desktop
   - installation/dud_addon
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -14,7 +14,6 @@ schedule:
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/registration/modules_selection
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning/new_partitioning_gpt


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/97973
- Verification run: [modules selection in YaST group](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23replace_modules_selection&version=15-SP4)
