### PR TITLE
Unregister unneeded boot needles in JeOS testing

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -18,7 +18,7 @@ use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
 use scheduler 'load_yaml_schedule';
-use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_pvm);
+use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_pvm is_ipmi);
 use main_containers;
 use main_publiccloud;
 use Utils::Architectures;
@@ -98,11 +98,24 @@ sub cleanup_needles {
 
     if (!is_sles4sap) {
         unregister_needle_tags("ENV-FLAVOR-SAP-DVD");
+        unregister_needle_tags('ENV-SLES4SAP-1');
     }
 
     if (!is_jeos) {
         unregister_needle_tags('ENV-FLAVOR-JeOS-for-kvm');
         unregister_needle_tags('ENV-JEOS-1');
+    }
+
+    if (is_jeos) {
+        unregister_needle_tags('inst-bootmenu');
+    }
+
+    if (!is_ipmi) {
+        unregister_needle_tags('ENV-BACKEND-ipmi');
+    }
+
+    if (!check_var('VIDEOMODE', 'text')) {
+        unregister_needle_tags('ENV-VIDEOMODE-text');
     }
 
     if (get_var('OFW')) {


### PR DESCRIPTION
- [bootloader_uefi fails in aarch64 image testing - needle stall detected](https://progress.opensuse.org/issues/90206)
- Verification runs:
  * [sle-15-SP4-JeOS-for-kvm-and-xen-aarch64](https://openqa.suse.de/tests/7643808#step/bootloader_uefi/5) 
  * [sle-15-SP4-JeOS-for-kvm-and-xen-aarch64](https://openqa.suse.de/tests/7643800#step/bootloader_uefi/5) 
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64](https://openqa.suse.de/tests/7643810#step/bootloader_uefi/5)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64](https://openqa.suse.de/tests/7643829#step/bootloader_uefi/5)  
  
 Seemingly, this is only the first step to reduce the amount of failures in grub2 for JeOS.