### PR TITLE
firefox_pdf: Drop fullscreen button, is removed on 91+

### DIFF
--- a/tests/x11/firefox/firefox_pdf.pm
+++ b/tests/x11/firefox/firefox_pdf.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2021 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,8 +16,6 @@
 # - Click on zoom out button
 # - Click on zoom in button
 # - Access zoom menu and select "Actual size"
-# - Select "Full screen"
-# - Select "Actual size"
 # - Jump to page 3
 # - Exit firefox
 # Maintainer: wnereiz <wnereiz@gmail.com>
@@ -45,13 +43,6 @@ sub run {
     assert_and_click 'firefox-pdf-zoom_menu_actual_size';    #"Actual Size"
     assert_screen('firefox-pdf-actual_size');
 
-    sleep 1;
-    assert_and_click 'firefox-pdf-icon_fullscreen';          #Full Screen
-
-    wait_still_screen 2;
-    send_key "esc";
-    sleep 1;
-    assert_and_click "firefox-pdf-actual_size";
     assert_and_click "firefox-pdf-page";
     sleep 1;
     send_key "3";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/98913
- Verification run: http://dzedro.suse.cz/tests/19375#step/firefox_pdf/20