### PR TITLE
Add RMT localization test for Chinese

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -240,7 +240,11 @@ sub handle_login {
     }
     assert_screen([qw(generic-desktop gnome-activities opensuse-welcome)], 180);
     if (match_has_tag('gnome-activities')) {
-        send_key_until_needlematch [qw(generic-desktop opensuse-welcome)], 'esc';
+        send_key_until_needlematch [qw(generic-desktop opensuse-welcome language-change-required-update-folder)], 'esc';
+        if (match_has_tag('language-change-required-update-folder')) {
+            assert_and_click('reserve_old_folder_name');
+            assert_screen([qw(generic-desktop opensuse-welcome)]);
+        }
     }
 }
 

--- a/schedule/migration/rmt_chinese.yaml
+++ b/schedule/migration/rmt_chinese.yaml
@@ -1,0 +1,6 @@
+name:    rmt_chinese
+description:    >
+    This is for rmt localization test (only for Chinese)
+schedule:
+  - boot/boot_to_desktop
+  - x11/rmt/rmt_chinese

--- a/tests/x11/rmt/rmt_chinese.pm
+++ b/tests/x11/rmt/rmt_chinese.pm
@@ -1,0 +1,80 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: yast2-rmt rmt-server
+# Summary: rmt-cli internationalization / localization test (only test Chinese)
+# Steps: 1. Set language to simply Chinese.
+#        2. Install and configure RMT server, ensure the configuration process
+#           in Chinese.
+#        3. Run rmt-cli sync and ensure the output is in Chinese.
+#
+# Maintainer: Lemon Li <leli@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use base 'x11test';
+use repo_tools;
+use utils;
+use x11utils;
+use version_utils;
+
+sub set_language_to_Chinese {
+    if (check_var('DESKTOP', 'gnome')) {
+        select_console 'root-console';
+        turn_off_gnome_screensaver_for_gdm;
+    }
+    select_console 'x11', await_console => 0;
+    wait_still_screen 15;
+    ensure_unlocked_desktop;
+    assert_screen "generic-desktop";
+
+    x11_start_program('xterm');
+    wait_still_screen 2, 2;
+    become_root;
+    script_run('yast2 language');
+    send_key_until_needlematch 'yast2-lang-simplified-chinese', 'down', 180;
+    send_key 'alt-o';
+
+    # Problem here is that sometimes installation takes longer than 10 minutes
+    # And then screen saver is activated, so add this step to wake
+    my $timeout = 0;
+    until (check_screen('generic-desktop', 30) || ++$timeout > 10) {
+        # Now it will install required language packages and exit
+        # Put in the loop, because sometimes button is not pressed
+        wait_screen_change { send_key 'alt-o'; };
+        sleep 60;
+        send_key 'ctrl';
+    }
+
+    # Logout and login to ensure the configuration for Chinese language take effect.
+    handle_relogin;
+
+    x11_start_program('gnome-terminal');
+    wait_still_screen 2, 2;
+    become_root;
+}
+
+sub run {
+    set_language_to_Chinese;
+
+    rmt_wizard();
+    rmt_sync;
+
+    # Check output is chinese
+    assert_screen 'rmt_sync_finished';
+
+    # Close the terminal
+    send_key 'alt-f4';
+    if (check_screen('close-terminal-warning-dialog', 30)) {
+        send_key 'alt-l';
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
To improve our test coverage, we will add the automation test of RMT localization test for Chinese.

- Related ticket: https://progress.opensuse.org/issues/101328
                        https://progress.opensuse.org/issues/101325
- Needles: Already integrated into OSD.
- Verification run: https://openqa.nue.suse.com/tests/7704169#step/rmt_chinese/91
  To avoid regression: https://openqa.nue.suse.com/tests/7704184#live  # rmt_feature test
                                https://openqa.nue.suse.com/tests/7704415#  # offline pscc test to verify no regression for 
                                  handle_login code update
