### PR TITLE
[hyperv] check for decompressed image file

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -112,8 +112,10 @@ sub run {
                 hyperv_cmd_with_retry("copy $root_nfs\\$hddpath\\$basenamehdd $root\\cache\\");
                 # Decompress the XZ compressed image
                 last if $hdd !~ m/vhdx\.xz/;
-                hyperv_cmd("xz --decompress --keep --verbose $root\\cache\\$basenamehdd");
-                last;
+                if ($svirt->run_cmd("Test-Path $root\\cache\\$basenamehdd -PathType Leaf")) {
+                    record_info 'unxz', "Decompressing $root\\cache\\$basenamehdd";
+                    hyperv_cmd("xz --decompress --keep --verbose $root\\cache\\$basenamehdd");
+                }
             }
             # Make sure the disk file is present
             hyperv_cmd("if not exist $root\\cache\\" . $basenamehdd =~ s/vhdx\.xz/vhdx/r . " ( exit 1 )");


### PR DESCRIPTION
```
[2021-10-28T10:59:15.494183+02:00] [debug] Use existing SSH connection (key:hostname=win2k19.qa.suse.cz,username=root,port=22)
[2021-10-28T10:59:15.586797+02:00] [debug] [run_ssh_cmd(xz --decompress
--keep --verbose
D:\cache\SLES15-SP4-JeOS.x86_64-15.4-MS-HyperV-Build1.95.vhdx.xz)]
stderr:
  xz: D:\cache\SLES15-SP4-JeOS.x86_64-15.4-MS-HyperV-Build1.95.vhdx:
File exists

[2021-10-28T10:59:15.588729+02:00] [debug] [run_ssh_cmd(xz --decompress
--keep --verbose
D:\cache\SLES15-SP4-JeOS.x86_64-15.4-MS-HyperV-Build1.95.vhdx.xz)]
exit-code: 1
[2021-10-28T10:59:15.744066+02:00] [debug] Command on Hyper-V returned:
1
```

- Latest failures:
  * [sle15sp4
  gen1](https://openqa.suse.de/tests/7555068#step/bootloader_hyperv/16)
  * [15sp4
  gen2](https://openqa.suse.de/tests/7555063#step/bootloader_hyperv/22)
- VRs:
  * [Decompression](http://kepler.suse.cz/tests/8402#step/bootloader_hyperv/13)
  * [Image file decompressed by other
    job](http://kepler.suse.cz/tests/8401#step/bootloader_hyperv/1)

