### PR TITLE
Increase timeout for zypper-docker up

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -129,8 +129,8 @@ sub build_with_zypper_docker {
     }
 
     zypper_call("in zypper-docker") if (script_run("which zypper-docker") != 0);
-    assert_script_run("zypper-docker list-updates $image", 240);
-    assert_script_run("zypper-docker up $image $derived_image", timeout => 160);
+    assert_script_run("zypper-docker list-updates $image", 300);
+    assert_script_run("zypper-docker up $image $derived_image", timeout => 300);
 
     # If zypper-docker list-updates lists no updates then derived image was successfully updated
     assert_script_run("zypper-docker list-updates $derived_image | grep 'No updates found'", 240);

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -279,7 +279,7 @@ sub cleanup_system_host {
     my ($self, $assert) = @_;
     $assert //= 1;
     $self->_engine_assert_script_run("ps -q | xargs -r " . $self->runtime . " stop", 180);
-    $self->_engine_assert_script_run("system prune -a -f", 180);
+    $self->_engine_assert_script_run("system prune -a -f", 300);
 
     if ($assert) {
         assert_equals(0, scalar @{$self->enum_containers()}, "containers have not been removed");


### PR DESCRIPTION
This should fix occasional timeouts in `docker_image` and `podman_image` on aarch64


- Related issue: https://progress.opensuse.org/issues/99789
- Verification run: https://openqa.suse.de/t7385414 | https://openqa.suse.de/t7386066 (fails in unrelated test)
