### PR TITLE
Bump timeout for libyui for slower archs

### DIFF
--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -46,7 +46,7 @@ sub run {
         $cmd .= YuiRestClient::get_yui_params_string($port) . " yast.ssh";
         enter_cmd($cmd);
     }
-    $app->check_connection(timeout => 500, interval => 10);
+    $app->check_connection(timeout => 540, interval => 10);
 }
 
 1;


### PR DESCRIPTION
Before we had around 7 minutes https://openqa.suse.de/tests/7200517
Let's try bumping only 40 seconds so we can round to 9 minutes, because it looks more related with aarch and other packages different than YaST ones. RAM should be fine after applying: https://bugzilla.suse.com/show_bug.cgi?id=1191203
