### PR TITLE
As openldap2 has been deleted at sles15sp4, added it for openldap to 389ds test

### DIFF
--- a/tests/migration/openldap_to_389ds.pm
+++ b/tests/migration/openldap_to_389ds.pm
@@ -37,8 +37,15 @@ sub run {
     zypper_call("in 389-ds sssd sssd-tools");
     zypper_call('info 389-ds');
     # Install openldap since we need use slaptest tools
-    add_suseconnect_product('sle-module-legacy') if is_sle;
-    zypper_call("in openldap2 sssd-ldap openldap2-client");
+    if (is_sle) {
+        my $openldap = get_required_var("OPENLDAP_PKG");
+        assert_script_run('wget ' . $openldap, 200);
+        my @ldap = split('/', $openldap);
+        assert_script_run 'rpm -i ' . $ldap[-1];
+    } else {
+        zypper_call("in openldap2");
+    }
+    zypper_call("in sssd-ldap openldap2-client");
 
     # Disable and stop the nscd daemon because it conflicts with sssd
     disable_and_stop_service("nscd");


### PR DESCRIPTION
As openldap2 has been deleted at sles15sp4, added it for openldap
to 389ds test
- Related ticket: https://progress.opensuse.org/issues/97646
- Verification run: https://openqa.suse.de/tests/7354745#
                            https://openqa.suse.de/tests/7371916#
                            https://openqa.suse.de/tests/7397410#
                           https://openqa.suse.de/tests/7397732#