### PR TITLE
php7_postgresql: Use old version handling if postgresql96 is installed

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -248,7 +248,7 @@ sub test_pgsql {
     # upgrade db from oldest version to latest version
     if (script_run('test $(sudo update-alternatives --list postgresql|wc -l) -gt 1') == 0) {
         assert_script_run 'for v in $(sudo update-alternatives --list postgresql); do rpm -q ${v##*/};done';
-        if (is_sle('<=12-sp3')) {
+        if (script_run('rpm -q postgresql96') == 0) {
             # due to orderless numbering untill version 94 is gone
             my $pg_versions = <<'EOF';
 #!/bin/bash
@@ -263,9 +263,25 @@ elif [[ $(echo $PG_VER|grep 11) ]]; then
     export PG_OLDEST='postgresql11'
 elif [[ $(echo $PG_VER|grep 12) ]]; then
     export PG_OLDEST='postgresql12'
+elif [[ $(echo $PG_VER|grep 13) ]]; then
+    export PG_OLDEST='postgresql13'
+elif [[ $(echo $PG_VER|grep 14) ]]; then
+    export PG_OLDEST='postgresql14'
+elif [[ $(echo $PG_VER|grep 15) ]]; then
+    export PG_OLDEST='postgresql15'
+elif [[ $(echo $PG_VER|grep 16) ]]; then
+    export PG_OLDEST='postgresql16'
 fi
 echo PG_OLDEST=/usr/lib/$PG_OLDEST >/tmp/pg_versions
-if [[ $(echo $PG_VER|grep 12) ]]; then
+if [[ $(echo $PG_VER|grep 16) ]]; then
+    export PG_LATEST='postgresql16'
+elif [[ $(echo $PG_VER|grep 15) ]]; then
+    export PG_LATEST='postgresql15'
+elif [[ $(echo $PG_VER|grep 14) ]]; then
+    export PG_LATEST='postgresql14'
+elif [[ $(echo $PG_VER|grep 13) ]]; then
+    export PG_LATEST='postgresql13'
+elif [[ $(echo $PG_VER|grep 12) ]]; then
     export PG_LATEST='postgresql12'
 elif [[ $(echo $PG_VER|grep 11) ]]; then
     export PG_LATEST='postgresql11'


### PR DESCRIPTION
Including Leap or any version, when old 96 version is installed use old extended, with additional latest versions, version handling

- Related ticket: https://progress.opensuse.org/issues/101788
- Verification run:
https://openqa.opensuse.org/tests/2016028 Leap 15.2
https://openqa.opensuse.org/tests/2016027 Leap 15.3
http://dzedro.suse.cz/tests/19918 12 SP2
http://dzedro.suse.cz/tests/19920 15 SP2
