### PR TITLE
Do not test ristretto on Rescue CDs

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1274,8 +1274,8 @@ sub load_x11tests {
     }
     if (xfcestep_is_applicable()) {
         # Midori got dropped from TW
-        loadtest "x11/midori" unless (is_staging || is_livesystem || !is_leap("<16.0"));
-        loadtest "x11/ristretto";
+        loadtest "x11/midori"    unless (is_staging || is_livesystem || !is_leap("<16.0"));
+        loadtest "x11/ristretto" unless rescuecdstep_is_applicable;
     }
     if (gnomestep_is_applicable()) {
         # TODO test on openSUSE https://progress.opensuse.org/issues/31972


### PR DESCRIPTION
https://progress.opensuse.org/issues/99585

- Related ticket: https://progress.opensuse.org/issues/99585
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1949278 - FAIL :(
