### PR TITLE
Cleanup downloaded files for disabled repos on rmt

### DIFF
--- a/tests/console/rmt/rmt_feature.pm
+++ b/tests/console/rmt/rmt_feature.pm
@@ -81,6 +81,15 @@ sub run {
     rmt_mirror_repo();
     assert_script_run("rmt-cli product list | grep sle-module-legacy/15/x86_64");
 
+    # disable the mirrored repos
+    assert_script_run("rmt-cli products disable sle-module-legacy/15/x86_64");
+    # cleanup the downloaded files
+    assert_script_run("yes yes | rmt-cli repos clean");
+    my $ret = script_run("ls /usr/share/rmt/public/repo/SUSE/Products/SLE-Module-Legacy/15/x86_64 | wc -l");
+    if ($ret > 0) {
+        die 'cleanup repos failed';
+    }
+
     # import smt data
     my $datapath = "/rmtdata/";
     my $datafile = get_var("SMT_DATA_FILE");


### PR DESCRIPTION
This pr aims to cleanup the downloaded files for disabled repos on
rmt server.

- Related ticket: https://progress.opensuse.org/issues/101343
- Verification run: https://openqa.suse.de/tests/7714756#step/rmt_feature/220