### PR TITLE
Remove pam test packages

### DIFF
--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -64,6 +64,7 @@ sub run {
     assert_script_run("snapper -v undochange \$snapbf..\$snapaf");
     assert_script_run("snapper delete \$snapaf \$snapbf");
     zypper_call('rr qa-head-repo');
+    zypper_call('rm bats pam-test');
 
     die "pam.sh failed, see results.tap for details" if ($ret);
 }


### PR DESCRIPTION
As the test case removes QA Head repo, it should also remove the test
packages pulled from it. Otherwise test suites are failing in [orphaned_packages_check](https://openqa.suse.de/tests/7395912#step/orphaned_packages_check/11)
