### PR TITLE
Revert save_and_restore

### DIFF
--- a/tests/virtualization/universal/save_and_restore.pm
+++ b/tests/virtualization/universal/save_and_restore.pm
@@ -2,15 +2,18 @@
 #
 # Copyright 2019 SUSE LLC
 # SPDX-License-Identifier: FSFAP
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
 
 # Package: libvirt-client nmap
-# Summary: Test if the guests can be saved and restored, by adding a
-# temp file and restoring to a state before the file existed.
+# Summary: Test if the guests can be saved and restored
 # Maintainer: Jan Baier <jbaier@suse.cz>
 
 use base "virt_feature_test_base";
 use virt_autotest::common;
-use virt_autotest::utils;
 use strict;
 use warnings;
 use testapi;
@@ -33,19 +36,6 @@ sub run_test {
         }
     }
 
-    # Starting all guests to create a test file in them, the file must not exist after restoring.
-    start_guests();
-
-    record_info "SSH", "Check hosts are listening on SSH";
-    wait_guest_online($_) foreach (keys %virt_autotest::common::guests);
-
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        assert_script_run("ssh root\@$guest 'touch /var/empty_temp_file'");
-    }
-
-    # Guest must be in power down state to be restored
-    shutdown_guests();
-
     record_info "Restore", "Restore guests";
     assert_script_run("virsh restore /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (keys %virt_autotest::common::guests);
 
@@ -53,14 +43,8 @@ sub run_test {
     assert_script_run "virsh list --all | grep $_ | grep running" foreach (keys %virt_autotest::common::guests);
 
     record_info "SSH", "Check hosts are listening on SSH";
-    ensure_online($_) foreach (keys %virt_autotest::common::guests);
-
-    record_info "Check", "Restored guests validation";
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        if (script_run("ssh root\@$guest 'test -f /var/empty_temp_file'") != 1) {
-            die "The temp file should not exist in the restored state.";
-        }
-    }
+    script_retry "nmap $_ -PN -p ssh | grep open", delay => 3, retry => 60 foreach (keys %virt_autotest::common::guests);
 }
 
 1;
+


### PR DESCRIPTION
Revert last improvements on save_and_restore as they cased a disk
corruption in some of the virtualization guests (See poo#101539).


- Related ticket: https://progress.opensuse.org/issues/101539
- Verification run: http://openqa.qam.suse.cz/tests/30010

Related PRs:

* https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13325
* https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13279