### PR TITLE
[virt_autotest] Double check xen kernel for xen host at login_console

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -146,7 +146,18 @@ sub login_to_console {
     set_ssh_console_timeout_before_use if (is_remote_backend && is_aarch64 && get_var('IPMI_HW') eq 'thunderx');
     # use console based on ssh to avoid unstable ipmi
     use_ssh_serial_console;
+    # double-check xen kernel for xen host
+    $self->double_check_xen_role if is_xen_host;
 
+}
+
+#Just only match bootmenu-xen-kernel needle was not enough for xen host if got Xen domain0 kernel panic(bsc#1192258)
+#Need to double-check xen kernel after matched bootmenu-xen-kernel needle successfully
+sub double_check_xen_role {
+    record_info 'INFO', 'Double-check xen kernel';
+    #assert_script_run("lsmod | grep xen");
+    die 'Double-check xen kernel failed' if (script_run('lsmod | grep xen') != 0);
+    save_screenshot;
 }
 
 sub run {


### PR DESCRIPTION
- Description
According to the latest OSD test gi-guest_win2019-on-host_developing-xen on 15-SP4 build61.1, find out that got Xen Domain0 kernel panic during login_console test. then boot up a normal kernel wihout xen kernel to continue the following test. mean that just only match virttest-bootmenu-xen-kernel needle at login_console step for xen host was not enough during getting kernel panic. 
So, we'd better double-check xen kernel module for xen host after matching virttest-bootmenu-xen-kernel needle successfully at login_console for this PR purpose. 
- Related ticket: https://progress.opensuse.org/issues/xyz
- Verification run: 
[gi-guest_win2019-on-host_developing-xen](https://openqa.suse.de/tests/7636500#)
wip
