### PR TITLE
Add softfail if sapconf is not started bsc#1190787

### DIFF
--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -97,6 +97,12 @@ sub run {
         systemctl "start sapconf";
     }
 
+    if (systemctl("-q is-active sapconf.service", ignore_failure => 1)) {
+        record_soft_failure("bsc#1190787 - sapconf is not started");
+        systemctl "enable sapconf";
+        systemctl "start sapconf";
+    }
+
     my $default_profile = $1;
     record_info("Current profile", "Current default profile: $default_profile");
 


### PR DESCRIPTION
This PR adds a softfail if sapconf is not started at boot time (bsc#1190787)

- Related ticket: N/A
- Needles: N/A
- Verification run: [15-SP3 QR](http://1b143.qa.suse.de/tests/8831) - [15-SP4](http://1b143.qa.suse.de/tests/8832)
