### PR TITLE
ipmi: Disable enlarge swap to RAM size on small disks

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -541,6 +541,14 @@ sub take_first_disk_storage_ng {
         assert_screen 'partition-scheme';
     }
     elsif (is_ipmi) {
+        select_console('install-shell');
+        my $mem_size = script_output 'free -b | awk \'/Mem/ {print $2}\'';
+        my $disk_size = script_output 'lsblk -dnb /dev/sda -o SIZE';
+        select_console 'installation';
+        if ($mem_size > $disk_size) {
+            send_key_until_needlematch [qw(enlarge-enabled enlarge-disabled)], $cmd{next};
+            send_key_until_needlematch('enlarge-disabled', 'alt-a') if (match_has_tag 'enlarge-enabled');
+        }
         send_key_until_needlematch 'after-partitioning', $cmd{next}, 10, 3;
         return;
     }


### PR DESCRIPTION
Fix poo#102083: We need to deselect enlarge swap to RAM size  during
guided setup of first disk on IPMI backend where disk size is smaller than RAM.

- Related ticket: https://progress.opensuse.org/issues/102083
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1579
- Verification run: 
kernel: http://10.100.12.105/tests/1371#step/partitioning_firstdisk/8 (enlarge disabled)
virtualization: https://openqa.suse.de/tests/7654319#step/partitioning_firstdisk/13 (no impact)
sap: https://openqa.suse.de/tests/7654360#step/partitioning_firstdisk/14 (no impact)
sap 15-sp1: https://openqa.suse.de/tests/7654351#step/partitioning_firstdisk/14 (no impact)