### PR TITLE
Replace pipeline with grep -q in ha/priority_fencing_delay

### DIFF
--- a/tests/ha/priority_fencing_delay.pm
+++ b/tests/ha/priority_fencing_delay.pm
@@ -22,7 +22,7 @@ sub stonith_iptables {
         script_run "iptables -A INPUT -s $partner_ip -j DROP; iptables -A OUTPUT -d $partner_ip -j DROP";
         if (is_node(1)) {
             # Wait for the stonith match, then flush the rules for the next test
-            script_run "until $crm_mon_cmd | grep -qi offline ; do sleep 1; done", 60;
+            script_run "until grep -qi offline <($crm_mon_cmd) ; do sleep 1; done", 60;
             assert_script_run "iptables -F; iptables -X";
         }
 


### PR DESCRIPTION
Starting with SLES+HA 15-SP4 Alpha build 39.1, some pipelines of the type
`cmd | grep -q` in HA tests started failing with retval 141 (bash
generates a SIGPIPE as the left hand side command is still writing to the
pipe while the right hand side command has exited) or retval 1 (no
match), even when a match is expected. These commands were changed to
`grep -q <(cmd)` in PR #13348 and #13356 to avoid using the pipe,
but this instance in `ha/priority_fencing_delay.pm` was missing from those
commits, and it is impacting HA Priority Fencing tests in x86_64 and ppc64le.

This commit fixes the issue for the Priority Fencing Delay test module.

- Related ticket: N/A
- Needles: N/A
- Verification run on aarch64: [node 1](http://mango.qa.suse.de/tests/4610), [node 2](http://mango.qa.suse.de/tests/4611), [support server](http://mango.qa.suse.de/tests/4609)
- Verification run on x86_64: [node 1](http://mango.qa.suse.de/tests/4614), [node 2](http://mango.qa.suse.de/tests/4613), [support server](http://mango.qa.suse.de/tests/4612)
