### PR TITLE
Add the openssl update check to 1.1.1+ for SLE15-SP4

### DIFF
--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -1,25 +1,38 @@
-# openssl fips test
+# SUSE's openQA tests
+# openssl FIPS test
 #
-# Copyright 2016-2020 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Package: openssl
-# Summary: FIPS : openssl should only list FIPS approved cryptographic functions
-#                 while system is working in fips mode
+# Summary: openssl should only list FIPS approved cryptographic functions
+#          while system is working in FIPS mode
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#44831, poo#65375
+# Tags: poo#44831, poo#65375, poo#101932
 
 use base "consoletest";
 use testapi;
 use strict;
 use warnings;
-use utils;
-use version_utils 'is_sle';
+use utils 'zypper_call';
+use version_utils qw(is_sle);
 
 sub run {
     select_console 'root-console';
-    zypper_call 'in openssl';
+
+    zypper_call('in openssl');
+    zypper_call('info openssl');
+    my $current_ver = script_output("rpm -q --qf '%{version}\n' openssl");
+
+    # openssl attempt to update to 1.1.1+ in SLE15 SP4 base on the feature
+    # SLE-19640: Update openssl 1.1.1 to current stable release
+    if (!is_sle('<15-sp4') && ($current_ver ge 1.1.1)) {
+        record_info('openssl version', "Version of Current openssl package: $current_ver");
+    }
+    else {
+        record_soft_failure('jsc#SLE-19640: openssl version is outdated and need to be updated over 1.1.1+ for SLE15-SP4');
+    }
 
     # Seperate the diffrent openssl command usage between SLE12 and SLE15
     if (is_sle('<15')) {


### PR DESCRIPTION
**Description:**
OpenSSL attempt to update to 1.1.1+ in SLE15 SP4 base on the Jira feature

_Jira#[SLE-19640](https://jira.suse.com/browse/SLE-19640): Update openssl 1.1.1 to current stable  release_

This PR is also adding the version check and record_info/soft_failure for openssl

- Related ticket: https://progress.opensuse.org/issues/101932
- Needles: NA
- Verification run: 
  https://openqa.suse.de/tests/7611053#step/openssl_fips_alglist/8 (x86_64) 
  https://openqa.suse.de/tests/7628311#step/openssl_fips_alglist/8 (s390x)
  https://openqa.suse.de/tests/7628338#step/openssl_fips_alglist/8 (aarch64)

In SLE15 SP4 Build 61.1, the latest Version of Current openssl package: **1.1.1l** is already updated and recorded.
 

Note: Please ignore the test failed caused by the bug
[1] Cipher: https://bugzilla.suse.com/show_bug.cgi?id=1161276#c45
[2] Hash:  https://bugzilla.suse.com/show_bug.cgi?id=1190888