### PR TITLE
Change the CC test code path

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -22,7 +22,8 @@ use Mojo::File 'path';
 use Mojo::Util 'trim';
 
 our @EXPORT = qw(
-  $testdir
+  $tmp_dir
+  $test_dir
   $testfile_tar
   $baseline_file
   $code_repo
@@ -35,7 +36,8 @@ our @EXPORT = qw(
   upload_audit_test_logs
 );
 
-our $testdir   = '/tmp/';
+our $tmp_dir   = '/tmp/';
+our $test_dir  = '/usr/local/eal4_testing';
 our $code_repo = get_var('CODE_BASE', 'https://gitlab.suse.de/security/audit-test-sle15/-/archive/master/audit-test-sle15-master.tar');
 my @lines = split(/[\/\.]+/, $code_repo);
 our $testfile_tar = $lines[-2];
@@ -78,7 +80,7 @@ sub prepare_for_test {
     my (%args) = @_;
 
     # Run test case
-    assert_script_run("cd ${testdir}${testfile_tar}/audit-test/");
+    assert_script_run("cd ${test_dir}/audit-test/");
     assert_script_run('make')           if ($args{make});
     assert_script_run('make netconfig') if ($args{make_netconfig});
 

--- a/tests/security/cc/audit_remote_libvirt.pm
+++ b/tests/security/cc/audit_remote_libvirt.pm
@@ -49,7 +49,7 @@ sub run {
     # Export AUDIT_TEST_REMOTE_VM
     assert_script_run("export AUDIT_TEST_REMOTE_VM=$vm_name");
     # Export AUGROK
-    assert_script_run("export AUGROK=$audit_test::testdir$audit_test::testfile_tar/audit-test/utils/augrok");
+    assert_script_run("export AUGROK=$audit_test::test_dir/audit-test/utils/augrok");
 
     # Run test case
     run_testcase('audit-remote-libvirt', make => 0, timeout => 120);

--- a/tests/security/cc/cc_audit_test_setup.pm
+++ b/tests/security/cc/cc_audit_test_setup.pm
@@ -21,7 +21,8 @@ use audit_test;
 
 sub run {
     my ($self)   = @_;
-    my $dir      = $audit_test::testdir;
+    my $tmp_dir  = $audit_test::tmp_dir;
+    my $test_dir = $audit_test::test_dir;
     my $file_tar = $audit_test::testfile_tar . '.tar';
 
     select_console 'root-console';
@@ -52,9 +53,11 @@ sub run {
     assert_script_run('sed -i \'s/-a task,never/#&/\' /etc/audit/rules.d/audit.rules');
     assert_script_run('systemctl restart auditd.service');
 
-    # Download "audit-test"
-    assert_script_run("wget --no-check-certificate $audit_test::code_repo -O ${dir}${file_tar}");
-    assert_script_run("tar -xvf ${dir}${file_tar} -C ${dir}");
+    # Download "audit-test", be aware of umask=0077 for cc role based system
+    assert_script_run("wget --no-check-certificate $audit_test::code_repo -O ${tmp_dir}${file_tar}");
+    assert_script_run("tar -xvf ${tmp_dir}${file_tar} -C ${tmp_dir}");
+    assert_script_run("mv ${tmp_dir}/$audit_test::testfile_tar ${test_dir}");
+    assert_script_run("chmod 755 ${test_dir}");
 }
 
 sub test_flags {

--- a/tests/security/cc/setup_net_test_env.pm
+++ b/tests/security/cc/setup_net_test_env.pm
@@ -58,7 +58,7 @@ sub run {
     }
 
     # start lblnet_tst_server
-    my $cmd        = "$audit_test::testdir$audit_test::testfile_tar/audit-test/utils/network-server/lblnet_tst_server";
+    my $cmd        = "$audit_test::test_dir/audit-test/utils/network-server/lblnet_tst_server";
     my $lblnet_pid = background_script_run($cmd);
 
     if ($role eq 'server') {


### PR DESCRIPTION
In cc audit test, there is a C script needs hard code test path,
so we need move the code path out from original "/tmp" directory.
btw, in CC role based system, "/tmp" directory should be cleaned
after next OS reboot, we need change the code path as well.

- Related ticket: 
https://progress.opensuse.org/issues/99300
https://progress.opensuse.org/issues/99324
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/7259903#step/trustedprograms/30

Please ignore the failed cases, they are failed case due to cc test code, not our openqa failure