### PR TITLE
Fix firefox send_key issues

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -24,8 +24,10 @@ sub run() {
     $self->start_firefox;
     wait_still_screen;
     send_key('alt');
+    wait_still_screen;
     assert_screen('firefox-top-bar-highlighted');
     send_key('h');
+    wait_still_screen;
     assert_screen('firefox-help-menu');
     send_key_until_needlematch('test-firefox-3', 'a', 9, 6);
 


### PR DESCRIPTION
In the Firefox module sometimes the top menu bar can't be shown 
with send_key 'alt' and the help menu can be shown by send_key 'h'

- Related ticket: https://progress.opensuse.org/issues/100880
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/t7531009 
   https://openqa.nue.suse.com/t7531010