### PR TITLE
Handle secureboot on&off for ima_evm tests

### DIFF
--- a/tests/security/ima/evm_protection_digital_signatures.pm
+++ b/tests/security/ima/evm_protection_digital_signatures.pm
@@ -3,16 +3,16 @@
 #
 # Summary: Test EVM protection using digital signatures
 # Note: This case should come after 'evm_protection_hmacs'
-# Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#53582, poo#92347
+# Maintainer: llzhao <llzhao@suse.com>, rfan1 <richard.fan@suse.com>
+# Tags: poo#53579, poo#100694, poo#102311
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
 use utils;
-use bootloader_setup "replace_grub_cmdline_settings";
-use power_action_utils "power_action";
+use bootloader_setup qw(replace_grub_cmdline_settings tianocore_disable_secureboot);
+use power_action_utils 'power_action';
 
 sub run {
     my ($self) = @_;
@@ -61,7 +61,11 @@ sub run {
     }
     else {
         replace_grub_cmdline_settings('evm=fix ima_appraise=fix', '', update_grub => 1);
+
+        # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
         power_action('reboot', textmode => 1);
+        $self->wait_grub(bootloader_time => 200);
+        $self->tianocore_disable_secureboot('re_enable');
         $self->wait_boot(textmode => 1);
         $self->select_serial_terminal;
 

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -1,18 +1,18 @@
-# Copyright 2019-2020 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Test EVM protection using HMACs
 # Note: This case should come after 'evm_setup'
-# Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#53579
+# Maintainer: llzhao <llzhao@suse.com>, rfan1 <richard.fan@suse.com>
+# Tags: poo#53579, poo#100694, poo#102311
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
 use utils;
-use bootloader_setup "replace_grub_cmdline_settings";
-use power_action_utils "power_action";
+use bootloader_setup qw(replace_grub_cmdline_settings tianocore_disable_secureboot);
+use power_action_utils 'power_action';
 
 sub run {
     my ($self) = @_;
@@ -40,7 +40,10 @@ sub run {
 
     replace_grub_cmdline_settings('evm=fix ima_appraise=fix', '', update_grub => 1);
 
+    # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
     power_action('reboot', textmode => 1);
+    $self->wait_grub(bootloader_time => 200);
+    $self->tianocore_disable_secureboot('re_enable');
     $self->wait_boot(textmode => 1);
     $self->select_serial_terminal;
     my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);

--- a/tests/security/ima/evm_setup.pm
+++ b/tests/security/ima/evm_setup.pm
@@ -1,18 +1,18 @@
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Setup environment for EVM protection testing
 # Note: This case should come after 'ima_setup'
-# Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#53579
+# Maintainer: llzhao <llzhao@suse.com>, rfan1 <richard.fan@suse.com>
+# Tags: poo#53579, poo#100694, poo#102311
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
 use utils;
-use bootloader_setup "add_grub_cmdline_settings";
-use power_action_utils "power_action";
+use bootloader_setup qw(replace_grub_cmdline_settings tianocore_disable_secureboot);
+use power_action_utils 'power_action';
 
 sub run {
     my ($self) = @_;
@@ -38,7 +38,10 @@ sub run {
 
     add_grub_cmdline_settings("evm=fix ima_appraise=fix ima_appraise_tcb", update_grub => 1);
 
-    power_action('reboot', textmode => 1);
+    record_info("bsc#1189988: ", "We need disable secureboot with ima fix mode");
+    power_action("reboot", textmode => 1);
+    $self->wait_grub(bootloader_time => 200);
+    $self->tianocore_disable_secureboot;
     $self->wait_boot(textmode => 1);
     $self->select_serial_terminal;
 

--- a/tests/security/ima/ima_appraisal_audit.pm
+++ b/tests/security/ima/ima_appraisal_audit.pm
@@ -6,13 +6,13 @@
 # Maintainer: llzhao <llzhao@suse.com>
 # Tags: poo#49568, poo#92347
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
-use power_action_utils "power_action";
+use power_action_utils 'power_action';
 
 sub audit_verify {
 }
@@ -44,7 +44,7 @@ sub run {
 
         # Test both default(no ima_apprais=) and ima_appraise=log situation
         add_grub_cmdline_settings("ima_appraise=log", update_grub => 1);
-        power_action('reboot', textmode => 1);
+        power_action("reboot", textmode => 1);
         $self->wait_boot(textmode => 1);
         $self->select_serial_terminal;
 

--- a/tests/security/ima/ima_appraisal_hashes.pm
+++ b/tests/security/ima/ima_appraisal_hashes.pm
@@ -1,17 +1,17 @@
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Test IMA appraisal using hashes
-# Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#49151
+# Maintainer: llzhao <llzhao@suse.com>, rfan1 <richard.fan@suse.com>
+# Tags: poo#53579, poo#100694, poo#102311
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
 use utils;
-use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
-use power_action_utils "power_action";
+use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings tianocore_disable_secureboot);
+use power_action_utils 'power_action';
 
 sub run {
     my ($self) = @_;
@@ -27,7 +27,10 @@ sub run {
 
     add_grub_cmdline_settings("ima_appraise=fix $tcb_cmdline", update_grub => 1);
 
-    power_action('reboot', textmode => 1);
+    record_info("bsc#1189988: ", "We need disable secureboot with ima fix mode");
+    power_action("reboot", textmode => 1);
+    $self->wait_grub(bootloader_time => 200);
+    $self->tianocore_disable_secureboot;
     $self->wait_boot(textmode => 1);
     $self->select_serial_terminal;
 
@@ -49,7 +52,10 @@ sub run {
 
     replace_grub_cmdline_settings('ima_appraise=fix', '', update_grub => 1);
 
+    # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
     power_action('reboot', textmode => 1);
+    $self->wait_grub(bootloader_time => 200);
+    $self->tianocore_disable_secureboot('re_enable');
     $self->wait_boot(textmode => 1);
     $self->select_serial_terminal;
 


### PR DESCRIPTION
Based on bsc#1189988, we need disable secureboot
if we set kernel parameter "ima_appraise=fix", but
we should make sure other tests can still run in
enabled state, so enhance the test logic.

- Related ticket: 
https://progress.opensuse.org/issues/100694
https://progress.opensuse.org/issues/102311

- Needles: already uploaded
- Verification run: 
 https://openqa.suse.de/tests/7654325
 https://openqa.suse.de/tests/7654326
 https://openqa.suse.de/tests/7654327