### PR TITLE
SLE Micro: soft fail bsc 1190662

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -127,7 +127,7 @@
         "type": "bug"
     },
     "bsc#1190662": {
-        "description": "Failed to write ATTR{/sys/bus/ccwgroup/drivers/qeth/group}",
+        "description": "/etc/udev/rules.d/41-qeth-.*Failed to write ATTR",
         "products": {
             "sle-micro": [ "5.1" ]
         },


### PR DESCRIPTION
Fixes 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13333
escaping the special characters

https://openqa.suse.de/tests/7239660#step/journal_check/5