### PR TITLE
Remove tgr192 algorithm in ima test if not exist

### DIFF
--- a/tests/security/ima/ima_kernel_cmdline_hash.pm
+++ b/tests/security/ima/ima_kernel_cmdline_hash.pm
@@ -1,9 +1,9 @@
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Test IMA kernel command line for IMA hash
-# Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#48932
+# Maintainer: llzhao <llzhao@suse.com>, rfan1 <richard.fan@suse.com>
+# Tags: poo#48932, poo#100892
 
 use base "opensusebasetest";
 use strict;
@@ -32,6 +32,16 @@ sub run {
 
     # Add kernel modules to enable some algorithms
     my $algo_modlist = "rmd160 wp512 tgr192";
+
+    # On newer kernel, tgr192 algorithms may be removed due to
+    # upsteam commit, then we need skip it, refer to bsc#1191521
+    my $results = script_run("zcat /proc/config.gz | grep CONFIG_CRYPTO_TGR192");
+    if ($results) {
+        for (my $i = 0; $i < scalar(@algo_list); $i++) {
+            splice @algo_list, $i, 1 if ($algo_list[$i]->{algo} eq 'tgr192');
+        }
+        $algo_modlist =~ s/ tgr192//;
+    }
     $algo_modlist .= " sha512" if (!is_sle && !is_leap);
 
     assert_script_run "echo -e $algo_modlist | sed 's/ /\\n/g' > /etc/modules-load.d/hash.conf";
@@ -41,9 +51,10 @@ sub run {
     add_grub_cmdline_settings('ima_policy=tcb ima_hash=none');
     my $last_algo = "none";
 
-    for my $i (@algo_list) {
-        replace_grub_cmdline_settings("ima_hash=$last_algo", "ima_hash=@$i{algo}", update_grub => 1);
-        $last_algo = @$i{algo};
+    foreach my $hash_algo (@algo_list) {
+        my $ima_hash = $hash_algo->{algo};
+        replace_grub_cmdline_settings("ima_hash=$last_algo", "ima_hash=$ima_hash", update_grub => 1);
+        $last_algo = $ima_hash;
 
         # Grep and output grub settings to the terminal for debugging
         assert_script_run("grep GRUB_CMDLINE_LINUX /etc/default/grub");
@@ -53,11 +64,11 @@ sub run {
         $self->wait_boot;
         $self->select_serial_terminal;
 
-        my $meas_tmpfile = "/tmp/ascii_runtime_measurements-" . @$i{algo};
+        my $meas_tmpfile = "/tmp/ascii_runtime_measurements-$ima_hash";
         assert_script_run("cp $meas_file $meas_tmpfile");
         upload_logs "$meas_tmpfile";
 
-        my $out = script_output("grep '^10\\s*[a-fA-F0-9]\\{40\\}\\s*ima-ng\\s*@$i{algo}:[a-fA-F0-9]\\{@$i{len}\\}\\s*\\/' $meas_file |wc -l");
+        my $out = script_output("grep '^10\\s*[a-fA-F0-9]\\{40\\}\\s*ima-ng\\s*$ima_hash:[a-fA-F0-9]\\{$hash_algo->{len}\\}\\s*\\/' $meas_file |wc -l");
         die('Too few items') if ($out < 100);
     }
 }


### PR DESCRIPTION
tgr192 algorithm is removed from upstream, we may
need handle this change in ima test

- Related ticket: https://progress.opensuse.org/issues/100892
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/7410730
