### PR TITLE
Bump default timeout for client libyui-rest-api

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -15,7 +15,7 @@ use warnings;
 
 use constant {
     API_VERSION => 'v1',
-    TIMEOUT     => 10,
+    TIMEOUT     => 30,
     INTERVAL    => 1
 };
 


### PR DESCRIPTION
Bump timeout from 10 to 30 seconds, afik we are using 1 minute in interactive installation overwriting the default and with Firstboot we found a couple of failure due to it is using the default. According to bug replies, something between 10 and 20 seconds is acceptable for screen response in most of the cases.

- Related ticket: https://progress.opensuse.org/issues/99000
- Verification run: [autoyast_y2_firstboot + yast2_firstboot_custom + yast2_firstboot_custom_textmode](https://openqa.suse.de/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%23bump_timeout_libyui&version=15-SP4&distri=sle)
