### PR TITLE
Increase timeout to 4200 seconds, some test need approx. one hour

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -145,7 +145,7 @@ sub run {
     $self->prepare_repos();
 
     $self->start_testrun();
-    my $testrun_finished = $self->wait_testrun(timeout => 45 * 60);
+    my $testrun_finished = $self->wait_testrun(timeout => 70 * 60);
 
     # Upload test logs
     my $tarball = "/tmp/qaset.tar.bz2";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/99591
- Fail: https://openqa.suse.de/tests/7324505/modules/acceptance_process_stress/steps/1/src
- Verification run:
https://openqa.suse.de/tests/7324897
https://openqa.suse.de/tests/7324898