### PR TITLE
Fix incorrect sriov setting

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -156,7 +156,7 @@ sub test_network_interface {
     save_screenshot;
 
     # Restore the network interface to the default for the Xen guests
-    if (!get_var("SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH")) {
+    if ($is_sriov_test ne "true") {
         if (is_xen_host()) {
             assert_script_run("ssh root\@$guest 'cd /etc/sysconfig/network/; cp ifcfg-eth0 ifcfg-$nic'");
         }


### PR DESCRIPTION
A minor fix to sriov tests. 

- Verification run:  
http://openqa.suse.de/tests/7521063

@alice-suse @guoxuguang @waynechen55 @nanzhg 