### PR TITLE
Modify test suite security_tpm2 in compliance with Factory First

### DIFF
--- a/schedule/security/tpm2.yaml
+++ b/schedule/security/tpm2.yaml
@@ -1,0 +1,16 @@
+name: tpm2
+description:    >
+    This is for tpm2 test on Tumbleweed
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/tpm2/tpm2_env_setup
+    - security/tpm2/tpm2_engine/tpm2_engine_info
+    - security/tpm2/tpm2_engine/tpm2_engine_random_data
+    - security/tpm2/tpm2_engine/tpm2_engine_rsa_operation
+    - security/tpm2/tpm2_engine/tpm2_engine_ecdsa_operation
+    - security/tpm2/tpm2_engine/tpm2_engine_self_sign
+    - security/tpm2/tpm2_tools/tpm2_tools_self_contain_tool
+    - security/tpm2/tpm2_tools/tpm2_tools_encrypt
+    - security/tpm2/tpm2_tools/tpm2_tools_sign_verify
+    - security/tpm2/tpm2_tools/tpm2_tools_auth


### PR DESCRIPTION
Add yaml schedule for security_tpm2. Add version specification due to differnent file location of tpm_server in Tumbleweed, change from 'systemctl start tpm2-abrmd' to 'systemctl restart tpm2-abrmd' since start service will fail on Tumbleweed while restart works fine. Add installation of expect in tpm2_env_setup, the package is not installed in Tumbleweed by default but mandatory in case tpm2_engine_self_sign

- Related ticket: https://progress.opensuse.org/issues/101590
- Needles: N/A
- Verification run: 
  - O3: https://openqa.opensuse.org/tests/2006249#
  - OSD: https://openqa.suse.de/tests/7580897
