### PR TITLE
Disable yast_keyboard for 12-SP2

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1452,7 +1452,7 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_rdp' if is_sle('15+');
     loadtest 'yast2_cmd/yast_users';
     loadtest 'yast2_cmd/yast_sysconfig';
-    loadtest 'yast2_cmd/yast_keyboard' unless is_sle("12-SP5");    #see progress ticket #99375
+    loadtest 'yast2_cmd/yast_keyboard' unless is_sle("12-SP2");    #see progress ticket #99375
     loadtest 'yast2_cmd/yast_nfs_server';
     loadtest 'yast2_cmd/yast_nfs_client';
     loadtest 'yast2_cmd/yast_dns_server';


### PR DESCRIPTION
Fixing typo

- Related ticket: https://progress.opensuse.org/issues/99375 

