### PR TITLE
Fix multi-machine test in CC system role

### DIFF
--- a/schedule/security/cc_netfilter_netfilebt.yaml
+++ b/schedule/security/cc_netfilter_netfilebt.yaml
@@ -5,9 +5,9 @@ schedule:
     - '{{bootloader_zkvm}}'
     - boot/boot_to_desktop
     - '{{setup_multimachine}}'
+    - '{{cc_audit_test_setup}}'
     - security/selinux/selinux_setup
     - security/cc/cc_selinux_setup
-    - security/cc/cc_audit_test_setup
     - security/cc/setup_net_test_env
 conditional_schedule:
     bootloader_zkvm:
@@ -20,6 +20,10 @@ conditional_schedule:
                 - network/setup_multimachine
             x86_64:
                 - network/setup_multimachine
+    cc_audit_test_setup:
+        ARCH:
+            s390x:
+                - security/cc/cc_audit_test_setup
 test_data:
     server:
         first_interface:

--- a/schedule/security/create_hdd_common_criteria_for_mm.yaml
+++ b/schedule/security/create_hdd_common_criteria_for_mm.yaml
@@ -1,0 +1,9 @@
+name: create_hdd_common_criteria_for_mm
+description: >
+    This is used to publish the qcow2 file which is CC system role without
+    bridge network, required packages for mm setup usage have been installed as well.
+schedule:
+    - boot/boot_to_desktop
+    - security/cc/remove_bridge_network
+    - security/cc/cc_audit_test_setup
+    - shutdown/shutdown

--- a/tests/security/cc/remove_bridge_network.pm
+++ b/tests/security/cc/remove_bridge_network.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Remove bridge network in CC system role for multi-machine test
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#102116
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = shift;
+    select_console 'root-console';
+
+    my $bridge_info = script_output('bridge link');
+    if ($bridge_info =~ /\d+:\s+(\S+):.*master\s(br\d).*/) {
+        my $eth_interface = $1;
+        my $br_interface = $2;
+        assert_script_run("rm -f /etc/sysconfig/network/ifcfg-$br_interface");
+        assert_script_run("sed -i 's/none/dhcp/' /etc/sysconfig/network/ifcfg-$eth_interface");
+        assert_script_run('systemctl restart network.service');
+    }
+}
+
+1;

--- a/tests/security/cc/setup_net_test_env.pm
+++ b/tests/security/cc/setup_net_test_env.pm
@@ -23,10 +23,6 @@ sub run {
 
     select_console 'root-console';
 
-    # Stop firewalld for multi-machine tests
-    systemctl('stop firewalld');
-    systemctl('disable firewalld');
-
     zypper_call('in bridge-utils');
 
     # Need to do 'make netconfig' to generate 'lblnet_tst_server'


### PR DESCRIPTION
Please see individual commit message.

- Related ticket: https://progress.opensuse.org/issues/102116
- Needles: N/A
- Verification run: 
         https://openqa.suse.de/tests/7635686 (create qcow2 file in x86_64)
         https://openqa.suse.de/tests/7635803 (create qcow2 file in aarch64)
         https://openqa.suse.de/tests/7635869 (multi-machine test in x86_64)
         https://openqa.suse.de/tests/7636180 (multi-machine test in aarch64)
         https://openqa.suse.de/tests/7647288 (selinux_setup passed in s390x )