### PR TITLE
Increase timeout in first MicroOS Toolbox command

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -47,7 +47,7 @@ sub run {
     assert_script_run 'toolbox -h';
 
     record_info 'Test',                    "Run toolbox without flags";
-    assert_script_run 'toolbox -r id',     timeout => 180;
+    assert_script_run 'toolbox -r id',     timeout => 300;
     validate_script_output 'podman ps -a', sub { m/toolbox-root/ };
     assert_script_run 'podman rm toolbox-root';
 


### PR DESCRIPTION
This first command pulls the image, so it takes longer and it hits
timeout in some tests on slower machines.

failures:
https://openqa.suse.de/tests/7367680#step/toolbox/17
https://openqa.suse.de/tests/7367681#step/toolbox/17

VRs:
https://openqa.suse.de/tests/7370511
https://openqa.suse.de/tests/7370513
