### PR TITLE
lib/containers: Have get_container_logs write directly to the file

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -202,8 +202,7 @@ sub test_container_image {
     return if $runtime->runtime eq 'buildah';
     $runtime->start_container('testing');
     $runtime->halt_container('testing');
-    my $logs = $runtime->get_container_logs('testing');
-    assert_script_run "echo '$logs' | tee '$logfile'";
+    $runtime->get_container_logs('testing', $logfile);
     $runtime->remove_container('testing');
     if (script_run("grep \"`uname -r`\" '$logfile'") != 0) {
         upload_logs("$logfile");

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -201,17 +201,16 @@ sub info {
     $self->_engine_assert_script_run(sprintf("info %s %s", $property, $expected));
 }
 
-=head2 get_container_logs($container)
+=head2 get_container_logs($container, $filename)
 
 Request container's logs.
 C<container> the running container.
-C<logs> returns a string.
+C<filename> file the logs are written to.
 
 =cut
 sub get_container_logs {
-    my ($self, $container) = @_;
-    my $logs = $self->_engine_script_output("container logs $container");
-    return $logs;
+    my ($self, $container, $filename) = @_;
+    $self->_engine_assert_script_run("container logs $container | tee $filename");
 }
 
 =head2 remove_image($image_name)


### PR DESCRIPTION
Just write it into the file directly instead of copying it manually.
This avoids various string escaping issues and improves performance.

- Verification run: https://openqa.opensuse.org/tests/1951903

`podman_3rd_party_images` went from 22m 24s back to 3m 10s.
