### PR TITLE
Fix substition for adding _debug repos

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -65,7 +65,7 @@ sub prepare_for_kdump_sle {
         # append _debug to the incident repo
         for my $i (split(/,/, get_var('MAINT_TEST_REPO'))) {
             next unless $i;
-            $i =~ s,/$,_debug/,;
+            $i =~ s/$/_debug/;
             $counter++;
             zypper_call("--no-gpg-checks ar -f $i 'DEBUG_$counter'");
         }


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/7197723#step/kdump_and_crash/1
- Verification run:
https://openqa.suse.de/tests/7204897
https://openqa.suse.de/tests/7204898