### PR TITLE
Update bug list for 15sp4

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -153,7 +153,7 @@
         "description": "systemd-vconsole-setup.service",
         "products": {
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
-            "sle": ["15-SP2", "15-SP3"]
+            "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "bug"
     },
@@ -193,11 +193,18 @@
         },
         "type": "bug"
     },
+    "bsc#1191951": {
+        "description": "kernel: wait_for_initramfs\\(\\) called before rootfs_initcalls",
+        "products": {
+            "sle": ["15-SP4"]
+        },
+        "type": "bug"
+    },
     "apci-bridge": {
         "description": "fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge|PCI: System does not support PCI",
         "products": {
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
-            "sle": ["15-SP2", "15-SP3"]
+            "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "ignore"
     },
@@ -227,7 +234,7 @@
             "sle-micro": [ "5.0", "5.1" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
-            "sle": ["15-SP2", "15-SP3"]
+            "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "ignore"
     },
@@ -237,7 +244,7 @@
             "sle-micro": [ "5.0", "5.1" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
-            "sle": ["15-SP2", "15-SP3"]
+            "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "ignore"
     },
@@ -254,7 +261,7 @@
     "xen-trim-btrfs-on-mechaninal-drive": {
         "description": "kernel: BTRFS warning.*: failed to trim.*, last error -512",
         "products": {
-            "sle": ["15-SP2", "15-SP3"]
+            "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "ignore"
     },
@@ -272,7 +279,7 @@
             "sle-micro": [ "5.0", "5.1" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
-            "sle": ["15-SP2", "15-SP3"]
+            "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "ignore"
     },


### PR DESCRIPTION
Add new bug [wait_for_initramfs() called before rootfs_initcalls](https://bugzilla.suse.com/show_bug.cgi?id=1191951)
Extend know bugs and issues for sle15sp4

VR: [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.86-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/8324#)

