### PR TITLE
Containers: basetest: Do not rollback on Public Cloud

### DIFF
--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -10,6 +10,7 @@ package containers::basetest;
 use containers::docker;
 use containers::podman;
 use Mojo::Base 'opensusebasetest';
+use testapi 'get_var';
 
 sub containers_factory {
     my ($self, $runtime) = @_;
@@ -26,6 +27,10 @@ sub containers_factory {
     }
     $engine->init();
     return $engine;
+}
+
+sub test_flags {
+    return get_var('PUBLIC_CLOUD') ? {no_rollback => 1} : {};
 }
 
 1;


### PR DESCRIPTION
As on Public Cloud we use SSH tunnel we should not rollback the QEMU worker where this tunnel runs.

- Verification run: TBD
