### PR TITLE
pynfs: Fix result validation

### DIFF
--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -28,7 +28,7 @@ sub upload_pynfs_log {
     script_run('../showresults.py --hidepass result-raw.txt > result-fail.txt');
     upload_logs('result-fail.txt', failok => 1);
 
-    if (script_run('[ -s result-fail.txt ]') == 0) {
+    if (script_output("cat result-fail.txt | grep 'Of those:.*Failed' | sed 's/.*, \\([0-9]\\+\\) Failed,.*/\\1/'") gt 0) {
         $self->result("fail");
         record_info("failed tests", script_output('cat result-fail.txt'), result => 'fail');
     }


### PR DESCRIPTION
showresults.py output also summary, not only failed tests,
thus it's wrong to expect zero file size on fixed tests:

```
../showresults.py --hidepass result-raw.txt
**************************************************
**************************************************
Command line asked for 169 of 259 tests
Of those: 0 Skipped, 0 Failed, 0 Warned, 169 Passed
```

=> detect failure from the summary.

Verification run:
expected to PASS
* http://quasar.suse.cz/tests/7359
* http://quasar.suse.cz/tests/7360

expected to FAIL (at least one test is failing)
* http://quasar.suse.cz/tests/7358
* http://quasar.suse.cz/tests/7361