### PR TITLE
products/microos/main: Replace repos before setting up SELinux

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -51,6 +51,7 @@ our @EXPORT = qw(
   is_livesystem
   is_memtest
   is_memtest
+  is_repo_replacement_required
   is_server
   is_sles4sap
   is_sles4sap_standard

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -37,7 +37,10 @@ sub load_boot_from_disk_tests {
     # Preparation for start testing
     loadtest 'microos/disk_boot';
     loadtest 'installation/system_workarounds' if is_aarch64;
-    loadtest 'transactional/enable_selinux'    if (get_var("ENABLE_SELINUX"));
+    replace_opensuse_repos_tests               if is_repo_replacement_required;
+    # ^ runs only outside of stagings, clear repos otherwise
+    loadtest 'update/zypper_clear_repos'    if is_staging;
+    loadtest 'transactional/enable_selinux' if (get_var("ENABLE_SELINUX"));
     loadtest 'microos/networking';
 }
 


### PR DESCRIPTION
Setting up SELinux on the image installs packages from the repos, so better
make sure those are configured correctly at that point already.

- Verification run: https://openqa.opensuse.org/tests/1953253#
