### PR TITLE
publiccloud: Add region variable to 'terraform destroy'

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -451,7 +451,8 @@ sub terraform_destroy {
     }
     # Retry 3 times with considerable delay. This has been introduced due to poo#95932 (RetryableError)
     # terraform keeps track of the allocated and destroyed resources, so its safe to run this multiple times.
-    my $ret = script_retry('terraform destroy -no-color -auto-approve', retry => 3, delay => 60, timeout => get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT), die => 0);
+    # Add region variable also to `terraform destroy` (poo#63604) -- needed by AWS.
+    my $ret = script_retry(sprintf(q(terraform destroy -no-color -auto-approve -var 'region=%s'), $self->region), retry => 3, delay => 60, timeout => get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT), die => 0);
     unless (defined $ret) {
         if (is_serial_terminal()) {
             type_string(qq(\c\\));    # Send QUIT signal


### PR DESCRIPTION
With provider AWS, the destroy of the instance doesn't worked, even if
the output of terraform assume it.
```
aws_instance.openqa[0]: Destroying... [id=i-0056a077e11402492]
aws_instance.openqa[0]: Destruction complete after 0s
```
Only the time of 0s could indicate something wrong.

With this change the destruction take some time and the output looks
like:
```
aws_instance.openqa[0]: Destroying... [id=i-032c27915d1f99aab]
aws_instance.openqa[0]: Still destroying... [id=i-032c27915d1f99aab, 10s elapsed]
aws_instance.openqa[0]: Still destroying... [id=i-032c27915d1f99aab, 20s elapsed]
aws_instance.openqa[0]: Still destroying... [id=i-032c27915d1f99aab, 30s elapsed]
aws_instance.openqa[0]: Still destroying... [id=i-032c27915d1f99aab, 40s elapsed]
aws_instance.openqa[0]: Destruction complete after 41s
```

The issue appears with the current used version 3.37.0 and also with
latest 3.59.0 of terraforms AWS provider.

Ticked: https://progress.opensuse.org/issues/63604

- Verification run: 
  - https://openqa.suse.de/tests/7173555#step/run_ltp/134 (GCE)
  - https://openqa.suse.de/tests/7173554#step/run_ltp/173 (EC2)
  - https://openqa.suse.de/tests/7182287#step/run_ltp/150 (Azure)
