### PR TITLE
Test rmt server before and after migration

### DIFF
--- a/schedule/migration/rmt_host_migration.yaml
+++ b/schedule/migration/rmt_host_migration.yaml
@@ -1,0 +1,38 @@
+name:    rmt_host_migration
+description:    >
+     Test rmt server before and after migration
+vars:
+  DESKTOP: gnome
+  BOOT_HDD_IMAGE: 1
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - '{{online_migration_test}}'
+  - '{{remove_ltss}}'
+  - console/rmt/rmt_host_migration
+  - migration/version_switch_upgrade_target
+  - migration/online_migration/pre_migration
+  - '{{migration_method}}'
+  - migration/online_migration/post_migration
+  - console/rmt/rmt_host_migration
+
+conditional_schedule:
+  remove_ltss:
+    REGRESSION_LTSS:
+      1:
+        - migration/online_migration/register_without_ltss
+  migration_method:
+    MIGRATION_METHOD:
+      yast:
+        - migration/online_migration/yast2_migration
+      zypper:
+        - migration/online_migration/zypper_migration
+  online_migration_test:
+    ONLINE_MIGRATION:
+      1:
+        - installation/isosize
+        - installation/bootloader
+        - migration/online_migration/online_migration_setup
+        - migration/online_migration/register_system
+        - migration/online_migration/zypper_patch

--- a/tests/console/rmt/rmt_host_migration.pm
+++ b/tests/console/rmt/rmt_host_migration.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: rmt-server
+# Summary: This tests rmt server can work before and after migration
+#    Add rmt configuration test and basic configuration via
+#    rmt-wizard, enable repo, check repo at base system, then upgrade
+#    to latest one. It can still work fine.
+# Maintainer: Yutao wang <yuwang@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use repo_tools;
+
+sub run {
+    select_console 'root-console';
+
+    if (check_var('VERSION', get_required_var('ORIGIN_SYSTEM_VERSION'))) {
+        rmt_wizard();
+        # Sync from SCC
+        rmt_sync;
+        # Enable one product
+        assert_script_run("rmt-cli product enable sle-module-live-patching/15/x86_64");
+    }
+
+    # After migation, need do rmt sync again
+    rmt_sync if (check_var('VERSION', get_required_var('UPGRADE_TARGET_VERSION')));
+
+    # Before and after migration, both need rmt gets expected product
+    assert_script_run("rmt-cli product list | grep sle-module-live-patching/15/x86_64");
+}
+
+1;


### PR DESCRIPTION
Test rmt server before and after migration. Before migration need
check rmt server can do sync, enable and list operation. After
migration, need check rmt server can do sync and also has expected
package.

- Related ticket: https://progress.opensuse.org/issues/101340
- Verification run: https://openqa.suse.de/tests/7635384