### PR TITLE
Containers: Don't disable unattended upgrades on Ubuntu

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -31,8 +31,6 @@ sub run {
         $interface = script_output q@ip r s default | head -1 | awk '{printf $5}'@;
         validate_script_output "ip a s '$interface'", sub { m/((\d{1,3}\.){3}\d{1,3}\/\d{1,2})/ };
         assert_script_run "curl http://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/ssl/certs/SUSE_Trust_Root.crt" if is_sle();
-        # Stop unattended-upgrades on Ubuntu hosts to prevent interference from automatic updates
-        assert_script_run "sed -i 's/Unattended-Upgrade \"1\"/Unattended-Upgrade \"0\"/' /etc/apt/apt.conf.d/20auto-upgrades" if check_os_release("ubuntu", "PRETTY_NAME");
     }
 }
 


### PR DESCRIPTION
On the prepared ubuntu image the unattended upgrades are now disabled by default

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: [poo#94871](https://progress.opensuse.org/issues/94871)
- Needles: [openqa.suse.de](https://openqa.suse.de/tests/7534628#)
- Verification run: [pdostal-server](http://pdostal-server.suse.cz/tests/12627)
