### PR TITLE
Correct SRIOV test setting names

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -106,7 +106,7 @@ sub setup_console_in_grub {
             if (is_sle('<=12-SP4') || is_sle('=15')) {
                 $dom0_options = "dom0_mem=2048M,max:2048M";
             }
-            if (get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH")) {
+            if (get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH")) {
                 $dom0_options .= " iommu=on";
             }
             $cmd
@@ -127,7 +127,7 @@ sub setup_console_in_grub {
 
         #enable Intel VT-d for SR-IOV test running on intel SUTs
         my $intel_option = "";
-        if (get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH") && script_run("grep Intel /proc/cpuinfo") == 0) {
+        if (get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH") && script_run("grep Intel /proc/cpuinfo") == 0) {
             $intel_option = "intel_iommu=on";
         }
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -326,7 +326,7 @@ elsif (get_var('VIRT_AUTOTEST')) {
         loadtest "virt_autotest/libvirt_host_bridge_virtual_network";
         loadtest "virt_autotest/libvirt_nated_virtual_network";
     }
-    loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var('ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH');
+    loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var('ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH');
     loadtest "virtualization/universal/hotplugging" if get_var('ENABLE_HOTPLUGGING');
     loadtest "virtualization/universal/storage" if get_var('ENABLE_STORAGE');
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -619,7 +619,7 @@ sub load_virt_feature_tests {
         loadtest "virt_autotest/libvirt_routed_virtual_network";
         loadtest "virt_autotest/libvirt_isolated_virtual_network";
     }
-    loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH");
+    loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH");
     loadtest "virtualization/universal/hotplugging" if get_var("ENABLE_HOTPLUGGING");
     loadtest "virtualization/universal/storage" if get_var("ENABLE_STORAGE");
     if (get_var("ENABLE_SNAPSHOT")) {
@@ -843,13 +843,13 @@ elsif (get_var("VIRT_AUTOTEST")) {
         load_virt_guest_install_tests;
         load_virt_feature_tests if (!(get_var("GUEST_PATTERN") =~ /win/img) && is_x86_64 && !get_var("LTSS"));
     }
-    #those tests which test extended features, such as hotpluggin, virtual network and SRIOV passhthrough etc.
+    #those tests which test extended features, such as hotpluggin, virtual network and SRIOV passthrough etc.
     #they can be seperated from prj1 if needed
     elsif (get_var("DIRECT_CHAINED_VIRT_FEATURE_TEST")) {
         loadtest "virt_autotest/restore_guests" if get_var("SKIP_GUEST_INSTALL");
         loadtest "virt_autotest/set_config_as_glue";
         loadtest "virt_autotest/setup_dns_service";
-        loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSSHTROUGH");
+        loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH");
     }
     elsif (get_var("VIRT_PRJ2_HOST_UPGRADE")) {
         loadtest "virt_autotest/host_upgrade_generate_run_file";


### PR DESCRIPTION
ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH was misspelled. test settings will be corrected as well after the pr is merged.

- Verification run: 
http://openqa.suse.de/tests/7581191   sriov test module is called as expected in a normal test
http://openqa.suse.de/tests/7581192   sriov test module is called  as expected in a chained test
http://openqa.suse.de/tests/7581194#step/update_package/22  install host for chained test with iommu enabled
