### PR TITLE
Adjust shortcut to open "Activities" in GNOME41

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_favorites.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_favorites.pm
@@ -21,7 +21,7 @@ use version_utils 'is_sle';
 sub run {
     # start destop application memu
     wait_still_screen;
-    send_key "alt-f1";
+    send_key "super";
     assert_screen('test-desktop_mainmenu-1');
 
     # find the favorites button


### PR DESCRIPTION
In GNOME41, use shortcut `alt-f1` to open "Activities" is removed.  So use shortcut `super` instead.

- Related ticket: https://progress.opensuse.org/issues/101917
- Needles: None
- Verification run: https://openqa.suse.de/tests/7647470#step/libreoffice_mainmenu_favorites/1
