### PR TITLE
publiccloud: Prepare terrafrom env only on terraform_apply()

### DIFF
--- a/lib/publiccloud/aws.pm
+++ b/lib/publiccloud/aws.pm
@@ -96,6 +96,6 @@ Returns a default tag for container images based of the current job id
 =cut
 sub get_default_tag {
     my ($self) = @_;
-    return join('-', get_var('PUBLIC_CLOUD_RESOURCE_NAME', 'openqa-vm'), get_current_job_id());
+    return join('-', $self->resource_name, get_current_job_id());
 }
 1;


### PR DESCRIPTION
the class `publiccloud::provider` is now used also on tests where we do
not need that terraform environment at all. But others like credential
handling and is used.
With this change, we make terraform not as one of the mandatory usages!

- Verification run : 
- https://openqa.suse.de/tests/7482707 - sle_15_SP3_image_on_eks
- https://openqa.suse.de/t7481502 - publiccloud_ltp_syscalls
