### PR TITLE
[virt_autotest] find out the correct vcpu number for 15-SP4 guest 

### DIFF
--- a/tests/virtualization/universal/hotplugging.pm
+++ b/tests/virtualization/universal/hotplugging.pm
@@ -145,7 +145,9 @@ sub test_add_vcpu {
             record_soft_failure 'bsc#1170026 vCPU hotplugging damages ' . $guest if (script_retry("ssh root\@$guest nproc", delay => 60, retry => 3, timeout => 60, die => 0) != 0);
             #$self->{test_results}->{$guest}->{"bsc#1170026 vCPU hotplugging damages this guest $guest"}->{status} = 'SOFTFAILED' if ($vcpu_nproc != 0);
         } else {
-            script_retry("ssh root\@$guest nproc | grep 3", delay => 60, retry => 3, timeout => 60);
+            # bsc#1191737 Get the wrong vcpu number for 15-SP4 guest via nproc tool
+            my $nproc = (is_kvm_host && $guest =~ m/sles-15-sp4-64/i) ? 'nproc --all' : 'nproc';
+            script_retry("ssh root\@$guest $nproc | grep 3", delay => 60, retry => 3, timeout => 60);
         }
         # Reset CPU count to two
         die "Resetting vcpus failed" unless (set_vcpus($guest, 2));


### PR DESCRIPTION
- Description:
Refer to the latest OSD 15-SP4 build50.1, figure out the new test failure about hotplugging::VCPU on all 15-SP4 guest. 
After more investigation about this new test failure, find out that add a vcpu to 15-SP4 guest is not brought online automatically, but kept offline as the default now. 
Please refer to [bsc#1191737 ](https://bugzilla.suse.com/show_bug.cgi?id=1191737)for more details about this product bug. 
By the way, figure out 'nproc --all' is available to get the total vCPU number from 15-SP4 guest as the workaround for bsc#1191737.  
So, just only use 'nproc --all' to detect the total vCPU number after add cpu to 15-SP4 guest as this PR purpose 
- Add
`my $nproc = (is_kvm_host && $guest =~ m/sles-15-sp4-64/i) ? 'nproc --all' : 'nproc';`
- Related ticket: https://progress.opensuse.org/issues/101115
- Verification run: 
[gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.suse.de/tests/7474384)
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/7474385#)
[gi-guest_developing-on-host_sles15sp3-kvm](https://openqa.suse.de/tests/7474388#)
[gi-guest_sles12sp5-on-host_developing-kvm](https://openqa.suse.de/tests/7476957#)
[gi-guest_sles15sp3-on-host_developing-kvm](https://openqa.suse.de/tests/7476958#)