### PR TITLE
Prohibit the warning of 'printer added' for all arches

### DIFF
--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -24,7 +24,7 @@ use x11utils 'turn_off_gnome_show_banner';
 sub run {
     my ($self) = @_;
     # We need to close gnome notification banner before migration.
-    if (check_var('DESKTOP', 'gnome') && (is_aarch64 || is_ppc64le)) {
+    if (check_var('DESKTOP', 'gnome')) {
         select_console 'user-console';
         turn_off_gnome_show_banner;
     }


### PR DESCRIPTION
Prohibit the warning of 'printer added' for all arches. This warning
message also happend at x86_64. Pohibit it for all arches

- Related ticket: https://progress.opensuse.org/issues/101764
- Verification run: http://openqa.suse.de/tests/7594874#
- s390: http://openqa.suse.de/tests/7596563