### PR TITLE
Containers: fix schedule for JeOS

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -80,7 +80,7 @@ sub load_host_tests_docker {
         loadtest 'containers/registry' if is_x86_64;
         loadtest 'containers/docker_compose';
     }
-    loadtest 'containers/validate_btrfs' if is_x86_64;
+    loadtest 'containers/validate_btrfs' if (is_x86_64 && !is_jeos);
     loadtest "containers/container_diff" if (is_opensuse());
 }
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -258,7 +258,7 @@ sub load_default_tests {
 }
 
 # load the tests in the right order
-if (is_jeos && !is_container_test) {
+if (is_jeos) {
     load_jeos_tests();
 }
 


### PR DESCRIPTION
This fixes:
https://progress.opensuse.org/issues/102272
https://progress.opensuse.org/issues/102278

This basically enables running the default jeos tests as it was done before, and then run the specific container tests.

In a follow-up PR, we could come up with a more smart default jeos test for container jobs only, instead of running all the default ones, but this is a different topic than this PR tries to fix.


VRs:
- [USBboot_aarch64 ](https://openqa.opensuse.org/tests/2030307)
- [x86_64](https://openqa.opensuse.org/tests/2031072)  (not sure why validate_btrfs fails)

**Some things need to be done in job configuration:**
- Add `NUMDISKS=2` for `validate_btrfs` test
- Remove `BOOT_HDD_IMAGE` -> JeOS tests don't need that variable.
- Remove `CONTAINERS_UNTESTED_IMAGES` -> this is a HOST test based to test container tools and packages on JeOS. We already have a job to validate the "untested" container image: https://openqa.opensuse.org/tests/2029146. If we want to enable also container image validation on JeOS, we should create a separate job. 


