### PR TITLE
Wait more time for zypper process in background to finish

### DIFF
--- a/lib/zypper.pm
+++ b/lib/zypper.pm
@@ -29,7 +29,9 @@ lock so that we can run a new zypper for our test.
 
 =cut
 sub wait_quit_zypper {
-    assert_script_run('until ! pgrep \'zypper|purge-kernels|rpm\' > /dev/null; do sleep 10; done', 600);
+    # sometimes the zypper processes already in quit process but can't pgrep, we
+    # need wait several seconds for them to finish deactivate.
+    assert_script_run('for ((i=60; i>0; i--)) do if (! pgrep \'zypper|purge-kernels|rpm\' > /dev/null); then sleep 10; break; else sleep 10; continue; fi done', 600);
 }
 
 1;


### PR DESCRIPTION
sometimes the zypper processes already in quit process but can't pgrep the process, we need wait several seconds for them to finish deactivate.

- Related ticket: https://progress.opensuse.org/issues/101103
- Needles: N/A
- Verification run: 

- https://openqa.nue.suse.com/tests/7530858#step/handle_reboot/19
