### PR TITLE
Replace and fix output in podman_3rd_party_images

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -183,7 +183,7 @@ Returns an array ref with the names of the images.
 =cut
 sub get_images_by_repo_name {
     my ($self)      = @_;
-    my $repo_images = $self->_engine_script_output("images --format '{{.Repository}}'", timeout => 60);
+    my $repo_images = $self->_engine_script_output("images --format '{{.Repository}}'", timeout => 120);
     my @images      = split /[\n\t ]/, $repo_images;
     return \@images;
 }

--- a/tests/containers/podman_3rd_party_images.pm
+++ b/tests/containers/podman_3rd_party_images.pm
@@ -31,7 +31,7 @@ sub run {
     my ($running_version, $sp, $host_distri) = get_os_release;
     my $engine = containers::engine::podman->new();
 
-    script_run("echo 'Container base image tests:' > /var/tmp/$engine-3rd_party_images_log.txt");
+    script_run("echo 'Container base image tests:' > /var/tmp/podman-3rd_party_images_log.txt");
     # In SLE we need to add the Containers module
     install_podman_when_needed($host_distri);
     $engine->configure_insecure_registries();


### PR DESCRIPTION
the output of the script_output uses the instance variable where it is expected
the name of the runtime engine.


- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
