### PR TITLE
Test multiple instance configuration in mariadb

### DIFF
--- a/data/console/mariadb/mynode1.cnf
+++ b/data/console/mariadb/mynode1.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+port             = 3310
+datadir          = /var/lib/mysql/node1/databases
+pid-file         = /var/lib/mysql/node1/databases/mysqld.pid
+socket           = /run/mysql/node1mysql.sock
+log-error        = /var/log/mysql/node1/mysqld.log
+secure_file_priv = /var/lib/mysql-files

--- a/data/console/mariadb/mynode2.cnf
+++ b/data/console/mariadb/mynode2.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+port             = 3315
+datadir          = /var/lib/mysql/node2/databases
+pid-file         = /var/lib/mysql/node2/databases/mysqld.pid
+socket           = /run/mysql/node2mysql.sock
+log-error        = /var/log/mysql/node2/mysqld.log
+secure_file_priv = /var/lib/mysql-files

--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -37,6 +37,7 @@ use constant {
           is_aarch64
           is_arm
           is_ppc64le
+          is_ppc64
           is_orthos_machine
           is_supported_suse_domain
         )
@@ -126,6 +127,17 @@ Returns C<check_var('ppc64le')>.
 =cut
 sub is_ppc64le {
     return check_var('ARCH', 'ppc64le');
+}
+
+=head2 is_ppc64
+
+ is_ppc64();
+
+ Returns C<check_var('ppc64')>.
+
+=cut
+sub is_ppc64 {
+    return check_var('ARCH', 'ppc64');
 }
 
 =head2 is_orthos_machine


### PR DESCRIPTION
The test is for now excluded from `Tumbleweed ppc64le` and `ppc64`. The issue is tracked by a [progress ticket ](https://progress.opensuse.org/issues/99558) and will be resolved in a future PR.

- Related ticket: https://progress.opensuse.org/issues/98256
- Needles: N/A
- Verification run: 
SLES [15sp3](https://openqa.suse.de/tests/7275418#step/mariadb_srv/41) | [15sp2](https://openqa.suse.de/tests/7275420#step/mariadb_srv/41) | [15sp1](https://openqa.suse.de/tests/7275421#step/mariadb_srv/41) | [15](https://openqa.suse.de/tests/7275422#step/mariadb_srv/41) | [12sp5](https://openqa.suse.de/tests/7275424#step/mariadb_srv/41) | [12sp4](https://openqa.suse.de/tests/7275425#step/mariadb_srv/41) | [12sp3](https://openqa.suse.de/tests/7275435#step/mariadb_srv/13) | [12sp2](https://openqa.suse.de/tests/7275463#step/mariadb_srv/13)
Tumbleweed : [x86_64](https://openqa.opensuse.org/tests/1947019#step/mariadb_srv/41) | [aarch64](https://openqa.opensuse.org/tests/1947020#step/mariadb_srv/41) | [JeOS-for-RPi-aarch64](https://openqa.opensuse.org/tests/1947023#step/mariadb_srv/40) | [JeOS-for-kvm-and-xen-x86_64](https://openqa.opensuse.org/tests/1947026#step/mariadb_srv/41) | 
[Leap 15.3](https://openqa.opensuse.org/tests/1947134) | [Leap 15.2](https://openqa.opensuse.org/tests/1947025#step/mariadb_srv/41)
