### PR TITLE
Containers: fix hardcoded name for Dockerfile

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -62,7 +62,7 @@ sub build_and_run_image {
         assert_script_run "curl -f -v " . data_url('containers/requirements.txt') . " > $dir/BuildTest/requirements.txt";
         assert_script_run "curl -f -v " . data_url('containers/app.py') . " > $dir/BuildTest/app.py";
     }
-    file_content_replace("$dir/BuildTest/Dockerfile", baseimage_var => $base) if defined $base;
+    file_content_replace("$dir/BuildTest/$dockerfile", baseimage_var => $base) if defined $base;
     assert_script_run "curl -f -v " . data_url('containers/index.html') . " > $dir/BuildTest/index.html";
 
     # Build the image


### PR DESCRIPTION
Detected failure: https://openqa.opensuse.org/tests/1913262#step/docker_image/111

