### PR TITLE
Add instance preparation to consoletests

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -108,8 +108,13 @@ sub load_publiccloud_tests {
             loadtest 'publiccloud/storage_perf';
         }
         elsif (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
+            my $args = OpenQA::Test::RunArgs->new();
+            loadtest "publiccloud/prepare_instance", run_args => $args;
+            loadtest "publiccloud/register_system", run_args => $args;
+            loadtest "publiccloud/ssh_interactive_start", run_args => $args;
             load_extra_tests_prepare();
             load_publiccloud_consoletests();
+            loadtest("publiccloud/ssh_interactive_end", run_args => $args);
         }
         elsif (get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) {
             loadtest "publiccloud/upload_image";


### PR DESCRIPTION
Add the routines for instance preparation to consoletests

- Related ticket: https://progress.opensuse.org/issues/91434
- VR: https://openqa.suse.de/tests/7628802
