### PR TITLE
BCI Containers: split main test module into 3 functional modules

### DIFF
--- a/schedule/containers/bci_tests.yaml
+++ b/schedule/containers/bci_tests.yaml
@@ -11,4 +11,6 @@ schedule:
   - '{{boot}}'
   - boot/boot_to_desktop
   - containers/host_configuration
-  - containers/bci_tests
+  - containers/bci_prepare
+  - containers/bci_build
+  - containers/bci_test

--- a/tests/containers/bci_build.pm
+++ b/tests/containers/bci_build.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: bci-tests runner
+#   SUSE Linux Enterprise Base Container Images (SLE BCI)
+#   provides truly open, flexible and secure container images and application
+#   development tools for immediate use by developers and integrators without
+#   the lock-in imposed by alternative offerings.
+#
+#   This module is used to test BCI repository and BCI container images.
+#   It performs the build step before running the actual tests
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $engine = get_required_var('CONTAINER_RUNTIME');
+    my $bci_devel_repo = get_var('BCI_DEVEL_REPO');
+
+    assert_script_run('cd bci-tests');
+    assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
+    assert_script_run("export CONTAINER_RUNTIME=$engine");
+    assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;
+    my $build_options = check_var('HOST_VERSION', '12-SP5') ? '' : '-- -n auto';
+    my $cmd = "tox -e build $build_options";
+    record_info('Build', $cmd);
+    assert_script_run($cmd, timeout => 900);
+    upload_logs('junit_build.xml', failok => 1);
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -1,0 +1,73 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: bci-tests runner
+#   SUSE Linux Enterprise Base Container Images (SLE BCI)
+#   provides truly open, flexible and secure container images and application
+#   development tools for immediate use by developers and integrators without
+#   the lock-in imposed by alternative offerings.
+#
+#   This module is used to test BCI repository and BCI container images.
+#   It installs the required packages and uses the existing BCI-test
+#   repository defined by BCI_TESTS_REPO.
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use XML::LibXML;
+use utils qw(zypper_call ensure_ca_certificates_suse_installed);
+use version_utils qw(get_os_release);
+use containers::common;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $engine = get_required_var('CONTAINER_RUNTIME');
+    my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
+
+    ensure_ca_certificates_suse_installed;
+
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    if ($engine eq 'podman') {
+        install_podman_when_needed($host_distri);
+        install_buildah_when_needed($host_distri);
+    }
+    elsif ($engine eq 'docker') {
+        install_docker_when_needed($host_distri);
+    }
+    else {
+        die("Runtime $engine not given or not supported");
+    }
+
+    record_info('Install', 'Install needed packages');
+    my @packages = ('git-core', 'python3', 'python3-devel', 'gcc');
+    if (check_var('HOST_VERSION', '12-SP5')) {
+        # pip is not installed in 12-SP5 by default in our hdds
+        push @packages, 'python36-pip';
+    } else {
+        # skopeo is not available in <=12-SP5
+        push @packages, 'skopeo';
+    }
+    foreach my $pkg (@packages) {
+        record_info('pkg', $pkg);
+        zypper_call("--quiet in $pkg", timeout => 300);
+    }
+    assert_script_run('pip3.6 --quiet install --upgrade pip', timeout => 600);
+    assert_script_run("pip3.6 --quiet install tox --ignore-installed six", timeout => 600);
+
+    record_info('Clone', "Clone BCI tests repository: $bci_tests_repo");
+    assert_script_run("git clone -q --depth 1 $bci_tests_repo");
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -9,31 +9,19 @@
 #   development tools for immediate use by developers and integrators without
 #   the lock-in imposed by alternative offerings.
 #
-#   This module is used to test BCI repository within a container.
-#
-#   It installs the required python packages and uses the existing BCI-test
-#   repository defined by BCI_TESTS_REPO. Then, it will run the different
-#   tests environments defined by BCI_TEST_ENVS.
-#   - install needed python environment
-#   - clone bci-tests repo
-#   - build project
-#   - run test for each given environment
+#   This module is used to test BCI repository and BCI container images.
+#   It makes the call to tox to run the different test environments and
+#   parses the resulting JUnit logs at the end.
 # Maintainer: qa-c team <qa-c@suse.de>
 
 use Mojo::Base qw(consoletest);
 use XML::LibXML;
-use utils qw(systemctl zypper_call ensure_ca_certificates_suse_installed);
-use version_utils qw(get_os_release);
-use containers::common;
 use testapi;
 
 our $test_envs = get_var('BCI_TEST_ENVS', 'base,init,dotnet,python,node,go,multistage');
 
 sub parse_logs {
     my $self = @_;
-
-    upload_logs('junit_build_serial.xml', failok => 1);
-    upload_logs('junit_build_parallel.xml', failok => 1);
 
     # bci-tests produce separate XUnit results files for each environment.
     # We need tp merge all together into a single xml file that will
@@ -44,8 +32,7 @@ sub parse_logs {
 
     # Dump xml contents to a location where we can access later using data_url
     for my $env (split(/,/, $test_envs)) {
-        upload_logs('junit_' . $env . '_serial.xml', failok => 1);
-        my $log_file = upload_logs('junit_' . $env . '_parallel.xml', failok => 1);
+        my $log_file = upload_logs('junit_' . $env . '.xml', failok => 1);
         if ($log_file) {
             my $dom = XML::LibXML->load_xml(location => "ulogs/$log_file");
             for my $node ($dom->findnodes('//testsuite')) {
@@ -68,51 +55,37 @@ sub run {
     $self->select_serial_terminal;
 
     my $engine = get_required_var('CONTAINER_RUNTIME');
-    my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
     my $bci_devel_repo = get_var('BCI_DEVEL_REPO');
-    my $bci_timeout = get_var('BCI_TIMEOUT', 900);
+    my $bci_timeout = get_var('BCI_TIMEOUT', 1200);
 
-    ensure_ca_certificates_suse_installed;
-
-    my ($running_version, $sp, $host_distri) = get_os_release;
-    if ($engine eq 'podman') {
-        install_podman_when_needed($host_distri);
-        install_buildah_when_needed($host_distri);
-    }
-    elsif ($engine eq 'docker') {
-        install_docker_when_needed($host_distri);
-    }
-    else {
-        die("Runtime $engine not given or not supported");
-    }
-
-    record_info('Install', 'Install needed packages');
-    zypper_call('--quiet in git-core python3 python3-devel gcc skopeo', timeout => 600);
-    assert_script_run('pip3.6 --quiet install tox pytest', timeout => 600);
-
-    record_info('Clone', 'Clone BCI tests repository');
-    assert_script_run("git clone -q --depth 1 $bci_tests_repo");
-
-    record_info('Build', 'Build bci-tests project');
+    record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     assert_script_run('cd bci-tests');
+    assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
     assert_script_run("export CONTAINER_RUNTIME=$engine");
     assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;
-    assert_script_run('tox -e build', timeout => 900);
 
     # Run the tests for each environment
+    my $cmd_options = check_var('HOST_VERSION', '12-SP5') ? '' : '-- -n auto';
     my $error_count = 0;
     for my $env (split(/,/, $test_envs)) {
-        record_info("Test: $env");
-        my $ret = script_run("tox -e $env", timeout => $bci_timeout);
-        if ($ret != 0) {
+        record_info($env);
+        my $ret = script_run("tox -e $env $cmd_options", timeout => $bci_timeout);
+        if (!defined($ret)) {
+            # script_run returns undef if the command times out
+            record_soft_failure("The command <tox -e $env $cmd_options> timed out.");
             $error_count += 1;
-            record_soft_failure("There was a problem running the test: $env");
+        } elsif ($ret != 0) {
+            record_soft_failure("The command <tox -e $env $cmd_options> failed.");
+            $error_count += 1;
+        } else {
+            record_info('PASSED');
         }
     }
 
     $self->parse_logs();
 
-    die("$error_count tests failed.") if ($error_count != 0);
+    # Mark the job as failed if any of the tests failed
+    die("$error_count tests failed.") if ($error_count > 0);
 }
 
 sub test_flags {


### PR DESCRIPTION
To help troubleshooting and future enhancement of the tests,
splitting it into 3 different parts makes everything easier.
In OpenQA it will be shown which module fails and will be
quicker to spot the failure.
This also opens the door to easy integrate support for 3rd
party hosts in bci_prepare.pm

VR: 
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=17.8.10&groupid=398
http://fromm.arch.suse.de/tests/overview?build=17.8.10&distri=sle&version=15-SP3&groupid=41