### PR TITLE
Fix myapp image not found issue on s390x

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -73,9 +73,10 @@ sub build_and_run_image {
 
     # At least on publiccloud, this image pull can take long and occasinally fails due to network issues
     $builder->build($dir . "/BuildTest", "myapp", (timeout => is_x86_64 ? 600 : 1200));
-    my $imgs = $builder->get_images_by_repo_name();
-    die "myapp image not found in the local registry" unless (grep { $_ =~ /myapp/ } @{$imgs});
     assert_script_run("rm -rf $dir");
+    script_run("$runtime images");
+    assert_script_run("$runtime images --all | grep myapp");
+
 
     if ($runtime->runtime eq 'docker' && $builder->runtime eq 'buildah') {
         assert_script_run "buildah push myapp docker-daemon:myapp:latest";


### PR DESCRIPTION
This commit fixes the 'myapp image not found' error on s390x by directly
querying the image name without going the extra path of querying
repositories in a special format.

- Related ticket: https://progress.opensuse.org/issues/100826
- Verification run: https://openqa.suse.de/t7386236 https://openqa.opensuse.org/t1964266 https://openqa.opensuse.org/t1964267 https://openqa.suse.de/t7386162 https://openqa.suse.de/t7386163
