### PR TITLE
Add mergify for additional checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,7 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: This pull request is now in conflicts. Could you fix it? 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,9 @@
 pull_request_rules:
+  - name: remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews:
   - name: ask to resolve conflict
     conditions:
       - conflict

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,27 @@ pull_request_rules:
       - base=master
     actions:
       dismiss_reviews:
+  - name: additional checks
+    conditions:
+      - and: &base_checks
+        - base=master
+        - -label~=^acceptance-tests-needed|notready|WIP
+        - -body~=PLACEHOLDER
+        - "status-success~=static tests.*"
+        - "status-success~=unit tests.*"
+        - "status-success~=compile tests.*"
+        - "#check-failure=0"
+        - "#check-pending=0"
+        - linear-history
+      - and:
+        - "#approved-reviews-by>=2"
+        - "#changes-requested-reviews-by=0"
+        # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
+        - "#review-requested=0"
+        - "body~=Verification run: http"
+    actions:
+      review:
+        type: APPROVE
   - name: ask to resolve conflict
     conditions:
       - conflict


### PR DESCRIPTION
After this PR is merged pull requests can be automatically merged with a special label and as soon as all rules specified are met. For example: Only if all checks pass, a verification run was provided, no review pending or asking for changes, at least two approvals given, no label to wait, etc. Additional checks are conducted and show up as check in github status details same as other checks. Pull requests can still be merged manually as is but this approach helps for a couple of reasons:
* Acceptance criteria for merge are codified into rules that everybody can read
* Nobody needs to wait anymore if everything was already provided and approved, verification runs have been checked but you just wait for the CI to finish
* No trivial things are overlooked in review which can be automatically checked
* The rules can be extended in the future to cover further checks. For example I plan to automatically check provided verification runs or use the feature to semi-automatically trigger verification runs and wait for their successful completion

You can try out how mergify behaves within the test pull request https://github.com/okurz/os-autoinst-distri-opensuse/pull/4

Related progress issues:
* https://progress.opensuse.org/issues/72841
* https://progress.opensuse.org/issues/49502
* https://progress.opensuse.org/issues/48641