### PR TITLE
Remove SCC_ADDONS=sdk from cryptlvm_minimal_x@s390x

### DIFF
--- a/schedule/staging/cryptlvm_minimal_x@s390x-staging.yaml
+++ b/schedule/staging/cryptlvm_minimal_x@s390x-staging.yaml
@@ -8,7 +8,6 @@ vars:
   ENCRYPT: 1
   LVM: 1
   MAX_JOB_TIME: 14400
-  SCC_ADDONS: sdk
   YUI_REST_API: 1
 schedule:
   - installation/bootloader_start


### PR DESCRIPTION
fix failure for https://openqa.suse.de/tests/7179097

- Verification run: https://openqa.suse.de/tests/7182901 (failure is on different point - unrelated)