### PR TITLE
Rename pcre to php_pcre

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1063,7 +1063,7 @@ sub load_console_server_tests {
     }
     if (!is_staging && (is_opensuse || get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/)) {
         # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-        loadtest "console/pcre" if is_sle;
+        loadtest "console/php_pcre" if is_sle;
         # TODO test on SLE https://progress.opensuse.org/issues/31972
         loadtest "console/mariadb_odbc" if is_opensuse;
         loadtest "console/php7";
@@ -1582,7 +1582,7 @@ sub load_extra_tests_opensuse {
     return unless is_opensuse;
     loadtest "console/rabbitmq";
     loadtest "console/rails";
-    loadtest "console/pcre";
+    loadtest "console/php_pcre";
     loadtest "console/openqa_review";
     loadtest "console/zbar";
     loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -56,7 +56,7 @@ conditional_schedule:
                 - appgeo/gdal
                 - console/rabbitmq
                 - console/rails
-                - console/pcre
+                - console/php_pcre
                 - console/openqa_review
                 - console/zbar
                 - console/a2ps

--- a/schedule/migration/s390x-zVM-Upgrade.yaml
+++ b/schedule/migration/s390x-zVM-Upgrade.yaml
@@ -59,7 +59,7 @@ conditional_schedule:
         - console/dns_srv
         - console/postgresql_server
         - console/shibboleth
-        - console/pcre
+        - console/php_pcre
         - console/php7
         - console/php7_mysql
         - console/php7_postgresql

--- a/schedule/qam/15-SP2/mau-webserver.yaml
+++ b/schedule/qam/15-SP2/mau-webserver.yaml
@@ -33,7 +33,7 @@ schedule:
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
 - console/hostname
-- console/pcre
+- console/php_pcre
 - console/curl_https
 - console/http_srv
 - console/dns_srv

--- a/schedule/qam/15-SP3/mau-webserver.yaml
+++ b/schedule/qam/15-SP3/mau-webserver.yaml
@@ -33,7 +33,7 @@ schedule:
 - locale/keymap_or_locale
 - console/force_scheduled_tasks
 - console/hostname
-- console/pcre
+- console/php_pcre
 - console/curl_https
 - console/http_srv
 - console/dns_srv

--- a/tests/console/php_pcre.pm
+++ b/tests/console/php_pcre.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,7 @@
 # - Run some php tests using pcre
 # - Run "grep -qP '^VERSI(O?)N' /etc/os-release"
 # - Cleanup test files
-# Maintainer: Stephan Kulow <coolo@suse.de>
+# Maintainer: QE-Core <qe-core@suse.de>
 
 use strict;
 use warnings;


### PR DESCRIPTION
This test depends on PHP being installed on the system, hence the name change