### PR TITLE
Increase assert_screen timeout for ensure_unlocked_desktop

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -122,7 +122,7 @@ sub ensure_unlocked_desktop {
         if ((match_has_tag 'displaymanager-password-prompt') || (match_has_tag 'screenlock-password')) {
             if ($password ne '') {
                 type_password;
-                assert_screen [qw(locked_screen-typed_password login_screen-typed_password generic-desktop)];
+                assert_screen [qw(locked_screen-typed_password login_screen-typed_password generic-desktop), timeout => 150];
                 next if match_has_tag 'generic-desktop';
             }
             send_key 'ret';


### PR DESCRIPTION
Fixes ppc64le failures like here:
https://openqa.suse.de/tests/7500012#step/consoletest_finish/22

- Related ticket: https://progress.opensuse.org/issues/101292
Already in production: shutdown-screenlock-blackscreen-20211112
- Verification runs:  https://openqa.suse.de/tests/7675241#next_previous
