### PR TITLE
WIP Increase timeout and repeat needle match in Tomcat

### DIFF
--- a/lib/Tomcat/JspTest.pm
+++ b/lib/Tomcat/JspTest.pm
@@ -15,8 +15,8 @@ use utils;
 use Tomcat::Utils;
 use version_utils 'is_sle';
 
-# allow a 60 second timeout for asserting needles
-use constant TIMEOUT => 60;
+# allow a 90 second timeout for asserting needles
+use constant TIMEOUT => 90;
 
 # test all JSP examples
 sub test_all_examples() {
@@ -32,10 +32,13 @@ sub test_all_examples() {
     # access the tomcat jsp examples page
     if ($mod_jk) {
         $self->firefox_open_url('localhost/examples/jsp');
+        wait_still_screen;
     } else {
         $self->firefox_open_url('localhost:8080/examples/jsp');
+        wait_still_screen;
     }
-    send_key_until_needlematch('tomcat-jsp-examples', 'ret');
+    send_key_until_needlematch('tomcat-jsp-examples', 'ret', 10, 5);
+    wait_still_screen;
 
     # Navigate with keyboard to each example and test it
     for my $i (0 .. $#jsp_examples) {
@@ -44,7 +47,8 @@ sub test_all_examples() {
     # test xhtml svg example
     if (!$mod_jk) {
         $self->firefox_open_url('localhost:8080/examples/jsp/jsp2/jspx/textRotate.jspx?name=testing');
-        send_key_until_needlematch('tomcat-xhtml-svg', 'ret');
+        send_key_until_needlematch('tomcat-xhtml-svg', 'ret', 10, 5);
+        wait_still_screen;
     }
 }
 

--- a/lib/Tomcat/ServletTest.pm
+++ b/lib/Tomcat/ServletTest.pm
@@ -16,7 +16,7 @@ use Tomcat::Utils;
 use version_utils 'is_sle';
 
 # allow a TIMEOUT second timeout for asserting needles
-use constant TIMEOUT => 60;
+use constant TIMEOUT => 90;
 
 # test all Servlet examples
 sub test_all_examples() {
@@ -35,7 +35,8 @@ sub test_all_examples() {
     } else {
         $self->firefox_open_url('localhost:8080/examples/servlets');
     }
-    send_key_until_needlematch('tomcat-servlet-examples-page', 'ret');
+    send_key_until_needlematch('tomcat-servlet-examples-page', 'ret', 10, 5);
+    wait_still_screen;
 
     # Navigate with keyboard to each example and test it
     for my $i (0 .. $#servlet_examples) {

--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -16,8 +16,8 @@ use utils;
 use version_utils 'is_sle';
 use registration;
 
-# allow a 60 second timeout for asserting needles
-use constant TIMEOUT => 60;
+# allow a 90 second timeout for asserting needles
+use constant TIMEOUT => 90;
 
 # Use keyboard to browse the examples faster
 sub browse_with_keyboard {
@@ -30,6 +30,7 @@ sub browse_with_keyboard {
 
     $test_func->();
     send_key('ctrl-w');
+    wait_still_screen;
 }
 
 # Install tomcat and set initial configuration
@@ -73,7 +74,7 @@ sub tomcat_manager_test() {
     my ($self) = shift;
 
     $self->firefox_open_url('localhost:8080/manager');
-    send_key_until_needlematch('tomcat-manager-authentication', 'ret');
+    send_key_until_needlematch('tomcat-manager-authentication', 'ret', 10, 5);
     type_string('admin');
     send_key('tab');
     type_string('admin');

--- a/lib/Tomcat/WebSocketsTest.pm
+++ b/lib/Tomcat/WebSocketsTest.pm
@@ -14,8 +14,8 @@ use testapi;
 use utils;
 use Tomcat::Utils;
 
-# allow a 60 second timeout for asserting needles
-use constant TIMEOUT => 60;
+# allow a 90 second timeout for asserting needles
+use constant TIMEOUT => 90;
 
 # test all WebSocket examples
 sub test_all_examples() {
@@ -26,7 +26,8 @@ sub test_all_examples() {
 
     # access the tomcat websocket examples page
     $self->firefox_open_url('localhost:8080/examples/websocket');
-    send_key_until_needlematch('tomcat-websocket-examples', 'ret');
+    send_key_until_needlematch('tomcat-websocket-examples', 'ret', 10, 5);
+    wait_still_screen;
 
     # Navigate with keyboard to each example and test it
     for my $i (0 .. $#websocket_examples) {
@@ -55,9 +56,18 @@ sub chat() {
 
 # test snake example
 sub snake() {
-    assert_screen('tomcat-snake-example-loaded', TIMEOUT);
-    send_key('right');
-    send_key('down');
+    assert_screen([qw(tomcat-snake-example-loaded websocket-snake-not-opened)], 120);
+    if (match_has_tag 'tomcat-snake-example-loaded') {
+        send_key('right');
+        send_key('down');
+    }
+    elsif (match_has_tag 'websocket-snake-not-opened') {
+        record_info 'poo#96611 - sporadic performance issue';
+        # give second chance after timeout
+        assert_screen('tomcat-snake-example-loaded', TIMEOUT);
+        send_key('right');
+        send_key('down');
+    }
     assert_screen('tomcat-snake-example', TIMEOUT);
 }
 


### PR DESCRIPTION
We still have sporadic performance issue in Tomcat.
Increase timeout for needle match and add wait_still_screen after
send_key 'ret'. Repeat needle match to avoid performance issue. 
Add record_info  about this performance issue.
see https://progress.opensuse.org/issues/96611
verification:
http://10.162.30.85/tests/4302#step/tomcat/205