### PR TITLE
Move is_enabled() to Base widget parent class

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AbstractSizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AbstractSizePage.pm
@@ -13,6 +13,7 @@ package Installation::Partitioner::LibstorageNG::v4_3::AbstractSizePage;
 use parent 'Installation::Navigation::NavigationBase';
 use strict;
 use warnings;
+use YuiRestClient::Wait;
 
 sub init {
     my $self = shift;
@@ -24,6 +25,9 @@ sub init {
 sub set_custom_size {
     my ($self, $size) = @_;
     if ($size) {
+        YuiRestClient::Wait::wait_until(object => sub {
+                return $self->{rb_custom_size}->is_enabled();
+        }, message => "Custom size radio button takes too long to be enabled");
         $self->{rb_custom_size}->select();
         $self->{tb_size}->set($size);
     }

--- a/lib/YuiRestClient/Widget/Base.pm
+++ b/lib/YuiRestClient/Widget/Base.pm
@@ -61,6 +61,12 @@ sub resolve_filter {
     $self->{filter}->resolve($json);
 }
 
+sub is_enabled {
+    my ($self) = @_;
+    my $is_enabled = $self->property('enabled');
+    return !defined $is_enabled || $is_enabled;
+}
+
 1;
 
 __END__

--- a/lib/YuiRestClient/Widget/Button.pm
+++ b/lib/YuiRestClient/Widget/Button.pm
@@ -14,12 +14,6 @@ sub click {
     return $self->action(action => YuiRestClient::Action::YUI_PRESS);
 }
 
-sub is_enabled {
-    my ($self) = @_;
-    my $is_enabled = $self->property('enabled');
-    return !defined $is_enabled || $is_enabled;
-}
-
 1;
 
 __END__

--- a/lib/YuiRestClient/Widget/ComboBox.pm
+++ b/lib/YuiRestClient/Widget/ComboBox.pm
@@ -30,14 +30,6 @@ sub value {
     return $self->property('value');
 }
 
-# When combobox is enabled it does not have 'enabled' property. Only in case it is disabled, the property appears
-# and equals to 'false'.
-sub is_enabled {
-    my ($self) = @_;
-    my $is_enabled = $self->property('enabled');
-    return !defined $is_enabled || $is_enabled;
-}
-
 1;
 
 __END__

--- a/lib/YuiRestClient/Widget/RadioButton.pm
+++ b/lib/YuiRestClient/Widget/RadioButton.pm
@@ -19,6 +19,12 @@ sub is_selected {
     $self->property('value');
 }
 
+sub is_enabled {
+    my ($self) = @_;
+    my $is_enabled = $self->property('enabled');
+    return !defined $is_enabled || $is_enabled;
+}
+
 1;
 
 __END__

--- a/lib/YuiRestClient/Widget/RadioButton.pm
+++ b/lib/YuiRestClient/Widget/RadioButton.pm
@@ -19,12 +19,6 @@ sub is_selected {
     $self->property('value');
 }
 
-sub is_enabled {
-    my ($self) = @_;
-    my $is_enabled = $self->property('enabled');
-    return !defined $is_enabled || $is_enabled;
-}
-
 1;
 
 __END__


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/100904
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/7629308#next_previous
