### PR TITLE
Fix gdm_sessioon_switch and change_password failure on SLE15SP4

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -104,7 +104,7 @@ sub switch_users {
     type_password "$pwd4newUser\n";
     # handle welcome screen, when needed
     handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
-    assert_screen "generic-desktop", 120;
+    handle_gnome_activities;
     switch_user;
     send_key "esc";
     assert_and_click "displaymanager-$username";
@@ -112,7 +112,7 @@ sub switch_users {
     # for poo#88247, we have to restore current user's password before migration,
     # so here need to use the original password.
     type_password(get_required_var('FLAVOR') =~ /Migration/ ? "$password\n" : "$newpwd\n");
-    assert_screen "generic-desktop", 120;
+    handle_gnome_activities;
 }
 
 # restore password to original value

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -19,7 +19,7 @@ use LWP::Simple;
 use Config::Tiny;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
-use x11utils 'select_user_gnome';
+use x11utils qw(select_user_gnome handle_gnome_activities);
 use POSIX 'strftime';
 use mm_network;
 
@@ -66,7 +66,7 @@ sub prepare_sle_classic {
     if (is_sle('15+')) {
         assert_and_click 'dm-gnome-shell';
         send_key 'ret';
-        assert_screen 'desktop-gnome-shell', 350;
+        handle_gnome_activities;
     }
     else {
         assert_and_click 'dm-sle-classic';

--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -20,6 +20,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils 'is_sle';
+use x11utils 'handle_gnome_activities';
 
 # Smoke test: launch some applications
 sub application_test {
@@ -53,7 +54,7 @@ sub run {
     # Log out and log in again
     $self->switch_wm;
     send_key "ret";
-    assert_screen 'generic-desktop', 350;
+    handle_gnome_activities;
 
     # Log out and switch to icewm
     $self->switch_wm;
@@ -84,7 +85,7 @@ sub run {
     assert_and_click "displaymanager-settings";
     assert_and_click "dm-gnome";
     send_key "ret";
-    assert_screen "generic-desktop", 350;
+    handle_gnome_activities;
 
     # Log out and switch to SLE classic
     $self->prepare_sle_classic;

--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -47,7 +47,7 @@ sub reboot_system {
     } else {
         $self->wait_boot();
     }
-    assert_screen "generic-desktop";
+    handle_gnome_activities;
 }
 
 sub auto_login_alter {


### PR DESCRIPTION
Gnome-activities appears after GNOME was upgraded to 40
Use handle_gnome_activities instead of 'assert_screen "generic-desktop";'
to fix gdm_session_switch and change_password on SLE15SP4
Related ticket: https://progress.opensuse.org/issues/97916

- Related ticket: https://progress.opensuse.org/issues/97916
- Needles: already added to osd when debugging
- Verification run: 
- SLE15SP4 https://openqa.suse.de/tests/7161391 (Please ignore the application_starts_on_login failure since it's another product issue)
