### PR TITLE
container: Use stringify to simply access $engine->runtime member

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -239,10 +239,10 @@ sub test_rpm_db_backend {
     die 'Argument $image not provided!'   unless $image;
     die 'Argument $runtime not provided!' unless $runtime;
 
-    my ($running_version, $sp, $host_distri) = get_os_release("$runtime->{runtime} run $image");
+    my ($running_version, $sp, $host_distri) = get_os_release("$runtime run $image");
     # TW and SLE 15-SP3+ uses rpm-ndb in the image
     if ($host_distri eq 'opensuse-tumbleweed' || ($host_distri eq 'sles' && check_version('>=15-SP3', "$running_version-SP$sp", qr/\d{2}(?:-sp\d)?/))) {
-        validate_script_output "$runtime->{runtime} run $image rpm --eval %_db_backend", sub { m/ndb/ };
+        validate_script_output "$runtime run $image rpm --eval %_db_backend", sub { m/ndb/ };
     }
 }
 

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -17,6 +17,11 @@ use Carp 'croak';
 use Test::Assert 'assert_equals';
 use containers::utils qw(registry_url);
 use utils qw(systemctl file_content_replace);
+use overload
+  '""'     => sub { return shift->runtime },
+  bool     => sub { return 1 },
+  fallback => sub { return 1 };
+
 
 has runtime => undef;
 

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -194,11 +194,11 @@ sub basic_container_tests {
     # Images can be deleted
     my $cmd_runtime_rmi = "$runtime rmi -a";
     $output_containers = script_output("$runtime container ls -a");
-    die("error: $runtime image rmi -a $leap")                                          if ($output_containers =~ m/Untagged:.*opensuse\/leap/);
-    die("error: $runtime image rmi -a $tumbleweed")                                    if ($output_containers =~ m/Untagged:.*opensuse\/tumbleweed/);
-    die("error: $runtime image rmi -a tw:saved")                                       if ($output_containers =~ m/Untagged:.*tw:saved/);
-    record_soft_failure("error: $runtime->{runtime} image rmi -a $alpine")             if ($output_containers =~ m/Untagged:.*alpine/);
-    record_soft_failure("error: $runtime->{runtime} image rmi -a $hello_world:latest") if ($output_containers =~ m/Untagged:.*hello-world:latest/);
+    die("error: $runtime image rmi -a $leap")                               if ($output_containers =~ m/Untagged:.*opensuse\/leap/);
+    die("error: $runtime image rmi -a $tumbleweed")                         if ($output_containers =~ m/Untagged:.*opensuse\/tumbleweed/);
+    die("error: $runtime image rmi -a tw:saved")                            if ($output_containers =~ m/Untagged:.*tw:saved/);
+    record_soft_failure("error: $runtime image rmi -a $alpine")             if ($output_containers =~ m/Untagged:.*alpine/);
+    record_soft_failure("error: $runtime image rmi -a $hello_world:latest") if ($output_containers =~ m/Untagged:.*hello-world:latest/);
 }
 
 =head2 can_build_sle_base


### PR DESCRIPTION
Simplify the access to $engine->runtime member variable in string
interpolation.

With this change a code like
```perl
for my $engine (containers::engine::buildah->new(), containers::engine::podman->new(), containers::engine::docker->new()) {
   print("Engine: $engine\n");
}
```
will retrive a output like:
```
Engine: buildah
Engine: podman
Engine: docker
```

