### PR TITLE
Fix send key issue for hyperv 2012r2 UEFI guest

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -48,7 +48,10 @@ sub grub_test {
         send_key 'ret';
     }
     # Avoid return key not received occasionally for hyperv-uefi guest at first boot
-    send_key 'ret' if (check_var('VIRSH_VMM_FAMILY', 'hyperv') && get_var('UEFI'));
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv') && get_var('UEFI')) {
+        sleep 5;
+        send_key 'ret';
+    }
 }
 
 =head2 handle_installer_medium_bootup


### PR DESCRIPTION
Hyper-V 2012UEFI guest install failure on OSD, this patch is for fixing the issue which return key was not received by console during first boot after install completed.

- Verification run: http://openqa.nue.suse.com/tests/7611188
