### PR TITLE
Reuse ima key dir if exist

### DIFF
--- a/tests/security/ima/evm_setup.pm
+++ b/tests/security/ima/evm_setup.pm
@@ -38,7 +38,7 @@ sub run {
 
     # Create Kernel Master Key
     assert_script_run "keyctl add user kmk-user '`dd if=/dev/urandom bs=1 count=32 2>/dev/null`' \@u";
-    assert_script_run "mkdir $key_dir";
+    script_run "[ -d $key_dir ] || mkdir $key_dir";
     assert_script_run "keyctl pipe `/bin/keyctl search \@u user kmk-user` > $userkey_blob";
 
     # Generate EVM key which will be used for HMACs


### PR DESCRIPTION
On sles15sp4, "/etc/keys" dir will be created after
installing "keyutils" package. we should re-use it
as evm keys' location as we do on previous release.

- Related ticket: https://progress.opensuse.org/issues/100656
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/7354689