### PR TITLE
Allow undefined settings to be used in test scheduler

### DIFF
--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -55,7 +55,7 @@ sub parse_schedule_module {
         my $condition = $schedule->{conditional_schedule}->{$module};
         # Iterate over variables in the condition
         foreach my $var (keys %{$condition}) {
-            next unless my $val = get_var($var);
+            my $val = get_var($var, 'undef');
             # If value of the variable matched the conditions
             # Iterate over the list of the modules to be loaded
             push(@scheduled, parse_schedule_module($schedule, $_)) for (@{$condition->{$var}->{$val}});


### PR DESCRIPTION
An undefined setting or a setting with value=0 are unable to be passed to yaml scheduler to filter test modules currently. Take a virtualization test as an example:

the snipet in test.yaml:
`  install_guest:
    SKIP_GUEST_INSTALL:
      **_undef_**:
        - virt_autotest/unified_guest_installation`

We expect only when SKIP_GUEST_INSTALL is set in the test suite,  virt_autotest/unified_guest_installation will be skipped. However, it is impossible in current logic even with SKIP_GUEST_INSTALL=0.

With this PR, 'undef' is allowed to be used in conditional_schedule to support the setting which is not set or value is 0 in test suites.

Only verified in my own test. Need review and verification from wider users as it may affect all the tests which use yaml scheduler.
