### PR TITLE
HPC package remain function need python module

### DIFF
--- a/lib/services/hpcpackage_remain.pm
+++ b/lib/services/hpcpackage_remain.pm
@@ -28,6 +28,7 @@ use utils;
 use strict;
 use Data::Dumper;
 use warnings;
+use registration;
 
 my @diffpkg;
 
@@ -89,10 +90,14 @@ sub full_pkgcompare_check {
     my $stage = $hash{stage};
 
     if ($stage eq 'before') {
+        # It need python2 module to compare packages
+        add_suseconnect_product("sle-module-python2", undef, undef, undef, 300, 1) if (get_var('DROPPED_MODULES', '') =~ /python2/);
         list_pkg("orignalq1w2.txt");
         install_pkg();
         list_pkg("installe3r4.txt");
         compare_pkg("/tmp/orignalq1w2.txt", "/tmp/installe3r4.txt");
+        # De-register python2 module again
+        remove_suseconnect_product('sle-module-python2') if (get_var('DROPPED_MODULES', '') =~ /python2/);
     }
     else {
         check_pkg;


### PR DESCRIPTION
This is a workaround. As the code will delete the dropped module python2 at patch_sle test module. But at install_service for hpc package remain check, it need python2 module. So, it need add python2 before hpc check then de-register python2 again.

- Related ticket: https://progress.opensuse.org/issues/98162
- Verification run: https://openqa.suse.de/tests/7124205