### PR TITLE
container: Fix check_image_in_host

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -240,8 +240,7 @@ Returns true if host contains C<img> or false.
 =cut
 sub check_image_in_host {
     my ($self, $img) = @_;
-    my @lregistry = $self->enum_images();
-    $img =~ @lregistry;
+    grep { $img eq $_ } @{$self->enum_images()};
 }
 
 =head2 configure_insecure_registries


### PR DESCRIPTION
The value associated to `=~` must be an lvalue. And others get
interpolated. So using an array there makes no sense.