### PR TITLE
bind: Increase testsuite timeout

### DIFF
--- a/tests/console/bind.pm
+++ b/tests/console/bind.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018-2020 SUSE LLC
+# Copyright © 2018-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,6 @@
 # - Upload "conf.sh" as reference
 # - Setup loopback interfaces
 # - Run "runall.sh" testsuite
-# - De register repositores
 # - In case of failure, upload "systests.output" log
 # Maintainer: Jozef Pupava <jpupava@suse.com>
 
@@ -81,11 +80,6 @@ sub run {
     # remove loopback interfaces
     assert_script_run 'sh ifconfig.sh down';
     assert_script_run 'ip a';
-}
-
-sub post_run_hook {
-    # deregister products or repositories added with first script run
-    assert_script_run 'bash /tmp/script.sh';
 }
 
 sub post_fail_hook {

--- a/tests/console/bind.pm
+++ b/tests/console/bind.pm
@@ -75,8 +75,22 @@ sub run {
     # setup loopback interfaces for testsuite
     assert_script_run 'sh ifconfig.sh up';
     assert_script_run 'ip a';
-    my $timeout = is_sle('<=12-SP3') ? 1500 : 3500;
-    assert_script_run 'runuser -u bernhard -- sh runall.sh', $timeout;
+    # workaround esp. on aarch64 some test fail occasinally due to low worker performance
+    # if there are failed tests run them again up to 3 times
+    eval {
+        assert_script_run 'runuser -u bernhard -- sh runall.sh -n', 7000;
+    };
+    if ($@) {
+        for (1 .. 3) {
+            eval {
+                record_soft_failure 'Retry: poo#71329';
+                assert_script_run 'TFAIL=$(awk -F: -e \'/^R:.*:FAIL/ {print$2}\' systests.output)';
+                assert_script_run 'for t in $TFAIL; do runuser -u bernhard -- sh run.sh $t; done', 2000;
+            };
+            last unless ($@);
+            record_info 'Retry', "Failed bind test retry: $_ of 3";
+        }
+    }
     # remove loopback interfaces
     assert_script_run 'sh ifconfig.sh down';
     assert_script_run 'ip a';


### PR DESCRIPTION
Use one timeout, bind is not schedulled on <=12-SP3 anymore

- Related ticket: https://progress.opensuse.org/issues/71329
- Verification run:
http://dzedro.suse.cz/tests/19340 15 SP2
http://dzedro.suse.cz/tests/19357 15 GA
