### PR TITLE
Exclude empathy_irc from openSUSE

### DIFF
--- a/schedule/functional/message.yaml
+++ b/schedule/functional/message.yaml
@@ -8,7 +8,6 @@ conditional_schedule:
     opensuse_tests:
         DISTRI:
             opensuse:
-                - x11/empathy/empathy_irc
                 - x11/pidgin/pidgin_IRC
                 - x11/pidgin/clean_pidgin
     sle_tests:


### PR DESCRIPTION
see https://progress.opensuse.org/issues/98418
