### PR TITLE
Remove softail net.ipv4.mem systcl check on 15SP1

### DIFF
--- a/tests/sles4sap/robot_fw.pm
+++ b/tests/sles4sap/robot_fw.pm
@@ -92,7 +92,6 @@ sub run {
         if ($robot_test eq "sysctl.robot") {
             # bsc#1181163 - unexpected values for net.ipv6.conf.lo.use_tempaddr and net.ipv6.conf.lo.accept_redirects
             add_softfail("sysctl.robot", "15-SP1", "bsc#1181163", qw(Sysctl_net_ipv6_conf_lo_accept_redirects Sysctl_net_ipv6_conf_lo_use_tempaddr));
-            add_softfail("sysctl.robot", "15-SP1", "poo#92566",   qw(Sysctl_net_ipv4_udp_mem));
         }
         parse_extra_log("XUnit", "$test_repo/$robot_test.xml");
         upload_logs("$test_repo/$robot_test.html", failok => 1);


### PR DESCRIPTION
This PR removes a softfail for `net.udp.mem` on 15-SP1, I no longer see the softfail triggering in the last fifteen versions.
Let's remove the softfail first, then monitor the test before adapting the value in the reference file.

- Related ticket: https://progress.opensuse.org/issues/92566
- Needles: N/A
- Verification run: N/A
