### PR TITLE
Set mouse_hide in init_desktop_runner to 1

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -176,7 +176,7 @@ sub init_desktop_runner {
 
     send_key($hotkey);
 
-    mouse_hide(200);
+    mouse_hide(1);
     if (!check_screen('desktop-runner', $timeout)) {
         record_info('workaround', "desktop-runner does not show up on $hotkey, retrying up to three times (see bsc#978027)");
         send_key 'esc';    # To avoid failing needle on missing 'alt' key - poo#20608


### PR DESCRIPTION
Not sure why it was 200, but looks like the offset thing was broken.

- Related ticket: https://progress.opensuse.org/issues/101941
- Verification run:
https://openqa.suse.de/tests/7613203 15 SP2
https://openqa.suse.de/tests/7613204 15 SP3