### PR TITLE
Containers: minor aesthetic improvements to EKS test

### DIFF
--- a/lib/publiccloud/aws.pm
+++ b/lib/publiccloud/aws.pm
@@ -72,7 +72,7 @@ sub init {
 }
 
 =head2 get_container_registry_prefix
-Get the full registry prefix URL for any containers image registry of ECR based on the account and region 
+Get the full registry prefix URL for any containers image registry of ECR based on the account and region
 =cut
 sub get_container_registry_prefix {
     my ($self) = @_;

--- a/lib/publiccloud/k8sbasetest.pm
+++ b/lib/publiccloud/k8sbasetest.pm
@@ -18,15 +18,14 @@ sub install_kubectl {
 }
 
 =head2 apply_manifest
-Apply a kubernetes manifest 
+Apply a kubernetes manifest
 =cut
 sub apply_manifest {
     my ($self, $manifest) = @_;
 
     my $path = sprintf('/tmp/%s.yml', random_string(32));
 
-    record_info('INFO', "Temporal manifest yaml $path \ncontent\n $manifest");
-    assert_script_run("echo -e '$manifest' >$path");
+    script_output("echo -e '$manifest' > $path");
     upload_logs($path, failok => 1);
 
     assert_script_run("kubectl apply -f $path");

--- a/schedule/containers/sle_image_on_amazon_eks.yaml
+++ b/schedule/containers/sle_image_on_amazon_eks.yaml
@@ -4,5 +4,5 @@ description: |
   containers Amazon on Elastic Kubernetes Service test
 schedule:
   - boot/boot_to_desktop
-  - containers/upload_container_images_to_ecr
+  - containers/push_container_image_to_ecr
   - containers/run_container_in_eks


### PR DESCRIPTION
- Dump some useful information using record_info for more test flow
visibility and faster troubleshooting.

- Replace assert_script_run by script_output which works better with
multi-line strings.

- Change default name for PUBLIC_CLOUD_RESOURCE_NAME to openqa.
`openqa-vm` might confuse people, as it doesn't create a VM...

VR: https://openqa.suse.de/tests/7477069