### PR TITLE
Add the cryptsetup update check to 2.4.0+ for SLE15-SP4

### DIFF
--- a/tests/console/cryptsetup.pm
+++ b/tests/console/cryptsetup.pm
@@ -1,52 +1,70 @@
 # SUSE's openQA tests
 #
-# Copyright 2016 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
-
+#
 # Package: cryptsetup
 # Summary: FIPS: cryptsetup
-#    This case is verify the command of cryptsetup whether can be work in FIPS mode
+#          Attempt to verify the command of cryptsetup whether can be worked in FIPS mode
+#
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: tc#1528909
+# Tags: tc#1528909, poo#101575
 
 
 use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use utils 'zypper_call';
+use version_utils qw(is_sle);
 
 sub run {
     # Strengthen password to avoid password quality check failed on Tumbleweed
     my $cryptpasswd = $testapi::password . '123';
-    select_console "root-console";
+    select_console 'root-console';
 
-    # create a random volume.
-    assert_script_run("dd if=/dev/urandom of=/test.dm bs=1k count=51200");
+    # Update related packages including latest systemd
+    zypper_call('in cryptsetup device-mapper systemd util-linux');
+
+    zypper_call('info cryptsetup');
+    my $current_ver = script_output("rpm -q --qf '%{version}\n' cryptsetup");
+
+    # cryptsetup attempt to update to 2.4.0+ in SLE15 SP4 base on the feature
+    # SLE-20275: cryptsetup update to 2.4.0
+    if (!is_sle('<15-sp4') && ($current_ver ge 2.4.0)) {
+        record_info('cryptsetup version', "Version of Current cryptsetup package: $current_ver");
+    }
+    else {
+        record_soft_failure('jsc#SLE-20275: cryptsetup version is outdate and need to be updated over 2.4.0+ for SLE15-SP4');
+    }
+
+    # Create a random volume.
+    assert_script_run('dd if=/dev/urandom of=/test.dm bs=1k count=51200');
     wait_still_screen;
 
-    # use cryptsetup to luksFormat and luksOpen volume
+    # Use cryptsetup to luksFormat and luksOpen volume
     assert_script_run("echo -e $cryptpasswd | cryptsetup -q luksFormat /test.dm");
     assert_script_run("echo -e $cryptpasswd | cryptsetup -q luksOpen /test.dm dmtest");
 
-    # format the dmtest and mount it with /test
-    assert_script_run("mkfs.ext4 /dev/mapper/dmtest");
+    # Format the dmtest and mount it with /test
+    assert_script_run('mkfs.ext4 /dev/mapper/dmtest');
     wait_still_screen;
-    assert_script_run("mkdir /test;mount /dev/mapper/dmtest /test");
+    assert_script_run('mkdir /test;mount /dev/mapper/dmtest /test');
 
-    # build some directory and files in the mount point ,try to catch file and delete directory and file
-    assert_script_run("cd /test");
+    # Build some directory and files in the mount point and try to catch file and delete directory and file
+    assert_script_run('cd /test');
     assert_script_run('for x in `seq 100`; do mkdir d$x; date > d$x/f$x.log; done');
-    assert_script_run("cat d39/f39.log");
-    assert_script_run("rm -rf d4*");
+    assert_script_run('cat d39/f39.log');
+    assert_script_run('rm -rf d4*');
 
-    # release the mount point and cryptsetup luksClose dmtest
-    assert_script_run("cd ~");
-    assert_script_run("umount /test");
-    assert_script_run("cryptsetup luksClose dmtest");
+    # Release the mount point and cryptsetup luksClose dmtest
+    assert_script_run('cd ~');
+    assert_script_run('umount /test');
+    assert_script_run('cryptsetup luksClose dmtest');
 
-    # cleanup
-    assert_script_run("rm -rf /test");
-    assert_script_run("rm -rf /test.dm");
+    # Cleanup
+    assert_script_run('rm -rf /test');
+    assert_script_run('rm -rf /test.dm');
 }
 
 1;


### PR DESCRIPTION
**Description:**
cryptsetup attempt to update to 2.4.0+ in SLE15 SP4 base on the Jira feature 
#SLE-20275: cryptsetup update to 2.4.0
This PR is also adding the version check and record_info/soft_failure for cryptsetup

- Related ticket: https://progress.opensuse.org/issues/101575
- Needles: NA
- Verification run: 
  https://openqa.suse.de/tests/7553898#step/cryptsetup/8 [Build 39.1 - cryptsetup 2.4.0]
  https://openqa.suse.de/tests/7581189#step/cryptsetup/8 [Build 55.1 - cryptsetup 2.4.1]