### PR TITLE
containers::engine: Croak on timeout in _engine_script_run()

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -13,6 +13,7 @@
 package containers::engine;
 use Mojo::Base -base;
 use testapi;
+use Carp 'croak';
 use Test::Assert 'assert_equals';
 use containers::utils qw(registry_url);
 use utils qw(systemctl file_content_replace);
@@ -25,8 +26,13 @@ sub _engine_assert_script_run {
 }
 
 sub _engine_script_run {
-    my ($self, $cmd, @args) = @_;
-    return script_run($self->runtime . " " . $cmd, @args);
+    my ($self, $cmd, %args) = @_;
+    $cmd = $self->runtime . " " . $cmd;
+    my $ret = script_run($cmd, %args);
+    if (!defined($ret) && (!defined($args{timeout}) || $args{timeout} > 0)) {
+        croak('Timeout on _engine_script_run(' . join(', ', $cmd, map { $_ . '=>' . $args{$_} } keys %args) . ')');
+    }
+    return $ret;
 }
 
 sub _engine_script_output {


### PR DESCRIPTION
The function `testapi::script_run()` it self, does not have a proper
handling if the command didn't reach the end in the given timeout. For
this case it simply return `undef`. I guess all our usecases in
container doesn't need this flexibility, so we can take care of that
error.

The if condition for `$args{timeout} > 0` is needed, as `timeout => 0`
is used to execute a command, without waiting for the prompt.

- Related ticket: https://progress.opensuse.org/issues/99765
- Verification run: 
  - https://openqa.suse.de/tests/7314786#step/rootless_podman/108 (with this change)
  - https://openqa.suse.de/tests/7311624#step/rootless_podman/116 (without this change, nothing tell me a timeout, instead that the console is still in the old command)
