### PR TITLE
HyperV: Enable enroll/delete of mock key in MokManager

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -652,7 +652,11 @@ sub wait_grub {
     }
     # if there was a request to enroll or remove a certificate used for SecureBoot process
     if (get_var('_EXPECT_EFI_MOK_MANAGER')) {
-        wait_serial('Shim UEFI key management', 60) or die 'MokManager has not been started!';
+        if (is_hyperv) {
+            assert_screen 'shim-key-management';
+        } else {
+            wait_serial('Shim UEFI key management', 60) or die 'MokManager has not been started!';
+        }
         send_key 'ret';
         assert_screen 'shim-perform-mok-management';
         send_key 'down';

--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -73,9 +73,9 @@ sub check_efi_state {
     # get data from efivars
     # {8be4df61-93ca-11d2-aa0d-00e098032b8c} {global} efi_guid_global EFI Global Variable
     # save only the first capture
-    my ($efi_guid_global, undef) = script_output('efivar --list-guids') =~ /\{((\w+-){4}\w+)\}.*\s+efi_guid_global\s+/;
+    my ($efi_guid_global, undef) = script_output('efivar --list-guids') =~ /\{((\w+-){3,4}\w+)\}.*\s+efi_guid_global\s+/;
     diag "Found efi guid=$efi_guid_global";
-    diag('Expected state of SecureBoot: ' . get_var('DISABLE_SECUREBOOT', 0) ? 'Disabled' : 'Enabled');
+    diag('Expected state of SecureBoot: ' . (get_var('DISABLE_SECUREBOOT', 0) ? 'Disabled' : 'Enabled'));
 
     if (script_run("efivar -dn $efi_guid_global-SecureBoot") == !get_var('DISABLE_SECUREBOOT', 0)) {
         push @errors, 'System\'s SecureBoot state is unexpected according to efivar';


### PR DESCRIPTION
- [[Hyperv] MokManager string does not appear in serial line](https://progress.opensuse.org/issues/96746)
- VRs:
  - [sle-15-SP3-JeOS-for-MS-HyperV-QR-x86_64-Build3.3.3-jeos-main@svirt-hyperv-uefi](http://kepler.suse.cz/tests/7061#step/verify_efi_mok/119)
  - [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.58-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/7062#step/verify_efi_mok/480)
