### PR TITLE
Increase timeout to return from rescue to default target

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -75,7 +75,7 @@ sub snapper_nodbus_restore {
     if (script_run('systemctl is-active dbus')) {
         script_run('systemctl default', 0);
         my $tty = get_root_console_tty;
-        assert_screen "tty$tty-selected", 60;
+        assert_screen "tty$tty-selected", 120;
         reset_consoles;
         select_console 'root-console';
     }


### PR DESCRIPTION
- [[xen-pv] snapper_undochange - snapper_nodbus_restore does not work properly](https://progress.opensuse.org/issues/68815)
- VRs: [sle15sp2@xen-pv](http://kepler.suse.cz/tests/7035#live)
