### PR TITLE
fix SAP wizard profile ready step in wizard_hana_install

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -83,7 +83,7 @@ sub run {
     type_password $sles4sap::instance_password;
     wait_screen_change { send_key 'tab' };
     type_password $sles4sap::instance_password;
-    if (check_version('<15-SP4', get_var('VERSION'), qr/\d{2}(?:-sp\d)?/)) {
+    if (is_sle('<15-SP4')) {
         wait_screen_change { send_key $cmd{ok} };
     } else {
         wait_screen_change { send_key $cmd{next} };


### PR DESCRIPTION
fix SAP wizard profile ready step in wizard_hana_install for SLE 15-SP4 and up

Works for the old version (sle-15-SP3-Online-x86_64-Build187.1-sles4sap_scc_textmode_hana_wizard@64bit-sap):
- Verification run: http://keks.qa.suse.de/tests/235

The new version may still need new needles.
