### PR TITLE
Enhance 389ds tests with services check

### DIFF
--- a/lib/services/389ds_server.pm
+++ b/lib/services/389ds_server.pm
@@ -1,0 +1,113 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Package for 389ds_server service tests
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+
+package services::389ds_server;
+use base "opensusebasetest";
+use testapi;
+use utils;
+use warnings;
+use strict;
+use opensslca;
+
+our @EXPORT = qw($local_ip $remote_ip $local_name $remote_name $ca_dir $inst_ca_dir);
+our $local_ip = '10.0.2.101';
+our $remote_ip = '10.0.2.102';
+our $local_name = '389ds';
+our $remote_name = 'sssdclient';
+our $ca_dir = '/etc/openldap/ssl';
+our $inst_ca_dir = '/etc/dirsrv/slapd-localhost';
+
+sub install_service {
+    zypper_call("in 389-ds openssl");
+}
+
+# The function below covers all required steps for 389ds server's configuration
+sub config_service {
+    # Start a local instance with basic configuration file
+    assert_script_run("wget --quiet " . data_url("389ds/instance.inf") . " -O /tmp/instance.inf");
+    assert_script_run("dscreate from-file /tmp/instance.inf");
+    validate_script_output("dsctl localhost status", sub { m/Instance.*is running/ });
+
+    # Configure CA Certificates for TLS
+    assert_script_run("wget --quiet " . data_url("389ds/.dsrc") . " -O /root/.dsrc");
+    self_sign_ca("$ca_dir", "$local_name");
+
+    # Deleted the default CA files since it can only resolve "localhost",
+    # Please refer to bug 1180628 for more detail information
+    assert_script_run("certutil -D -d $inst_ca_dir -n Server-Cert");
+    assert_script_run("certutil -D -d $inst_ca_dir -n Self-Signed-CA");
+
+    # Import new CA files and resart the instance
+    assert_script_run("dsctl localhost tls import-server-key-cert $ca_dir/server.pem $ca_dir/server.key");
+    assert_script_run("dsctl localhost tls import-ca $ca_dir/myca.pem myca");
+    assert_script_run("cp $ca_dir/myca.pem $inst_ca_dir/ca.crt");
+    systemctl("restart dirsrv\@localhost.service");
+
+    # Configure host names for C/S communication
+    assert_script_run("sed -i -e 's/master/$local_name.example.com/' -e 's/minion/$remote_name.example.com/' /etc/hosts");
+
+    # Create ldap user and group
+    my $ldap_user = get_var('SSS_USERNAME');
+    my $ldap_passwd = $testapi::password;
+    my $ldap_group = 'server_admins';
+    my $uid = '1003';
+    my $gid = '1003';
+    my $display_name = 'Domain User';
+    assert_script_run(
+"dsidm localhost user create --uid $ldap_user --cn $ldap_user --displayName '$display_name' --uidNumber $uid --gidNumber $gid --homeDirectory /home/$ldap_user"
+    );
+    script_run_interactive(
+        "dsidm localhost account reset_password uid=$ldap_user,ou=people,dc=example,dc=com",
+        [
+            {
+                prompt => qr/Enter new password.*/m,
+                string => "$ldap_passwd\n",
+            },
+            {
+                prompt => qr/CONFIRM.*/m,
+                string => "$ldap_passwd\n",
+            },
+        ],
+        60
+    );
+    script_run_interactive(
+        "dsidm localhost group create",
+        [
+            {
+                prompt => qr/Enter value.*/m,
+                string => "$ldap_group\n",
+            },
+        ],
+        60
+    );
+    assert_script_run("dsidm localhost group add_member $ldap_group uid=$ldap_user,ou=people,dc=example,dc=com");
+
+    # Generate the sample sssd configuration file
+    assert_script_run("dsidm localhost client_config sssd.conf $ldap_group > /tmp/sssd.conf");
+
+    # Delete the first 2 lines for the sample sssd.conf due to invalid messages there
+    assert_script_run("sed -i '1,2d' /tmp/sssd.conf");
+
+    # Set the ldap_uri with LDAP over SSL (LDAPS) Certificate
+    assert_script_run("sed -i 's/^ldap_uri =.*\$/ldap_uri = ldaps:\\/\\/$local_name.example.com/' /tmp/sssd.conf");
+
+    # Permit ssh/scp from client as root
+    permit_root_ssh();
+}
+
+sub enable_service {
+    systemctl("enable dirsrv\@localhost.service");
+}
+
+sub check_service {
+    systemctl("is-active dirsrv\@localhost.service");
+    validate_script_output("dsctl localhost status", sub { m/Instance.*is running/ });
+}
+
+1;

--- a/lib/services/389ds_sssd_client.pm
+++ b/lib/services/389ds_sssd_client.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Package for 389ds sssd client service tests
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+
+package services::389ds_sssd;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use warnings;
+use strict;
+use Utils::Systemd 'disable_and_stop_service';
+
+our @EXPORT = qw($remote_ip $remote_name $inst_ca_dir $tls_dir $ldap_user $uid);
+our $remote_ip = '10.0.2.101';
+our $remote_name = '389ds';
+our $inst_ca_dir = '/etc/dirsrv/slapd-localhost';
+our $tls_dir = '/etc/openldap/certs';
+our $ldap_user = get_var('SSS_USERNAME');
+our $uid = '1003';
+
+sub install_service {
+    zypper_call("in 389-ds sssd sssd-ldap openssl");
+    # Disable and stop the nscd daemon because it conflicts with sssd
+    disable_and_stop_service("nscd", ignore_failure => 1);
+}
+
+# The function below covers all required steps for 389ds sssd client's configuration
+sub config_service {
+    # Copy the /etc/hosts, sample sssd.conf and CA files from server
+    # Configure tls CA key on client
+    assert_script_run("mkdir -p $tls_dir");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:/etc/hosts /etc/hosts");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:/tmp/sssd.conf /tmp");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:$inst_ca_dir/ca.crt $tls_dir");
+    assert_script_run("/usr/bin/openssl rehash $tls_dir");
+
+    # On newer environments, nsswitch.conf is located in /usr/etc
+    # Copy it to /etc directory
+    script_run("f=/etc/nsswitch.conf; [ ! -f \$f ] && cp /usr\$f \$f");
+    assert_script_run("sed -i -e '/^passwd.*/ s/\$/ sss/' -e '/^group.*/ s/\$/ sss/' -e '/^shadow.*/ s/\$/ sss/' /etc/nsswitch.conf");
+
+    # Configure pam to enable sssd
+    assert_script_run("pam-config -a --sss");
+    assert_script_run("pam-config -q --sss");
+
+    # Write the sssd configuration file
+    assert_script_run("cat /tmp/sssd.conf > /etc/sssd/sssd.conf");
+}
+
+sub start_service {
+    systemctl("start sssd");
+}
+
+sub enable_service {
+    systemctl("enable sssd");
+}
+
+sub check_service {
+    systemctl("is-active sssd");
+    # Verify the sssd client can communicate with server in secure mode
+    # Make sure ldap user can login from client as well
+    assert_script_run("LDAPTLS_REQCERT=never ldapwhoami -H ldaps://$remote_name.example.com:636 -x");
+    assert_script_run("id $ldap_user | grep $uid");
+}
+
+1;

--- a/tests/security/389ds/tls_389ds_server.pm
+++ b/tests/security/389ds/tls_389ds_server.pm
@@ -5,7 +5,7 @@
 #          This test module covers the server setup processes
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#88513, poo#92410, poo#93832, poo#101698, tc#1768672
+# Tags: poo#88513, poo#92410, poo#93832, poo#101698, poo#101800, tc#1768672
 
 use base 'consoletest';
 use testapi;
@@ -14,89 +14,17 @@ use warnings;
 use utils;
 use lockapi;
 use mmapi 'wait_for_children';
-use opensslca;
+use services::389ds_server;
 
 sub run {
     select_console("root-console");
 
-    my $local_ip = '10.0.2.101';
-    my $remote_ip = '10.0.2.102';
-    my $local_name = '389ds';
-    my $remote_name = 'sssdclient';
-    my $ca_dir = '/etc/openldap/ssl';
-    my $inst_ca_dir = '/etc/dirsrv/slapd-localhost';
+    services::389ds_server::install_service();
+    services::389ds_server::config_service();
+    services::389ds_server::enable_service();
+    services::389ds_server::check_service();
 
-    # Install 389-ds and create an server instance
-    zypper_call("in 389-ds openssl");
-    assert_script_run("wget --quiet " . data_url("389ds/instance.inf") . " -O /tmp/instance.inf");
-    assert_script_run("dscreate from-file /tmp/instance.inf");
-    validate_script_output("dsctl localhost status", sub { m/Instance.*is running/ });
-
-    # Configure CA Certificates for TLS
-    assert_script_run("wget --quiet " . data_url("389ds/.dsrc") . " -O /root/.dsrc");
-    self_sign_ca("$ca_dir", "$local_name");
-
-    # Deleted the default CA files since it can only resolve "localhost",
-    # Please refer to bug 1180628 for more detail information
-    assert_script_run("certutil -D -d $inst_ca_dir -n Server-Cert");
-    assert_script_run("certutil -D -d $inst_ca_dir -n Self-Signed-CA");
-
-    # Import new CA files and resart the instance
-    assert_script_run("dsctl localhost tls import-server-key-cert $ca_dir/server.pem $ca_dir/server.key");
-    assert_script_run("dsctl localhost tls import-ca $ca_dir/myca.pem myca");
-    assert_script_run("cp $ca_dir/myca.pem $inst_ca_dir/ca.crt");
-    systemctl("restart dirsrv\@localhost.service");
-
-    # Configure host names for C/S communication
-    assert_script_run("sed -i -e 's/master/$local_name.example.com/' -e 's/minion/$remote_name.example.com/' /etc/hosts");
-
-    # Create ldap user and group
-    my $ldap_user = get_var('SSS_USERNAME');
-    my $ldap_passwd = $testapi::password;
-    my $ldap_group = 'server_admins';
-    my $uid = '1003';
-    my $gid = '1003';
-    my $display_name = 'Domain User';
-    assert_script_run(
-"dsidm localhost user create --uid $ldap_user --cn $ldap_user --displayName '$display_name' --uidNumber $uid --gidNumber $gid --homeDirectory /home/$ldap_user"
-    );
-    script_run_interactive(
-        "dsidm localhost account reset_password uid=$ldap_user,ou=people,dc=example,dc=com",
-        [
-            {
-                prompt => qr/Enter new password.*/m,
-                string => "$ldap_passwd\n",
-            },
-            {
-                prompt => qr/CONFIRM.*/m,
-                string => "$ldap_passwd\n",
-            },
-        ],
-        60
-    );
-    script_run_interactive(
-        "dsidm localhost group create",
-        [
-            {
-                prompt => qr/Enter value.*/m,
-                string => "$ldap_group\n",
-            },
-        ],
-        60
-    );
-    assert_script_run("dsidm localhost group add_member $ldap_group uid=$ldap_user,ou=people,dc=example,dc=com");
-
-    # Generate the sample sssd configuration file
-    assert_script_run("dsidm localhost client_config sssd.conf $ldap_group > /tmp/sssd.conf");
-
-    # Delete the first 2 lines for the sample sssd.conf due to invalid messages there
-    assert_script_run("sed -i '1,2d' /tmp/sssd.conf");
-
-    # Set the ldap_uri with LDAP over SSL (LDAPS) Certificate
-    assert_script_run("sed -i 's/^ldap_uri =.*\$/ldap_uri = ldaps:\\/\\/$local_name.example.com/' /tmp/sssd.conf");
-
-    # Permit ssh/scp from client as root
-    permit_root_ssh();
+    # Add lock for client
     mutex_create("389DS_READY");
 
     # Finish job

--- a/tests/security/389ds/tls_389ds_sssd_client.pm
+++ b/tests/security/389ds/tls_389ds_sssd_client.pm
@@ -5,7 +5,7 @@
 #          This test module covers the sssd client tests
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#88513, poo#92410, poo#101698, tc#1768672
+# Tags: poo#88513, poo#92410, poo#101698, poo#101800, tc#1768672
 
 use base 'consoletest';
 use testapi;
@@ -13,51 +13,19 @@ use strict;
 use warnings;
 use utils;
 use lockapi;
-use Utils::Systemd qw(systemctl disable_and_stop_service);
+use services::389ds_sssd_client;
 
 sub run {
     select_console("root-console");
 
-    my $remote_ip = '10.0.2.101';
-    my $remote_name = '389ds';
-    my $inst_ca_dir = '/etc/dirsrv/slapd-localhost';
-    my $tls_dir = '/etc/openldap/certs';
-    my $ldap_user = get_var('SSS_USERNAME');
-    my $uid = '1003';
+    services::389ds_sssd::install_service();
 
-    # Install 389-ds and sssd on client
-    zypper_call("in 389-ds sssd sssd-ldap openssl");
-
-    # Disable and stop the nscd daemon because it conflicts with sssd
-    disable_and_stop_service("nscd", ignore_failure => 1);
-
-    # Copy the /etc/hosts, sample sssd.conf and CA files from server
-    # Configure tls CA key on client
     mutex_wait("389DS_READY");
-    assert_script_run("mkdir -p $tls_dir");
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:/etc/hosts /etc/hosts");
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:/tmp/sssd.conf /tmp");
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@$remote_ip:$inst_ca_dir/ca.crt $tls_dir");
-    assert_script_run("/usr/bin/openssl rehash $tls_dir");
 
-    # On newer environments, nsswitch.conf is located in /usr/etc
-    # Copy it to /etc directory
-    script_run("f=/etc/nsswitch.conf; [ ! -f \$f ] && cp /usr\$f \$f");
-    assert_script_run("sed -i -e '/^passwd.*/ s/\$/ sss/' -e '/^group.*/ s/\$/ sss/' -e '/^shadow.*/ s/\$/ sss/' /etc/nsswitch.conf");
-
-    # Configure pam to enable sssd
-    assert_script_run("pam-config -a --sss");
-    assert_script_run("pam-config -q --sss");
-
-    # Now, we can start the sssd service
-    assert_script_run("cat /tmp/sssd.conf > /etc/sssd/sssd.conf");
-    systemctl("enable sssd");
-    systemctl("start sssd");
-
-    # Verify the sssd client can communicate with server in secure mode
-    # Make sure ldap user can login from client as well
-    assert_script_run("LDAPTLS_REQCERT=never ldapwhoami -H ldaps://$remote_name.example.com:636 -x");
-    assert_script_run("id $ldap_user | grep $uid");
+    services::389ds_sssd::config_service();
+    services::389ds_sssd::start_service();
+    services::389ds_sssd::enable_service();
+    services::389ds_sssd::check_service();
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Based on the requirement from migration team,
they need cover 389ds tests along with migration
path, so integrate the code to services module.

- Related ticket: https://progress.opensuse.org/issues/101800
- Needles: n/a
- Verification run: 
 SLE:
https://openqa.suse.de/tests/7677801
https://openqa.suse.de/tests/7677802
 TW:
https://openqa.opensuse.org/tests/2038386
https://openqa.opensuse.org/tests/2038387
