### PR TITLE
install_ltp: Use openSUSE:Factory/standard package

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -215,7 +215,7 @@ sub add_ltp_repo {
         if ((is_leap('=15.2') && is_x86_64) || (is_leap('15.3+') && !is_s390x)) {
             $repo = sprintf("Leap_%s", get_var('VERSION'));
         } elsif (is_tumbleweed) {
-            $repo = "Tumbleweed";
+            $repo = "Factory";
             $repo = "Factory_PowerPC"  if is_ppc64le();
             $repo = "Factory_zSystems" if is_s390x();
         } else {


### PR DESCRIPTION
x86_64 used package built against (published) Tumbleweed, which occasionally

1) required incompatible perl version (thus job failed due install error) which was fixed by removed %{perl_requires} from LTP
   package spec,

2) was built against older kernel headers, which should be mostly ok, as built LTP on slightly older headers is not a big problem s most of the errors are found in runtime. But to fix this problem properly, use package built against [openSUSE:Factory/standard](https://build.opensuse.org/package/binaries/benchmark:ltp:devel/ltp/openSUSE_Factory).

Fixes: https://progress.opensuse.org/issues/93237#note-10

Verification run: TODO
