### PR TITLE
Rename test module ssh_interactive_init to prepare_instance

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2807,10 +2807,10 @@ sub load_qam_publiccloud_tests {
     my $args = OpenQA::Test::RunArgs->new();
 
     loadtest "publiccloud/download_repos";
-    loadtest "publiccloud/ssh_interactive_init", run_args => $args;
-    loadtest "publiccloud/register_system",      run_args => $args;
-    loadtest "publiccloud/transfer_repos",       run_args => $args;
-    loadtest "publiccloud/patch_and_reboot",     run_args => $args;
+    loadtest "publiccloud/prepare_instance", run_args => $args;
+    loadtest "publiccloud/register_system",  run_args => $args;
+    loadtest "publiccloud/transfer_repos",   run_args => $args;
+    loadtest "publiccloud/patch_and_reboot", run_args => $args;
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
         loadtest("publiccloud/img_proof", run_args => $args);
     } elsif (get_var('PUBLIC_CLOUD_LTP')) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -713,12 +713,12 @@ the second run will update the system.
 
 =cut
 sub ssh_fully_patch_system {
-    my $host = shift;
+    my $remote = shift;
     # first run, possible update of packager -- exit code 103
-    my $ret = script_run("ssh root\@$host 'zypper -n patch --with-interactive -l'", 1500);
+    my $ret = script_run("ssh $remote 'sudo zypper -n patch --with-interactive -l'", 1500);
     die "Zypper failed with $ret" if ($ret != 0 && $ret != 102 && $ret != 103);
     # second run, full system update
-    $ret = script_run("ssh root\@$host 'zypper -n patch --with-interactive -l'", 6000);
+    $ret = script_run("ssh $remote 'sudo zypper -n patch --with-interactive -l'", 6000);
     die "Zypper failed with $ret" if ($ret != 0 && $ret != 102);
 }
 

--- a/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-docker-publiccloud.yml
@@ -14,7 +14,7 @@ conditional_schedule:
 schedule:
   - boot/boot_to_desktop
   - publiccloud/download_repos
-  - publiccloud/ssh_interactive_init
+  - publiccloud/prepare_instance
   - publiccloud/register_system
   - publiccloud/transfer_repos
   - publiccloud/patch_and_reboot

--- a/schedule/publiccloud/mau-extratests-publiccloud.yml
+++ b/schedule/publiccloud/mau-extratests-publiccloud.yml
@@ -5,7 +5,7 @@ description: |
 schedule:
   - boot/boot_to_desktop
   - publiccloud/download_repos
-  - publiccloud/ssh_interactive_init
+  - publiccloud/prepare_instance
   - publiccloud/register_system
   - publiccloud/transfer_repos
   - publiccloud/patch_and_reboot

--- a/schedule/publiccloud/qem_publiccloud_img_proof.yml
+++ b/schedule/publiccloud/qem_publiccloud_img_proof.yml
@@ -5,7 +5,7 @@ description: |
 schedule:
   - boot/boot_to_desktop
   - publiccloud/download_repos
-  - publiccloud/ssh_interactive_init
+  - publiccloud/prepare_instance
   - publiccloud/register_system
   - publiccloud/transfer_repos
   - publiccloud/patch_and_reboot

--- a/schedule/publiccloud/smoketest.yml
+++ b/schedule/publiccloud/smoketest.yml
@@ -10,7 +10,7 @@ conditional_schedule:
 schedule:
   - boot/boot_to_desktop
   - publiccloud/download_repos
-  - publiccloud/ssh_interactive_init
+  - publiccloud/prepare_instance
   - publiccloud/register_system
   - publiccloud/transfer_repos
   - publiccloud/patch_and_reboot

--- a/schedule/publiccloud/staging_images/mau-extratests-docker-publiccloud.yml
+++ b/schedule/publiccloud/staging_images/mau-extratests-docker-publiccloud.yml
@@ -11,7 +11,7 @@ conditional_schedule:
         - containers/podman
 schedule:
   - boot/boot_to_desktop
-  - publiccloud/ssh_interactive_init
+  - publiccloud/prepare_instance
   - publiccloud/register_system
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview

--- a/schedule/publiccloud/staging_images/mau-extratests-publiccloud.yml
+++ b/schedule/publiccloud/staging_images/mau-extratests-publiccloud.yml
@@ -4,7 +4,7 @@ description: |
   Run mau-extratests on public cloud instances
 schedule:
   - boot/boot_to_desktop
-  - publiccloud/ssh_interactive_init
+  - publiccloud/prepare_instance
   - publiccloud/register_system
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -24,8 +24,10 @@ sub run {
     my ($self, $args) = @_;
     select_host_console();    # select console on the host, not the PC instance
 
+    my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
+
     $args->{my_instance}->retry_ssh_command(cmd => "sudo zypper -n ref", timeout => 240, retry => 6);
-    ssh_fully_patch_system($args->{my_instance}->public_ip);
+    ssh_fully_patch_system($remote);
     $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
 }
 

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,7 +10,7 @@
 # Package: openssh
 # Summary: This tests will deploy the public cloud instance and prepare the ssh
 #
-# Maintainer: Pavel Dostal <pdostal@suse.cz>
+# Maintainer: <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use publiccloud::utils "select_host_console";

--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,7 +10,7 @@
 # Package: cloud-regionsrv-client
 # Summary: Register the remote system
 #
-# Maintainer: Pavel Dostal <pdostal@suse.cz>, Felix Niederwanger <felix.niederwanger@suse.de>
+# Maintainer: <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::ssh_interactive_init';
 use version_utils;
@@ -37,18 +37,19 @@ sub run {
         $args->{my_instance}->retry_ssh_command("sudo SUSEConnect -r $regcode", timeout => 420, retry => 3);
         my $arch = get_var('PUBLIC_CLOUD_ARCH') // "x86_64";
         $arch = "aarch64" if ($arch eq "arm64");
+        my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
         for my $addon (@addons) {
             next if ($addon =~ /^\s+$/);
             record_info $addon, "Going to register '$addon' addon";
             if ($addon =~ /ltss/) {
                 $regcode = get_required_var('SCC_REGCODE_LTSS');
-                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '${VERSION_ID}', $arch, "-r $regcode");
+                ssh_add_suseconnect_product($remote, get_addon_fullname($addon), '${VERSION_ID}', $arch, "-r $regcode");
             } elsif (is_sle('<15') && $addon =~ /tcm|wsm|contm|asmm|pcm/) {
-                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '`echo ${VERSION} | cut -d- -f1`', $arch);
+                ssh_add_suseconnect_product($remote, get_addon_fullname($addon), '`echo ${VERSION} | cut -d- -f1`', $arch);
             } elsif (is_sle('<15') && $addon =~ /sdk|we/) {
-                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), '${VERSION_ID}', $arch);
+                ssh_add_suseconnect_product($remote, get_addon_fullname($addon), '${VERSION_ID}', $arch);
             } else {
-                ssh_add_suseconnect_product($args->{my_instance}->public_ip, get_addon_fullname($addon), undef, $arch);
+                ssh_add_suseconnect_product($remote, get_addon_fullname($addon), undef, $arch);
             }
         }
     }

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2019-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,7 +10,7 @@
 # Package: rsync
 # Summary: Transfer repositories to the public cloud instasnce
 #
-# Maintainer: Pavel Dostal <pdostal@suse.cz>
+# Maintainer: <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::ssh_interactive_init';
 use registration;
@@ -24,6 +24,7 @@ sub run {
     my ($self, $args) = @_;
     select_host_console();    # select console on the host, not the PC instance
 
+    my $remote  = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
     my @addons  = split(/,/, get_var('SCC_ADDONS', ''));
     my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);
 
@@ -36,7 +37,7 @@ sub run {
 
         # Mitigate occasional CSP network problems (especially one CSP is prone to those issues!)
         # Delay of 2 minutes between the tries to give their network some time to recover after a failure
-        script_retry("rsync --timeout=$timeout -uvahP -e ssh ~/repos 'root@" . $args->{my_instance}->public_ip . ":/tmp/repos'", timeout => $timeout + 10, retry => 3, delay => 120);
+        script_retry("rsync --timeout=$timeout -uvahP -e ssh ~/repos 'root@" . $remote . ":/tmp/repos'", timeout => $timeout + 10, retry => 3, delay => 120);
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar -p10 '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");


### PR DESCRIPTION
The test module `publiccloud/ssh_interactive_init.pm` has misleading name.
 * This module creates public cloud instance, adds `bernhard` user and enables password login.
 * This module does not prepare neither use ssh interactive terminal, neither its tunnel.

The ssh tunnel specific settings is now not executed when `TUNNELED` variable is not set.
Modules `transfer_repos`, `register_system` and `patch_and_reboot` now use normal user instead of root.

- Verification run: [containers](http://pdostal-server.suse.cz/tests/12484) [LTP](http://pdostal-server.suse.cz/tests/12494) [img-proof](http://pdostal-server.suse.cz/tests/12493)
