### PR TITLE
Switch aide_check journald_fss to select_serial_terminal

### DIFF
--- a/tests/console/aide_check.pm
+++ b/tests/console/aide_check.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2020 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Package: aide
@@ -13,7 +13,7 @@
 #          4. Modified the file system and run aide check again
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#64364, tc#1744128
+# Tags: poo#64364, poo#102032, tc#1744128
 
 use base "consoletest";
 use testapi;
@@ -22,10 +22,10 @@ use strict;
 use warnings;
 
 sub run {
-    select_console 'root-console';
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     zypper_call "in aide";
-
     assert_script_run "cp /etc/aide.conf /etc/aide.conf.bak";
 
     # Initialize the database and move it to the appropriate place before using the --check command

--- a/tests/console/journald_fss.pm
+++ b/tests/console/journald_fss.pm
@@ -1,17 +1,19 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2018 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
-
+#
 # Case 1560070  - FIPS: systemd journald FSS
-
+#
 # Package: systemd
 # Summary: Add Case 1463314-FIPS:systemd-journald test
 #    Systemd depend on libgcrypt for journald's FSS(Forward Secure Sealing) function
 #    It is only needed to test journald's key generation and verification function
 #    Verify key should be generated,as well as a QR code
 #    No failed messages output
+#
 # Maintainer: Ben Chou <bchou@suse.com>
+# Tags: poo#102038
 
 use base "consoletest";
 use strict;
@@ -20,7 +22,8 @@ use testapi;
 use utils;
 
 sub run {
-    select_console "root-console";
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     # Enable FSS (Forward Secure Sealing)
     assert_script_run("sed -i -e 's/^Storage/#Storage/g' -e 's/^Seal/#Seal/g' /etc/systemd/journald.conf");


### PR DESCRIPTION
**Description:**
Use select_serial_terminal instead of root_console to make test more robust,
poo#102032, poo#102038: Fix the missing character problem on aarch64.

- Related ticket: 
  https://progress.opensuse.org/issues/102032 (aide_check)
  https://progress.opensuse.org/issues/102038 (journald_fss)
- Needles: NA
- Verification run:
https://openqa.suse.de/t7642972 (x86_64)
https://openqa.suse.de/t7642971 (s390x)
https://openqa.suse.de/t7642967 (aarch64)

