### PR TITLE
Install 'iputils' for CC test case `ebtables_NETFILTER_PKT FAIL`

### DIFF
--- a/tests/security/cc/cc_audit_test_setup.pm
+++ b/tests/security/cc/cc_audit_test_setup.pm
@@ -41,6 +41,9 @@ sub run {
     # Install tool packages
     zypper_call('in wget');
 
+    # Install command ping. It's used by ip+eb-tables test case and audit-remote
+    zypper_call('in iputils');
+
     # Workaround for restarting audit service
     assert_script_run('sed -i \'/\[Unit\]/aStartLimitIntervalSec=0\' /usr/lib/systemd/system/auditd.service');
     assert_script_run('systemctl daemon-reload');

--- a/tests/security/cc/fail_safe.pm
+++ b/tests/security/cc/fail_safe.pm
@@ -20,7 +20,7 @@ sub run {
     select_console 'root-console';
 
     # Run test case
-    run_testcase('fail-safe', make => 1, timeout => 300);
+    run_testcase('fail-safe', make => 1, timeout => 500);
 
     # Compare current test results with baseline
     my $result = compare_run_log('fail_safe');


### PR DESCRIPTION
Please see the individual commit message
Related: https://progress.opensuse.org/issues/98856, https://progress.opensuse.org/issues/101644, https://progress.opensuse.org/issues/101920
Verify run: https://openqa.suse.de/tests/7604230# (s390)
                 https://openqa.suse.de/tests/7604488# (aarch64)
                 https://openqa.suse.de/tests/7604235# (64bit)
