### PR TITLE
lib/main_common: Install updates after performing a DVD upgrade as well

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -3130,11 +3130,17 @@ sub load_ha_cluster_tests {
 }
 
 sub updates_is_applicable {
-    # we don't want live systems to run out of memory or virtual disk space.
+    # We don't want live systems to run out of memory or virtual disk space.
     # Applying updates on a live system would not be persistent anyway.
-    # Also, applying updates on BOOT_TO_SNAPSHOT is useless.
+    return 0 if is_livesystem;
+    # Applying updates on BOOT_TO_SNAPSHOT is useless.
     # Also, updates on INSTALLONLY do not match the meaning
-    return !get_var('INSTALLONLY') && !get_var('BOOT_TO_SNAPSHOT') && !get_var('DUALBOOT') && !get_var('UPGRADE') && !is_livesystem;
+    return 0 if get_var('INSTALLONLY') || get_var('BOOT_TO_SNAPSHOT') || get_var('DUALBOOT');
+    # After upgrading using only the DVD, packages not on the DVD can be
+    # updated in the installed system with online repos.
+    return 0 if get_var('UPGRADE') && !check_var('FLAVOR', 'DVD');
+
+    return 1;
 }
 
 sub guiupdates_is_applicable {


### PR DESCRIPTION
When upgrading with the DVD, only packages on the DVD can be upgraded.
The rest can be upgraded once online repos are available in the running system.

- Related ticket: https://progress.opensuse.org/issues/97103
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/745
- Verification runs:
42.1 to TW KDE: http://10.160.67.86/tests/1052
42.3 to TW cryptlvm@uefi: http://10.160.67.86/tests/1050
15.2 to TW KDE: http://10.160.67.86/tests/1051

The GIMP failures are somehow local to that machine - different DPI with TW's QEMU maybe?

Does `UPGRADE=1` + `FLAVOR=DVD` affect SLE as well? No idea who to ask for review.