### PR TITLE
lib/utils: Fix script_run_interactive

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1641,14 +1641,15 @@ sub script_run_interactive {
         push(@words, $k->{prompt});
     }
 
-    push(@words, $endmark);
+    # Hack: '$' doesn't match '\r\n' line endings, so use '\s' instead
+    push(@words, qr/${endmark}\d+\s/m);
 
     {
         do {
             $output = wait_serial(\@words, $timeout) || die "No message matched!";
 
-            last if ($output =~ /($endmark)0$/m);    # return value is 0
-            die  if ($output =~ /$endmark/m);        # other return values
+            last if ($output =~ /${endmark}0\s/m);    # return value is 0
+            die  if ($output =~ /${endmark}/m);       # other return values
 
             for my $i (@$scan) {
                 next if ($output !~ $i->{prompt});


### PR DESCRIPTION
wait_serial only returns the match, never more than that. So the return value
was missing in the returned string, which caused it to die.

Fix this by waiting for the return value up to the line ending.

- Verification run: https://openqa.opensuse.org/tests/1959708
