### PR TITLE
publiccloud: Use null value for boot_diagnostics 

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -199,7 +199,8 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
   }
 
   boot_diagnostics {
-    storage_account_uri = "https://${var.storage-account}.blob.core.windows.net/"
+    /* Passing a null value will utilize a Managed Storage Account to store Boot Diagnostics */
+    storage_account_uri = null
   }
 }
 


### PR DESCRIPTION
We encountered unknown failures when using our storage account to store
the boot_diagnostics. From azurerm docs [1] we see that using a `null`
for `storage_account_uri` value will enable boot_diagnostics, but
using a "Managed Storage Account".

[1] https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine#storage_account_uri

- Related ticket: https://progress.opensuse.org/issues/98547


