### PR TITLE
Adjust test case order in load_x11_gnome

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1950,20 +1950,20 @@ sub load_x11_documentation {
 
 sub load_x11_gnome {
     return unless check_var('DESKTOP', 'gnome');
-    if (is_sle('12-SP2+')) {
-        loadtest "x11/gdm_session_switch";
-    }
+    loadtest "x11/gnomecase/login_test";
+    loadtest "x11/gnomecase/change_password";
     loadtest "x11/gnomecase/nautilus_cut_file";
     loadtest "x11/gnomecase/nautilus_permission";
     loadtest "x11/gnomecase/nautilus_open_ftp";
     loadtest "x11/gnomecase/application_starts_on_login";
-    loadtest "x11/gnomecase/login_test";
     if (is_sle '12-SP1+') {
         loadtest "x11/gnomecase/gnome_classic_switch";
     }
     loadtest "x11/gnomecase/gnome_default_applications";
     loadtest "x11/gnomecase/gnome_window_switcher";
-    loadtest "x11/gnomecase/change_password";
+    if (is_sle('12-SP2+')) {
+        loadtest "x11/gdm_session_switch";
+    }
 }
 
 sub load_x11_other {


### PR DESCRIPTION
The login_test and change_password failed when running in the current order.
Run login_test and change_password separately, the result is PASS. See https://openqa.suse.de/tests/7506597

Before finding the root cause of the failure,
I am changing the test cases order `load_x11_gnome` to fix the failure.

- Related ticket: https://progress.opensuse.org/issues/101572
- Needles: N/A
- Verification run: 
> 15SP4 x11-desktopapps-gnome https://openqa.suse.de/tests/7551945
> 15SP4 wayland-desktopapps-gnome https://openqa.suse.de/tests/7551946
> 15SP3 qam-regression-gnome https://openqa.suse.de/tests/7543895
