### PR TITLE
console/clamav: Uninstall clamav during cleanup

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -114,6 +114,7 @@ sub post_run_hook {
     assert_script_run("swapoff /var/lib/swap/swapfile") if is_jeos && !(is_opensuse && is_aarch64);
     systemctl('stop clamd', timeout => 500);
     systemctl('stop freshclam');
+    zypper_call('rm -u clamav');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
While it stops the service at the end, it's started again after the reboot.
At that point however the environment is no longer prepared, which causes
issues like slowdowns and the system running out of memory.

So just uninstall the package at the end.

This fixes the cascade of errors in the `jeos-extra` test: https://openqa.opensuse.org/tests/2010513#step/rails/31

- Verification run: http://fussheizung/tests/1109#step/clamav/143
