### PR TITLE
Cleanup buildah modules after each version

### DIFF
--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -53,12 +53,12 @@ sub run {
                 # the image has been committed as refreshed
 
                 build_and_run_image(runtime => $docker, builder => $buildah, base => $iname);
+                $docker->cleanup_system_host(0);
+                $buildah->cleanup_system_host();
             }
         }
     }
     scc_restore_docker_image_credentials();
-    $docker->cleanup_system_host(0);
-    $buildah->cleanup_system_host();
 }
 
 1;

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -52,12 +52,12 @@ sub run {
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
                 build_and_run_image(runtime => $podman, builder => $buildah, base => $iname);
+                $podman->cleanup_system_host(0);
+                $buildah->cleanup_system_host();
             }
         }
     }
     scc_restore_docker_image_credentials();
-    $podman->cleanup_system_host(0);
-    $buildah->cleanup_system_host();
 }
 
 1;


### PR DESCRIPTION
Due to the default name that the buildah is build an image on, this seems
to cause conflict in the test assertions, because it uses wrong images to
validate

- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
