### PR TITLE
Use YAML_SCHEDULE for test 'toolchain_zypper'

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -96,7 +96,6 @@ our @EXPORT = qw(
   load_system_update_tests
   loadtest
   load_testdir
-  load_toolchain_tests
   load_virtualization_tests
   load_x11tests
   load_hypervisor_tests
@@ -2799,14 +2798,6 @@ sub load_extra_tests_syscontainer {
     loadtest 'virtualization/syscontainer_image_test';
 }
 
-sub load_toolchain_tests {
-    loadtest "console/force_scheduled_tasks";
-    loadtest "toolchain/install";
-    loadtest "toolchain/gcc_fortran_compilation";
-    loadtest "toolchain/gcc_compilation";
-    loadtest "console/kdump_and_crash" if is_sle && kdump_is_applicable;
-}
-
 sub load_extra_tests_kernel {
     loadtest "kernel/module_build";
     loadtest "kernel/tuned";
@@ -2915,7 +2906,6 @@ sub load_common_opensuse_sle_tests {
     load_publiccloud_tests              if get_var('PUBLIC_CLOUD');
     loadtest "terraform/create_image"   if get_var('TERRAFORM');
     load_create_hdd_tests               if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
-    load_toolchain_tests                if get_var("TCM")         || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
     load_transactional_role_tests       if is_transactional && (get_var('ARCH') !~ /ppc64|s390/);

--- a/schedule/functional/toolchain.yaml
+++ b/schedule/functional/toolchain.yaml
@@ -1,0 +1,22 @@
+---
+name: toolchain
+description: >
+    Maintainer: zluo
+    toolchain tests for sles and opensuse
+conditional_schedule:
+    bootloader:
+        BACKEND:
+            'svirt':
+                - installation/bootloader_zkvm
+    kdump_and_crash:
+        DISTRI:
+            sle:
+                - console/kdump_and_crash
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - console/force_scheduled_tasks
+    - toolchain/install
+    - toolchain/gcc_fortran_compilation
+    - toolchain/gcc_compilation
+    - '{{kdump_and_crash}}'


### PR DESCRIPTION
see https://progress.opensuse.org/issues/98391
and https://progress.opensuse.org/issues/68527
Verifications:
http://10.160.64.152/tests/3354 (sles 64bit-smp)
http://10.160.64.152/tests/3359 (sles aarch64)
http://10.160.64.152/tests/3362 (Tumbelweed)
http://10.160.64.152/tests/3365 (Leap 15.4)
https://openqa.opensuse.org/tests/1919108 (Tumbleweed aarch64)
http://openqa.suse.de/tests/7136532 (sles s390x svirt)
http://openqa.suse.de/tests/7136627 (sles ppc64le)
http://openqa.suse.de/tests/7136802 (sles 64bit-smp)