### PR TITLE
Enable rules_and_classes for openSUSE

### DIFF
--- a/data/autoyast_opensuse/rule-based_example/classes/default
+++ b/data/autoyast_opensuse/rule-based_example/classes/default
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <classes config:type="list">
+    <class>
+      <class_name>general</class_name>
+      <configuration>users.xml</configuration>
+    </class>
+    <class>
+      <class_name>general</class_name>
+      <configuration>software.xml</configuration>
+    </class>
+    <class>
+      <class_name>swap</class_name>
+      <configuration>bigswap.xml</configuration>
+      <dont_merge config:type="list">
+        <element>partition</element>
+      </dont_merge>
+    </class>
+    <class>
+      <class_name>swap</class_name>
+      <configuration>smallswap.xml</configuration>
+      <dont_merge config:type="list">
+        <element>partition</element>
+      </dont_merge>
+    </class>
+  </classes>
+</profile>

--- a/data/autoyast_opensuse/rule-based_example/classes/general/software.xml
+++ b/data/autoyast_opensuse/rule-based_example/classes/general/software.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <products config:type="list">
+      <product>openSUSE</product>
+    </products>
+    <patterns config:type="list">
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>gnome</pattern>
+    </patterns>
+    <packages config:type="list">
+      <package>apache2</package>
+    </packages>
+  </software>
+</profile>

--- a/data/autoyast_opensuse/rule-based_example/classes/general/users.xml
+++ b/data/autoyast_opensuse/rule-based_example/classes/general/users.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <login_settings>
+    <autologin_user>bernhard</autologin_user>
+  </login_settings>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_opensuse/rule-based_example/classes/swap/bigswap.xml
+++ b/data/autoyast_opensuse/rule-based_example/classes/swap/bigswap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <partitioning config:type="list">
+    <drive>
+      <partitions config:type="list">
+        <partition>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>swap</mount>
+          <size>2000mb</size>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
+</profile>

--- a/data/autoyast_opensuse/rule-based_example/classes/swap/smallswap.xml
+++ b/data/autoyast_opensuse/rule-based_example/classes/swap/smallswap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <partitioning config:type="list">
+    <drive>
+      <partitions config:type="list">
+        <partition>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>swap</mount>
+          <size>1000mb</size>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
+</profile>

--- a/data/autoyast_opensuse/rule-based_example/profile_a.xml
+++ b/data/autoyast_opensuse/rule-based_example/profile_a.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+    </bootloader>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+    <networking>
+      <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <partitioning config:type="list">
+    <drive>
+      <device>/dev/sda</device>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+	  <mountby config:type="symbol">uuid</mountby>
+          <size>70%</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+	  <filesystem config:type="symbol">xfs</filesystem>
+          <mount>/home</mount>
+          <mountby config:type="symbol">uuid</mountby>
+	  <size>max</size>
+        </partition>
+      </partitions>
+    </drive>
+    </partitioning>
+    <classes config:type="list">
+      <class>
+        <class_name>general</class_name>
+        <configuration>users.xml</configuration>
+      </class>
+      <class>
+        <class_name>general</class_name>
+        <configuration>software.xml</configuration>
+      </class>
+      <class>
+        <class_name>swap</class_name>
+        <configuration>bigswap.xml</configuration>
+        <dont_merge config:type="list">
+          <element>partition</element>
+        </dont_merge>
+      </class>
+    </classes>
+</profile>

--- a/data/autoyast_opensuse/rule-based_example/profile_b.xml
+++ b/data/autoyast_opensuse/rule-based_example/profile_b.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+    </bootloader>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+    <networking>
+      <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <size>70%</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">true</format>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <mount>/home</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <size>max</size>
+        </partition>
+      </partitions>
+    </drive>
+    </partitioning>
+    <classes config:type="list">
+      <class>
+        <class_name>general</class_name>
+        <configuration>users.xml</configuration>
+      </class>
+      <class>
+        <class_name>general</class_name>
+        <configuration>software.xml</configuration>
+      </class>
+      <class>
+        <class_name>swap</class_name>
+        <configuration>smallswap.xml</configuration>
+        <dont_merge config:type="list">
+          <element>partition</element>
+        </dont_merge>
+      </class>      
+    </classes>
+</profile>

--- a/data/autoyast_opensuse/rule-based_example/rules/rules.xml
+++ b/data/autoyast_opensuse/rule-based_example/rules/rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<autoinstall xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <rules config:type="list">
+    <rule>
+      <disksize>
+        <match>/dev/sda 19000</match>
+        <match_type>greater</match_type>
+      </disksize>
+      <result>
+        <profile>profile_a.xml</profile>
+        <continue config:type="boolean">false</continue>
+      </result>
+    </rule>
+    <rule>
+      <disksize>
+        <match>/dev/vda 10000</match>
+        <match_type>greater</match_type>
+      </disksize>
+      <result>
+        <profile>profile_b.xml</profile>
+        <continue config:type="boolean">false</continue>
+      </result>
+    </rule>
+  </rules>
+</autoinstall>

--- a/schedule/yast/autoyast/autoyast_opensuse_rules_and_classes.yaml
+++ b/schedule/yast/autoyast/autoyast_opensuse_rules_and_classes.yaml
@@ -3,7 +3,7 @@ name: autoyast_rules_and_classes
 description: >
   For future testing of AutoYaST rules and classes
 vars:
-  AUTOYAST: autoyast_sle15/rule-based_example/
+  AUTOYAST: autoyast_opensuse/rule-based_example/
 schedule:
   - autoyast/prepare_rules_and_classes
   - installation/bootloader_start
@@ -17,13 +17,3 @@ schedule:
   - autoyast/autoyast_reboot
   - installation/grub_test
   - installation/first_boot
-  - console/validate_partition_table_via_blkid
-  - console/validate_blockdevices
-  - console/zypper_lr
-  - console/zypper_ref
-  - console/ncurses
-  - update/zypper_up
-  - console/zypper_in
-  - console/zypper_log
-  - console/orphaned_packages_check
-  - autoyast/verify_cloned_profile


### PR DESCRIPTION
Enable AutoYaST rules_and_classes for openSUSE

- Related ticket: https://progress.opensuse.org/issues/97874
- Verification run: https://openqa.opensuse.org/tests/1906987

