### PR TITLE
Add x11_yast pattern to textmode scenarios

### DIFF
--- a/test_data/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/test_data/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -9,6 +9,7 @@ software:
     - devel_yast
     - enhanced_base
     - x11
+    - x11_yast
     - yast2_basis
     - yast2_desktop
     - yast2_server


### PR DESCRIPTION
It will fix missing scenario for powerVM: [select_modules_and_patterns+registration](https://openqa.suse.de/tests/7387580)
