### PR TITLE
[WIP][PoC] Implement Factory pattern on containers with runargs as singleton

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -44,7 +44,7 @@ you want to build the image with buildah but run it with $<runtime>
 sub build_and_run_image {
     my %args       = @_;
     my $runtime    = $args{runtime};
-    my $buildah    = $args{buildah}    // 0;
+    my $builder    = $args{builder} ? $args{builder} : $runtime;
     my $dockerfile = $args{dockerfile} // 'Dockerfile';
     my $base       = $args{base};
 
@@ -66,37 +66,31 @@ sub build_and_run_image {
     assert_script_run "curl -f -v " . data_url('containers/index.html') . " > $dir/BuildTest/index.html";
 
     # Build the image
-    assert_script_run("cd $dir");
-    if (!$buildah) {
-        # At least on publiccloud, this image pull can take long and occasinally fails due to network issues
-        assert_script_run("$runtime build -t myapp BuildTest", timeout => 600);
-        assert_script_run("$runtime images | grep myapp");
-    } else {
-        assert_script_run("buildah bud -t myapp BuildTest", timeout => 600);
-        assert_script_run("buildah images | grep myapp");
-    }
-    assert_script_run("cd");
+    # At least on publiccloud, this image pull can take long and occasinally fails due to network issues
+    $builder->build($dir . "/BuildTest", "myapp", timeout => 600);
+    my $imgs = $builder->get_images_by_repo_name();
+    die "myapp image not found in the local registry" unless (grep { $_ =~ /myapp/ } @{$imgs});
     assert_script_run("rm -rf $dir");
 
-    if ($runtime eq 'docker' && $buildah) {
+    if ($runtime->runtime eq 'docker' && $builder->runtime eq 'buildah') {
         assert_script_run "buildah push myapp docker-daemon:myapp:latest";
-        script_run "$runtime images";
+        script_run "$runtime->{runtime} images";
     }
 
     # Test that we can execute programs in the container and test container's variables
-    assert_script_run("$runtime run --entrypoint 'printenv' myapp WORLD_VAR | grep Arda");
+    assert_script_run("$runtime->{runtime} run --entrypoint 'printenv' myapp WORLD_VAR | grep Arda");
 
     # Run the container with port 80 exported as port 8888
-    assert_script_run("$runtime run -dit -p 8888:80 myapp");
+    assert_script_run("$runtime->{runtime} run -dit -p 8888:80 myapp");
 
     # Make sure our container is running
-    script_retry("$runtime ps -a | grep myapp", delay => 5, retry => 3);
+    script_retry("$runtime->{runtime} ps -a | grep myapp", delay => 5, retry => 3);
 
     # Test that the exported port is reachable
     script_retry('curl http://localhost:8888/ | grep "The test shall pass"', delay => 5, retry => 6);
 
     # Clean up
-    assert_script_run("$runtime stop `$runtime ps -q`");
+    assert_script_run("$runtime->{runtime} stop `$runtime->{runtime} ps -q`");
 }
 
 # Build a sle container image using zypper_docker
@@ -113,7 +107,7 @@ sub build_with_zypper_docker {
     die 'Argument $runtime not provided!' unless $runtime;
 
     my ($host_version,  $host_sp,  $host_id)  = get_os_release();
-    my ($image_version, $image_sp, $image_id) = get_os_release("$runtime run $image");
+    my ($image_version, $image_sp, $image_id) = get_os_release("$runtime->{runtime} run $image");
 
     # The zypper-docker works only on openSUSE or on SLE based image on SLE host
     unless (($host_id =~ 'sles' && $image_id =~ 'sles') || $image_id =~ 'opensuse') {
@@ -124,11 +118,11 @@ sub build_with_zypper_docker {
     if ($distri eq 'sle') {
         my $pretty_version = $version =~ s/-SP/ SP/r;
         my $betaversion    = get_var('BETA') ? '\s\([^)]+\)' : '';
-        validate_script_output("$runtime run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'",
+        validate_script_output("$runtime->{runtime} run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'",
             sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
     } else {
         $version =~ s/^Jump://i;
-        validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
+        validate_script_output qq{$runtime->{runtime} container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
     }
 
     zypper_call("in zypper-docker") if (script_run("which zypper-docker") != 0);
@@ -138,8 +132,8 @@ sub build_with_zypper_docker {
     # If zypper-docker list-updates lists no updates then derived image was successfully updated
     assert_script_run("zypper-docker list-updates $derived_image | grep 'No updates found'", 240);
 
-    my $local_images_list = script_output("$runtime image ls");
-    die("$runtime $derived_image not found") unless ($local_images_list =~ $derived_image);
+    my $local_images_list = script_output("$runtime->{runtime} image ls");
+    die("$runtime->{runtime} $derived_image not found") unless ($local_images_list =~ $derived_image);
 
     record_info("Testing derived", "Derived image: $derived_image");
     test_opensuse_based_image(image => $derived_image, runtime => $runtime, version => $version);
@@ -162,10 +156,10 @@ sub test_opensuse_based_image {
     my ($host_version, $host_sp, $host_id) = get_os_release();
     my ($image_version, $image_sp, $image_id);
 
-    if ($runtime =~ /buildah/) {
-        ($image_version, $image_sp, $image_id) = get_os_release("$runtime run $image");
+    if ($runtime->runtime =~ /buildah/) {
+        ($image_version, $image_sp, $image_id) = get_os_release("$runtime->{runtime} run $image");
     } else {
-        ($image_version, $image_sp, $image_id) = get_os_release("$runtime run --entrypoint '' $image");
+        ($image_version, $image_sp, $image_id) = get_os_release("$runtime->{runtime} run --entrypoint '' $image");
     }
     record_info "Host",  "Host has '$host_version', '$host_sp', '$host_id' in /etc/os-release";
     record_info "Image", "Image has '$image_version', '$image_sp', '$image_id' in /etc/os-release";
@@ -177,40 +171,40 @@ sub test_opensuse_based_image {
             my $pretty_version = $version =~ s/-SP/ SP/r;
             my $betaversion    = $beta ? '\s\([^)]+\)' : '';
             record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
-            if ($runtime =~ /buildah/) {
-                validate_script_output("$runtime run $image grep PRETTY_NAME /etc/os-release | cut -d= -f2",
+            if ($runtime->runtime =~ /buildah/) {
+                validate_script_output("$runtime->{runtime} run $image grep PRETTY_NAME /etc/os-release | cut -d= -f2",
                     sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
             } else {
                 # zypper-docker changes the layout of the image
-                validate_script_output("$runtime run --entrypoint /bin/bash $image -c 'grep PRETTY_NAME /etc/os-release' | cut -d= -f2",
+                validate_script_output("$runtime->{runtime} run --entrypoint /bin/bash $image -c 'grep PRETTY_NAME /etc/os-release' | cut -d= -f2",
                     sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
             }
 
             # SUSEConnect zypper service is supported only on SLE based image on SLE host
             my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
-            if ($runtime =~ /buildah/) {
-                assert_script_run "$runtime run -t $image -- $plugin -v";
-                script_run "$runtime run -t $image -- $plugin lp", 420;
-                script_run "$runtime run -t $image -- $plugin lm", 420;
+            if ($runtime->runtime =~ /buildah/) {
+                assert_script_run "$runtime->{runtime} run -t $image -- $plugin -v";
+                script_run "$runtime->{runtime} run -t $image -- $plugin lp", 420;
+                script_run "$runtime->{runtime} run -t $image -- $plugin lm", 420;
             } else {
-                assert_script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin -v'";
-                script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lp'", 420;
-                script_run "$runtime container run --entrypoint '/bin/bash' --rm $image -c '$plugin lm'", 420;
+                assert_script_run "$runtime->{runtime} container run --entrypoint '/bin/bash' --rm $image -c '$plugin -v'";
+                script_run "$runtime->{runtime} container run --entrypoint '/bin/bash' --rm $image -c '$plugin lp'", 420;
+                script_run "$runtime->{runtime} container run --entrypoint '/bin/bash' --rm $image -c '$plugin lm'", 420;
             }
         } else {
             record_info "non-SLE host", "This host ($host_id) does not support zypper service";
         }
     } else {
         $version =~ s/^Jump://i;
-        if ($runtime =~ /buildah/) {
-            if (script_output("$runtime run $image grep PRETTY_NAME /etc/os-release") =~ /WARN.+from \"\/etc\/containers\/mounts.conf\" doesn\'t exist, skipping/) {
+        if ($runtime->runtime =~ /buildah/) {
+            if (script_output("$runtime->{runtime} run $image grep PRETTY_NAME /etc/os-release") =~ /WARN.+from \"\/etc\/containers\/mounts.conf\" doesn\'t exist, skipping/) {
                 record_soft_failure "bcs#1183482 - libcontainers-common contains SLE files on TW";
             }
-            validate_script_output("$runtime run $image grep PRETTY_NAME /etc/os-release | cut -d= -f2",
+            validate_script_output("$runtime->{runtime} run $image grep PRETTY_NAME /etc/os-release | cut -d= -f2",
                 sub { /"openSUSE (Leap )?${version}.*"/ });
         }
         else {
-            validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
+            validate_script_output qq{$runtime->{runtime} container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
         }
     }
 
@@ -225,23 +219,23 @@ sub verify_userid_on_container {
     my $huser_id = script_output "echo \$UID";
     record_info "host uid",          "$huser_id";
     record_info "root default user", "rootless mode process runs with the default container user(root)";
-    my $cid = script_output "$runtime run -d --rm --name test1 $image sleep infinity";
-    validate_script_output "$runtime top $cid user huser", sub { /root\s+1000/ };
-    validate_script_output "$runtime top $cid capeff",     sub { /setuid/i };
+    my $cid = script_output "$runtime->{runtime} run -d --rm --name test1 $image sleep infinity";
+    validate_script_output "$runtime->{runtime} top $cid user huser", sub { /root\s+1000/ };
+    validate_script_output "$runtime->{runtime} top $cid capeff",     sub { /setuid/i };
 
     record_info "non-root user", "process runs under the range of subuids assigned for regular user";
-    $cid = script_output "$runtime run -d --rm --name test2 --user 1000 $image sleep infinity";
+    $cid = script_output "$runtime->{runtime} run -d --rm --name test2 --user 1000 $image sleep infinity";
     my $id = $start_id + $huser_id - 1;
-    validate_script_output "$runtime top $cid user huser", sub { /1000\s+${id}/ };
-    validate_script_output "$runtime top $cid capeff",     sub { /none/ };
+    validate_script_output "$runtime->{runtime} top $cid user huser", sub { /1000\s+${id}/ };
+    validate_script_output "$runtime->{runtime} top $cid capeff",     sub { /none/ };
 
     record_info "root with keep-id", "the default user(root) starts process with the same uid as host user";
-    $cid = script_output "$runtime run -d --rm --userns keep-id $image sleep infinity";
+    $cid = script_output "$runtime->{runtime} run -d --rm --userns keep-id $image sleep infinity";
     # Remove once the softfail removed. it is just checks the user's mapped uid
-    validate_script_output "$runtime exec -it $cid cat /proc/self/uid_map", sub { /1000/ };
+    validate_script_output "$runtime->{runtime} exec -it $cid cat /proc/self/uid_map", sub { /1000/ };
     if (is_sle) {
-        validate_script_output "$runtime top $cid user huser", sub { /bernhard\s+bernhard/ };
-        validate_script_output "$runtime top $cid capeff",     sub { /setuid/i };
+        validate_script_output "$runtime->{runtime} top $cid user huser", sub { /bernhard\s+bernhard/ };
+        validate_script_output "$runtime->{runtime} top $cid capeff",     sub { /setuid/i };
     }
     else {
         record_soft_failure "bsc#1182428 - Issue with nsenter from podman-top";
@@ -255,13 +249,13 @@ sub test_zypper_on_container {
     die 'Argument $runtime not provided!' unless $runtime;
 
     # zypper lr
-    assert_script_run("$runtime run $image zypper lr -s", 120);
+    $runtime->up($image, cmd => "zypper lr -s", daemon => 1, keep_container => 1);
 
     if ($runtime =~ /buildah/) {
         assert_script_run("$runtime run $image -- zypper -nv ref", 120);
 
         # Create new image and remove the working container
-        assert_script_run("$runtime commit --rm $image refreshed", 120);
+        assert_script_run("$runtime->{runtime} commit --rm $image refreshed", 120);
 
         # Verify the new image works
         assert_script_run("$runtime run \$($runtime from refreshed) -- zypper -nv ref", 120);
@@ -269,10 +263,10 @@ sub test_zypper_on_container {
         assert_script_run("$runtime run --name refreshed $image sh -c 'zypper -nv ref'", 120);
 
         # Commit the image
-        assert_script_run("$runtime commit refreshed refreshed-image", 120);
+        assert_script_run("$runtime->{runtime} commit refreshed refreshed-image", 120);
 
         # Remove it
-        assert_script_run("$runtime rm refreshed", 120);
+        assert_script_run("$runtime->{runtime} rm refreshed", 120);
 
         # Verify the image works
         assert_script_run("$runtime run --rm refreshed-image sh -c 'zypper -nv ref'", 120);
@@ -304,7 +298,7 @@ sub ensure_container_rpm_updates {
 sub exec_on_container {
     my ($image, $runtime, $command, $timeout) = @_;
     $timeout //= 120;
-    assert_script_run("$runtime run --rm $image $command", $timeout);
+    $runtime->up($image, cmd => $command, daemon => 1, timeout => $timeout);
 }
 
 sub test_3rd_party_image {

--- a/lib/containers/runtime.pm
+++ b/lib/containers/runtime.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2020 SUSE LLC
+# Copyright © 2020-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,6 +14,8 @@ package containers::runtime;
 use Mojo::Base -base;
 use testapi;
 use Test::Assert 'assert_equals';
+use containers::utils qw(registry_url);
+use utils qw(systemctl file_content_replace);
 
 has runtime => undef;
 
@@ -32,22 +34,71 @@ sub _rt_script_output {
     return script_output($self->runtime . " " . $cmd, @args);
 }
 
-=head2 build
+=head2 create_container($image, $name, [%args])
 
-Build a container.
+Creates a container.
+C<image> the name of the image we create the container from.
+C<name> is the given name of the created container.
+C<args> can be anything you want to run in the container, similar to C<run>. for 
+instance: C<docker create -it tumbleweed bash>
+
+=cut
+sub create_container {
+    my ($self, $image, $name, $args) = @_;
+    die 'wrong number of arguments' if @_ < 3;
+    $self->_rt_assert_script_run("container create --name $name $image $args", 300);
+    record_info "$name container created", "";
+}
+
+=head2 start_container($image_name)
+
+Starts container named C<image_name>.
+
+=cut
+sub start_container {
+    my ($self, $image_name) = @_;
+    die 'wrong number of arguments' if @_ < 2;
+    $self->_rt_assert_script_run("container start $image_name");
+    record_info "$image_name container started", "";
+}
+
+=head2 halt_container($container_name)
+
+Blocks a container until exits.
+C<container_name> which runs. 
+https://docs.docker.com/engine/reference/commandline/wait/
+
+=cut
+sub halt_container {
+    my ($self, $container_name) = @_;
+    die 'wrong number of arguments' if @_ < 2;
+    $self->_rt_assert_script_run("wait $container_name");
+    record_info "$container_name container is blocked.", "";
+}
+
+
+=head2 build($dockerfile_path, $container_tag, [%args])
+
+Build a container from a Dockerfil.
 C<dockerfile_path> is the directory with the Dockerfile as well as the root of the build context.
 C<container_tag> will be the name of the container.
+Give C<timeout> if you want to change the timeout passed to C<assert_script_run>. Default for containers is 300.
 
 =cut
 sub build {
-    my ($self, $dockerfile_path, $container_tag) = @_;
+    my ($self, $dockerfile_path, $container_tag, %args) = @_;
     die 'wrong number of arguments' if @_ < 3;
-    #TODO add build with URL https://docs.docker.com/engine/reference/commandline/build/
-    $self->_rt_assert_script_run("build -f $dockerfile_path/Dockerfile -t $container_tag $dockerfile_path", 300);
+    unless ($self->runtime eq 'buildah') {
+        #TODO add build with URL https://docs.docker.com/engine/reference/commandline/build/
+        $self->_rt_assert_script_run("build -f $dockerfile_path/Dockerfile -t $container_tag $dockerfile_path", $args{timeout} // 300);
+    }
+    else {
+        $self->_rt_assert_script_run("bud -t $container_tag $dockerfile_path", $args{timeout} // 300);
+    }
     record_info "$container_tag created", "";
 }
 
-=head2 up
+=head2 up($image_name, [mode, remote, keep_container, timeout])
 
 Run a container.
 C<image_name> is required and can be the image id, the name or name with tag.
@@ -65,20 +116,21 @@ sub up {
     my $mode           = $args{daemon}         ? '-d'    : '-it';
     my $remote         = $args{cmd}            ? 'sh -c' : '';
     my $keep_container = $args{keep_container} ? ''      : '--rm';
-    my $ret            = $self->_rt_script_run(sprintf qq(run %s %s %s %s '%s'), $keep_container, $mode, $image_name, $remote, $args{cmd});
+    my $ret = $self->_rt_script_run(sprintf qq(run %s %s %s %s '%s'), $keep_container, $mode, $image_name, $remote, $args{cmd}, timeout => $args{timeout});
     record_info "Remote run on $image_name", "options $keep_container $mode $image_name $remote $args{cmd}";
     return $ret;
 }
 
-=head2 pull
+=head2 pull($image_name, [%args])
 
 Pull a container with the given C<image_name>
 where C<image_name> can be the name or id of the image.
+C<args> passes parameters to C<script_run>
 
 =cut
 sub pull {
-    my ($self, $image_name) = @_;
-    my $ret = $self->_rt_script_run("pull $image_name");
+    my ($self, $image_name, %args) = @_;
+    my $ret = $self->_rt_script_run("pull $image_name", timeout => $args{timeout} // 300);
     return $ret;
 }
 
@@ -108,6 +160,24 @@ sub enum_containers {
     return \@containers;
 }
 
+=head2 get_images_by_repo_name
+
+Returns an array ref with the names of the images.
+
+=cut
+sub get_images_by_repo_name {
+    my ($self) = @_;
+    my $repo_images;
+    unless ($self->runtime eq 'buildah') {
+        $repo_images = $self->_rt_script_output("images --format '{{.Repository}}'");
+    }
+    else {
+        $repo_images = $self->_rt_script_output("images --format '{{.Name}}'");
+    }
+    my @images = split /[\n\t ]/, $repo_images;
+    return \@images;
+}
+
 =head2 info
 
 Assert a C<property> against given expected C<value> if C<value> is given.
@@ -121,7 +191,20 @@ sub info {
     $self->_rt_assert_script_run(sprintf("info %s %s", $property, $expected));
 }
 
-=head2 remove_image
+=head2 get_container_logs($container)
+
+Request container's logs.
+C<container> the running container.
+C<logs> returns a string. 
+
+=cut
+sub get_container_logs {
+    my ($self, $container) = @_;
+    my $logs = $self->_rt_script_output("container logs $container");
+    return $logs;
+}
+
+=head2 remove_image($image_name)
 
 Remove a image from the pool.
 
@@ -131,18 +214,85 @@ sub remove_image {
     $self->_rt_assert_script_run("rmi -f $image_name");
 }
 
+=head2 remove_container
+
+Remove a container from the pool.
+
+=cut
+sub remove_container {
+    my ($self, $container_name) = @_;
+    $self->_rt_assert_script_run("rm -f $container_name");
+}
+
+=head2 check_image_in_host_registry
+
+Returns true if host contains C<img> or false.
+
+=cut
+sub check_image_in_host_registry {
+    my ($self, $img) = shift;
+    my @lregistry = $self->enum_images();
+    $img =~ @lregistry;
+}
+
+=head2 setup_registry
+
+Updates the registry files for the running container runtime to allow access to
+insecure registries.
+
+=cut
+sub setup_registry {
+    my ($self) = shift;
+    my $registry = registry_url();
+    if ($self->runtime =~ /docker/) {
+        # Allow our internal 'insecure' registry
+        assert_script_run(
+'echo "{ \"debug\": true, \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\", \"' . $registry . '\"] }" > /etc/docker/daemon.json');
+        assert_script_run('cat /etc/docker/daemon.json');
+        systemctl('restart docker');
+    } elsif ($self->runtime =~ /podman/) {
+        assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
+        assert_script_run "chmod 644 /etc/containers/registries.conf";
+        file_content_replace("/etc/containers/registries.conf", REGISTRY => $registry);
+    } else {
+        die "Unsupported runtime - " . $self->runtime;
+    }
+}
+
 =head2 cleanup_system_host
 
-Remove containers and then all the images respectively and then make sure that everything was cleaned up.
+Remove containers and then all the images respectively. 
+Asserts that everything was cleaned up unless c<assert> is set to 0.
 
 =cut
 sub cleanup_system_host {
-    my ($self) = shift;
-    # copy from common > clean_container_host
-    $self->_rt_assert_script_run("stop \$($self->{runtime} ps -q)", 180) if script_output("$self->{runtime} ps -q | wc -l") != '0';
-    $self->_rt_assert_script_run("system prune -a -f",              180);
-    assert_equals(0, scalar @{$self->enum_containers()}, "containers have not been removed");
-    assert_equals(0, scalar @{$self->enum_images()},     "images have not been removed");
+    my ($self, $assert) = @_;
+    $assert // 1;
+    if ($self->runtime eq 'buildah') {
+        $self->_rt_assert_script_run("rm --all");
+        $self->_rt_assert_script_run("rmi --all --force");
+    }
+    else {
+        $self->_rt_assert_script_run("ps -q | xargs -r $self->{runtime} stop", 180);
+        $self->_rt_assert_script_run("system prune -a -f",                     180);
+    }
+    if ($assert) {
+        assert_equals(0, scalar @{$self->enum_containers()}, "containers have not been removed");
+        assert_equals(0, scalar @{$self->enum_images()},     "images have not been removed");
+    }
 }
+
+# Container runtime subclasses here
+package containers::runtime::docker;
+use Mojo::Base 'containers::runtime';
+has runtime => 'docker';
+
+package containers::runtime::podman;
+use Mojo::Base 'containers::runtime';
+has runtime => "podman";
+
+package containers::runtime::buildah;
+use Mojo::Base 'containers::runtime';
+has runtime => "buildah";
 
 1;

--- a/lib/containers/runtime.pm
+++ b/lib/containers/runtime.pm
@@ -396,4 +396,26 @@ sub commit {
     my ($self, $mycontainer, $new_image_name, %args) = @_;
     $self->_rt_assert_script_run("commit --rm $mycontainer $new_image_name", timeout => $args{timeout});
 }
+
+
+package containers::runtime::Factory;
+use Mojo::Base -base;
+use containers::runtime;
+use testapi;
+use Data::Dumper;
+has runtime_instance => undef;
+
+sub get_instance {
+    my ($self) = shift;
+    if (check_var('DOCKER', 1)) {
+        $self->runtime_instance(containers::runtime::docker->new());
+    }
+    elsif (check_var('PODMAN', 1)) {
+        $self->runtime_instance(containers::runtime::podman->new());
+    }
+    else {
+        die 'job doesnt provide Runtime Container tool';
+    }
+    return $self->runtime_instance;
+}
 1;

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -101,6 +101,7 @@ sub registry_url {
 sub basic_container_tests {
     my %args    = @_;
     my $runtime = $args{runtime};
+    record_info "$runtime";
     die "You must define the runtime!" unless $runtime;
     my $alpine_image_version = '3.6';
     my $alpine               = registry_url('alpine', $alpine_image_version);
@@ -109,94 +110,94 @@ sub basic_container_tests {
     my $tumbleweed           = "registry.opensuse.org/opensuse/tumbleweed";
 
     # Test search feature
-    validate_script_output("$runtime->{runtime} search --no-trunc tumbleweed", sub { m/Official openSUSE Tumbleweed images/ });
+    validate_script_output("$runtime search --no-trunc tumbleweed", sub { m/Official openSUSE Tumbleweed images/ });
 
     #   - pull minimalistic alpine image of declared version using tag
     #   - https://store.docker.com/images/alpine
-    assert_script_run("$runtime->{runtime} image pull $alpine", timeout => 300);
+    assert_script_run("$runtime image pull $alpine", timeout => 300);
     #   - pull typical docker demo image without tag. Should be latest.
     #   - https://store.docker.com/images/hello-world
-    assert_script_run("$runtime->{runtime} image pull $hello_world", timeout => 300);
+    assert_script_run("$runtime image pull $hello_world", timeout => 300);
     #   - pull image of last released version of openSUSE Leap
     if (!is_s390x) {
-        assert_script_run("$runtime->{runtime} image pull $leap", timeout => 600);
+        assert_script_run("$runtime image pull $leap", timeout => 600);
     } else {
         record_soft_failure("bsc#1171672 Missing Leap:latest container image for s390x");
     }
     #   - pull image of openSUSE Tumbleweed
-    assert_script_run("$runtime->{runtime} image pull $tumbleweed", timeout => 600);
+    assert_script_run("$runtime image pull $tumbleweed", timeout => 600);
 
     # All images can be listed
-    assert_script_run("$runtime->{runtime} image ls");
+    assert_script_run("$runtime image ls");
     # Local images can be listed
-    assert_script_run("$runtime->{runtime} image ls none");
+    assert_script_run("$runtime image ls none");
     #   - filter with tag
-    assert_script_run(qq{$runtime->{runtime} image ls $alpine | grep "alpine\\s*$alpine_image_version"});
+    assert_script_run(qq{$runtime image ls $alpine | grep "alpine\\s*$alpine_image_version"});
     #   - filter without tag
-    assert_script_run(qq{$runtime->{runtime} image ls $hello_world | grep "hello-world\\s*latest"});
+    assert_script_run(qq{$runtime image ls $hello_world | grep "hello-world\\s*latest"});
     #   - all local images
-    my $local_images_list = script_output("$runtime->{runtime} image ls");
+    my $local_images_list = script_output("$runtime image ls");
     die("$runtime image $tumbleweed not found") unless ($local_images_list =~ /opensuse\/tumbleweed\s*latest/);
     die("$runtime image $leap not found") if (!is_s390x && !$local_images_list =~ /opensuse\/leap\s*latest/);
 
     # Containers can be spawned
     #   - using 'run'
-    assert_script_run("$runtime->{runtime} container run --name test_1 $hello_world | grep 'Hello from Docker\!'");
+    assert_script_run("$runtime container run --name test_1 $hello_world | grep 'Hello from Docker\!'");
     #   - using 'create', 'start' and 'logs' (background container)
-    assert_script_run("$runtime->{runtime} container create --name test_2 $alpine /bin/echo Hello world");
-    assert_script_run("$runtime->{runtime} container start test_2 | grep test_2");
-    assert_script_run("$runtime->{runtime} container logs test_2 | grep 'Hello world'");
+    assert_script_run("$runtime container create --name test_2 $alpine /bin/echo Hello world");
+    assert_script_run("$runtime container start test_2 | grep test_2");
+    assert_script_run("$runtime container logs test_2 | grep 'Hello world'");
     #   - using 'run --rm'
-    assert_script_run(qq{$runtime->{runtime} container run --name test_ephemeral --rm $alpine /bin/echo Hello world | grep "Hello world"});
+    assert_script_run(qq{$runtime container run --name test_ephemeral --rm $alpine /bin/echo Hello world | grep "Hello world"});
     #   - using 'run -d' and 'inspect' (background container)
     my $container_name = 'tw';
-    assert_script_run("$runtime->{runtime} container run -d --name $container_name $tumbleweed tail -f /dev/null");
-    assert_script_run("$runtime->{runtime} container inspect --format='{{.State.Running}}' $container_name | grep true");
-    my $output_containers = script_output("$runtime->{runtime} container ls -a");
+    assert_script_run("$runtime container run -d --name $container_name $tumbleweed tail -f /dev/null");
+    assert_script_run("$runtime container inspect --format='{{.State.Running}}' $container_name | grep true");
+    my $output_containers = script_output("$runtime container ls -a");
     die('error: missing container test_1') unless ($output_containers =~ m/test_1/);
     die('error: missing container test_2') unless ($output_containers =~ m/test_2/);
     die('error: ephemeral container was not removed') if ($output_containers =~ m/test_ephemeral/);
     die("error: missing container $container_name") unless ($output_containers =~ m/$container_name/);
 
     # Containers' state can be saved to a docker image
-    if (script_run("$runtime->{runtime} container exec $container_name zypper -n in curl", 300)) {
+    if (script_run("$runtime container exec $container_name zypper -n in curl", 300)) {
         record_info('poo#40958 - curl install failure, try with force-resolution.');
-        my $output = script_output("$runtime->{runtime} container exec $container_name zypper in --force-resolution -y -n curl", 600);
+        my $output = script_output("$runtime container exec $container_name zypper in --force-resolution -y -n curl", 600);
         die('error: curl not installed in the container') unless (($output =~ m/Installing: curl.*done/) || ($output =~ m/\'curl\' .* already installed/));
     }
-    assert_script_run("$runtime->{runtime} container commit $container_name tw:saved", 240);
+    assert_script_run("$runtime container commit $container_name tw:saved", 240);
 
     # Network is working inside of the containers
-    my $output = script_output("$runtime->{runtime} container run tw:saved curl -I google.de");
+    my $output = script_output("$runtime container run tw:saved curl -I google.de");
     die("network is not working inside of the container tw:saved") unless ($output =~ m{Location: http://www\.google\.de/});
 
     # Using an init process as PID 1
-    assert_script_run "$runtime->{runtime} run --rm --init $tumbleweed ps --no-headers -xo 'pid args' | grep '1 .*init'";
+    assert_script_run "$runtime run --rm --init $tumbleweed ps --no-headers -xo 'pid args' | grep '1 .*init'";
 
     if (script_run('command -v man') == 0) {
-        assert_script_run("man -P cat $runtime->{runtime} build | grep '$runtime->{runtime}-build - Build'");
+        assert_script_run("man -P cat $runtime build | grep '$runtime-build - Build'");
     }
 
     # Containers can be stopped
-    assert_script_run("$runtime->{runtime} container stop $container_name");
-    assert_script_run("$runtime->{runtime} container inspect --format='{{.State.Running}}' $container_name | grep false");
+    assert_script_run("$runtime container stop $container_name");
+    assert_script_run("$runtime container inspect --format='{{.State.Running}}' $container_name | grep false");
 
     # Containers can be deleted
-    my $cmd_docker_rm = "$runtime->{runtime} rm test_1";
+    my $cmd_docker_rm = "$runtime rm test_1";
     assert_script_run("$cmd_docker_rm");
-    $output_containers = script_output("$runtime->{runtime} container ls -a");
+    $output_containers = script_output("$runtime container ls -a");
     die("error: container was not removed: $cmd_docker_rm") if ($output_containers =~ m/test_1/);
-    my $cmd_docker_container_prune = "$runtime->{runtime} container prune -f";
+    my $cmd_docker_container_prune = "$runtime container prune -f";
     assert_script_run("$cmd_docker_container_prune");
-    $output_containers = script_output("$runtime->{runtime} container ls -a");
+    $output_containers = script_output("$runtime container ls -a");
     die("error: container was not removed: $cmd_docker_container_prune") if ($output_containers =~ m/test_2/);
 
     # Images can be deleted
-    my $cmd_runtime_rmi = "$runtime->{runtime} rmi -a";
-    $output_containers = script_output("$runtime->{runtime} container ls -a");
-    die("error: $runtime->{runtime} image rmi -a $leap")                               if ($output_containers =~ m/Untagged:.*opensuse\/leap/);
-    die("error: $runtime->{runtime} image rmi -a $tumbleweed")                         if ($output_containers =~ m/Untagged:.*opensuse\/tumbleweed/);
-    die("error: $runtime->{runtime} image rmi -a tw:saved")                            if ($output_containers =~ m/Untagged:.*tw:saved/);
+    my $cmd_runtime_rmi = "$runtime rmi -a";
+    $output_containers = script_output("$runtime container ls -a");
+    die("error: $runtime image rmi -a $leap")                                          if ($output_containers =~ m/Untagged:.*opensuse\/leap/);
+    die("error: $runtime image rmi -a $tumbleweed")                                    if ($output_containers =~ m/Untagged:.*opensuse\/tumbleweed/);
+    die("error: $runtime image rmi -a tw:saved")                                       if ($output_containers =~ m/Untagged:.*tw:saved/);
     record_soft_failure("error: $runtime->{runtime} image rmi -a $alpine")             if ($output_containers =~ m/Untagged:.*alpine/);
     record_soft_failure("error: $runtime->{runtime} image rmi -a $hello_world:latest") if ($output_containers =~ m/Untagged:.*hello-world:latest/);
 }

--- a/schedule/containers/engines_and_tools_podman.yaml
+++ b/schedule/containers/engines_and_tools_podman.yaml
@@ -12,7 +12,9 @@ schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/podman
-  - containers/buildah_podman
+  #- containers/buildah_podman
   - containers/rootless_podman
-  - containers/podman_3rd_party_images
-  - console/coredump_collect
+  #- containers/podman_3rd_party_images
+  #- console/coredump_collect
+vars:
+  TEST_CONTEXT: "OpenQA::Test::RunArgs"

--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -49,7 +49,8 @@ sub run {
                 test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => $buildah, version => $version);
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
-                build_and_run_image(runtime => $docker, builder => $buildah, base => 'refreshed');
+
+                build_and_run_image(runtime => $docker, builder => $buildah, base => $iname);
             }
         }
     }

--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -22,13 +22,16 @@ use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release is_sle);
+use containers::runtime;
 
 sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_buildah_when_needed($host_distri);
     install_docker_when_needed($host_distri);
-    allow_selected_insecure_registries(runtime => 'docker');
+    my $docker  = containers::runtime::docker->new();
+    my $buildah = containers::runtime::buildah->new();
+    allow_selected_insecure_registries(runtime => $docker);
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
@@ -38,21 +41,21 @@ sub run {
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
         for my $iname (@{$images_to_test}) {
             record_info "IMAGE", "Testing image: $iname";
-            test_container_image(image => $iname, runtime => 'buildah');
+            test_container_image(image => $iname, runtime => $buildah);
             if (check_os_release('suse', 'PRETTY_NAME')) {
                 # Use container which it is created in test_container_image
                 # Buildah default name is conducted by <image-name>-working-container
                 my ($prefix_img_name) = $iname =~ /([^\/:]+)(:.+)?$/;
-                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah', version => $version);
+                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => $buildah, version => $version);
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
-                build_and_run_image(runtime => 'docker', buildah => 1, base => 'refreshed');
+                build_and_run_image(runtime => $docker, builder => $buildah, base => 'refreshed');
             }
         }
     }
     scc_restore_docker_image_credentials();
-    clean_container_host(runtime => 'docker');
-    clean_container_host(runtime => 'buildah');
+    $docker->cleanup_system_host(0);
+    $buildah->cleanup_system_host();
 }
 
 1;

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -49,7 +49,7 @@ sub run {
                 test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => $buildah, version => $version);
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
-                build_and_run_image(runtime => $podman, builder => $buildah, base => 'refreshed');
+                build_and_run_image(runtime => $podman, builder => $buildah, base => $iname);
             }
         }
     }

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -22,13 +22,16 @@ use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release is_sle);
+use containers::runtime;
 
 sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_buildah_when_needed($host_distri);
     install_podman_when_needed($host_distri);
-    allow_selected_insecure_registries(runtime => 'podman');
+    my $podman  = containers::runtime::podman->new();
+    my $buildah = containers::runtime::buildah->new();
+    allow_selected_insecure_registries(runtime => $podman);
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
@@ -38,21 +41,21 @@ sub run {
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
         for my $iname (@{$images_to_test}) {
             record_info "IMAGE", "Testing image: $iname";
-            test_container_image(image => $iname, runtime => 'buildah');
+            test_container_image(image => $iname, runtime => $buildah);
             if (check_os_release('suse', 'PRETTY_NAME')) {
                 # Use container which it is created in test_container_image
                 # Buildah default name is conducted by <image-name>-working-container
                 my ($prefix_img_name) = $iname =~ /([^\/:]+)(:.+)?$/;
-                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => 'buildah', version => $version);
+                test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => $buildah, version => $version);
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
-                build_and_run_image(runtime => 'podman', buildah => 1, base => 'refreshed');
+                build_and_run_image(runtime => $podman, builder => $buildah, base => 'refreshed');
             }
         }
     }
     scc_restore_docker_image_credentials();
-    clean_container_host(runtime => 'podman');
-    clean_container_host(runtime => 'buildah');
+    $podman->cleanup_system_host(0);
+    $buildah->cleanup_system_host();
 }
 
 1;

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -9,7 +9,7 @@
 
 # Package: container-diff
 # Summary: Print and save diffs between two cotaniners using container-diff tool
-# Maintainer: Pavel Dostál <pdostal@suse.cz>
+# Maintainer: qac team <qa-c@suse.de>
 
 use base 'consoletest';
 use testapi;
@@ -20,16 +20,17 @@ use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use version_utils qw(is_sle get_os_release);
+use containers::runtime;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
-
+    my $docker = containers::runtime::docker->new();
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_docker_when_needed($host_distri);
-    allow_selected_insecure_registries(runtime => 'docker') if (is_sle());
-    zypper_call("install container-diff")                   if (script_run("which container-diff") != 0);
+    allow_selected_insecure_registries(runtime => $docker) if (is_sle());
+    zypper_call("install container-diff")                  if (script_run("which container-diff") != 0);
 
     my ($untested_images, $released_images) = get_suse_container_urls();
     # container-diff
@@ -44,7 +45,7 @@ sub run {
     }
 
     # Clean container
-    clean_container_host(runtime => "docker");
+    $docker->cleanup_system_host();
 }
 
 1;

--- a/tests/containers/docker.pm
+++ b/tests/containers/docker.pm
@@ -61,7 +61,7 @@ sub run {
         check_docker_firewall();
     }
     # Run basic docker tests
-    basic_container_tests(runtime => $runtime);
+    basic_container_tests(runtime => $runtime->runtime);
 
     # Build an image from Dockerfile and test it
     build_and_run_image(runtime => $runtime, base => 'registry.opensuse.org/opensuse/leap:latest');

--- a/tests/containers/docker_3rd_party_images.pm
+++ b/tests/containers/docker_3rd_party_images.pm
@@ -22,16 +22,16 @@ use containers::common;
 use containers::urls 'get_3rd_party_images';
 use containers::container_images qw(test_3rd_party_image upload_3rd_party_images_logs);
 use registration;
-
+use containers::runtime;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $runtime = 'docker';
+    my $runtime = containers::runtime::docker->new();
 
-    script_run("echo 'Container base image tests:' > /var/tmp/$runtime-3rd_party_images_log.txt");
+    script_run("echo 'Container base image tests:' > /var/tmp/docker-3rd_party_images_log.txt");
     # In SLE we need to add the Containers module
     install_docker_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => $runtime);
@@ -39,7 +39,7 @@ sub run {
     for my $image (@{$images}) {
         test_3rd_party_image($runtime, $image);
     }
-    clean_container_host(runtime => $runtime);
+    $runtime->cleanup_system_host();
 }
 
 sub post_fail_hook {

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@
 #      * Single commands can be executed inside of running container
 #      * Exposed ports are accessible from outside of a container
 #      * Logs can be retrieved
-# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>, Pavel Dostal <pdostal@suse.cz>
+# Maintainer: qac team <qa-c@suse.de>
 
 
 use base "consoletest";
@@ -30,11 +30,12 @@ use containers::common;
 use publiccloud::utils 'is_ondemand';
 use strict;
 use warnings;
+use containers::runtime;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
-
+    my $docker = containers::runtime::docker->new();
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_docker_when_needed($host_distri);
@@ -59,7 +60,7 @@ sub run {
     assert_script_run("curl -O " . data_url("containers/docker-compose.yml"));
     assert_script_run("curl -O " . data_url("containers/haproxy.cfg"));
 
-    allow_selected_insecure_registries(runtime => 'docker');
+    allow_selected_insecure_registries(runtime => $docker);
     file_content_replace("docker-compose.yml", REGISTRY => get_var('REGISTRY', 'docker.io'));
     assert_script_run 'docker-compose pull', 600;
 
@@ -87,7 +88,7 @@ sub run {
     # De-registration is disabled for on-demand instances
     remove_suseconnect_product(get_addon_fullname('phub'))    if (is_sle()          && !is_ondemand());
     remove_suseconnect_product(get_addon_fullname('python2')) if (is_sle('=15-sp1') && !is_ondemand());
-    clean_container_host(runtime => 'docker');
+    $docker->cleanup_system_host();
 }
 
 sub post_fail_hook {

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -26,13 +26,14 @@ use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release is_tumbleweed);
+use containers::runtime;
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal();
 
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $runtime = "docker";
+    my $runtime = containers::runtime::docker->new();
 
     install_docker_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => $runtime);
@@ -60,7 +61,7 @@ sub run {
         }
     }
     scc_restore_docker_image_credentials();
-    clean_container_host(runtime => $runtime);
+    $runtime->cleanup_system_host();
 }
 
 1;

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -30,7 +30,7 @@ sub run {
     $self->select_serial_terminal;
 
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $docker   = containers::runtime->new(runtime => 'docker');
+    my $docker   = containers::runtime::docker->new();
     my @runtimes = ();
     push @runtimes, "runc" if (is_leap(">15.1") or !is_sle('=15'));
 

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -47,7 +47,7 @@ sub run {
     allow_selected_insecure_registries(runtime => $podman);
 
     # Run basic tests for podman
-    basic_container_tests(runtime => $podman);
+    basic_container_tests(runtime => $podman->runtime);
 
     # Build an image from Dockerfile and test it
     build_and_run_image(runtime => $podman, base => 'registry.opensuse.org/opensuse/leap:latest');

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,7 +21,7 @@
 #      * containers can be stopped
 #      * containers can be deleted
 #      * images can be deleted
-# Maintainer: Richard Brown <rbrown@suse.com>
+# Maintainer: qac team <qa-c@suse.de>
 
 use base "consoletest";
 use testapi;
@@ -33,26 +33,27 @@ use containers::common;
 use version_utils qw(is_sle is_leap is_jeos get_os_release);
 use containers::utils;
 use containers::container_images;
+use containers::runtime;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    my $dir = "/root/DockerTest";
-
+    my $dir    = "/root/DockerTest";
+    my $podman = containers::runtime::podman->new();
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_podman_when_needed($host_distri);
-    allow_selected_insecure_registries(runtime => 'podman');
+    allow_selected_insecure_registries(runtime => $podman);
 
     # Run basic tests for podman
-    basic_container_tests(runtime => "podman");
+    basic_container_tests(runtime => $podman);
 
     # Build an image from Dockerfile and test it
-    build_and_run_image(runtime => 'podman', base => 'registry.opensuse.org/opensuse/leap:latest');
+    build_and_run_image(runtime => $podman, base => 'registry.opensuse.org/opensuse/leap:latest');
 
     # Clean container
-    clean_container_host(runtime => "podman");
+    $podman->cleanup_system_host();
 }
 
 sub post_fail_hook {

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -36,11 +36,14 @@ use containers::container_images;
 use containers::runtime;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $runargs) = @_;
     $self->select_serial_terminal;
 
     my $dir    = "/root/DockerTest";
-    my $podman = containers::runtime::podman->new();
+    my $factory = containers::runtime::Factory->new();
+    my $instance = $factory->get_instance(); #containers::runtime::podman->new();
+    $runargs->{podman} = $instance;
+    my $podman = $runargs->{podman};
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_podman_when_needed($host_distri);

--- a/tests/containers/podman_3rd_party_images.pm
+++ b/tests/containers/podman_3rd_party_images.pm
@@ -22,14 +22,14 @@ use containers::common;
 use containers::urls 'get_3rd_party_images';
 use containers::container_images qw(test_3rd_party_image upload_3rd_party_images_logs);
 use registration;
-
+use containers::runtime;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $runtime = 'podman';
+    my $runtime = containers::runtime::podman->new();
 
     script_run("echo 'Container base image tests:' > /var/tmp/$runtime-3rd_party_images_log.txt");
     # In SLE we need to add the Containers module
@@ -39,7 +39,7 @@ sub run {
     for my $image (@{$images}) {
         test_3rd_party_image($runtime, $image);
     }
-    clean_container_host(runtime => $runtime);
+    $runtime->cleanup_system_host();
 }
 
 sub post_fail_hook {

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -19,14 +19,14 @@ use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use version_utils qw(get_os_release check_os_release);
+use containers::runtime;
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal();
 
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $runtime = "podman";
-
+    my $runtime = containers::runtime::podman->new();
     install_podman_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => $runtime);
 
@@ -50,7 +50,7 @@ sub run {
             }
         }
     }
-    clean_container_host(runtime => $runtime);
+    $runtime->cleanup_system_host();
 }
 
 1;

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -38,31 +38,31 @@ sub registry_push_pull {
     die 'Argument $runtime not provided!' unless $runtime;
 
     # Pull $image
-    assert_script_run "$runtime->{runtime} pull $image",            600;
-    assert_script_run "$runtime->{runtime} images | grep '$image'", 60;
+    assert_script_run $runtime->runtime . " pull $image",            600;
+    assert_script_run $runtime->runtime . " images | grep '$image'", 60;
 
     # Tag $image for the local registry
-    assert_script_run "$runtime->{runtime} tag $image localhost:5000/$image",      90;
-    assert_script_run "$runtime->{runtime} images | grep 'localhost:5000/$image'", 60;
+    assert_script_run $runtime->runtime . " tag $image localhost:5000/$image",      90;
+    assert_script_run $runtime->runtime . " images | grep 'localhost:5000/$image'", 60;
 
     # Push $image to the local registry
-    assert_script_run "$runtime->{runtime} push localhost:5000/$image", 90;
+    assert_script_run $runtime->runtime . " push localhost:5000/$image", 90;
 
     # Remove $image as well as the local registry $image
     # The localhost:5000/$image must be removed first
-    assert_script_run "$runtime->{runtime} image rm -f localhost:5000/$image", 90;
-    if (script_run("$runtime->{runtime} images | grep '$image'") == 0) {
-        assert_script_run "$runtime->{runtime} image rm -f $image", 90;
+    assert_script_run $runtime->runtime . " image rm -f localhost:5000/$image", 90;
+    if (script_run($runtime->runtime . " images | grep '$image'") == 0) {
+        assert_script_run $runtime->runtime . " image rm -f $image", 90;
     } else {
         record_soft_failure("containers/podman#10685",
             "Known issue - containers/podman#10685: podman image rm --force also untags other images (3.2.0 regression)");
     }
-    assert_script_run "! $runtime->{runtime} images | grep '$image'",                60;
-    assert_script_run "! $runtime->{runtime} images | grep 'localhost:5000/$image'", 60;
+    assert_script_run "! " . $runtime->runtime . " images | grep '$image'",                60;
+    assert_script_run "! " . $runtime->runtime . " images | grep 'localhost:5000/$image'", 60;
 
     # Pull $image from the local registry
-    assert_script_run "$runtime->{runtime} pull localhost:5000/$image",            90;
-    assert_script_run "$runtime->{runtime} images | grep 'localhost:5000/$image'", 60;
+    assert_script_run $runtime->runtime . " pull localhost:5000/$image",            90;
+    assert_script_run $runtime->runtime . " images | grep 'localhost:5000/$image'", 60;
 }
 
 sub run {

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@
 # - images can be searched
 # - images can be pulled
 # - images can be deleted
-# Maintainer: Pavel Dostal <pdostal@suse.cz>
+# Maintainer: qac team <qa-c@suse.de>
 
 use base "consoletest";
 use testapi;
@@ -27,6 +27,7 @@ use version_utils qw(is_sle is_tumbleweed is_leap get_os_release);
 use registration;
 use containers::common;
 use containers::utils;
+use containers::runtime;
 
 sub registry_push_pull {
     my %args    = @_;
@@ -37,31 +38,31 @@ sub registry_push_pull {
     die 'Argument $runtime not provided!' unless $runtime;
 
     # Pull $image
-    assert_script_run "$runtime pull $image",            600;
-    assert_script_run "$runtime images | grep '$image'", 60;
+    assert_script_run "$runtime->{runtime} pull $image",            600;
+    assert_script_run "$runtime->{runtime} images | grep '$image'", 60;
 
     # Tag $image for the local registry
-    assert_script_run "$runtime tag $image localhost:5000/$image",      90;
-    assert_script_run "$runtime images | grep 'localhost:5000/$image'", 60;
+    assert_script_run "$runtime->{runtime} tag $image localhost:5000/$image",      90;
+    assert_script_run "$runtime->{runtime} images | grep 'localhost:5000/$image'", 60;
 
     # Push $image to the local registry
-    assert_script_run "$runtime push localhost:5000/$image", 90;
+    assert_script_run "$runtime->{runtime} push localhost:5000/$image", 90;
 
     # Remove $image as well as the local registry $image
     # The localhost:5000/$image must be removed first
-    assert_script_run "$runtime image rm -f localhost:5000/$image", 90;
-    if (script_run("$runtime images | grep '$image'") == 0) {
-        assert_script_run "$runtime image rm -f $image", 90;
+    assert_script_run "$runtime->{runtime} image rm -f localhost:5000/$image", 90;
+    if (script_run("$runtime->{runtime} images | grep '$image'") == 0) {
+        assert_script_run "$runtime->{runtime} image rm -f $image", 90;
     } else {
         record_soft_failure("containers/podman#10685",
             "Known issue - containers/podman#10685: podman image rm --force also untags other images (3.2.0 regression)");
     }
-    assert_script_run "! $runtime images | grep '$image'",                60;
-    assert_script_run "! $runtime images | grep 'localhost:5000/$image'", 60;
+    assert_script_run "! $runtime->{runtime} images | grep '$image'",                60;
+    assert_script_run "! $runtime->{runtime} images | grep 'localhost:5000/$image'", 60;
 
     # Pull $image from the local registry
-    assert_script_run "$runtime pull localhost:5000/$image",            90;
-    assert_script_run "$runtime images | grep 'localhost:5000/$image'", 60;
+    assert_script_run "$runtime->{runtime} pull localhost:5000/$image",            90;
+    assert_script_run "$runtime->{runtime} images | grep 'localhost:5000/$image'", 60;
 }
 
 sub run {
@@ -81,17 +82,19 @@ sub run {
 
     # Run docker tests
     install_docker_when_needed($host_distri);
-    allow_selected_insecure_registries(runtime => 'docker');
+    my $docker = containers::runtime::docker->new();
+    allow_selected_insecure_registries(runtime => $docker);
     my $tumbleweed = 'registry.opensuse.org/opensuse/tumbleweed';
-    registry_push_pull(image => $tumbleweed, runtime => 'docker');
-    clean_container_host(runtime => 'docker');
+    registry_push_pull(image => $tumbleweed, runtime => $docker);
+    $docker->cleanup_system_host();
 
     # Run podman tests
     if (is_leap('15.1+') || is_tumbleweed || is_sle("15-sp1+")) {
+        my $podman = containers::runtime::podman->new();
         install_podman_when_needed($host_distri);
-        allow_selected_insecure_registries(runtime => 'podman');
-        registry_push_pull(image => $tumbleweed, runtime => 'podman');
-        clean_container_host(runtime => 'podman');
+        allow_selected_insecure_registries(runtime => $podman);
+        registry_push_pull(image => $tumbleweed, runtime => $podman);
+        $podman->cleanup_system_host();
     }
 }
 

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -31,12 +31,12 @@ use version_utils 'is_sle';
 use containers::runtime;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $runargs) = @_;
     $self->select_serial_terminal;
     my ($untested_images, $released_images) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $runtime = containers::runtime::podman->new();
-
+    my $runtime = $runargs->{podman}; # containers::runtime::podman->new();
+    use Data::Dumper; record_info Dumper $runtime;
     install_podman_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => $runtime);
     my $user         = $testapi::username;

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -28,13 +28,14 @@ use containers::urls 'get_suse_container_urls';
 use containers::utils 'registry_url';
 use version_utils qw(get_os_release);
 use version_utils 'is_sle';
+use containers::runtime;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     my ($untested_images, $released_images) = get_suse_container_urls();
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $runtime = "podman";
+    my $runtime = containers::runtime::podman->new();
 
     install_podman_when_needed($host_distri);
     allow_selected_insecure_registries(runtime => $runtime);
@@ -60,7 +61,7 @@ sub run {
         test_zypper_on_container($runtime, $iname);
         verify_userid_on_container($runtime, $iname, $subuid_start);
     }
-    clean_container_host(runtime => $runtime);
+    $runtime->cleanup_system_host();
 }
 
 sub softfail_and_skip_on_bsc1182874 {

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -99,11 +99,12 @@ sub run {
     $self->select_serial_terminal;
     die "Module requires two disks to run" unless check_var('NUMDISKS', 2);
     my ($running_version, $sp, $host_distri) = get_os_release;
-    install_docker_when_needed($host_distri);
-    allow_selected_insecure_registries(runtime => 'docker');
-    my $docker    = containers::runtime->new(runtime => 'docker');
     my $btrfs_dev = '/var/lib/docker';
     my ($untested_images, $released_images) = get_suse_container_urls();
+    my $docker = containers::runtime::docker->new();
+    install_docker_when_needed($host_distri);
+    allow_selected_insecure_registries(runtime => $docker);
+
     _sanity_test_btrfs($docker, $btrfs_dev, $released_images->[0]);
     _test_btrfs_thin_partitioning($docker, $btrfs_dev);
     _test_btrfs_device_mgmt($docker, $btrfs_dev);

--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -26,11 +26,12 @@ use version_utils 'get_os_release';
 use strict;
 use warnings;
 use containers::common;
+use containers::runtime;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
-
+    my $docker = containers::runtime::docker->new();
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_docker_when_needed($host_distri);
@@ -59,7 +60,7 @@ sub run {
         assert_script_run("zypper-docker list-patches-container tmp_container", timeout => 600);
         # apply all the updates to a new_image
         assert_script_run("zypper-docker update --auto-agree-with-licenses $testing_image new_image", timeout => 900);
-        clean_container_host(runtime => 'docker');
+        $docker->cleanup_system_host();
     }
 
 }


### PR DESCRIPTION
Extends runtime.pm to use a factory class for the creation of the
    container runtime. With this design the divided modules of _podman and _docker
    which have common code can be merged into one.
    
    Also instead of Singleton class we can reuse the RunArgs to pass the runtime instance
    to all the modules of the test.
    Added TEST_CONTEXT to the yaml for now, make sure that works and it can be moved to the
    job groups eventually
    
    This implementation is based on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/12842


http://aquarius.suse.cz/tests/7056