### PR TITLE
Disable rootless_podman on s390x

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -25,10 +25,16 @@ use containers::utils 'registry_url';
 use version_utils qw(get_os_release);
 use version_utils 'is_sle';
 use containers::engine;
+use Utils::Architectures 'is_s390x';
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
+
+    if (is_s390x) {
+        record_soft_failure("poo#101154 - Test images broken for s390x");
+        return;
+    }
 
     my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
 


### PR DESCRIPTION
Disables the `rootless_podman` test on s390x because the used Tumbleweed
(and Leap images) for s390x are broken at the moment.

- Related ticket: https://progress.opensuse.org/issues/101154
- Verification run: [SLE15-SP3 aarch64](https://openqa.suse.de/t7478089) | [SLE15-SP3 s390x](https://openqa.suse.de/t7478087) | [SLE15-SP3 x86_64](https://openqa.suse.de/t7478088)
