### PR TITLE
Fix yast apparmor needles mismatch: assert & click

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -654,9 +654,9 @@ sub yast2_apparmor_setup {
 # Yast2 Apparmor: check apparmor is enabled
 sub yast2_apparmor_is_enabled {
     enter_cmd("yast2 apparmor &");
-    assert_screen("AppArmor-Configuration-Settings", timeout => 180);
-    send_key "alt-l";
-    assert_screen("AppArmor-Settings-Enable-Apparmor");
+    assert_screen("AppArmor-Configuration-Settings", timeout => 300);
+    assert_and_click("AppArmor-Launch", timeout => 60);
+    assert_screen("AppArmor-Settings-Enable-Apparmor", timeout => 60);
 }
 
 # Yast2 Apparmor clean up

--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 SUSE LLC
+# Copyright (C) 2019-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -82,7 +82,7 @@ sub samba_server_setup {
     type_string("/home/$testdir");
     send_key "alt-o";
     assert_screen("samba-server-configuration-shares-newshare-createdir");
-    send_key "alt-y";
+    assert_and_click("samba-server-configuration-shares-newshare-createdir-Yes", timeout => 60);
     assert_screen("samba-server-configuration");
     send_key "alt-o";
 

--- a/tests/security/yast2_apparmor/manually_add_profile.pm
+++ b/tests/security/yast2_apparmor/manually_add_profile.pm
@@ -19,7 +19,7 @@
 # Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#70537, tc#1741266
 
-use base apparmortest;
+use base 'apparmortest';
 use strict;
 use warnings;
 use testapi;
@@ -51,10 +51,10 @@ sub run {
     # "marked as a program that should not have its own profile",
     # it should be failed
     assert_and_click("AppArmor-Manually-Add-Profile", timeout => 60);
-    send_key "alt-l";
+    assert_and_click("AppArmor-Launch",               timeout => 60);
     send_key_until_needlematch("AppArmor-Chose-a-program-to-generate-a-profile", "alt-n", 30, 3);
     type_string("$test_file");
-    send_key "alt-o";
+    assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
     assert_screen("AppArmor-generate-a-profile-Error");
     # Exit "yast2 apparmor"
     wait_screen_change { send_key "alt-o" };
@@ -66,10 +66,10 @@ sub run {
     # *NOT* "marked as a program that should not have its own profile",
     # it should be succeeded
     assert_and_click("AppArmor-Manually-Add-Profile", timeout => 60);
-    send_key "alt-l";
+    assert_and_click("AppArmor-Launch",               timeout => 60);
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_bk");
-    send_key "alt-o";
+    assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
     assert_screen("AppArmor-Scan-system-log");
     # Scan systemlog
     send_key "alt-s";
@@ -84,10 +84,10 @@ sub run {
     # Enter "yast2 apparmor" again
     enter_cmd("yast2 apparmor &");
     assert_and_click("AppArmor-Manually-Add-Profile", timeout => 60);
-    send_key "alt-l";
+    assert_and_click("AppArmor-Launch",               timeout => 60);
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_vsftpd");
-    send_key "alt-o";
+    assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
     assert_screen("AppArmor-Inactive-local-profile");
     # Check "View Profile"
     send_key "alt-v";

--- a/tests/security/yast2_apparmor/scan_audit_logs.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs.pm
@@ -17,7 +17,7 @@
 # Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#67933, tc#1741266
 
-use base apparmortest;
+use base 'apparmortest';
 use strict;
 use warnings;
 use testapi;
@@ -43,8 +43,8 @@ sub run {
     # Enter "yast2 apparmor"
     enter_cmd("yast2 apparmor &");
     # Enter "Scan Audit logs" and check there should no records
-    assert_and_click("AppArmor-Scan-Audit-logs", timeout => 60);
-    send_key "alt-l";
+    assert_and_click("AppArmor-Scan-Audit-logs", timeout => 120);
+    assert_and_click("AppArmor-Launch",          timeout => 60);
     assert_screen("AppArmor-Scan-Audit-logs-no-records");
     # Exit "yast2 apparmor"
     wait_screen_change { send_key "alt-o" };
@@ -71,8 +71,8 @@ sub run {
     # Enter "yast2 apparmor" and verify apparmor can revise the profile based on former violation
     enter_cmd("yast2 apparmor &");
     # Enter "Scan Audit logs" and check there should have records
-    assert_and_click("AppArmor-Scan-Audit-logs", timeout => 60);
-    send_key "alt-l";
+    assert_and_click("AppArmor-Scan-Audit-logs", timeout => 120);
+    assert_and_click("AppArmor-Launch",          timeout => 60);
     assert_screen("AppArmor-Scan-Audit-logs-scan-records");
 
     # Audit the entry

--- a/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
+++ b/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
@@ -17,7 +17,7 @@
 # Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#67021, tc#1741266
 
-use base apparmortest;
+use base 'apparmortest';
 use strict;
 use warnings;
 use testapi;
@@ -41,8 +41,8 @@ sub run {
 
     # Enable apparmor service and check
     enter_cmd("yast2 apparmor &");
-    assert_screen("AppArmor-Configuration-Settings", timeout => 60);
-    send_key "alt-l";
+    assert_screen("AppArmor-Configuration-Settings", timeout => 120);
+    assert_and_click("AppArmor-Launch", timeout => 60);
     assert_screen("AppArmor-Settings-Disable-Apparmor");
     send_key "alt-e";
     assert_screen("AppArmor-Settings-Enable-Apparmor");


### PR DESCRIPTION
Fix Apparmor needles mismatch: using assert and click instead of sending hot key.
The gnome big version upgrade introduces needles mismatch.
The new failures can be tracked by bsc#1190292 and bsc#1190295.

- Related tickets: 
poo#98177 - [sle][security][sle15sp4] test fails in scan_audit_logs: new GNOME version introduces needle mismatch
poo#98180 - [sle][security][sle15sp4] test fails in manually_add_profile: new GNOME version introduces needle mismatch
poo#98033 - [sle][security][sle15sp4] test fails in usr_sbin_smbd: new GNOME version introduces needle mismatch
poo#98027 - [sle][security][sle15sp4] test fails in apache2_changehat: new GNOME version introduces needle mismatch
poo#98039 - [sle][security][sle15sp4] test fails in settings_disable_enable_apparmor: new GNOME version introduces needle mismatch

- Needles: added already
- Verification run: 
   https://openqa.suse.de/tests/7039636# (all passed)
   https://openqa.suse.de/tests/7059105# (The failed test cases can be tracked by bugs, see "Comments")
