### PR TITLE
Fix lvm_multipath_encrypted test suite failure

### DIFF
--- a/schedule/yast/lvm_multipath_encrypted.yaml
+++ b/schedule/yast/lvm_multipath_encrypted.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/module_selection/skip_module_selection
   - installation/multipath
   - installation/add_on_product/skip_install_addons
-  - installation/system_role/select_role_text_mode
+  - installation/system_role/accept_selected_role_text_mode
   - installation/partitioning/select_guided_setup
   - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
   - installation/partitioning/guided_setup/accept_default_fs_options


### PR DESCRIPTION
LibyuiClient selected Text Mode role even though it was selected by
default. That changeed radiobutton status to 'disabled'. The commit
changes schedule to use the proper test module to verify that Text Mode
is selected and press "Next". (e.g. of failure: https://openqa.suse.de/tests/7553469)

- Verification run: https://openqa.suse.de/tests/7564498
