### PR TITLE
Containers: skip zypper related host tests for 15-SP4

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -25,9 +25,15 @@ use utils qw(zypper_call systemctl file_content_replace script_retry);
 use version_utils qw(is_sle is_leap is_microos is_sle_micro is_opensuse is_jeos is_public_cloud get_os_release check_version);
 use containers::utils qw(can_build_sle_base registry_url);
 
-our @EXPORT = qw(install_podman_when_needed install_docker_when_needed
+our @EXPORT = qw(is_unreleased_sle install_podman_when_needed install_docker_when_needed
   test_container_runtime test_container_image scc_apply_docker_image_credentials
   scc_restore_docker_image_credentials install_buildah_when_needed test_rpm_db_backend activate_containers_module);
+
+
+sub is_unreleased_sle {
+    # If "SCC_URL" is set, it means we are in not-released SLE host and it points to proxy SCC url
+    return (get_var('SCC_URL', '') =~ /proxy/);
+}
 
 sub activate_containers_module {
     my ($running_version, $sp, $host_distri) = get_os_release;

--- a/tests/containers/buildah_docker.pm
+++ b/tests/containers/buildah_docker.pm
@@ -52,8 +52,9 @@ sub run {
                 test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => $buildah, version => $version, beta => $beta);
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
-
-                build_and_run_image(runtime => $docker, builder => $buildah, base => $iname);
+                # If we are in not-released SLE host, we can't use zypper commands inside containers
+                # that are not the same version as the host, so we skip this test.
+                build_and_run_image(runtime => $docker, builder => $buildah, base => $iname) unless is_unreleased_sle;
                 $docker->cleanup_system_host(0);
                 $buildah->cleanup_system_host();
             }

--- a/tests/containers/buildah_podman.pm
+++ b/tests/containers/buildah_podman.pm
@@ -52,7 +52,7 @@ sub run {
                 test_opensuse_based_image(image => "${prefix_img_name}-working-container", runtime => $buildah, version => $version, beta => $beta);
                 # Due to the steps from the test_opensuse_based_image previously,
                 # the image has been committed as refreshed
-                build_and_run_image(runtime => $podman, builder => $buildah, base => $iname);
+                build_and_run_image(runtime => $podman, builder => $buildah, base => $iname) unless is_unreleased_sle;
                 $podman->cleanup_system_host(0);
                 $buildah->cleanup_system_host();
             }

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -49,11 +49,13 @@ sub run {
             record_info "IMAGE", "Testing image: $iname";
             test_container_image(image => $iname, runtime => $engine);
             test_rpm_db_backend(image => $iname, runtime => $engine);
-            build_and_run_image(base => $iname, runtime => $engine, dockerfile => $dockerfile);
+            # If we are in not-released SLE host, we can't use zypper commands inside containers
+            # that are not the same version as the host, so we skip this test.
+            build_and_run_image(base => $iname, runtime => $engine, dockerfile => $dockerfile) unless is_unreleased_sle;
             if (check_os_release('suse', 'PRETTY_NAME')) {
                 my $beta = $version eq get_var('VERSION') ? get_var('BETA', 0) : 0;
                 test_opensuse_based_image(image => $iname, runtime => $engine, version => $version, beta => $beta);
-                build_with_zypper_docker(image => $iname, runtime => $engine, version => $version) unless is_tumbleweed;
+                build_with_zypper_docker(image => $iname, runtime => $engine, version => $version) unless (is_tumbleweed || is_unreleased_sle);
             }
             else {
                 exec_on_container($iname, $engine, 'cat /etc/os-release');

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -40,7 +40,7 @@ sub run {
             record_info "IMAGE", "Testing image: $iname";
             test_container_image(image => $iname, runtime => $engine);
             test_rpm_db_backend(image => $iname, runtime => $engine);
-            build_and_run_image(base => $iname, runtime => $engine, dockerfile => $dockerfile);
+            build_and_run_image(base => $iname, runtime => $engine, dockerfile => $dockerfile) unless is_unreleased_sle;
             if (check_os_release('suse', 'PRETTY_NAME')) {
                 my $beta = $version eq get_var('VERSION') ? get_var(BETA => 0) : 0;
                 test_opensuse_based_image(image => $iname, runtime => $engine, version => $version, beta => $beta);


### PR DESCRIPTION
Using zypper in containers with different version as the host
doesn't work if we are registered against SCC Proxy, which
gets the assets from local storage.

To avoid this, we skip the tests on latest products that are
not released (15-SP4) for this case and we set the variable
SCC_URL pointing to the corresponding proxy url.

- Related ticket: https://progress.opensuse.org/issues/99738
- VR: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=43.1&groupid=313&test=docker_tests&test=podman_tests
