### PR TITLE
Containers: small fixes for BCI Tests

### DIFF
--- a/schedule/containers/bci_tests.yaml
+++ b/schedule/containers/bci_tests.yaml
@@ -1,7 +1,7 @@
-name:           sle_image_on_sle_host_podman
+name:           bci_tests
 description:    >
   Maintainer: qa-c@suse.de
-  Container images specific tests with podman
+  BCI Tests on container images
 conditional_schedule:
   boot:
     ARCH:
@@ -11,4 +11,4 @@ schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
-  - containers/podman_image
+  - containers/bci_tests

--- a/schedule/containers/sle_image_on_sle_host_docker.yaml
+++ b/schedule/containers/sle_image_on_sle_host_docker.yaml
@@ -7,14 +7,9 @@ conditional_schedule:
     ARCH:
       's390x':
         - installation/bootloader_start
-  bci:
-    FLAVOR:
-      'Container-Image-Updates':
-        - containers/bci_tests
 schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
   - containers/docker_image
-  - '{{bci}}'
   - containers/container_diff


### PR DESCRIPTION
- don't fail in upload_logs commands
- collect number of failed test cases and die at the end if any fails

I created a new group in Development for BCI. Once the tests are more stable, we can move them to our image validation process.
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=17.8.1&groupid=398