### PR TITLE
SLE Micro: soft fail bsc 1190662

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -126,6 +126,13 @@
         },
         "type": "bug"
     },
+    "bsc#1190662": {
+        "description": "Failed to write ATTR{/sys/bus/ccwgroup/drivers/qeth/group}",
+        "products": {
+            "sle-micro": [ "5.1" ]
+        },
+        "type": "bug"
+    },
     "bsc#1182961": {
         "description": "could not read from '/sys/module/pcc_pufreq/initstate': No such device",
         "products": {


### PR DESCRIPTION
This bug is not SLE Micro related. It might come from SLE. So, as request from RM, making it soft.

VR: https://openqa.suse.de/tests/7239370