### PR TITLE
Use developing container image for developing sle in sssd 389ds test

### DIFF
--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -10,7 +10,6 @@ schedule:
     - '{{wpa_supplicant}}'
     - console/vmstat
     - console/sssd_389ds_functional
-    - console/sssd_openldap_functional
     - console/coredump_collect
 conditional_schedule:
     wpa_supplicant:


### PR DESCRIPTION
This sssd_389ds_functional test module currently builds sle15sp3 container by default. It need 15sp3 repos but proxy.scc.suse.de in openQA only provides 15sp4 repos. Therefore it fails on 15sp4 test.
We can fix it by building container of the same sle version as host for developing sle product. In this case it means building a 15sp4 container.

- Related ticket: https://progress.opensuse.org/issues/101207
- Needles: no
- Verification run: 
- sles15sp4: http://10.67.17.201/tests/1699
- sles15sp3: http://10.67.17.201/tests/1700
- sles12sp5: http://10.67.17.201/tests/1703
- sles15sp4-aarch64: http://openqa.suse.de/tests/7654303
- sles15sp4-s390x: https://openqa.suse.de/tests/7654304