### PR TITLE
Enable missing system role selection for Leap

### DIFF
--- a/lib/Distribution/Opensuse/Leap/15.pm
+++ b/lib/Distribution/Opensuse/Leap/15.pm
@@ -20,6 +20,7 @@ use warnings FATAL => 'all';
 use parent 'Distribution::Sle::15_current';
 use Installation::License::Opensuse::Firstboot::LicenseAgreementController;
 use Installation::License::Opensuse::LicenseAgreementController;
+use Installation::SystemRole::SystemRoleController;
 
 =head2 get_firstboot_license_agreement
 
@@ -33,6 +34,10 @@ sub get_firstboot_license_agreement {
 
 sub get_license_agreement {
     return Installation::License::Opensuse::LicenseAgreementController->new();
+}
+
+sub get_system_role_controller {
+    return Installation::SystemRole::SystemRoleController->new();
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [poo#96803](https://progress.opensuse.org/issues/96803)
- Verification run: https://openqa.opensuse.org/tests/1959259
