### PR TITLE
Only use Dockerfile.python3 in container runtime tests

### DIFF
--- a/tests/containers/docker.pm
+++ b/tests/containers/docker.pm
@@ -66,6 +66,9 @@ sub run {
     # Build an image from Dockerfile and test it
     build_and_run_image(runtime => $engine, base => 'registry.opensuse.org/opensuse/leap:latest');
 
+    # Build a third-party image and test it
+    build_and_run_image(runtime => $engine, dockerfile => 'Dockerfile.python3')
+
     # Clean container
     $engine->cleanup_system_host();
 }

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -52,6 +52,9 @@ sub run {
     # Build an image from Dockerfile and test it
     build_and_run_image(runtime => $podman, base => 'registry.opensuse.org/opensuse/leap:latest');
 
+    # Build a third-party image and test it
+    build_and_run_image(runtime => $podman, dockerfile => 'Dockerfile.python3')
+
     # Clean container
     $podman->cleanup_system_host();
 }

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -32,7 +32,6 @@ sub run {
 
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGES
     my $versions   = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
-    my $dockerfile = $host_distri !~ m/^sle/i ? 'Dockerfile.python3' : 'Dockerfile';
     for my $version (split(/,/, $versions)) {
         my ($untested_images, $released_images) = get_suse_container_urls(version => $version);
         my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
@@ -40,8 +39,8 @@ sub run {
             record_info "IMAGE", "Testing image: $iname";
             test_container_image(image => $iname, runtime => $engine);
             test_rpm_db_backend(image => $iname, runtime => $engine);
-            build_and_run_image(base => $iname, runtime => $engine, dockerfile => $dockerfile) unless is_unreleased_sle;
             if (check_os_release('suse', 'PRETTY_NAME')) {
+                build_and_run_image(base => $iname, runtime => $engine) unless is_unreleased_sle;
                 my $beta = $version eq get_var('VERSION') ? get_var(BETA => 0) : 0;
                 test_opensuse_based_image(image => $iname, runtime => $engine, version => $version, beta => $beta);
             }


### PR DESCRIPTION
`Dockerfile.python3` does not actually use the provided base image. This makes it unsuitable for base image tests.

Instead, use `Dockerfile` which actually uses the provided base image if possible, and don't build anything otherwise.

- Verification runs:
https://openqa.opensuse.org/t1956024
(more to come)
