### PR TITLE
Update test_opensuse_based_image with get_tty

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -171,16 +171,7 @@ sub test_opensuse_based_image {
             my $pretty_version = $version =~ s/-SP/ SP/r;
             my $betaversion = $beta ? '\s\([^)]+\)' : '';
             record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
-            # TODO: implement
-            # $out = $runtime->read($image, cmd => "grep PRETTY_NAME /etc/os-release | cut -d= -f2");
-            if ($runtime->runtime =~ /buildah/) {
-                validate_script_output("$runtime run $image grep PRETTY_NAME /etc/os-release | cut -d= -f2",
-                    sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
-            } else {
-                # zypper-docker changes the layout of the image
-                validate_script_output("$runtime run --entrypoint /bin/bash $image -c 'grep PRETTY_NAME /etc/os-release' | cut -d= -f2",
-                    sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
-            }
+            validate_container_output($runtime, $image, "grep PRETTY_NAME /etc/os-release", "SUSE Linux Enterprise Server ${pretty_version}${betaversion}");
 
             unless (is_unreleased_sle) {
                 # SUSEConnect zypper service is supported only on SLE based image on SLE host

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -213,7 +213,7 @@ Otherwise it prints the output of info.
 
 =cut
 sub info {
-    my ($self, %args) = shift;
+    my ($self, %args) = @_;
     my $property = $args{property} ? qq(--format '{{.$args{property}}}') : '';
     my $expected = $args{value} ? qq( | grep $args{value}) : '';
     $self->_engine_assert_script_run(sprintf("info %s %s", $property, $expected));
@@ -229,6 +229,19 @@ C<filename> file the logs are written to.
 sub get_container_logs {
     my ($self, $container, $filename) = @_;
     $self->_engine_assert_script_run("container logs $container | tee $filename");
+}
+
+=head2 read_tty
+
+Assert a C<property> against given expected C<value> if C<value> is given.
+Otherwise it prints the output of info.
+
+=cut
+sub read_tty {
+    my ($self) = shift;
+    my %args = (image => '', params => '', pipe => '', cmd => '', @_);
+    my $pipe_cmd = $args{pipe} ? '|' . $args{pipe} : $args{pipe};
+    return $self->_engine_script_output(sprintf("run --entrypoint /bin/bash %s %s -c '%s' %s", $args{params}, $args{image}, $args{cmd}, $pipe_cmd));
 }
 
 =head2 remove_image($image_name)

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -21,7 +21,7 @@ use version_utils;
 use Mojo::Util 'trim';
 
 our @EXPORT = qw(test_seccomp basic_container_tests get_vars can_build_sle_base check_docker_firewall
-  get_docker_version check_runtime_version container_ip registry_url);
+  get_docker_version check_runtime_version container_ip registry_url validate_container_output);
 
 sub test_seccomp {
     my $no_seccomp = script_run('docker info | tee /tmp/docker_info.txt | grep seccomp');
@@ -212,6 +212,23 @@ sub can_build_sle_base {
     # script_run returns 0 if true, but true is 1 on perl
     my $has_sle_registration = !script_run("test -e /etc/zypp/credentials.d/SCCcredentials");
     return check_os_release('sles', 'ID') && $has_sle_registration;
+}
+
+=head2 validate_container_output
+
+validate_container_output($engine, $image, $cmd, $validator)
+
+C<validate_container_output> should be used to validate the output of the C<cmd> which the C<image>
+will run in a container. 
+
+The advantage of C<validate_container_output> is that the I<engine> will know how to run the container for you.
+
+=cut
+
+sub validate_container_output {
+    my ($engine, $image, $cmd, $validator) = @_;
+    my $out = $engine->read_tty(image => $image, cmd => $cmd);
+    $out =~ /$validator/ or die "$validator mismatch: $out";
 }
 
 1;


### PR DESCRIPTION
The new design is missing a way to get the output of the pseudo_tty from a container
Add `get_tty` and update test_opensuse_based_image to use it

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2313523&version=15-SP3&distri=sle
