### PR TITLE
Fix users can't login after logout

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -156,7 +156,7 @@ sub full_users_check {
         }
     }
     select_console 'x11', await_console => 0;
-    wait_still_screen 5;
+    wait_still_screen 15;
     ensure_unlocked_desktop;
     assert_screen "generic-desktop";
     if ($stage eq 'before') {

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -308,7 +308,12 @@ sub select_user_gnome {
         assert_and_click "displaymanager-$myuser";
     }
     elsif (match_has_tag('displaymanager-user-selected')) {
-        send_key 'ret';
+        if ($myuser =~ 'bernhard') {
+            send_key 'ret';
+        }
+        else {
+            assert_and_click "displaymanager-$myuser";
+        }
     }
     elsif (match_has_tag('dm-nousers')) {
         type_string $myuser;


### PR DESCRIPTION
We need make 'select_user_gnome/handle_login' support non-default arguments, to deal with the scenario to select displaymanager for test users besides 'bernhard'.

- Related ticket: https://progress.opensuse.org/issues/97277
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/7394924#step/check_upgraded_service/24
