### PR TITLE
Use LibyuiClient for lvm and lvm_no_separate_home test modules

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetup/FilesystemOptionsController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetup/FilesystemOptionsController.pm
@@ -41,6 +41,11 @@ sub get_filesystem_options_page {
     return $self->{FilesystemOptionsPage};
 }
 
+sub do_not_propose_separate_home {
+    my ($self) = @_;
+    $self->get_filesystem_options_page()->unselect_propose_separate_home();
+}
+
 sub select_root_filesystem_type {
     my ($self, $fs_type) = @_;
     $self->get_filesystem_options_page()->select_root_filesystem($fs_type);

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetup/FilesystemOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetup/FilesystemOptionsPage.pm
@@ -18,7 +18,13 @@ sub init {
     $self->SUPER::init();
     $self->{lbl_settings_root_part} = $self->{app}->label({label => 'Settings for the Root Partition'});
     $self->{cmb_root_fs_type} = $self->{app}->combobox({id => '"vol_0_fs_type"'});
+    $self->{chb_separate_home} = $self->{app}->checkbox({id => '"vol_1_proposed"'});
     return $self;
+}
+
+sub unselect_propose_separate_home {
+    my ($self) = @_;
+    $self->{chb_separate_home}->uncheck();
 }
 
 sub select_root_filesystem {

--- a/schedule/qam/QR/15-SP3/lvm/lvm+resize_lv.yaml
+++ b/schedule/qam/QR/15-SP3/lvm/lvm+resize_lv.yaml
@@ -11,17 +11,19 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/welcome
-  - installation/accept_license
-  - installation/scc_registration
-  - installation/addon_products_sle
-  - installation/system_role
-  - installation/partitioning
-  - installation/partitioning/lvm_no_separate_home
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_selection/skip_module_selection
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_text_mode
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup/enable_lvm
+  - installation/partitioning/guided_setup/do_not_propose_separate_home
   - installation/partitioning/resize_existing_lv
-  - installation/installer_timezone
-  - installation/user_settings
-  - installation/user_settings_root
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -18,7 +18,9 @@ schedule:
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/lvm_no_separate_home
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup/enable_lvm
+  - installation/partitioning/guided_setup/do_not_propose_separate_home
   - installation/partitioning/resize_existing_lv
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -20,7 +20,9 @@ schedule:
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/lvm
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup/enable_lvm
+  - installation/partitioning/guided_setup/accept_default_fs_options
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -21,7 +21,9 @@ schedule:
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/lvm
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup/enable_lvm
+  - installation/partitioning/guided_setup/accept_default_fs_options
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root

--- a/schedule/yast/lvm_multipath.yaml
+++ b/schedule/yast/lvm_multipath.yaml
@@ -20,7 +20,9 @@ schedule:
   - installation/multipath
   - installation/add_on_product/skip_install_addons
   - installation/system_role/select_role_text_mode
-  - installation/partitioning/lvm_no_separate_home
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup/enable_lvm
+  - installation/partitioning/guided_setup/do_not_propose_separate_home
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst

--- a/schedule/yast/opensuse/lvm/lvm.yaml
+++ b/schedule/yast/opensuse/lvm/lvm.yaml
@@ -20,7 +20,9 @@ schedule:
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_generic_desktop
-  - installation/partitioning/lvm
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup/enable_lvm
+  - installation/partitioning/guided_setup/accept_default_fs_options
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -16,7 +16,9 @@ schedule:
   - installation/module_selection/select_nonconflicting_modules
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/no_separate_home
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/do_not_propose_separate_home
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst

--- a/tests/installation/partitioning/guided_setup/do_not_propose_separate_home.pm
+++ b/tests/installation/partitioning/guided_setup/do_not_propose_separate_home.pm
@@ -1,0 +1,17 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: The test module disables separate home partition on Filesystem Options Screen of Guided Setup
+# and navigates to the next screen.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    $testapi::distri->get_filesystem_options()->do_not_propose_separate_home();
+    $testapi::distri->get_filesystem_options()->go_forward();
+}
+
+1;

--- a/tests/installation/partitioning/guided_setup/enable_lvm.pm
+++ b/tests/installation/partitioning/guided_setup/enable_lvm.pm
@@ -1,0 +1,18 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: The test module enables LVM on Partitioning Scheme Screen of Guided Setup
+# and navigates to the next screen.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    my $partitioning_scheme = $testapi::distri->get_partitioning_scheme();
+    $partitioning_scheme->enable_lvm();
+    $partitioning_scheme->go_forward();
+}
+
+1;


### PR DESCRIPTION
Use LibyuiClient for lvm and lvm_no_separate_home test modules.

Also split the modules to be atomic.

- Related ticket: https://progress.opensuse.org/issues/96813
- Verification runs: 
   - QR (lvm_no_separate_home): https://openqa.suse.de/tests/7500028
   - TW (lvm): https://openqa.opensuse.org/tests/1982272
   - YaST (lvm): https://openqa.suse.de/tests/7500030
   - YaST (lvm_no_separate_home): https://openqa.suse.de/tests/7500682
