### PR TITLE
poo#101824 replace 'saptune daemon status' cmd

### DIFF
--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -25,7 +25,7 @@ sub run {
     # saptune is not installed by default on SLES4SAP 12 on ppc64le
     zypper_call "-n in saptune" if (is_ppc64le() and is_sle('<15'));
 
-    assert_script_run "saptune daemon status";
+    assert_script_run "saptune version";
 }
 
 1;


### PR DESCRIPTION
In sles4sap/saptune command 'saptune daemon status' is failing as it 
returns 1 if the service is not running. According to 
058f751f0c8ed5116a114064ff550e762e1b8c2c saptune should not be 
started. This PR replaces command with 'saptune version' which returns 
0 unless the command itself fails. 

- Related ticket: https://progress.opensuse.org/issues/101824
- Verification run: https://mordor.suse.cz/tests/1516#
