### PR TITLE
Increase default timeout in YuiRestClient

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use constant {
     API_VERSION => 'v1',
-    TIMEOUT => 45,
+    TIMEOUT => 60,
     INTERVAL => 1
 };
 


### PR DESCRIPTION
Internally this will be 120 seconds of max time waiting. With 45 which in reality is 90 was not enough for some aarch jobs by a few seconds: https://openqa.suse.de/tests/7583741#step/skip_install_addons/1

Related ticket: https://progress.opensuse.org/issues/100907

