### PR TITLE
Increase tab count to get to ssh key import

### DIFF
--- a/tests/installation/ssh_key_setup.pm
+++ b/tests/installation/ssh_key_setup.pm
@@ -13,7 +13,7 @@ use warnings;
 use testapi;
 
 sub run {
-    send_key_until_needlematch 'ssh-key-import-selected', 'tab';
+    send_key_until_needlematch 'ssh-key-import-selected', 'tab', 30, 1;
     send_key 'ret';
     assert_screen "inst-import-ssh-key";
     if (get_var('SSH_KEY_IMPORT')) {


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/7619372#step/ssh_key_setup/24
- Verification run:
http://dzedro.suse.cz/tests/19953#step/ssh_key_setup/24
https://openqa.suse.de/tests/7643857