### PR TITLE
Fix typo in assert_screen

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -122,7 +122,7 @@ sub ensure_unlocked_desktop {
         if ((match_has_tag 'displaymanager-password-prompt') || (match_has_tag 'screenlock-password')) {
             if ($password ne '') {
                 type_password;
-                assert_screen [qw(locked_screen-typed_password login_screen-typed_password generic-desktop), timeout => 150];
+                assert_screen([qw(locked_screen-typed_password login_screen-typed_password generic-desktop)], timeout => 150);
                 next if match_has_tag 'generic-desktop';
             }
             send_key 'ret';


### PR DESCRIPTION
There was a typo in previous fix, the timeout was recognized as needle tag and the real timeout remained 30 sec as default
