### PR TITLE
Add module validation for installer_extended

### DIFF
--- a/lib/Installation/ModuleSelection/ModuleSelectionController.pm
+++ b/lib/Installation/ModuleSelection/ModuleSelectionController.pm
@@ -53,4 +53,14 @@ sub view_development_versions {
     $self->get_module_selection_page()->uncheck_hide_development_versions();
 }
 
+sub get_selected_modules {
+    my ($self) = @_;
+    return $self->get_module_selection_page()->get_selected_modules();
+}
+
+sub get_modules {
+    my ($self) = @_;
+    return $self->get_module_selection_page()->get_modules();
+}
+
 1;

--- a/lib/Installation/ModuleSelection/ModuleSelectionPage.pm
+++ b/lib/Installation/ModuleSelection/ModuleSelectionPage.pm
@@ -39,22 +39,29 @@ sub is_shown {
     return $self->{rt_items}->exist();
 }
 
-sub get_modules {
+sub get_modules_full_name {
     my ($self) = @_;
     my @modules = ($self->{rt_items}->text() =~ /<a href='(.*?)'.*<\/a>/g);
     return \@modules;
 }
 
+sub get_modules {
+    my ($self) = @_;
+    my @modules = ($self->{rt_items}->text() =~ /<a href='?"?(.*?)-\d+/g);
+    return \@modules;
+}
+
 sub get_selected_modules {
     my ($self) = @_;
-    my @modules = ($self->{rt_items}->text() =~ /<a href='(.*?)'.*inst_checkbox-on.*<\/a>/g);
+    my @modules = ($self->{rt_items}->text() =~ /<a href='(.*?)-\d+.*inst_checkbox-on|<a href="(.*?)-\d+.*\[x\]/g);
+    @modules = grep defined, @modules;
     return \@modules;
 }
 
 sub select_module {
     my ($self, $module) = @_;
     my $module_name = $self->{"rt_item_$module"};
-    my ($module_full_name) = grep { /$module_name/ } $self->get_modules()->@*;
+    my ($module_full_name) = grep { /$module_name/ } $self->get_modules_full_name()->@*;
     return $self->{rt_items}->activate_link($module_full_name);
 }
 

--- a/lib/Installation/ModuleSelection/ModuleSelectionPage.pm
+++ b/lib/Installation/ModuleSelection/ModuleSelectionPage.pm
@@ -41,7 +41,8 @@ sub is_shown {
 
 sub get_modules_full_name {
     my ($self) = @_;
-    my @modules = ($self->{rt_items}->text() =~ /<a href='(.*?)'.*<\/a>/g);
+    my @modules = ($self->{rt_items}->text() =~ /<a href="(.*?)">|<a href='(.*?)' /g);
+    @modules = grep defined, @modules;
     return \@modules;
 }
 

--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -6,6 +6,7 @@ description: >
      - License has to be accepted and there is pop-up with a hint.
      - License translations (except SLE 15 due to missing translations in the
        beta phase).
+     - Check available and selected by default modules for installation.
 vars:
   CHECK_PRESELECTED_MODULES: '1'
   CHECK_RELEASENOTES: '1'
@@ -25,6 +26,7 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_selection/view_development_versions
+  - installation/module_selection/verify_module_selection
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_text_mode
@@ -78,3 +80,20 @@ test_data:
       - language: Traditional Chinese
         text: 版軟體的
   beta_text: 'You are accessing our Beta Distribution'
+  modules:
+    - sle-ha
+    - sle-module-live-patching
+    - sle-we
+    - sle-module-basesystem
+    - sle-module-containers
+    - sle-module-desktop-applications
+    - sle-module-development-tools
+    - sle-module-legacy
+    - sle-module-public-cloud
+    - PackageHub
+    - sle-module-server-applications
+    - sle-module-transactional-server
+    - sle-module-web-scripting
+  selected_modules:
+    - sle-module-basesystem
+    - sle-module-server-applications

--- a/test_data/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/test_data/yast/installer_extended/installer_extended_aarch64.yaml
@@ -1,0 +1,44 @@
+---
+license:
+  language: English (US)
+  translations:
+    - language: Czech
+      text: Licenční smlouva společnosti
+    - language: English (US)
+      text: End User License Agreement
+    - language: French
+      text: Contrat de licence utilisateur final
+    - language: German
+      text: Endbenutzer-Lizenzvereinbarung
+    - language: Italian
+      text: Contratto di licenza
+    - language: Japanese
+      text: 版ソフトウェア
+    - language: Korean
+      text: 소프트웨어
+    - language: Portuguese (Brazilian)
+      text: Contrato de Licença para Usuário Final
+    - language: Russian
+      text: Лицензионное соглашение
+    - language: Simplified Chinese
+      text: 软件的
+    - language: Spanish
+      text: Acuerdo de licencia de usuario final
+    - language: Traditional Chinese
+      text: 版軟體的
+beta_text: 'You are accessing our Beta Distribution'
+modules:
+  - sle-ha
+  - sle-module-basesystem
+  - sle-module-containers
+  - sle-module-desktop-applications
+  - sle-module-development-tools
+  - sle-module-legacy
+  - sle-module-public-cloud
+  - PackageHub
+  - sle-module-server-applications
+  - sle-module-transactional-server
+  - sle-module-web-scripting
+selected_modules:
+  - sle-module-basesystem
+  - sle-module-server-applications

--- a/test_data/yast/installer_extended/installer_extended_ppc64le_s390x.yaml
+++ b/test_data/yast/installer_extended/installer_extended_ppc64le_s390x.yaml
@@ -1,0 +1,45 @@
+---
+license:
+  language: English (US)
+  translations:
+    - language: Czech
+      text: Licenční smlouva společnosti
+    - language: English (US)
+      text: End User License Agreement
+    - language: French
+      text: Contrat de licence utilisateur final
+    - language: German
+      text: Endbenutzer-Lizenzvereinbarung
+    - language: Italian
+      text: Contratto di licenza
+    - language: Japanese
+      text: 版ソフトウェア
+    - language: Korean
+      text: 소프트웨어
+    - language: Portuguese (Brazilian)
+      text: Contrato de Licença para Usuário Final
+    - language: Russian
+      text: Лицензионное соглашение
+    - language: Simplified Chinese
+      text: 软件的
+    - language: Spanish
+      text: Acuerdo de licencia de usuario final
+    - language: Traditional Chinese
+      text: 版軟體的
+beta_text: 'You are accessing our Beta Distribution'
+modules:
+  - sle-ha
+  - sle-module-live-patching
+  - sle-module-basesystem
+  - sle-module-containers
+  - sle-module-desktop-applications
+  - sle-module-development-tools
+  - sle-module-legacy
+  - sle-module-public-cloud
+  - PackageHub
+  - sle-module-server-applications
+  - sle-module-transactional-server
+  - sle-module-web-scripting
+selected_modules:
+  - sle-module-basesystem
+  - sle-module-server-applications

--- a/tests/installation/module_selection/verify_module_selection.pm
+++ b/tests/installation/module_selection/verify_module_selection.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Verify that the expected modules appear on the module list
+#          during graphical installation and that only default ones
+#          are selected.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use scheduler 'get_test_suite_data';
+use utils 'arrays_differ';
+
+sub run {
+    my @expected_modules = @{get_test_suite_data()->{modules}};
+    my @modules = @{$testapi::distri->get_module_selection()->get_modules()};
+    die "Modules do not match with the expected ones."
+      . "\nExpected:\n" . join(', ', @expected_modules)
+      . "\nActual:\n" . join(', ', @modules)
+      if arrays_differ(\@expected_modules, \@modules);
+    my @expected_selected_modules = @{get_test_suite_data()->{selected_modules}};
+    my @selected_modules = @{$testapi::distri->get_module_selection()->get_selected_modules()};
+    die "Selected modules are not the default ones"
+      . "\nExpected:\n" . join(', ', @expected_selected_modules)
+      . "\nActual:\n" . join(', ', @selected_modules)
+      if arrays_differ(\@expected_selected_modules, \@selected_modules);
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/97394
- Verification runs: 
https://openqa.suse.de/tests/overview?version=15-SP4&build=sofiasyria%2Fos-autoinst-distri-opensuse%23dev_modules&distri=sle

VRs for 3rd commit "Modify get_module_full_name to work for textmode":
http://falafel.suse.cz/tests/759
http://falafel.suse.cz/tests/757#step/exp/1
http://falafel.suse.cz/tests/758#step/exp/1