### PR TITLE
Add 'ncurses' into extra_tests_misc

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1157,7 +1157,7 @@ sub load_consoletests {
         loadtest "jeos/glibc_locale";
         loadtest "jeos/kiwi_templates" unless (is_leap('<15.2'));
     }
-    loadtest "console/ncurses";
+    loadtest "console/ncurses" if is_leap;
     loadtest "console/yast2_lan" unless is_bridged_networking;
     # no local certificate store
     if (!is_krypton_argon) {

--- a/schedule/functional/extra_tests_misc.yaml
+++ b/schedule/functional/extra_tests_misc.yaml
@@ -14,6 +14,7 @@ schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
     - update/zypper_up
+    - console/ncurses
     - console/iotop
     - console/gd
     - console/journalctlLevels

--- a/schedule/functional/minimal+proxy_SCC-postreg_SUSEconnect.yaml
+++ b/schedule/functional/minimal+proxy_SCC-postreg_SUSEconnect.yaml
@@ -9,7 +9,6 @@ schedule:
     - console/zypper_in
     - console/firewall_enabled
     - console/sshd_running
-    - console/ncurses
     - x11/xterm
     - console/suseconnect_scc
 test_data:


### PR DESCRIPTION
move ncurses out of installation tests.
keep ncurses in main_common.pm for leap untill yaml schedule can be 
introduced for leap.

see https://progress.opensuse.org/issues/95365 and
https://progress.opensuse.org/issues/100868

verifications:
http://10.162.30.85/tests/3784 (sles)
http://10.162.30.85/tests/3785 (Tumbleweed)