### PR TITLE
Create named subroutines for test loader

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -139,6 +139,7 @@ PUBLIC_CLOUD_BUILD_KIWI | string | "" | The image kiwi build number. Used only w
 PUBLIC_CLOUD_CHECK_BOOT_TIME | boolean | false | If set, boottime test module is added to the job.
 PUBLIC_CLOUD_CLIENT_ID | string | "" | In GCE one of the variables used to authenticate  user.
 PUBLIC_CLOUD_CONFIDENTIAL_VM | boolean | false | GCE Confidential VM instance
+PUBLIC_CLOUD_CREATE_TOOLS_IMG | boolean | false | If set, `publiccloud/upload_image` test module is added to the job.
 PUBLIC_CLOUD_CONSOLE_TESTS | boolean | false | If set, console tests are added to the job.
 PUBLIC_CLOUD_CONTAINERS | boolean | false | If set, containers tests are added to the job.
 PUBLIC_CLOUD_DOWNLOAD_TESTREPO | boolean | false | If set, it schedules `publiccloud/download_repos` job.


### PR DESCRIPTION
That was one out of two things i left out of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13534

This is to make the scheduler readable as the else block in the `load_publiccloud_tests` was not self-explanatory.
i include also loader in replacement of `create_hdd_autoyast_pc.yaml` from the `PC Tools Image`.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/101427
- Verification run: 
[released](https://openqa.suse.de/t7605743)
[load_publiccloud_tools](https://openqa.suse.de/t7605744)
[load_publiccloud_download_repos](https://openqa.suse.de/t7605746)
[staging](https://openqa.suse.de/t7605745)
latest - some might fail likely due to missing variables:
[released](https://openqa.suse.de/tests/7637079)
[load_publiccloud_tools](https://openqa.suse.de/tests/7637078)
[load_publiccloud_download_repos](https://openqa.suse.de/tests/7637077)
[staging](https://openqa.suse.de/tests/7637076)