### PR TITLE
Add back modules_selection.pm

### DIFF
--- a/tests/installation/registration/modules_selection.pm
+++ b/tests/installation/registration/modules_selection.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Register SCC modules.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use registration 'process_modules';
+
+sub run {
+    process_modules();
+}
+
+1;


### PR DESCRIPTION
Module selection when we select only the desktop is already developed with libyui, but for the rest of cases we should keep the module refactored and still using needles. This PR will add back the module while we analyze case by case in YaST group what we need.

- Related ticket: https://progress.opensuse.org/issues/97973
- Verification run: [ext4_yast](https://openqa.suse.de/tests/7030870)
