### PR TITLE
wait for a still screen when selecting x11 console

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -887,7 +887,10 @@ sub console_selected {
     set_var('CONSOLE_JUST_ACTIVATED', 0);
     # x11 needs special handling because we can not easily know if screen is
     # locked, display manager is waiting for login, etc.
-    return ensure_unlocked_desktop if $args{tags} =~ /x11/;
+    if ($args{tags} =~ /x11/) {
+        wait_still_screen;
+        return ensure_unlocked_desktop;
+    }
     assert_screen($args{tags}, no_wait => 1, timeout => $args{timeout});
     if (match_has_tag('workqueue_lockup')) {
         record_soft_failure 'bsc#1126782';


### PR DESCRIPTION
This commit is meant to fix https://bugzilla.opensuse.org/show_bug.cgi?id=1191994.

The root cause is https://bugzilla.suse.com/show_bug.cgi?id=1168979.

So the solution is to wait for a still screen when selecting x11 console, before `ensure_unlocked_desktop` is called.


- Related ticket: https://progress.opensuse.org/issues/101503
- Needles: none
- Verification run: https://openqa.opensuse.org/tests/1993664#step/shutdown/1
