### PR TITLE
Update gnome-control-center process for default page changed after users test

### DIFF
--- a/tests/x11/gnome_control_center.pm
+++ b/tests/x11/gnome_control_center.pm
@@ -26,13 +26,9 @@ sub run {
     mouse_hide(1);
     # for timeout selection see bsc#965857
     x11_start_program('gnome-control-center', match_timeout => 120);
-    # If the default page of gnome control center changed by other test, need to
-    # back to default page and continue for the test.
-    if (match_has_tag('gnome-control-center-detail-layout')) {
-        assert_and_click "gnome-control-center-back";
-        assert_screen "gnome-control-center";
-    }
-    if (match_has_tag('gnome-control-center-new-layout')) {
+    # The gnome control center updated, the work flow for non-default page
+    # will be same as gnome-control-center-new-layout.
+    if (match_has_tag('gnome-control-center-new-layout') || match_has_tag('gnome-control-center-detail-layout')) {
         # with GNOME 3.26, the control-center got a different layout / workflow
         type_string "about";
         assert_screen "gnome-control-center-about-typed";


### PR DESCRIPTION
The gnome control center updated, the work flow for non-default page should be same as gnome-control-center-new-layout.

- Related ticket: https://progress.opensuse.org/issues/101224
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/7495177#step/gnome_control_center/7
