### PR TITLE
Validate output of zypper commands

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -114,7 +114,7 @@ sub build {
     record_info "$container_tag created", "";
 }
 
-=head2 run_container($image_name, [mode, name, remote, keep_container, timeout])
+=head2 run_container($image_name, [mode, name, remote, keep_container, timeout, retry, delay])
 
 Run a container.
 C<image_name> is required and can be the image id, the name or name with tag.
@@ -125,6 +125,8 @@ if C<cmd> found then it will execute the given command into the container.
 The container is always removed after exit.
 if C<keep_container> is 1 the container is not removed after creation. Default to get removed
 when it exits or when the daemon exits
+if C<retry> is given, the command is being repeated the given amount of times on failure
+If C<delay> is given, this defines the number of seconds between retries
 
 =cut
 sub run_container {


### PR DESCRIPTION
Instead of relying on the return code only, validate part of the output
of some of the zypper commands to ensure, that the command handling
works properly.

- Related ticket: https://progress.opensuse.org/issues/102527
- Verification runs:
- [SLE15-SP3 docker](http://duck-norris.qam.suse.de/tests/7494) | [SLE15-SP3 podman](http://duck-norris.qam.suse.de/tests/7495) | [SLE15-SP3 podman aarch64](https://openqa.suse.de/tests/7728189) | [SLE15-SP3 docker aarch64](https://openqa.suse.de/tests/7728190)
- [12-SP5 docker](http://duck-norris.qam.suse.de/tests/7496)
- [12-SP3 docker](http://duck-norris.qam.suse.de/tests/7497)
- [15-SP3_image_on_sle-15-SP3_host_docker](http://duck-norris.qam.suse.de/tests/7498)
- [15-SP3_image_on_sle-15-SP3_host_podman aarch64](https://openqa.suse.de/tests/7728191)
- [Tumbleweed podman](https://openqa.opensuse.org/tests/2052545) | [Tumbleweed docker](https://openqa.opensuse.org/tests/2052546)
- [Tumbleweed podman aarch64](https://openqa.opensuse.org/tests/2052547) | [Tumbleweed docker aarch64](https://openqa.opensuse.org/tests/2052548)