### PR TITLE
Wait for custom size radio button to be enabled

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AbstractSizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AbstractSizePage.pm
@@ -13,6 +13,7 @@ package Installation::Partitioner::LibstorageNG::v4_3::AbstractSizePage;
 use parent 'Installation::Navigation::NavigationBase';
 use strict;
 use warnings;
+use YuiRestClient::Wait;
 
 sub init {
     my $self = shift;
@@ -24,6 +25,9 @@ sub init {
 sub set_custom_size {
     my ($self, $size) = @_;
     if ($size) {
+        YuiRestClient::Wait::wait_until(object => sub {
+                return $self->{rb_custom_size}->is_enabled();
+        }, message => "Custom size radio button takes too long to be enabled");
         $self->{rb_custom_size}->select();
         $self->{tb_size}->set($size);
     }

--- a/lib/YuiRestClient/Widget/RadioButton.pm
+++ b/lib/YuiRestClient/Widget/RadioButton.pm
@@ -19,6 +19,12 @@ sub is_selected {
     $self->property('value');
 }
 
+sub is_enabled {
+    my ($self) = @_;
+    my $is_enabled = $self->property('enabled');
+    return !defined $is_enabled || $is_enabled;
+}
+
 1;
 
 __END__


### PR DESCRIPTION
We need to check if radio button is enabled before selecting custom size radio button.

- Related ticket: https://progress.opensuse.org/issues/100904
- Needles: No needles
- Verification runs: https://openqa.suse.de/tests/7614138#next_previous
