### PR TITLE
Replace pipeline with grep -q in ha/migrate_clvmd_to_lvmlockd.pm

### DIFF
--- a/tests/ha/migrate_clvmd_to_lvmlockd.pm
+++ b/tests/ha/migrate_clvmd_to_lvmlockd.pm
@@ -29,7 +29,7 @@ sub run {
 
     # Only perform clvm to lvmlockd migration if the cluster is up and has clvm resources
     assert_script_run $crm_mon_cmd;
-    my $clvm_rsc = script_run "$crm_mon_cmd | grep -wq clvm";
+    my $clvm_rsc = script_run "grep -wq clvm <($crm_mon_cmd)";
     return unless (defined $clvm_rsc and $clvm_rsc == 0);
 
     barrier_wait("CLVM_TO_LVMLOCKD_START_$cluster_name");


### PR DESCRIPTION
Starting with SLES+HA 15-SP4 Alpha build 39.1, some pipelines of the type
`cmd | grep -q` in HA tests started failing with retval 141 (bash
generates a SIGPIPE as the left hand side command is still writing to the
pipe while the right hand side command has exited) or retval 1 (no
match), even when a match is expected. These commands were changed to
`grep -q <(cmd)` in PR #13348 to avoid using the pipe, but this instance in
`ha/migrate_clvmd_to_lvmlockd.pm` was missing from that commit.

- Related ticket: PR #13348 
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/7257292#step/migrate_clvmd_to_lvmlockd/11
- Verification run: N/A
