### PR TITLE
Enhance code to check NIC name

### DIFF
--- a/tests/security/create_swtpm_hdd/build_hdd.pm
+++ b/tests/security/create_swtpm_hdd/build_hdd.pm
@@ -45,7 +45,8 @@ sub run {
 
     # Define a new udev rule file to keep the NIC name persistent across OS rebooting
     my $udev_rule_file = '/etc/udev/rules.d/70-persistent-net.rules';
-    my $nic_name = script_output("ls /etc/sysconfig/network | grep ifcfg- | grep -v lo | awk -F '-' '{print \$2}'");
+    my $mac_addr = get_var("NICMAC");
+    my $nic_name = script_output("grep $mac_addr /sys/class/net/*/address |cut -d / -f 5");
     assert_script_run("wget --quiet " . data_url("swtpm/70-persistent-net.rules") . " -O $udev_rule_file");
     assert_script_run("sed -i 's/NAME=\"\"/ NAME=\"$nic_name\"/' $udev_rule_file");
 


### PR DESCRIPTION
Use mac address as index to find the right NIC name

   - Related ticket: https://progress.opensuse.org/issues/100811
    - Needles: n/a
    - Verification run:
    https://openqa.opensuse.org/tests/1964232 (TW)
    https://openqa.suse.de/tests/7384675 (SLES)
