### PR TITLE
Handle VERSION invocation in ensure_ca_certificates_suse_installed

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1830,7 +1830,8 @@ This functions checks if ca-certificates-suse is installed and if it is not it a
 sub ensure_ca_certificates_suse_installed {
     return unless is_sle;
     if (script_run('rpm -qi ca-certificates-suse') == 1) {
-        my $distversion = get_required_var("VERSION") =~ s/-SP/_SP/r;    # 15 -> 15, 15-SP1 -> 15_SP1
+        my $host_version = get_var("HOST_VERSION") ? 'HOST_VERSION' : 'VERSION';
+        my $distversion  = get_required_var($host_version) =~ s/-SP/_SP/r;         # 15 -> 15, 15-SP1 -> 15_SP1
         zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_$distversion/SUSE:CA.repo");
         zypper_call("in ca-certificates-suse");
     }


### PR DESCRIPTION
In containers we use HOST_VERSION to identify the version that the host
    is using and distinguish from the version that the container is running on.
    
    `ensure_ca_certificates_suse_installed` omits the HOST_VERSION resulting
    to use wrong repo to install ca-certifications in the host.

keep `get_required_var` to not change the current behavior.

- Related ticket: https://progress.opensuse.org/issues/98553
Verification run: 
- https://openqa.suse.de/tests/7090715 check repos https://openqa.suse.de/tests/7090715#step/host_configuration/34