### PR TITLE
Workaround for bsc#1176901

### DIFF
--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -68,6 +68,10 @@ sub check_suseconnect {
         foreach (@$json) {
             my $iden = $_->{identifier};
             my $status = $_->{status};
+            if ($iden eq 'sle-module-packagehub-subpackages') {
+                record_soft_failure('bsc#1176901', "openQA test fails in system_prepare - 'sle-module-packagehub-subpackages' is not registered ");
+                next;
+            }
             push(@addons, $iden);
             die "$iden register status is: $status" if ($status ne 'Registered');
         }
@@ -84,7 +88,7 @@ sub check_suseconnect_cmd {
     my $status_out = script_output("SUSEConnect --status-text", 120);
     diag "$status_out";
     for (my $i = 0; $i < @addons; $i = $i + 1) {
-        next if ($addons[$i] =~ /^SLE(S|D|_HPC)$/);
+        next if ($addons[$i] =~ /^SLE(S|D|_HPC)$|^sle-module-packagehub-subpackages$/);
         diag "$addons[$i]";
         die "$addons[$i] is not existed at SUSEConnect --list-extensions" if ($ls_out !~ /Deactivate(.*)$addons[$i]/);
         die "$addons[$i] is not existed at SUSEConnect --status-text" if ($status_out !~ /$addons[$i]/);

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -87,7 +87,6 @@ sub run {
         }
         diag "SUSEConnect --status-text: $out";
         if (!get_var('MEDIA_UPGRADE')) {
-            assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'";
             services::registered_addons::full_registered_check;
         }
     }


### PR DESCRIPTION
We did workaround as bsc#1176901 not be fixed for a long time
'sle-module-packagehub-subpackages' is not registered
Just ignore subpackage status check

- Related ticket: https://progress.opensuse.org/issues/101557
- Verification run: https://openqa.suse.de/tests/7589141#
- https://openqa.suse.de/tests/7589510