### PR TITLE
Fix cleanup validation for buildah

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -316,6 +316,7 @@ use Mojo::Base 'containers::engine';
 use testapi;
 use containers::utils qw(registry_url);
 use utils qw(systemctl file_content_replace);
+use Test::Assert 'assert_equals';
 has runtime => "buildah";
 
 sub cleanup_system_host {
@@ -388,6 +389,14 @@ sub build {
 sub commit {
     my ($self, $mycontainer, $new_image_name, %args) = @_;
     $self->_engine_assert_script_run("commit --rm $mycontainer $new_image_name", timeout => $args{timeout});
+}
+
+sub enum_containers {
+    my ($self) = shift;
+    my $containers_s = $self->_engine_script_output("ls -q");
+    record_info "Containers", $containers_s;
+    my @containers = split /[\n\t]/, $containers_s;
+    return \@containers;
 }
 
 1;

--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -25,6 +25,8 @@ use version_utils qw(get_os_release check_os_release is_sle);
 use containers::engine;
 
 sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_buildah_when_needed($host_distri);

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -25,6 +25,8 @@ use version_utils qw(get_os_release check_os_release is_sle);
 use containers::engine;
 
 sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
     my ($running_version, $sp, $host_distri) = get_os_release;
 
     install_buildah_when_needed($host_distri);


### PR DESCRIPTION
Override the enum_containers function to make it work on buildah.

Make also the buildah modules self-contained adding `select_serial_terminal`.


- Verification run: https://openqa.opensuse.org/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313371&distri=opensuse&version=Tumbleweed
