### PR TITLE
Retry pull of container image

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -16,7 +16,7 @@ use testapi;
 use Carp 'croak';
 use Test::Assert 'assert_equals';
 use containers::utils qw(registry_url);
-use utils qw(systemctl file_content_replace);
+use utils qw(systemctl file_content_replace script_retry);
 use overload
   '""' => sub { return shift->runtime },
   bool => sub { return 1 },
@@ -45,6 +45,13 @@ sub _engine_script_run {
 sub _engine_script_output {
     my ($self, $cmd, @args) = @_;
     return script_output($self->runtime . " " . $cmd, @args);
+}
+
+sub _engine_script_retry {
+    my ($self, $cmd, %args) = @_;
+    $cmd = $self->runtime . " " . $cmd;
+    # script_retry by default dies on timeouts, so the timeout check is not required here
+    return script_retry($cmd, %args);
 }
 
 =head2 create_container($image, $name, [$cmd])
@@ -150,8 +157,9 @@ sub pull {
     if (my $rc = $self->_engine_script_run("image inspect --format='{{.RepoTags}}' $image_name | grep '$image_name'") == 0) {
         return;
     }
+    my $die = $args{die} // 1;
     # At least on publiccloud, this image pull can take long and occasinally fails due to network issues
-    return $self->_engine_script_run("pull $image_name", timeout => $args{timeout} // 300);
+    return $self->_engine_script_retry("pull $image_name", timeout => $args{timeout} // 300, retry => 3, delay => 30, die => $die);
 }
 
 =head2 commit

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -82,7 +82,7 @@ sub _test_btrfs_device_mgmt {
     # check if the partition is full
     my ($total, $used) = _btrfs_fi("/var");
     die "partition should be full" unless (int($used) >= int($total * 0.99));
-    die("pull should fail on full partition") if ($rt->pull($container) == 0);
+    die("pull should fail on full partition") if ($rt->pull($container, die => 0) == 0);
     # Increase the amount of available storage by adding the second HDD ('/dev/vdb') to the pool
     assert_script_run "btrfs device add /dev/vdb $dev_path";
     assert_script_run "btrfs fi show $dev_path/btrfs";


### PR DESCRIPTION
Retry container pull three times to mitigate possible network issues.

- Related ticket: https://progress.opensuse.org/issues/100473
- Verification run: [15-SP3 docker](http://duck-norris.qam.suse.de/t7362) | [15-SP3 podman](http://duck-norris.qam.suse.de/t7363)
