### PR TITLE
Add x11_yast to patterns in yast2_gui

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
@@ -41,6 +41,7 @@ test_data:
             - fonts
             - gnome_basic
             - x11
+            - x11_yast
             - yast2_basis
             - yast2_desktop
             - yast2_server

--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -135,6 +135,7 @@ test_data:
       - fonts
       - gnome_basic
       - x11
+      - x11_yast
       - yast2_basis
       - yast2_desktop
       - yast2_server


### PR DESCRIPTION
Fixes https://openqa.suse.de/tests/7405313 as set of YaST pattern changed according to control files in SLE-15-SP4.
