### PR TITLE
Add x11_yast for system role SLES with GNOME

### DIFF
--- a/test_data/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/test_data/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -11,6 +11,7 @@ software:
     - fonts
     - gnome_basic
     - x11
+    - x11_yast
     - yast2_basis
     - yast2_desktop
     - yast2_server


### PR DESCRIPTION
x11_yast pattern is listed as the default pattern for the "SLES with GNOME" role: https://github.com/yast/system-role-server-default/blob/master/control/installation.xml#L32

- Verification run: [select_modules_and_patterns+registration](https://openqa.suse.de/tests/7374978)
