### PR TITLE
Increase timeout for tty after systemctl default

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -75,7 +75,7 @@ sub snapper_nodbus_restore {
     if (script_run('systemctl is-active dbus')) {
         script_run('systemctl default', 0);
         my $tty = get_root_console_tty;
-        assert_screen "tty$tty-selected", 60;
+        assert_screen "tty$tty-selected", 300;
         reset_consoles;
         select_console 'root-console';
     }


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/7284162#step/snapper_undochange/43
- Verification run: https://openqa.suse.de/tests/7289854