### PR TITLE
Add ability of adding additional disk to pc run

### DIFF
--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -44,6 +44,8 @@ sub run {
     assert_script_run("cat /etc/hosts");
     assert_script_run("cat /etc/resolv.conf");
 
+    assert_script_run("lsblk");
+
     # Install bzip2 to check for bsc#1165915
     if (script_run("zypper -n in bzip2") == 8) {
         record_soft_failure('bsc#1165915');

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -61,9 +61,15 @@ sub run {
 
     select_host_console();    # select console on the host, not the PC instance
 
+    my $additional_disk_size = get_var('PUBLIC_CLOUD_HDD2_SIZE', 0);
+    my $additional_disk_type = get_var('PUBLIC_CLOUD_HDD2_TYPE', '');    # Optional variable, also if PUBLIC_CLOUD_HDD2_SIZE is set
+
     # Create public cloud instance
     my $provider = $self->provider_factory();
-    my $instance = $provider->create_instance(check_connectivity => 1);
+    my %instance_args;
+    $instance_args{check_connectivity} = 1;
+    $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
+    my $instance = $provider->create_instance(%instance_args);
     $instance->wait_for_guestregister();
     $args->{my_provider} = $provider;
     $args->{my_instance} = $instance;

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -22,8 +22,8 @@ sub run {
     my ($self) = @_;
     my $reg_code = get_var('SCC_REGCODE');
     my $runtime = get_var('PUBLIC_CLOUD_FIO_RUNTIME', 300);
-    my $disk_size = get_var('PUBLIC_CLOUD_FIO_SSD_SIZE');
-    my $disk_type = get_var('PUBLIC_CLOUD_FIO_SSD_TYPE');
+    my $disk_size = get_var('PUBLIC_CLOUD_HDD2_SIZE');
+    my $disk_type = get_var('PUBLIC_CLOUD_HDD2_TYPE');
     my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI');
 
     my @scenario = (

--- a/variables.md
+++ b/variables.md
@@ -131,6 +131,8 @@ _SECRET_PUBLIC_CLOUD_REST_SSL_INSECURE | boolean | true | Do not validate Vault 
 PUBLIC_CLOUD | boolean | false | All Public Cloud tests have this variable set to true. Contact: qa-c@suse.de
 PUBLIC_CLOUD_ACCOUNT | string | "" | For GCE will set account via `gcloud config set account ' . $self->account`.
 PUBLIC_CLOUD_ACCNET | boolean | false | If set, az_accelerated_net test module is added to the job.
+PUBLIC_CLOUD_HDD2_SIZE | integer | "" | If set, the instance will have an additional disk with the given capacity in GB
+PUBLIC_CLOUD_HDD2_TYPE | string | "" | If PUBLIC_CLOUD_ADDITIONAL_DISK_SIZE is set, this defines the additional disk type (optional). The required value depends on the cloud service provider.
 PUBLIC_CLOUD_ARCH | string | "x86_64" | The architecture of created VM.
 PUBLIC_CLOUD_AZURE_OFFER | string | "" | Specific to Azure. Allow to query for image based on offer and sku. Should be used together with PUBLIC_CLOUD_AZURE_SKU.
 PUBLIC_CLOUD_AZURE_SKU | string | "" | Specific to Azure.


### PR DESCRIPTION
Add the ability to add additional disks to publiccloud on maintenance test runs. 
We rename the existing variables from the FIO test, namely `PUBLIC_CLOUD_FIO_SSD_SIZE` and `PUBLIC_CLOUD_FIO_SSD_TYPE` to `PUBLIC_CLOUD_HDD2_SIZE` and `PUBLIC_CLOUD_HDD2_TYPE` and will use them throughout the PC test scenarios.

This PR is a preparation step for implementing xfs tests on publiccloud.

- Related ticket: https://progress.opensuse.org/issues/60179
- Verification run: [Test run with additional disk](http://duck-norris.qam.suse.de/tests/7455#step/instance_overview/22) | [Test run without additional disk](http://duck-norris.qam.suse.de/tests/7454) (`prepare_instance` is passing)
