### PR TITLE
Fix for SystemSettingsPage

### DIFF
--- a/lib/YaST/SystemSettings/SystemSettingsPage.pm
+++ b/lib/YaST/SystemSettings/SystemSettingsPage.pm
@@ -35,7 +35,7 @@ sub press_ok {
 
 sub switch_tab_kernel {
     my ($self) = @_;
-    $self->{tab_cwm}->select("&Kernel Settings");
+    $self->{tab_cwm}->select("Kernel Settings");
     return $self;
 }
 

--- a/lib/YuiRestClient/Widget/Tab.pm
+++ b/lib/YuiRestClient/Widget/Tab.pm
@@ -44,7 +44,7 @@ QE YaST <qa-sle-yast@suse.de>
 
 =head1 SYNOPSIS
 
-$self->{tab_cwm}->select("&Kernel Settings");
+$self->{tab_cwm}->select("Kernel Settings");
 
 return $self->{tb_boot_options}->selected_tab();
 

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -445,6 +445,10 @@ Start a root shell in xterm.
 sub start_root_shell_in_xterm {
     select_console 'x11';
     x11_start_program("xterm -geometry 155x50+5+5", target_match => 'xterm');
+    # Verification runs for poo#102557 showed that the terminal window does not get focus,
+    # so we click into it.
+    mouse_set(400, 400);
+    mouse_click(['left']);
     become_root;
 }
 


### PR DESCRIPTION
- poo#102557
- Tab handling got the sanitize function implemented, so
   select statement for Tab labels should not have '&' in it.
- Fixed also the documentation for Tab.pm.

The first verificaton run also showed that the xterm used to become root didn't get
the focus automatically. So I added a patch for this as well. 

- Related ticket: https://progress.opensuse.org/issues/102557
- Needles: na
- Verification run: https://openqa.opensuse.org/tests/2041700 