### PR TITLE
Fix a good name for the ECR image tag name

### DIFF
--- a/lib/publiccloud/aws.pm
+++ b/lib/publiccloud/aws.pm
@@ -96,6 +96,6 @@ Returns a default tag for container images based of the current job id
 =cut
 sub get_default_tag {
     my ($self) = @_;
-    return join('-', get_var('PUBLIC_CLOUD_RESOURCE_NAME'), get_current_job_id());
+    return join('-', get_var('PUBLIC_CLOUD_RESOURCE_NAME', 'openqa-vm'), get_current_job_id());
 }
 1;


### PR DESCRIPTION
When the default tag is defined, if PUBLIC_CLOUD_RESOURCE_NAME is
not defined then the tag name begins with '-'

- Related ticket: https://progress.opensuse.org/issues/97724
- Verification run: http://copland.arch.suse.de/tests/444
NOTE: the default value is used the tag .../suse-qec-testing:openqa-vm-444