### PR TITLE
Remove reload_needles for set_var

### DIFF
--- a/tests/migration/version_switch_origin_system.pm
+++ b/tests/migration/version_switch_origin_system.pm
@@ -27,7 +27,7 @@ sub run {
 
     if (get_var('VERSION') ne $original_version) {
         # Switch to original system version and reload needles
-        set_var('VERSION', $original_version, reload_needles => 1);
+        set_var('VERSION', $original_version);
     }
 
     # Reset vars for autoyast installation of origin system

--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -28,7 +28,7 @@ sub run {
 
     if (get_var('VERSION') ne $upgrade_target_version) {
         # Switch to upgrade target version and reload needles
-        set_var('VERSION', $upgrade_target_version, reload_needles => 1);
+        set_var('VERSION', $upgrade_target_version);
     }
 
     # Reset vars for upgrade on zVM


### PR DESCRIPTION
In version_switch_upgrade_target.pm and version_switch_origin_system.pm
we call set_var with reload_needles => 1, which will reload all the needle
and it's a time-consuming action. this will cause a timeout when the system
boots and resulted in boot into the default grub item.

We can remove this to save time and will not affect the tests, because all
needles are not classified with version.

- Related ticket: https://progress.opensuse.org/issues/98502
- Needles: N/A
- Verification run: 

https://openqa.nue.suse.com/tests/7099558  
https://openqa.nue.suse.com/t7098821  
https://openqa.nue.suse.com/t7098822  
https://openqa.nue.suse.com/t7098825 
https://openqa.nue.suse.com/t7098826 
https://openqa.nue.suse.com/t7098827 

12sp5
https://openqa.nue.suse.com/tests/7136147 
https://openqa.nue.suse.com/tests/7148155 
https://openqa.nue.suse.com/t7123853 
https://openqa.nue.suse.com/t7123854  
https://openqa.nue.suse.com/t7123855  
https://openqa.nue.suse.com/t7123856  