### PR TITLE
Refactor tomcat test 

### DIFF
--- a/tests/x11/tomcat.pm
+++ b/tests/x11/tomcat.pm
@@ -63,37 +63,28 @@ sub run() {
     my $websocket_test = Tomcat::WebSocketsTest->new();
     $websocket_test->test_all_examples();
 
-    # Close firefox
-    $self->close_firefox();
     assert_screen('generic-desktop');
 
     # Install and configure apache2 and apache2-mod_jk connector
     Tomcat::ModjkTest->mod_jk_setup();
     $self->switch_to_desktop();
 
-    # start firefox
-    $self->start_firefox_with_profile();
     $self->firefox_open_url('http://localhost/examples/servlets');
     send_key_until_needlematch('tomcat-servlet-examples-page', 'ret');
 
     $self->firefox_open_url('http://localhost/examples/jsp');
     send_key_until_needlematch('tomcat-jsp-examples', 'ret');
-    $self->close_firefox();
 
     $self->select_serial_terminal();
     systemctl('start tomcat');
 
     my $with_modjk = 1;
     $self->switch_to_desktop();
-    # start firefox
-    $self->start_firefox_with_profile();
     record_info('Servlet Testing');
     $servlet_test->test_all_examples($with_modjk);
 
     record_info('JSP Testing');
     $jsp_test->test_all_examples($with_modjk);
-
-    $self->close_firefox();
 
     $self->select_serial_terminal();
     # Connection from apache2 to tomcat: Functionality test
@@ -101,9 +92,6 @@ sub run() {
 
     # switch to desktop
     $self->switch_to_desktop();
-
-    # start firefox
-    $self->start_firefox_with_profile();
 
     $self->firefox_open_url('http://localhost');
     send_key_until_needlematch('tomcat-succesfully-installed', 'ret');


### PR DESCRIPTION
Refactor tomcat test to keep one firefox instance open for the whole module and close at the end of test.
- Related ticket: https://progress.opensuse.org/issues/98261
- Needles:  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1559
                  https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/746
- Verification run: 
     SLE 15 SP3 - http://10.161.229.147/tests/1242
     SLE 15 SP2 - http://10.161.229.147/tests/1233
     SLE  15 SP1 - http://10.161.229.147/tests/1234
     SLE 12 SP5 - http://10.161.229.147/tests/1236
     SLE 12 SP4 - http://10.161.229.147/tests/1238
     SLE 12 SP3 - http://10.161.229.147/tests/1239
     SLE 12 SP2 - http://10.161.229.147/tests/1240
     Tumbleweed - http://10.161.229.147/tests/1241
     