### PR TITLE
Don't operate firewall when system role is Common Criteria

### DIFF
--- a/lib/Utils/Systemd.pm
+++ b/lib/Utils/Systemd.pm
@@ -15,6 +15,7 @@ our @EXPORT = qw(
   get_started_systemd_services
   clear_started_systemd_services
   systemctl
+  check_unit_file
 );
 
 =head1 Utils::Systemd
@@ -84,6 +85,18 @@ Clear the list of started systemd services
 =cut
 sub clear_started_systemd_services {
     %started_systemd_services = ();
+}
+
+=head2 check_unit_file
+
+Check if the unit file exist
+
+=cut
+
+sub check_unit_file {
+    my $unit_file = shift;
+    return 1 if (script_run("systemctl list-unit-files --all $unit_file*") == 0);
+    return 0;
 }
 
 1;

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -13,7 +13,7 @@ use testapi;
 use lockapi;
 use mm_network 'setup_static_mm_network';
 use utils qw(zypper_call permit_root_ssh);
-use Utils::Systemd qw(disable_and_stop_service systemctl);
+use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
 use version_utils qw(is_sle is_opensuse);
 
 sub is_networkmanager {
@@ -31,7 +31,7 @@ sub run {
     assert_script_run('echo "10.0.2.102 client minion" >> /etc/hosts');
 
     # Configure static network, disable firewall
-    disable_and_stop_service($self->firewall);
+    disable_and_stop_service($self->firewall) if check_unit_file($self->firewall);
     disable_and_stop_service('apparmor', ignore_failure => 1);
 
     # Configure the internal network an  try it


### PR DESCRIPTION
When system role is Common Criteria, the firewall is not installed in
the system by default. Then it will report `Unit file firewalld.service
does not exist` when disabling it in setup_multimachine.pm.

- Related ticket:  https://progress.opensuse.org/issues/102116
- Needles: N/A
- Verification run:  
            https://openqa.suse.de/tests/7642614#

