### PR TITLE
Fix module lynis_perform_system_audit timed out

### DIFF
--- a/tests/security/lynis/lynis_perform_system_audit.pm
+++ b/tests/security/lynis/lynis_perform_system_audit.pm
@@ -24,7 +24,7 @@ sub run {
     # Run "# lynis audit system" to "Performs a system audit" and save the outputs
     assert_script_run("rm -rf $lynis_audit_system_current_file");
     assert_script_run("rm -rf $lynis_audit_system_error_file");
-    assert_script_run("lynis audit system --nocolors > $lynis_audit_system_current_file 2> $lynis_audit_system_error_file", timeout => 600);
+    assert_script_run("lynis audit system --nocolors > $lynis_audit_system_current_file 2> $lynis_audit_system_error_file", timeout => 900);
 
     # Upload the outputs for reference: e.g.,
     # file "$lynis_audit_system_current_file" can be used to be a new baseline


### PR DESCRIPTION
It timed out on aarch64 currently so increase the time out value to 900s.
The command executed for 12 minutes we can improve the timeout value to 15 minutes accordingly.

poo#101106 - [sle][security][sle15sp4] test fails in lynis_perform_system_audit: command 'lynis audit system --nocolors' timed out

- Related ticket: https://progress.opensuse.org/issues/101106
- Needles: NA
- Verification run: https://openqa.suse.de/tests/7520922#