### PR TITLE
SLE Micro: add smoke tests for transactional update

### DIFF
--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -52,6 +52,7 @@ sub load_feature_tests {
     loadtest 'microos/image_checks' if is_image_flavor;
     loadtest 'microos/one_line_checks';
     loadtest 'microos/services_enabled';
+    loadtest 'transactional/trup_smoke';
     load_transactional_role_tests;
     loadtest 'microos/cockpit_service' unless is_staging;
     loadtest 'console/journal_check';

--- a/schedule/sle-micro/dvd.yaml
+++ b/schedule/sle-micro/dvd.yaml
@@ -49,6 +49,7 @@ schedule:
   - microos/one_line_checks
   - microos/services_enabled
   - microos/cockpit_service
+  - transactional/trup_smoke
   - transactional/filesystem_ro
   - transactional/transactional_update
   - transactional/rebootmgr

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -28,6 +28,7 @@ conditional_schedule:
     SLE_MICRO_K3S:
       '1':
         - containers/k3s_cli_check
+
 schedule:
   - '{{boot}}'
   - transactional/host_config
@@ -41,6 +42,7 @@ schedule:
   - microos/one_line_checks
   - microos/services_enabled
   - microos/cockpit_service
+  - transactional/trup_smoke
   - transactional/filesystem_ro
   - transactional/transactional_update
   - transactional/rebootmgr

--- a/tests/transactional/trup_smoke.pm
+++ b/tests/transactional/trup_smoke.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Basic smoke test to verify all basic transactional update
+#           operations work and system can properly boot.
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use transactional;
+
+
+sub action {
+    my ($target, $text, $reboot) = @_;
+    $reboot //= 1;
+    record_info('TEST', $text);
+    trup_call($target);
+    check_reboot_changes if $reboot;
+}
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'root-console';
+
+    action('bootloader', 'Reinstall bootloader');
+    action('grub.cfg',   'Regenerate grub.cfg');
+    action('initrd',     'Regenerate initrd');
+    action('kdump',      'Regenerate kdump');
+    action('cleanup',    'Run cleanup', 0);
+}
+
+1;


### PR DESCRIPTION
Basic checks for transactional update operations that
are not tested anywhere else.
This test can be extended later on if needed adding additional
changes in initrd, grub, and performing more checks.

- Related ticket: https://progress.opensuse.org/issues/98538
