### PR TITLE
Fix timeout issues: docker_image and podman_image

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -239,11 +239,11 @@ sub test_zypper_on_container {
     die 'Argument $runtime not provided!' unless $runtime;
 
     $runtime->run_container($image, cmd => "zypper lr -s", keep_container => 1, timeout => 120);
-    $runtime->run_container($image, name => 'refreshed', cmd => "zypper -nv ref", keep_container => 1, timeout => 120);
+    $runtime->run_container($image, name => 'refreshed', cmd => "zypper -nv ref", keep_container => 1, timeout => 300);
     unless ($runtime->runtime eq 'buildah') {
         $runtime->commit('refreshed', "refreshed-image", timeout => 120);
         $runtime->remove_container('refreshed');
-        $runtime->run_container($image, name => "refreshed-image", cmd => "zypper -nv ref", timeout => 120);
+        $runtime->run_container($image, name => "refreshed-image", cmd => "zypper -nv ref", timeout => 300);
     }
     record_info "The End", "zypper test completed";
 }


### PR DESCRIPTION
Increase the timeout to fix the `docker_image` and `podman_image` test runs

- Related ticket: https://progress.opensuse.org/issues/99789
- Verification runs: https://openqa.suse.de/tests/7326598 | https://openqa.suse.de/tests/7326599 | https://openqa.suse.de/tests/7326600 | https://openqa.suse.de/tests/7326601 | https://openqa.suse.de/tests/7326602 | https://openqa.suse.de/tests/7326603 - passing the relevant test suites, other issues are still ongoing
