### PR TITLE
Boot from hdd image to run test tomcat

### DIFF
--- a/schedule/functional/tomcat.yaml
+++ b/schedule/functional/tomcat.yaml
@@ -1,40 +1,10 @@
 ---
 name: tomcat
 description: >
-    Maintainer: zluo
+    Maintainer: zluo@suse.com
     Install and test tomcat packages after Online-installation of SLES,
     Boot from HDD directly to run tomcat on Tumbleweed.
-conditional_schedule:
-    tw_tests:
-        DISTRI:
-            opensuse:
-                - boot/boot_to_desktop
-    sles_tests:
-        DISTRI:
-            sle:
-                - installation/bootloader_start
-                - installation/welcome
-                - installation/accept_license
-                - installation/scc_registration
-                - installation/addon_products_sle
-                - installation/system_role
-                - installation/partitioning
-                - installation/partitioning_finish
-                - installation/installer_timezone
-                - installation/user_settings
-                - installation/user_settings_root
-                - installation/resolve_dependency_issues
-                - installation/select_patterns
-                - installation/installation_overview
-                - installation/disable_grub_timeout
-                - installation/start_install
-                - installation/await_install
-                - installation/logs_from_installation_system
-                - installation/reboot_after_installation
-                - installation/handle_reboot
-                - installation/first_boot
 schedule:
-    - '{{tw_tests}}'
-    - '{{sles_tests}}'
+    - boot/boot_to_desktop
     - x11/tomcat
     - shutdown/shutdown


### PR DESCRIPTION
at moment it runs a full installation and then run tomcat, this should be changed into
boot from hdd image and run tomcat.
Need to schedule test after 'create-hdd-allmodules-allpatterns-gnome' in test suite tomcat.
see https://progress.opensuse.org/issues/98817
verifications:
http://10.162.30.85/tests/3777 (sles)
http://10.162.30.85/tests/3779 (Tumbleweed)
