### PR TITLE
Modify test suite security_pam to run on Tumbleweed

### DIFF
--- a/tests/security/pam/pam_config.pm
+++ b/tests/security/pam/pam_config.pm
@@ -23,18 +23,28 @@ use warnings;
 use testapi;
 use registration qw(add_suseconnect_product remove_suseconnect_product);
 use utils 'zypper_call';
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
     # Create a simple Unix authentication configuration, all backup files will not be deleted
-    assert_script_run 'pam-config --create';
-    assert_script_run 'ls /etc/pam.d | grep config-backup';
+    if (!is_sle) {
+        zypper_call 'in systemd-experimental';
+    }
+    assert_script_run 'pam-config --create', timeout => 180;
+    if (is_sle) {
+        assert_script_run 'ls /etc/pam.d | grep config-backup';
+    }
 
     # Add a new authentication method, add the module to install the "pam_ldap" package
-    add_suseconnect_product('sle-module-legacy');
-    zypper_call 'in pam_ldap';
+    if (is_sle) {
+        add_suseconnect_product('sle-module-legacy');
+        zypper_call 'in pam_ldap';
+    } else {
+        zypper_call 'in nss-pam-ldapd';
+    }
     assert_script_run 'pam-config --add --ldap';
     assert_script_run 'find /etc/pam.d -type f | grep common | xargs egrep ldap';
     assert_script_run 'pam-config --add --ldap-debug';
@@ -44,10 +54,14 @@ sub run {
     assert_script_run 'pam-config --delete --ldap';
     assert_script_run 'pam-config --delete --ldap-debug';
     validate_script_output "find /etc/pam.d -type f | grep common | xargs egrep ldap || echo 'check pass'", sub { m/check pass/ };
-    upload_logs("/var/log/messages");
-
-    # Tear down, remove the added module
-    remove_suseconnect_product('sle-module-legacy');
+    if (is_sle) {
+        upload_logs("/var/log/messages");
+        # Tear down, remove the added module
+        remove_suseconnect_product('sle-module-legacy');
+    } else {
+        script_run("journalctl --no-pager -o short-precise > /tmp/full_journal.log");
+        upload_logs "/tmp/full_journal.log";
+    }
 }
 
 sub test_flags {

--- a/tests/security/pam/pam_login.pm
+++ b/tests/security/pam/pam_login.pm
@@ -36,7 +36,17 @@ sub run {
     my $pam_login = '/etc/pam.d/login';
     my $pam_sshd_bak = '/tmp/sshd_bak';
     my $pam_login_bak = '/tmp/login_bak';
+    my $pam_sshd_tw = '/usr/etc/pam.d/sshd';
+    my $pam_login_tw = '/usr/etc/pam.d/login';
+    my $ret_sshd = script_run("[[ -e $pam_sshd ]]");
+    my $ret_login = script_run("[[ -e $pam_login ]]");
     assert_script_run "echo $user > $deny_user_file";
+    if ($ret_sshd != 0) {
+        script_run "cp $pam_sshd_tw $pam_sshd";
+    }
+    if ($ret_login != 0) {
+        script_run "cp $pam_login_tw $pam_login";
+    }
     assert_script_run "cp $pam_sshd $pam_sshd_bak";
     assert_script_run "cp $pam_login $pam_login_bak";
     assert_script_run "sed -i '\$a auth      required   pam_listfile.so   onerr=succeed  item=user  sense=deny  file=$deny_user_file' $pam_sshd";

--- a/tests/security/pam/pam_mount.pm
+++ b/tests/security/pam/pam_mount.pm
@@ -39,6 +39,7 @@ sub run {
     my $user = 'bernhard';
     my $key = 'SUSE_t595_qw';
     my $testfile = 'testfile';
+    assert_script_run "modprobe loop";
     my $loopdev = script_output 'losetup -f';
     my $loop_vol = 'enc_loop';
 

--- a/tests/security/pam/pam_su.pm
+++ b/tests/security/pam/pam_su.pm
@@ -38,6 +38,16 @@ sub run {
     my $su_file_bak = '/tmp/su';
     my $sul_file = '/etc/pam.d/su-l';
     my $sul_file_bak = '/tmp/su-l';
+    my $ret_su = script_run("[[ -e $su_file ]]");
+    my $ret_sul = script_run("[[ -e $sul_file ]]");
+    my $su_file_tw = '/usr/etc/pam.d/su';
+    my $sul_file_tw = '/usr/etc/pam.d/su-l';
+    if ($ret_su != 0) {
+        script_run "cp $su_file_tw $su_file";
+    }
+    if ($ret_sul != 0) {
+        script_run "cp $sul_file_tw $sul_file";
+    }
     assert_script_run "cp $su_file $su_file_bak";
     assert_script_run "cp $sul_file $sul_file_bak";
     assert_script_run "sed -i '\$a auth     required       pam_wheel.so use_uid' $su_file";


### PR DESCRIPTION
According to Factory First, all test cases should run on Tumbleweed. Cases modified are under security_pam. Added file copy mechanism to pam_su and pam_login due to different file locations in SLE and Tumbleweed. Added version specification in pam_config since some functions are only available in SLE. Manually load loop module to avoid multiple lines of output being returned.

- Related ticket: 
  https://progress.opensuse.org/issues/100691
  https://progress.opensuse.org/issues/100700
  https://progress.opensuse.org/issues/100715
- Needles: N/A
- Verification run: 
  - O3: https://openqa.opensuse.org/tests/1983169
  - x86_64: https://openqa.suse.de/tests/7494175
  - aarch64: https://openqa.suse.de/tests/7494183
  - s390x: https://openqa.suse.de/tests/7505445
  - power: https://openqa.suse.de/tests/7494199
