### PR TITLE
Fix rules_and_classes for SLE15

### DIFF
--- a/data/autoyast_sle15/rule-based_example/rules/rules.xml
+++ b/data/autoyast_sle15/rule-based_example/rules/rules.xml
@@ -13,8 +13,8 @@
     </rule>
     <rule>
       <disksize>
-        <match>/dev/vda 10000-19000</match>
-        <match_type>range</match_type>
+        <match>/dev/vda 10000</match>
+        <match_type>greater</match_type>
       </disksize>
       <result>
         <profile>profile_b.xml</profile>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -740,6 +740,11 @@ sub test_ayp_url {
         # replace default qemu gateway by loopback
         $ayp_url =~ s/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/localhost/;
 
+        # if the $ayp_url ends with a / we use the rules_and_classes approach
+        # that means we should test for rules/rules.xml because retrieving
+        # the directory will end up in a 404.
+        $ayp_url =~ s/\/$/\/rules\/rules.xml/;
+
         if (head($ayp_url)) {
             record_info("ayp url ok", "Autoyast profile url $ayp_url is reachable from the worker");
         } else {


### PR DESCRIPTION
Some small patches for rules_and_classes on SLE

- changed match rules in rules.xml because of this bug:
  https://bugzilla.suse.com/show_bug.cgi?id=1190245
- if rules_and_classes is used, then test_ayp_url appends
  "rules/rules.xml" to the URL to be tested if its reachable.
  The command server would respond with 404 if we want to
  access a direcory.

- Related ticket: https://progress.opensuse.org/issues/97871
- Verification run: https://openqa.suse.de/tests/7052844
