### PR TITLE
Retry container-suseconnect-zypp lp command

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -186,7 +186,7 @@ sub test_opensuse_based_image {
                 # SUSEConnect zypper service is supported only on SLE based image on SLE host
                 my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
                 $runtime->run_container($image, cmd => "$plugin -v", keep_container => 1);
-                $runtime->run_container($image, cmd => "$plugin lp", keep_container => 1, timeout => 420);
+                $runtime->run_container($image, cmd => "$plugin lp", keep_container => 1, timeout => 420, retry => 3, delay => 60);
                 $runtime->run_container($image, cmd => "$plugin lm", keep_container => 1, timeout => 420);
             }
         } else {

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -137,7 +137,8 @@ sub run_container {
     my $params = sprintf qq(%s %s %s), $keep_container, $mode, $name;
     my $cmd = sprintf qq(run %s %s %s), $params, $image_name, $remote;
     record_info "cmd_info", "Container executes:\noptions $params $image_name $remote";
-    $self->_engine_assert_script_run($cmd, timeout => $args{timeout});
+    my $retries = $args{retry} // 1;
+    return $self->_engine_script_retry($cmd, timeout => $args{timeout}, retry => $retries, delay => $args{delay});
 }
 
 =head2 pull($image_name, [%args])


### PR DESCRIPTION
The container-suseconnect-zypp lp command will be tried now three times
before failure. This should help to mitigate some network issues.

- Related ticket: https://progress.opensuse.org/issues/99759
- Verification run: [15-SP3 aarch64](https://openqa.suse.de/t7544018) | [15-SP3 x86_64](https://openqa.suse.de/t7545187) | [12-SP5 x86_64](https://openqa.suse.de/t7543963) | [Tumbleweed docker](https://openqa.opensuse.org/t1993972) | [Tumbleweed podman](https://openqa.opensuse.org/t1993973)