### PR TITLE
Remove one line of dead code in SystemRolePage

### DIFF
--- a/lib/Installation/SystemRole/SystemRolePage.pm
+++ b/lib/Installation/SystemRole/SystemRolePage.pm
@@ -28,7 +28,6 @@ sub init {
     my ($self) = @_;
     $self->SUPER::init();
     $self->{sel_role}                  = $self->{app}->itemselector({id => 'role_selector'});
-    $self->{btn_next}                  = $self->{app}->button({id => 'next'});
     $self->{role_KDE_desktop}          = 'Desktop with KDE Plasma';
     $self->{role_GNOME_desktop}        = 'Desktop with GNOME';
     $self->{role_XFCE_desktop}         = 'Desktop with Xfce';


### PR DESCRIPTION
We now inherit the "next" method from a parent class,
so we no longer need this here.