### PR TITLE
Update HA cluster preflight check with the new syntax

### DIFF
--- a/schedule/ha/bv/ha_crash_test_node.yaml
+++ b/schedule/ha/bv/ha_crash_test_node.yaml
@@ -39,7 +39,7 @@ schedule:
   - ha/iscsi_client
   - ha/watchdog
   - '{{cluster_setup}}'
-  - '{{ha_cluster_preflight_check}}'
+  - '{{ha_cluster_crash_test}}'
   - ha/check_logs
 conditional_schedule:
   cluster_setup:
@@ -48,7 +48,7 @@ conditional_schedule:
         - ha/ha_cluster_init
       no:
         - ha/ha_cluster_join
-  ha_cluster_preflight_check:
+  ha_cluster_crash_test:
     PREFLIGHT_CHECK:
       1:
-        - ha/ha_cluster_preflight_check
+        - ha/ha_cluster_crash_test

--- a/tests/ha/ha_cluster_crash_test.pm
+++ b/tests/ha/ha_cluster_crash_test.pm
@@ -15,12 +15,12 @@ use hacluster qw(check_cluster_state get_cluster_name get_node_index get_node_nu
 use utils qw(zypper_call);
 use Mojo::JSON qw(encode_json);
 
-our $dir_log = '/var/lib/crmsh/preflight_check/';
+our $dir_log = '/var/lib/crmsh/crash_test/';
 
-sub upload_preflight_check_logs {
+sub upload_crash_test_logs {
     my @report_files = split(/\n/, script_output("ls $dir_log 2>/dev/null", proceed_on_failure => 1));
     upload_logs("$dir_log/$_", failok => 1) foreach (@report_files);
-    upload_logs('/var/log/crmsh/preflight_check.log', failok => 1);
+    upload_logs('/var/log/crmsh/crash_test.log', failok => 1);
 }
 
 sub run {
@@ -36,19 +36,13 @@ sub run {
     barrier_wait("PREFLIGHT_CHECK_INIT_${cluster_name}_NODE$_") foreach (1 .. (get_node_index) - 1);
 
     # List of things to check
-    my @checks = qw(kill-sbd kill-corosync kill-pacemaker split-brain-iptables);
-
-    # Check the overall cluster status first
+    my @checks = qw(kill-sbd kill-corosync kill-pacemakerd split-brain-iptables);
     my $preflight_start_time = time;
-    my $cmd_status = "crm analyze preflight_check";
-    record_info("cluster status", "Executing ${cmd_status}");
-    my $cmd_fails = script_run "${cmd_status}";
-    record_info('ERROR', "Failure while executing '$cmd_status'", result => 'fail') unless (defined $cmd_fails and $cmd_fails == 0);
 
     # Loop on each check
     foreach my $check (@checks) {
         # Execute the command
-        my $cmd = "crm analyze preflight_check --yes --${check}";
+        my $cmd = "crm cluster crash_test --${check} --force";
         record_info("${check}", "Executing ${cmd}");
         my $cmd_fails = script_run "${cmd}";
         #record_info('ERROR', "Failure while executing '$cmd'", result => 'fail') unless (defined $cmd_fails and $cmd_fails == 0);
@@ -74,7 +68,7 @@ sub run {
     }
 
     my $preflight_end_time = time;
-    upload_preflight_check_logs;
+    upload_crash_test_logs;
 
     # Parse the logs to get a better overview in openQA
     my $results_file = '/tmp/preflight_cluster.json';
@@ -122,7 +116,7 @@ sub post_fail_hook {
     select_console('root-console');
 
     # Upload the logs
-    $self->upload_preflight_check_logs;
+    $self->upload_crash_test_logs;
     ha_export_logs;
 
     # Execute the common part


### PR DESCRIPTION
HA Cluster Preflight Check has been renamed in https://github.com/ClusterLabs/crmsh/pull/825 as Crash Test; this includes a syntax change from `crm analyze preflight check` to `crm cluster crash_test` among other things. This commit updates the names and syntax of the commands.

- Related ticket: N/A
- Needles: N/A
- Failing Tests: https://openqa.suse.de/tests/7431105#step/ha_cluster_preflight_check/90
- Verification run: [node 1](http://mango.qa.suse.de/tests/4709), [node 2](http://mango.qa.suse.de/tests/4710), [node 3](http://mango.qa.suse.de/tests/4711), [support server](http://mango.qa.suse.de/tests/4708)
- Job Group Configuration Update: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/337

**Note:** please also merge the MR updating the Job Group configuration whenever this is merged, as this PR includes a change in the YAML schedule file name.