### PR TITLE
workaround: qa_automation issue with query to some dashboard

### DIFF
--- a/tests/qa_automation/kernel_multipath.pm
+++ b/tests/qa_automation/kernel_multipath.pm
@@ -142,6 +142,8 @@ sub start_testrun {
     }
 
     $self->qaset_config();
+    # workaround dashboard query https://sd.suse.com/servicedesk/customer/portal/1/SD-62274
+    assert_script_run('rm /usr/share/qa/qaset/libs/msg_queue.sh');
     assert_script_run("/usr/share/qa/qaset/qaset reset");
 
     if (get_var('ISCSI_MULTIPATH_FLAKY')) {

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -107,6 +107,8 @@ sub prepare_repos {
 sub start_testrun {
     my $self = shift;
     $self->qaset_config();
+    # workaround dashboard query https://sd.suse.com/servicedesk/customer/portal/1/SD-62274
+    assert_script_run('rm /usr/share/qa/qaset/libs/msg_queue.sh');
     assert_script_run("/usr/share/qa/qaset/qaset reset");
     assert_script_run("/usr/share/qa/qaset/run/kernel-all-run.openqa");
 }


### PR DESCRIPTION
Disable curl <dashboard.qa2.suse.asia> until it's clarified what is with the dashboard. [1]
As far as I understand it's not required for test itself. [2]
[1] https://sd.suse.com/servicedesk/customer/portal/1/SD-62274
[2] https://github.com/SUSE/qa-testsuites/blob/master/sets/qa_testset_automation/automation/qaset/libs/msg_queue.sh

- Related ticket: https://progress.opensuse.org/issues/99591
- Verification run:
https://openqa.suse.de/tests/7319696
http://dzedro.suse.cz/tests/19518
http://dzedro.suse.cz/tests/19523