### PR TITLE
Containers: Enable log collection for autoyast installations

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -121,7 +121,7 @@
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
-      % if ($get_var->('VERSION') =~ /15|15-SP1|15-SP2|15-SP3|15-SP4/ and $get_var->('ARCH') !~ /aarch64/) {
+      % if ($get_var->('VERSION') =~ /^15/) {
       <pattern>enhanced_base</pattern>
       % }
     </patterns>

--- a/schedule/containers/create_hdd_autoyast.yaml
+++ b/schedule/containers/create_hdd_autoyast.yaml
@@ -16,6 +16,10 @@ schedule:
     - autoyast/prepare_profile
     - installation/bootloader_start
     - autoyast/installation
+    - autoyast/console
+    - autoyast/login
+    - autoyast/logs
+    - autoyast/save_y2logs
     - '{{grub_set_bootargs}}'
     - shutdown/cleanup_before_shutdown
     - shutdown/shutdown

--- a/tests/autoyast/save_y2logs.pm
+++ b/tests/autoyast/save_y2logs.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+# Summary: run save_y2logs and upload the generated tar.bz2
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+
+
+use strict;
+use warnings;
+use parent 'y2_module_consoletest';
+use testapi;
+
+sub run {
+    my $self = shift;
+    assert_script_run 'save_y2logs /tmp/y2logs.tar.bz2';
+    upload_logs '/tmp/y2logs.tar.bz2';
+}
+
+1;


### PR DESCRIPTION
Minor additions to collect `save_y2logs` logs from autoyast installation in container hdd tests.
