### PR TITLE
autoyast: Make GRUB matching more reliable

### DIFF
--- a/data/autoyast_opensuse/opensuse_autoyast_local_tftp.xml
+++ b/data/autoyast_opensuse/opensuse_autoyast_local_tftp.xml
@@ -7,6 +7,11 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">30</timeout>
+    </global>
+  </bootloader>
   <keyboard>
     <keyboard_values>
       <delay/>

--- a/data/autoyast_opensuse/opensuse_autoyast_tftp.xml
+++ b/data/autoyast_opensuse/opensuse_autoyast_tftp.xml
@@ -6,6 +6,11 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">30</timeout>
+    </global>
+  </bootloader>
   <keyboard>
     <keyboard_values>
       <delay/>

--- a/data/autoyast_opensuse/opensuse_gnome.xml
+++ b/data/autoyast_opensuse/opensuse_gnome.xml
@@ -6,6 +6,11 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">30</timeout>
+    </global>
+  </bootloader>
   <login_settings>
     <autologin_user>bernhard</autologin_user>
   </login_settings>

--- a/data/autoyast_opensuse/opensuse_leap_gnome.xml
+++ b/data/autoyast_opensuse/opensuse_leap_gnome.xml
@@ -6,6 +6,11 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">30</timeout>
+    </global>
+  </bootloader>
   <login_settings>
     <autologin_user>bernhard</autologin_user>
   </login_settings>

--- a/data/autoyast_opensuse/opensuse_leap_minimal.xml
+++ b/data/autoyast_opensuse/opensuse_leap_minimal.xml
@@ -6,6 +6,11 @@
       <confirm config:type="boolean">true</confirm>
     </mode>
   </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">30</timeout>
+    </global>
+  </bootloader>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>

--- a/data/autoyast_opensuse/opensuse_minimal.xml
+++ b/data/autoyast_opensuse/opensuse_minimal.xml
@@ -6,6 +6,11 @@
       <confirm config:type="boolean">true</confirm>
     </mode>
   </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">30</timeout>
+    </global>
+  </bootloader>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -167,6 +167,7 @@ sub run {
 
     check_screen \@needles, $check_time;
     until (match_has_tag('reboot-after-installation')
+          || match_has_tag('opensuse-welcome')
           || match_has_tag('bios-boot')
           || match_has_tag('autoyast-stage1-reboot-upcoming')
           || match_has_tag('inst-bootmenu')
@@ -345,7 +346,9 @@ sub run {
     push(@needles, 'opensuse-welcome') if opensuse_welcome_applicable;
     # There will be another reboot for IPMI backend
     push @needles, qw(prague-pxe-menu qa-net-selection) if is_ipmi;
-    until (match_has_tag 'reboot-after-installation') {
+    until (match_has_tag('reboot-after-installation')
+          || match_has_tag('opensuse-welcome'))
+    {
         #Verify timeout and continue if there was a match
         next unless verify_timeout_and_check_screen(($timer += $check_time), \@needles);
         if (match_has_tag('autoyast-postinstall-error')) {
@@ -379,9 +382,6 @@ sub run {
         }
         elsif (match_has_tag('lang_and_keyboard')) {
             return;
-        }
-        elsif (match_has_tag('opensuse-welcome')) {
-            return;             # Popup itself is processed in opensuse_welcome module
         }
         elsif (match_has_tag('encrypted-disk-password-prompt')) {
             return;


### PR DESCRIPTION
Some autoyast xml files didn't define a timeout, use 30s as a compromise
between the default value of 10s and waiting indefinitely (-1).

Now that the GRUB menu can be reliably matched by autoyast/installation,
drop the match for opensuse-welcome, which was most likely a workaround/hack
anyway (it didn't handle generic-desktop either).

Example of a failure: https://openqa.opensuse.org/tests/2010257

Verification runs:
TW autoyast_gnome: http://10.160.67.86/tests/1106
TW autoyast_minimal: http://10.160.67.86/tests/1105