### PR TITLE
Prohibit the warning of 'printer added' for all arches on online migration case

### DIFF
--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -59,7 +59,7 @@ sub run {
     # create btrfs subvolume for aarch64 before migration
     create_btrfs_subvolume() if (is_aarch64);
     # We need to close gnome notification banner before migration.
-    if (check_var('DESKTOP', 'gnome') && (is_aarch64 || is_ppc64le)) {
+    if (check_var('DESKTOP', 'gnome')) {
         select_console 'user-console';
         turn_off_gnome_show_banner;
     }


### PR DESCRIPTION
Prohibit the warning of 'printer added' for all arches. This warning
message also happend at x86_64. Pohibit it for all arches.

- Related ticket: https://progress.opensuse.org/issues/101764
- Verification run: http://openqa.suse.de/t7609887
