### PR TITLE
SLE Micro: Remove journal history before installing updates

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -24,6 +24,12 @@ sub run {
     if (is_sle_micro) {
         assert_script_run 'curl -k https://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt';
         assert_script_run 'update-ca-certificates -v';
+
+        # Clean the journal to avoid capturing bugs that are fixed after installing updates
+        assert_script_run('journalctl --no-pager -o short-precise | tail -n +2 > /tmp/journal_before');
+        upload_logs('/tmp/journal_before');
+        assert_script_run('journalctl --sync --flush --rotate --vacuum-time=1second');
+        assert_script_run('rm /tmp/journal_before');
     }
     add_test_repositories;
     record_info 'Updates', script_output('zypper lu');


### PR DESCRIPTION
Journal_check module will capture bugs that are shown in the
journal before installing the updates. By removing all the
history, we make sure those are not shown any more and only
potential new error messages are shown in the test.

- Related ticket: https://progress.opensuse.org/issues/100739
- Related discussion: https://bugzilla.suse.com/show_bug.cgi?id=1177695#c19

issue: https://openqa.suse.de/tests/7367650#step/journal_check/20
VR: https://openqa.suse.de/tests/7377581
