### PR TITLE
yast_virtualization: Accept current behaviour without soft-fail

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -59,7 +59,9 @@ sub run {
     # manually start the 'default' network if it is not active
     if (script_run("virsh net-info default |& grep '^Active.*no'") == 0) {
         record_soft_failure 'bsc#1123699';
-        record_info("start default network", "libvirtd did not start the network by default");
+        record_info("start default network", "libvirtd did not start the
+            network by default. See
+            https://bugzilla.opensuse.org/show_bug.cgi?id=1123699");
         assert_script_run("virsh net-start default");
     }
     send_key 'ret';


### PR DESCRIPTION
The test shows how the system can be configured also in case where
pre-requisites differ, e.g. in case wicked or NetworkManager is used. As
both https://bugzilla.opensuse.org/show_bug.cgi?id=1123699 and
https://bugzilla.opensuse.org/show_bug.cgi?id=1169214 have seen
improvements and have been set to RESOLVED FIXED with according changes
reaching the product we should just accept the current behaviour and not
soft-fail the module anymore.