### PR TITLE
Schedule NFS MM test in JeOS

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -124,11 +124,13 @@ sub client_common_tests {
     # remove added nfs from /etc/fstab
     assert_script_run 'sed -i \'/nfs/d\' /etc/fstab';
 
-    # compare saved and current fstab, should be same
-    assert_script_run 'diff -b /etc/fstab fstab_before';
+    unless (is_jeos) {
+        # compare saved and current fstab, should be same
+        assert_script_run 'diff -b /etc/fstab fstab_before';
 
-    # compare last line, should be not deleted
-    assert_script_run 'diff -b <(tail -n1 /etc/fstab) <(tail -n1 fstab_before)';
+        # compare last line, should be not deleted
+        assert_script_run 'diff -b <(tail -n1 /etc/fstab) <(tail -n1 fstab_before)';
+    }
 
     # Remote symlinked directory is visible, removable but not accessible
     assert_script_run "ls -la /tmp/nfs/client/symlinkeddir";

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -262,6 +262,14 @@ if (is_jeos) {
     load_jeos_tests();
 }
 
+if (get_var("NFSSERVER") || get_var("NFSCLIENT")) {
+    load_mm_nfs_test;
+    return 1;
+}
+if (get_var("NFS4SERVER") || get_var("NFS4CLIENT")) {
+    load_mm_nfsv4_test;
+    return 1;
+}
 
 if (is_kernel_test()) {
     load_kernel_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1059,24 +1059,12 @@ else {
         return 1;
     }
     elsif (get_var("NFSSERVER") || get_var("NFSCLIENT")) {
-        set_var('INSTALLONLY', 1);
-        boot_hdd_image;
-        if (get_var("NFSSERVER")) {
-            loadtest "console/yast2_nfs_server";
-        }
-        else {
-            loadtest "console/yast2_nfs_client";
-        }
+        load_mm_nfs_test;
+        return 1;
     }
     elsif (get_var("NFS4SERVER") || get_var("NFS4CLIENT")) {
-        set_var('INSTALLONLY', 1);
-        boot_hdd_image;
-        if (get_var("NFS4SERVER")) {
-            loadtest "console/yast2_nfs4_server";
-        }
-        else {
-            loadtest "console/yast2_nfs4_client";
-        }
+        load_mm_nfsv4_test;
+        return 1;
     }
     elsif (get_var('QAM_CURL')) {
         set_var('INSTALLONLY', 1);

--- a/tests/console/yast2_nfs4_server.pm
+++ b/tests/console/yast2_nfs4_server.pm
@@ -21,7 +21,7 @@ use base "y2_module_consoletest";
 use strict;
 use warnings;
 use utils qw(clear_console zypper_call systemctl);
-use version_utils;
+use version_utils qw(is_jeos);
 use testapi;
 use lockapi;
 use mmapi;
@@ -37,9 +37,14 @@ sub run {
     server_configure_network($self);
 
     # Make sure packages are installed
-    zypper_call 'in yast2-nfs-server', timeout => 480, exitcode => [0, 106, 107];
+    # JeOS does not pull recommended packages by default
+    if (is_jeos) {
+        zypper_call 'in yast2-nfs-server nfs-kernel-server', timeout => 480, exitcode => [0, 106, 107];
+    } else {
+        zypper_call 'in yast2-nfs-server', timeout => 480, exitcode => [0, 106, 107];
+        try_nfsv2();
+    }
 
-    try_nfsv2();
 
     prepare_exports($rw, $ro);
 


### PR DESCRIPTION
PoC of multimachine test suite executed against JeOS.
I have picked NFS test suite in order to verify status of [nfsd kernel
module is missing from kernel-default-base](https://bugzilla.suse.com/show_bug.cgi?id=1089118).

Test suite environment variables:
* jeos_base_test
```
EXTRABOOTPARAMS=quiet
PUBLISH_HDD_1=JeOS-%VERSION%-%ARCH%-Build%BUILD%@%MACHINE%-.qcow2
```
* nfs-server
```
+HDD_1=JeOS-%VERSION%-%ARCH%-Build%BUILD%@%MACHINE%-.qcow2
NFS4SERVER=1
NICTYPE=tap
START_AFTER_TEST=jeos_base_test
```
* nfs-client
```
+HDD_1=JeOS-%VERSION%-%ARCH%-Build%BUILD%@%MACHINE%-.qcow2
NFS4CLIENT=1
NICTYPE=tap
PARALLEL_WITH=jeos-nfs-server
START_AFTER_TEST=jeos_base_test
```



- Verification runs: 
#### TW
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20211102-jeos-nfs-client@uefi-virtio-vga](http://kepler.suse.cz/tests/10476)
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20211102-jeos-nfs-server@uefi-virtio-vga](http://kepler.suse.cz/tests/10475)
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20211102-jeos_base_test@uefi-virtio-vga](http://kepler.suse.cz/tests/10463)

#### SLE 15SP4
   * [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.105-jeos_base_test@uefi-virtio-vga](http://kepler.suse.cz/tests/10458)
   * [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.105-jeos-nfs-client@uefi-virtio-vga](http://kepler.suse.cz/tests/10478)
   * [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.105-jeos-nfs-server@uefi-virtio-vga](http://kepler.suse.cz/tests/10477)