### PR TITLE
Fix the SAP product hotkey for QR build

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -71,7 +71,6 @@ sub get_product_shortcuts {
             sled => 'x',
             sles4sap => is_ppc64le() ? 'i'
             : (is_sle('15-SP2+') && is_x86_64() && !is_quarterly_iso()) ? 't'
-            : (is_sle('15-SP3+') && is_x86_64()) ? 't'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',
             rt  => is_x86_64() ? 't' : undef


### PR DESCRIPTION
This PR fixes the hotkey to use for selecting the SAP product for testing a QR build.

- Related ticket: N/A
- Needles: N/A
- Verification run: [15-SP3 QR](https://openqa.suse.de/tests/7181788) - [15-SP4 graphical](http://1b143.qa.suse.de/tests/8812#) - [15 - SP4 textmode](https://openqa.suse.de/tests/7183310)
