### PR TITLE
Create hdd with "Common Criteria" System Role

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2009-2021 Bernhard M. Wiedemann
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,6 +21,10 @@ use version_utils qw(is_leap is_storage_ng is_sle is_tumbleweed);
 use partition_setup qw(%partition_roles is_storage_ng_newui);
 
 sub run {
+    if (check_var('SYSTEM_ROLE', 'Common_Criteria')) {
+        assert_screen 'Common-Criteria-Evaluated-Configuration-RN-Next';
+        send_key 'alt-n';
+    }
     assert_screen 'partitioning-edit-proposal-button', 40;
     if (check_var('PARTITION_EDIT', 'ext4_btrfs')) {
         send_key 'alt-g';

--- a/tests/security/cc/cc_audit_test_setup.pm
+++ b/tests/security/cc/cc_audit_test_setup.pm
@@ -41,6 +41,9 @@ sub run {
     # Install audit packages
     zypper_call('in audit audit-audispd-plugins');
 
+    # Install tool packages
+    zypper_call('in wget');
+
     # Workaround for restarting audit service
     assert_script_run('sed -i \'/\[Unit\]/aStartLimitIntervalSec=0\' /usr/lib/systemd/system/auditd.service');
     assert_script_run('systemctl daemon-reload');


### PR DESCRIPTION
Create qcow2 with "Common Criteria" System Role

- Related ticket: https://progress.opensuse.org/issues/97748
- Needles: added already
- Verification run with "CC", all passed: 
   x86: https://openqa.suse.de/tests/7123524
   aarch64: https://openqa.suse.de/tests/7123525
   s390x: https://openqa.suse.de/tests/7123523
- Verification run **without** "CC", all passed: 
   x86: https://openqa.suse.de/tests/7123532
   aarch64: https://openqa.suse.de/tests/7123528
   s390x: https://openqa.suse.de/tests/7123529
- Verification run for "audit-test" with "CC" qcow2, the it works and failed cases can be tracked by poo atm
   x86: https://openqa.suse.de/tests/7100004
   aarch64: https://openqa.suse.de/tests/7100005
   s390x: https://openqa.suse.de/tests/7105962