### PR TITLE
Bump timeout for installer tests with LibyuiClient

### DIFF
--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -15,7 +15,7 @@ use testapi;
 use YuiRestClient;
 
 sub run {
-    my $app = YuiRestClient::get_app(installation => 1, timeout => 60, interval => 1);
+    my $app = YuiRestClient::get_app(installation => 1, timeout => 120, interval => 1);
     my $port = $app->get_port();
     record_info('SERVER', "Used host for libyui: " . $app->get_host());
     record_info('PORT', "Used port for libyui: " . $port);


### PR DESCRIPTION
Tests failed on some systems when a lot of packages were installed,
because the installation takes more then 60 seconds.

The commit increases timeout to avoid that issue.

- Related ticket: https://progress.opensuse.org/issues/101957
- Verification run: https://openqa.suse.de/tests/7649112
