### PR TITLE
Upload logs after rebuilding initrd in SLEM

### DIFF
--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -30,6 +30,8 @@ sub run {
     # install and enable SELinux if not done by default
     if (script_run('test -d /sys/fs/selinux && test -e /etc/selinux/config') != 0) {
         assert_script_run('transactional-update setup-selinux');
+        upload_logs('/var/log/transactional-update.log');
+        shift->save_and_upload_log('rpm -qa', 'installed_pkgs.txt');
         process_reboot(trigger => 1);
     }
 


### PR DESCRIPTION
SLEM5.1 image for s390x shows symptoms that point to rebuilding of
initrd on running system. In order to get more information it seems
useful to upload logs after rebuilding initrd as the system might end up
unbootable.

- VR http://kepler.suse.cz/tests/6813
