### PR TITLE
Add documentation to YuiRestClient

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient;
 use strict;
@@ -163,3 +158,148 @@ sub get_yui_params_string {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient - Perl module to interact with YaST applications via libyui-rest-api
+
+=head1 COPYRIGHT
+
+Copyright © 2021 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  my $app  = YuiRestClient::get_app(installation => 1, timeout => 60, interval => 1);
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+See documentation of the L<libyui-rest-api project|https://github.com/libyui/libyui/tree/master/libyui-rest-api/doc>.
+for more details about server side implementation.
+
+=head2 Class and object methods
+
+=head3 Main interface methods
+
+B<get_app(%args)> - main routine to create app object.
+Parameters are:
+
+=over 4
+
+=item B<{timeout}> - Timeout for server communication, defaults to 30.
+
+=item B<{interval}> - Retry interval for communication, defaults to 1.
+
+=item B<{installation}> - boolean that triggers code to determine IP addresses on various backends.
+
+=back   
+
+C<get_host()> will call C<init_port()> and C<init_host()> from the low level interface
+functions (see below) and then create an app object that will be used during the session.
+
+B<get_host(%args)> - returns name or IP of the REST server.
+
+The %args is a boolean $installation (see parameters of C<get_app()> above.)
+
+B<get_port()> - returns port number for the rest server.
+
+B<init_logger> - Initializes logger instance.
+
+The log path is 'ulogs/yui-log.txt'
+
+B<set_host($host)> - change REST server host to new address or IP.
+
+B<set_port($port)> - change REST server port number.
+
+B<set_interval($interval)> - change retry interval.
+
+B<set_timeout($timeout)> - change timeout value.
+
+=head3 Low level interface methods
+
+B<init_port()> - Determine port for the REST server,
+
+The port number starts at C<YUI_START_PORT>, if C<VNC> is present then ths VNC port number 
+will be added, otherwise the function take a random numer between 0..1000.
+This function will also set the environment variable. C<YUI_PORT>.
+
+B<init_host()> - Initialize REST server and determine its host address.
+
+This method checks what backend is used for the system under test and adjusts the 
+host address for the REST server accordingly. The following backends are checked:
+
+=over 4
+
+=item B<QEMU>: Use 'localhost'.
+
+=item B<PowerVM> or B<IPMI>: Use what is defined in C<SUT_IP>.
+
+=item B<S390 Virtual Machine>: Use what is defined in C<VIRSH_GUEST>.
+
+=item B<s390x>: Extract IP address from output of "ip addr" command. 
+
+=item B<HyperV Hypervisor>: Extract IP address from PowerShell command.
+
+=item B<Xen>: Extract IP address from output of "ip addr" command. 
+
+=back
+
+=head3 Helper methods 
+
+B<is_libyui_rest_api()> - Returns environment variable C<YUI_REST_API>.
+
+B<set_libyui_backend_vars()> - Sets C<NICTYPE_USER_OPTIONS> and C<EXTRABOOTPARAMS>.
+
+B<get_yui_params_string($yuiport)> - creates String for C<EXTRABOOTPARAMS>.
+This will return "YUI_HTTP_PORT=$yuiport YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1" 
+so that this string can be appended to the boot parameters.
+
+=head1 ENVIRONMENT
+
+B<BACKEND> - Defines which Backend is used. C<host_init()> tests for 's390x'.
+
+B<EXTRABOOTPARAMS> - Additional boot parameters for the bootloader. YuiRestClient will 
+add " extend=libyui-rest-api YUI_HHTP_PORT=$yuiport YUI_HTTP_REMOTE=1 YUI_REUSE_PORT=1"
+to this variable.
+
+B<NICTYPE_USER_OPTIONS> - options for the virtual SUT network configuration. On QEMU backends
+this variable will get "hostfwd=tcp::$yuiport-:$yuiport" appended. 
+
+B<S390_ZKVM> - Defines that the SUT is on a S390 Virtual Machine.
+
+B<SUT_IP> - IP address of the system under test on PowerVM or IPMI backends.
+
+B<VIRSH_GUEST> - defines the host address for S390 Virtual Machines. 
+
+B<VIRSH_VMM_FAMILY> - defines the Hypervisor for virtual shells. C<host_init()> tests for 'xen'.
+
+B<VNC> - Port number for VNC connection.
+
+B<YUI_HTTP_PORT> - Port number that the REST server should use for listening.
+
+B<YUI_HTTP_REMOTE> - Boolean, if true, then remote connections to the REST server are allowed.
+
+B<YUI_LOG_LEVEL> - Log lever lor C<init_logger()>, defaults to 'debug'.
+
+B<YUI_PORT> - Port for REST server, caclulated by C<init_port()>.
+
+B<YUI_REST_API> - Boolean that defines if the REST API is present.
+
+B<YUI_REUSE_PORT> - Boolean, if 1 then the socket can be reused by other processes.
+
+B<YUI_SERVER> The host address for the REST server.
+
+B<YUI_START_PORT> - Base value for calculating REST server port number, defaults to 39000.
+
+=cut

--- a/lib/YuiRestClient/Action.pm
+++ b/lib/YuiRestClient/Action.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Action;
 
@@ -20,3 +15,45 @@ use constant {
 };
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Action - Define actions for widgets 
+
+=head1 COPYRIGHT
+
+Copyright ©2020  SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+This class defines constants to use for actions:
+
+=over 4
+
+=item * YUI_PRESS      - action to press a button
+
+=item * YUI_TOGGLE     - action to toggle a checkbox
+
+=item * YUI_CHECK      - action to check a checkbox
+
+=item * YUI_UNCHECK    - action to uncheck a checkbox
+
+=item * YUI_SELECT     - action to select an item
+
+=item * YUI_ENTER_TEXT - action to enter text
+
+=back
+
+=cut

--- a/lib/YuiRestClient/App.pm
+++ b/lib/YuiRestClient/App.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020-2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::App;
 use strict;
@@ -178,3 +173,129 @@ sub tab {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::App - Class to create a UI widget object
+
+=head1 COPYRIGHT
+
+Copyright © 2021 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+  
+   $app = YuiRestClient::App->new({
+            port        => $port,
+            host        => $host,
+            api_version => API_VERSION,
+            timeout     => $timeout,
+            interval    => $interval});
+   $app->get_widget_controller()->set_host($yuihost);
+   $app->get_widget_controller()->set_host($yuiport); 
+   YuiRestClient::get_app()->check_connection(); 
+   $self->{btn_guided_setup} = $self->{app}->button({id => 'guided'});       
+   $self->{ch_autologin} = $self->{app}->checkbox({id => 'autologin'});
+   $self->{cb_filesystem}       = $self->{app}->combobox({id => '"Y2Partitioner::Widgets::BlkDeviceFilesystem"'});
+   $self->{isel_keyboard_layout} = $self->{app}->itemselector({id => 'layout_list'});
+   $self->{lbl_settings_root_part} = $self->{app}->label({label => 'Settings for the Root Partition'});
+   $self->{menu_btn_add} = $self->{app}->menucollection({label => 'Add...'});
+   $self->{rb_operating_system} = $self->{app}->radiobutton({id => 'system'});
+   $self->{txt_overview} = $self->{app}->richtext({id => 'proposal'});
+   $self->{lst_target_disks} = $self->{app}->selectionbox({
+            id => '"Y2Partitioner::Dialogs::PartitionTableClone::DevicesSelector"'
+    });
+   $self->{tbl_available_devices} = $self->{app}->table({id => '"unselected"'});
+   $self->{tb_password} = $self->{app}->textbox({id => 'pw1'});
+   $self->{tree_system_view}       = $self->{app}->tree({id => '"Y2Partitioner::Widgets::OverviewTree"'});
+   $self->{tab_cwm} = $self->{app}->tab({id => '_cwm_tab'});
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+This class is a generic representation of the UI widget tree. The 
+class is using the WidgetController class to communicate with the 
+REST-Server and is providing methods to create 'handles' for the 
+various UI elements (buttons, checkboxes, text etc.).
+
+=head2 Class and object methods
+
+Class attributes:
+
+=over 4
+
+=item B<{api_version}> - The version of the YUI Rest API
+
+=item B<{host}> - The hostname or IP of the REST server
+
+=item B<{port}> - The port of the REST server
+
+=item B<{timeout}> - The timeout for communication with the server
+
+=item B<{interval}> - Interval time to try to reach the server
+
+=item B<{widget_controller}> - The instance of the widget controller to communicate with the server
+
+=back
+
+Class methods:
+
+A: Methods for communicating with the REST server
+
+B<new(%args)> - create new app
+
+The argument %args is a hash of named parameters C<{port}>, C<{host}>, C<{api_version}>, C<{timeout}> and
+C<{interval}>. With this the constructor creates a WidgetController.
+
+B<get_widget_controller()> - Get reference to the widget controller assigned to 
+the instance of app.
+
+B<get_port()> - get port used for the communication with the REST server
+
+B<get_host()> - get name or IP address for communication with REST server
+
+B<check_connection()> - checks if connection to REST server is working
+
+B: Methods for creating references to UI objects
+
+All these methods have in common that the method name describes what kind 
+of UI object is referenced. Every method has an argument $filter which 
+describes the identification of the UI element.
+
+B<button($filter)> - creates reference to a button
+
+B<checkbox($filter)> - creates a reference to a checkbox
+
+B<combobox($filter)> - creates a reference to a combobox
+
+B<itemselector($filter)> - creates a reference to an itemselector
+
+B<label($filter)> - creates a reference to a label
+
+B<menucollection($filter)> - creates a reference to a menucollection
+
+B<radiobutton($filter)> - creates a reference to a radiobutton
+
+B<richttext($filter)> - creates a reference to a richtext
+
+B<selectionbox($filter)> - creates a reference to a selectionbox
+
+B<table($filter)> - creates a reference to a table
+
+B<textbox($filter)> - creates a reference to a textbox
+
+B<tree($filter)> - creates a reference to a tree
+
+B<tab($filter)> - creates a reference to a tab
+
+=cut

--- a/lib/YuiRestClient/Filter.pm
+++ b/lib/YuiRestClient/Filter.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Filter;
 
@@ -56,3 +51,87 @@ sub resolve {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Filter - manage filter for YuiRestClient
+
+=head1 COPYRIGHT
+
+Copyright © 2021 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  $filter = YuiRestClient::Filter->new($filter);
+  return $self->{widget_controller}->find($self->{filter}->get_filter());
+  return $self->{filter}->is_resolved();
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Every YUI object that is created in the YuiRestClient is identified
+with a 'filter' that identifies the object. This class provides 
+methods to work with those filters. 
+
+=head2 Class and object methods
+
+Class attributes:
+
+=over 4
+
+=item B<{resolved}> - boolean to indicate that regex matched.
+On initialization of an object this will be 1 for standard arguments and
+0 if the argument contains a reglular expression. 
+
+=item B<{regex}> - a hash that stores the regex in {k, v}.
+If the argument list contains a regular expression then this is stored
+in the regex attribute as a hash with a key 'k' and a value 'v', where
+'v' represents the regular expression.
+
+=item B<{filter}> - a hash that contains the filter arguments. 
+If the argument list contains a regex, then this regex is removed from {filter} 
+during initialization.
+
+=back
+
+Object methods:
+
+B<new($args)> - create a filter object.
+
+The argument $args is a hash that can contain several key/value pairs to identify
+an UI object. Key values match the keys in the JSON representation of the UI widgets
+and values can be either simple strings or regular expressions ( qr/.../). 
+
+B<get_filter()> - returns the filter hash used to create the filter object
+
+Note that when a regex was used on creation then this is removed from the filter
+hash after initialization of the object. You need to call method resolve() to 
+insert a filter with the found match for the regex before calling get_filter()
+then.
+
+B<is_resolved()> - returns status of regex matching
+
+The method returns the value of the {resolved} attribute. This value will be 
+altered by the resolve() method. 
+
+B<resolve($json)> - resolve a regex 
+
+This method tries to match the regular expression that was used during 
+object creation. If exactly B<one> match was found the {filter} attribute gets
+a new key/value pair that holds the key and the true matching value for the
+regular expression. If the regex is resolved, then the attribute {resolve} is
+set to 1 (true). 
+
+
+=cut

--- a/lib/YuiRestClient/Http/HttpClient.pm
+++ b/lib/YuiRestClient/Http/HttpClient.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Http::HttpClient;
 use strict;
@@ -46,3 +41,77 @@ sub compose_uri {
     $url->query($args{params}) if $args{params};
     return $url;
 }
+
+1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Http::HttpClient - Interface to the Rest API on the server 
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  my $response = YuiRestClient::Http::HttpClient::http_get($uri);
+  my $response = YuiRestClient::Http::HttpClient::http_post($uri);
+  my $uri = YuiRestClient::Http::HttpClient::compose_uri(
+      host => $self->{host},
+      port => $self->{port},
+      path => $self->{api_version} . '/widgets',
+      params => $args
+  );
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Class to handle the HTTP traffic with the libYUI instance on the SUT. 
+Uses Mojo::UserAgent for HTTP protocol. 
+
+=head2 Class and object methods
+
+B<http_get($url)> - perform a HTTP/GET to the specified URL
+
+If the GET is successful (HTTP 200) then the data that was retrieved will be 
+returned. If HTTP errors occur the method will log a "Widget not found by url" 
+error message and then die with the error message returned by the server.
+
+B<http_post($url)> - perform a HTTP/POST to the specified URL
+
+If the POST is successful (HTTP 200) then the data that was retrieved will be 
+returned. If HTTP errors occur the method will log a "Widget not found by url" 
+error message and then die with the error message returned by the server.
+
+B<compose_url(%args)> - compose an URL using the named parameter list 
+
+This method uses a hash for a named parameter list. The following parameters can be used:
+
+=over 4
+
+=item * B<{port}> - the port number of the libYUI rest server, defaults to 80.
+
+=item * B<{host}> - The host name or IP address of the libYUI server.
+
+=item * B<{path}> - The access path. This is optional and can be omitted.
+
+=item * B<{params}> - Query parameters that can be used. This is optional and can be omitted.
+
+=back
+
+With those parameters compose_url() will create an URL that looks like this:
+
+http://{host}:{port}/{path}?{params}
+
+=cut

--- a/lib/YuiRestClient/Http/WidgetController.pm
+++ b/lib/YuiRestClient/Http/WidgetController.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Http::WidgetController;
 use strict;
@@ -86,3 +81,85 @@ sub send_action {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Http::WidgetController - Class to communicate with the REST server
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  return $self->{widget_controller}->find($self->{filter}->get_filter());
+  $self->{widget_controller}->send_action($params);
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+A class that provides a controller to retrieve widgets from the REST server
+or send actions to the server.
+
+=head2 Class and object methods
+
+Class attributes:
+
+=over 4
+
+=item B<{api_version}> - The version of the YUI Rest API
+
+=item B<{host}> - The hostname or IP of the REST server
+
+=item B<{port}> - The port of the REST server
+
+=item B<{timeout}> - The timeout for communication with the server
+
+=item B<{interval}> - Interval time to try to reach the server
+
+=back
+
+Class methods:
+
+B<new($args)> - create a new WidgetController instance
+
+Arguments in $args use the same names as the class attributes described above.
+
+B<set_timeout($timeout)> - change timeout setting
+
+Allows adjustments of timeout settings after the instance is created.
+
+B<set_interval($interval> - change interval time
+
+Allows adjustments to the interval time after the instance is created.
+
+B<set_host()> - change host name or IP address
+
+Allows adjustments to the host parameter after the instance is created.
+
+B<set_port()> - changes the port
+
+Allows adjustments to the port number after the instance is created.
+
+B<find($args)> - retrieve JSON data for UI widget
+
+The widget is defined by $args. Args is a hash that identifies a widget.
+The JSON data is retrieved using http_get() from Http::HttpClient.
+
+B<send_action($args)> - sends action to an UI widget
+
+The widget is defined by $args. Args is a hash that identifies the widget.
+The action is submitted to the server by using http_post() from Http::HttpClient.
+
+=cut

--- a/lib/YuiRestClient/Logger.pm
+++ b/lib/YuiRestClient/Logger.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Logger;
 use strict;
@@ -55,3 +50,84 @@ sub fatal {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Logger - class to log messages 
+
+=head1 COPYRIGHT
+
+Copyright © 2021 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  YuiRestClient::Logger->get_instance({format => \&bmwqemu::log_format_callback, 
+                         path => $path_to_log, level => $yui_log_level});
+
+  YuiRestClient::Logger->get_instance()->debug('Finding widget by url: ' . $uri);
+  YuiRestClient::Logger->info("Info message");
+  YuiRestClient::Logger->warn("Warn message");
+  YuiRestClient::Logger->error("Error message");
+  YuiRestClient::Logger->fatal("Fatal message");
+
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+A class that provides logging services. The class uses Mojo::Log for
+logging and works with Term::ANSIColor to colorize the log messages
+according to their level.
+
+=head2 Class and object methods
+
+B<get_instance(%args)> - create or use existing logger instance
+
+The %arg named parameters are
+
+=over 4
+
+=item * B<{level}> - the minimum log levels, log entries below this level will not appear in the log.
+
+=item * B<{format}> - a callback for formatting log messages
+
+=item * B<{path}> - the path and filename for the log file
+
+=back
+
+An instance for Logger is only created on the first invocation of get_instance(),
+further invocations use the already existing instance.
+
+B<debug($message)> - logs a debug message
+
+Debug messages are logged in white text color.
+
+=for Maintenance: Hopefully on a black background :-)
+
+B<info($message)> - logs an info message
+
+Info messages are logged in blue text color.
+
+B<warn($message)> - logs a warn message
+
+Warn messages are logged in yellow text color.
+
+B<error($message)> - logs an error message
+
+Error messages are logged in bold red text color.
+
+B<fatal($message)> - logs a fatal message
+
+Fatal messages are logged in bold red text color.
+
+=cut

--- a/lib/YuiRestClient/Sanitizer.pm
+++ b/lib/YuiRestClient/Sanitizer.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Sanitizer;
 use strict;
@@ -17,3 +12,40 @@ sub sanitize {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Sanitizer - remove '&' from labels
+
+=head1 COPYRIGHT
+
+Copyright © 2021 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+ $item = '&OK';
+ $item = YuiRestClient::Sanitizer::sanitize($item); 
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+This method removes the '&' from widget labels. The '&' is used in
+UI widgets to mark the hot key that is assigned to the widget,
+for example '&OK' to label an OK button.
+
+=head2 Class and object methods 
+
+B<sanitize($item)> - remove first '&' from item. 
+
+=cut

--- a/lib/YuiRestClient/Wait.pm
+++ b/lib/YuiRestClient/Wait.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Wait;
 use strict;
@@ -32,3 +27,62 @@ sub wait_until {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Wait - Wait for something
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+wait_until ( object => sub {...}, timeout => 10, interval => 1, message => '');
+
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+This class implements a method to wait for external triggers. The trigger is defined as
+a parameter called object which should define a sub that e.g. runs external commands. 
+The method waits for a defined amount of time if the object function returned a value,
+if not it will die with a timeout message.
+
+=head2 Class and object methods
+
+B<wait_until(%args)> - Wait until trigger or timeout
+
+The %args hash has the following named elements:
+
+=over 4
+
+=item * B<{object}> - defines the external function that should return a value within the specified time. 
+If no object is provided the method will die with an error message.
+
+=item * B<{timeout}> - defines the time to wait in seconds for the trigger to occur. The default is 10.
+
+=item * B<{intervall}> - defines how many seconds to wait before evaluating the object function again. 
+The default is 1.
+
+=item * B<{message}> - the error message that is used when the method timed out. 
+
+=back
+
+With all defaults this means, that the object function is evaluated every second for a maximum
+time of 10 seconds. If the object function does not succeed then the method dies and displays the
+error message. If the object function returned an error code in $@ then this error will be appended 
+to the message. 
+
+=cut

--- a/lib/YuiRestClient/Widget/Base.pm
+++ b/lib/YuiRestClient/Widget/Base.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::Base;
 
@@ -67,3 +62,69 @@ sub resolve_filter {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::Base - base class for all UI objects
+
+=head1 COPYRIGHT
+
+Copyright © 2021 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+ 
+  return $self->action(action => YuiRestClient::Action::YUI_PRESS);
+  return $self->{rt_eula}->exist();
+  my $is_enabled = $self->property('enabled');
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+This class provides base methods for all UI widget classes
+
+=head2 Class and object methods
+
+Class attributes:
+
+=over 4
+
+=item * B<{widget_controller}> - reference to WidgetController class
+
+=item * B<{filter}> - filter expression for identifying widgets
+
+=back
+
+Class methods:
+
+B<new($args)> - constructor for UI objects
+
+Arguments are I<widget_controller> and I<filter>. 
+
+B<action(%args)> - perform action on UI widget
+
+Arguments are a hash like C<{action =E<gt> YuiRestClient::Action::YUI_PRESS}>. 
+
+B<exist()> - check if UI widget exists
+
+Tries to find widget, returns 0 if widget exists.
+
+B<propery($property)> - return JSON property value
+
+If property does not exist the method will return C<undef>. 
+
+B<find_widgets()> - retrieves JSON hash for the widget
+
+The widget is specified by the C<filter> parameter on creation of the object.
+
+=cut

--- a/lib/YuiRestClient/Widget/Button.pm
+++ b/lib/YuiRestClient/Widget/Button.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::Button;
 
@@ -26,3 +21,51 @@ sub is_enabled {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::Button - Handle YQWizardButton, YPushButton
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+$self->{btn_next}->click()
+
+$self->{button}->is_enabled()
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+This class provides methods to interact with libyui button objects.
+
+=head2 Class and object methods 
+
+B<click()> - Send a press event to a button
+
+The button object receives a press event. 
+
+B<is_enabled()> - Check if button is enabled 
+
+=over 4
+
+=item * If the button object has a property 'enabled' then the value of this property is returned
+
+=item * If the button object has no property 'enabled' then it is considered to be enabled by default
+
+=back
+
+=cut

--- a/lib/YuiRestClient/Widget/CheckBox.pm
+++ b/lib/YuiRestClient/Widget/CheckBox.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::CheckBox;
 
@@ -34,3 +29,71 @@ sub uncheck {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::CheckBox - handle checkboxes
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  $self->{checkbox}->check();
+  $self->{checkbox}->is_checked();
+  $self->{checkbox}->toggle();
+  $self->{checkbox}->uncheck();
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+This class provides methods to interact with checkbox objects.
+
+The JSON representation of a checkbox object on the server side looks like this:
+
+    {
+     "class": "YCheckBox",
+     "debug_label": "Change the Time Now",
+     "id": "change_now",
+     "label": "Chan&ge the Time Now",
+     "notify": true,
+     "value": true
+    }
+
+
+=head2 Class and object methods 
+
+=for Maintenance:
+     It is probably a bug that methods like check(), uncheck() and toggle 
+     expect a parameter $item. Therefore I left it out of the method 
+     description.
+
+B<check()> - checks a checkbox
+
+Set "value" to "true" in YCheckBox. 
+
+B<is_checked()> - tests if a checkbox is checked.
+
+Returns the value property, so "true" if the checkbox is checked.
+
+B<toggle()> - inverts the current state of the checkbox
+
+Toggles the checkbox, therefore checked boxes become unchecked and viceversa.
+
+B<uncheck()> - unchecks a checkbox
+
+The value property is set to "false".
+
+=cut

--- a/lib/YuiRestClient/Widget/ComboBox.pm
+++ b/lib/YuiRestClient/Widget/ComboBox.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::ComboBox;
 
@@ -44,3 +39,68 @@ sub is_enabled {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::ComboBox - handle a ComboBox in the UI
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  $self->{cb_language}->items();
+  $self->{cb_language}->select($item);
+  $self->{cb_mount_point}->set($mount_point);
+  $self->{cb_language}->value();
+  $self->{cb_filesystem}->is_enabled();
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Class representing a ComboBox in the UI. It can be YComboBox.
+
+      {
+        "class": "YComboBox",
+        "debug_label": "NFS Version",
+        "icon_base_path": "",
+        "id": "nfs_version",
+        "items": [
+          {
+            "label": "Any (Highest Available)",
+            "selected": true
+          },
+          {
+            "label": "Force NFSv3"
+          }
+        ],
+        "items_count": 5,
+        "label": "NFS &Version",
+        "value": "Any (Highest Available)"
+      }
+
+=head2 Class and object methods
+
+B<items()> - returns a list of ComboBox items
+
+B<select($item> - selects an item in the ComboBox
+
+B<set($item)> - enters text into the ComboBox 
+
+B<value()> - returns the "value" property of the ComboBox
+
+B<is_enabled()> - returns if the ComboBox is enabled or not
+
+=cut

--- a/lib/YuiRestClient/Widget/ItemSelector.pm
+++ b/lib/YuiRestClient/Widget/ItemSelector.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::ItemSelector;
 
@@ -28,3 +23,49 @@ sub selected_items {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::ItemSelector - handle item selectors
+
+=head1 COPYRIGHT
+
+Copyright © 2021 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+$self->{rb_skip_registration}->select();
+$self->{cb_chunk_size}->select($chunk_size);
+
+return $self->{sel_role}->selected_items();
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+This class provides methods to select items like radio buttons
+or dropdown lists and to read out the current selection.
+
+=head2 Class and object methods 
+
+B<select($item)> - selects an item
+
+If the class object is a radio button then $item can be omitted. If the object is
+a multi-selector object you need to provide $item to specify what selection to make.
+
+B<selected_items()> - get a list of selected items
+
+This method returns an array with all the (sanitized) labels of items that are selected in the
+current class object. 
+
+=cut

--- a/lib/YuiRestClient/Widget/Label.pm
+++ b/lib/YuiRestClient/Widget/Label.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::Label;
 
@@ -18,3 +13,50 @@ sub text {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::Label - Handle YLabel, YLabel_Heading
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+$self->{rt_welcome}->text()
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Returns text value for the label. 
+
+If the JSON looks like this:
+
+   {
+      "class": "YLabel",
+      "debug_label": "short message",
+      "label": "test label",
+      "text": "text label"
+   }
+ 
+Then {app}->label({label => 'test label'})->text() will return 'text label'.
+
+=head2 Class and object methods 
+
+B<text()> - return text property for object.
+
+Returns the string from the object structure that has the key 'text'.
+
+=cut

--- a/lib/YuiRestClient/Widget/MenuCollection.pm
+++ b/lib/YuiRestClient/Widget/MenuCollection.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::MenuCollection;
 
@@ -22,3 +17,60 @@ sub select {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::MenuCollection - handle YMenuButton, YMenuBar
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+$self->{menu_btn_add}->select('&From List');
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Selects menu items by using their menu path description.
+
+      {
+        "class": "YMenuButton",
+        "debug_label": "test",
+        "icon_base_path": "",
+        "id": "test_id",
+        "items": [
+          {
+            "label": "button1"
+          },
+          {
+            "label": "button2"
+          },
+          {
+            "label": "button3"
+          }
+        ],
+        "items_count": 3,
+        "label": "button group"
+        }
+
+=head2 Class and object methods
+
+B<select($path)> - select menu item specified by path
+
+Path descriptions can be strings like '&From List' or '&File|Open File...' for 
+nested menu items.
+
+=cut

--- a/lib/YuiRestClient/Widget/RadioButton.pm
+++ b/lib/YuiRestClient/Widget/RadioButton.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::RadioButton;
 
@@ -25,3 +20,53 @@ sub is_selected {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::RadioButton - Handle radio buttons
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+$self->{rb_skip_registration}->select();
+
+$self->{$rb_name}->is_selected();
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Class representing a RadioButton in the UI. It can be YRadioButton.
+
+    {
+      "class": "YRadioButton",
+      "debug_label": "Manually",
+      "id": "manual",
+      "label": "&Manually",
+      "notify": true,
+      "value": false
+    }
+
+=head2 Class and object methods
+
+B<select()> - selects the radio button 
+
+This will set the "value" property to true and deselect all other radio buttons
+of the current group.
+
+B<is_selected()> - returns the "value" property of the radio button
+
+=cut

--- a/lib/YuiRestClient/Widget/RichText.pm
+++ b/lib/YuiRestClient/Widget/RichText.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020-2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::RichText;
 
@@ -24,3 +19,54 @@ sub activate_link {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::RichText - handle rich text objects
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+return $self->{rt_welcome}->text();
+
+return $self->{rt_items}->activate_link($module_full_name);
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Class to work with YRichText objects. Rich text objects are
+
+    {
+         "class": "YRichText",
+         "enabled": false,
+         "hstretch": true,
+         "id": "test",
+         "text": "<small>Select something here</small>",
+         "vstretch": true,
+         "vweight": 25
+    }
+
+=head2 Class and object methods
+
+B<text()> - return the value of the "text" property.
+
+B<activate_link($link)> - activates a link in the rich text
+
+If the rich text field contains a link, then this link can be activated with
+this function. 
+
+=cut

--- a/lib/YuiRestClient/Widget/SelectionBox.pm
+++ b/lib/YuiRestClient/Widget/SelectionBox.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::SelectionBox;
 
@@ -37,3 +32,71 @@ sub items {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::SelectionBox - Class representing a selection box in the UI. It can be YSelectionBox
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Handles a selection box.
+
+      {
+        "class" : "YSelectionBox",
+        "debug_label" : "selection box title",
+        "hstretch" : true,
+        "icon_base_path" : "",
+        "id" : "test_id",
+        "items" :
+        [
+          {
+            "label" : "selection 1",
+            "selected" : true
+          },
+          {
+            "label" : "selection 2"
+          },
+          {
+            "label" : "selection 3"
+          }
+        ],
+        "items_count" : 3,
+        "label" : "&selection box title",
+        "vstretch" : true
+      }
+
+=head2 Class and object methods
+
+B<select($item)> - Select item in a SelectionBox object.
+
+The item is identified by its label.
+
+B<check($item)> - Select item in a SelectionBox object.
+
+The item is identified by its label.
+
+B<uncheck($item)> - Unselect item in a SelectionBox object.
+
+The item is identified by its label.
+
+B<items()> - returns a map of available items in the SelectionBox object.
+
+=cut

--- a/lib/YuiRestClient/Widget/Tab.pm
+++ b/lib/YuiRestClient/Widget/Tab.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2021 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::Tab;
 
@@ -17,7 +12,6 @@ sub select {
     my ($self, $item) = @_;
     $self->action(action => YuiRestClient::Action::YUI_SELECT, value => $item);
 }
-
 sub selected_tab {
     my ($self) = @_;
     my $tabs = $self->property('items');
@@ -25,3 +19,63 @@ sub selected_tab {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::Tab - Class representing a tab in the UI. It can be YDumbTab.
+
+=head1 COPYRIGHT
+
+Copyright ©2021  SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+$self->{tab_cwm}->select("&Kernel Settings");
+
+return $self->{tb_boot_options}->selected_tab();
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+A class to handle a tab.
+
+    {
+      "class": "YDumbTab",
+      "debug_label": "YDumbTab [tab1] [tab2] [tab3]",
+      "hstretch": true,
+      "icon_base_path": "",
+      "id": "test_id",
+      "items": [
+         {
+           "label": "tab1"
+         },
+         {
+           "label": "tab2",
+           "selected": true
+         },
+         {
+           "label": "tab3"
+         }
+       ],
+       "items_count": 3,
+       "vstretch": true
+    }
+
+=head2 Class and object methods
+
+B<select($item)> - sends an action to click the tab in the UI
+
+B<selected_tab()> - returns the label of the selected tab
+
+=cut

--- a/lib/YuiRestClient/Widget/Table.pm
+++ b/lib/YuiRestClient/Widget/Table.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::Table;
 
@@ -51,3 +46,107 @@ sub get_index {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::Table - Handle table objects in the UI
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  $self->{tbl_available_devices}->select(value => $device);
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Class representing a table in the UI. It can be YTable.
+
+        {
+          "class": "YTable",
+          "columns": 4,
+          "header": [
+            "header1",
+            "header2",
+            "header3",
+            "header4"
+          ],
+          "id": "test_id",
+          "items": [
+              {
+                  "labels": [
+                     "test.item.1",
+                     "",
+                     "",
+                     ""
+                  ],
+                  "selected": true
+              },
+              {
+                  "labels": [
+                      "test.item.2",
+                      "",
+                      "",
+                      ""
+                  ]
+              }
+          ],
+          "items_count": 2
+        }
+
+=head2 Class and object methods
+
+B<select(%args)> - select a row in a table
+
+Sends action to select a row in a table. Row can be selected either by
+cell value in the column (first column will be used by default), or by
+row number directly. If both are provided, value will be used.
+NOTE: row number corresponds to the position of the
+item in the list of column values which might differ to the display order.
+
+The %args has has the following keys:
+
+=over 4
+
+=item * B<{value}> - [String] value to select in the table
+
+=item * B<{column}> - [String] column name where value is present
+
+=item * B<{row}> - [Numeric] row number to select in the table
+
+=back
+
+Example: Select row with value "test.item.2" for column "header1" in table 
+
+  $self->{table}->select(value => 'test.item.2', column => 'header1');
+
+Example: Select row number 3
+
+  $self->{table}->select(row => 3);
+
+B<header()> - returns array with the column names
+
+B<items()> - returns all table items
+
+For the example table above this function would return
+
+  (["test.item.1", "", ""],["Test.item.2", "", ""])
+
+B<get_index($column)> - return the index of the column 
+
+The parameter $column specifies the header string that we're looking for. 
+
+=cut

--- a/lib/YuiRestClient/Widget/Textbox.pm
+++ b/lib/YuiRestClient/Widget/Textbox.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::Textbox;
 
@@ -24,3 +19,53 @@ sub value {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::Textbox - handle text boxes
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+return $self->{tb_full_name}->set($full_name);
+
+$self->{tb_keyboard_test}->value();
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Class to represent a text box. It can be YInputField. 
+
+    {
+       "class": "YInputField",
+       "debug_label": "label_test",
+       "hstretch": true,
+       "id": "test",
+       "input_max_length": 256,
+       "label": "label_test",
+       "password_mode": false,
+       "valid_chars": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.",
+       "value": ""
+    }
+
+=head2 Class and object methods
+
+B<set($value)> - sets "value" property to $value.
+
+B<value()> - returns the current string stored in the "value" property. 
+
+=cut

--- a/lib/YuiRestClient/Widget/Tree.pm
+++ b/lib/YuiRestClient/Widget/Tree.pm
@@ -1,9 +1,4 @@
 # SUSE's openQA tests
-#
-# Copyright 2020 SUSE LLC
-# SPDX-License-Identifier: FSFAP
-
-# Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package YuiRestClient::Widget::Tree;
 
@@ -44,3 +39,102 @@ sub get_selected_node {
 }
 
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+YuiRestClient::Widget::Tree - handle a tree in the UI
+
+=head1 COPYRIGHT
+
+Copyright © 2020 SUSE LLC
+
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE YaST <qa-sle-yast@suse.de>
+
+=head1 SYNOPSIS
+
+  $self->{tree_system_view}->select($item);
+  $self->{tree_system_view}->selected_item();
+  $self->{tree_system_view}->get_selected_node($item);
+
+=head1 DESCRIPTION
+
+=head2 Overview
+
+Class representing a tree in UI. It can be YTree.
+
+      {
+        "class": "YTree",
+        "debug_label": "node_0",
+        "hstretch": true,
+        "hweight": 30,
+        "icon_base_path": "",
+        "id": "test_id",
+        "items": [
+          {
+            "children": [
+              {
+                "icon_name": "icon",
+                "label": "node1_1"
+              },
+              {
+                "children": [
+                  {
+                    "label": "node1_2_1"
+                  },
+                  {
+                    "label": "node1_2_2",
+                    "selected": true
+                  }
+                ],
+                "icon_name": "icon",
+                "label": "node1_2"
+              }
+            ],
+            "icon_name": "icon",
+            "label": "node1",
+          },
+          {
+            "icon_name": "icon",
+            "label": "node2"
+          }
+        ],
+        "items_count": 2,
+        "label": "node_0",
+        "notify": true,
+        "vstretch": true
+      }
+
+=head2 Class and object methods
+
+B<select($path)> - selects item that is specified by $path. 
+
+The parameter $path is defining the label property of the node in the tree.
+
+B<selected_item()> - returns the path to the selected item
+
+The returned path contains the node labels (separated by "|") in the branch 
+of the tree were the selected item is found. So in the example tree above 
+the method would return "node1|node1_2|node21_2_2"
+
+B<get_selected_node( %args )> - return path to selected node
+
+Args has 2 named parameters:
+
+=over 4
+
+* item => the property that we're looking for, eg. property('items').
+
+* path => the path starting with a node
+
+The path parameter is used for recursion in this function. 
+
+=cut
+


### PR DESCRIPTION
Add some POD documentation text to YuiRestClient

- added doc for Sanitizer.pm
- added doc for ItemSelector.pm
- added doc for Label.pm
- added doc for Button.pm
- added doc for Checkbox.pm
- added doc for Action.pm
- added doc for MenuCollection.pm
- added doc for RadioButton.pm
- added doc for RichText.pm
- added doc for Textbox.pm
- added doc for SelectionBox.pm
- added doc for Tab.pm

- Related ticket: https://progress.opensuse.org/issues/93306

