### PR TITLE
Modify eth0 autoyast configuration

### DIFF
--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -184,15 +184,14 @@
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>
-        <device>eth0</device>
         <dhclient_set_default_route>yes</dhclient_set_default_route>
-        <name>RTL-8139/8139C/8139C+</name>
+        <name>eth0</name>
         <startmode>auto</startmode>
       </interface>
       <interface>
         <bootproto>static</bootproto>
         <broadcast>127.255.255.255</broadcast>
-        <device>lo</device>
+        <name>lo</name>
         <firewall>no</firewall>
         <ipaddr>127.0.0.1</ipaddr>
         <netmask>255.0.0.0</netmask>


### PR DESCRIPTION
According to the [autoyast documentation](https://documentation.suse.com/sles/15-SP3/single-html/SLES-autoyast/#CreateProfile-Network-Resource) concerning the definition of a network interface, `eth0` should be in the `<name>` section, not in the `<device>` section.

- Related ticket: no related ticket
- Needles: No needles
- Verification run: [without change](https://openqa.suse.de/tests/7262812#step/clone/4) | [with change](https://openqa.suse.de/tests/7287164#step/clone/3)
