### PR TITLE
Fix fail of validate_lvm in Leap

### DIFF
--- a/tests/console/validate_lvm.pm
+++ b/tests/console/validate_lvm.pm
@@ -78,7 +78,7 @@ sub run {
     record_info('LVM usage stats', 'Verify LVM usage stats are updated after adding a file.');
     my $test_file = '/home/test_file.txt';
     assert_script_run 'df -h  | tee original_usage';
-    assert_script_run "dd if=/dev/zero of=$test_file count=1024 bs=1M";
+    assert_script_run "fallocate -l 1G $test_file";
     assert_script_run "ls -lah $test_file";
     if ((script_run "sync && diff <(cat original_usage) <(df -h)") != 1) {
         die "LVM usage stats do not differ!";


### PR DESCRIPTION
This test fails sporadically in Leap, dd command timeouts from time to time and it has been now replaced with fallocate.

- Related ticket: https://progress.opensuse.org/issues/102080
- Needles: N/A
- Verification run: [Leap15.3](https://openqa.opensuse.org/tests/2023330#step/validate_lvm/45) | [sle15sp4](https://openqa.suse.de/tests/7631443#step/validate_lvm/49)
