### PR TITLE
Makefile: Use https protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 
 .PHONY: prepare
 prepare:
-	git clone git://github.com/os-autoinst/os-autoinst
+	git clone https://github.com/os-autoinst/os-autoinst.git
 	$(MAKE) check-links
 	cd os-autoinst && cpanm -nq --installdeps .
 	cpanm -nq --installdeps .


### PR DESCRIPTION
To fix CI error on github change:
```
./tools/update_spec
git clone git://github.com/os-autoinst/os-autoinst
Cloning into 'os-autoinst'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
make: *** [Makefile:12: prepare] Error 128
Error: Process completed with exit code 2.
```

Link: https://github.blog/2021-09-01-improving-git-protocol-security-github/