### PR TITLE
Change logic for GRUB auth test on SLES UEFI mode

### DIFF
--- a/tests/security/grub_auth/grub_authorization.pm
+++ b/tests/security/grub_auth/grub_authorization.pm
@@ -24,13 +24,14 @@
 #             3) Wrong user/password is not able to access the grub
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81721, poo#95548, tc#1768659
+# Tags: poo#81721, poo#95548, poo#97175, tc#1768659
 
 use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
 use base 'consoletest';
+use version_utils 'is_sle';
 
 my $sup_user     = 'admin';
 my $sup_passwd   = 'pw_admin';
@@ -41,7 +42,9 @@ my $test_passwd  = 'pw_test';
 
 sub switch_boot_menu {
     my $switch = shift;
-    if (get_var('UEFI')) {
+
+    # Currently, SLES doesn't include this new grub feature
+    if (get_var('UEFI') && !is_sle) {
         assert_screen("grub_uefi_firmware_menu_entry", timeout => 90);
         send_key_until_needlematch("grub_auth_boot_menu_entry", "down", 5, 2) if $switch;
     }


### PR DESCRIPTION
For sles platform, the grub package is not updated to the newer version as TW, so change the logic for now

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1190281
                          https://progress.opensuse.org/issues/97175                     
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/7048960
