### PR TITLE
Implement Secure Boot support tests on aarch64

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2020 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 package bootloader_setup;
@@ -915,6 +915,7 @@ sub tianocore_disable_secureboot {
     send_key_until_needlematch 'tianocore-devicemanager', 'esc';
     send_key_until_needlematch 'tianocore-mainmenu-reset', 'down';
     send_key 'ret';
+    send_key 'ret' if check_screen('tianocore-secureboot-not-enabled', 20);
     $basetest->wait_grub;
 }
 

--- a/schedule/security/aarch64_secureboot.yaml
+++ b/schedule/security/aarch64_secureboot.yaml
@@ -1,0 +1,9 @@
+name: aarch64 secureboot
+description:    >
+    Secure Boot support in
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - console/verify_efi_mok
+    - security/aarch64_secure_boot/boot_without_secureboot
+    - security/aarch64_secure_boot/yast2_bootloader

--- a/tests/security/aarch64_secure_boot/boot_without_secureboot.pm
+++ b/tests/security/aarch64_secure_boot/boot_without_secureboot.pm
@@ -1,0 +1,34 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: For aarch64 system with secureboot enabled,
+#          we need make sure it can boot up successfully
+#          after disabling the secureboot
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#81712
+
+use base 'opensusebasetest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use power_action_utils 'power_action';
+use bootloader_setup 'tianocore_disable_secureboot';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Reboot and disable secureboot
+    power_action('reboot', textmode => 1);
+    $self->wait_grub(bootloader_time => 200);
+    $self->tianocore_disable_secureboot;
+    $self->wait_boot(textmode => 1);
+
+    # Make sure secureboot is disabled
+    $self->select_serial_terminal;
+    validate_script_output('mokutil --sb-state', sub { m/SecureBoot disabled/ });
+}
+
+1;

--- a/tests/security/aarch64_secure_boot/yast2_bootloader.pm
+++ b/tests/security/aarch64_secure_boot/yast2_bootloader.pm
@@ -1,0 +1,62 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Use "yast2 bootloader" to enable or
+#          disable secureboot support
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#81712
+
+use base 'opensusebasetest';
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use power_action_utils 'power_action';
+
+sub run {
+    my ($self) = shift;
+
+    # Start yast2 bootloader to un-select Secure Boot Support
+    # This operation will not disable the secureboot from UEFI
+    # ROM, it will change the bootloader file from shim.efi to
+    # grubaa64.efi
+    select_console("root-console");
+    enter_cmd("yast2 bootloader");
+    assert_screen("yast2-bootloder-GRUB2-for-EFI");
+    send_key_until_needlematch("yast2_bootloader-Secureboot-Support", "tab", 6, 2);
+    send_key("ret");
+    assert_screen("yast2_bootloader-Secureboot-unselect");
+    send_key_until_needlematch("yast2_bootloader-Secureboot-unselect-ok", "tab", 5, 2);
+    send_key("ret");
+    reset_consoles;
+
+    # Make sure boot loader does not uses shim any more
+    select_console("root-console");
+    my $boot_opt = script_output("efibootmgr -v | grep BootOrder|awk '{print \$NF}' | awk -F, '{print \$1}'");
+    my $boot_inf = script_output("efibootmgr -v | grep Boot$boot_opt");
+    record_info("Bootloader info:", "$boot_inf");
+    my $results = script_run("efibootmgr -v | grep Boot$boot_opt | grep shim.efi");
+    if (!$results) {
+        die("ERROR", "shim.efi is still used, it is not by design");
+    }
+
+    # Reboot the node to check again
+    # Then both shim.efi and grubaa64.efi can
+    # boot up the system successfully
+    power_action("reboot", textmode => 1);
+    $self->wait_boot(textmode => 1);
+
+    select_console("root-console");
+    my $results1 = script_run("efibootmgr -v | grep BootCurrent | grep $boot_opt");
+    if ($results1) {
+        die("ERROR", "Wrong Bootloder is used");
+    }
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Based on jira feature:
SLE-15020 - Complete Secure Boot support on aarch64,
add the secureboot related test into openQA

- Related ticket: https://progress.opensuse.org/issues/81712
- Needles: uploaded already
- Verification run: 
https://openqa.suse.de/tests/7532682 - SLE

On TW, it failed due to bug https://bugzilla.suse.com/show_bug.cgi?id=1191989
https://openqa.opensuse.org/tests/1989457

I Will try to run the test on TW later