### PR TITLE
console/btrfs_qgroups: Check for --reflink=never before using it

### DIFF
--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -79,9 +79,14 @@ sub run {
 
     # Check limits
     assert_script_run "dd if=/dev/zero bs=10M count=3 of=nofile";
+
+    # Use the --reflink=never option if it exists
+    my $reflink_never = "--reflink=never";
+    $reflink_never = "" if script_run('cp --reflink=never /dev/null /tmp/null && rm /tmp/null');
+
     foreach my $c ('a' .. 'b') {
         assert_script_run "cp --reflink=always nofile $c/nofile";
-        assert_script_run "! cp --reflink=never --remove-destination nofile $c/nofile";
+        assert_script_run "! cp $reflink_never --remove-destination nofile $c/nofile";
         assert_script_run "sync && rm $c/nofile";
     }
     assert_script_run "cp nofile c/nofile";


### PR DESCRIPTION
That value is only available on coreutils >= 8.30.

Fixes a false positive: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13663#issuecomment-967115652

- Verification runs:

Leap 15.2 (old coreutils, option not used): https://openqa.opensuse.org/tests/2032133
Leap 15.3 (new coreutils, option used): https://openqa.opensuse.org/tests/2031820
