### PR TITLE
data/delete_users: Avoid userdel -f

### DIFF
--- a/data/delete_users
+++ b/data/delete_users
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/sh
+set -eu
 
 n_users="$1"
 
 for i in `seq 1 $n_users` ; do
 	num=`printf "%02d" $i`
-	userdel -rf "user${i}"
+	killall -9 -u "user${i}" || true
+	userdel -r "user${i}"
 done


### PR DESCRIPTION
Instead of deleting the user forcibly, kill all processes by the to be deleted
user explicitly. The "dangling" processes cause issues like a crash of
the system dbus-daemon: https://gitlab.freedesktop.org/dbus/dbus/-/issues/343

- Verification run: https://openqa.opensuse.org/tests/1932598
