### PR TITLE
assert_and_click expects timeout via keyword argument

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -149,7 +149,7 @@ sub run {
 
         # Add max_interval while type password and extend time of click needle match
         type_string($fips_password, max_interval => 2);
-        assert_and_click("firefox-enter-password-OK", 120);
+        assert_and_click("firefox-enter-password-OK" => 120);
         wait_still_screen 10;
 
         # Add a condition to avoid the password missed input

--- a/tests/x11/firefox/firefox_extensions.pm
+++ b/tests/x11/firefox/firefox_extensions.pm
@@ -46,14 +46,14 @@ sub run {
     }
     else {
         send_key_until_needlematch 'firefox-extensions-flagfox', 'f5', 5, 5;
-        assert_and_click 'firefox-extensions-flagfox', 60;
+        assert_and_click 'firefox-extensions-flagfox', timeout => 60;
         wait_still_screen 3;
         assert_and_click_until_screen_change('firefox-extensions-add-to-firefox', 5, 5);
     }
     wait_still_screen 3;
-    assert_and_click 'firefox-extensions-confirm-add', 60;
-    assert_and_click 'firefox-extensions-added', 60;
-    assert_and_click 'firefox-extensions-flagfox-tab', 60;
+    assert_and_click 'firefox-extensions-confirm-add', timeout => 60;
+    assert_and_click 'firefox-extensions-added', timeout => 60;
+    assert_and_click 'firefox-extensions-flagfox-tab', timeout => 60;
     # close the flagfox relase notes tab and flagfox search tab
     send_key_until_needlematch 'firefox-addons-plugins', 'ctrl-w', 3, 3;
     # refresh the page to see addon buttons

--- a/tests/x11/gnomeapps/gnome_multi_writer.pm
+++ b/tests/x11/gnomeapps/gnome_multi_writer.pm
@@ -16,7 +16,7 @@ use utils;
 sub run {
     x11_start_program('gnome-multi-writer', target_match => [qw(test-gnome-multi-writer-started polkit-unmount-auth-required)]);
     # With GNOME 3.34, elevated permissions using polkit need be confirmed even if root has no password
-    assert_and_click('polkit-unmount-auth-required', 1) if (match_has_tag 'polkit-unmount-auth-required');
+    assert_and_click('polkit-unmount-auth-required', timeout => 1) if (match_has_tag 'polkit-unmount-auth-required');
     assert_screen('test-gnome-multi-writer-started', 2);
     send_key "alt-f4";
 }


### PR DESCRIPTION
    Odd number of elements in hash assignment at /usr/lib/os-autoinst/testapi.pm line 505.
    testapi::assert_and_click("firefox-enter-password-OK", 120) called at sle/tests/fips/mozilla_nss/firefox_nss.pm line 152

As seen in https://openqa.suse.de/tests/7452647/logfile?filename=autoinst-log.txt. No ticket since I noticed this by chance because the failure was being discussed in chat.

Used `rg 'assert_and_click.*,[^a-z]*\d'` to find more occurances.