### PR TITLE
Add lynis baselines for SLES15 SP4 and fix await_install() time out issue on s390x

### DIFF
--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-aarch64-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-aarch64-gnome
@@ -1,0 +1,645 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-59.19-default
+  Kernel version:            5.3.18
+  Hardware platform:         aarch64
+  Hostname:                  susetest
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 306
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ ENABLED ]
+[2C- Checking Secure Boot[37C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 32 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 28 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 5 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: No PAE or NoeXecute supported[15C [ NONE ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 100 active modules[31C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ UNKNOWN ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 24 shells (valid shells: 16).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: hfsplus squashfs udf [7C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ ENABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 10.0.2.3[33C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ WARNING ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 5 ports[40C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ OK ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/2][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.6.1.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.6-1.1.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.Agent.conf[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.6-1.1.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.65-2.1.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.65-2.1.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.65-2.1.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.65-2.1.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.65-2.1.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.16-1.1.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package bluez-5.60-1.3.aarch64 installs an unknown D-BUS autostart/system service: org.bluez.service[0C [ WARNING ]
+[4CWarning: Package flatpak-1.11.2-1.1.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.Flatpak.SystemHelper.service[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.6-1.1.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.service[0C [ WARNING ]
+[4CWarning: Package fwupd-1.5.8-1.13.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.fwupd.service[0C [ WARNING ]
+[4CWarning: Package systemd-246.15-7.11.1.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.16-1.1.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 6197 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (3):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  ! Couldn't find 2 responsive nameservers [NETW-2705] 
+      https://cisofy.com/controls/NETW-2705/
+
+  ! iptables module(s) loaded, but no rules active [FIRE-4512] 
+      https://cisofy.com/controls/FIRE-4512/
+
+  Suggestions (34):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Use a PAE enabled kernel when possible to gain native No eXecute/eXecute Disable support [KRNL-5677] 
+      https://cisofy.com/controls/KRNL-5677/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+      https://cisofy.com/controls/NAME-4028/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Check your resolv.conf file and fill in a backup nameserver if possible [NETW-2705] 
+      https://cisofy.com/controls/NETW-2705/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 90 [##################  ]
+  Tests performed : 222
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 306
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-aarch64-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-aarch64-textmode
@@ -1,0 +1,639 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-47-default
+  Kernel version:            5.3.18
+  Hardware platform:         aarch64
+  Hostname:                  susetest
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 303
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ ENABLED ]
+[2C- Checking Secure Boot[37C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 24 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 27 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 3 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: No PAE or NoeXecute supported[15C [ NONE ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 96 active modules[32C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ UNKNOWN ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 24 shells (valid shells: 16).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: hfsplus squashfs udf [7C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ ENABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 10.0.2.3[33C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ WARNING ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 5 ports[40C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/0][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.3.1.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package systemd-246.10-1.5.aarch64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.aarch64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 4450 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (2):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  ! Couldn't find 2 responsive nameservers [NETW-2705] 
+      https://cisofy.com/controls/NETW-2705/
+
+  Suggestions (35):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Use a PAE enabled kernel when possible to gain native No eXecute/eXecute Disable support [KRNL-5677] 
+      https://cisofy.com/controls/KRNL-5677/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+      https://cisofy.com/controls/NAME-4028/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Check your resolv.conf file and fill in a backup nameserver if possible [NETW-2705] 
+      https://cisofy.com/controls/NETW-2705/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+      https://cisofy.com/controls/FIRE-4513/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 87 [#################   ]
+  Tests performed : 222
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 303
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-ppc64le-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-ppc64le-gnome
@@ -1,0 +1,639 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-47-default
+  Kernel version:            5.3.18
+  Hardware platform:         ppc64le
+  Hostname:                  susetest
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 303
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 32 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 36 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 5 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: No PAE or NoeXecute supported[15C [ NONE ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 79 active modules[32C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ UNKNOWN ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 24 shells (valid shells: 16).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: hfsplus squashfs udf [7C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ ENABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 10.0.2.3[33C [ OK ]
+[8CNameserver: fec0::3[34C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ OK ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 5 ports[40C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/2][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.3.1.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.Agent.conf[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package bluez-5.55-1.52.ppc64le installs an unknown D-BUS autostart/system service: org.bluez.service[0C [ WARNING ]
+[4CWarning: Package flatpak-1.10.1-1.11.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.Flatpak.SystemHelper.service[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.service[0C [ WARNING ]
+[4CWarning: Package fwupd-1.5.3-1.32.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.fwupd.service[0C [ WARNING ]
+[4CWarning: Package systemd-246.10-1.5.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 6243 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (1):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  Suggestions (34):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Use a PAE enabled kernel when possible to gain native No eXecute/eXecute Disable support [KRNL-5677] 
+      https://cisofy.com/controls/KRNL-5677/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+      https://cisofy.com/controls/NAME-4028/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+      https://cisofy.com/controls/FIRE-4513/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 91 [##################  ]
+  Tests performed : 222
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 303
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-ppc64le-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-ppc64le-textmode
@@ -1,0 +1,635 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-47-default
+  Kernel version:            5.3.18
+  Hardware platform:         ppc64le
+  Hostname:                  redcurrant-3
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 303
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 24 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 30 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 3 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: No PAE or NoeXecute supported[15C [ NONE ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 58 active modules[32C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ UNKNOWN ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 24 shells (valid shells: 16).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: hfsplus squashfs udf [7C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ DISABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Checking search domains[34C [ FOUND ]
+[2C- Searching DNS domain name[32C [ FOUND ]
+[6CDomain name: qa.suse.de[32C
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 2620:113:80c0:80a0:10:162:0:1[12C [ OK ]
+[8CNameserver: 10.162.0.1[31C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ OK ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 14 ports[39C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+[2C- Checking for a running NTP daemon or client[14C [ WARNING ]
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/0][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ NOT FOUND ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ NONE ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.3.1.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package systemd-246.10-1.5.ppc64le installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.ppc64le installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 4186 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (1):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  Suggestions (34):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Use a PAE enabled kernel when possible to gain native No eXecute/eXecute Disable support [KRNL-5677] 
+      https://cisofy.com/controls/KRNL-5677/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+      https://cisofy.com/controls/FIRE-4513/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Use NTP daemon or NTP client to prevent time issues. [TIME-3104] 
+      https://cisofy.com/controls/TIME-3104/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 90 [##################  ]
+  Tests performed : 221
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 303
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-s390x-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-s390x-gnome
@@ -1,0 +1,640 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-47-default
+  Kernel version:            5.3.18
+  Hardware platform:         s390x
+  Hostname:                  susetest
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 303
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 31 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 32 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 5 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: No PAE or NoeXecute supported[15C [ NONE ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 74 active modules[32C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ UNKNOWN ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 25 shells (valid shells: 17).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: hfsplus squashfs udf [7C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ DISABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Checking search domains[34C [ FOUND ]
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 10.160.2.88[30C [ OK ]
+[8CNameserver: 10.160.0.1[31C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ OK ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 35 ports[39C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/2][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.3.1.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.Agent.conf[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package bluez-5.55-1.52.s390x installs an unknown D-BUS autostart/system service: org.bluez.service[0C [ WARNING ]
+[4CWarning: Package flatpak-1.10.1-1.11.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.Flatpak.SystemHelper.service[0C [ WARNING ]
+[4CWarning: Package fwupd-1.5.3-1.32.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.fwupd.service[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.service[0C [ WARNING ]
+[4CWarning: Package systemd-246.10-1.5.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 6207 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (1):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  Suggestions (34):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Use a PAE enabled kernel when possible to gain native No eXecute/eXecute Disable support [KRNL-5677] 
+      https://cisofy.com/controls/KRNL-5677/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+      https://cisofy.com/controls/NAME-4028/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+      https://cisofy.com/controls/FIRE-4513/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 91 [##################  ]
+  Tests performed : 222
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 303
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-s390x-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-s390x-textmode
@@ -1,0 +1,634 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-47-default
+  Kernel version:            5.3.18
+  Hardware platform:         s390x
+  Hostname:                  susetest
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 303
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 23 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 30 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 3 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: No PAE or NoeXecute supported[15C [ NONE ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 74 active modules[32C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ UNKNOWN ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 25 shells (valid shells: 17).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: hfsplus squashfs udf [7C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ DISABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Checking search domains[34C [ FOUND ]
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 10.160.2.88[30C [ OK ]
+[8CNameserver: 10.160.0.1[31C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ OK ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 10 ports[39C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/0][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.3.1.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package systemd-246.10-1.5.s390x installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.s390x installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 4494 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (1):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  Suggestions (34):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Use a PAE enabled kernel when possible to gain native No eXecute/eXecute Disable support [KRNL-5677] 
+      https://cisofy.com/controls/KRNL-5677/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+      https://cisofy.com/controls/NAME-4028/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+      https://cisofy.com/controls/FIRE-4513/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 87 [#################   ]
+  Tests performed : 222
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 303
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-x86_64-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-x86_64-gnome
@@ -1,0 +1,636 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-47-default
+  Kernel version:            5.3.18
+  Hardware platform:         x86_64
+  Hostname:                  susetest
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 303
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 32 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 29 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 5 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: PAE and/or NoeXecute supported[14C [ FOUND ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 105 active modules[31C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ NO ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 24 shells (valid shells: 16).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: hfsplus squashfs udf [7C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ ENABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 10.0.2.3[33C [ OK ]
+[8CNameserver: fec0::3[34C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ OK ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 5 ports[40C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/2][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.3.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.Agent.conf[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package bluez-5.55-1.52.x86_64 installs an unknown D-BUS autostart/system service: org.bluez.service[0C [ WARNING ]
+[4CWarning: Package flatpak-1.10.1-1.11.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.Flatpak.SystemHelper.service[0C [ WARNING ]
+[4CWarning: Package geoclue2-2.5.4-1.32.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.GeoClue2.service[0C [ WARNING ]
+[4CWarning: Package fwupd-1.5.3-1.32.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.fwupd.service[0C [ WARNING ]
+[4CWarning: Package systemd-246.10-1.5.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.28.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 6231 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (1):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  Suggestions (33):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+      https://cisofy.com/controls/NAME-4028/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+      https://cisofy.com/controls/FIRE-4513/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 91 [##################  ]
+  Tests performed : 222
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 303
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-x86_64-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-x86_64-textmode
@@ -1,0 +1,630 @@
+
+[ Lynis 2.6.1 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           2.6.1
+  Operating system:          Linux
+  Operating system name:     Linux
+  Operating system version:  5.3.18-43-default
+  Kernel version:            5.3.18
+  Hardware platform:         x86_64
+  Hostname:                  susetest
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /usr/share/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ WARNING ]
+
+      ===============================================================================
+        Lynis update available
+      ===============================================================================
+
+        Current version is more than 4 months old
+
+        Current version : 261   Latest version : 303
+
+        Please update to the latest version.
+        New releases include additional features, bug fixes, tests, and baselines.
+
+        Download the latest version:
+
+        Packages (DEB/RPM) -  https://packages.cisofy.com
+        Website (TAR)      -  https://cisofy.com/downloads/
+        GitHub (source)    -  https://github.com/CISOfy/lynis
+
+      ===============================================================================
+
+
+[+] System Tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugins enabled[42C [ NONE ]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ WARNING ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 24 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 27 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Checking sulogin in rescue.service[23C [ NOT FOUND ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 3 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: PAE and/or NoeXecute supported[14C [ FOUND ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 104 active modules[31C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking core dumps configuration[24C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ PROTECTED ]
+[2C- Check if reboot is needed[32C [ NO ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ OK ]
+[2C- Searching for IO waiting processes[23C [ OK ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- sudoers file[45C [ FOUND ]
+[4C- Check sudoers file permissions[25C [ OK ]
+[2C- PAM password strength tools[30C [ OK ]
+[2C- PAM configuration file (pam.conf)[24C [ NOT FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ OK ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Checking user password aging (minimum)[19C [ DISABLED ]
+[2C- User password aging (maximum)[28C [ DISABLED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ SUGGESTION ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 24 shells (valid shells: 16).[14C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/csh.cshrc[15C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ OK ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ OK ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ OK ]
+[2C- Mount options of /home[35C [ NON DEFAULT ]
+[2C- Mount options of /tmp[36C [ NON DEFAULT ]
+[2C- Mount options of /var[36C [ NON DEFAULT ]
+[2C- Disable kernel support of some filesystems[15C
+[4C- Discovered kernel modules: hfsplus squashfs udf [7C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ ENABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Query rpc registered programs[28C [ DONE ]
+[2C- Query NFS versions[39C [ DONE ]
+[2C- Query NFS protocols[38C [ DONE ]
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking nscd status[37C [ RUNNING ]
+[2C- Checking /etc/hosts[38C
+[4C- Checking /etc/hosts (duplicates)[23C [ OK ]
+[4C- Checking /etc/hosts (hostname)[25C [ SUGGESTION ]
+[4C- Checking /etc/hosts (localhost)[24C [ OK ]
+[4C- Checking /etc/hosts (localhost to IP)[18C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching RPM package manager[26C [ FOUND ]
+[6C- Querying RPM package manager[25C
+[2C- Using Zypper to find vulnerable packages[17C [ NONE ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: zypper[44C
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[8CNameserver: 10.0.2.3[33C [ OK ]
+[8CNameserver: fec0::3[34C [ OK ]
+[4C- Minimal of 2 responsive nameservers[20C [ OK ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[6C* Found 6 ports[40C
+[2C- Checking status DHCP client[30C [ NOT ACTIVE ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+[2C- Postfix status[43C [ RUNNING ]
+[4C- Postfix configuration[34C [ FOUND ]
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache (binary /usr/sbin/httpd2-prefork)[8C [ FOUND ]
+[6CInfo: Configuration file found (/etc/apache2/httpd.conf)[0C
+[6CInfo: No virtual hosts found[27C
+[4C* Loadable modules[39C [ FOUND (117) ]
+[8C- Found 117 loadable modules[25C
+[10Cmod_evasive: anti-DoS/brute force[18C [ NOT FOUND ]
+[10Cmod_reqtimeout/mod_qos[29C [ FOUND ]
+[10CModSecurity: web application firewall[14C [ NOT FOUND ]
+[2C- Checking nginx[43C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- SSH option: AllowTcpForwarding[25C [ SUGGESTION ]
+[4C- SSH option: ClientAliveCountMax[24C [ SUGGESTION ]
+[4C- SSH option: ClientAliveInterval[24C [ OK ]
+[4C- SSH option: Compression[32C [ SUGGESTION ]
+[4C- SSH option: FingerprintHash[28C [ OK ]
+[4C- SSH option: GatewayPorts[31C [ OK ]
+[4C- SSH option: IgnoreRhosts[31C [ OK ]
+[4C- SSH option: LoginGraceTime[29C [ OK ]
+[4C- SSH option: LogLevel[35C [ SUGGESTION ]
+[4C- SSH option: MaxAuthTries[31C [ SUGGESTION ]
+[4C- SSH option: MaxSessions[32C [ SUGGESTION ]
+[4C- SSH option: PermitRootLogin[28C [ SUGGESTION ]
+[4C- SSH option: PermitUserEnvironment[22C [ OK ]
+[4C- SSH option: PermitTunnel[31C [ OK ]
+[4C- SSH option: Port[39C [ SUGGESTION ]
+[4C- SSH option: PrintLastLog[31C [ OK ]
+[4C- SSH option: Protocol[35C [ NOT FOUND ]
+[4C- SSH option: StrictModes[32C [ OK ]
+[4C- SSH option: TCPKeepAlive[31C [ SUGGESTION ]
+[4C- SSH option: UseDNS[37C [ OK ]
+[4C- SSH option: UsePrivilegeSeparation[21C [ NOT FOUND ]
+[4C- SSH option: VerifyReverseMapping[23C [ NOT FOUND ]
+[4C- SSH option: X11Forwarding[30C [ SUGGESTION ]
+[4C- SSH option: AllowAgentForwarding[23C [ SUGGESTION ]
+[4C- SSH option: AllowUsers[33C [ NOT FOUND ]
+[4C- SSH option: AllowGroups[32C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[4CNo database engines found[32C
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ DONE ]
+[2C- Checking deleted files in use[28C [ FILES FOUND ]
+
+[+] Insecure services
+------------------------------------
+[2C- Checking inetd status[36C [ NOT ACTIVE ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ SYMLINK ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ NOT FOUND ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab/cronjob[33C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/0][14C [ NONE ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking for IDS/IPS tooling[29C [ NONE ]
+
+[+] Software: Malware
+------------------------------------
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4C/root/.ssh[47C [ OK ]
+
+[+] Home directories
+------------------------------------
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ DIFFERENT ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ DIFFERENT ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ DIFFERENT ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.suid_dumpable (exp: 0)[26C [ DIFFERENT ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ OK ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ DIFFERENT ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+
+[+] System Tools
+------------------------------------
+[2C- Starting dbus policy check...[28C
+[4CWarning: Package autofs-5.1.3-7.3.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.AutoMount.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.AUTO4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP4.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.DHCP6.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.Nanny.conf[0C [ WARNING ]
+[4CWarning: Package wicked-0.6.64-3.3.4.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Network.conf[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.12.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.conf[0C [ WARNING ]
+[4CWarning: Package systemd-246.9-1.2.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.8.15-1.12.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Starting password check for users...[21C
+
+[+] Binary integrity
+------------------------------------
+[2C- Starting binary RPATH check...[27C
+[4CNo bad RPATH usage found in 4499 executables[13C [ OK ]
+
+[+] File systems
+------------------------------------
+[2C- Starting look-up of symlinks in /tmp...[18C
+
+[+] File systems
+------------------------------------
+[2C- Starting file permissions check for world-writeable files...[0C
+[4C/tmp is world-writeable[34C [ WARNING ]
+
+[+] Memory and processes
+------------------------------------
+[2C- Starting look-up of 'nobody' processes...[16C
+
+[+] Networking
+------------------------------------
+[2C- Starting verifying open network ports (22 25 80 111 443)...[0C
+
+[+] Custom Tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 2.6.1 Results ]-
+
+  Warnings (1):
+  ----------------------------
+  ! Version of Lynis is very old and should be updated [LYNIS] 
+      https://cisofy.com/controls/LYNIS/
+
+  Suggestions (33):
+  ----------------------------
+  * Set a password on GRUB bootloader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+      https://cisofy.com/controls/BOOT-5122/
+
+  * Protect rescue.service by using sulogin [BOOT-5260] 
+      https://cisofy.com/controls/BOOT-5260/
+
+  * Configure minimum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Configure maximum password age in /etc/login.defs [AUTH-9286] 
+      https://cisofy.com/controls/AUTH-9286/
+
+  * Default umask in /etc/login.defs could be more strict like 027 [AUTH-9328] 
+      https://cisofy.com/controls/AUTH-9328/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [STRG-1840] 
+      https://cisofy.com/controls/STRG-1840/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+      https://cisofy.com/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+      https://cisofy.com/controls/NAME-4028/
+
+  * Add the IP name and FQDN to /etc/hosts for proper name resolving [NAME-4404] 
+      https://cisofy.com/controls/NAME-4404/
+
+  * Consider running ARP monitoring software (arpwatch,arpon) [NETW-3032] 
+      https://cisofy.com/controls/NETW-3032/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+      https://cisofy.com/controls/FIRE-4513/
+
+  * Install Apache mod_evasive to guard webserver against DoS/brute force attempts [HTTP-6640] 
+      https://cisofy.com/controls/HTTP-6640/
+
+  * Install Apache modsecurity to guard webserver against web application attacks [HTTP-6643] 
+      https://cisofy.com/controls/HTTP-6643/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowTcpForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : ClientAliveCountMax (3 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Compression (YES --> (DELAYED|NO))
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : LogLevel (INFO --> VERBOSE)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxAuthTries (6 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : MaxSessions (10 --> 2)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : PermitRootLogin (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (22 --> )
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : TCPKeepAlive (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : X11Forwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : AllowAgentForwarding (YES --> NO)
+      https://cisofy.com/controls/SSH-7408/
+
+  * Check what deleted files are still in use and why. [LOGG-2190] 
+      https://cisofy.com/controls/LOGG-2190/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+      https://cisofy.com/controls/BANN-7126/
+
+  * Enable process accounting [ACCT-9622] 
+      https://cisofy.com/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+      https://cisofy.com/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+      https://cisofy.com/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+      https://cisofy.com/controls/TOOL-5002/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+      https://cisofy.com/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+      https://cisofy.com/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC
+      https://cisofy.com/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 87 [#################   ]
+  Tests performed : 222
+  Plugins enabled : 0
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Lynis Modules:
+  - Compliance Status      [?]
+  - Security Audit         [V]
+  - Vulnerability Scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+  Notice: Lynis update available
+  Current version : 261    Latest version : 303
+================================================================================
+
+  Lynis 2.6.1
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2018, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -109,7 +109,7 @@ sub _set_timeout {
 sub run {
     my $self = shift;
     # NET isos are slow to install
-    my $timeout = 2000;
+    my $timeout = is_s390x ? 2400 : 2000;
 
     # workaround for yast popups and
     # detect "Wrong Digest" error to end test earlier


### PR DESCRIPTION
Add lynis baselines for SLES15 SP4 and fix await_install() time out issue on s390x

- Related ticket:
  https://progress.opensuse.org/issues/99447
  https://progress.opensuse.org/issues/99291
- Needles: none
- Verification run:
  VR for lynis on all arches, the failed case can be tracked by bsc#1189415.
  https://openqa.suse.de/tests/7260453 (aarch64 gnome)
  https://openqa.suse.de/tests/7260413 (aarch64 textmode)
  https://openqa.suse.de/tests/7260414 (ppc64 gnome)
  https://openqa.suse.de/tests/7260415 (ppc64 textmode)
  https://openqa.suse.de/tests/7260416 (s390x gnome)
  https://openqa.suse.de/tests/7260416 (s390x textmode)
  https://openqa.suse.de/tests/7260418 (x86_64 gnome)
  https://openqa.suse.de/tests/7260419 (x86_64 textmode)

  VR for create_hdd_textmode on s390x:
  https://openqa.suse.de/tests/7259945#details (passed)
  https://openqa.suse.de/tests/7259946#details (passed)