### PR TITLE
Fix wireshark test

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -80,14 +80,15 @@ sub run {
     wait_still_screen 2;
     # Load the Capture file
     enter_cmd "wireshark /tmp/capture.pcap -Y 'dns.a and dns.qry.name==\"www.suse.com\"'";
-    wait_still_screen 3;
+    wait_still_screen 5;
     assert_screen("wireshark-capturing-list", TIMEOUT);
     assert_screen("wireshark-dns-response-list", TIMEOUT);
     send_key "alt-f4";
     wait_still_screen 2;
 
     enter_cmd "wireshark";
-    assert_screen "wireshark-welcome", 30;
+    assert_screen("wireshark-welcome", TIMEOUT);
+    wait_still_screen 3;
     # Unselect the display of the Protocol in the UI.
     send_key "ctrl-shift-p";
     assert_screen("wireshark-preferences", TIMEOUT);


### PR DESCRIPTION
Wireshark UI is taking more time to complete the initialization, so increased Timeout and added wait screen. 

SLE15 SP4 - https://openqa.suse.de/tests/7589401#step/wireshark/1
SLE12 SP5 - https://openqa.suse.de/tests/7578646#step/wireshark/1
SLE15 SP3 - https://openqa.suse.de/tests/7578644#step/wireshark/1
SLE15  SP2- https://openqa.suse.de/tests/7589632#step/wireshark/1