### PR TITLE
Integrate kvm_svirt_apparmor into openQA

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2394,6 +2394,7 @@ sub load_security_tests_cc_audit_test {
     loadtest 'security/cc/audit_tools';
     loadtest 'security/cc/fail_safe';
     loadtest 'security/cc/ip_eb_tables';
+    loadtest 'security/cc/kvm_svirt_apparmor';
 
     # Some audit tests must be run in selinux enabled mode. so load selinux setup here
     # Setup environment for cc testing: SELinux setup

--- a/tests/security/cc/kvm_svirt_apparmor.pm
+++ b/tests/security/cc/kvm_svirt_apparmor.pm
@@ -1,0 +1,52 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run 'kvm_svirt_apparmor' test case of 'audit-test' test suite
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#101761
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Mojo::File 'path';
+use audit_test 'prepare_for_test';
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # The steps of testing kvm_svirt_apparmor is not same as other audit-test,
+    # so we need to do the `make` in the test case directory and run the test.
+    prepare_for_test();
+
+    assert_script_run('cd kvm_svirt_apparmor/');
+
+    # prepare_for test did the `export MODE=64`, that will make this make fail in aarch64
+    script_run('unset MODE');
+    assert_script_run('make');
+    assert_script_run('cd tests/');
+    assert_script_run('./vm-sep');
+
+    # There is no baseline file, so we need to check the test result by parse log file
+    # in /tmp/vm-sep/vm-sep-crack.log
+    my $log_file = '/tmp/vm-sep/vm-sep-crack.log';
+    assert_script_run("[[ -e $log_file ]]");
+    my $test_results = {};
+    my $output = script_output("cat $log_file");
+    my @lines = split(/\n/, $output);
+    foreach (@lines) {
+        if ($_ =~ /Number of tests (executed|failed|passed):\s+(\d+)/) {
+            $test_results->{$1} = $2;
+        }
+    }
+    $self->result('fail') if ($test_results->{passed} ne $test_results->{executed});
+
+    upload_logs($log_file);
+}
+
+1;


### PR DESCRIPTION
The test `kvm_svirt_apparmor` is one of cases in CC. We have tested it 
in x86_64 manually. We plan to integrate it into openQA and do the daily
run in SLE 15-sp4.

See: https://confluence.suse.com/display/CC/Evaluator+Test+Plan+SLES+15+SP2#EvaluatorTestPlanSLES15SP2-3.1.3KVMapparmortests

- Related ticket: https://progress.opensuse.org/issues/101761
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/7567469#  (x86_64 This job faied in other job modules, kvm_svirt_apparmor passed)
                            https://openqa.suse.de/tests/7581214# (s390)
