### PR TITLE
Skip the installation of fips pattern for SLED

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1947,6 +1947,10 @@ sub install_patterns {
         if (($pt =~ /sap_server/) && is_sle('=11-SP4')) {
             next;
         }
+        # skip the installation of "fips" for SLED cases, poo#98745.
+        if (($pt =~ /fips/) && check_var('SLE_PRODUCT', 'sled')) {
+            next;
+        }
         # if pattern is common-criteria and PATTERNS is all, skip, poo#73645
         next if (($pt =~ /common-criteria/) && check_var('PATTERNS', 'all'));
         zypper_call("in -t pattern $pt", timeout => 1800);


### PR DESCRIPTION
Recently, there is a fips pattern released to Basesystem-15-SP3-Update repo, which 
is also available on SLED. When installing the fips pattern on SLED, there is a conflict.
While fips pattern is tested on SLES only, no need to install it on SLED. So skip the
installation of fips pattern for SLED.

- Related ticket: https://progress.opensuse.org/issues/98745
- Verification run: 
https://openqa.nue.suse.com/tests/7152596#step/zypper_patch/15
https://openqa.nue.suse.com/tests/7151288#step/patch_sle/102