### PR TITLE
Fix  ldap user name conflict issue in 389ds test

### DIFF
--- a/tests/security/389ds/tls_389ds_server.pm
+++ b/tests/security/389ds/tls_389ds_server.pm
@@ -5,7 +5,7 @@
 #          This test module covers the server setup processes
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#88513, poo#92410, poo#93832, tc#1768672
+# Tags: poo#88513, poo#92410, poo#93832, poo#101698, tc#1768672
 
 use base 'consoletest';
 use testapi;
@@ -51,7 +51,7 @@ sub run {
     assert_script_run("sed -i -e 's/master/$local_name.example.com/' -e 's/minion/$remote_name.example.com/' /etc/hosts");
 
     # Create ldap user and group
-    my $ldap_user = $testapi::username;
+    my $ldap_user = get_var('SSS_USERNAME');
     my $ldap_passwd = $testapi::password;
     my $ldap_group = 'server_admins';
     my $uid = '1003';

--- a/tests/security/389ds/tls_389ds_sssd_client.pm
+++ b/tests/security/389ds/tls_389ds_sssd_client.pm
@@ -5,7 +5,7 @@
 #          This test module covers the sssd client tests
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#88513, poo#92410, tc#1768672
+# Tags: poo#88513, poo#92410, poo#101698, tc#1768672
 
 use base 'consoletest';
 use testapi;
@@ -22,7 +22,7 @@ sub run {
     my $remote_name = '389ds';
     my $inst_ca_dir = '/etc/dirsrv/slapd-localhost';
     my $tls_dir = '/etc/openldap/certs';
-    my $ldap_user = $testapi::username;
+    my $ldap_user = get_var('SSS_USERNAME');
     my $uid = '1003';
 
     # Install 389-ds and sssd on client


### PR DESCRIPTION
We used $testapi::username as ldap user and defined
a new value in 389ds tests for security job group,
it conflicted with the user name which used by migration
tests, so fix the logic to use a new variable

- Related ticket: https://progress.opensuse.org/issues/101698
- Needles: n/a
- Verification run: 
http://openqa.suse.de/t7563948
http://openqa.suse.de/t7563949