### PR TITLE
Master password is replaced by primary password in newer versions of MozillaFirefox

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -68,8 +68,8 @@ sub run {
     # - at least 8 characters
     # - at least one upper case
     # - at least one non-alphabet-non-number character (like: @-.=%)
-    my $fips_password = 'openqa@SUSE';
-
+    my $fips_password   = 'openqa@SUSE';
+    my $firefox_version = script_output(q(rpm -q MozillaFirefox | awk -F '-' '{ split($2, a, "."); print a[1]; }'));
     select_console 'x11';
     x11_start_program('firefox https://html5test.opensuse.org', target_match => 'firefox-html-test', match_timeout => 360);
 
@@ -77,7 +77,11 @@ sub run {
     firefox_preferences;
 
     # Search "Passwords" section
-    type_string "Use a master", timeout => 2;
+    if ($firefox_version >= 91) {
+        type_string "Use a primary", timeout => 2;
+    } else {
+        type_string "Use a master", timeout => 2;
+    }
     assert_and_click("firefox-master-password-checkbox");
     assert_screen("firefox-passwd-master_setting");
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/98964
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1564/
- Verification run: SLES [15sp3](https://openqa.suse.de/tests/7184614#step/firefox_nss/15) | [15sp2](https://openqa.suse.de/tests/7184623#step/firefox_nss/15) | [15sp1](http://10.161.229.247/tests/2281#step/firefox_nss/11)
The failure in `firefox_nss.pm` is a different topic than what this PR is handling, which is the following bug: https://bugzilla.suse.com/show_bug.cgi?id=1190710
In all sle12 versions, this module is excluded from the runs
