### PR TITLE
Fix system boot from hard disk not upgrade in grub after reboot

### DIFF
--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -50,11 +50,7 @@ sub run {
     }
 
     record_info('Version', 'VERSION=' . get_var('VERSION'));
-    if (is_pvm) {
-        reconnect_mgmt_console;
-    } else {
-        reset_consoles_tty;
-    }
+    reconnect_mgmt_console if is_pvm;
 }
 
 1;


### PR DESCRIPTION
When we reboot the system to upgrade, sometimes in grub it will timeout
and boot directly into the local disk. We need to call disable_grub_timeout
to avoid this error

- Related ticket: https://progress.opensuse.org/issues/95962
- Needles: N/A
- Verification run: 

 https://openqa.nue.suse.com/tests/7071000
 https://openqa.nue.suse.com/tests/7071001
 https://openqa.nue.suse.com/tests/7087181
 https://openqa.nue.suse.com/tests/7087182