### PR TITLE
Add simple test for workload memory protection (WMP)

### DIFF
--- a/schedule/kernel/sles4sap/wmp_simple_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/wmp_simple_hana_baremetal.yaml
@@ -1,0 +1,46 @@
+---
+name: install_sles4sap_dvd
+description: >
+  Installation tests for SLES4SAP, use the DVD to boot the installer.
+
+  Can be used to install sles4sap on baremetal machines using ipxe_install
+vars:
+  DESKTOP: textmode
+  GRUB_TIMEOUT: 300
+  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
+  INSTANCE_SID: NDB
+  INSTANCE_ID: '00'
+  INSTANCE_TYPE: HBD
+  RECLAIM_ROOT: '1'
+  START_AFTER_TEST: sles4sap_online_dvd_gnome
+  WMP_TEST_REPO: https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - '{{test_sles4sap}}'
+  - '{{scc_deregister}}'
+  - '{{generate_image}}'
+conditional_schedule:
+  sles4sap_product_installation_mode:
+    SYSTEM_ROLE:
+      default:
+        - installation/sles4sap_product_installation_mode
+  test_sles4sap:
+    TEST_SLES4SAP:
+      1:
+        - sles4sap/hana_install
+        - sles4sap/wmp_setup
+        - sles4sap/wmp_check_process
+        - kernel/wmp_simple
+  scc_deregister:
+    SCC_DEREGISTER:
+      1:
+        - console/scc_deregistration
+  generate_image:
+    GENERATE_IMAGE:
+      1:
+        - console/hostname
+        - console/force_scheduled_tasks
+        - shutdown/grub_set_bootargs
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown

--- a/tests/kernel/wmp_simple.pm
+++ b/tests/kernel/wmp_simple.pm
@@ -1,0 +1,77 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+#
+# Summary: consume memory and make sure selected process don't get swapped
+#
+# Maintainer: Michael Moese <mmoese@suse.de>
+# Tags: https://progress.opensuse.org/issues/49031
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Mojo::Util 'trim';
+
+sub run {
+    my $self = shift;
+    my $meminfo;
+    my $failed;
+
+    my $cgroup_mem = get_required_var('WMP_MEMORY_LOW');
+    my $stressng_mem = get_required_var('WMP_STRESS_MEM');
+
+    $self->select_serial_terminal;
+
+    zypper_ar("https://download.opensuse.org/repositories/benchmark/SLE_15_SP3/benchmark.repo", no_gpg_check => 1);
+    zypper_call("in stress-ng");
+
+    #assert_script_run('sysctl vm.swappiness=100');
+
+    # configure memory.low
+    assert_script_run("systemctl set-property SAP.slice MemoryLow=$cgroup_mem");
+
+    # start hana again and wait for the memory consumption to settle
+    assert_script_run('sudo -u ndbadm bash -c "/usr/sap/NDB/HDB00/exe/sapcontrol -nr 00 -function StartSystem ALL"');
+
+
+    # wait until memory usage of HANA settled, this takes a while and we have to patiently wait
+    sleep 300;
+
+    # consume memory in the background
+    background_script_run("stress-ng --vm-bytes $stressng_mem --vm-keep -m 1");
+
+    # let everything run for a while
+    sleep 300;
+
+    $meminfo = script_output("cat /proc/meminfo");
+    record_info("meminfo", "$meminfo");
+
+    my $scope = trim(script_output('systemd-cgls -u SAP.slice | grep \'wmp-.*.scope\' | cut -c 3-'));
+
+    my @pids = split(' ', script_output("cat /sys/fs/cgroup/SAP.slice/$scope/cgroup.procs"));
+
+    foreach (@pids) {
+        my $vmswap = trim(script_output("grep \"VmSwap:\"  /proc/$_/status | cut -d ':' -f 2"));
+        my $cmdline = trim(script_output("cat /proc/$_/cmdline"));
+
+        if ($vmswap eq "0 kB") {
+            record_info("not swapped", "Process $cmdline (Pid $_) is not using swap", result => 'ok');
+        } else {
+            record_info("swapped", "Process $cmdline (Pid $_) is using $vmswap of swap", result => 'fail');
+            $failed = 1;
+        }
+    }
+    die "at least one process is using swap memory" if $failed;
+    $meminfo = script_output("cat /proc/meminfo");
+    record_info("meminfo", "$meminfo");
+}
+
+1;


### PR DESCRIPTION
Workload memory protection prevents swapping for the cgroup configured
to contain the SAP processes.
This schedules a simple test, installing HANA, configuring WMP and also
running the simple WMP tests.
In order to test the required behaviour, we partition the system RAM as
follows: use a minimum of 32 GB for the cgroup, specify the amount in
the variable WMP_MEMORY_LOW and specify the remainder of the system
memory plus 1 GB in WMP_STRESS_MEM. There are no default values and no
automatic detection, but as this is a test to be executed on baremetal,
you should know the system specs of your target machine.

The tests take quite long to run, as we don't know when HANA is done
populating its memory or when stress-ng has built enough memory
pressure.


- Related ticket: https://progress.opensuse.org/issues/95425
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: [http://baremetal-support.qa.suse.de/tests/1614#](http://baremetal-support.qa.suse.de/tests/1614#)
