### PR TITLE
Design yamls with podman and docker to run as separate jobs

### DIFF
--- a/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
+++ b/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
@@ -2,41 +2,46 @@
 description: 'Functional test of tools and container engines pulled from Containers (contm) and Package Hub (phub) modules'
 name: 'jeos-container-engines_and_tools'
 conditional_schedule:
-    bootloader:
-        MACHINE:
-            'svirt-xen-pv':
-                - installation/bootloader_svirt
-            'svirt-xen-hvm':
-                - installation/bootloader_svirt
-                - installation/bootloader_uefi
-            'svirt-hyperv-uefi':
-                - installation/bootloader_hyperv
-            'svirt-hyperv':
-                - installation/bootloader_hyperv
-                - installation/bootloader_uefi
-            'svirt-vmware65':
-                - installation/bootloader_svirt
-                - installation/bootloader_uefi
+  bootloader:
+    MACHINE:
+      'svirt-xen-pv':
+        - installation/bootloader_svirt
+      'svirt-xen-hvm':
+        - installation/bootloader_svirt
+        - installation/bootloader_uefi
+      'svirt-hyperv-uefi':
+        - installation/bootloader_hyperv
+      'svirt-hyperv':
+        - installation/bootloader_hyperv
+        - installation/bootloader_uefi
+      'svirt-vmware65':
+        - installation/bootloader_svirt
+        - installation/bootloader_uefi
+  containers:
+    CONTAINER_RUNTIME:
+      docker:
+        - containers/docker
+        - containers/docker_runc
+        - containers/docker_image
+        - containers/docker_3rd_party_images
+        - containers/registry
+        - containers/zypper_docker
+        - containers/container_diff
+      podman:
+        - containers/podman
+        - containers/podman_image
+        - containers/buildah
+        - containers/podman_3rd_party_images
+        - containers/rootless_podman
 schedule:
-    - '{{bootloader}}'
-    - jeos/firstrun
-    - jeos/record_machine_id
-    - console/system_prepare
-    - console/force_scheduled_tasks
-    - jeos/diskusage
-    - jeos/build_key
-    - console/suseconnect_scc
-    - console/consoletest_setup
-    - console/zypper_ref
-    - containers/podman
-    - containers/podman_image
-    - containers/buildah
-    - containers/docker
-    - containers/docker_runc
-    - containers/docker_image
-    - containers/docker_3rd_party_images
-    - containers/podman_3rd_party_images
-    - containers/registry
-    - containers/zypper_docker
-    - containers/container_diff
-    - containers/rootless_podman
+  - '{{bootloader}}'
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/diskusage
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/consoletest_setup
+  - console/zypper_ref
+  - '{{containers}}'


### PR DESCRIPTION
We need to split the jobs which get scheduled with both container engines together, to run separately.
Redesign the yamls schedules which fit those conditions to be able to do so.
This follows the latest trend in the qa-c.

The need cames from another task which tries to merge podman_image and docker_image in one side and
podman__3rd_party_images and docker_3rd_party_images.

Those apparently touch pubcloud jobs and jeos and it wouldnt necessity if they were scheduled by main.pm.
make the change only for jeos for now.
This comes with https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/482

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/101210
