### PR TITLE
 Increase assert_screen timeout in repo_inst.pm for startshell

### DIFF
--- a/tests/installation/validation/repo_inst.pm
+++ b/tests/installation/validation/repo_inst.pm
@@ -19,7 +19,7 @@ use testapi;
 
 
 sub run {
-    assert_screen 'startshell', 90;
+    assert_screen 'startshell', 180;
     my $arch = get_var('ARCH');
     assert_script_run("grep -Pzo \"instsys url:(.|\\n)*disk:/boot/$arch/root\" /var/log/linuxrc.log");
     my $mirror = get_netboot_mirror;


### PR DESCRIPTION
Loading hardware in the beginning of the installation can take more than 90'' so assert_screen "startshell" fails.

- Verification run: https://openqa.suse.de/t7242665
