### PR TITLE
Add check for next button pressability in accept_timezone_configuration

### DIFF
--- a/lib/Installation/Navigation/NavigationBar.pm
+++ b/lib/Installation/Navigation/NavigationBar.pm
@@ -35,6 +35,9 @@ sub is_shown {
 
 sub press_next {
     my ($self) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            return $self->{btn_next}->is_enabled();
+    }, message => "Next button takes too long to be enabled");
     return $self->{btn_next}->click();
 }
 

--- a/lib/YuiRestClient/Widget/Button.pm
+++ b/lib/YuiRestClient/Widget/Button.pm
@@ -23,4 +23,10 @@ sub click {
     return $self->action(action => YuiRestClient::Action::YUI_PRESS);
 }
 
+sub is_enabled {
+    my ($self) = @_;
+    my $is_enabled = $self->property('enabled');
+    return !defined $is_enabled || $is_enabled;
+}
+
 1;


### PR DESCRIPTION
system is pressing "Next" before it's enabled and this causes failure

- Related ticket: https://progress.opensuse.org/issues/97709
- Verification run: https://openqa.suse.de/tests/7110422#next_previous
