### PR TITLE
Prevent continues with the job when the first test in EKS fails

### DIFF
--- a/tests/containers/upload_container_images_to_ecr.pm
+++ b/tests/containers/upload_container_images_to_ecr.pm
@@ -33,4 +33,8 @@ sub post_fail_hook {
     $self->{provider}->delete_image($self->tag);
 }
 
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
 1;


### PR DESCRIPTION
When the upload to AWS Elastic Container Registry fails shouldn't continue with the next test.

- Related ticket: https://progress.opensuse.org/issues/97724