### PR TITLE
Journal check: handle cases when there are no entries

### DIFF
--- a/tests/console/journal_check.pm
+++ b/tests/console/journal_check.pm
@@ -52,7 +52,7 @@ sub run {
 
     $self->select_serial_terminal;
 
-    my @journal_output = split(/\n/, script_output("journalctl --no-pager -p ${\get_var('JOURNAL_LOG_LEVEL', 'err')} -o short-precise | tail -n +2"));
+    my @journal_output = split(/\n/, script_output("journalctl --no-pager --quiet -p ${\get_var('JOURNAL_LOG_LEVEL', 'err')} -o short-precise"));
 
     # Find lines which matches to the pattern_bug
     foreach my $bug (keys %$bug_pattern) {


### PR DESCRIPTION
If there are no error messages in the journal, it will print
"-- No entries --" message, which is considered by the test module
as a failure. We should filter those cases.

- Related ticket: https://progress.opensuse.org/issues/101984
- VR: https://openqa.opensuse.org/tests/2022765 https://openqa.suse.de/tests/7629279
