### PR TITLE
RFC:Use functions to verify arch and backend types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ and additionally the following rules:
 * Use `my ($self) = @_;` for parameter parsing in methods when accessing the
   `$self` object. Do not parse any parameter if you do not need any.
 * [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself)
+* Use defined architecture and backend functions defined in
+  'lib/Utils/Architecture.pm' and 'lib/Utils/Backends.pm' for checking specific 
+  ARCH and BACKEND types instead of calling the function calls check_var(). 
+  If they don't exist, add them.
 * Avoid `sleep()`: Do not use `sleep()` or simulate a sleep-like
   functionality. This introduces the risk of either unnecessarily wasting time
   or just shifting race conditions and making them even harder to investigate.

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -35,6 +35,10 @@ use constant {
           is_svirt
           is_image_backend
           is_ssh_installation
+          is_backend_s390x
+          is_spvm
+          is_pvm_hmc
+          is_generalhw
         )
     ],
     CONSOLES => [
@@ -206,6 +210,38 @@ Returns true if the current instance is running on backend with image support
 sub is_image_backend {
     return (is_qemu || is_svirt);
 }
+
+=head2 is_backend_s390x
+
+Returns true if the current instance is running on backend with s390x
+
+=cut
+
+sub is_backend_s390x { check_var('BACKEND', 's390x'); }
+
+=head2 is_spvm
+
+Returns true if the current instance is running as PowerVM backend 'spvm'
+
+=cut
+
+sub is_spvm { check_var('BACKEND', 'spvm'); }
+
+=head2 is_pvm_hmc
+
+Returns true if the current instance is running as PowerVM backend 'hmc_pvm'
+
+=cut
+
+sub is_pvm_hmc { check_var('BACKEND', 'pvm_hmc'); }
+
+=head2 is_generalhw
+
+Returns true if the current instance is running on backend 'generalhw'
+
+=cut
+
+sub is_generalhw { check_var('BACKEND', 'generalhw'); }
 
 #This subroutine takes absolute file path of sshd config file and desired ssh connection timeout as arguments
 #The ssh connection timeout is counted as seconds

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -110,7 +110,7 @@ sub init_host {
         $host = get_var('SUT_IP');
     } elsif (get_var('S390_ZKVM')) {
         $host = get_var('VIRSH_GUEST');
-    } elsif (check_var('BACKEND', 's390x')) {
+    } elsif (is_backend_s390x) {
         $installation ? select_console('install-shell') : select_console('root-console');
         $host = &$get_ip_from_console_output;
         select_console('installation') if $installation;

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -624,7 +624,7 @@ sub expand_version {
 sub adjust_network_conf {
     my ($profile) = @_;
     my $hostip;
-    if (check_var('BACKEND', 's390x')) {
+    if (is_backend_s390x) {
         ($hostip) = get_var('S390_NETWORK_PARAMS') =~ /HostIP=(.*?)\//;
     }
     elsif (is_svirt) {

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -21,6 +21,7 @@ use bootloader_setup;
 use registration 'registration_bootloader_params';
 use utils qw(get_netboot_mirror type_string_slow enter_cmd_slow);
 use version_utils 'is_upgrade';
+use Utils::Backends;
 use YuiRestClient;
 
 our @EXPORT = qw(
@@ -140,9 +141,9 @@ sub prepare_pvm_installation {
 }
 
 sub boot_pvm {
-    if (check_var('BACKEND', 'spvm')) {
+    if (is_spvm) {
         boot_spvm();
-    } elsif (check_var('BACKEND', 'pvm_hmc')) {
+    } elsif (is_pvm_hmc) {
         boot_hmc_pvm();
     }
 }

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -112,7 +112,7 @@ sub add_custom_grub_entries {
     my $distro = "openSUSE" . ' \\?' . get_required_var('VERSION');
 
     # LTSS is supported only on aarch64 HPC 12-SP4
-    if (check_var('VERSION', '12-SP4') && check_var('ARCH', 'aarch64')) {
+    if (check_var('VERSION', '12-SP4') && is_aarch64) {
         $distro = 'SLE-HPC' . ' \\?' . get_required_var('VERSION');
     }
     elsif (check_var('SLE_PRODUCT', 'slert')) {

--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use Utils::Architectures;
+use Utils::Backends;
 use version_utils 'is_sle';
 use utils 'type_string_slow';
 
@@ -27,7 +28,7 @@ sub await_password_check {
     # PW too easy (cracklib)
     # bsc#937012 is resolved in > SLE 12, skip if VERSION=12
     return if (is_sle('=12') && is_s390x);
-    assert_screen('inst-userpasswdtoosimple', (check_var('BACKEND', 'pvm_hmc')) ? 60 : 30);
+    assert_screen('inst-userpasswdtoosimple', (is_pvm_hmc) ? 60 : 30);
     send_key 'ret';
 
 }

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -301,7 +301,7 @@ sub configure_service {
     $self->wait_boot(bootloader_time => 300);
 
     select_console 'root-console';
-    if (is_ppc64le || check_var('ARCH', 'ppc64')) {
+    if (is_ppc64le || is_ppc64) {
         if (script_run('kver=$(uname -r); kconfig="/boot/config-$kver"; [ -f $kconfig ] && grep ^CONFIG_RELOCATABLE $kconfig')) {
             record_soft_failure 'poo#49466 -- No kdump if no CONFIG_RELOCATABLE in kernel config';
             return 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -174,7 +174,7 @@ sub setup_env {
     }
 
     # By default format DASD devices before installation
-    if (check_var('BACKEND', 's390x')) {
+    if (is_backend_s390x) {
         # Format DASD before the installation by default
         # Skip format dasd before origin system installation by autoyast in 'Upgrade on zVM'
         # due to channel not activation issue. Need further investigation on it.
@@ -772,7 +772,7 @@ sub unregister_needle_tags {
 sub load_bootloader_s390x {
     return 0 unless is_s390x;
 
-    if (check_var("BACKEND", "s390x")) {
+    if (is_backend_s390x) {
         loadtest "installation/bootloader_s390";
     }
     else {
@@ -830,7 +830,7 @@ sub load_inst_tests {
         loadtest "installation/disk_activation_iscsi";
     }
     if (is_s390x) {
-        if (check_var('BACKEND', 's390x')) {
+        if (is_backend_s390x) {
             loadtest "installation/disk_activation";
         }
         elsif (is_sle('<12-SP2')) {
@@ -950,7 +950,7 @@ sub load_inst_tests {
     # functionality needs to be covered by other backends
     # Skip release notes test on sle 15 if have addons
     if (get_var('CHECK_RELEASENOTES') &&
-        is_sle && !check_var('BACKEND', 'generalhw') && !is_ipmi &&
+        is_sle && !is_generalhw && !is_ipmi &&
         !(is_sle('15+') && get_var('ADDONURL'))) {
         loadtest "installation/releasenotes";
     }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -768,7 +768,7 @@ sub reconnect_s390 {
     my $textmode = $args{textmode};
     return undef unless is_s390x;
     my $login_ready = get_login_message();
-    if (check_var('BACKEND', 's390x')) {
+    if (is_backend_s390x) {
         my $console = console('x3270');
         # skip grub handle for 11sp4
         if (!is_sle('=11-SP4')) {

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -136,7 +136,7 @@ sub create_new_partition_table {
 
     # create new partition table, change gpt table if it's available
     # storage-ng always allows partition table selection
-    if (!get_var('UEFI') && !check_var('BACKEND', 's390x') || is_storage_ng) {
+    if (!get_var('UEFI') && !is_backend_s390x || is_storage_ng) {
         assert_screen "create-new-partition-table";
         send_key $table_type_hotkey{$table_type};
         assert_screen "partition-table-$table_type-selected";
@@ -240,7 +240,7 @@ sub addpart {
     my (%args) = @_;
     assert_screen 'expert-partitioner';
     send_key $cmd{addpart};
-    unless (get_var('UEFI') || check_var('BACKEND', 's390x') || is_storage_ng) {
+    unless (get_var('UEFI') || is_backend_s390x || is_storage_ng) {
         assert_screen 'partitioning-type';
         send_key $cmd{next};
     }

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -20,6 +20,7 @@ use warnings;
 use utils;
 use testapi;
 use Utils::Architectures;
+use Utils::Backends;
 use version_utils qw(is_sle is_leap is_opensuse is_tumbleweed is_vmware is_jeos);
 use Carp 'croak';
 
@@ -49,7 +50,7 @@ sub prepare_system_shutdown {
     console('root-ssh')->kill_ssh if get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/;
 
     if (is_s390x) {
-        if (check_var('BACKEND', 's390x')) {
+        if (is_backend_s390x) {
             # kill serial ssh connection (if it exists)
             eval { console('iucvconn')->kill_ssh unless get_var('BOOT_EXISTING_S390', ''); };
             diag('ignoring already shut down console') if ($@);
@@ -270,7 +271,7 @@ sub power_action {
             reboot_x11;
         }
         elsif ($action eq 'poweroff') {
-            if (check_var('BACKEND', 's390x')) {
+            if (is_backend_s390x) {
                 record_soft_failure('poo#58127 - Temporary workaround, because shutdown module is marked as failed on s390x backend when shutting down from GUI.');
                 select_console 'root-console';
                 enter_cmd "$action";

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -530,7 +530,7 @@ sub init_consoles {
         $hostname = get_var('VIRSH_GUEST') if get_var('S390_ZKVM');
         $hostname = get_required_var('SUT_IP') if get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/;
 
-        if (check_var('BACKEND', 's390x')) {
+        if (is_backend_s390x) {
 
             # expand the S390 params
             my $s390_params = get_var("S390_NETWORK_PARAMS");

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -19,7 +19,7 @@ use microos 'microos_reboot';
 use power_action_utils qw(power_action prepare_system_shutdown);
 use version_utils qw(is_opensuse is_microos is_sle_micro is_sle);
 use utils 'reconnect_mgmt_console';
-use Utils::Backends 'is_pvm';
+use Utils::Backends;
 use Utils::Architectures;
 
 our @EXPORT = qw(
@@ -71,7 +71,7 @@ sub process_reboot {
 
     if (is_microos || is_sle_micro && !is_s390x) {
         microos_reboot $args{trigger};
-    } elsif (check_var('BACKEND', 's390x')) {
+    } elsif (is_backend_s390x) {
         prepare_system_shutdown;
         enter_cmd "reboot";
         opensusebasetest::wait_boot(opensusebasetest->new(), bootloader_time => 200);

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -306,7 +306,7 @@ sub unlock_if_encrypted {
         type_line_svirt '', expect => "Please enter passphrase for disk.*", timeout => 100, fail_message => 'Could not find "enter passphrase" prompt';
         type_line_svirt "$password";
     }    # Handle zVM scenario
-    elsif (check_var('BACKEND', 's390x')) {
+    elsif (is_backend_s390x) {
         my $console = console('x3270');
         # Enter password before GRUB if boot is encrypted
         # Boot partition is always encrypted, if not using expert partitioner with
@@ -667,7 +667,7 @@ the second run will update the system.
 =cut
 sub fully_patch_system {
     # special handle for 11-SP4 s390 install
-    if (is_sle('=11-SP4') && is_s390x && check_var('BACKEND', 's390x')) {
+    if (is_sle('=11-SP4') && is_s390x && is_backend_s390x) {
         # first run, possible update of packager -- exit code 103
         zypper_call('patch --with-interactive -l', exitcode => [0, 102, 103], timeout => 3000);
         handle_patch_11sp4_zvm();
@@ -1234,7 +1234,7 @@ sub disable_serial_getty {
     my ($self) = @_;
     my $service_name = "serial-getty\@$testapi::serialdev";
     # Do not run on zVM as running agetty is required by iucvconn in order to work
-    return if check_var('BACKEND', 's390x');
+    return if is_backend_s390x;
     # No need to apply on more recent kernels
     return unless is_sle('<=15-SP2') || is_leap('<=15.2');
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt
@@ -1334,7 +1334,7 @@ sub _handle_login_not_found {
     return record_soft_failure 'bsc#1040606 - incomplete message when LeanOS is implicitly selected instead of SLES'
       if $str =~ /Welcome to SUSE Linux Enterprise 15/;
     my $error_details = $str;
-    if (check_var('BACKEND', 's390x')) {
+    if (is_backend_s390x) {
         diag 'Trying to look for "blocked tasks" with magic sysrq';
         console('x3270')->sequence_3270("String(\"^-w\\n\")");
         my $r = console('x3270')->expect_3270(buffer_full => qr/(MORE\.\.\.|HOLDING)/);
@@ -1364,7 +1364,7 @@ sub reconnect_mgmt_console {
         console('installation')->disable_vnc_stalls;
 
         # different behaviour for z/VM and z/KVM
-        if (check_var('BACKEND', 's390x')) {
+        if (is_backend_s390x) {
             my $console = console('x3270');
             # grub is handled in unlock_if_encrypted unless affected by bsc#993247 or https://fate.suse.com/321208
             handle_grub_zvm($console) if (!get_var('ENCRYPT') || get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE'));
@@ -1412,9 +1412,9 @@ sub reconnect_mgmt_console {
         }
     }
     elsif (is_ppc64le) {
-        if (check_var('BACKEND', 'spvm')) {
+        if (is_spvm) {
             select_console 'novalink-ssh', await_console => 0;
-        } elsif (check_var('BACKEND', 'pvm_hmc')) {
+        } elsif (is_pvm_hmc) {
             select_console 'powerhmc-ssh', await_console => 0;
             if ($args{grub_expected_twice}) {
                 check_screen 'grub2', 60;

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use LWP::Simple;
 use Config::Tiny;
+use Utils::Architectures;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
 use x11utils qw(select_user_gnome handle_gnome_activities);
@@ -740,7 +741,7 @@ sub start_gnome_settings {
 
     if (!$is_sle_12_sp1 || $settings_menu_loaded) {
         assert_and_click 'settings';
-        my $timeout = (check_var('ARCH', 'aarch64')) ? '180' : '30';
+        my $timeout = (is_aarch64) ? '180' : '30';
         assert_screen 'gnome-settings', $timeout;
     }
 }

--- a/t/01_style.t
+++ b/t/01_style.t
@@ -8,4 +8,6 @@ my $out = qx{git grep -I -l 'Copyright \\((C)\\|(c)\\|©\\)' '!:*.ps'};
 ok $? != 0 && $out eq '', 'No redundant copyright character' or diag $out;
 ok system(qq{git grep -I -l 'This program is free software.*if not, see <http://www.gnu.org/licenses/' ':!t/01_style.t'}) != 0, 'No verbatim GPL licenses in source files';
 ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!t/01_style.t'}) != 0, 'SPDX-License-Identifier correctly terminated';
+$out = qx{git grep -ne "check_var('ARCH',.*)" -e "check_var('BACKEND',.*)" ':!lib/Utils/Architectures.pm' ':!lib/Utils/Backends.pm' 'lib' 'tests'};
+ok $? != 0 && $out eq '', 'No check_var function to verify ARCH/BACKEND types' or diag $out;
 done_testing;

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -156,7 +156,7 @@ sub run {
     # If we have an encrypted root or boot volume, we reboot to a grub password prompt.
     push(@needles, 'encrypted-disk-password-prompt') if get_var("ENCRYPT_ACTIVATE_EXISTING");
     # Kill ssh proactively before reboot to avoid half-open issue on zVM, do not need this on zKVM
-    prepare_system_shutdown if check_var('BACKEND', 's390x');
+    prepare_system_shutdown if is_backend_s390x;
     my $postpartscript = 0;
     my $confirmed = 0;
     my $pxe_boot_done = 0;

--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -73,7 +73,7 @@ my (
 );
 # Prepare test data depending on specific architecture/product
 sub prepare_test_data {
-    if (is_ppc64le || check_var('ARCH', 'ppc64')) {
+    if (is_ppc64le || is_ppc64) {
         @partitioning = (
             $raid_partitions_3_arrays, $hard_disks, $linux_raid_member_3_arrays,
             $ext4_boot,

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use base 'y2_installbase';
 use testapi;
+use Utils::Backends;
 use utils qw(addon_license handle_untrusted_gpg_key assert_screen_with_soft_timeout);
 use version_utils 'is_sle';
 use qam 'advance_installer_window';
@@ -158,7 +159,7 @@ sub run {
         if ($self->process_unsigned_files([qw(inst-addon addon-products)])) {
             assert_screen_with_soft_timeout(
                 [qw(inst-addon addon-products)],
-                timeout => check_var('BACKEND', 'pvm_hmc') ? 600 : 120,
+                timeout => is_pvm_hmc ? 600 : 120,
                 soft_timeout => 60,
                 bugref => 'bsc#1166504');
         }

--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -46,6 +46,7 @@ use lockapi;
 use mmapi;
 use utils;
 use Utils::Architectures;
+use Utils::Backends;
 use version_utils qw(:VERSION :BACKEND is_sle is_leap is_sle_micro);
 use ipmi_backend_utils;
 
@@ -91,7 +92,7 @@ sub _set_timeout {
     # aarch64 can be particularily slow depending on the hardware
     ${$timeout} *= 2 if is_aarch64 && get_var('MAX_JOB_TIME');
     # PPC HMC (Power9) performs very slow in general
-    ${$timeout} *= 2 if check_var('BACKEND', 'pvm_hmc') && get_var('MAX_JOB_TIME');
+    ${$timeout} *= 2 if is_pvm_hmc && get_var('MAX_JOB_TIME');
     # encryption, LVM and RAID makes it even slower
     ${$timeout} *= 2 if (get_var('ENCRYPT') || get_var('LVM') || get_var('RAID'));
     # "allpatterns" tests install a lot of packages
@@ -218,7 +219,7 @@ sub run {
     }
 
     # Stop reboot countdown where necessary for e.g. uploading logs
-    unless (check_var('REBOOT_TIMEOUT', 0) || get_var("REMOTE_CONTROLLER") || is_microos || (is_sle('=11-sp4') && is_s390x && check_var('BACKEND', 's390x'))) {
+    unless (check_var('REBOOT_TIMEOUT', 0) || get_var("REMOTE_CONTROLLER") || is_microos || (is_sle('=11-sp4') && is_s390x && is_backend_s390x)) {
         # Depending on the used backend the initial key press to stop the
         # countdown might not be evaluated correctly or in time. In these
         # cases we keep hitting the keys until the countdown stops.

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -23,7 +23,7 @@ use testapi;
 use Utils::Architectures;
 use lockapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends;
 use version_utils 'is_sle';
 use ipmi_backend_utils;
 
@@ -35,7 +35,7 @@ sub run {
     # permit root ssh login for CC test:
     # in "Common Criteria" "System Role" system, root ssh login is disabled
     # by default, we need enable it
-    if (check_var('SYSTEM_ROLE', 'Common_Criteria') && is_sle && check_var('ARCH', 's390x')) {
+    if (check_var('SYSTEM_ROLE', 'Common_Criteria') && is_sle && is_s390x) {
         my $stor_inst = "/var/log/YaST2/storage-inst/*committed.yml";
         my $root_hd = script_output("cat $stor_inst | grep -B4 'mount_point: \"/\"' | grep name | awk -F \\\" '{print \$2}'");
         assert_script_run("mount $root_hd /mnt");
@@ -44,7 +44,7 @@ sub run {
     }
 
     # check for right boot-device on s390x (zVM, DASD ONLY)
-    if (check_var('BACKEND', 's390x') && !check_var('S390_DISK', 'ZFCP')) {
+    if (is_backend_s390x && !check_var('S390_DISK', 'ZFCP')) {
         if (script_run("lsreipl | grep $dasd_path")) {
             die "IPL device was not set correctly";
         }

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -20,6 +20,7 @@ use warnings;
 use lockapi;
 use testapi;
 use Utils::Architectures;
+use Utils::Backends;
 use mmapi;
 use version_utils qw(is_sle is_upgrade);
 
@@ -105,7 +106,7 @@ sub run {
         && !get_var("NICEVIDEO")
         && !get_var("UPGRADE")
         && !check_var('VIDEOMODE', 'text')
-        && (!is_sle('=11-sp4') || !is_s390x || !check_var('BACKEND', 's390x')))
+        && (!is_sle('=11-sp4') || !is_s390x || !is_backend_s390x))
     {
         my $counter = 20;
         while ($counter--) {

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -12,7 +12,7 @@ use warnings;
 use testapi;
 use version_utils qw(is_sle is_tumbleweed is_leap is_opensuse);
 use Utils::Architectures;
-use Utils::Backends 'is_hyperv';
+use Utils::Backends;
 use jeos qw(expect_mount_by_uuid);
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);
 
@@ -116,7 +116,7 @@ sub run {
     # when there are more jobs running concurrently. We need to wait for
     # various disk optimizations and snapshot enablement to land.
     # Meltdown/Spectre mitigations makes this even worse.
-    if (check_var('BACKEND', 'generalhw') && !defined(get_var('GENERAL_HW_VNC_IP'))) {
+    if (is_generalhw && !defined(get_var('GENERAL_HW_VNC_IP'))) {
         # Wait jeos-firstboot is done and clear screen, as we are already logged-in via ssh
         wait_still_screen;
         $self->clear_and_verify_console;

--- a/tests/jeos/prepare_firstboot.pm
+++ b/tests/jeos/prepare_firstboot.pm
@@ -12,6 +12,7 @@ use base "opensusebasetest";
 use testapi;
 use utils 'zypper_call';
 use version_utils 'is_leap';
+use Utils::Backends;
 
 sub run {
     my ($self) = @_;
@@ -20,7 +21,7 @@ sub run {
     my $distripassword = $testapi::password;
     my $reboot_for_jeos_firstboot = 1;
 
-    my $is_generalhw_via_ssh = check_var('BACKEND', 'generalhw') && !defined(get_var('GENERAL_HW_VNC_IP'));
+    my $is_generalhw_via_ssh = is_generalhw && !defined(get_var('GENERAL_HW_VNC_IP'));
 
     if ($is_generalhw_via_ssh) {
         # Run jeos-firstboot manually and do not reboot as we use SSH


### PR DESCRIPTION
Proposal:  Use of existing functions defined in Architecture.pm and Backends.pm to verify specific ARCH and BACKEND types instead of calling check_var function and the corresponding checks to verify on modified files in the t/01_style.t.

- Related ticket: https://progress.opensuse.org/issues/96675
-  Verification run:
    https://openqa.suse.de/tests/7843719
    https://openqa.suse.de/tests/7843025
    https://openqa.suse.de/tests/7843720
    https://openqa.suse.de/tests/7843192