### PR TITLE
Fix terraform destroy condition

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -634,7 +634,7 @@ This method is called called after each test on failure or success.
 =cut
 sub cleanup {
     my ($self) = @_;
-    $self->terraform_destroy() unless script_run('test -d ' . TERRAFORM_DIR . '/.terraform');
+    $self->terraform_destroy() unless script_run('test -d ' . TERRAFORM_DIR . '/.terraform') && check_var('PUBLIC_CLOUD_SERVICE', 'EKS');
     $self->vault_revoke();
     assert_script_run "cd";
 }


### PR DESCRIPTION
A bug was introduced by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13202
creating a failure in HA/SAP cleanup.

With this PR the terraform_destroy only will be omitted in case of EKS
tests

- Related ticket: progress.opensuse.org/issues/97715
- Verification run: http://copland.arch.suse.de/tests/273
