### PR TITLE
Remove usage of nonexistent method to fix Staging

### DIFF
--- a/lib/Installation/Registration/RegistrationController.pm
+++ b/lib/Installation/Registration/RegistrationController.pm
@@ -28,11 +28,9 @@ sub init {
     my ($self, $args) = @_;
     $self->{RegistrationPage}    = Installation::Registration::RegistrationPage->new({app => YuiRestClient::get_app()});
     $self->{UseUpdateReposPopup} = Installation::Warnings::ConfirmationWarning->new({
-            app        => YuiRestClient::get_app(),
-            match_text => "The registration server offers update repos.*"});
+            app => YuiRestClient::get_app()});
     $self->{SkipRegistrationPopup} = Installation::Warnings::ConfirmationWarningRichText->new({
-            app        => YuiRestClient::get_app(),
-            match_text => ".*Please confirm to proceed without updates.*"});
+            app => YuiRestClient::get_app()});
     return $self;
 }
 
@@ -44,15 +42,13 @@ sub get_registration_page {
 
 sub get_enable_update_repositories_popup {
     my ($self) = @_;
-    die "Update repositories popup is not displayed"               unless $self->{UseUpdateReposPopup}->is_shown();
-    die "Update repositories popup contains an unexpected message" unless $self->{UseUpdateReposPopup}->has_valid_text();
+    die "Update repositories popup is not displayed" unless $self->{UseUpdateReposPopup}->is_shown();
     return $self->{UseUpdateReposPopup};
 }
 
 sub get_skip_registration_popup {
     my ($self) = @_;
-    die "Warning for skipping registration is not displayed"               unless $self->{SkipRegistrationPopup}->is_shown();
-    die "Warning for skipping registration contains an unexpected message" unless $self->{SkipRegistrationPopup}->has_valid_text();
+    die "Warning for skipping registration is not displayed" unless $self->{SkipRegistrationPopup}->is_shown();
     return $self->{SkipRegistrationPopup};
 }
 


### PR DESCRIPTION
The method 'has_valid_text' was recently removed, but it is still used by Registration Controller.

The PR removes its usage.

- Verification run: https://openqa.suse.de/tests/7184596
