### PR TITLE
php7_postgresql: Update postgresql version handling

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -335,7 +335,6 @@ sub test_mysql {
 
 # poo#62000
 sub postgresql_cleanup {
-    select_console 'root-console';
     # Clean up
     systemctl 'stop postgresql';
     systemctl 'disable postgresql';

--- a/tests/console/postgresql_server.pm
+++ b/tests/console/postgresql_server.pm
@@ -22,7 +22,8 @@ use apachetest qw(setup_pgsqldb destroy_pgsqldb test_pgsql postgresql_cleanup);
 use Utils::Systemd 'systemctl';
 
 sub run {
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     # install the postgresql server package
     zypper_call "in postgresql-server sudo";


### PR DESCRIPTION
Post db upgrade is done differently on latest version, I guess starting on 14

```
Upgrade Complete
----------------
Optimizer statistics are not transferred by pg_upgrade.
Once you start the new server, consider running:
    /usr/lib/postgresql14/bin/vacuumdb --all --analyze-in-stages

Running this script will delete the old cluster's data files:
    ./delete_old_cluster.sh
```
- Related ticket: https://progress.opensuse.org/issues/101788
- Verification run:
http://dzedro.suse.cz/tests/19820 15 SP3
http://dzedro.suse.cz/tests/19823 15 SP2
http://dzedro.suse.cz/tests/19822 15 SP1
http://dzedro.suse.cz/tests/19849 TW
https://openqa.suse.de/tests/7582888 15 SP4 failing due to missing package
https://openqa.suse.de/tests/7582889 15 SP3
https://openqa.suse.de/tests/7582890 15 SP2
https://openqa.suse.de/tests/7582891 15 SP1