### PR TITLE
console/regproxy: Backdate /etc/hosts to work around boo#1190532

### DIFF
--- a/tests/console/regproxy.pm
+++ b/tests/console/regproxy.pm
@@ -39,12 +39,16 @@ sub run {
     assert_script_run('popd');
 
     # Redirect to localhost
+    assert_script_run('cp -a /etc/hosts hosts.bak');
     assert_script_run('echo -e "127.0.0.1\tregistry.opensuse.org" >> /etc/hosts');
     script_run('nscd -i hosts');    # Just ignore the return value
 
     # Verify that it works
     validate_script_output('curl -kH "Host: registry.opensuse.org" https://localhost/v2', sub { m/{}/ });
     validate_script_output('curl https://registry.opensuse.org/v2',                       sub { m/{}/ });
+
+    # Backdate /etc/hosts to not trigger mkdumprd on reboot (boo#1190532)
+    assert_script_run('touch -r hosts.bak /etc/hosts && rm hosts.bak');
 }
 
 sub test_flags {


### PR DESCRIPTION
Modifications of /etc/hosts trigger kdump initrd generation on the next boot,
but on read-only systems that results in an error.

Instead of wasting time to perform a regeneration and reboot, just set back the
mtime.

- Verification run: https://openqa.opensuse.org/tests/1918264
