### PR TITLE
Setuid root for cc polkit test

### DIFF
--- a/tests/security/cc/polkit_tests.pm
+++ b/tests/security/cc/polkit_tests.pm
@@ -25,6 +25,15 @@ sub run {
 
     # PASSWD is needed by polkit_success
     script_run("export PASSWD=$testapi::password");
+
+    # In cc role based system,polkit-agent-helper-1 needs to be setuid root.
+    # Authentication is required to set the statically configured local
+    # hostname, as well as the pretty hostname.
+    my $results = script_run("journalctl -u dracut-pre-pivot | grep 'crypto checks done'");
+    if (!$results) {
+        assert_script_run('chmod u+s /usr/lib/polkit-1/polkit-agent-helper-1');
+    }
+
     run_testcase('polkit-tests');
 
     # Compare current test results with baseline


### PR DESCRIPTION
In cc role based system,polkit-agent-helper-1 needs to be setuid root.
Authentication is required to set the statically configured local
hostname, as well as the pretty hostname.


- Related ticket: https://progress.opensuse.org/issues/99297
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/7272081