### PR TITLE
Fix 'Printer Added' notification banner after migration

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -38,6 +38,7 @@ our @EXPORT = qw(
   turn_off_kde_screensaver
   turn_off_gnome_screensaver
   turn_off_gnome_suspend
+  turn_off_gnome_show_banner
   untick_welcome_on_next_startup
   start_root_shell_in_xterm
   workaround_boo1170586
@@ -365,6 +366,11 @@ sub turn_off_screensaver {
     x11_start_program('xterm');
     turn_off_gnome_screensaver;
     script_run 'exit', 0;
+}
+
+# turn off the gnome deskop's notification
+sub turn_off_gnome_show_banner {
+    script_run 'gsettings set org.gnome.desktop.notifications show-banners false';
 }
 
 =head2 untick_welcome_on_next_startup

--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -18,7 +18,8 @@ use testapi;
 use Utils::Architectures;
 use utils;
 use migration;
-use version_utils 'is_sle';
+use version_utils;
+use x11utils 'turn_off_gnome_show_banner';
 
 sub check_or_install_packages {
     if (get_var("FULL_UPDATE") || get_var("MINIMAL_UPDATE")) {
@@ -61,6 +62,11 @@ sub run {
     remove_kgraft_patch if is_sle('<15');
     # create btrfs subvolume for aarch64 before migration
     create_btrfs_subvolume() if (is_aarch64);
+    # We need to close gnome notification banner before migration.
+    if (check_var('DESKTOP', 'gnome') && (is_aarch64 || is_ppc64le)) {
+        select_console 'user-console';
+        turn_off_gnome_show_banner;
+    }
 }
 
 sub test_flags {

--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -22,10 +22,16 @@ use utils;
 use Utils::Backends 'is_pvm';
 use power_action_utils 'power_action';
 use bootloader_setup 'stop_grub_timeout';
+use version_utils;
+use x11utils 'turn_off_gnome_show_banner';
 
 sub run {
     my ($self) = @_;
-
+    # We need to close gnome notification banner before migration.
+    if (check_var('DESKTOP', 'gnome') && (is_aarch64 || is_ppc64le)) {
+        select_console 'user-console';
+        turn_off_gnome_show_banner;
+    }
     select_console 'root-console';
 
     # Mark the hdd has been patched


### PR DESCRIPTION
If we run cups service check before migration, after migration,
sometimes it will show the gnome notification banner. This will
cause assert_screen 'generic-desktop' to fail. We need to close the
gnome notification banner before the migration.

- Related ticket: https://progress.opensuse.org/issues/98799
- Needles: N/A
- Verification run: 
online:
 https://openqa.nue.suse.com/t7252329 
 https://openqa.nue.suse.com/t7252330
 https://openqa.nue.suse.com/t7259898 
 https://openqa.nue.suse.com/t7259899
offline:
https://openqa.nue.suse.com/t7260573 
