### PR TITLE
Fix users switch users to deal with gnome activities

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -105,6 +105,8 @@ sub switch_users {
     type_password "$pwd4newUser\n";
     # handle welcome screen, when needed
     handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
+    assert_screen "gnome-activities", 120;
+    send_key 'esc';
     assert_screen "generic-desktop", 120;
     switch_user;
     send_key "esc";


### PR DESCRIPTION
We need deal with the gnome activities during the desktop login process since the new gnome version there.

Related ticket: https://progress.opensuse.org/issues/98583
Needles: already merged in OSD server.
Verification run: https://openqa.nue.suse.com/tests/7149325#step/check_upgraded_service/68
