### PR TITLE
Remove the MODE=64 before doing make

### DIFF
--- a/tests/security/cc/crypto.pm
+++ b/tests/security/cc/crypto.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Run 'crypto' test case of 'audit-test' test suite
-# Maintainer: llzhao <llzhao@suse.com>
+# Maintainer: llzhao <llzhao@suse.com>, liuxiaojing <xiaojing.liu@suse.com>
 # Tags: poo#95485
 
 use base 'consoletest';
@@ -21,9 +21,6 @@ sub run {
 
     # Install certification-sles-eal4: needed by test case `crypto`
     zypper_call('in certification-sles-eal4');
-
-    # Export MODE
-    assert_script_run("export MODE=$audit_test::mode");
 
     # Run test case
     run_testcase('crypto', make => 1, timeout => 900);


### PR DESCRIPTION
When we do `export MODE=64` before doing `make`, it will cause `make`
fail due to `cc: error: unrecognized command line option '-m64'`.
So we should remove the `export` before making

- Related: https://progress.opensuse.org/issues/97931
- Verification run: https://openqa.suse.de/tests/7588808#

