### PR TITLE
Fix tracker failures on SLE15SP4

### DIFF
--- a/tests/x11/tracker/tracker_by_command.pm
+++ b/tests/x11/tracker/tracker_by_command.pm
@@ -32,9 +32,16 @@ sub run {
         script_run "tracker-search newfile";
     }
     else {
-        my $trackercmd = (is_sle('<16') or is_leap('<16.0')) ? 'tracker' : 'tracker3';
+        my $trackercmd = (is_sle('<=15-sp3') or is_leap('<=15.3')) ? 'tracker' : 'tracker3';
         script_run "$trackercmd search emptyfile";
-        assert_screen('tracker-cmdsearch-emptyfile');
+        assert_screen([qw(tracker-cmdsearch-emptyfile tracker-cmdsearch-noemptyfile)]);
+        if (match_has_tag 'tracker-cmdsearch-noemptyfile') {
+            record_soft_failure 'bsc#1190296 tracker3 can not index empty files for the first time';
+            enter_cmd "clear";
+            wait_still_screen 10;
+            assert_script_run "$trackercmd search emptyfile";
+            assert_screen 'tracker-cmdsearch-emptyfile';
+        }
         script_run "$trackercmd search newfile";
     }
     assert_screen 'tracker-cmdsearch-newfile';

--- a/tests/x11/tracker/tracker_info.pm
+++ b/tests/x11/tracker/tracker_info.pm
@@ -31,7 +31,7 @@ sub run {
         script_run "tracker-info newpl.pl";
     }
     else {
-        my $trackercmd = (is_sle('<16') or is_leap('<16.0')) ? 'tracker' : 'tracker3';
+        my $trackercmd = (is_sle('<=15-sp3') or is_leap('<=15.3')) ? 'tracker' : 'tracker3';
         script_run "$trackercmd info newpl.pl";
     }
     assert_screen 'tracker-info-newpl';


### PR DESCRIPTION
Adjust the condition to handle different tracker versions
Add a softfailure for tracker search due to bsc#1190296

- Related ticket: https://progress.opensuse.org/issues/97940
- Needles: already added when debugging on osd
- Verification run: 

Updated on 2021-09-15
> SLE15SP4 https://openqa.suse.de/tests/7097788
> TW x86_64 https://openqa.opensuse.org/tests/1914765
> TW aarch64 https://openqa.opensuse.org/tests/1914766