### PR TITLE
lib/main_common: Run logs_from_installation_system also on MicroOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -795,7 +795,7 @@ sub boot_hdd_image {
 
 sub load_common_installation_steps_tests {
     loadtest 'installation/await_install';
-    unless (get_var('REMOTE_CONTROLLER') || is_microos || is_hyperv_in_gui) {
+    unless (get_var('REMOTE_CONTROLLER') || is_hyperv_in_gui) {
         loadtest "installation/add_serial_console" if is_vmware;
         loadtest 'installation/logs_from_installation_system';
     }


### PR DESCRIPTION
I can't think of a good reason not to collect logs in those tests.

- Verification run: http://10.160.67.86/tests/1053
