### PR TITLE
Avoid possible endless loop in wait_until

### DIFF
--- a/lib/YuiRestClient/Wait.pm
+++ b/lib/YuiRestClient/Wait.pm
@@ -18,9 +18,9 @@ sub wait_until {
 
     die "No object passed to the method" unless $args{object};
 
-    my $counter = $args{timeout} / $args{interval};
+    my $counter = abs(int($args{timeout} / $args{interval}));
     my $result;
-    while ($counter--) {
+    while (--$counter >= 0) {
         eval { $result = $args{object}->() };
         return $result if $result;
         sleep($args{interval});


### PR DESCRIPTION
Stumbled over this possibility to create an endless_loop whil documenting YuiRestClient.

Changed exit criteria so that the wait loop exits even if the submitted timeout parameter is not a multiple of  the interval parameter.

- related ticket: N/A
- needles: N/A
- VR: NA 