### PR TITLE
[virt_autotest] remove soft_failure bsc#1188898

### DIFF
--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -136,11 +136,6 @@ sub test_add_vcpu {
     }
     return if (is_xen_host && $guest =~ m/hvm/i);    # not supported on HVM guest
 
-    if ($sles_running_version eq '15' && $sles_running_sp eq '4' && is_xen_host && is_fv_guest($guest)) {
-        record_soft_failure('bsc#1188898 Failed to set live vcpu count on fv guest on 15-SP4 Xen host');
-        return;
-    }
-
     # Ensure guest CPU count is 2
     die "Setting vcpus failed" unless (set_vcpus($guest, 2));
     assert_script_run("ssh root\@$guest nproc | grep 2", 60);


### PR DESCRIPTION
Due to bsc#1188898 was updated as VERIFIED on the latest sles15sp4 build39.1 now. 

So, create this PR to remove soft_failure bsc#1188898 for hotplugging test module.

- Verification run: wip 
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/7221668)
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/7221734)