### PR TITLE
Fix failing hotplugging test

### DIFF
--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -263,7 +263,13 @@ sub run_test {
 
     # 3. Hotplugging of vCPUs
     record_info("CPU", "Changing the number of CPUs available");
-    test_add_vcpu($_) foreach (keys %virt_autotest::common::guests);
+    foreach my $guest (keys %virt_autotest::common::guests) {
+        if ($guest eq "sles12sp3PV") {
+            record_soft_failure("Skipping vcpu hotplugging on $guest due to bsc#1187341");
+        } else {
+            test_add_vcpu($guest);
+        }
+    }
 
     # 4. Live memory change of guests
     record_info "Memory", "Changing the amount of memory available";


### PR DESCRIPTION
Exclude the failing vcpu test run for sles12sp3PV due to bsc#1187341
This is a hotfix to fix the currently ongoing test runs.

- Verification run: http://openqa.qam.suse.cz/tests/28327#step/hotplugging/1136
