### PR TITLE
Extend the current save_and_restore test by adding a test file, after…

### DIFF
--- a/tests/virtualization/universal/save_and_restore.pm
+++ b/tests/virtualization/universal/save_and_restore.pm
@@ -1,49 +1,66 @@
 # XEN regression tests
-#
-# Copyright © 2019 SUSE LLC
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved. This file is offered as-is,
-# without any warranty.
+ #
+ # Copyright © 2019 SUSE LLC
+ #
+ # Copying and distribution of this file, with or without modification,
+ # are permitted in any medium without royalty provided the copyright
+ # notice and this notice are preserved. This file is offered as-is,
+ # without any warranty.
+ 
+ # Package: libvirt-client nmap
+ # Summary: Test if the guests can be saved and restored
+ # Maintainer: Jan Baier <jbaier@suse.cz>
+ 
+ use base "virt_feature_test_base";
+ use virt_autotest::common;
+ use strict;
+ use warnings;
+ use testapi;
+ use utils;
+ 
+ sub run_test {
+     assert_script_run "mkdir -p /var/lib/libvirt/images/saves/";
+ 
+     record_info "Remove", "Remove previous saves (if there were any)";
+     script_run "rm /var/lib/libvirt/images/saves/$_.vmsave || true" foreach (keys %virt_autotest::common::guests);
 
-# Package: libvirt-client nmap
-# Summary: Test if the guests can be saved and restored
-# Maintainer: Jan Baier <jbaier@suse.cz>
+     record_info "Save", "Save the machine states";
+     assert_script_run("virsh save $_ /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (keys %virt_autotest::common::guests);
 
-use base "virt_feature_test_base";
-use virt_autotest::common;
-use strict;
-use warnings;
-use testapi;
-use utils;
+     record_info "Check", "Check saved states";
+     foreach my $guest (keys %virt_autotest::common::guests) {
+         if (script_run("virsh list --all | grep $guest | grep shut") != 0) {
+             record_soft_failure "Guest $guest should be shut down now";
+             script_run "virsh destroy $guest", 90;
+         }
+     }
 
-sub run_test {
-    assert_script_run "mkdir -p /var/lib/libvirt/images/saves/";
+     record_info "Start", "Start all VMs";
+     assert_script_run("virsh start $_", 300) foreach (keys %virt_autotest::common::guests);
 
-    record_info "Remove", "Remove previous saves (if there were any)";
-    script_run "rm /var/lib/libvirt/images/saves/$_.vmsave || true" foreach (keys %virt_autotest::common::guests);
+     record_info "SSH", "Check hosts are listening on SSH";
+     script_retry "nmap $_ -PN -p ssh | grep open", delay => 3, retry => 60 foreach (keys %virt_autotest::common::guests);
 
-    record_info "Save", "Save the machine states";
-    assert_script_run("virsh save $_ /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (keys %virt_autotest::common::guests);
+     foreach my $guest (keys %virt_autotest::common::guests) {
+     assert_script_run("ssh root\@$guest 'touch /var/empty_temp_file'");
+     assert_script_run("virsh destroy $guest", 90);
+     }
 
-    record_info "Check", "Check saved states";
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        if (script_run("virsh list --all | grep $guest | grep shut") != 0) {
-            record_soft_failure "Guest $guest should be shut down now";
-            script_run "virsh destroy $guest", 90;
-        }
-    }
-
-    record_info "Restore", "Restore guests";
-    assert_script_run("virsh restore /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (keys %virt_autotest::common::guests);
-
-    record_info "Check", "Check restored states";
-    assert_script_run "virsh list --all | grep $_ | grep running" foreach (keys %virt_autotest::common::guests);
-
-    record_info "SSH", "Check hosts are listening on SSH";
-    script_retry "nmap $_ -PN -p ssh | grep open", delay => 3, retry => 60 foreach (keys %virt_autotest::common::guests);
-}
-
-1;
-
+     record_info "Restore", "Restore guests";
+     assert_script_run("virsh restore /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (keys %virt_autotest::common::guests);
+ 
+     record_info "Check", "Check restored states";
+     assert_script_run "virsh list --all | grep $_ | grep running" foreach (keys %virt_autotest::common::guests);
+ 
+     record_info "SSH", "Check hosts are listening on SSH";
+     script_retry "nmap $_ -PN -p ssh | grep open", delay => 3, retry => 60 foreach (keys %virt_autotest::common::guests);
+   
+     record_info "Check", "Restored guests validation";
+     foreach my $guest (keys %virt_autotest::common::guests) {
+        if (script_run("ssh root\@$guest 'test -f /var/empty_temp_file'") != 1) {
+		die "The temp file should not exist in the restored state.";
+	}
+     }
+ }
+ 
+ 1;


### PR DESCRIPTION
… the machine state has been saved. This test file must not be present after the VM has been restored.


- Related ticket: https://progress.opensuse.org/issues/97373
- Needles: N/A
- Verification run: http://d488.qam.suse.de/tests/113
