### PR TITLE
Add test to verify sapstart is compliant with systemd on SLES

### DIFF
--- a/schedule/systemd/systemd-sapstart-check.yaml
+++ b/schedule/systemd/systemd-sapstart-check.yaml
@@ -1,0 +1,10 @@
+---
+name: sap-library-tests
+description: >
+  Run external test suite to verify systemd is compliant with the SAP
+  start framework.
+vars: {}
+schedule:
+  - boot/boot_to_desktop
+  - console/systemd_sapstart_check
+  - shutdown/shutdown

--- a/tests/console/systemd_sapstart_check.pm
+++ b/tests/console/systemd_sapstart_check.pm
@@ -1,0 +1,129 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: install and execute the external systemd lib sapstart
+# test script. Parse and upload the results so they are presented
+# as External Results.
+# - Determine the repository where the external systemd lib sapstart
+#   test script is located or use the one provided in the
+#   QA_TEST_REPO setting.
+# - Add the repository and install the SAP-systemdlib-tests package.
+# - Prepare and run the external test script.
+# - Collect the results and format them in JSON so they can be added
+#   to the report with testapi::parse_extra_log()
+# - Upload results and logs.
+# Maintainer: Alvaro Carvajal <acarvajal@suse.com>
+
+use base 'consoletest';
+use testapi;
+use utils;
+use version_utils qw(is_sle is_opensuse is_tumbleweed);
+use Mojo::JSON qw(encode_json);
+use strict;
+use warnings;
+
+my $log = '/tmp/systemd_run.log';
+
+sub install_test_package {
+    my ($self) = @_;
+    my $version = get_required_var('VERSION');
+    my $qatest_repo = get_var('QA_TEST_REPO', '');
+    my $repo_name = 'SAP-systemdlib-testrepo';
+    my $pkg_name = 'SAP-systemdlib-tests';
+
+    if (!$qatest_repo) {
+        if (is_opensuse()) {
+            my $sub_project;
+            if (is_tumbleweed()) {
+                $sub_project = 'Tumbleweed/openSUSE_Tumbleweed/';
+            }
+            else {
+                (my $version, my $service_pack) = split('\.', $version);
+                $sub_project = "Leap:/$version/openSUSE_Leap_$version.$service_pack/";
+            }
+            $qatest_repo = 'https://download.opensuse.org/repositories/devel:/openSUSE:/QA:/' . $sub_project;
+        }
+        else {
+            $qatest_repo = "http://download.suse.de/ibs/QA:/Head/SLE-$version/";
+        }
+        die '$qatest_repo is not set' unless ($qatest_repo);
+    }
+
+    zypper_ar $qatest_repo, name => $repo_name;
+    zypper_call "in $pkg_name";
+}
+
+sub parse_results_from_output {
+    my ($self, $out) = @_;
+    my $results_file = 'systemd_run.results';
+    my $distro = uc(get_required_var('DISTRI'));
+    my $testunit = '';
+    my $outcome = '';
+    my %results = (
+        tests => [],
+        info => {timestamp => 0, distro => $distro, results_file => $results_file},
+        summary => {duration => 0, passed => 0, num_tests => 0}
+    );
+
+    $out =~ s/\r//gs;
+    foreach my $line (split(/\n/, $out)) {
+        if ($line =~ /^\/home.+\/([a-z0-9]+)\/run_test.sh$/) {
+            # Test block started. Identify test unit name and assume test will pass
+            $testunit = $1;
+            $outcome = 'passed';
+            next;
+        }
+        $outcome = 'failed' if ($line =~ /(ERROR:|FAILED:|failed$)/);
+        if ($testunit && ($line =~ /^=+$/)) {
+            # Test block end has been reached. Record results
+            $results{summary}{num_tests}++;
+            $results{summary}{passed}++ if ($outcome eq 'passed');
+            push @{$results{tests}}, {nodeid => $testunit, test_index => 0, outcome => $outcome};
+            $testunit = '';
+            $outcome = '';
+        }
+        last if ($line =~ /^### JOURNALCTL/);
+    }
+
+    my $json = encode_json \%results;
+    assert_script_run "echo '$json' > /tmp/$results_file";
+    parse_extra_log(IPA => "/tmp/$results_file");
+}
+
+sub upload_systemdlib_tests_logs {
+    my ($self) = @_;
+    $self->tar_and_upload_log($log, "$log.tar.bz2");
+    $self->save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.txt');
+}
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'root-console';
+    $self->install_test_package;
+    enter_cmd 'cd /usr/lib/systemd/test/SAP';
+    # systemd_prepare.sh can fail with a 0 retval, so we run it with sh -e
+    # to attempt to catch any errors and abort if necessary
+    assert_script_run 'sh -e ./systemd_prepare.sh';
+    # Run the test and save the logs and results
+    # systemd_run.sh will fail with a non-zero retval is any of the sub-tests
+    # fail. We ignore it to parse the individual results from the log
+    my $out = script_output "su - abcadm -c '/usr/lib/systemd/test/SAP/systemd_run.sh' 2>&1 | tee $log", proceed_on_failure => 1;
+    $self->parse_results_from_output($out);
+    $self->upload_systemdlib_tests_logs;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    #upload logs from given testname
+    $self->tar_and_upload_log('/var/log/journal /run/log/journal', 'binary-journal-log.tar.bz2');
+    $self->upload_systemdlib_tests_logs;
+}
+
+1;


### PR DESCRIPTION
This PR adds a test module that downloads the `SAP-systemdlib-tests` package into a SUT, and then runs it, saves and uploads the logs, and parses the results and exports it to openQA. The purpose of this package is to verify that the sapstart framework is compliant with systemd.

- Related ticket: https://jira.suse.com/browse/TEAM-3861
- Needles: N/A
- Verification runs: [15](http://mango.qa.suse.de/tests/4533), [15-SP1](http://mango.qa.suse.de/tests/4530), [15-SP2](http://mango.qa.suse.de/tests/4532), [15-SP3](http://mango.qa.suse.de/tests/4531), [15-SP4](http://mango.qa.suse.de/tests/4529)
- Notes: failures in 15-SP3 and 15-SP4 come from the external tool and are not related to the code in this PR. In fact, they work as verification runs as how the test module handles failures from the external tool.
