### PR TITLE
Add missing checks for return codes

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -136,9 +136,8 @@ sub run_container {
     my $keep_container = $args{keep_container} ? '' : '--rm';
     my $params = sprintf qq(%s %s %s), $keep_container, $mode, $name;
     my $cmd = sprintf qq(run %s %s %s), $params, $image_name, $remote;
-    my $ret = $self->_engine_script_run($cmd, timeout => $args{timeout});
     record_info "cmd_info", "Container executes:\noptions $params $image_name $remote";
-    return $ret;
+    $self->_engine_assert_script_run($cmd, timeout => $args{timeout});
 }
 
 =head2 pull($image_name, [%args])


### PR DESCRIPTION
The return codes of certain calls within the container engine were not
checked for errors. This increases the risk for undetected issues and
hides certain errors. This commit fixes this issue, by making the
affected calls fail the test run, in case of failures.

- Verification run: [15-SP3 docker](http://duck-norris.qam.suse.de/t7379) | [15-SP3 podman](http://duck-norris.qam.suse.de/t7381)
- [Tumbleweed docker](http://duck-norris.qam.suse.de/t7395) | [Tumbleweed podman](http://duck-norris.qam.suse.de/t7395)
- [15-SP2 aarch64 podman](https://openqa.suse.de/t7414754)
- [15-SP1 aarch64 docker](https://openqa.suse.de/t7414756)
- [15 GA s390x docker](https://openqa.suse.de/t7414758)
- [12-SP5 docker](https://openqa.suse.de/t7417592)
- [12-SP4 docker](https://openqa.suse.de/t7414762) (unrelated sporadic failure, relevant test passes)
- [12-SP3 docker](https://openqa.suse.de/t7414764)
