### PR TITLE
Fix 'check_screen' in 'handle_login' for S390x 'first_boot'

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -233,7 +233,7 @@ sub handle_login {
     # for S390x testing, since they are not using qemu built-in vnc, it is
     # expected that polkit authentication window can open for first time login.
     # see bsc#1177446 for more information.
-    if (check_screen(qw[authentication-required-user-settings authentication-required-modify-system], 5)) {
+    if (check_screen([qw(authentication-required-user-settings authentication-required-modify-system)], 10)) {
         type_password($mypwd);
         send_key 'ret';
     }


### PR DESCRIPTION
https://progress.opensuse.org/issues/101289

First, there was an error in the usage of `qw`.

Second, we give 5 more seconds for the slower arch to initialize for the first boot.

- Related ticket: https://progress.opensuse.org/issues/101289
- Needles: None
- Verification run: https://openqa.suse.de/tests/7603022#step/first_boot/8
