### PR TITLE
Fix restart rpcbind.socket timeout

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -288,7 +288,7 @@ sub check_y2_nfs_func {
         systemctl('is-active nfs-server');
         systemctl('restart rpcbind');
         systemctl('is-active rpcbind');
-        systemctl('restart rpcbind.socket');
+        systemctl('restart rpcbind.socket', timeout => 120);
         systemctl('is-active rpcbind.socket');
     }
 }


### PR DESCRIPTION
On s390x the restart rpcbind.socket service will timeout on some jobs.
We need to wait more time for the service to be restarted.

- Related ticket: https://progress.opensuse.org/issues/97259
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t7252337 
  https://openqa.nue.suse.com/t7252338 
  https://openqa.nue.suse.com/t7252339 