### PR TITLE
wicked: Fix missing include in before_test of wicked::wlan

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -17,6 +17,7 @@ use network_utils qw(iface setup_static_network);
 use serial_terminal;
 use main_common 'is_updates_tests';
 use repo_tools 'generate_version';
+use wicked::wlan;
 
 sub run {
     my ($self, $ctx) = @_;


### PR DESCRIPTION
- Verification run: http://openqa-3.wicked.suse.de/tests/32844
  - Failed version: http://openqa-3.wicked.suse.de/tests/31464#step/before_test/19
