### PR TITLE
Wait screen to change after user selected

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -298,6 +298,8 @@ sub select_user_gnome {
     elsif (match_has_tag('displaymanager-user-selected')) {
         if ($myuser =~ 'bernhard') {
             send_key 'ret';
+            # sometimes the system is slow, need wait several seconds for the screen to change.
+            wait_still_screen 5 if is_s390x;
         }
         else {
             assert_and_click "displaymanager-$myuser";


### PR DESCRIPTION
Sometimes the system is slow, we need to wait several seconds for the screen to change.

- Related ticket: https://progress.opensuse.org/issues/101770
- Needles: N/A
- Verification run: 
  http://openqa.nue.suse.com/tests/7629804
  http://openqa.nue.suse.com/tests/7629805
  http://openqa.nue.suse.com/tests/7629806
  http://openqa.nue.suse.com/tests/7629807
  http://openqa.nue.suse.com/tests/7629808