### PR TITLE
Move to kernel line in grub2 menu (2.06)

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -350,7 +350,9 @@ sub uefi_bootmenu_params {
         send_key "home";
         for (1 .. 6) { send_key "down"; }
         # On Leap/SLE we need to move down (grub 2.04)
-        if (is_sle('<16') || is_leap('<16.0')) {
+        # skip additional movement downwards in
+        # sle15sp4+, leap15.4+ and TW (grub 2.06)
+        if (is_sle('<15-SP4') || is_leap('<15.4')) {
             for (1 .. 4) { send_key "down"; }
         }
     }


### PR DESCRIPTION
Starting with grub 2.06 the grub2 config layout is similar in TW, Leap15.4
and sle15sp4. Therefore the number of lines has changed.
In order to append additional kernel parameters correctly, provided by
`EXTRABOOTPARAMS`, we need to adjust how many time the test case should
hit `down` key.

* Issues:
  * [15.4](http://kepler.suse.cz/tests/8842#step/bootloader_uefi/5)
  * [sle15sp4](http://kepler.suse.cz/tests/8845)

#### VRs:

* [opensuse-15.4-JeOS-for-kvm-and-xen-x86_64-Build4.9-kernel_parameters@64bit_virtio-2G](http://kepler.suse.cz/tests/8857#step/check_kernel_params/2)
* [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.111-kernel_parameters@uefi-virtio-vga](http://kepler.suse.cz/tests/8852#step/check_kernel_params/2)
* [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.273-kernel_parameters@uefi_virtio-2G](http://kepler.suse.cz/tests/8854#step/check_kernel_params/2)
* [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20211107-kernel_parameters@64bit_virtio](http://kepler.suse.cz/tests/8855#step/check_kernel_params/2)
* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20211109-1-kernel_parameters@uefi-virtio-vga](http://kepler.suse.cz/tests/8853#step/check_kernel_params/2)
* [opensuse-15.2-JeOS-for-kvm-and-xen-x86_64-Build31.592-kernel_parameters@uefi_virtio-2G](http://kepler.suse.cz/tests/8858#step/check_kernel_params/2)
* [sle-15-SP2-JeOS-for-kvm-and-xen-Updates-x86_64-Build20211109-1-kernel_parameters@uefi-virtio-vga](http://kepler.suse.cz/tests/8851#step/check_kernel_params/2)
* [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20211109-1-kernel_parameters@64bit-virtio-vga](http://kepler.suse.cz/tests/8850#step/check_kernel_params/2)