### PR TITLE
Use my ($self) = @_; for parameter parsing in methods

### DIFF
--- a/lib/Installation/Overview/OverviewPage.pm
+++ b/lib/Installation/Overview/OverviewPage.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{btn_install}  = $self->{app}->button({id => 'next'});
     $self->{txt_overview} = $self->{app}->richtext({id => 'proposal'});
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AbstractSizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AbstractSizePage.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{rb_custom_size} = $self->{app}->radiobutton({id => 'custom_size'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AddLogicalVolumePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AddLogicalVolumePage.pm
@@ -27,7 +27,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{tb_lv_name}     = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::LvmLvInfo::NameWidget"'});
     $self->{rb_thin_pool}   = $self->{app}->radiobutton({id => 'thin_pool'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AddVolumeGroupPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AddVolumeGroupPage.pm
@@ -27,7 +27,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{btn_add}               = $self->{app}->button({id => 'add'});
     $self->{btn_add_all}           = $self->{app}->button({id => 'add_all'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ClonePartitionsDialog.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ClonePartitionsDialog.pm
@@ -27,7 +27,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->{btn_ok}           = $self->{app}->button({id => 'ok'});
     $self->{lst_target_disks} = $self->{app}->selectionbox({

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/CreatePartitionTablePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/CreatePartitionTablePage.pm
@@ -27,7 +27,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{rb_msdos_part_table} = $self->{app}->radiobutton({id => '"msdos"'});
     $self->{rb_gpt_part_table}   = $self->{app}->radiobutton({id => '"gpt"'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/DeletingCurrentDevicesWarning.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/DeletingCurrentDevicesWarning.pm
@@ -17,7 +17,7 @@ use warnings;
 use parent 'Installation::Popups::YesNoPopup';
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{lbl_warning} = $self->{app}->label({label => 'Confirm Deleting of Current Devices'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/EncryptPartitionPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/EncryptPartitionPage.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{tb_pass}         = $self->{app}->textbox({id => 'pw1'});
     $self->{tb_pass_reenter} = $self->{app}->textbox({id => 'pw2'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ErrorDialog.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ErrorDialog.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{btn_ok}      = $self->{app}->button({id => 'ok'});
     $self->{rt_error}    = $self->{app}->richtext({type => 'YRichText'});
     $self->{lbl_heading} = $self->{app}->label({label => 'Error'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
@@ -28,7 +28,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{btn_add_partition}      = $self->{app}->button({id    => '"Y2Partitioner::Widgets::PartitionAddButton"'});
     $self->{btn_edit_partition}     = $self->{app}->button({id    => '"Y2Partitioner::Widgets::BlkDeviceEditButton"'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/FilesystemOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/FilesystemOptionsPage.pm
@@ -26,7 +26,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{lbl_settings_root_part} = $self->{app}->label({label => 'Settings for the Root Partition'});
     $self->{cb_root_fs_type}        = $self->{app}->combobox({id => '"vol_0_fs_type"'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/FormatMountOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/FormatMountOptionsPage.pm
@@ -26,7 +26,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{cb_filesystem}       = $self->{app}->combobox({id => '"Y2Partitioner::Widgets::BlkDeviceFilesystem"'});
     $self->{cb_enable_snapshots} = $self->{app}->checkbox({id => '"Y2Partitioner::Widgets::Snapshots"'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/FstabOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/FstabOptionsPage.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{btn_fstab_options} = $self->{app}->button({id => '"Y2Partitioner::Widgets::FstabOptionsButton"'});
     $self->{cb_mount_by}       = $self->{app}->combobox({id => '"Y2Partitioner::Widgets::MountBy"'});
     $self->{btn_ok}            = $self->{app}->button({id => 'ok'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/LogicalVolumeSizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/LogicalVolumeSizePage.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my ($self) = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{tb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::LvmLvSize::CustomSizeInput"'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ModifiedDevicesWarning.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ModifiedDevicesWarning.pm
@@ -18,7 +18,7 @@ use warnings;
 use parent 'Installation::Popups::YesNoPopup';
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{lbl_warning} = $self->{app}->label({label => "You have modified some devices. These changes will be lost\nif you exit the Partitioner.\nReally exit?"});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/MsdosPartitionTypePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/MsdosPartitionTypePage.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{rb_primary}  = $self->{app}->radiobutton({id => '"primary"'});
     $self->{rb_extended} = $self->{app}->radiobutton({id => '"extended"'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/NewPartitionSizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/NewPartitionSizePage.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my ($self) = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{tb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::PartitionSize::CustomSizeInput"'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/PartitionIdFormatMountOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/PartitionIdFormatMountOptionsPage.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my ($self) = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{partition_id} = $self->{app}->combobox({id => '"Y2Partitioner::Widgets::PartitionIdComboBox"'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/PartitioningSchemePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/PartitioningSchemePage.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{cb_enable_lvm} = $self->{app}->combobox({id => 'lvm'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/RaidOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/RaidOptionsPage.pm
@@ -27,7 +27,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{cb_chunk_size} = $self->{app}->combobox({id => '"Y2Partitioner::Dialogs::MdOptions::ChunkSize"'});
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/RaidTypePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/RaidTypePage.pm
@@ -27,7 +27,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{btn_add}     = $self->{app}->button({id => 'add'});
     $self->{btn_add_all} = $self->{app}->button({id => 'add_all'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ResizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ResizePage.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my ($self) = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{tb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::BlkDeviceResize::CustomSizeWidget"'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/RolePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/RolePage.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{rb_operating_system} = $self->{app}->radiobutton({id => 'system'});
     $self->{rb_data_isv_apps}    = $self->{app}->radiobutton({id => 'data'});

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/SelectDisksToUsePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/SelectDisksToUsePage.pm
@@ -26,7 +26,7 @@ sub new {
 }
 
 sub init {
-    my ($self) = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->{lbl_select_disks_to_use} = $self->{app}->label({label => 'Select one or more (max 3) hard disks'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/SuggestedPartitioningPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/SuggestedPartitioningPage.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{summary}          = $self->{app}->richtext({id => 'summary'});
     $self->{btn_guided_setup} = $self->{app}->button({id => 'guided'});
     return $self;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/SummaryPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/SummaryPage.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::init();
     return $self;
 }

--- a/lib/Installation/Popups/OkPopup.pm
+++ b/lib/Installation/Popups/OkPopup.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{rt_warning} = $self->{app}->label({type => 'YRichText'});
     $self->{btn_ok}     = $self->{app}->button({id => 'ok'});
     return $self;

--- a/lib/Installation/Popups/YesNoPopup.pm
+++ b/lib/Installation/Popups/YesNoPopup.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{btn_yes}     = $self->{app}->button({id => 'yes'});
     $self->{btn_no}      = $self->{app}->button({id => 'no'});
     $self->{lbl_warning} = $self->{app}->label({type => 'YLabel'});

--- a/lib/Mitigation.pm
+++ b/lib/Mitigation.pm
@@ -155,12 +155,12 @@ sub sysfs_name {
     return $self->{sysfs_name};
 }
 sub CPUID {
-    my $self = shift;
+    my ($self) = @_;
     return $self->{CPUID};
 }
 
 sub MSR {
-    my $self = shift;
+    my ($self) = @_;
     return $self->{IA32_ARCH_CAPABILITIES};
 }
 
@@ -184,17 +184,17 @@ sub read_cpuid_base {
 }
 
 sub read_cpuid_edx {
-    my $self = shift;
+    my ($self) = @_;
     return $self->read_cpuid_base(CPUID_EDX);
 }
 
 sub read_cpuid_ebx {
-    my $self = shift;
+    my ($self) = @_;
     return $self->read_cpuid_base(CPUID_EBX);
 }
 
 sub read_msr {
-    my $self = shift;
+    my ($self) = @_;
     script_output('modprobe msr');
     my $edx = script_output(
         "perl -e \'open(M,\"<\",\"/dev/cpu/0/msr\") and seek(M,0x10a,0) and read(M,\$_,8) and print\' | od -t u8 -A n"
@@ -203,7 +203,7 @@ sub read_msr {
 }
 
 sub vulnerabilities {
-    my $self = shift;
+    my ($self) = @_;
     if ($self->read_cpuid_edx() & $self->CPUID()) {
         if ($self->read_msr() & $self->MSR()) {
             record_info("$self->{'name'} Not Affected", "This machine needn't be tested.");
@@ -225,7 +225,7 @@ sub sysfs {
 }
 
 sub dmesg {
-    my $self = shift;
+    my ($self) = @_;
     for my $p (keys %{$self->{dmesg}}) {
         print "dmesg " . $self->Name . "\n";
         print $self->{dmesg}->{$p} . "\n";
@@ -233,12 +233,12 @@ sub dmesg {
 }
 
 sub cmdline {
-    my $self = shift;
+    my ($self) = @_;
     return $self->{cmdline};
 }
 
 sub lscpu {
-    my $self = shift;
+    my ($self) = @_;
     for my $p (keys %{$self->{lscpu}}) {
         print $p. "\n";
     }
@@ -249,7 +249,7 @@ sub lscpu {
 #This function will finish testing in default status.
 #As out of box testing. and clean up all mitigations parameters.
 sub check_default_status {
-    my $self = shift;
+    my ($self) = @_;
     assert_script_run('cat /proc/cmdline');
     if (ref($self->{parameter}) ne 'ARRAY') {
         $self->{parameter} = [$self->{parameter}];
@@ -322,7 +322,7 @@ sub check_dmesg {
 }
 
 sub check_cmdline {
-    my $self = shift;
+    my ($self) = @_;
     assert_script_run(
         'cat /proc/cmdline'
     );
@@ -345,7 +345,7 @@ sub check_one_parameter_value {
 #check all cmdline items.
 sub check_each_parameter_value {
     #testing each parameter.
-    my $self = shift;
+    my ($self) = @_;
     foreach my $cmd (@{$self->cmdline()}) {
         record_info("$self->{name}=$cmd", "Mitigation $self->{name}=$cmd testing start.");
         $self->add_parameter($cmd);
@@ -563,7 +563,7 @@ sub guest_cycle {
 #This function will check if current machine has a hardware fix.
 #If the current machine is not affected, test over.
 sub do_test {
-    my $self = shift;
+    my ($self) = @_;
     select_console 'root-console';
 
     if (!check_var('TEST', 'MITIGATIONS') && !check_var('TEST', 'KVM_GUEST_MITIGATIONS')) {

--- a/lib/Tomcat/ModjkTest.pm
+++ b/lib/Tomcat/ModjkTest.pm
@@ -24,7 +24,7 @@ use registration;
 # install and configure apache2, apache2-mod_jk and verify the interaction between apache2 and tomcat
 # via the package apache2-mod_jk
 sub mod_jk_setup() {
-    my $self = shift;
+    my ($self) = @_;
     $self->select_serial_terminal();
 
     record_info('install and configure apache2 and apache2-mod_jk connector Setup');
@@ -36,7 +36,7 @@ sub mod_jk_setup() {
 
 # Connection from apache2 to tomcat: Functionality test
 sub func_conn_apache2_tomcat() {
-    my $self = shift;
+    my ($self) = @_;
     $self->select_serial_terminal();
     systemctl('stop apache2');
     systemctl('stop tomcat');

--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -74,7 +74,7 @@ EOF
 
 # Access the tomcat web application manager
 sub tomcat_manager_test() {
-    my ($self) = shift;
+    my ($self) = @_;
 
     $self->firefox_open_url('localhost:8080/manager');
     send_key_until_needlematch('tomcat-manager-authentication', 'ret');

--- a/lib/Tomcat/WebSocketsTest.pm
+++ b/lib/Tomcat/WebSocketsTest.pm
@@ -23,7 +23,7 @@ use constant TIMEOUT => 60;
 
 # test all WebSocket examples
 sub test_all_examples() {
-    my ($self) = shift;
+    my ($self) = @_;
 
     # array with example test function and number of tabs required to select the example
     my @websocket_examples = ([\&echo, 1], [\&chat, 1], [\&snake, 1], [\&drawboard, 1]);

--- a/lib/YaST/NetworkSettings/ActionButtons.pm
+++ b/lib/YaST/NetworkSettings/ActionButtons.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{btn_ok} = $self->{app}->button({id => 'next'});
     return $self;
 }

--- a/lib/YaST/NetworkSettings/HostnameDNSTab.pm
+++ b/lib/YaST/NetworkSettings/HostnameDNSTab.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{cb_set_hostname_via_dhcp} = $self->{app}->combobox({id => '"DHCP_HOSTNAME"'});
     return $self;
 }

--- a/lib/YaST/NetworkSettings/TopNavigationBar.pm
+++ b/lib/YaST/NetworkSettings/TopNavigationBar.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{menu_bar} = $self->{app}->menucollection({id => '_cwm_tab'});
     return $self;
 }

--- a/lib/YaST/NetworkSettings/v4_3/OverviewTab.pm
+++ b/lib/YaST/NetworkSettings/v4_3/OverviewTab.pm
@@ -27,7 +27,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{tbl_devices} = $self->{app}->table({id => '"Y2Network::Widgets::InterfacesTable"'});
     return $self;
 }

--- a/lib/YaST/SystemSettings/AddPCIIDPopup.pm
+++ b/lib/YaST/SystemSettings/AddPCIIDPopup.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{btn_ok}    = $self->{app}->button({id => 'ok'});
     $self->{tb_driver} = $self->{app}->textbox({id => 'driver'});
     $self->{tb_sysdir} = $self->{app}->textbox({id => 'sysdir'});

--- a/lib/YaST/SystemSettings/KernelSettingsTab.pm
+++ b/lib/YaST/SystemSettings/KernelSettingsTab.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{cb_sysrq} = $self->{app}->checkbox({id => '"sysrq"'});
     return $self;
 }

--- a/lib/YaST/SystemSettings/PCIIDSetupTab.pm
+++ b/lib/YaST/SystemSettings/PCIIDSetupTab.pm
@@ -26,7 +26,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{menu_btn_add} = $self->{app}->menucollection({label => 'Add...'});
     $self->{btn_delete}   = $self->{app}->button({id => 'delete'});
     return $self;

--- a/lib/YaST/SystemSettings/SystemSettingsPage.pm
+++ b/lib/YaST/SystemSettings/SystemSettingsPage.pm
@@ -25,7 +25,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{btn_ok}  = $self->{app}->button({id => 'next'});
     $self->{tab_cwm} = $self->{app}->tab({id => '_cwm_tab'});
     return $self;

--- a/lib/YaST/Warning/Notification.pm
+++ b/lib/YaST/Warning/Notification.pm
@@ -24,7 +24,7 @@ sub new {
 }
 
 sub init {
-    my $self = shift;
+    my ($self) = @_;
     $self->{btn_ok}      = $self->{app}->button({id => 'ok_msg'});
     $self->{lbl_header}  = $self->{app}->label({label => 'Warning'});
     $self->{lbl_warning} = $self->{app}->label({type  => 'YLabel'});

--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -791,7 +791,7 @@ Run post_fail_hook and upload audit logs
 
 =cut
 sub post_fail_hook {
-    my ($self) = shift;
+    my ($self) = @_;
 
     # Exit x11 and turn to console in case
     send_key("alt-f4");

--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -85,7 +85,7 @@ sub snapper_nodbus_restore {
 }
 
 sub post_fail_hook {
-    my ($self) = shift;
+    my ($self) = @_;
     select_console('log-console');
     $self->SUPER::post_fail_hook;
 

--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -58,9 +58,8 @@ our @guest_installations_done = ();
 #Guest profile xml file will be guest profile name + '.xml' extension and fetched using HTTP::Request and
 #parsed using XML::Simple.
 sub instantiate_guests_and_profiles {
-    my $self                       = shift;
-    my $_guests_to_be_instantiated = shift;
-    my %_store_of_guests           = %$_guests_to_be_instantiated;
+    my ($self, $_guests_to_be_instantiated) = @_;
+    my %_store_of_guests = %$_guests_to_be_instantiated;
 
     $self->reveal_myself;
     foreach my $_element (keys(%_store_of_guests)) {
@@ -84,7 +83,7 @@ sub instantiate_guests_and_profiles {
 #Detach guest installation screen anyway after first time attach and needle detection to obtain guest installation screen information.
 #This subroutine also accepts hash/dictionary argument to be passed to guest_installation_run to further customize guest instance.
 sub install_guest_instances {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_num_of_guests = scalar(keys %guest_instances);
@@ -121,7 +120,7 @@ sub install_guest_instances {
 #If [guest_installation_result] has final result,push it into @guest_installations_done,collect_guest_installation_logs_via_ssh if not PASSED and calculate how many guests are left.
 #If no [guest_installation_result], detach current guest and move to next one,or keep curren guest screen if it is the last one left so there is no need to re-attach.
 sub monitor_concurrent_guest_installations {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_installation_timeout             = 0;
@@ -154,7 +153,7 @@ sub monitor_concurrent_guest_installations {
 
 #Mark guest installation as UNKNOWN if there is no [guest_installation_result].Fail test run if there is unsuccessful result.
 sub validate_guest_installations_results {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_overall_test_result = '';
@@ -173,7 +172,7 @@ sub validate_guest_installations_results {
 
 #Do cleanup actions by calling detach_guest_installation_screen, terminate_guest_installation_session,get_guest_ipaddr and print_guest_params.
 sub clean_up_guest_installations {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     foreach (keys %guest_instances) {
@@ -213,7 +212,7 @@ sub junit_log_provision {
 
 #Check whether current console is root-ssh console and re-connect if needle 'text-logged-in-root' can not be detected.
 sub check_root_ssh_console {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     save_screenshot;
@@ -229,8 +228,7 @@ sub check_root_ssh_console {
 #holds all guest names to be created and $_guest_profiles_list is a reference to array that holds all guest profiles to be used for guest configurations
 #and installations.
 sub concurrent_guest_installations_run {
-    my $self             = shift;
-    my $_store_of_guests = shift;
+    my ($self, $_store_of_guests) = @_;
 
     $self->reveal_myself;
     croak("Guest names and profile must be given to create, configure and install guests.") if ((scalar(keys(%$_store_of_guests)) eq 0) or (scalar(values(%$_store_of_guests)) eq 0));
@@ -247,7 +245,7 @@ sub concurrent_guest_installations_run {
 
 #Call virt_autotest_base::upload_guest_assets to upload guest assets if it is successfully installed.
 sub save_guest_installations_assets {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     return $self if (!get_var('UPLOAD_GUEST_ASSETS'));
@@ -261,7 +259,7 @@ sub save_guest_installations_assets {
 }
 
 sub post_fail_hook {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->check_root_ssh_console;

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -44,7 +44,7 @@ instance: C<docker create -it tumbleweed bash>
 
 =cut
 sub create_container {
-    my ($self) = shift;
+    my ($self) = @_;
     my %args = (
         image => '',
         name  => '',
@@ -156,7 +156,7 @@ Return an array ref of the images
 
 =cut
 sub enum_images {
-    my ($self) = shift;
+    my ($self) = @_;
     my $images_s = $self->_engine_script_output("images -q");
     record_info "Images", $images_s;
     my @images = split /[\n\t]/, $images_s;
@@ -169,7 +169,7 @@ Return an array ref of the containers
 
 =cut
 sub enum_containers {
-    my ($self) = shift;
+    my ($self) = @_;
     my $containers_s = $self->_engine_script_output("container ls -q");
     record_info "Containers", $containers_s;
     my @containers = split /[\n\t]/, $containers_s;
@@ -283,7 +283,7 @@ use utils qw(systemctl file_content_replace);
 has runtime => 'docker';
 
 sub configure_insecure_registries {
-    my ($self) = shift;
+    my ($self) = @_;
     my $registry = registry_url();
     # Allow our internal 'insecure' registry
     assert_script_run(
@@ -301,7 +301,7 @@ use utils qw(systemctl file_content_replace);
 has runtime => "podman";
 
 sub configure_insecure_registries {
-    my ($self) = shift;
+    my ($self) = @_;
     my $registry = registry_url();
 
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
@@ -359,7 +359,7 @@ sub pull {
 }
 
 sub create_container {
-    my ($self) = shift;
+    my ($self) = @_;
     my %args = (
         image => '',
         name  => '',
@@ -391,7 +391,7 @@ sub commit {
 }
 
 sub enum_containers {
-    my ($self) = shift;
+    my ($self) = @_;
     my $containers_s = $self->_engine_script_output("ls -q");
     record_info "Containers", $containers_s;
     my @containers = split /[\n\t]/, $containers_s;

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -197,7 +197,7 @@ our $common_environment_prepared = 'false';
 
 #Any subroutine calls this subroutine announces its identity and it is being executed
 sub reveal_myself {
-    my $self = shift;
+    my ($self) = @_;
 
     my $_my_identity = (caller(1))[3];
     diag("Test execution inside $_my_identity.");
@@ -206,7 +206,7 @@ sub reveal_myself {
 
 #Create guest instance by assigning values to its parameters but do no install it
 sub create {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->initialize_guest_params;
@@ -217,7 +217,7 @@ sub create {
 
 #Initialize all guest parameters to avoid uninitialized parameters
 sub initialize_guest_params {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->{$_} //= '' foreach (keys %guest_params);
@@ -235,7 +235,7 @@ sub initialize_guest_params {
 #Secondly,config_guest_params can also be called direcly, for example,$self->config_guest_params(%testhash).
 #Call revise_guest_version_and_build to correct guest version and build parameters to avoid mismatch if necessary.
 sub config_guest_params {
-    my $self          = shift;
+    my ($self) = @_;
     my %_guest_params = @_;
 
     $self->reveal_myself;
@@ -267,7 +267,7 @@ sub config_guest_params {
 #if non-developing [guest_version].This subroutine help make things better and life easier but the end user should always pay attention and use
 #meaningful and correct guest parameter and profile.
 sub revise_guest_version_and_build {
-    my $self          = shift;
+    my ($self) = @_;
     my %_guest_params = @_;
 
     $self->reveal_myself;
@@ -305,7 +305,7 @@ sub revise_guest_version_and_build {
 
 #Print out guest instance parameters
 sub print_guest_params {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     diag("The guest instance $self->{guest_name} created is as below:");
@@ -330,7 +330,7 @@ sub print_guest_params {
 
 #Install necessary packages, patterns, setup ssh config, create [common_log_folder].These are common environment affairs which will be used for all guest instances.
 sub prepare_common_environment {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     if ($common_environment_prepared eq 'false') {
@@ -360,7 +360,7 @@ sub prepare_common_environment {
 
 #Remove all existing guests and storage files in /var/lib/libvirt/images/
 sub clean_up_all_guests {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my @_guests_to_clean_up = split(/\n/, script_output("virsh list --all --name | grep -v Domain-0", proceed_on_failure => 1));
@@ -381,7 +381,7 @@ sub clean_up_all_guests {
 
 #Create individual guest log folder using its name and remove existing entry in /etc/hosts
 sub prepare_guest_environment {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->{guest_log_folder} = $common_log_folder . '/' . $self->{guest_name};
@@ -393,7 +393,7 @@ sub prepare_guest_environment {
 
 #Configure [guest_domain_name] and [guest_name_options].User can still change [guest_name] and [guest_domain_name] by passing non-empty arguments using hash.
 sub config_guest_name {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->config_guest_params(@_) if (scalar(@_) gt 0);
@@ -408,7 +408,7 @@ sub config_guest_name {
 #Configure [guest_metadata_options].User can still change [guest_metadata] by passing non-empty arguments using hash.
 #If installation already passes,modify_guest_params will be called to modify [guest_metadata] using already modified [guest_metadata_options].
 sub config_guest_metadata {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_metadata_options = $self->{guest_metadata_options};
@@ -423,7 +423,7 @@ sub config_guest_metadata {
 #Configure [guest_vcpus_options].User can still change [guest_vcpus] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_vcpus] using already modified [guest_vcpus_options].
 sub config_guest_vcpus {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_vcpus_options    = $self->{guest_vcpus_options};
@@ -440,7 +440,7 @@ sub config_guest_vcpus {
 #Configure [guest_memory_options].User can still change [guest_memory] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_memory] using already modified [guest_memory_options].
 sub config_guest_memory {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_memory_options = $self->{guest_memory_options};
@@ -453,7 +453,7 @@ sub config_guest_memory {
 
 #Configure [guest_virt_options].User can still change [host_hypervisor_uri],[host_virt_type] and [guest_virt_options] by passing non-empty arguments using hash.
 sub config_guest_virtualization {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->config_guest_params(@_) if (scalar(@_) gt 0);
@@ -472,7 +472,7 @@ sub config_guest_virtualization {
 
 #Configure [guest_platform_options].User can still change [guest_arch] and [guest_machine_type] by passing non-empty arguments using hash.
 sub config_guest_platform {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->config_guest_params(@_) if (scalar(@_) gt 0);
@@ -486,7 +486,7 @@ sub config_guest_platform {
 #Configure [guest_os_variant_options].User can still change [guest_os_variant] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_os_variant] using already modified [guest_os_variant_options].
 sub config_guest_os_variant {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_os_variant_options = $self->{guest_os_variant_options};
@@ -501,7 +501,7 @@ sub config_guest_os_variant {
 #Configure [guest_graphics_and_video_options].User can still change [guest_video] and [guest_graphics] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_video] and [guest_graphics] using already modified [guest_graphics_and_video_options].
 sub config_guest_graphics_and_video {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_graphics_and_video_options = $self->{guest_graphics_and_video_options};
@@ -516,7 +516,7 @@ sub config_guest_graphics_and_video {
 #If installations already passes,modify_guest_params will be called to modify [guest_console] and [guest_serial] using already modified [guest_console_options] and
 #[guest_serial_options].
 sub config_guest_consoles {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_console_options = $self->{guest_console_options};
@@ -536,7 +536,7 @@ sub config_guest_consoles {
 #Configure [guest_features_options].User can still change [guest_features] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_features] using already modified [guest_features_options].
 sub config_guest_features {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_features_options = $self->{guest_features_options};
@@ -551,7 +551,7 @@ sub config_guest_features {
 #Configure [guest_events_options].User can still change [guest_events] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_events] using already modified [guest_events_options].
 sub config_guest_events {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_events_options = $self->{guest_events_options};
@@ -566,7 +566,7 @@ sub config_guest_events {
 #Configure [guest_boot_options].User can still change [guest_boot_settings] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_boot_settings] using already modified [guest_boot_options].
 sub config_guest_boot_settings {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_boot_options = $self->{guest_boot_options};
@@ -581,7 +581,7 @@ sub config_guest_boot_settings {
 #Configure [guest_power_management_options].User can still change [guest_power_management] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_power_management] using already modified [guest_power_management_options].
 sub config_guest_power_management {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_power_management_options = $self->{guest_power_management_options};
@@ -596,7 +596,7 @@ sub config_guest_power_management {
 #Configure [guest_xpath_options].User can still change [guest_xpath] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_xpath] using already modified [guest_xpath_options].
 sub config_guest_xpath {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_xpath_options = $self->{guest_xpath_options};
@@ -612,7 +612,7 @@ sub config_guest_xpath {
 #Configure [guest_qemu_command_options].User can still change [guest_qemu_command] by passing non-empty arguments using hash.
 #If installations already passes,modify_guest_params will be called to modify [guest_qemu_command] using already modified [guest_qemu_command_options].
 sub config_guest_qemu_command {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_qemu_command_options = $self->{guest_qemu_command_options};
@@ -628,7 +628,7 @@ sub config_guest_qemu_command {
 #and [guest_storage_others] by passing non-empty arguments using hash.If installations already passes,modify_guest_params will be called to modify [guest_storage_type],
 #[guest_storage_size],[guest_storage_format],[guest_storage_path] and [guest_storage_others] using already modified [guest_storage_options].
 sub config_guest_storage {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_current_storage_options = $self->{guest_storage_options};
@@ -658,7 +658,7 @@ sub config_guest_storage {
 #guest mac address if it has not been set.Calls config_guest_network_bridge to create [guest_network_device] in subnet [guest_netaddr].Turn off firewall/apparmor,loosen iptables
 #rules and enable forwarding by calling config_guest_network_bridge_policy.
 sub config_guest_network_selection {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->config_guest_params(@_) if (scalar(@_) gt 0);
@@ -707,7 +707,7 @@ sub config_guest_network_selection {
 
 #Generate nearly random mac address
 sub config_guest_macaddr {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_guest_macaddr_lower_half = join ":", map { unpack "H*", chr(rand(256)) } 1 .. 3;
@@ -779,12 +779,9 @@ EOF
 #Create [guest_network_device] by writing device information into ifcfg file in /etc/sysconfig/network.Mark guest installation as FAILED if [guest_network_device] can not be
 #successfully started up.If [guest_network_device] or [guest_netaddr] already exists and active on host judging by "ip route show",both of them will not be created anyway.
 sub config_guest_network_bridge_device {
-    my $self = shift;
+    my ($self, $_bridge_network, $_bridge_network_in_route, $_bridge_device) = @_;
 
     $self->reveal_myself;
-    my $_bridge_network          = shift;
-    my $_bridge_network_in_route = shift;
-    my $_bridge_device           = shift;
     $_bridge_device //= $self->{guest_network_device};
     if ((script_output("ip route show | grep -o $_bridge_device", proceed_on_failure => 1) eq '') and (script_output("ip route show | grep -o $_bridge_network_in_route", proceed_on_failure => 1) eq '')) {
         my $_detect_active_route   = '';
@@ -946,7 +943,7 @@ EOF
 #[guest_version_minor],[guest_installation_fine_grained] and [guest_autoconsole] by passing non-empty arguments using hash.Call config_guest_installation_media to set correct
 #installation media.
 sub config_guest_installation_method {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->config_guest_params(@_) if (scalar(@_) gt 0);
@@ -966,7 +963,7 @@ sub config_guest_installation_method {
 #can help correct installation media major and minor version if necessary, it is just auxiliary functionality and end user should always pay attendtion and use the meaningful
 #and correct guest parameters and profile.
 sub config_guest_installation_media {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->{guest_installation_media} =~ s/12345/$self->{guest_build}/g if ($self->{guest_build} ne 'gm');
@@ -1030,7 +1027,7 @@ sub config_guest_installation_media {
 
 #Configure [guest_installation_extra_args_options].User can still change [guest_installation_extra_args],[guest_ipaddr] and [guest_ipaddr_static] by passing non-empty arguments using hash.
 sub config_guest_installation_extra_args {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->config_guest_params(@_) if (scalar(@_) gt 0);
@@ -1061,7 +1058,7 @@ sub config_guest_installation_extra_args {
 #Currently the following common variables are supported:[Module-Basesystem,Module-Desktop-Applications,Module-Development-Tools,Module-Legacy,Module-Server-Applications,Module-Web-Scripting,
 #Product-SLES,Authorized-Keys,Secure-Boot,Boot-Loader-Type,Disk-Label,Domain-Name,Host-Name,Device-MacAddr,Logging-HostName and Logging-HostPort]
 sub config_guest_installation_automation {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->config_guest_params(@_) if (scalar(@_) gt 0);
@@ -1143,7 +1140,7 @@ sub config_guest_installation_automation {
 #Validate autoyast file using xmllint and yast2-schema.This is only for reference purpose if guest and host oses have different release major version.
 #Output kickstart file content directly because its content can not be validated on SLES or opensuse host by using ksvalidator.
 sub validate_guest_installation_automation_file {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     if ($self->{guest_installation_automation} eq 'autoyast') {
@@ -1164,7 +1161,7 @@ sub validate_guest_installation_automation_file {
 #Calls prepare_guest_installation to do guest configuration.Call start_guest_installation to start guest installation.
 #This subroutine also accepts hash/dictionary argument to be passed to prepare_guest_installation to further customize guest object if necessary.
 sub guest_installation_run {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->prepare_guest_installation(@_);
@@ -1175,7 +1172,7 @@ sub guest_installation_run {
 #Configure and prepare guest before installation starts.
 #This subroutine also accepts hash/dictionary argument to be passed to config_guest_params to further customize guest object if necessary.
 sub prepare_guest_installation {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->config_guest_params(@_) if (scalar(@_) gt 0);
@@ -1204,7 +1201,7 @@ sub prepare_guest_installation {
 
 #If [virt_install_command_line_dryrun] succeeds,start real guest installation using screen and virt_install_command_line.
 sub start_guest_installation {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     if ($self->{guest_installation_result} ne '') {
@@ -1243,7 +1240,7 @@ sub start_guest_installation {
 
 #Get guest installation screen process information and store it in [guest_installation_session] which is in the form of 3401.pts-1.vh017.
 sub get_guest_installation_session {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     if ($self->{guest_installation_session} ne '') {
@@ -1260,7 +1257,7 @@ sub get_guest_installation_session {
 
 #Kill all guest installation screen processes stored in [guest_installation_session] after test finishes.
 sub terminate_guest_installation_session {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     if ($self->{guest_installation_session} ne '') {
@@ -1275,7 +1272,7 @@ sub terminate_guest_installation_session {
 
 #Get dynamic allocated guest ip address using nmap scan and store it in [guest_ipaddr].
 sub get_guest_ipaddr {
-    my $self             = shift;
+    my ($self) = @_;
     my @subnets_in_route = @_;
 
     $self->reveal_myself;
@@ -1310,7 +1307,7 @@ sub get_guest_ipaddr {
 #If needle 'guest_installation_in_progress' is detected,this means installation is still in progress.Will check its result in the next round.
 #If none of above needles is detected,makr it as PASSED if ssh connection to it is good,otherwise mark it as FAILED by calling check_guest_installation_result_via_ssh.
 sub monitor_guest_installation {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     save_screenshot;
@@ -1362,7 +1359,7 @@ sub monitor_guest_installation {
 #Get guest ip address and check whether it is already up and running by using ip address and name sequentially.
 #Use very common linux command 'hostname' to do the actual checking because it is almost available on any linux flavor and release.
 sub check_guest_installation_result_via_ssh {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $_guest_transient_hostname = '';
@@ -1392,7 +1389,7 @@ sub check_guest_installation_result_via_ssh {
 #If [guest_installation_session] is not available and has [guest_autoconsole],call get_guest_installation_session, then attach based on whether installation session is available.
 #If [guest_installation_session] is already available,call do_attach_guest_installation_screen directly.
 sub attach_guest_installation_screen {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     save_screenshot;
@@ -1427,7 +1424,7 @@ sub attach_guest_installation_screen {
 #If fails to attach guest installation screen, [guest_installation_session] may terminate at reboot/shutoff or be in mysterious state or just broken somehow,
 #call do_attach_guest_installation_screen_without_sesssion to re-attach.
 sub do_attach_guest_installation_screen {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->do_attach_guest_installation_screen_with_session;
@@ -1449,7 +1446,7 @@ sub do_attach_guest_installation_screen {
 
 #Retry attach [guest_installation_session] and detect needle 'text-logged-in-root'.
 sub do_attach_guest_installation_screen_with_session {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     assert_screen('text-logged-in-root');
@@ -1477,7 +1474,7 @@ sub do_attach_guest_installation_screen_with_session {
 #If [guest_installation_session] is already terminated at reboot/shutoff or somehow, power it on and retry attaching using [guest_installation_session_command] and detect
 #needle 'text-logged-in-root'.Mark it as FAILED if needle 'text-logged-in-root' can still be detected and poweron can not bring it back.
 sub do_attach_guest_installation_screen_without_session {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     script_run("screen -X -S $self->{guest_installation_session} kill");
@@ -1530,7 +1527,7 @@ sub do_attach_guest_installation_screen_without_session {
 
 #Detach guest installation screen by calling do_detach_guest_installation_screen.Try to get guest installation screen information if [guest_installation_session] is not available.
 sub detach_guest_installation_screen {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     save_screenshot;
@@ -1549,7 +1546,7 @@ sub detach_guest_installation_screen {
 #If needle 'text-logged-in-root' is detected,this means successful detach.
 #If needle 'text-logged-in-root' can not be detected,recover ssh console by select_console('root-ssh').
 sub do_detach_guest_installation_screen {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     send_key('ctrl-a-d');
@@ -1595,7 +1592,7 @@ sub do_detach_guest_installation_screen {
 #Return true if guest has [guest_autoconsole] and [guest_noautoconsole] that are not equal to 'none', 'true' or empty which indicates guest definitely has autoconsole.
 #Empty value may indicate there is autoconsole or the opposite which depends on detailed configuration of guest.
 sub has_autoconsole_for_sure {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     return (($self->{guest_autoconsole} ne 'none') and ($self->{guest_autoconsole} ne '') and ($self->{guest_noautoconsole} ne 'true') and ($self->{guest_noautoconsole} ne ''));
@@ -1604,7 +1601,7 @@ sub has_autoconsole_for_sure {
 #Return true if guest has [guest_autoconsole] or [guest_noautoconsole] that are equal to 'none' or 'true' which indicates guest definitely has no autoconsole.
 #Empty value may indicate there is autoconsole or the opposite which depends on detailed configuration of guest.
 sub has_noautoconsole_for_sure {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     return (($self->{guest_autoconsole} eq 'none') or ($self->{guest_noautoconsole} eq 'true'));
@@ -1625,7 +1622,7 @@ sub record_guest_installation_result {
 
 #Collect guest y2logs via ssh and save guest config xml file.
 sub collect_guest_installation_logs_via_ssh {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->get_guest_ipaddr;
@@ -1644,7 +1641,7 @@ sub collect_guest_installation_logs_via_ssh {
 
 #Upload logs collect by collect_guest_installation_logs_via_ssh.
 sub upload_guest_installation_logs {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     assert_script_run("tar czvf /tmp/guest_installation_and_configuration_logs.tar.gz $common_log_folder");
@@ -1654,7 +1651,7 @@ sub upload_guest_installation_logs {
 
 #Unmount all mounted nfs shares to avoid unnecessary logs to be collected by supportconfig or sosreport which may take extremely long time.
 sub detach_all_nfs_mounts {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     script_run("umount -a -f -l -t nfs,nfs4") if (script_run("umount -a -t nfs,nfs4") ne 0);
@@ -1715,7 +1712,7 @@ sub remove_guest_device {
 
 #AUTOLOAD to be called if called subroutine does not exist.
 sub AUTOLOAD {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     my $type  = ref($self) || croak "$self is not an object";
@@ -1735,7 +1732,7 @@ sub AUTOLOAD {
 #Collect logs and gues extra log '/root' by using virt_utils::collect_host_and_guest_logs.
 #'Root' directory on guest contains very valuable content that is generated automatically after guest installation finishes.
 sub post_fail_hook {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->reveal_myself;
     $self->upload_guest_installation_logs;

--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -90,7 +90,7 @@ sub get_keystroke_list {
 # post_fail_hook for upload logs for test module which uses it as base
 # see https://progress.opensuse.org/issues/56636
 sub post_fail_hook {
-    my ($self) = shift;
+    my ($self) = @_;
     select_console('log-console');
     $self->SUPER::post_fail_hook;
     $self->export_logs_basic;

--- a/lib/networkdbase.pm
+++ b/lib/networkdbase.pm
@@ -170,7 +170,7 @@ Upload the logs of all known containers.
 
 =cut
 sub post_fail_hook {
-    my ($self) = shift;
+    my ($self) = @_;
     select_console('log-console');
 
     my $machines = script_output("machinectl --no-legend --no-pager | cut -d ' ' -f 1");

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -155,7 +155,7 @@ The files will be uploaded as a single tarball called C<problem_detection_logs.t
 
 =cut
 sub problem_detection {
-    my $self = shift;
+    my ($self) = @_;
 
     enter_cmd "pushd \$(mktemp -d)";
     $self->detect_bsc_1063638;
@@ -457,7 +457,7 @@ This method will call several other log gathering methods from this class.
 
 =cut
 sub export_logs {
-    my ($self) = shift;
+    my ($self) = @_;
     select_log_console;
     save_screenshot;
     show_oom_info;
@@ -492,7 +492,7 @@ This includes C<locale>, C<localectl> and C</etc/vconsole.conf>.
 
 =cut
 sub export_logs_locale {
-    my ($self) = shift;
+    my ($self) = @_;
     $self->save_and_upload_log('locale',                 '/tmp/locale.log');
     $self->save_and_upload_log('localectl status',       '/tmp/localectl.log');
     $self->save_and_upload_log('cat /etc/vconsole.conf', '/tmp/vconsole.conf');

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -98,7 +98,7 @@ This function creates a new partitioning setup from scratch.
 
 =cut
 sub create_new_partition_table {
-    my ($table_type) = shift // (is_storage_ng) ? 'GPT' : 'MSDOS';
+    my ($table_type) = @_ // (is_storage_ng) ? 'GPT' : 'MSDOS';
     my %table_type_hotkey = (
         MSDOS => 'alt-m',
         GPT   => 'alt-g',
@@ -161,7 +161,7 @@ Set mount point and volume label. C<$mount> is mount point.
 
 =cut
 sub mount_device {
-    my ($mount) = shift;
+    my ($mount) = @_;
     send_key 'alt-o';
     wait_still_screen 1;
     send_key 'alt-m';
@@ -410,7 +410,7 @@ C<$part_size> is the size of partition.
 
 =cut
 sub addboot {
-    my $part_size          = shift;
+    my $part_size          = @_;
     my %default_boot_sizes = (
         ofw        => 8,
         uefi       => 256,
@@ -494,7 +494,7 @@ Enable encryption in guided setup during installation.
 
 =cut
 sub enable_encryption_guided_setup {
-    my $self = shift;
+    my ($self) = @_;
     send_key $cmd{encryptdisk};
     # Bug is only in old storage stack
     if (get_var('ENCRYPT_ACTIVATE_EXISTING') && !is_storage_ng) {

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -50,8 +50,8 @@ sub create_keypair {
 }
 
 sub delete_keypair {
-    my $self = shift;
-    my $name = shift || $self->ssh_key;
+    my ($self, $name) = @_;
+    $name = $self->ssh_key if (!$name);
 
     return unless $name;
 

--- a/lib/publiccloud/eks.pm
+++ b/lib/publiccloud/eks.pm
@@ -41,7 +41,7 @@ sub push_container_image {
 }
 
 sub cleanup {
-    my $self = shift;
+    my ($self) = @_;
     assert_script_run("aws ecr batch-delete-image --repository-name " . $self->{repository} . " --image-ids imageTag=" . $self->{tag});
     $self->SUPER::cleanup();
     return;

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -47,8 +47,8 @@ C<<$instance->username()>>.
 Use argument C<rc_only> to only check for the return code of the command.
 =cut
 sub run_ssh_command {
-    my $self = shift;
-    my %args = testapi::compat_args({cmd => undef}, ['cmd'], @_);
+    my ($self, @args) = @_;
+    my %args = testapi::compat_args({cmd => undef}, ['cmd'], @args);
     die('Argument <cmd> missing') unless ($args{cmd});
     $args{ssh_opts} //= $self->ssh_opts() . " -i '" . $self->ssh_key . "'";
     $args{username} //= $self->username();
@@ -106,8 +106,8 @@ Use argument C<username> to specify a different username then
 C<<$instance->username()>>.
 =cut
 sub retry_ssh_command {
-    my $self = shift;
-    my %args = testapi::compat_args({cmd => undef}, ['cmd'], @_);
+    my ($self, @args) = @_;
+    my %args = testapi::compat_args({cmd => undef}, ['cmd'], @args);
     $args{rc_only} = 1;
     $args{timeout} //= 90;    # Timeout before we cancel the command
     my $tries = delete $args{retry} // 3;
@@ -281,7 +281,7 @@ Stop the instance using the CSP api calls.
 =cut
 sub stop
 {
-    my $self = shift;
+    my ($self) = @_;
     $self->provider->stop_instance($self, @_);
 }
 
@@ -307,7 +307,7 @@ Get the status of the instance using the CSP api calls.
 =cut
 sub get_state
 {
-    my $self = shift;
+    my ($self) = @_;
     return $self->provider->get_state_from_instance($self, @_);
 }
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -493,7 +493,7 @@ sub terraform_param_tags
 }
 
 sub escape_single_quote {
-    my $s = shift;
+    my $s = @_;
     $s =~ s/'/'"'"'/g;
     return $s;
 }
@@ -530,7 +530,7 @@ sub __vault_login
 Wrapper arround C<<$self->vault_login()>> to have retry capability.
 =cut
 sub vault_login {
-    my $self  = shift;
+    my ($self) = @_;
     my $tries = 3;
     my $ret;
     while ($tries-- > 0) {

--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -135,7 +135,7 @@ Method executed when run() finishes and the module has result => 'fail'
 
 =cut
 sub post_fail_hook {
-    my ($self) = shift;
+    my ($self) = @_;
     select_console('log-console');
 
     # fetch Salt specific logs

--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -50,7 +50,7 @@ sub run_test {
 }
 
 sub prepare_run_test {
-    my $self = shift;
+    my ($self) = @_;
 
     script_run("rm -f /root/{commands_history,commands_failure}");
     assert_script_run("history -c");
@@ -106,7 +106,7 @@ sub junit_log_provision {
 }
 
 sub junit_log_params_provision {
-    my $self = shift;
+    my ($self) = @_;
 
     my $start_time = $self->{"start_run"};
     my $stop_time  = $self->{"stop_run"};
@@ -158,7 +158,7 @@ sub analyzeResult {
 }
 
 sub post_fail_hook {
-    my ($self) = shift;
+    my ($self) = @_;
 
     $self->{"stop_run"} = time();
     assert_script_run("history -w /root/commands_history");

--- a/lib/vt_perf_libs.pm
+++ b/lib/vt_perf_libs.pm
@@ -50,8 +50,8 @@ C<$git_branch_name> Branch name in string.
 C<$git_repo_url> URL in string.
 =cut
 sub switch_to_linux_default_enable {
-    my $self = shift;
-    my $ret  = script_run("grep \"mitigations=off\" /proc/cmdline");
+    my ($self) = @_;
+    my $ret = script_run("grep \"mitigations=off\" /proc/cmdline");
     if ($ret eq 0) {
         #Sometime parameter be writen on the line of GRUB_CMDLINE_LINUX
         assert_script_run("sed -i '/GRUB_CMDLINE_LINUX=/s/mitigations=off/ /g' /etc/default/grub");
@@ -82,7 +82,7 @@ C<$git_branch_name> Branch name in string.
 C<$git_repo_url> URL in string.
 =cut
 sub switch_to_xen_default_enable {
-    my $self   = shift;
+    my ($self) = @_;
     my $reboot = 0;
 
     my $ret = script_run("xl info | grep \"xen_commandline\" | grep \"spec-ctrl=off\"");

--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -53,7 +53,7 @@ has use_dhcp     => 1;
 has use_radius   => 0;
 
 sub sut_hw_addr {
-    my $self = shift;
+    my ($self) = @_;
     $self->{sut_hw_addr} //= $self->get_hw_address($self->sut_ifc);
     return $self->{sut_hw_addr};
 }
@@ -135,7 +135,7 @@ sub stop_dhcp_server {
 }
 
 sub before_test {
-    my $self = shift // wicked::wlan->new();
+    my $self = @_ // wicked::wlan->new();
     $self->prepare_packages();
     $self->prepare_phys();
     $self->prepare_freeradius_server();
@@ -143,7 +143,7 @@ sub before_test {
 }
 
 sub prepare_packages {
-    my $self = shift;
+    my ($self) = @_;
     if (is_sle()) {
         set_var('QA_HEAD_REPO', 'http://download.suse.de/ibs/QA:/Head/' . generate_version('-')) unless (get_var('QA_HEAD_REPO'));
         add_qa_head_repo();
@@ -155,7 +155,7 @@ sub prepare_packages {
 }
 
 sub prepare_phys {
-    my $self = shift;
+    my ($self) = @_;
     assert_script_run('modprobe mac80211_hwsim radios=2');
     assert_script_run('ip netns add ' . $self->netns_name);
     assert_script_run('ip netns list');
@@ -175,7 +175,7 @@ sub prepare_phys {
 }
 
 sub prepare_freeradius_server {
-    my $self = shift;
+    my ($self) = @_;
     # The default installation of freeradius-server gives us a config where
     # we can authenticate with PEAP+MSCHAPv2, TLS and TTLS/PAP
     assert_script_run(sprintf(q(echo '%s ClearText-Password := "%s"' >> /etc/raddb/users),
@@ -328,7 +328,7 @@ sub assert_connection {
 }
 
 sub setup_ref {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->netns_exec('ip addr add dev ' . $self->ref_ifc() . ' ' . $self->ref_ip(netmask => 1));
     $self->restart_dhcp_server()                if ($self->use_dhcp());
@@ -336,7 +336,7 @@ sub setup_ref {
 }
 
 sub __as_array {
-    my $ref = shift;
+    my $ref = @_;
 
     if (ref($ref) eq 'ARRAY') {
         return @$ref;
@@ -348,7 +348,7 @@ sub __as_array {
 }
 
 sub __as_config_array {
-    my $param = shift;
+    my $param = @_;
     my @ret;
     foreach my $in (__as_array($param)) {
         my $cfg = {config => '', wicked_version => '>=0.0.0'};
@@ -376,7 +376,7 @@ sub skip_by_wicked_version
 }
 
 sub run {
-    my $self = shift;
+    my ($self) = @_;
     $self->select_serial_terminal;
     return if ($self->skip_by_wicked_version());
 

--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -158,20 +158,20 @@ sub upload_widgets_json {
 }
 
 sub post_fail_hook {
-    my $self = shift;
+    my ($self) = @_;
     upload_widgets_json();
     $self->SUPER::post_fail_hook;
 }
 
 sub pre_run_hook {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->SUPER::pre_run_hook;
     YuiRestClient::Logger->info($autotest::current_test->{name} . " test module started") if YuiRestClient::is_libyui_rest_api;
 }
 
 sub post_run_hook {
-    my $self = shift;
+    my ($self) = @_;
 
     $self->SUPER::post_run_hook;
     save_screenshot;

--- a/lib/y2_firstboot_basetest.pm
+++ b/lib/y2_firstboot_basetest.pm
@@ -28,7 +28,7 @@ sub post_run_hook {
 }
 
 sub post_fail_hook {
-    my $self = shift;
+    my ($self) = @_;
     $self->SUPER::post_fail_hook;
     upload_logs('/etc/YaST2/firstboot.xml', log_name => "firstboot.xml.conf");
 }

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -535,7 +535,7 @@ sub save_remote_upload_y2logs {
 }
 
 sub post_fail_hook {
-    my $self = shift;
+    my ($self) = @_;
 
     if (check_var("REMOTE_CONTROLLER", "ssh") || check_var("REMOTE_CONTROLLER", "vnc")) {
         mutex_create("installation_done");

--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -108,7 +108,7 @@ sub wait_for_exit {
 }
 
 sub post_fail_hook {
-    my $self = shift;
+    my ($self) = @_;
     $self->upload_widgets_json();
     my $defer_blocked_task_info = testapi::is_serial_terminal();
     show_tasks_in_blocked_state unless ($defer_blocked_task_info);

--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -80,8 +80,8 @@ Helper to create a snapper snapshot. C<$name> is the name of snapshot.
 
 =cut
 sub y2snapper_create_snapshot {
-    my $self = shift;
-    my $name = shift || "Awesome Snapshot";
+    my ($self, $name) = @_;
+    $name = "Awesome Snapshot" if (!$name);
     # Open the 'C'reate dialog and wait until it is there
     send_key "alt-c";
     assert_screen 'yast2_snapper-createsnapshotdialog', 100;

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -39,7 +39,7 @@ sub get_ltp_rpm
 
 sub instance_log_args
 {
-    my $self = shift;
+    my ($self) = @_;
     return sprintf('"%s" "%s" "%s" "%s"',
         get_required_var('PUBLIC_CLOUD_PROVIDER'),
         $self->{my_instance}->instance_id,

--- a/tests/publiccloud/sev.pm
+++ b/tests/publiccloud/sev.pm
@@ -19,7 +19,7 @@ use utils;
 #use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
 
 sub run {
-    my $self = shift;
+    my ($self) = @_;
     $self->select_serial_terminal;
 
     # Skip this test run, unless defined to run

--- a/tests/publiccloud/smoketest.pm
+++ b/tests/publiccloud/smoketest.pm
@@ -17,7 +17,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $self = shift;
+    my ($self) = @_;
     $self->select_serial_terminal;
 
     # Check if systemd completed sucessfully

--- a/tools/check_code_style
+++ b/tools/check_code_style
@@ -31,5 +31,8 @@ fail() {
     exit 1
 }
 
+files=('**.p[ml]')
+res=$(grep -noP  "check_var\('ARCH', .*\)|check_var\('BACKEND',.*\)"  $(git status --porcelain "${files[@]}" | awk '{ print $2 }') | grep -v "Utils") 
+echo "Use the existing functions defined in 'lib/Utils/Architecture.pm' and 'lib/Utils/Backends.pm' for checking the specific ARCH and BACKEND types instead of calling check_var()"  &&echo && echo   "$res"
 git grep -P 'check_screen.*00(?!.*nocheck:)' || exit 0
 fail "See https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/CONTRIBUTING.md#coding-style for more details"


### PR DESCRIPTION
We are seeing the mix between my $self = shift and my ($self) = @_ for parameter parsing in functions, so the proposal would be to stick to my ($self) = @_

- Related ticket: https://progress.opensuse.org/issues/97097
- Needles: No
- Verification run: 