### PR TITLE
xfstests: Remove checkpoint for bsc#1104778

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -32,13 +32,9 @@ sub run {
     my $self = shift;
     select_console 'root-console';
 
-    # Also panic when softlockup
-    # workaround bsc#1104778, skip s390x in 12SP4
+    # Enable panic when softlockup happens
     assert_script_run('echo "kernel.softlockup_panic = 1" >> /etc/sysctl.conf');
-    my $output = script_output('sysctl -p', 10, proceed_on_failure => 1);
-    unless ($output =~ /kernel.softlockup_panic = 1/) {
-        record_soft_failure 'bsc#1104778';
-    }
+    script_run('sysctl -p');
 
     # Activate kdump
     prepare_for_kdump;


### PR DESCRIPTION
The behavior of no output about softlockup_panic in 'sysctl -p' is acceptable by developer(refer to bsc#1104778), so disable this checkpoint to remove useless information

- Verification run: http://10.67.133.102/tests/454
