### PR TITLE
Integrate cc individual test suites into one job

### DIFF
--- a/schedule/security/cc_audit_tests.yaml
+++ b/schedule/security/cc_audit_tests.yaml
@@ -1,0 +1,13 @@
+name: cc_audit_tests
+description:    >
+    This is for cc audit tests in single node
+schedule:
+    - boot/boot_to_desktop
+    - security/cc/cc_audit_test_setup
+    - security/cc/filter
+    - security/cc/syscalls
+    - security/cc/polkit_tests
+    - security/cc/audit_trail_protection
+    - security/cc/trustedprograms
+    - security/selinux/selinux_setup
+    - security/cc/libpam

--- a/schedule/security/cc_audit_trail_protection.yaml
+++ b/schedule/security/cc_audit_trail_protection.yaml
@@ -1,7 +1,0 @@
-name: cc_audit_trail_protection
-description:    >
-    This is for audit_test audit-trail-protection
-schedule:
-    - boot/boot_to_desktop
-    - security/cc/cc_audit_test_setup
-    - security/cc/audit_trail_protection

--- a/schedule/security/cc_filter.yaml
+++ b/schedule/security/cc_filter.yaml
@@ -1,7 +1,0 @@
-name: cc_filter
-description:    >
-    This is for audit_test filter
-schedule:
-    - boot/boot_to_desktop
-    - security/cc/cc_audit_test_setup
-    - security/cc/filter

--- a/schedule/security/cc_libpam.yaml
+++ b/schedule/security/cc_libpam.yaml
@@ -1,8 +1,0 @@
-name: cc_libpam
-description:    >
-    This is for audit_test libpam
-schedule:
-    - boot/boot_to_desktop
-    - security/selinux/selinux_setup
-    - security/cc/cc_audit_test_setup
-    - security/cc/libpam

--- a/schedule/security/cc_polkit.yaml
+++ b/schedule/security/cc_polkit.yaml
@@ -1,7 +1,0 @@
-name: cc_polkit
-description:    >
-    This is for audit_test polkit
-schedule:
-    - boot/boot_to_desktop
-    - security/cc/cc_audit_test_setup
-    - security/cc/polkit_tests

--- a/schedule/security/cc_syscalls.yaml
+++ b/schedule/security/cc_syscalls.yaml
@@ -1,7 +1,0 @@
-name: cc_syscalls
-description:    >
-    This is for audit_test syscalls
-schedule:
-    - boot/boot_to_desktop
-    - security/cc/cc_audit_test_setup
-    - security/cc/syscalls

--- a/schedule/security/cc_trustedprograms.yaml
+++ b/schedule/security/cc_trustedprograms.yaml
@@ -1,7 +1,0 @@
-name: cc_trustedprograms
-description:    >
-    This is for audit_test trustedprograms
-schedule:
-    - boot/boot_to_desktop
-    - security/cc/cc_audit_test_setup
-    - security/cc/trustedprograms

--- a/tests/security/cc/audit_trail_protection.pm
+++ b/tests/security/cc/audit_trail_protection.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Run 'audit-trail-protection' test case of 'audit-test' test suite
-# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Maintainer: rfan1 <richard.fan@suse.com>, Liu Xiaojing <xiaojing.liu@suse.com>
 # Tags: poo#94447
 
 use base 'consoletest';

--- a/tests/security/cc/filter.pm
+++ b/tests/security/cc/filter.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Run 'filter' test case of 'audit-test' test suite
-# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Maintainer: rfan1 <richard.fan@suse.com>, Liu Xiaojing <xiaojing.liu@suse.com>
 # Tags: poo#95464
 
 use base 'consoletest';

--- a/tests/security/cc/libpam.pm
+++ b/tests/security/cc/libpam.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Run 'libpam' test case of 'audit-test' test suite
-# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Maintainer: rfan1 <richard.fan@suse.com>, Liu Xiaojing <xiaojing.liu@suse.com>
 # Tags: poo#95911
 
 use base 'consoletest';

--- a/tests/security/cc/polkit_tests.pm
+++ b/tests/security/cc/polkit_tests.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Run 'polkit-tests' test case of 'audit-test' test suite
-# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Maintainer: rfan1 <richard.fan@suse.com>, Liu Xiaojing <xiaojing.liu@suse.com>
 # Tags: poo#95762
 
 use base 'consoletest';

--- a/tests/security/cc/syscalls.pm
+++ b/tests/security/cc/syscalls.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Run 'syscalls' test case of 'audit-test' test suite
-# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Maintainer: rfan1 <richard.fan@suse.com>, Liu Xiaojing <xiaojing.liu@suse.com>
 # Tags: poo#94684
 
 use base 'consoletest';

--- a/tests/security/cc/trustedprograms.pm
+++ b/tests/security/cc/trustedprograms.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Run 'trustedprograms' test case of 'audit-test' test suite
-# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Maintainer: rfan1 <richard.fan@suse.com>, Liu Xiaojing <xiaojing.liu@suse.com>
 # Tags: poo#95908
 
 use base 'consoletest';


### PR DESCRIPTION
We have several individual cc test suites which are run within openQA,
these cases can be integrated to one job, then we can review them in
single page

- Related ticket: https://progress.opensuse.org/issues/98240
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/7038493