### PR TITLE
Remove ensure_unlocked_desktop call in tomcat test

### DIFF
--- a/tests/x11/tomcat.pm
+++ b/tests/x11/tomcat.pm
@@ -27,7 +27,7 @@ use Tomcat::Utils;
 use Tomcat::ModjkTest;
 use utils;
 use version_utils 'is_sle';
-use x11utils 'ensure_unlocked_desktop';
+use x11utils qw(turn_off_screensaver);
 
 sub run() {
 
@@ -39,6 +39,7 @@ sub run() {
     $self->switch_to_desktop();
 
     # start firefox
+    $self->turn_off_screensaver();
     $self->start_firefox_with_profile();
 
     # check that the tomcat web service works
@@ -62,8 +63,6 @@ sub run() {
     record_info('WebSocket Testing');
     my $websocket_test = Tomcat::WebSocketsTest->new();
     $websocket_test->test_all_examples();
-
-    assert_screen('generic-desktop');
 
     # Install and configure apache2 and apache2-mod_jk connector
     Tomcat::ModjkTest->mod_jk_setup();
@@ -109,7 +108,6 @@ sub switch_to_desktop {
     # switch to desktop
     if (!check_var('DESKTOP', 'textmode')) {
         select_console('x11', await_console => 0);
-        ensure_unlocked_desktop;
     }
 }
 


### PR DESCRIPTION
The needle( tomcat-generic-desktop-20210906.json) in the tomcat test is making the other test fail. So removed the needle and changed the tomcat test logic to avoid matching the generic desktop needle when switching from serial terminal to desktop and keep one firefox instance open for the whole module and close at the end of the test.

- Related ticket: https://progress.opensuse.org/issues/98261
- Needles: No
- Verification run: 
        Tumbleweed : http://10.161.229.147/tests/1265
        SLE 15 SP3 : http://10.161.229.147/tests/1271
        SLE 15 SP2 : http://10.161.229.147/tests/1267
        SLE 15 SP1 : 
        SLE 12 SP5 : http://10.161.229.147/tests/1272 
         SLE 12 SP4: http://10.161.229.147/tests/1273
        SLE 12 SP3 : http://10.161.229.147/tests/1268 
        