### PR TITLE
Fix gnome_session_switch failure on x11

### DIFF
--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -42,6 +42,7 @@ sub run {
     assert_and_click "displaymanager-systembutton";
     assert_and_click "displaymanager-system-powerbutton";
     assert_and_click "displaymanager-reboot";
+    assert_and_click "confirm-restart" if (is_sle('>=15-SP4'));
 
     if (get_var("SHUTDOWN_NEEDS_AUTH")) {
         assert_screen 'reboot-auth', 15;


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/97916
- Needles: already added to o.s.d when debugging
- Verification run: https://openqa.suse.de/tests/7239211
