### PR TITLE
update_kernel: Update system before installing alternative kernel

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -63,6 +63,7 @@ sub first_azure_release {
 sub prepare_azure {
     my $self = shift;
 
+    fully_patch_system;
     remove_kernel_packages();
     zypper_call("in -l kernel-azure", exitcode => [0, 100, 101, 102, 103], timeout => 700);
     check_kernel_package('kernel-azure');
@@ -73,6 +74,7 @@ sub prepare_azure {
 sub prepare_kernel_base {
     my $self = shift;
 
+    fully_patch_system;
     remove_kernel_packages();
     zypper_call("in -l kernel-default-base", exitcode => [0, 100, 101, 102, 103], timeout => 700);
     check_kernel_package('kernel-default-base');


### PR DESCRIPTION
Some system pattern upgrades may pull in kernel-default after it has been uninstalled and replaced by a different kernel type, which will cause error during kernel package checks at the end. Run system update before switching kernels.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - kernel-azure: https://openqa.suse.de/tests/7339024
  - kernel-default-base: https://openqa.suse.de/tests/7345816
