### PR TITLE
Fix 'df -PT /boot/grub2/arm64-efi/'  timeout on Aarch64

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1679,7 +1679,7 @@ ref:bsc#1122591
 =cut
 sub create_btrfs_subvolume {
     my $fstype;
-    $fstype = script_output("df -PT /boot/grub2/arm64-efi/ | grep -v \"Filesystem\" | awk '{print \$2}'");
+    $fstype = script_output("df -PT /boot/grub2/arm64-efi/ | grep -v \"Filesystem\" | awk '{print \$2}'", 120);
     return if ('btrfs' ne chomp($fstype));
     my @sub_list = split(/\n/, script_output("btrfs subvolume list /boot/grub2/arm64-efi/", 120));
     foreach my $line (@sub_list) {


### PR DESCRIPTION
In create_btrfs_subvolume, the 'df -PT /boot/grub2/arm64-efi/' will
timed out in the default timeout  30s for script_out function. We need
to enlarge it to make it pass on the Aarch64 platform.

- Related ticket: https://progress.opensuse.org/issues/100647
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/7354281#step/patch_sle/162
