### PR TITLE
Fix snapper_rollback rollback service activating issue

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -172,8 +172,8 @@ sub check_rollback_system {
     # Check SUSEConnect status for SLE
     # check rollback-helper service is enabled and worked properly
     # If rollback service is activating, need wait some time
-    # Add wait in a loop, max time is 15 minute, because case with much more modules need more time
-    for (1 .. 15) {
+    # Add wait in a loop, max time is 20 minute, because case with much more modules need more time
+    for (1 .. 20) {
         last unless script_run('systemctl --no-pager status rollback') != 0;
         sleep 60;
     }


### PR DESCRIPTION
We need to wait more time to make rollback service transit from activating to active.

- Related ticket: https://progress.opensuse.org/issues/101767
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t7604932
  https://openqa.nue.suse.com/t7604934