### PR TITLE
Reduce timeout for qa_run jobs

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -143,7 +143,7 @@ sub run {
     $self->prepare_repos();
 
     $self->start_testrun();
-    my $testrun_finished = $self->wait_testrun(timeout => 180 * 60);
+    my $testrun_finished = $self->wait_testrun(timeout => 45 * 60);
 
     # Upload test logs
     my $tarball = "/tmp/qaset.tar.bz2";


### PR DESCRIPTION
Change timeout from 3h to 45m



- Related ticket: https://progress.opensuse.org/issues/99591
- Needles:  no needles
- Verification run: jobs are failing anyway. This is to make them fail faster and not keep worker busy for nothing. In case more failures arises due to this change, can be reverted or re-adjusted.
