### PR TITLE
Don't look for `systemd-logger` in TW

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -153,8 +153,12 @@ sub run {
     # To enable persistent logging in opensuse, we use systemd-logger.rpm that creates */var/log/journal/* directory
     get_current_boot_id \@boots;
     if (has_default_persistent_journal) {
-        assert_script_run 'rpm -q systemd-logger';
-        assert_script_run "rpm -q --conflicts systemd-logger | tee -a /dev/$serialdev | grep syslog";
+        if (is_tumbleweed) {
+            script_output(sprintf("test -d %s && ls --almost-all %s", PERSISTENT_LOG_DIR, PERSISTENT_LOG_DIR));
+        } else {
+            assert_script_run 'rpm -q systemd-logger';
+            assert_script_run "rpm -q --conflicts systemd-logger | tee -a /dev/$serialdev | grep syslog";
+        }
     } else {
         script_run("journalctl --boot=-1 | grep 'no persistent journal was found'") or die "Persistent journal should not be enabled by default on SLE!\n";
         assert_script_run "mkdir ${\ PERSISTENT_LOG_DIR }";


### PR DESCRIPTION
- [[qe-core] test fails in journalctl - systemd-logger deprecated](https://progress.opensuse.org/issues/100470)
- VRs:
  - [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build31.574-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/7851#step/journalctl/1)
  - [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20211008-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/7858#step/journalctl/18)
