### PR TITLE
Containers: split engine class into different files

### DIFF
--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -7,18 +7,19 @@
 # Maintainer: qac team <qa-c@suse.de>
 
 package containers::basetest;
+use containers::docker;
+use containers::podman;
 use Mojo::Base 'opensusebasetest';
-use containers::engine;
 
 sub containers_factory {
     my ($self, $runtime) = @_;
     my $engine;
 
     if ($runtime eq 'docker') {
-        $engine = containers::engine::docker->new();
+        $engine = containers::docker->new();
     }
     elsif ($runtime eq 'podman') {
-        $engine = containers::engine::podman->new();
+        $engine = containers::podman->new();
     }
     else {
         die("Unknown runtime $runtime. Only 'docker' and 'podman' are allowed.");

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright 2020-2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: engine subclass for docker specific implementations
+# Maintainer: qac team <qa-c@suse.de>
+
+package containers::docker;
+use Mojo::Base 'containers::engine';
+use testapi;
+use containers::utils qw(registry_url);
+use utils qw(systemctl file_content_replace);
+has runtime => 'docker';
+
+sub configure_insecure_registries {
+    my ($self) = shift;
+    my $registry = registry_url();
+    # Allow our internal 'insecure' registry
+    assert_script_run(
+        'echo "{ \"debug\": true, \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\", \"' . $registry . '\"] }" > /etc/docker/daemon.json');
+    assert_script_run('cat /etc/docker/daemon.json');
+    systemctl('restart docker');
+    record_info "setup $self->runtime", "deamon.json ready";
+}
+
+1;

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright 2020-2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: engine subclass for podman specific implementations
+# Maintainer: qac team <qa-c@suse.de>
+
+package containers::podman;
+use Mojo::Base 'containers::engine';
+use testapi;
+use containers::utils qw(registry_url);
+use utils qw(file_content_replace);
+has runtime => "podman";
+
+sub configure_insecure_registries {
+    my ($self) = shift;
+    my $registry = registry_url();
+
+    assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
+    assert_script_run "chmod 644 /etc/containers/registries.conf";
+    file_content_replace("/etc/containers/registries.conf", REGISTRY => $registry);
+}
+
+1;


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/101839

[openSUSE](https://openqa.opensuse.org/tests/overview?build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_split_engine&distri=opensuse&version=Tumbleweed)
[SLE](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_split_engine)
