### PR TITLE
sles4sap: Rename saptune_v2 test names to saptune

### DIFF
--- a/schedule/sles4sap/installation/sles4sap_gnome_saptune_baremetal.yaml
+++ b/schedule/sles4sap/installation/sles4sap_gnome_saptune_baremetal.yaml
@@ -1,7 +1,7 @@
 ---
-name: sles4sap_gnome_saptune_v2_baremetal
+name: sles4sap_gnome_saptune_baremetal
 description: >
-  saptune_V2 tests SLES4SAP.
+  saptune tests for SLES4SAP on baremetal
 vars:
   MR_TEST: '%ARCH%'
 schedule:

--- a/schedule/sles4sap/sles4sap_gnome_saptune.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune.yaml
@@ -1,9 +1,8 @@
 ---
-name: sles4sap_gnome_saptune_v2
+name: sles4sap_gnome_saptune
 description: >
-  saptune V2 test
+  saptune tests for SLES4SAP on VM's
 
-  MR_TEST variable should be set in the YAML file
 vars:
   BOOTFROM: c
   BOOT_HDD_IMAGE: '1'

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -52,7 +52,7 @@ sub run {
     # Skip test if saptune version is 1 in case of upgrade only!
     if (is_upgrade()) {
         return if (script_output("rpm -q saptune") =~ m/saptune-1\./);
-        # saptune_v2 can run in v1 compat mode
+        # NOTE: Remove when saptune v3 is released
         return if (script_output("saptune version") =~ m/current active saptune version is '1'/);
     }
 


### PR DESCRIPTION
With the upcoming release of saptune v3, we need to rename the tests having `saptune_v2`.

Related MR:
https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/327

- Verification run: http://ix64hae1001.qa.suse.de/tests/2272
