### PR TITLE
yast2_nfs_client: Increse timeout to get reason of failure if not pass

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -154,7 +154,7 @@ sub client_common_tests {
     assert_script_run "rm /tmp/nfs/client/symlinkedfile";
 
     # Copy large file from NFS and test it's checksum
-    assert_script_run "time cp /tmp/nfs/client/random /var/tmp/", 120;
+    assert_script_run "time cp /tmp/nfs/client/random /var/tmp/", 300;
     assert_script_run "md5sum /var/tmp/random | cut -d' ' -f1 > /var/tmp/random.md5sum";
     assert_script_run "diff /tmp/nfs/client/random.md5sum /var/tmp/random.md5sum";
 }


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/7086789#step/yast2_nfs_client/94
- Verification run: Not needed, it's just occassinal fail ... timeout