### PR TITLE
Containers: install skopeo for BCI before running the tests

### DIFF
--- a/tests/containers/bci_tests.pm
+++ b/tests/containers/bci_tests.pm
@@ -91,7 +91,7 @@ sub run {
     }
 
     record_info('Install', 'Install needed packages');
-    zypper_call('--quiet in git-core python3 python3-devel gcc', timeout => 600);
+    zypper_call('--quiet in git-core python3 python3-devel gcc skopeo', timeout => 600);
     assert_script_run('pip3.6 --quiet install tox pytest', timeout => 600);
 
     record_info('Clone', 'Clone BCI tests repository');
@@ -101,7 +101,7 @@ sub run {
     assert_script_run('cd bci-tests');
     assert_script_run("export CONTAINER_RUNTIME=$runtime");
     assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;
-    assert_script_run('tox -e build', timeout => 600);
+    assert_script_run('tox -e build', timeout => 900);
 
     # Run the tests for each environment
     my $error_count = 0;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/98183
- VR: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=17.8.6&groupid=398

This is needed to run bci-tests suite on all the architectures on 15-SP3.