### PR TITLE
Select desktop module in ext4 test suite on 390x

### DIFF
--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/module_selection/skip_module_selection
+  - installation/module_selection/select_module_desktop
   - installation/add_on_product/skip_install_addons
   - installation/system_role
   - installation/partitioning/select_guided_setup


### PR DESCRIPTION
The commit fixes [ext4 test suite](https://openqa.suse.de/tests/7125516) on s390x by selecting Desktop module
during installation, as it is expected to be installed.

- Verification run: https://openqa.suse.de/tests/7184626
