### PR TITLE
Replace grep -q pipelines in lib/hacluster

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -361,7 +361,7 @@ true or false.
 
 sub check_rsc {
     my $rsc = shift;
-    my $ret = script_run "$crm_mon_cmd 2>/dev/null | grep -q '\\<$rsc\\>'";
+    my $ret = script_run "grep -q '\\<$rsc\\>' <($crm_mon_cmd 2>/dev/null)";
 
     _test_var_defined $ret;
     return ($ret == 0);
@@ -411,7 +411,7 @@ sub ensure_resource_running {
     my $starttime = time;
     my $ret       = undef;
 
-    while ($ret = script_run("crm resource status $rsc | grep -E -q '$regex'", $default_timeout)) {
+    while ($ret = script_run("grep -E -q '$regex' <(crm resource status $rsc)", $default_timeout)) {
         my $timerun = time - $starttime;
         if ($timerun < $default_timeout) {
             sleep 5;


### PR DESCRIPTION
Starting with SLES+HA 15-SP4 Alpha build 39.1, some pipelines of the type
`cmd | grep -q` in `lib/hacluster` started failing with retval 141 (bash
generates a *SIGPIPE* as the left hand side command is still writing to the
pipe while the right hand side command has exited) or retval 1 (no
match), even when a match is expected. These commands were changed to
`grep -q <(cmd)` to avoid using the pipe.

- Related ticket: N/A
- Needles: N/A
- Failing tests: https://openqa.suse.de/tests/7242139#step/vg/5, https://openqa.suse.de/tests/7251378#step/clvmd_lvmlockd/3, https://openqa.suse.de/tests/7241884#step/migrate_clvmd_to_lvmlockd/11
- Verification run: [node 1](http://mango.qa.suse.de/tests/4423) & [node 2](http://mango.qa.suse.de/tests/4424)
