### PR TITLE
Fix rsync command with two user names produced by 3cc75b0

### DIFF
--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -37,7 +37,7 @@ sub run {
 
         # Mitigate occasional CSP network problems (especially one CSP is prone to those issues!)
         # Delay of 2 minutes between the tries to give their network some time to recover after a failure
-        script_retry("rsync --timeout=$timeout -uvahP -e ssh ~/repos 'root@" . $remote . ":/tmp/repos'", timeout => $timeout + 10, retry => 3, delay => 120);
+        script_retry("rsync --timeout=$timeout -uvahP -e ssh ~/repos '$remote:/tmp/repos'", timeout => $timeout + 10, retry => 3, delay => 120);
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar -p10 '{}' \\;");
         $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");


### PR DESCRIPTION
- Related pull request: #13246
- Related error: [15-SP3-GCE-Updates](https://openqa.suse.de/tests/7196223#step/transfer_repos/11)
- Verification run: [15-SP3-GCE-Updates](http://pdostal-server.suse.cz/tests/12505)

The failure was caused by `PUBLIC_CLOUD_SKIP_MU=1` variable in previous pull request's verification run.
