### PR TITLE
cthon04: add time into dependency

### DIFF
--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -41,6 +41,7 @@ sub install_dependencies_cthon04 {
       nfs-client
       nfs-kernel-server
       libtirpc-devel
+      time
     );
     zypper_call('in ' . join(' ', @deps));
 }


### PR DESCRIPTION
When run cthon04 in some product, it will block by lack of this package. Add this time package into dependency.

- Related ticket: https://progress.opensuse.org/issues/99471
- Verification run: http://10.67.133.102/tests/397