### PR TITLE
Precede multipath from registration

### DIFF
--- a/schedule/qam/QR/15-SP3/zfcp.yaml
+++ b/schedule/qam/QR/15-SP3/zfcp.yaml
@@ -11,8 +11,8 @@ schedule:
   - installation/welcome
   - installation/accept_license
   - installation/disk_activation
-  - installation/scc_registration
   - installation/multipath
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -29,7 +29,6 @@ schedule:
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_zfcp
-  - console/validate_multipath
 test_data:
   software:
     packages:


### PR DESCRIPTION
After a recent change where the multipath activation pop up appears
right after disk activation has been completed, the multipath module
needs to preced the registration module in the zfcp jobs.

- Verification run: https://openqa.suse.de/tests/7216206#details
