### PR TITLE
Remove sle-we module from test data

### DIFF
--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -83,7 +83,6 @@ test_data:
   modules:
     - sle-ha
     - sle-module-live-patching
-    - sle-we
     - sle-module-basesystem
     - sle-module-containers
     - sle-module-desktop-applications


### PR DESCRIPTION
Module sle-we is no longer listed in verify module selection and should not be expected by the test.

- Related ticket: No ticket
- Needles: No Needles
- Verification run: [ppc64le ](https://openqa.suse.de/tests/7599587#) | [s390x](https://openqa.suse.de/tests/7599588)
