### PR TITLE
Containers: create init method to call runtime installation and config

### DIFF
--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -24,7 +24,7 @@ sub containers_factory {
     else {
         die("Unknown runtime $runtime. Only 'docker' and 'podman' are allowed.");
     }
-
+    $engine->init();
     return $engine;
 }
 

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -10,8 +10,16 @@ package containers::docker;
 use Mojo::Base 'containers::engine';
 use testapi;
 use containers::utils qw(registry_url);
+use containers::common qw(install_docker_when_needed);
 use utils qw(systemctl file_content_replace);
+use version_utils qw(get_os_release);
 has runtime => 'docker';
+
+sub init {
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    install_docker_when_needed($host_distri);
+    configure_insecure_registries();
+}
 
 sub configure_insecure_registries {
     my ($self) = shift;

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -10,8 +10,16 @@ package containers::podman;
 use Mojo::Base 'containers::engine';
 use testapi;
 use containers::utils qw(registry_url);
+use containers::common qw(install_podman_when_needed);
 use utils qw(file_content_replace);
+use version_utils qw(get_os_release);
 has runtime => "podman";
+
+sub init {
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    install_podman_when_needed($host_distri);
+    configure_insecure_registries();
+}
 
 sub configure_insecure_registries {
     my ($self) = shift;

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -13,16 +13,12 @@ use utils;
 use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
-use version_utils qw(is_sle get_os_release);
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     my $docker = $self->containers_factory('docker');
-    my ($running_version, $sp, $host_distri) = get_os_release;
 
-    install_docker_when_needed($host_distri);
-    $docker->configure_insecure_registries() if is_sle();
     zypper_call("install container-diff") if (script_run("which container-diff") != 0);
 
     my ($untested_images, $released_images) = get_suse_container_urls();

--- a/tests/containers/docker.pm
+++ b/tests/containers/docker.pm
@@ -28,7 +28,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use utils;
 use containers::common;
-use version_utils qw(is_sle is_leap is_tumbleweed is_jeos get_os_release);
+use version_utils qw(is_jeos);
 use containers::utils;
 use containers::container_images;
 use publiccloud::utils;
@@ -42,11 +42,8 @@ sub run {
     my $sleep_time = 90 * get_var('TIMEOUT_SCALE', 1);
     my $dir = "/root/DockerTest";
 
-    my ($running_version, $sp, $host_distri) = get_os_release;
     my $engine = $self->containers_factory('docker');
-    install_docker_when_needed($host_distri);
     test_seccomp();
-    $engine->configure_insecure_registries();
 
     if ($self->firewall() eq 'firewalld') {
         # on publiccloud we need to install firewalld first

--- a/tests/containers/docker_3rd_party_images.pm
+++ b/tests/containers/docker_3rd_party_images.pm
@@ -11,7 +11,6 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use utils;
-use version_utils;
 use containers::common;
 use containers::urls 'get_3rd_party_images';
 use containers::container_images qw(test_3rd_party_image upload_3rd_party_images_logs);
@@ -21,13 +20,8 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    my ($running_version, $sp, $host_distri) = get_os_release;
-
     script_run("echo 'Container base image tests:' > /var/tmp/docker-3rd_party_images_log.txt");
-    # In SLE we need to add the Containers module
-    install_docker_when_needed($host_distri);
     my $engine = $self->containers_factory('docker');
-    $engine->configure_insecure_registries();
     my $images = get_3rd_party_images();
     for my $image (@{$images}) {
         test_3rd_party_image($engine, $image);

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -21,7 +21,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use registration;
 use utils;
-use version_utils qw(is_sle get_os_release);
+use version_utils qw(is_sle);
 use containers::common;
 use publiccloud::utils 'is_ondemand';
 
@@ -29,9 +29,7 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     my $docker = $self->containers_factory('docker');
-    my ($running_version, $sp, $host_distri) = get_os_release;
 
-    install_docker_when_needed($host_distri);
     add_suseconnect_product(get_addon_fullname('phub')) if is_sle();
     add_suseconnect_product(get_addon_fullname('python2')) if is_sle('=15-sp1');
 
@@ -53,7 +51,6 @@ sub run {
     assert_script_run("curl -O " . data_url("containers/docker-compose.yml"));
     assert_script_run("curl -O " . data_url("containers/haproxy.cfg"));
 
-    $docker->configure_insecure_registries();
     file_content_replace("docker-compose.yml", REGISTRY => get_var('REGISTRY', 'docker.io'));
     assert_script_run 'docker-compose pull', 600;
 

--- a/tests/containers/docker_image.pm
+++ b/tests/containers/docker_image.pm
@@ -21,17 +21,13 @@ use utils;
 use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
-use version_utils qw(get_os_release check_os_release is_tumbleweed);
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal();
 
-    my ($running_version, $sp, $host_distri) = get_os_release;
     my $engine = $self->containers_factory('docker');
 
-    install_docker_when_needed($host_distri);
-    $engine->configure_insecure_registries();
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
 
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGE_VERSIONS

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -29,8 +29,6 @@ sub run {
 
     record_info 'Setup', 'Setup the environment';
     # runC cannot create or extract the root filesystem on its own. Use Docker to create it.
-    install_docker_when_needed($host_distri);
-    $docker->configure_insecure_registries();
 
     # create the rootfs directory
     assert_script_run('mkdir rootfs');

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -24,7 +24,6 @@ use testapi;
 use utils;
 use registration;
 use containers::common;
-use version_utils qw(is_sle is_leap is_jeos get_os_release);
 use containers::utils;
 use containers::container_images;
 
@@ -34,10 +33,6 @@ sub run {
 
     my $dir = "/root/DockerTest";
     my $podman = $self->containers_factory('podman');
-    my ($running_version, $sp, $host_distri) = get_os_release;
-
-    install_podman_when_needed($host_distri);
-    $podman->configure_insecure_registries();
 
     # Run basic runtime tests
     basic_container_tests(runtime => $podman->runtime);

--- a/tests/containers/podman_3rd_party_images.pm
+++ b/tests/containers/podman_3rd_party_images.pm
@@ -11,7 +11,6 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use utils;
-use version_utils;
 use containers::common;
 use containers::urls 'get_3rd_party_images';
 use containers::container_images qw(test_3rd_party_image upload_3rd_party_images_logs);
@@ -21,13 +20,8 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    my ($running_version, $sp, $host_distri) = get_os_release;
-
     script_run("echo 'Container base image tests:' > /var/tmp/podman-3rd_party_images_log.txt");
-    # In SLE we need to add the Containers module
-    install_podman_when_needed($host_distri);
     my $engine = $self->containers_factory('podman');
-    $engine->configure_insecure_registries();
     my $images = get_3rd_party_images();
     for my $image (@{$images}) {
         test_3rd_party_image($engine, $image);

--- a/tests/containers/podman_image.pm
+++ b/tests/containers/podman_image.pm
@@ -14,16 +14,12 @@ use utils;
 use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
-use version_utils qw(get_os_release check_os_release);
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal();
 
-    my ($running_version, $sp, $host_distri) = get_os_release;
     my $engine = $self->containers_factory('podman');
-    install_podman_when_needed($host_distri);
-    $engine->configure_insecure_registries();
 
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGE_VERSIONS
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -22,7 +22,6 @@ use containers::common;
 use containers::container_images;
 use containers::urls 'get_suse_container_urls';
 use containers::utils 'registry_url';
-use version_utils qw(get_os_release);
 use version_utils 'is_sle';
 use Utils::Architectures;
 
@@ -38,11 +37,8 @@ sub run {
     my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
 
     my ($untested_images, $released_images) = get_suse_container_urls();
-    my ($running_version, $sp, $host_distri) = get_os_release;
     my $podman = $self->containers_factory('podman');
 
-    install_podman_when_needed($host_distri);
-    $podman->configure_insecure_registries();
     my $user = $testapi::username;
     my $subuid_start = get_user_subuid($user);
     if ($subuid_start eq '') {

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -17,7 +17,6 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use containers::common;
 use containers::urls 'get_suse_container_urls';
-use version_utils qw(get_os_release);
 
 # Get the total and used GiB of a given btrfs device
 sub _btrfs_fi {
@@ -93,10 +92,7 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     die "Module requires two disks to run" unless check_var('NUMDISKS', 2);
-    my ($running_version, $sp, $host_distri) = get_os_release;
     my $docker = $self->containers_factory('docker');
-    install_docker_when_needed($host_distri);
-    $docker->configure_insecure_registries();
     my $btrfs_dev = '/var/lib/docker';
     my $images_to_test = 'registry.opensuse.org/opensuse/leap:15';
     _sanity_test_btrfs($docker, $btrfs_dev, $images_to_test);

--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -18,16 +18,12 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use Utils::Architectures;
 use utils;
-use version_utils 'get_os_release';
 use containers::common;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     my $docker = $self->containers_factory('docker');
-    my ($running_version, $sp, $host_distri) = get_os_release;
-
-    install_docker_when_needed($host_distri);
 
     # install zypper-docker and verify installation
     zypper_call('in zypper-docker');


### PR DESCRIPTION
By doing this, we avoid calling the installation and registry configuration methods in the test modules repeatedly.

- Related ticket: https://progress.opensuse.org/issues/101893
- VRs: [SLE](https://openqa.suse.de/tests/overview?build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_init_function&version=15-SP3&distri=sle) [TW](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_init_function&version=Tumbleweed)
