### PR TITLE
Add PoC of the container tester

### DIFF
--- a/schedule/containers/test_runner.yaml
+++ b/schedule/containers/test_runner.yaml
@@ -1,0 +1,18 @@
+name:           sle_image_on_sle_host
+description:    >
+  Maintainer: jalausuch@suse.com, qa-c@suse.de.
+  Extra tests about software in containers module
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+  validate_btrfs:
+    ARCH:
+      x86_64:
+        - containers/validate_btrfs
+schedule:
+  - '{{boot}}'
+  - boot/boot_to_desktop
+  - containers/host_configuration
+  - containers/container_test_runner

--- a/tests/containers/container_test_runner.pm
+++ b/tests/containers/container_test_runner.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Container test runner.
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use utils;
+use containers::common;
+use suse_container_urls 'get_suse_container_urls';
+use version_utils qw(get_os_release);
+
+sub run {
+    my ($self) = @_;
+    my ($image_names, $stable_names) = get_suse_container_urls();
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
+    install_docker_when_needed($host_distri);
+    allow_selected_insecure_registries(runtime => 'docker');
+
+    assert_script_run "git clone https://gitlab.com/b10n1k/madtes.git";
+    assert_script_run "cd madtes";
+    assert_script_run "zypper -n in python3-pip";
+    assert_script_run "pip install -r requirements.txt";
+    assert_script_run "py.test -v --rootdir=/root/madtes/tests/ --junitxml=report.xml";
+    parse_extra_log("XUnit" => "report.xml");
+}
+
+1;


### PR DESCRIPTION
With this commit you can start a job which will launch a container
and run test inside them.
However there are a few things still to be be done.
This is the test configuration aspects and the test results gathering,
as minimum.
As for now it run a tw container with static configuration.



- Related ticket: https://progress.opensuse.org/issues/88343
- Verification run: http://aquarius.suse.cz/tests/6974
