### PR TITLE
WIP: Add post-installation modules in lvm+RAID1 for hyperv-uefi

### DIFF
--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -29,6 +29,8 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/validate_lvm_raid1
 test_data:
   <<: !include test_data/yast/lvm_raid1/lvm+raid1_hyperv.yaml

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -30,6 +30,8 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/validate_lvm_raid1
 test_data:
   <<: !include test_data/yast/lvm_raid1/lvm+raid1_svirt-xen.yaml

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -28,6 +28,8 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/first_boot
+  - console/system_prepare
+  - console/force_scheduled_tasks
   - console/validate_lvm_raid1
 test_data:
   <<: !include test_data/yast/lvm_raid1/lvm+raid1_svirt-xen.yaml


### PR DESCRIPTION
- Related ticket: [poo#100970](https://progress.opensuse.org/issues/100970)
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: [lvm+RAID1@svirt-hyperv-uefi ](https://openqa.suse.de/tests/7476991)
