### PR TITLE
console/x_vt: Check for gnome-session as well as X

### DIFF
--- a/tests/console/x_vt.pm
+++ b/tests/console/x_vt.pm
@@ -15,13 +15,15 @@ use version_utils qw(is_tumbleweed is_leap is_sle);
 
 sub run {
     # First, list all X processes, including user process and gdm process
-    script_run('ps -ef | grep bin/X');
-    if (script_run("ps -ef | grep bin/X | egrep 'tty7|wayland'") == 1) {
-        if ((is_tumbleweed || is_leap('>=15.2') || is_sle('>=15-SP2')) && script_run('ps -ef | grep bin/X | grep tty2') == 0) {
-            diag('user X process runs on tty2 for systems with GNOME 3.32+, see boo#1138327');
+    script_run("ps -ef | grep -E 'bin/X|/gnome-session'");
+    if (script_run("ps -ef | grep bin/X | grep -E 'tty7|wayland'") == 1) {
+        if (check_var('DESKTOP', 'gnome')
+            && (is_tumbleweed || is_leap('>=15.2') || is_sle('>=15-SP2'))
+            && script_run("ps -ef | grep -E 'bin/X|/gnome-session' | grep tty2") == 0) {
+            diag('user session runs on tty2 for systems with GNOME 3.32+, see boo#1138327');
         }
         else {
-            die 'Expected tty7 used by X or wayland not found';
+            die 'Graphical session not found on tty7';
         }
     }
 }


### PR DESCRIPTION
On 15.2+ as well as TW, check for gnome-session running on tty2 as well.

Previously it didn't care about GNOME running on the wrong tty because of the `tty7|wayland` condition, but now without `Xwayland` it'll detect `gnome-session` running on `tty2` as well.

I didn't add code to detect `gnome-session` on `tty7` because there's nothing to test it with so far.

Also restrict the "soft softfail" to GNOME only and change deprecated `egrep` to `grep -E`.

- Related ticket: https://progress.opensuse.org/issues/99582
- Verification run: http://10.160.67.86/tests/1099
