### PR TITLE
Drop containers/container_diff from JeOS tests

### DIFF
--- a/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
+++ b/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
@@ -38,5 +38,4 @@ schedule:
     - containers/podman_3rd_party_images
     - containers/registry
     - containers/zypper_docker
-    - containers/container_diff
     - containers/rootless_podman


### PR DESCRIPTION
Only HOST related container tests should run on top of JeOS

