### PR TITLE
Attached vf needs more time to be down

### DIFF
--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -375,7 +375,7 @@ sub unplug_vf_from_vm {
     record_info("Unplug VF from vm", "$vf->{host_id} \nGuest: $vm \nbdf='$vf->{vm_bdf}'   mac='$vf->{vm_mac}'   nic='$vf->{vm_nic}'");
 
     #bring the nic down
-    script_run("ssh root\@$vm 'ifdown $vf->{vm_nic}'", 60);
+    script_run("ssh root\@$vm 'ifdown $vf->{vm_nic}'", 300);
 
     #detach vf from guest
     my $vf_xml_file = "vf_in_vm.xml";


### PR DESCRIPTION
* **Attached** vf interface needs more time before becoming down by using ifdown on it, otherwise the command may not return as normal like [this](https://openqa.suse.de/tests/7486615#step/sriov_network_card_pci_passthrough/668)

* **Verification run:**
  [12sp5 on 15sp4 xen](https://openqa.suse.de/tests/7542291)