### PR TITLE
Fix xdmcp_xdm and xdmcp_gdm failure on SLE15SP4

### DIFF
--- a/tests/x11/remote_desktop/xdmcp_gdm.pm
+++ b/tests/x11/remote_desktop/xdmcp_gdm.pm
@@ -31,7 +31,7 @@ sub run {
     enter_cmd "exit";
 
     # Remote access SLES via Xephyr
-    enter_cmd "Xephyr -query 10.0.2.1 -screen 1024x768+0+0 -terminate :1";
+    enter_cmd "Xephyr -query 10.0.2.1 -screen 1024x768+0+0 -terminate :2";
     assert_screen 'xdmcp-gdm', 90;
     send_key 'ret';
     assert_screen 'xdmcp-login-gdm';

--- a/tests/x11/remote_desktop/xdmcp_xdm.pm
+++ b/tests/x11/remote_desktop/xdmcp_xdm.pm
@@ -29,7 +29,7 @@ sub run {
     enter_cmd "exit";
 
     # Remote access SLES via Xephyr
-    enter_cmd "Xephyr -query 10.0.2.1 -terminate :1";
+    enter_cmd "Xephyr -query 10.0.2.1 -terminate :2";
     assert_screen 'xdmcp-xdm', 90;
     enter_cmd "$username";
     wait_still_screen 3;


### PR DESCRIPTION
Use an available display number for Xephyr connection

Background of why the previous DISPLAY number :1 isn't available now could be found from:
https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1680
https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/945

- Related ticket: https://progress.opensuse.org/issues/97901
- Needles: already added to o.s.d when debugging
- Verification run: 
- desktop-desktopapps-remote-client2 https://openqa.suse.de/tests/7594929
- desktop-desktopapps-remote-client3 https://openqa.suse.de/tests/7595401
