### PR TITLE
schedule: Disable sporadically failing HA test modules (poo#95788)

### DIFF
--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01.yaml
@@ -38,10 +38,12 @@ schedule:
   - migration/online_migration/post_migration
   - '{{cluster_boot_mgmt}}'
   - '{{console_reboot}}'
-  - ha/check_cluster_integrity
-  - ha/check_hawk
-  - ha/wait_others_upgraded_or_updated
-  - ha/check_logs
+  # Disabled sporadically failing test modules
+  # See https://progress.opensuse.org/issues/95788
+  # - ha/check_cluster_integrity
+  # - ha/check_hawk
+  # - ha/wait_others_upgraded_or_updated
+  # - ha/check_logs
 conditional_schedule:
   cluster_boot_mgmt:
     QAM_INCI:


### PR DESCRIPTION
For example as observed in
https://openqa.suse.de/tests/latest?arch=x86_64&distri=sle&flavor=Server-DVD-HA-Updates&machine=64bit&test=qam_ha_rolling_upgrade_migration_node01&version=12-SP4
the test module "check_cluster_integrity" is failing often. auto-review
is catching these cases and linking the related progress issue. The
fail-rate from the above scenario seems to be around 70%. As the related
progress issue is "Normal" priority I do not assume this issue to be
fixed soon so despite of the obvious test coverage loss we need to
prevent sporadically failing tests that do not provide clear feedback
about the cause of the issue hence removing the test modules that fail
or are dependant on the failing module from the schedule.

Related progress issue: https://progress.opensuse.org/issues/95788