### PR TITLE
After install_services, the configuration file needs keep clean

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -279,6 +279,11 @@ sub install_services {
             $srv_check_results{'before_migration'} = 'FAIL';
         }
     }
+    # Keep the configuration file clean
+    if (is_ppc64le) {
+        assert_script_run("sed -i '\$d' /etc/bash.bashrc.local");
+        assert_script_run '. /etc/bash.bashrc.local';
+    }
 }
 
 =head2 check_services


### PR DESCRIPTION
After install_services, the configuration file needs keep clean.
Need delete the unexpected code in the configuration file.

- Related ticket: https://progress.opensuse.org/issues/102002
- Verification run: https://openqa.suse.de/tests/7689165
https://openqa.suse.de/tests/7689345#