### PR TITLE
Containers: create factory class

### DIFF
--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Base class for container tests
+# Maintainer: qac team <qa-c@suse.de>
+
+package containers::basetest;
+use Mojo::Base 'opensusebasetest';
+
+sub containers_factory {
+    my ($self, $runtime) = @_;
+    my $engine;
+
+    if ($runtime eq 'docker') {
+        $engine = containers::engine::docker->new();
+    }
+    elsif ($runtime eq 'podman') {
+        $engine = containers::engine::podman->new();
+    }
+    else {
+        die("Unknown runtime $runtime. Only 'docker' and 'podman' are allowed.");
+    }
+
+    return $engine;
+}
+
+1;

--- a/tests/containers/docker_3rd_party_images.pm
+++ b/tests/containers/docker_3rd_party_images.pm
@@ -8,9 +8,7 @@
 #          Log the test results in docker-3rd_party_images_log.txt
 # Maintainer: qa-c team <qa-c@suse.de>
 
-use base 'consoletest';
-use strict;
-use warnings;
+use Mojo::Base 'containers::basetest';
 use testapi;
 use utils;
 use version_utils;
@@ -25,11 +23,11 @@ sub run {
     $self->select_serial_terminal;
 
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $engine = containers::engine::docker->new();
 
     script_run("echo 'Container base image tests:' > /var/tmp/docker-3rd_party_images_log.txt");
     # In SLE we need to add the Containers module
     install_docker_when_needed($host_distri);
+    my $engine = $self->containers_factory('docker');
     $engine->configure_insecure_registries();
     my $images = get_3rd_party_images();
     for my $image (@{$images}) {

--- a/tests/containers/podman_3rd_party_images.pm
+++ b/tests/containers/podman_3rd_party_images.pm
@@ -8,9 +8,7 @@
 #          Log the test results in docker-3rd_party_images_log.txt
 # Maintainer: qa-c team <qa-c@suse.de>
 
-use base 'consoletest';
-use strict;
-use warnings;
+use Mojo::Base 'containers::basetest';
 use testapi;
 use utils;
 use version_utils;
@@ -25,11 +23,11 @@ sub run {
     $self->select_serial_terminal;
 
     my ($running_version, $sp, $host_distri) = get_os_release;
-    my $engine = containers::engine::podman->new();
 
     script_run("echo 'Container base image tests:' > /var/tmp/podman-3rd_party_images_log.txt");
     # In SLE we need to add the Containers module
     install_podman_when_needed($host_distri);
+    my $engine = $self->containers_factory('podman');
     $engine->configure_insecure_registries();
     my $images = get_3rd_party_images();
     for my $image (@{$images}) {


### PR DESCRIPTION
This allows creating the engine object via
my $engine = $self->containers_factory('docker');
instead of
$engine = containers::engine::docker->new();

So, the test module only needs to pass 1 argument to the
constructor. This will allow us later on keep doing more
improvements.

NOTE: this is the first task after breaking down https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13370 into smaller ones.


- Related ticket: https://progress.opensuse.org/issues/101442
- VRs:
[SLE](https://openqa.suse.de/tests/overview?build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_factory&distri=sle&version=15-SP3)
[Tumbleweed](https://openqa.opensuse.org/tests/overview?version=Tumbleweed&build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_factory&distri=opensuse)

For now, I have only applied it to 3rd party image tests as an example and as a firs step. 

Next steps:
- [Move install_podman_when_needed and install_docker_when_needed to engine class.](https://progress.opensuse.org/issues/101444)
- [Make sure that all the container tests are using CONTAINER_RUNTIME variable](https://progress.opensuse.org/issues/101755)
- [Merge `podman_3rd_party_images.pm` and `docker_3rd_party_images.pm` into single module "3rd_party_images.pm"](https://progress.opensuse.org/issues/101213)
