### PR TITLE
Increase default timeout in YuiRestClient

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use constant {
     API_VERSION => 'v1',
-    TIMEOUT => 60,
+    TIMEOUT => 90,
     INTERVAL => 1
 };
 


### PR DESCRIPTION
Internally this will be 180 seconds of max time waiting. With 60 which in reality is 120 was not enough for some aarch jobs by a few seconds: https://openqa.suse.de/tests/7604687#step/skip_install_addons/1
