### PR TITLE
sles4sap: saptune no longer uses tuned

### DIFF
--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -84,9 +84,9 @@ sub run {
     assert_script_run("rpm -q sapconf");
 
     if (is_upgrade()) {
-        # Stop & disable tuned service to avoid conflict with active saptune
-        systemctl "stop tuned";
-        systemctl "disable tuned";
+        # Stop & disable saptune service to avoid conflict with active saptune
+        systemctl "stop saptune";
+        systemctl "disable saptune";
         # Some versions of sapconf check for this directory and refuse to start
         assert_script_run "rm -rf /var/lib/saptune/saved_state";
         systemctl "enable sapconf";


### PR DESCRIPTION
Fix for failing tests on the `sapconf` module. 

saptune v3 no longer depends on the tuned service, so we have to stop & disable saptune instead.