### PR TITLE
Run "console/openssl_alpn" module as needed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2140,7 +2140,7 @@ sub load_security_console_prepare {
     loadtest "console/consoletest_setup";
     loadtest "security/test_repo_setup" if (get_var("SECURITY_TEST") =~ /^crypt_/ && !is_opensuse);
     loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
-    loadtest "console/openssl_alpn";
+    loadtest "console/openssl_alpn" if (get_var("FIPS_ENABLED") && get_var("JEOS"));
 }
 
 # The function name load_security_tests_crypt_* is to avoid confusing


### PR DESCRIPTION
Fix "console/openssl_alpn" is invoked in all security test cases by misunderstanding and run this module as needed

poo#100964 - [sle][security][sle15sp4] investigate and fix: not all Security test cases need to execute module "console/openssl_alpn"

- Related ticket: https://progress.opensuse.org/issues/100964
- Needles: NA
- Verification run:
  osd: https://openqa.suse.de/tests/7456476#details (the module "openssl_alpn" is not run now)
  NOTE: It seems I have no permission to run Jeos test cases at "http://kepler.suse.cz" 

