### PR TITLE
Increase default timeout in YuiRestClient

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -11,7 +11,7 @@ use warnings;
 
 use constant {
     API_VERSION => 'v1',
-    TIMEOUT => 30,
+    TIMEOUT => 45,
     INTERVAL => 1
 };
 


### PR DESCRIPTION
Internally this will be 90 seconds of max time waiting.

- Related ticket: https://progress.opensuse.org/issues/100907
