### PR TITLE
console/clamav: Avoid timeout failures due to upstream database timeouts

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -116,6 +116,13 @@ sub post_run_hook {
     systemctl('stop freshclam');
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->SUPER::post_fail_hook;
+    upload_logs('/etc/freshclam.conf');
+
+}
+
 sub test_flags {
     return {fatal => 0};
 }


### PR DESCRIPTION
- console/clamav: Avoid upstream database
- console/clamav: Attach config file when test fails

VR: https://openqa.suse.de/tests/7496514
