### PR TITLE
poo#101824 missing 'is_upgrade' subroutine

### DIFF
--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -9,7 +9,7 @@
 use base "sles4sap";
 use testapi;
 use utils "zypper_call";
-use version_utils "is_sle";
+use version_utils qw(is_sle is_upgrade);
 use Utils::Architectures;
 use strict;
 use warnings;


### PR DESCRIPTION
Module sles4sap/saptune.pm is failing because of missing import. This 
PR adds missing 'is_upgrade' subroutine to imports and addresses part 
of the poo#101824.

- Related ticket: https://progress.opensuse.org/issues/101824
- Verification run: https://mordor.suse.cz/tests/1501#step/saptune/14
