### PR TITLE
ipmi: Revert enlarge swap to RAM size on small disks

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -541,14 +541,6 @@ sub take_first_disk_storage_ng {
         assert_screen 'partition-scheme';
     }
     elsif (is_ipmi) {
-        select_console('install-shell');
-        my $mem_size = script_output 'free -b | awk \'/Mem/ {print $2}\'';
-        my $disk_size = script_output 'lsblk -dnb /dev/sda -o SIZE';
-        select_console 'installation';
-        if ($mem_size > $disk_size) {
-            send_key_until_needlematch [qw(enlarge-enabled enlarge-disabled)], $cmd{next};
-            send_key_until_needlematch('enlarge-disabled', 'alt-a') if (match_has_tag 'enlarge-enabled');
-        }
         send_key_until_needlematch 'after-partitioning', $cmd{next}, 10, 3;
         return;
     }

--- a/schedule/kernel/prepare_baremetal.yaml
+++ b/schedule/kernel/prepare_baremetal.yaml
@@ -14,6 +14,7 @@ schedule:
     - installation/addon_products_sle
     - installation/system_role
     - installation/partitioning
+    - installation/partitioning/no_enlarge_swap
     - installation/partitioning_firstdisk
     - installation/partitioning_finish
     - installation/installer_timezone


### PR DESCRIPTION
Fix poo#102644: Revert enlarge swap to RAM size on small disks and use
no_enlarge_swap in prepare_baremetal YAML schedule.

Reverts https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13669 which was duplicating already existing function.

- Related ticket: https://progress.opensuse.org/issues/102644
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1581
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=czerw%2Fos-autoinst-distri-opensuse%2313710&version=15-SP4

prepare_baremetal is only used in kernel jobs.
