### PR TITLE
WIP: Don't die if releasenotes URL is not available

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -96,7 +96,6 @@ our @EXPORT = qw(
   load_system_update_tests
   loadtest
   load_testdir
-  load_toolchain_tests
   load_virtualization_tests
   load_x11tests
   load_hypervisor_tests
@@ -2799,14 +2798,6 @@ sub load_extra_tests_syscontainer {
     loadtest 'virtualization/syscontainer_image_test';
 }
 
-sub load_toolchain_tests {
-    loadtest "console/force_scheduled_tasks";
-    loadtest "toolchain/install";
-    loadtest "toolchain/gcc_fortran_compilation";
-    loadtest "toolchain/gcc_compilation";
-    loadtest "console/kdump_and_crash" if is_sle && kdump_is_applicable;
-}
-
 sub load_extra_tests_kernel {
     loadtest "kernel/module_build";
     loadtest "kernel/tuned";
@@ -2915,7 +2906,6 @@ sub load_common_opensuse_sle_tests {
     load_publiccloud_tests              if get_var('PUBLIC_CLOUD');
     loadtest "terraform/create_image"   if get_var('TERRAFORM');
     load_create_hdd_tests               if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
-    load_toolchain_tests                if get_var("TCM")         || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
     load_transactional_role_tests       if is_transactional && (get_var('ARCH') !~ /ppc64|s390/);

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1062,7 +1062,7 @@ sub load_console_server_tests {
     }
     if (!is_staging && (is_opensuse || get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/)) {
         # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-        loadtest "console/pcre" if is_sle;
+        loadtest "console/php_pcre" if is_sle;
         # TODO test on SLE https://progress.opensuse.org/issues/31972
         loadtest "console/mariadb_odbc" if is_opensuse;
         loadtest "console/php7";
@@ -1581,7 +1581,7 @@ sub load_extra_tests_opensuse {
     return unless is_opensuse;
     loadtest "console/rabbitmq";
     loadtest "console/rails";
-    loadtest "console/pcre";
+    loadtest "console/php_pcre";
     loadtest "console/openqa_review";
     loadtest "console/zbar";
     loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1947,6 +1947,10 @@ sub install_patterns {
         if (($pt =~ /sap_server/) && is_sle('=11-SP4')) {
             next;
         }
+        # skip the installation of "fips" for SLED cases, poo#98745.
+        if (($pt =~ /fips/) && check_var('SLE_PRODUCT', 'sled')) {
+            next;
+        }
         # if pattern is common-criteria and PATTERNS is all, skip, poo#73645
         next if (($pt =~ /common-criteria/) && check_var('PATTERNS', 'all'));
         zypper_call("in -t pattern $pt", timeout => 1800);

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -56,7 +56,7 @@ conditional_schedule:
                 - appgeo/gdal
                 - console/rabbitmq
                 - console/rails
-                - console/pcre
+                - console/php_pcre
                 - console/openqa_review
                 - console/zbar
                 - console/a2ps

--- a/schedule/functional/toolchain.yaml
+++ b/schedule/functional/toolchain.yaml
@@ -1,0 +1,22 @@
+---
+name: toolchain
+description: >
+    Maintainer: zluo
+    toolchain tests for sles and opensuse
+conditional_schedule:
+    bootloader:
+        BACKEND:
+            'svirt':
+                - installation/bootloader_zkvm
+    kdump_and_crash:
+        DISTRI:
+            sle:
+                - console/kdump_and_crash
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - console/force_scheduled_tasks
+    - toolchain/install
+    - toolchain/gcc_fortran_compilation
+    - toolchain/gcc_compilation
+    - '{{kdump_and_crash}}'

--- a/schedule/migration/s390x-zVM-Upgrade.yaml
+++ b/schedule/migration/s390x-zVM-Upgrade.yaml
@@ -59,7 +59,7 @@ conditional_schedule:
         - console/dns_srv
         - console/postgresql_server
         - console/shibboleth
-        - console/pcre
+        - console/php_pcre
         - console/php7
         - console/php7_mysql
         - console/php7_postgresql

--- a/schedule/qam/15-SP2/mau-webserver.yaml
+++ b/schedule/qam/15-SP2/mau-webserver.yaml
@@ -33,7 +33,7 @@ schedule:
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
 - console/hostname
-- console/pcre
+- console/php_pcre
 - console/curl_https
 - console/http_srv
 - console/dns_srv

--- a/schedule/qam/15-SP3/mau-webserver.yaml
+++ b/schedule/qam/15-SP3/mau-webserver.yaml
@@ -33,7 +33,7 @@ schedule:
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
 - console/hostname
-- console/pcre
+- console/php_pcre
 - console/curl_https
 - console/http_srv
 - console/dns_srv

--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -4,7 +4,7 @@ description:    >
   Offline installation. Skipping registration for SLE 15, as requires network connection.
   This is default behavior for SLE 12.
 vars:
-  SCC_REGISTER: 'none'
+  SCC_REGISTER: 'installation'
   ADDONS: all-packages
 schedule:
   - installation/bootloader_start
@@ -13,6 +13,7 @@ schedule:
   - installation/network_configuration
   - installation/scc_registration
   - installation/addon_products_sle
+  - installation/releasenotes_origin
   - installation/system_role
   - installation/partitioning
   - installation/partitioning_finish

--- a/tests/console/php_pcre.pm
+++ b/tests/console/php_pcre.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,7 @@
 # - Run some php tests using pcre
 # - Run "grep -qP '^VERSI(O?)N' /etc/os-release"
 # - Cleanup test files
-# Maintainer: Stephan Kulow <coolo@suse.de>
+# Maintainer: QE-Core <qe-core@suse.de>
 
 use strict;
 use warnings;

--- a/tests/installation/releasenotes_origin.pm
+++ b/tests/installation/releasenotes_origin.pm
@@ -25,7 +25,7 @@ sub run {
     enter_cmd "grep -o \"Got release notes.*\" /var/log/YaST2/y2log";
     assert_screen [qw(got-releasenotes-RPM got-releasenotes-URL)];
     unless (match_has_tag "got-releasenotes-$src") {
-        die "Release notes source does NOT match expectaions or not found in YaST logs, expected source: $src";
+        record_soft_failure("poo#97316: Release notes source does NOT match expectations or not found in YaST logs, expected source: $src");
     }
     enter_cmd "exit";
     # If we don't have system role screen, release notes origin is verified on partitioning screen

--- a/tests/x11/tracker/tracker_by_command.pm
+++ b/tests/x11/tracker/tracker_by_command.pm
@@ -32,9 +32,16 @@ sub run {
         script_run "tracker-search newfile";
     }
     else {
-        my $trackercmd = (is_sle('<16') or is_leap('<16.0')) ? 'tracker' : 'tracker3';
+        my $trackercmd = (is_sle('<=15-sp3') or is_leap('<=15.3')) ? 'tracker' : 'tracker3';
         script_run "$trackercmd search emptyfile";
-        assert_screen('tracker-cmdsearch-emptyfile');
+        assert_screen([qw(tracker-cmdsearch-emptyfile tracker-cmdsearch-noemptyfile)]);
+        if (match_has_tag 'tracker-cmdsearch-noemptyfile') {
+            record_soft_failure 'bsc#1190296 tracker3 can not index empty files for the first time';
+            enter_cmd "clear";
+            wait_still_screen 10;
+            assert_script_run "$trackercmd search emptyfile";
+            assert_screen 'tracker-cmdsearch-emptyfile';
+        }
         script_run "$trackercmd search newfile";
     }
     assert_screen 'tracker-cmdsearch-newfile';

--- a/tests/x11/tracker/tracker_info.pm
+++ b/tests/x11/tracker/tracker_info.pm
@@ -31,7 +31,7 @@ sub run {
         script_run "tracker-info newpl.pl";
     }
     else {
-        my $trackercmd = (is_sle('<16') or is_leap('<16.0')) ? 'tracker' : 'tracker3';
+        my $trackercmd = (is_sle('<=15-sp3') or is_leap('<=15.3')) ? 'tracker' : 'tracker3';
         script_run "$trackercmd info newpl.pl";
     }
     assert_screen 'tracker-info-newpl';


### PR DESCRIPTION
- poo#97316: Sometimes URL for release notes is not yet available
  for SLES. In this case record a soft failure instead of dying.

- Related ticket: https://progress.opensuse.org/issues/97316

- Verification run:https://openqa.suse.de/tests/7100006
