### PR TITLE
Move rmt automation test to the console folder

### DIFF
--- a/schedule/migration/rmt_export.yaml
+++ b/schedule/migration/rmt_export.yaml
@@ -4,4 +4,4 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - network/setup_multimachine
-  - x11/rmt/rmt_export
+  - console/rmt/rmt_export

--- a/schedule/migration/rmt_feature.yaml
+++ b/schedule/migration/rmt_feature.yaml
@@ -3,4 +3,4 @@ description:    >
     This is for rmt feature test
 schedule:
   - boot/boot_to_desktop
-  - x11/rmt/rmt_feature
+  - console/rmt/rmt_feature

--- a/schedule/migration/rmt_import.yaml
+++ b/schedule/migration/rmt_import.yaml
@@ -4,4 +4,4 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - network/setup_multimachine
-  - x11/rmt/rmt_import
+  - console/rmt/rmt_import

--- a/tests/console/rmt/rmt_export.pm
+++ b/tests/console/rmt/rmt_export.pm
@@ -12,18 +12,14 @@
 use strict;
 use warnings;
 use testapi;
-use base 'x11test';
+use base 'consoletest';
 use repo_tools;
 use utils;
-use x11utils 'turn_off_gnome_screensaver';
 use lockapi 'mutex_create';
 use mmapi 'wait_for_children';
 
 sub run {
-    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
-    # Avoid blank screen since smt sync needs time
-    turn_off_gnome_screensaver;
-    become_root;
+    select_console 'root-console';
     rmt_wizard();
     # sync, enable, mirror and list products
     rmt_sync();

--- a/tests/console/rmt/rmt_feature.pm
+++ b/tests/console/rmt/rmt_feature.pm
@@ -9,19 +9,15 @@
 #    rmt mirror, test import SMT data to RMT
 # Maintainer: Yutao wang <yuwang@suse.com>
 
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use base 'x11test';
 use repo_tools;
 use utils;
-use x11utils 'turn_off_gnome_screensaver';
 
 sub run {
-    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
-    # Avoid blank screen since smt sync needs time
-    turn_off_gnome_screensaver;
-    become_root;
+    select_console 'root-console';
     rmt_wizard();
     # sync from SCC
     rmt_sync;
@@ -102,9 +98,6 @@ sub run {
     assert_script_run("rmt-cli repo list");
     assert_script_run("rmt-cli repo list | grep 4205");
     assert_script_run("rmt-cli repo list | grep 4203");
-
-
-    enter_cmd "killall xterm";
 }
 
 sub test_flags {

--- a/tests/console/rmt/rmt_import.pm
+++ b/tests/console/rmt/rmt_import.pm
@@ -11,17 +11,13 @@
 use strict;
 use warnings;
 use testapi;
-use base 'x11test';
+use base 'consoletest';
 use repo_tools;
 use utils;
-use x11utils 'turn_off_gnome_screensaver';
 use lockapi qw(mutex_create mutex_wait);
 
 sub run {
-    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
-    # Avoid blank screen since smt sync needs time
-    turn_off_gnome_screensaver;
-    become_root;
+    select_console 'root-console';
     rmt_wizard();
     # sync from SCC
     rmt_sync;


### PR DESCRIPTION
Move rmt automation test to the console folder. As x11 need desktop,
we change to use console to ignore desktop.

- Related ticket:https://progress.opensuse.org/issues/102014
- Verification run: 
    rmt_featrue: https://openqa.suse.de/tests/7628353#
    rmt_export: https://openqa.suse.de/tests/7628654#
    rmt_import: https://openqa.suse.de/tests/7628655