### PR TITLE
Need wait more time for background zypper process to finish

### DIFF
--- a/lib/zypper.pm
+++ b/lib/zypper.pm
@@ -31,7 +31,7 @@ lock so that we can run a new zypper for our test.
 sub wait_quit_zypper {
     # sometimes the zypper processes already in quit process but can't pgrep, we
     # need wait several seconds for them to finish deactivate.
-    assert_script_run('for ((i=60; i>0; i--)) do if (! pgrep \'zypper|purge-kernels|rpm\' > /dev/null); then sleep 10; break; else sleep 10; continue; fi done', 600);
+    assert_script_run('for ((i=60; i>0; i--)) do if (! pgrep \'zypper|purge-kernels|rpm\' > /dev/null); then sleep 20; break; else sleep 10; continue; fi done', 600);
 }
 
 1;


### PR DESCRIPTION
Sometimes the system is very slow, we need wait more time for background zypper process to finish

- Related ticket: https://progress.opensuse.org/issues/101103
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/7542588#step/handle_reboot/19
                          http://openqa.nue.suse.com/tests/7542855#step/handle_reboot/19
                          http://openqa.nue.suse.com/tests/7542853#step/handle_reboot/19
                          https://openqa.nue.suse.com/tests/7543177#step/handle_reboot/19
                          