### PR TITLE
lib/kdump_utils: Use usrmerged location of vmlinux on Tumbleweed

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -348,7 +348,8 @@ sub check_function {
     if ($args{test_type} eq 'function') {
         # Check, that vmcore exists, otherwise fail
         assert_script_run('ls -lah /var/crash/*/vmcore');
-        my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`*";
+        my $vmlinux   = (is_sle("<16") || is_leap("<16.0")) ? '/boot/vmlinux-$(uname -r)*' : '/usr/lib/modules/$(uname -r)/vmlinux*';
+        my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` $vmlinux";
         validate_script_output "$crash_cmd", sub { m/PANIC:\s([^\s]+)/ }, 600;
     }
     else {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/97511
- Verification runs:
Tumbleweed: https://openqa.opensuse.org/tests/1910418
Leap 15.3: https://openqa.opensuse.org/tests/1910424

TW test still fails, needs some investigation. Looks like a product bug now.
