### PR TITLE
Add pam.pm to JeOS main test suite

### DIFF
--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -36,6 +36,7 @@ schedule:
     - jeos/build_key
     - console/prjconf_excluded_rpms
     - console/journal_check
+    - console/pam
     - microos/libzypp_config
     - console/suseconnect_scc
     - '{{maintenance}}'


### PR DESCRIPTION
- VRs
  * [15-SP3-JeOS-for-kvm-and-xen-QR-x86_64-Build3.3.6-jeos-main@svirt-xen-pv](http://kepler.suse.cz/tests/7841)
  * [15-SP3-JeOS-for-VMware-QR-x86_64-Build3.3.6-jeos-main@svirt-vmware65](http://kepler.suse.cz/tests/7842)
  * [15-SP3-JeOS-for-MS-HyperV-QR-x86_64-Build3.3.6-jeos-main@svirt-hyperv-uefi](http://kepler.suse.cz/tests/7839)
  * [15-SP3-JeOS-for-kvm-and-xen-QR-x86_64-Build3.3.6-jeos-main@svirt-xen-hvm](http://kepler.suse.cz/tests/7840)
  * [15-SP3-JeOS-for-kvm-and-xen-QR-x86_64-Build3.3.6-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/7838)
  * [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.69-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/7837)

