### PR TITLE
console/btrfs_qgroups: Wait for qgroup rescan before writing file

### DIFF
--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -80,6 +80,7 @@ sub run {
     # Check limits
     assert_script_run "dd if=/dev/zero bs=10M count=3 of=nofile";
     foreach my $c ('a' .. 'b') {
+        assert_script_run "btrfs quota rescan -w .";
         assert_script_run "cp --reflink=always nofile $c/nofile";
         assert_script_run "! cp --reflink=never --remove-destination nofile $c/nofile";
         assert_script_run "sync && rm $c/nofile";


### PR DESCRIPTION
Otherwise there can be a spurious EDQUOT. Not entirely sure whether this is the cause for the random failures.

See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13663#issuecomment-967123234 and https://bugzilla.suse.com/show_bug.cgi?id=1192630

- Verification runs (by @dzedro):
SLE 15 x86_64: https://openqa.suse.de/tests/7654861#step/btrfs_qgroups/90
SLE 15 aarch64: https://openqa.suse.de/tests/7654862#step/btrfs_qgroups/90
SLE 12 SP4 x86_64: https://openqa.suse.de/tests/7654863#step/btrfs_qgroups/90
