### PR TITLE
Remove / at the end of url to fix following _debug append

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -65,6 +65,7 @@ sub prepare_for_kdump_sle {
         # append _debug to the incident repo
         for my $i (split(/,/, get_var('MAINT_TEST_REPO'))) {
             next unless $i;
+            $i =~ s/\/$//;       # Delete / at the end of url
             $i =~ s/$/_debug/;
             $counter++;
             zypper_call("--no-gpg-checks ar -f $i 'DEBUG_$counter'");


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/7199668#step/kdump_and_crash/28
- Verification run: http://dzedro.suse.cz/tests/19448