### PR TITLE
Push an image to Amazon ECR

### DIFF
--- a/lib/publiccloud/aws.pm
+++ b/lib/publiccloud/aws.pm
@@ -15,7 +15,6 @@ package publiccloud::aws;
 use Mojo::Base 'publiccloud::provider';
 use Mojo::JSON 'decode_json';
 use testapi;
-use publiccloud::utils "is_byos";
 
 use constant CREDENTIALS_FILE => '/root/amazon_credentials';
 
@@ -66,6 +65,10 @@ sub init {
         save_tmp_file(CREDENTIALS_FILE, $credentials_file);
         assert_script_run('curl -O ' . autoinst_url . "/files/" . CREDENTIALS_FILE);
     }
+
+    $self->{aws_account_id} = script_output("aws sts get-caller-identity | jq -r '.Account'");
+    die("Cannot get the UserID")                                        unless ($self->{aws_account_id});
+    die("The UserID doesn't have the correct format: $self->{user_id}") unless $self->{aws_account_id} =~ /^\d{12}$/;
 }
 
 1;

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -16,6 +16,7 @@ use base 'opensusebasetest';
 use testapi;
 use publiccloud::azure;
 use publiccloud::ec2;
+use publiccloud::eks;
 use publiccloud::gce;
 use strict;
 use warnings;
@@ -27,12 +28,21 @@ sub provider_factory {
     die("Provider already initialized") if ($self->{provider});
 
     if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
-        $provider = publiccloud::ec2->new(
-            key_id     => get_var('PUBLIC_CLOUD_KEY_ID'),
-            key_secret => get_var('PUBLIC_CLOUD_KEY_SECRET'),
-            region     => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1'),
-            username   => get_var('PUBLIC_CLOUD_USER',   'ec2-user')
-        );
+        if (check_var('PUBLIC_CLOUD_SERVICE', 'EKS')) {
+            $provider = publiccloud::eks->new(
+                key_id     => get_var('PUBLIC_CLOUD_KEY_ID'),
+                key_secret => get_var('PUBLIC_CLOUD_KEY_SECRET'),
+                region     => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1'),
+                username   => get_var('PUBLIC_CLOUD_USER',   'ec2-user')
+            );
+        } else {
+            $provider = publiccloud::ec2->new(
+                key_id     => get_var('PUBLIC_CLOUD_KEY_ID'),
+                key_secret => get_var('PUBLIC_CLOUD_KEY_SECRET'),
+                region     => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1'),
+                username   => get_var('PUBLIC_CLOUD_USER',   'ec2-user')
+            );
+        }
 
     }
     elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {

--- a/lib/publiccloud/eks.pm
+++ b/lib/publiccloud/eks.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Helper class for Amazon Elastic Container Registry (ECR)
+#
+# Maintainer: Ivan Lausuch <ilausuch@suse.de>, qa-c team <qa-c@suse.de>
+# Documentation: https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
+
+package publiccloud::eks;
+use Mojo::Base 'publiccloud::aws';
+use testapi;
+
+=head2 push_container_image
+Upload a container image to the ECR. Required parameter is the
+name of the image, previously stored in the local registry. And
+the tag (name) in the public cloud containers repository
+Retrieves the full name of the uploaded image or die.
+=cut
+sub push_container_image {
+    my ($self, $image, $tag) = @_;
+
+    my $region     //= $self->region();
+    my $repository //= get_var("PUBLIC_CLOUD_CONTAINER_IMAGES_REPO", 'suse-qec-testing');
+    my $aws_account_id   = $self->{aws_account_id};
+    my $full_name_prefix = "$aws_account_id.dkr.ecr.$region.amazonaws.com";
+    my $full_name        = "$full_name_prefix/$repository:$tag";
+
+    $self->{repository} = $repository;
+    $self->{tag}        = $tag;
+
+    assert_script_run("aws ecr get-login-password --region $region | docker login --username AWS --password-stdin $full_name_prefix");
+    assert_script_run("docker tag $image $full_name");
+    assert_script_run("docker push $full_name", 180);
+    return $full_name;
+}
+
+sub cleanup {
+    my $self = shift;
+    assert_script_run("aws ecr batch-delete-image --repository-name " . $self->{repository} . " --image-ids imageTag=" . $self->{tag});
+    $self->SUPER::cleanup();
+    return;
+}
+
+1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -633,7 +633,7 @@ This method is called called after each test on failure or success.
 =cut
 sub cleanup {
     my ($self) = @_;
-    $self->terraform_destroy();
+    $self->terraform_destroy() unless script_run('test -d ' . TERRAFORM_DIR . '/.terraform');
     $self->vault_revoke();
     assert_script_run "cd";
 }

--- a/schedule/containers/sle_image_on_amazon_eks.yaml
+++ b/schedule/containers/sle_image_on_amazon_eks.yaml
@@ -1,0 +1,7 @@
+---
+name: sle_image_on_amazon_eks
+description: |
+  containers Amazon on Elastic Kubernetes Service test
+schedule:
+  - boot/boot_to_desktop
+  - containers/upload_container_images_to_ecr

--- a/tests/containers/upload_container_images_to_ecr.pm
+++ b/tests/containers/upload_container_images_to_ecr.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Push a container image to the public cloud container registry
+#
+# Maintainer: Ivan Lausuch <ilausuch@suse.com>, qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use containers::urls 'get_suse_container_urls';
+use mmapi 'get_current_job_id';
+
+sub run {
+    my ($self, $args) = @_;
+
+    $self->select_serial_terminal;
+
+    my ($untested_images, $released_images) = get_suse_container_urls();
+
+    my $provider = $self->provider_factory();
+    my $image    = $untested_images->[0];
+    my $tag      = join('-', get_var('PUBLIC_CLOUD_RESOURCE_NAME'), get_current_job_id());
+    assert_script_run("docker pull $image", 360);
+    $provider->push_container_image($image, $tag);
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -239,3 +239,4 @@ ZDUPREPOS | string | | Comma separated list of repositories to be added/used for
 ZFCP_ADAPTERS | string | | Comma separated list of available ZFCP adapters in the machine (usually 0.0.fa00 and/or 0.0.fc00)
 LINUXRC_BOOT | boolean | true | To be used only in scenarios where we are booting an installed system from the installer medium (for example, a DVD) with the menu option "Boot Linux System" (not "boot From Hard Disk"). This option uses linuxrc.
 ZYPPER_WHITELISTED_ORPHANS | string | empty | Whitelist expected orphaned packages, do not fail if any are found. Upgrade scenarios are expecting orphans by default. Used by console/orphaned_packages_check.pm
+PUBLIC_CLOUD_CONTAINER_IMAGES_REPO | string | | The Container images repository in CSP


### PR DESCRIPTION
This test check the connectivity from the tests to the Amazon ECR
and pushes a container image

- Related ticket: https://progress.opensuse.org/issues/97715
- Verification run: http://copland.arch.suse.de/tests/225