### PR TITLE
Fix SUSEConnect -s timeout on s390x

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -89,7 +89,7 @@ sub run {
     script_run('zypper lr | tee /tmp/zypperlr.txt');
 
     # Need make sure the system is registered then check modules
-    my $output = script_output 'SUSEConnect -s';
+    my $output = script_output('SUSEConnect -s', timeout => 180);
     # Check the expected addons before migration
     if (check_var('VERSION', get_required_var('ORIGIN_SYSTEM_VERSION')) && ($output !~ /Not Registered/)) {
         my $addons = get_var('SCC_ADDONS', "");


### PR DESCRIPTION
On s390x, the 'SUSEConnect -s' need to wait more time before it can
output the result.
- Related ticket: https://progress.opensuse.org/issues/101599?
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t7698417
  https://openqa.nue.suse.com/t7698418