### PR TITLE
Replace inconsistent license in tests/autoyast/save_y2logs.pm

### DIFF
--- a/tests/autoyast/save_y2logs.pm
+++ b/tests/autoyast/save_y2logs.pm
@@ -1,14 +1,10 @@
 # SUSE's openQA tests
 #
 # Copyright 2021 SUSE LLC
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-License-Identifier: FSFAP
+
 # Summary: run save_y2logs and upload the generated tar.bz2
 # Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
-
 
 
 use strict;


### PR DESCRIPTION
This seems to be the only trivial left-over of inconsistent license which I could find