### PR TITLE
[virt_autotest] change unprivileged_userfaultfd behaviour on 15-SP4 KVM

### DIFF
--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -24,6 +24,8 @@ use version_utils 'is_sle';
 sub run {
     my ($self) = @_;
 
+    script_run("echo 1 > /proc/sys/vm/unprivileged_userfaultfd") if (is_sle('=15-sp4') && is_kvm_host);
+
     my $ip_out = script_output('ip route show | grep -Eo "src\s+([0-9.]*)\s+" | head -1 | cut -d\' \' -f 2', 30);
     set_var('DST_IP', $ip_out);
     set_var('DST_USER', "root");
@@ -50,7 +52,7 @@ sub run {
     script_run('[ -d /tmp/prj3_migrate_admin_log/ ] && rm -rf /tmp/prj3_migrate_admin_log/', 30);
 
     # bsc#1191511 change unprivileged_userfaultfd behaviour on 15-SP4 KVM for guest_migration
-    script_run("echo 1 > /proc/sys/vm/unprivileged_userfaultfd") if (is_sle('=15-sp4') && is_kvm_host);
+    #script_run("echo 1 > /proc/sys/vm/unprivileged_userfaultfd") if (is_sle('=15-sp4') && is_kvm_host);
 
     #mark ready state
     mutex_create('DST_READY_TO_START');

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -127,7 +127,7 @@ sub run {
     bmwqemu::save_vars();
 
     # bsc#1191511 change unprivileged_userfaultfd behaviour on 15-SP4 KVM for guest_migration
-    script_run("echo 1 > /proc/sys/vm/unprivileged_userfaultfd") if (is_sle('=15-sp4') && is_kvm_host);
+    #script_run("echo 1 > /proc/sys/vm/unprivileged_userfaultfd") if (is_sle('=15-sp4') && is_kvm_host);
 
     #wait for destination to be ready
     $self->set_mutex_lock('DST_READY_TO_START');


### PR DESCRIPTION
- Description:
Before kernel v5.11, The default value of unprivileged_userfaultfd sysctl is 1,
It means using the userfaultfd syscalls is allowed by unprivileged users.
Since kernel v5.11(current 5.14 for 15-SP4),  The default value of unprivileged_userfaultfd sysctl is
set to 0, In this case, The UFFD_USER_MODE_ONLY is needed if unprivileged
user(without SYS_CAP_PTRACE capability) want to use userfaultfd syscalls.
So, need to change unprivileged_userfaultfd behavior on 15-SP4 KVM for our OSD guest migration test
- Change:
Change unprivileged_userfaultfd behavior both guest migration SRC and DST together. 

- Related ticket: https://progress.opensuse.org/issues/100659
- Verification run: 
virt-guest-migration-developing-from-developing-to-developing-kvm-src
virt-guest-migration-developing-from-developing-to-developing-kvm-dst
virt-guest-migration-sles12sp5-from-sles12sp5-to-developing-kvm-dst
virt-guest-migration-sles12sp5-from-sles12sp5-to-developing-kvm-src
virt-guest-migration-sles15sp3-from-sles15sp3-to-developing-kvm-dst
virt-guest-migration-sles12sp5-from-sles12sp5-to-developing-kvm-src