### PR TITLE
Fix non-existent test modules check

### DIFF
--- a/tools/detect_unused_modules
+++ b/tools/detect_unused_modules
@@ -37,7 +37,7 @@ done
 
 for test in $MODULES ; do
     # Don't check non-existing modules it as it was either renamed or removed
-    if [ -z `git ls-files "*$test*"` ]; then
+    if [ -z `git ls-files "tests/$test*"` ]; then
         continue
     fi
     t=$(basename $test | sed -e 's@\.pm$@@')


### PR DESCRIPTION
- Related pull request: #13246

The `tools/detect_unused_modules` sh script is run exclusively from `Makefile` and is used only *for test modules*:
```bash
$ tools/detect_unused_modules -m `git --no-pager diff --unified=0 origin/master schedule/* | grep -oP "^-\s+- [\"']?\K.*(?=[\"']?)" | grep -v '{{'`
publiccloud/ssh_interactive_init module is not used in any schedule
```

But in the `sh` script mentioned above we check that if such *file* exists (as it may be removed / renamed - which is the case of my pull request mentioned also above). So in my case this command is executed:
```bash
$ git ls-files "*publiccloud/ssh_interactive_init*"
lib/publiccloud/ssh_interactive_init.pm
```
In my case the test module I renamed is not detected as there is similar module under `lib/` and the test fails.

As `tools/detect_unused_modules` is used only for test modules, I propose this solution.
I may also rename it to `tools/detect_unused_test_modules` if you agree.

Thank you for your cooperation.