### PR TITLE
Bump timeout waiting serial when running console YaST modules

### DIFF
--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -21,7 +21,7 @@ sub run {
     if (check_screen 'autoyast2-install-accept', 10) {
         send_key 'alt-i';    # confirm package installation
     }
-    wait_serial("$module_name-0", 400) || die "'yast2 clone_system' exited with non-zero code";
+    wait_serial("$module_name-0", 700) || die "'yast2 clone_system' exited with non-zero code";
     upload_logs '/root/autoinst.xml';
 
     # original autoyast on kernel cmdline


### PR DESCRIPTION
Due to recent lower performance in aarch.

- Related ticket: [poo#96293](https://progress.opensuse.org/issues/96293)
- Verification run: [qam-allpatterns+addons@aarch64](https://openqa.suse.de/tests/latest?arch=aarch64&distri=sle&flavor=Online-QR&machine=aarch64&test=qam-allpatterns%2Baddons%40jknphy%2Fos-autoinst-distri-opensuse%23bump_timeout_serial_clone&version=15-SP3#step/clone/14)

Note: given the time that takes to run the job, not considering other improvements like reduce RAM from 6G to something reasonable.
