### PR TITLE
Remove condition which create wrong scheduling on JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -554,6 +554,9 @@ sub load_system_role_tests {
     }
 }
 sub load_jeos_tests {
+    # o3 runs container jobs with jeos flavor which their schuduling is not related with this loader. Skip and let
+    # load_container_tests take care of those(lean on ppc64le and container tests on centos/ubuntu)
+    return if (get_var('CONTAINER_RUNTIME', 0) && (is_leap && is_ppc64le) || check_var('CONTAINERS_NO_SUSE_OS', 1));
     if ((is_arm || is_aarch64) && is_opensuse()) {
         # Enable jeos-firstboot, due to boo#1020019
         load_boot_tests();

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -258,7 +258,7 @@ sub load_default_tests {
 }
 
 # load the tests in the right order
-if (is_jeos && !is_container_test) {
+if (is_jeos) {
     load_jeos_tests();
 }
 


### PR DESCRIPTION
The main issue was the condition is `products/opensuse/main.pm` in L261
which was evaluated to *false* and then later another condition linked to *load_container_tests*.

The solution was to remove this condition, so letting *load_jeos_tests* run first and then
find *load_container_tests* which in turn will *load_jeos_containers* as it was before.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/102272
- Verification run: 

https://openqa.opensuse.org/tests/2029918
https://openqa.opensuse.org/tests/2029917
https://openqa.opensuse.org/tests/2030191

https://openqa.suse.de/tests/7650121
https://openqa.suse.de/tests/7650120

VR for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/commits/366eb59b5758501a37278acc1dd6090ee502badd:
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.opensuse.org/tests/2031116
Github oauth token provided, performing authenticated requests
Created job #2036430: opensuse-15.3-JeOS-for-kvm-and-xen-ppc64le-Build9.279-containers_docker_on_15.2_gm@ppc64le -> https://openqa.opensuse.org/t2036430
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.opensuse.org/tests/2031115
Github oauth token provided, performing authenticated requests
Created job #2036431: opensuse-15.3-JeOS-for-kvm-and-xen-ppc64le-Build9.279-containers_podman_on_15.2_gm@ppc64le -> https://openqa.opensuse.org/t2036431
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.opensuse.org/tests/2034865
Github oauth token provided, performing authenticated requests
Created job #2036432: opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20211113-jeos-containers@64bit_virtio -> https://openqa.opensuse.org/t2036432
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.opensuse.org/tests/2034867
Github oauth token provided, performing authenticated requests
Created job #2036433: opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20211113-jeos@64bit_virtio -> https://openqa.opensuse.org/t2036433
❯ 
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.opensuse.org/tests/2031132
Github oauth token provided, performing authenticated requests
Created job #2036434: opensuse-15.3-JeOS-for-AArch64-aarch64-Build9.279-jeos-containers@USBboot_aarch64 -> https://openqa.opensuse.org/t2036434
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.opensuse.org/tests/2031116
Github oauth token provided, performing authenticated requests
Created job #2036436: opensuse-15.3-JeOS-for-kvm-and-xen-ppc64le-Build9.279-containers_docker_on_15.2_gm@ppc64le -> https://openqa.opensuse.org/t2036436
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.opensuse.org/tests/2031118
Github oauth token provided, performing authenticated requests
Created job #2036437: opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.279-containers_on_centos_host_x86_64@64bit-2G -> https://openqa.opensuse.org/t2036437
❯ 
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.suse.de/tests/7675887
Github oauth token provided, performing authenticated requests
Created job #7678825: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20211115-1-jeos-filesystem@uefi-virtio-vga -> https://openqa.suse.de/t7678825
❯  openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13668/ https://openqa.suse.de/tests/7677181
Github oauth token provided, performing authenticated requests
Created job #7678827: sle-15-SP3-Server-DVD-Updates-x86_64-Build20211115-1-docker_tests@64bit -> https://openqa.suse.de/t7678827
