### PR TITLE
Modify test suite aarch64_secureboot

### DIFF
--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -110,7 +110,8 @@ sub check_mok {
     diag('Expected regex used to verify SecureBoot: ' . $state);
     validate_script_output 'mokutil --sb-state', $state;
 
-    if (script_output('mokutil --list-new', proceed_on_failure => 1) =~ /MokNew is empty/) {
+    my $output = script_output('mokutil --list-new', proceed_on_failure => 1);
+    if ($output eq '' || $output =~ /MokNew is empty/) {
         record_info 'MOK updates', 'No new certificates are expected to be enrolled';
     } else {
         push @errors, 'No new boot certificates are expected';


### PR DESCRIPTION
Modified verify_efi_mok.pm to fit Tumbleweed, mokutil --list-new returns no output on Tumbleweed while sle returns output of 'Moknew is empty'. Added condition to check if there is nothing being returned as the behavior in Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/101701
- Needles: N/A
- Verification run: 
    - O3: https://openqa.opensuse.org/tests/2040389
    - OSD: https://openqa.suse.de/tests/7698506