### PR TITLE
Add UEFI firmware check on SLES for grub auth test

### DIFF
--- a/tests/security/grub_auth/grub_authorization.pm
+++ b/tests/security/grub_auth/grub_authorization.pm
@@ -12,7 +12,7 @@
 #             3) Wrong user/password is not able to access the grub
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81721, poo#95548, poo#97175, tc#1768659
+# Tags: poo#81721, poo#95548, poo#97175, poo#101238, tc#1768659
 
 use base 'opensusebasetest';
 use strict;
@@ -31,8 +31,7 @@ my $test_passwd = 'pw_test';
 sub switch_boot_menu {
     my $switch = shift;
 
-    # Currently, SLES doesn't include this new grub feature
-    if (get_var('UEFI') && !is_sle) {
+    if (get_var('UEFI')) {
         assert_screen("grub_uefi_firmware_menu_entry", timeout => 90);
         send_key_until_needlematch("grub_auth_boot_menu_entry", "down", 5, 2) if $switch;
     }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/101238
- Needles: already uploaded
- Verification run: https://openqa.suse.de/tests/7505468