### PR TITLE
Independize vault client from the publiccloud::provider

### DIFF
--- a/lib/publiccloud/aws.pm
+++ b/lib/publiccloud/aws.pm
@@ -24,7 +24,7 @@ sub vault_create_credentials {
     my ($self) = @_;
 
     record_info('INFO', 'Get credentials from VAULT server.');
-    my $data = $self->vault_get_secrets('/aws/creds/openqa-role');
+    my $data = $self->vault->get_secrets('/aws/creds/openqa-role');
     $self->key_id($data->{access_key});
     $self->key_secret($data->{secret_key});
     die('Failed to retrieve key') unless (defined($self->key_id) && defined($self->key_secret));

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -64,11 +64,11 @@ sub vault_create_credentials {
     my ($self) = @_;
 
     record_info('INFO', 'Get credentials from VAULT server.');
-    my $data = $self->vault_get_secrets('/azure/creds/openqa-role');
+    my $data = $self->vault->get_secrets('/azure/creds/openqa-role');
     $self->key_id($data->{client_id});
     $self->key_secret($data->{client_secret});
 
-    my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/secret/azure/openqa-role', method => 'get');
+    my $res = $self->vault->api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/secret/azure/openqa-role', method => 'get');
     $self->tenantid($res->{data}->{tenant_id});
     $self->subscription($res->{data}->{subscription_id});
 

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -161,7 +161,7 @@ sub cleanup {
     my ($self) = @_;
     $self->terraform_destroy() if ($self->terraform_applied);
     $self->delete_keypair();
-    $self->vault_revoke();
+    $self->vault->revoke();
 }
 
 sub describe_instance

--- a/lib/publiccloud/eks.pm
+++ b/lib/publiccloud/eks.pm
@@ -20,7 +20,7 @@ sub vault_create_credentials {
 
     record_info('INFO', 'Get credentials from VAULT server for EKS');
     my $path = '/aws/sts/openqa-role-eks';
-    my $res = $self->vault_api('/v1/' . get_required_var('PUBLIC_CLOUD_VAULT_NAMESPACE') . $path, method => 'post');
+    my $res = $self->vault->api('/v1/' . get_required_var('PUBLIC_CLOUD_VAULT_NAMESPACE') . $path, method => 'post');
     my $data = $res->{data};
 
     $self->key_id($data->{access_key});

--- a/lib/publiccloud/gcp.pm
+++ b/lib/publiccloud/gcp.pm
@@ -85,9 +85,9 @@ sub create_credentials_file {
     } else {
         record_info('INFO', 'Get credentials from VAULT server.');
 
-        my $data = $self->vault_retry(
-            sub { $self->vault_get_secrets('/gcp/key/' . $self->get_next_vault_role(), max_tries => 1) },
-            name => 'vault_get_secrets(gcp)',
+        my $data = $self->vault->retry(
+            sub { $self->vault->get_secrets('/gcp/key/' . $self->get_next_vault_role(), max_tries => 1) },
+            name => 'get_secrets(gcp)',
             max_tries => scalar($self->vault_gcp_roles()) * 2,
             sleep_duration => get_var('PUBLIC_CLOUD_VAULT_TIMEOUT', 5)
         );

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -11,6 +11,7 @@ package publiccloud::provider;
 use testapi qw(is_serial_terminal :DEFAULT);
 use Mojo::Base -base;
 use publiccloud::instance;
+use publiccloud::vault;
 use Carp;
 use List::Util qw(max);
 use Data::Dumper;
@@ -28,9 +29,8 @@ has username => undef;
 has prefix => 'openqa';
 has terraform_env_prepared => 0;
 has terraform_applied => 0;
-has vault_token => undef;
-has vault_lease_id => undef;
 has resource_name => sub { get_var('PUBLIC_CLOUD_RESOURCE_NAME', 'openqa-vm') };
+has vault => undef;
 
 =head1 METHODS
 
@@ -42,6 +42,7 @@ Needs provider specific credentials, e.g. key_id, key_secret, region.
 sub init {
     my ($self) = @_;
     $self->create_ssh_key();
+    $self->vault(publiccloud::vault->new());
 }
 
 =head2 conv_openqa_tf_name
@@ -513,151 +514,6 @@ sub escape_single_quote {
     return $s;
 }
 
-sub vault_retry {
-    my ($self, $code, %args) = @_;
-    my $max_tries = max(1, get_var('PUBLIC_CLOUD_VAULT_TRIES', $args{max_tries} // 3));
-    my $sleep_duration = get_var('PUBLIC_CLOUD_VAULT_TIMEOUT', $args{sleep_duration} // 60);
-    $args{name} //= Carp::shortmess("vault_retry()");
-
-    my $ret;
-    my $try_cnt = 0;
-
-    while ($try_cnt++ < $max_tries) {
-        eval {
-            $ret = $code->();
-        };
-        return $ret unless ($@);
-        sleep $sleep_duration;
-    }
-    die($args{name} . " call failed after $max_tries attempts -- " . $@);
-}
-
-=head2 __vault_login
-
-Login to vault using C<_SECRET_PUBLIC_CLOUD_REST_USER> and
-C<_SECRET_PUBLIC_CLOUD_REST_PW>. The retrieved VAULT_TOKEN is stored in this
-instance and used for further C<publiccloud::provider::vault_api()> calls.
-=cut
-sub __vault_login
-{
-    my ($self) = @_;
-    my $url = get_required_var('_SECRET_PUBLIC_CLOUD_REST_URL');
-    my $user = get_required_var('_SECRET_PUBLIC_CLOUD_REST_USER');
-    my $password = get_required_var('_SECRET_PUBLIC_CLOUD_REST_PW');
-    my $ua = Mojo::UserAgent->new;
-
-    $ua->insecure(get_var('_SECRET_PUBLIC_CLOUD_REST_SSL_INSECURE', 0));
-    $url = $url . '/v1/auth/userpass/login/' . $user;
-    my $res = $ua->post($url => json => {password => $password})->result;
-    if (!$res->is_success) {
-        my $err_msg = 'Request ' . $url . ' failed with: ' . $res->message . ' (' . $res->code . ')';
-        $err_msg .= "\n" . join("\n", @{$res->json->{errors}}) if ($res->code == 400);
-        record_info('Vault login', $err_msg, result => 'fail');
-        die("Vault login failed - $url");
-    }
-
-    return $self->vault_token($res->json('/auth/client_token'));
-}
-
-=head2 vault_login
-
-Wrapper arround C<<$self->vault_login()>> to have retry capability.
-=cut
-sub vault_login {
-    my $self = shift;
-    return $self->vault_retry(
-        sub { $self->__vault_login() },
-        name => 'vault_login()', sleep_duration => 10
-    );
-}
-
-=head2 __vault_api
-
-Invoke a vault API call. It use _SECRET_PUBLIC_CLOUD_REST_URL as base
-url.
-Depending on the method (get|post) you can pass additional data as json.
-=cut
-sub __vault_api {
-    my ($self, $path, %args) = @_;
-    my $method = $args{method} // 'get';
-    my $data = $args{data} // {};
-    my $ua = Mojo::UserAgent->new;
-    my $url = get_required_var('_SECRET_PUBLIC_CLOUD_REST_URL');
-    my $res;
-
-    $self->vault_login() unless ($self->vault_token);
-
-    $ua->insecure(get_var('_SECRET_PUBLIC_CLOUD_REST_SSL_INSECURE', 0));
-    $ua->request_timeout(40);
-    $url = $url . $path;
-    bmwqemu::diag("Request Vault REST API: $url");
-    if ($method eq 'get') {
-        $res = $ua->get($url =>
-              {'X-Vault-Token' => $self->vault_token()})->result;
-    } elsif ($method eq 'post') {
-        $res = $ua->post($url =>
-              {'X-Vault-Token' => $self->vault_token()} =>
-              json => $data)->result;
-    } else {
-        die("Unknown method $method");
-    }
-
-    if (!$res->is_success) {
-        my $err_msg = 'Request ' . $url . ' failed with: ' . $res->message . ' (' . $res->code . ')';
-        $err_msg .= "\n" . join("\n", @{$res->json->{errors}}) if ($res->code == 400);
-        record_info('Vault API', $err_msg, result => 'fail');
-        die("Vault REST api call failed - $url");
-    }
-
-    return $res->json;
-}
-
-=head2 vault_api
-
-Wrapper around C<<$self->vault_api()>> to get retry capability.
-=cut
-sub vault_api {
-    my ($self, $path, %args) = @_;
-    my $max_tries = delete($args{max_tries}) // 3;
-    my $sleep_duration = delete($args{sleep_duration}) // 60;
-
-    return $self->vault_retry(
-        sub { $self->__vault_api($path, %args) },
-        name => 'vault_api()', max_tries => $max_tries, sleep_duration => $sleep_duration
-    );
-}
-
-=head2 vault_get_secrets
-
-  my $data = $csp->vault_get_secrets('/azure/creds/openqa-role' [, max_tries => 3][, sleep_duration => 60])
-
-This is a wrapper around C<vault_api()> to retrieve secrets from aws, gce or
-azure secret engine.
-It prepend C<'/v1/' + $NAMESPACE> to the given path before sending the request.
-It stores lease_id and also adjust the token-live-time.
-=cut
-sub vault_get_secrets {
-    my ($self, $path, %args) = @_;
-    my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . $path, method => 'get', %args);
-    $self->vault_lease_id($res->{lease_id});
-    $self->vault_api('/v1/auth/token/renew-self', method => 'post', data => {increment => $res->{lease_duration} . 's'}, %args);
-    return $res->{data};
-}
-
-=head2 vault_revoke
-
-Revoke a previous retrieved credential
-=cut
-sub vault_revoke {
-    my ($self) = @_;
-
-    return unless (defined($self->vault_lease_id));
-
-    $self->vault_api('/v1/sys/leases/revoke', method => 'post', data => {lease_id => $self->vault_lease_id});
-    $self->vault_lease_id(undef);
-}
-
-
 =head2 cleanup
 
 This method is called called after each test on failure or success.
@@ -666,7 +522,7 @@ This method is called called after each test on failure or success.
 sub cleanup {
     my ($self) = @_;
     $self->terraform_destroy();
-    $self->vault_revoke();
+    $self->vault->revoke();
     assert_script_run "cd";
 }
 

--- a/lib/publiccloud/vault.pm
+++ b/lib/publiccloud/vault.pm
@@ -1,0 +1,170 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Base helper class for vault client
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+package publiccloud::vault;
+use testapi qw(is_serial_terminal :DEFAULT);
+use Mojo::Base -base;
+use List::Util qw(max);
+
+has token => undef;
+has lease_id => undef;
+
+=head2 retry
+
+Retry n times the execution of a function.
+=cut
+sub retry {
+    my ($self, $code, %args) = @_;
+    my $max_tries = max(1, get_var('PUBLIC_CLOUD_VAULT_TRIES', $args{max_tries} // 3));
+    my $sleep_duration = get_var('PUBLIC_CLOUD_VAULT_TIMEOUT', $args{sleep_duration} // 60);
+    $args{name} //= Carp::shortmess("retry()");
+
+    my $ret;
+    my $try_cnt = 0;
+
+    while ($try_cnt++ < $max_tries) {
+        eval { $ret = $code->(); };
+        return $ret unless ($@);
+        sleep $sleep_duration;
+    }
+    die($args{name} . " call failed after $max_tries attempts -- " . $@);
+}
+
+=head2 __login
+
+Login to vault using C<_SECRET_PUBLIC_CLOUD_REST_USER> and
+C<_SECRET_PUBLIC_CLOUD_REST_PW>. The retrieved TOKEN is stored in this
+instance and used for further C<publiccloud::provider::api()> calls.
+=cut
+sub __login {
+    my ($self) = @_;
+    my $url = get_required_var('_SECRET_PUBLIC_CLOUD_REST_URL');
+    my $user = get_required_var('_SECRET_PUBLIC_CLOUD_REST_USER');
+    my $password = get_required_var('_SECRET_PUBLIC_CLOUD_REST_PW');
+    my $ua = Mojo::UserAgent->new;
+
+    $ua->insecure(get_var('_SECRET_PUBLIC_CLOUD_REST_SSL_INSECURE', 0));
+    $url = $url . '/v1/auth/userpass/login/' . $user;
+    my $res = $ua->post($url => json => {password => $password})->result;
+    if (!$res->is_success) {
+        my $err_msg = 'Request ' . $url . ' failed with: ' . $res->message . ' (' . $res->code . ')';
+        $err_msg .= "\n" . join("\n", @{$res->json->{errors}}) if ($res->code == 400);
+        record_info('Vault login', $err_msg, result => 'fail');
+        die("Vault login failed - $url");
+    }
+
+    return $self->token($res->json('/auth/client_token'));
+}
+
+=head2 login
+
+Wrapper arround C<<$self->login()>> to have retry capability.
+=cut
+sub login {
+    my $self = shift;
+    return $self->retry(
+        sub { $self->__login() },
+        name => 'login()',
+        sleep_duration => 10
+    );
+}
+
+=head2 __api
+
+Invoke a vault API call. It use _SECRET_PUBLIC_CLOUD_REST_URL as base
+url.
+Depending on the method (get|post) you can pass additional data as json.
+=cut
+sub __api {
+    my ($self, $path, %args) = @_;
+    my $method = $args{method} // 'get';
+    my $data = $args{data} // {};
+    my $ua = Mojo::UserAgent->new;
+    my $url = get_required_var('_SECRET_PUBLIC_CLOUD_REST_URL');
+    my $res;
+
+    $self->login() unless ($self->token);
+
+    $ua->insecure(get_var('_SECRET_PUBLIC_CLOUD_REST_SSL_INSECURE', 0));
+    $ua->request_timeout(40);
+    $url = $url . $path;
+    bmwqemu::diag("Request Vault REST API: $url");
+    if ($method eq 'get') {
+        $res = $ua->get($url => {'X-Vault-Token' => $self->token()})->result;
+    }
+    elsif ($method eq 'post') {
+        $res = $ua->post($url => {'X-Vault-Token' => $self->token()} => json => $data)->result;
+    }
+    else {
+        die("Unknown method $method");
+    }
+
+    if (!$res->is_success) {
+        my $err_msg = 'Request ' . $url . ' failed with: ' . $res->message . ' (' . $res->code . ')';
+        $err_msg .= "\n" . join("\n", @{$res->json->{errors}}) if ($res->code == 400);
+        record_info('Vault API', $err_msg, result => 'fail');
+        die("Vault REST api call failed - $url");
+    }
+
+    return $res->json;
+}
+
+=head2 api
+
+Wrapper around C<<$self->api()>> to get retry capability.
+=cut
+sub api {
+    my ($self, $path, %args) = @_;
+    my $max_tries = delete($args{max_tries}) // 3;
+    my $sleep_duration = delete($args{sleep_duration}) // 60;
+
+    return $self->retry(
+        sub { $self->__api($path, %args) },
+        name => 'api()',
+        max_tries => $max_tries,
+        sleep_duration => $sleep_duration
+    );
+}
+
+=head2 get_secrets
+
+  my $data = $csp->get_secrets('/azure/creds/openqa-role' [, max_tries => 3][, sleep_duration => 60])
+
+This is a wrapper around C<api()> to retrieve secrets from aws, gce or
+azure secret engine.
+It prepend C<'/v1/' + $NAMESPACE> to the given path before sending the request.
+It stores lease_id and also adjust the token-live-time.
+=cut
+sub get_secrets {
+    my ($self, $path, %args) = @_;
+    my $res = $self->api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . $path, method => 'get', %args);
+    $self->lease_id($res->{lease_id});
+    $self->api(
+        '/v1/auth/token/renew-self',
+        method => 'post',
+        data => {increment => $res->{lease_duration} . 's'},
+        %args
+    );
+    return $res->{data};
+}
+
+=head2 revoke
+
+Revoke a previous retrieved credential
+=cut
+sub revoke {
+    my ($self) = @_;
+
+    return unless (defined($self->lease_id));
+
+    $self->api('/v1/sys/leases/revoke', method => 'post', data => {lease_id => $self->lease_id});
+    $self->lease_id(undef);
+}
+
+1;

--- a/t/08-publiccloud.t
+++ b/t/08-publiccloud.t
@@ -19,7 +19,7 @@ subtest 'get_next_gcp_role' => sub {
 };
 
 subtest 'vault_retry' => sub {
-    my $provider = publiccloud::provider->new();
+    my $vault = publiccloud::vault->new();
 
     my $cnt = 0;
     my $max_failed = 1;
@@ -31,17 +31,17 @@ subtest 'vault_retry' => sub {
     };
 
     $cnt = 0; $max_failed = 0;
-    is($provider->vault_retry($test_func1, max_tries => 0, sleep_duration => 0), 'SUCCESS', 'No exception with 1 retry');
+    is($vault->retry($test_func1, max_tries => 0, sleep_duration => 0), 'SUCCESS', 'No exception with 1 retry');
 
     $cnt = 0; $max_failed = 2;
-    is($provider->vault_retry($test_func1, max_tries => 3, sleep_duration => 0), 'SUCCESS', 'No exception with 1 retry');
+    is($vault->retry($test_func1, max_tries => 3, sleep_duration => 0), 'SUCCESS', 'No exception with 1 retry');
 
     $cnt = 0; $max_failed = 3;
-    throws_ok { $provider->vault_retry($test_func1, max_tries => 3, sleep_duration => 0) } qr/call failed after 3/, 'Exception if retry Exhausted';
+    throws_ok { $vault->retry($test_func1, max_tries => 3, sleep_duration => 0) } qr/call failed after 3/, 'Exception if retry Exhausted';
 
     $cnt = 0; $max_failed = 3;
     set_var('PUBLIC_CLOUD_VAULT_TRIES', 4);
-    is($provider->vault_retry($test_func1, max_tries => 3, sleep_duration => 0), 'SUCCESS', 'OpenQA variable has precedence over arguments');
+    is($vault->retry($test_func1, max_tries => 3, sleep_duration => 0), 'SUCCESS', 'OpenQA variable has precedence over arguments');
 };
 
 done_testing;


### PR DESCRIPTION
Now vault client actions are part of the provider class
this forces to use code of instance creation (e.g. terraform)
in tests where are not necessary create instances (e.g. kubernetes)

- Related ticket: https://progress.opensuse.org/issues/101491
- Verification runs:
- http://copland.arch.suse.de/tests/512
- http://copland.arch.suse.de/tests/511
- (Google) http://openqa.suse.de/tests/7648540
- (Amazon) http://openqa.suse.de/t7654342
- (Azure) https://openqa.suse.de/tests/7654359