### PR TITLE
Disable junit report in qa_automation on SLE 15-SP4 and newer

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -95,8 +95,9 @@ sub prepare_repos {
 
     add_qa_head_repo;
     add_qa_web_repo;
-    add_suseconnect_product('sle-module-python2') if is_sle('>15') && get_var('FLAVOR') !~ /-Updates$|-Incidents/;
-    zypper_call("in qa_testset_automation qa_tools python-base python-xml");
+    add_suseconnect_product('sle-module-python2') if is_sle('>15') && is_sle('<15-sp4') && get_var('FLAVOR') !~ /-Updates$|-Incidents/;
+    my $python_packages = is_sle('<15-sp4') ? 'python-base python-xml' : '';
+    zypper_call("in qa_testset_automation qa_tools ${python_packages}");
 }
 
 # Create qaset/config file, reset qaset, and start testrun
@@ -151,8 +152,10 @@ sub run {
     upload_logs($log, timeout => 100);
 
     # JUnit xml report
-    assert_script_run("/usr/share/qa/qaset/bin/junit_xml_gen.py -n 'regression' -d -o /tmp/junit.xml /var/log/qaset");
-    parse_junit_log("/tmp/junit.xml");
+    if (is_sle('<15-sp4')) {
+        assert_script_run("/usr/share/qa/qaset/bin/junit_xml_gen.py -n 'regression' -d -o /tmp/junit.xml /var/log/qaset");
+        parse_junit_log("/tmp/junit.xml");
+    }
 
     unless ($testrun_finished) {
         die "Test run didn't finish within time limit";


### PR DESCRIPTION
Fix poo#102506: SLE 15-SP4 doesn't have python2 module. Junit report
script is python2 only. It was decided that old qa_automation scripts
will not be used and will be replaced in the future. It means that
script migration to python3 is not worth. We can still use
qa_automation scripts, but without human friendly openQA presentation.

- Related ticket: https://progress.opensuse.org/issues/102506
- Needles: none
- Verification run: 
15-SP4 (without report): https://openqa.suse.de/tests/7690030
15-SP3 (with report): https://openqa.suse.de/t7690046
