### PR TITLE
[hyperv] Kill hanging VNC sessions according to PID

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -138,7 +138,9 @@ sub run {
     enter_cmd "mkdir -p ~/.vnc/";
     enter_cmd "vncpasswd -f <<<$testapi::password > ~/.vnc/passwd";
     enter_cmd "chmod 0600 ~/.vnc/passwd";
-    enter_cmd "pkill -f \"Xvnc :$xvncport\"; pkill -9 -f \"Xvnc :$xvncport\"";
+    enter_cmd 'pgrep -a Xvnc';
+    enter_cmd "pvnc=\$(pgrep -f Xvnc[[:space:]]*:${xvncport}[[:space:]]*-geometry)";
+    enter_cmd '[ -n "$pvnc" ] && kill -9 $pvnc';
     enter_cmd "Xvnc :$xvncport -geometry 1024x768 -pn -rfbauth ~/.vnc/passwd &";
 
     my $ps = 'powershell -Command';


### PR DESCRIPTION
As we have more hyperv workers, we need to cleanup hanging VNC sessions from
previous jobs. The `Xvnc` processes are handled in a standalone VM managing
RDP2VNC for hyperv jobs in o.s.d. The previous cleanup solution was
killing other active VNC sessions as a side effect.

- Verification runs:
  * [sle-15-SP4-JeOS-for-MS-HyperV-x86_64-Build1.86-jeos-main@svirt-hyperv](http://kepler.suse.cz/tests/8398#step/bootloader_hyperv/44)
  * [sle-15-SP4-JeOS-for-MS-HyperV-x86_64-Build1.86-jeos-main@svirt-hyperv](http://kepler.suse.cz/tests/8399#step/bootloader_hyperv/44)
