### PR TITLE
LTP: Record missing kernel config only in install_ltp

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -349,7 +349,7 @@ sub run {
         install_from_repo();
     }
 
-    log_versions;
+    log_versions 1;
 
     zypper_call('in efivar') if is_sle('12+') || is_opensuse;
 


### PR DESCRIPTION
It was not intended to soft fail all LTP tests.

Verification run:
* http://quasar.suse.cz/tests/7158 (opensuse-Tumbleweed-DVD-x86_64-Build20210910-ltp_net_stress_route@64bit)
