### PR TITLE
Add REGRESSION_SERVICE setting to control service check modules

### DIFF
--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -14,6 +14,7 @@ schedule:
   - migration/version_switch_origin_system
   - '{{online_migration_test}}'
   - '{{remove_ltss}}'
+  - '{{install_service}}'
   - migration/version_switch_upgrade_target
   - migration/online_migration/pre_migration
   - '{{migration_method}}'
@@ -24,13 +25,21 @@ schedule:
   - console/system_state
   - console/prepare_test_data
   - console/consoletest_setup
-  - console/check_upgraded_service
+  - '{{check_upgraded_service}}'
   - '{{openldap_to_389ds}}'
   - '{{regression_tests}}'
   - boot/grub_test_snapshot
   - migration/version_switch_origin_system
   - boot/snapper_rollback
 conditional_schedule:
+  check_upgraded_service:
+    REGRESSION_SERVICE:
+      1:
+        - console/check_upgraded_service
+  install_service:
+    REGRESSION_SERVICE:
+      1:
+        - installation/install_service
   remove_ltss:
     REGRESSION_LTSS:
       1:
@@ -49,7 +58,6 @@ conditional_schedule:
         - migration/online_migration/online_migration_setup
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
-        - installation/install_service
   openldap_to_389ds:
     REGRESSION_389DS:
       1:


### PR DESCRIPTION
Add REGRESSION_SERVICE setting to control service check modules
Need add setting 'REGRESSION_SERVICE', it will be very useful for debug regression cases.
If any regression module fail, we can set REGRESSION_SERVICE=0 to ignore install_service.

- Related ticket: https://progress.opensuse.org/issues/102242
- Verification run: (https://openqa.suse.de/tests/7693338#)