### PR TITLE
Add test summary with version information to hana_install

### DIFF
--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -66,6 +66,8 @@ sub run {
     $self->test_start;
 
     assert_script_run "HDB info";
+    my $ver_info = script_output 'HDB version';
+    record_info 'HANA Version', $ver_info;
 
     # Disconnect SAP account
     $self->reset_user_change;


### PR DESCRIPTION
This PR adds a `record_info()` call to the `sles4sap/hana_install` test module that prints some information regarding the OS & HANA versions used in the test to make it easier for reviewers to access this information. Also included is the upload of files containing the list of installed OS packages in the system and the status of systemd services right after the HANA installation.

An `HDB version` command was also added to the `sles4sap/hana_test` test module to supply HANA version information as well in this module.

- Related ticket: N/A
- Needles: N/A
- Verification run: [15-SP4](http://mango.qa.suse.de/tests/4384#step/hana_install/270) ; [12-SP3](http://mango.qa.suse.de/tests/4386#step/hana_install/278)
