### PR TITLE
wget is not a part of base install for sle-15-SP2 and older, fixed by…

### DIFF
--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -62,7 +62,7 @@ sub run {
             # Download the diskimage. Note: this could be merged with download_image.pm at some point
             my $source = $guest->{source};
             my $disk   = $guest->{disk};
-            script_retry("wget -qO '$disk' '$source'", retry => 3, delay => 60, timeout => 300);
+            script_retry("curl -so '$disk' '$source'", retry => 3, delay => 60, timeout => 300);
             import_guest($guest);
         } else {
             die "Unsupported method '$method' for guest $guest";


### PR DESCRIPTION
… replacing it with curl
This PR fixes an issue introduced in this [PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13211)

- Related ticket: N/A
- Needles: N/A
- Verification run: http://d488.qam.suse.de/tests/942#step/prepare_guests/1

*VR will fail at waitfor_guests it is a[ know issue](https://progress.opensuse.org/issues/99030) and not related to this change.
