### PR TITLE
LTP: Warn on missing symlink of kernel config in /boot

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -110,6 +110,9 @@ sub log_versions {
             record_soft_failure 'boo#1189879 missing kernel config in kernel package, use /proc/config.gz';
             $cmd .= "zcat $kernel_config";
         } else {
+            if ($kernel_config !~ /^\/boot\/config-/) {
+                record_soft_failure 'boo#1189879 missing symlink to /boot, use config in /usr/lib/modules/';
+            }
             $cmd .= "cat $kernel_config";
         }
 


### PR DESCRIPTION
This further improves 2c6ead199.

Fixes: 2c6ead199 ("LTP: Warn on missing symlink of kernel config in /boot")

Verification run: http://quasar.suse.cz/tests/7112#step/install_ltp/89
