### PR TITLE
Modify check_kernel_config test cases to run on Tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2451,7 +2451,7 @@ sub load_security_tests_system_check {
 sub load_security_tests_check_kernel_config {
     load_security_console_prepare;
 
-    loadtest "security/check_kernel_config/CC_STACKPROTECTOR_STRONG";
+    loadtest "security/check_kernel_config/CC_STACKPROTECTOR_STRONG" if(is_sle);
     loadtest "security/check_kernel_config/CONFIG_FORTIFY_SOURCE";
     loadtest "security/check_kernel_config/dm_crypt";
 }

--- a/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
+++ b/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
@@ -25,13 +25,20 @@ use warnings;
 use testapi;
 use Utils::Architectures;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     # check the kernel configuration file to make sure the parameter is there
     if (!is_s390x) {
-        validate_script_output "cat /boot/config-`uname -r`|grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
+        if (is_sle) {
+            validate_script_output "cat /boot/config-`uname -r`| grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
+        }
     }
     else {
+        if (is_sle) {
+            validate_script_output "cat /boot/config-`uname -r`| grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
+        }
+
         my $results = script_run("grep CONFIG_STACKPROTECTOR_STRONG=y /boot/config-`uname -r`");
         if (!$results) {
             die("Error: the kernel parameter is wrongly configured on s390x platform");
@@ -39,5 +46,6 @@ sub run {
     }
 
 }
+
 
 1;

--- a/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
+++ b/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
@@ -25,20 +25,21 @@ use warnings;
 use testapi;
 use Utils::Architectures;
 use utils;
-use version_utils 'is_sle';
 
 sub run {
-    # check the kernel configuration file to make sure the parameter is there
-    if (is_sle) {
-        validate_script_output "cat /boot/config-`uname -r`| grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
-    }
-    if (is_s390x) {
-        my $results = script_run("grep CONFIG_STACKPROTECTOR_STRONG=y /boot/config-`uname -r`");
-        if (!$results) {
-            die("Error: the kernel parameter is wrongly configured on s390x platform");
-        }
-    }
+     # check the kernel configuration file to make sure the parameter is there
+     if (!is_s390x) {
+         validate_script_output "cat /boot/config-`uname -r`|grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
+     }
+     else {
+         my $results = script_run("grep CONFIG_STACKPROTECTOR_STRONG=y /boot/config-`uname -r`");
+         if (!$results) {
+             die("Error: the kernel parameter is wrongly configured on s390x platform");
+         }
+     }
+
 }
+
 
 
 1;

--- a/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
+++ b/tests/security/check_kernel_config/CC_STACKPROTECTOR_STRONG.pm
@@ -29,22 +29,15 @@ use version_utils 'is_sle';
 
 sub run {
     # check the kernel configuration file to make sure the parameter is there
-    if (!is_s390x) {
-        if (is_sle) {
-            validate_script_output "cat /boot/config-`uname -r`| grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
-        }
+    if (is_sle) {
+        validate_script_output "cat /boot/config-`uname -r`| grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
     }
-    else {
-        if (is_sle) {
-            validate_script_output "cat /boot/config-`uname -r`| grep CONFIG_STACKPROTECTOR", qr/CONFIG_STACKPROTECTOR_STRONG=y/;
-        }
-
+    if (is_s390x) {
         my $results = script_run("grep CONFIG_STACKPROTECTOR_STRONG=y /boot/config-`uname -r`");
         if (!$results) {
             die("Error: the kernel parameter is wrongly configured on s390x platform");
         }
     }
-
 }
 
 

--- a/tests/security/check_kernel_config/CONFIG_FORTIFY_SOURCE.pm
+++ b/tests/security/check_kernel_config/CONFIG_FORTIFY_SOURCE.pm
@@ -23,14 +23,19 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
     # Check the kernel configuration file to make sure the parameter is enabled by default
-    assert_script_run "cat /boot/config-`uname -r` | grep 'CONFIG_FORTIFY_SOURCE=y'";
-    assert_script_run "zcat /proc/config.gz | grep CONFIG_FORTIFY_SOURCE=y";
+    if (is_sle) {
+        assert_script_run "cat /boot/config-`uname -r` | grep 'CONFIG_FORTIFY_SOURCE=y'";
+        assert_script_run "zcat /proc/config.gz | grep CONFIG_FORTIFY_SOURCE=y";
+    } else {
+        validate_script_output "zcat /proc/config.gz | grep CONFIG_FORTIFY", qr/CONFIG_FORTIFY_SOURCE is not set/;
+    }
 
     # Check the syslog and 'dmesg' output to make sure no error or warning messages
     my $results = script_run("dmesg | grep -i FORTIFY");
@@ -42,5 +47,6 @@ sub run {
         die("Error: please check syslog for FORTIFY failure");
     }
 }
+
 
 1;

--- a/tests/security/check_kernel_config/dm_crypt.pm
+++ b/tests/security/check_kernel_config/dm_crypt.pm
@@ -27,13 +27,16 @@ use testapi;
 use utils;
 use power_action_utils 'power_action';
 use Utils::Backends 'is_pvm';
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
     # Make sure the code changes are there
-    assert_script_run("rpm -q kernel-default --changelog | grep 'dm crypt' | grep 'kcryptd workqueues'");
+    if (is_sle) {
+        assert_script_run("rpm -q kernel-default --changelog | grep 'dm crypt' | grep 'kcryptd workqueues'");
+    }
 
     # Simulate a ram device
     assert_script_run("modprobe brd rd_nr=1 rd_size=512000");
@@ -57,5 +60,6 @@ sub run {
     $self->wait_boot(textmode => 1, bootloader_time => 400, ready_time => 600);
     $self->select_serial_terminal;
 }
+
 
 1;


### PR DESCRIPTION
According to Factory First, all test cases should run on Tumbleweed. So, we need to modify the test cases to make sure these cases can run and pass on Tumbleweed. Cases modified are under security_check_kernel_config, added version specification checking to fit Tumbleweed and SLE since there are some differentials in files and configurations between Tumbleweed and SLE.

- Related ticket:
  https://progress.opensuse.org/issues/99102
  https://progress.opensuse.org/issues/99093
- Needles: N/A
- Verification run: 
  -  O3: https://openqa.opensuse.org/tests/1944994#
  -  x86_64: https://openqa.suse.de/tests/7274062
  - s390x: https://openqa.suse.de/tests/7274063
  - aarch64: https://openqa.suse.de/tests/7274064
  - power: https://openqa.suse.de/tests/7274087# (Please note that test case failed on power Build 43.1, however not caused by this code change)
