### PR TITLE
Ensure stable ssh connection to SLE 15+ uefi guest

### DIFF
--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -178,6 +178,10 @@
         <service>sshd</service>
         <service>systemd-remount-fs</service>
       </enable>
+      <disable config:type="list">
+        <service>firewalld</service>
+        <service>apparmor</service>
+      </disable>
     </services>
   </services-manager>
   <software t="map">
@@ -227,7 +231,7 @@
   </timezone>
   <user_defaults t="map">
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive>-1</inactive>
@@ -259,4 +263,28 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is the default sshd config file in sles  -->
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_multi-user_x86_64.xml
@@ -178,6 +178,10 @@
         <service>sshd</service>
         <service>systemd-remount-fs</service>
       </enable>
+      <disable config:type="list">
+        <service>firewalld</service>
+        <service>apparmor</service>
+      </disable>
     </services>
   </services-manager>
   <software t="map">
@@ -227,7 +231,7 @@
   </timezone>
   <user_defaults t="map">
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive>-1</inactive>
@@ -259,4 +263,28 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is the default sshd config file in sles  -->      
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_graphical_x86_64.xml
@@ -179,6 +179,10 @@
         <service>sshd</service>
         <service>systemd-remount-fs</service>
       </enable>
+      <disable config:type="list">
+        <service>firewalld</service>
+        <service>apparmor</service>
+      </disable>
     </services>
   </services-manager>
   <software t="map">
@@ -229,7 +233,7 @@
   </timezone>
   <user_defaults t="map">
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive>-1</inactive>
@@ -262,4 +266,28 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is the default sshd config file in sles  -->
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_multi-user_x86_64.xml
@@ -179,6 +179,10 @@
         <service>sshd</service>
         <service>systemd-remount-fs</service>
       </enable>
+      <disable config:type="list">
+        <service>firewalld</service>
+        <service>apparmor</service>
+      </disable>
     </services>
   </services-manager>
   <software t="map">
@@ -229,7 +233,7 @@
   </timezone>
   <user_defaults t="map">
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive>-1</inactive>
@@ -262,4 +266,28 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is the default sshd config file in sles  -->      
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_graphical_x86_64.xml
@@ -179,6 +179,10 @@
         <service>sshd</service>
         <service>systemd-remount-fs</service>
       </enable>
+      <disable config:type="list">
+        <service>firewalld</service>
+        <service>apparmor</service>
+      </disable>
     </services>
   </services-manager>
   <software t="map">
@@ -230,7 +234,7 @@
   </timezone>
   <user_defaults t="map">
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive>-1</inactive>
@@ -263,4 +267,28 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is the default sshd config file in sles  -->      
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_multi-user_x86_64.xml
@@ -179,6 +179,10 @@
         <service>sshd</service>
         <service>systemd-remount-fs</service>
       </enable>
+      <disable config:type="list">
+        <service>firewalld</service>
+        <service>apparmor</service>
+      </disable>
     </services>
   </services-manager>
   <software t="map">
@@ -230,7 +234,7 @@
   </timezone>
   <user_defaults t="map">
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive>-1</inactive>
@@ -263,4 +267,28 @@
       <username>root</username>
     </user>
   </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is the default sshd config file in sles  -->
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
 </profile>


### PR DESCRIPTION
* **Disable** firewalld and apparmor services on SLE 15+ uefi guest installation to ensure it will not block ssh connection under any circumstances. Otherwise it may fail like [this](https://openqa.suse.de/tests/7369491#step/1_unified_guest_installation/1).

* **Use** default group 100 instead of 500 because group 500 does not exist on SLE 15+ uefi guest. The warning can be seen [here](https://openqa.suse.de/tests/7369492#step/unified_guest_installation/437).

* **Manual** copy host ssh public key onto uefi guest by using scripts to ensure passwordless ssh connection is always available on uefi guest of SLE 15+. Otherwise it may fail like [this](https://openqa.suse.de/tests/7369491#step/1_unified_guest_installation/1).

* **Verification runs:**
  * [15sp4 on 15sp4 kvm](https://openqa.suse.de/tests/7410640)
  * [15sp4 on 12sp5 kvm](https://openqa.suse.de/tests/7410641)
  * [15sp4 on 15sp3 kvm](https://openqa.suse.de/tests/7410805)
  * [15sp3 on 15sp4 kvm](https://openqa.suse.de/t7413324)
  * [15sp3 on 15sp4 xen](https://openqa.suse.de/tests/7411595)