### PR TITLE
containers: Increase timeout for apt-get install podman to 5min

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -52,7 +52,7 @@ sub install_podman_when_needed {
             assert_script_run qq(echo "deb $ubuntu_repo/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list);
             assert_script_run "curl -L $ubuntu_repo/Release.key | apt-key add -";
             assert_script_run "apt-get update",            timeout => 160;
-            assert_script_run "apt-get -y install podman", timeout => 220;
+            assert_script_run "apt-get -y install podman", timeout => 300;
         } else {
             # We may run openSUSE with DISTRI=sle and opensuse doesn't have SUSEConnect
             activate_containers_module if $host_os =~ 'sles';


### PR DESCRIPTION
A test run show a time consumption of:
```
real    3m12.710s
user    0m46.945s
sys     0m17.429s
```

- Related ticket: https://progress.opensuse.org/issues/99783
- Verification run: https://openqa.suse.de/tests/7319478
