### PR TITLE
console/btrfs_qgroups: Explicitly pass the reflink option to cp

### DIFF
--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -80,7 +80,8 @@ sub run {
     # Check limits
     assert_script_run "dd if=/dev/zero bs=10M count=3 of=nofile";
     foreach my $c ('a' .. 'b') {
-        assert_script_run "! cp nofile $c/nofile";
+        assert_script_run "cp --reflink=always nofile $c/nofile";
+        assert_script_run "! cp --reflink=never --remove-destination nofile $c/nofile";
         assert_script_run "sync && rm $c/nofile";
     }
     assert_script_run "cp nofile c/nofile";


### PR DESCRIPTION
Instead of relying on the default value of that option (which changed with
coreutils 9.0), pass it explicitly. This also allows testing that using
reflinks does not cause the quota to be exceeded.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1192570
- Verification run: https://openqa.opensuse.org/tests/2028742#step/btrfs_qgroups/75
