### PR TITLE
Increase default timeout in YuiRestClient

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use constant {
     API_VERSION => 'v1',
-    TIMEOUT => 90,
+    TIMEOUT => 150,
     INTERVAL => 1
 };
 


### PR DESCRIPTION
After n tries, unfortunately without VR because I thought that the screen was almost reaching the point we want (my bad) we can get to the right value for now for the timeout.

We should revert this in some point, because only for aarch and in a particular scenario [skip_install_addons in select_modules_and_patterns](https://openqa.suse.de/tests/7605134) we need such a big timeout, with 30-45 seconds should enough for most of the cases, but as agreed by the team, we will make it stable for now.

Verification run: [select_modules_and_patterns](https://openqa.suse.de/tests/7610148)

Follow-up ticket: https://progress.opensuse.org/issues/101957
