### PR TITLE
[WIP] Add waiting time for ssh second xterm to show the prompt

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -24,7 +24,7 @@ sub run {
     mouse_hide(1);
     x11_start_program('xterm');
     enter_cmd("ssh -o StrictHostKeyChecking=no -XC root\@localhost xterm");
-    assert_screen "ssh-second-xterm";
+    assert_screen "ssh-second-xterm", 120;
     $self->set_standard_prompt();
     $self->enter_test_text('ssh-X-forwarding', cmd => 1);
     assert_screen 'test-sshxterm-1';


### PR DESCRIPTION
Add time for waiting for ssh-second-xterm to show the prompt.

- Related ticket: https://progress.opensuse.org/issues/100886
- Verification run: 
https://openqa.suse.de/tests/7547782#step/sshxterm/4
https://openqa.suse.de/tests/7547788#step/sshxterm/4

The problem is not always reproducible, running more cases to investigate it. Will update the results here.
