### PR TITLE
Containers: enable containers_main in O3

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -28,7 +28,16 @@ our @EXPORT = qw(
 );
 
 sub is_container_test {
-    get_var('CONTAINER_RUNTIME') ? return 1 : return 0;
+    return get_var('CONTAINER_RUNTIME', 0);
+}
+
+sub is_container_image_test {
+    return get_var('CONTAINERS_UNTESTED_IMAGES', 0);
+}
+
+sub is_res_host {
+    # returns if booted image is RedHat Expanded Support
+    return get_var("HDD_1") =~ /(res82.qcow2|res79.qcow2)/;
 }
 
 sub load_tests_podman_image {
@@ -37,7 +46,11 @@ sub load_tests_podman_image {
 
 sub load_tests_docker_image {
     loadtest 'containers/docker_image';
-    loadtest 'containers/container_diff';
+    # container_diff package is not avaiable for <=15 in aarch64
+    # Also, we don't want to run it on 3rd party hosts
+    unless ((is_sle("<=15") and is_aarch64) || get_var('CONTAINERS_NO_SUSE_OS')) {
+        loadtest 'containers/container_diff';
+    }
 }
 
 sub load_tests_podman_common {
@@ -45,22 +58,22 @@ sub load_tests_podman_common {
         # podman package is only available as of 15-SP1
         loadtest 'containers/podman';
         loadtest 'containers/podman_image';
+        loadtest 'containers/podman_3rd_party_images';
         loadtest 'containers/buildah_podman';
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podman_3rd_party_images';
     }
 }
 
 sub load_tests_docker_common {
     loadtest 'containers/docker';
-    unless (is_sle("<=15") and is_aarch64) {
+    loadtest 'containers/docker_image';
+    loadtest 'containers/docker_3rd_party_images';
+    loadtest 'containers/buildah_docker' if is_sle('>=15-SP1');
+    unless (is_sle("<=15") && is_aarch64) {
         # these 2 packages are not avaiable for <=15 (aarch64 only)
         loadtest 'containers/zypper_docker';
         loadtest 'containers/docker_runc';
     }
-    loadtest 'containers/docker_image';
-    loadtest 'containers/buildah_docker' if is_sle('>=15-SP1');
-    loadtest 'containers/docker_3rd_party_images';
     unless (check_var('BETA', 1)) {
         # These tests use packages from Package Hub, so they are applicable
         # to maintenance jobs or new products after Beta release
@@ -73,22 +86,20 @@ sub load_tests_docker_common {
 
 sub load_container_tests {
     my $runtime = get_required_var('CONTAINER_RUNTIME');
-    boot_hdd_image;
-    # Container Image tests
-    if (get_var('FLAVOR', '') =~ /Container-Image/) {
-        loadtest 'containers/host_configuration' unless get_var("HDD_1") =~ /res/;
-        if ($runtime eq 'podman') {
-            load_tests_podman_image();
-        } else {
-            load_tests_docker_image();
-        }
-        # Container Host tests
+    if (get_var('BOOT_HDD_IMAGE')) {
+        loadtest 'installation/bootloader_zkvm' if is_s390x;
+        loadtest 'boot/boot_to_desktop';
+    }
+
+    if (is_container_image_test()) {
+        # Container Image tests
+        loadtest 'containers/host_configuration' unless is_res_host;
+        load_tests_podman_image() if ($runtime =~ 'podman');
+        load_tests_docker_image() if ($runtime =~ 'docker');
     } else {
-        if ($runtime eq 'podman') {
-            load_tests_podman_common();
-        } else {
-            load_tests_docker_common();
-        }
+        # Container Host tests
+        load_tests_podman_common() if ($runtime =~ 'podman');
+        load_tests_docker_common() if ($runtime =~ 'docker');
     }
     loadtest 'console/coredump_collect';
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -18,6 +18,7 @@ use File::Find;
 use File::Basename;
 use DistributionProvider;
 use scheduler 'load_yaml_schedule';
+use main_containers;
 
 BEGIN {
     unshift @INC, dirname(__FILE__) . '/../../lib';
@@ -261,12 +262,16 @@ sub load_default_tests {
 }
 
 # load the tests in the right order
-if (is_jeos) {
+if (is_jeos && !is_container_test) {
     load_jeos_tests();
 }
 
+
 if (is_kernel_test()) {
     load_kernel_tests();
+}
+elsif (is_container_test) {
+    load_container_tests();
 }
 elsif (get_var('NFV')) {
     load_nfv_tests();

--- a/variables.md
+++ b/variables.md
@@ -32,10 +32,11 @@ CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test mo
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
 CLUSTER_TYPES | string | false | Set the type of cluster that have to be analyzed (example: "drbd hana"). This variable belongs to PUBLIC_CLOUD_.
-CONTAINER_RUNTIME | string | | Container runtime to be used, e.g.  `docker`, `podman`.
+CONTAINER_RUNTIME | string | | Container runtime to be used, e.g.  `docker`, `podman`, or both `podman,docker`.
+CONTAINERS_NO_SUSE_OS | boolean | false | Used by main_containers to see if the host is different than SLE or openSUSE.
+CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.
 COMMAND_FILE | string | | The LTP test command file (e.g. syscalls, cve)
 COMMAND_EXCLUDE | string | | This regex is used to exclude tests from LTP command file.
-CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.
@@ -152,7 +153,7 @@ PUBLIC_CLOUD_IMAGE_LOCATION | string | "" | The URL where the image gets downloa
 PUBLIC_CLOUD_IMAGE_PROJECT | string | "" | Google Compute Engine image project
 PUBLIC_CLOUD_IMG_PROOF_TESTS | string | false | Tests run  by img-proof. (We use 'default')
 PUBLIC_CLOUD_INSTANCE_TYPE | string | "" | Specify the instance type. Which instance types exists depends on the CSP. (default-azure: Standard_A2, default-ec2: t2.large )
-PUBLIC_CLOUD_KEY | string | "" | Private key data for gce, similar to `PUBLIC_CLOUD_KEY_SECRET`. 
+PUBLIC_CLOUD_KEY | string | "" | Private key data for gce, similar to `PUBLIC_CLOUD_KEY_SECRET`.
 PUBLIC_CLOUD_KEY_ID | string | "" | The CSP credentials key-id to used to access API.
 PUBLIC_CLOUD_KEY_SECRET | string | "" | The CSP credentials secret used to access API.
 PUBLIC_CLOUD_LTP | boolean | false | If set, the run_ltp test module is added to the job.


### PR DESCRIPTION
Due to previous change #13286, some yaml schedules were deleted
in favor of using main_containers scheduling approach.
However, I missed the fact that some jobs in O3 use those
yaml schedules. This fixes the issue.

Failing jobs:
https://openqa.opensuse.org/tests/1943358
https://openqa.opensuse.org/tests/1943359

VRs:
https://openqa.opensuse.org/tests/overview?version=Tumbleweed&build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_o3_centos_fix&distri=opensuse