### PR TITLE
publiccloud: rename and tidy up consoletest for publiccloud

### DIFF
--- a/schedule/publiccloud/consoletest.yml
+++ b/schedule/publiccloud/consoletest.yml
@@ -4,39 +4,25 @@ description: |
   Run mau-extratests on public cloud instances
 schedule:
   - boot/boot_to_desktop
+  - publiccloud/download_repos
   - publiccloud/prepare_instance
   - publiccloud/register_system
+  - publiccloud/transfer_repos
+  - publiccloud/patch_and_reboot
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview
-  - console/system_prepare
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - console/check_os_release
   - console/cleanup_qam_testrepos
   - console/openvswitch
-  - console/sshd
   - console/rpm
-  - console/command_not_found
   - console/openssl_alpn
-  - console/cron
-  - console/syslog
-  - console/mta
   - console/check_default_network_manager
   - console/sysctl
   - console/sysstat
-  - console/wget_ipv6
   - console/gpg
-  - console/shells
   - console/sudo
   - console/supportutils
   - console/journalctl
-  - console/quota
-  - console/rpcbind
-  - console/timezone
   - console/procps
   - console/suse_module_tools
-  - console/firewalld
-  - console/aaa_base
-  - console/osinfo_db
   - console/libgcrypt
   - publiccloud/ssh_interactive_end

--- a/schedule/publiccloud/staging_images/consoletest.yml
+++ b/schedule/publiccloud/staging_images/consoletest.yml
@@ -4,40 +4,26 @@ description: |
   Run mau-extratests on public cloud instances
 schedule:
   - boot/boot_to_desktop
-  - publiccloud/download_repos
   - publiccloud/prepare_instance
   - publiccloud/register_system
-  - publiccloud/transfer_repos
-  - publiccloud/patch_and_reboot
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview
+  - console/system_prepare
+  - console/prepare_test_data
+  - console/consoletest_setup
   - console/check_os_release
   - console/cleanup_qam_testrepos
   - console/openvswitch
-  - console/sshd
   - console/rpm
-  - console/command_not_found
   - console/openssl_alpn
-  - console/cron
-  - console/syslog
-  - console/mta
   - console/check_default_network_manager
-  - console/gdb
   - console/sysctl
   - console/sysstat
   - console/gpg
-  - console/shells
   - console/sudo
   - console/supportutils
   - console/journalctl
-  - console/quota
-  - console/rpcbind
-  - console/timezone
   - console/procps
   - console/suse_module_tools
-  - console/firewalld
-  - console/aaa_base
-  - console/osinfo_db
   - console/libgcrypt
-  - console/valgrind
   - publiccloud/ssh_interactive_end


### PR DESCRIPTION
Keeping in mind that this all tests already running against same subset of updates but just not in PubCloud we decided to lower scope which is running in PubCloud . Also I get rid of old name which does not make sense anymore 
VRs: http://autobot.qa.suse.de/tests/2559
http://autobot.qa.suse.de/tests/2558