### PR TITLE
Bump wait_still_screen timeout to avoid loosing focus with notifications

### DIFF
--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -65,7 +65,8 @@ sub run {
     wait_still_screen 2;
     type_password;
     send_key("ret");
-    wait_still_screen 2;
+    # bumped timeout to 10 to avoid loosing focus with desktop notification
+    wait_still_screen 10;
     send_key "alt-k";
     wait_still_screen 2;
     send_key "e";


### PR DESCRIPTION
- Related ticket: [poo#101861](https://progress.opensuse.org/issues/101861)
- Verification run: [yast2_keyboard x5](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_yast2_keyboard&version=12-SP4)

Note: if we see more of this failure we should consider deactivate notifications to make more stable the environment, in the failure what happens is that the YaST module changes title and takes a while to load, the change on the title of the module triggers the change in the title in the notification as well, so we loose focus because the automation try to send key to something that is not ready, which as a user could not be reproduced (no bug IMO).
