### PR TITLE
Replace pipe with process substitution in crm_mon

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -696,8 +696,8 @@ sub wait_until_resources_started {
     my $ret = undef;
 
     # Some CRM options can only been added on recent versions
-    push @cmds, "$crm_mon_cmd | grep -iq 'no inactive resources'" if is_sle '12-sp3+';
-    push @cmds, "! ($crm_mon_cmd | grep -Eioq ':[[:blank:]]*failed|:[[:blank:]]*starting')";
+    push @cmds, "grep -iq 'no inactive resources' <($crm_mon_cmd)" if is_sle '12-sp3+';
+    push @cmds, "! (grep -Eioq ':[[:blank:]]*failed|:[[:blank:]]*starting' <($crm_mon_cmd))";
 
     # Execute each comnmand to validate that the cluster is running
     # This can takes time, so a loop is a good idea here


### PR DESCRIPTION
jsc#TEAM-5180 In lib/hacluster.pm  test check_after_reboot fails 
because of 'crm_mon' output is being piped to 'grep -g'. This results 
in 141 RC being returned even if a match was found. This PR changes 
pipe to process substitution. 

- Related ticket: https://jira.suse.com/browse/TEAM-5180
- Verification run: https://mordor.suse.cz/tests/1659#step/check_after_reboot/17