### PR TITLE
Enable firewall on SLE 15+ all archs

### DIFF
--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -145,7 +145,6 @@
       <interface>
         <bootproto>static</bootproto>
         <device>lo</device>
-        <firewall>no</firewall>
         <ipaddr>127.0.0.1</ipaddr>
         <netmask>255.0.0.0</netmask>
         <network>127.0.0.0</network>
@@ -217,6 +216,7 @@
       </interface>
     </interfaces>
   </networking>
+  % }
   <firewall>
     <enable_firewall config:type="boolean">true</enable_firewall>
     <start_firewall config:type="boolean">true</start_firewall>
@@ -227,6 +227,9 @@
           <interface>eth0</interface>
         </interfaces>
         <services config:type="list">
+          % if ($check_var->('ARCH', 's390x')) {
+          <service>vnc-server</service>
+          % }
           <service>ssh</service>
         </services>
         <ports config:type="list">
@@ -235,7 +238,6 @@
       </zone>
     </zones>
   </firewall>
-  % }
   <report>
     <errors>
       <log config:type="boolean">true</log>


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/7562069#step/firewall_enabled/1
- Verification run:
https://openqa.suse.de/tests/7644651 x86_64 15 GA
https://openqa.suse.de/tests/7644652 x86_64 15 GA
https://openqa.suse.de/tests/7644653 s390x 15 GA
https://openqa.suse.de/tests/7644654 aarch64 15 GA
https://openqa.suse.de/tests/7644771 x86_64 15 SP1
https://openqa.suse.de/tests/7644772 x86_64 15 SP1
https://openqa.suse.de/tests/7644852 s390x 15 SP1
https://openqa.suse.de/tests/7644774 aarch64 15 SP1
https://openqa.suse.de/tests/7644775 x86_64 15 SP2
https://openqa.suse.de/tests/7644776 x86_64 15 SP2
https://openqa.suse.de/tests/7644777 s390x 15 SP2
https://openqa.suse.de/tests/7644778 aarch64 15 SP2
https://openqa.suse.de/tests/7644779 x86_64 15 SP3
https://openqa.suse.de/tests/7644780 x86_64 15 SP3
https://openqa.suse.de/tests/7644781 s390x 15 SP3
https://openqa.suse.de/tests/7644782 aarch64 15 SP3