### PR TITLE
Fix no disk space problem during the regression tests

### DIFF
--- a/tests/migration/online_migration/minimal_patch.pm
+++ b/tests/migration/online_migration/minimal_patch.pm
@@ -18,6 +18,7 @@ sub run {
     select_console 'root-console';
     disable_installation_repos;
     minimal_patch_system(version_variable => 'HDDVERSION');
+    cleanup_disk_space if get_var('REMOVE_SNAPSHOTS');
     deregister_dropped_modules;
 }
 

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -27,6 +27,7 @@ sub run {
     fully_patch_system;
     install_patterns() if (get_var('PATTERNS'));
     deregister_dropped_modules;
+    cleanup_disk_space if get_var('REMOVE_SNAPSHOTS');
     power_action('reboot', keepconsole => 1, textmode => 1);
     reconnect_mgmt_console if is_pvm;
 

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -84,6 +84,9 @@ sub patching_sle {
     # create btrfs subvolume for aarch64
     create_btrfs_subvolume() if (is_aarch64);
 
+    # cleanup useless snapshots to save diskspace if we set REMOVE_SNAPSHOTS
+    cleanup_disk_space if get_var('REMOVE_SNAPSHOTS');
+
     # Remove test repos after system being patched
     remove_test_repositories;
 


### PR DESCRIPTION
We need to delete the useless snapshots in the system patch stage
and avoid creating snapshots during the 'zypper install'.

- Related ticket: https://progress.opensuse.org/issues/100958
- Needles: N/A
- Verification run:  
daily:
 https://openqa.nue.suse.com/t7563482 
 https://openqa.nue.suse.com/tests/7565791 
 https://openqa.nue.suse.com/t7563484 
 https://openqa.nue.suse.com/t7563485 
 https://openqa.nue.suse.com/t7563487 

regression:
 https://openqa.nue.suse.com/tests/7654711
 https://openqa.nue.suse.com/tests/7654712