### PR TITLE
Register SLEM in AY deployment scenario

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro.xml
+++ b/data/autoyast_sle15/autoyast_sle-micro.xml
@@ -2,9 +2,8 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
+    <do_registration config:type="boolean">true</do_registration>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <install_updates config:type="boolean">false</install_updates>
     <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <bootloader>

--- a/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
@@ -2,9 +2,9 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
+    <do_registration config:type="boolean">true</do_registration>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <install_updates config:type="boolean">false</install_updates>
+    <install_updates config:type="boolean">true</install_updates>
     <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <add-on>


### PR DESCRIPTION
- ['cockpit' not found in sle-micro 5.0](https://progress.opensuse.org/issues/98517)

