### PR TITLE
To test 389ds before and after migration

### DIFF
--- a/schedule/migration/tls_389ds_sssd.yaml
+++ b/schedule/migration/tls_389ds_sssd.yaml
@@ -1,0 +1,31 @@
+name: tls_389ds_sssd
+description:    >
+    This is for 389ds and sssd authentication before and after migration check
+vars:
+    ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+    UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+    - '{{tls_389ds}}'
+conditional_schedule:
+    tls_389ds:
+        HOSTNAME:
+            server:
+                - migration/version_switch_origin_system
+                - installation/isosize
+                - installation/bootloader
+                - migration/online_migration/online_migration_setup
+                - console/consoletest_setup
+                - network/setup_multimachine
+                - migration/online_migration/register_system
+                - migration/online_migration/zypper_patch
+                - console/389ds/tls_389ds_server
+                - migration/version_switch_upgrade_target
+                - migration/online_migration/pre_migration
+                - migration/online_migration/zypper_migration
+                - migration/online_migration/post_migration
+                - console/389ds/tls_389ds_server
+            client:
+                - boot/boot_to_desktop
+                - console/consoletest_setup
+                - network/setup_multimachine
+                - console/389ds/tls_389ds_sssd_client

--- a/tests/console/389ds/tls_389ds_server.pm
+++ b/tests/console/389ds/tls_389ds_server.pm
@@ -1,0 +1,45 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Implement & Integrate 389ds + sssd test case into openQA,
+#          This test module covers the server features check before
+#          and after migration, 389ds exsits sles15sp3+
+#
+# Maintainer: Yutao Wang<yuwang@suse.com>
+
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use lockapi;
+use mmapi;
+use services::389ds_server;
+
+sub run {
+    select_console("root-console");
+
+    if (check_var('VERSION', get_required_var('ORIGIN_SYSTEM_VERSION'))) {
+        services::389ds_server::install_service();
+        services::389ds_server::config_service();
+        services::389ds_server::enable_service();
+        services::389ds_server::check_service();
+
+        # Add lock for client
+        mutex_create("389DS_READY");
+
+        # Finish job
+        my $children = get_children();
+        mutex_wait("FINISH_STEP1", (keys %$children)[0]);
+    }
+    if (check_var('VERSION', get_required_var('UPGRADE_TARGET_VERSION'))) {
+        validate_script_output("dsctl localhost status", sub { m/Instance.*is running/ });
+
+        mutex_create("389DS_READY_2");
+
+        # Finish job
+        wait_for_children;
+    }
+}
+
+1;

--- a/tests/console/389ds/tls_389ds_sssd_client.pm
+++ b/tests/console/389ds/tls_389ds_sssd_client.pm
@@ -1,0 +1,40 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: use 389ds client to connect with server before
+#          and after migration
+#
+# Maintainer: Yutao Wang<yuwang@suse.com>
+
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use lockapi;
+use services::389ds_sssd_client;
+
+sub run {
+    select_console("root-console");
+
+    services::389ds_sssd::install_service();
+
+    mutex_wait("389DS_READY");
+
+    services::389ds_sssd::config_service();
+    services::389ds_sssd::start_service();
+    services::389ds_sssd::enable_service();
+    services::389ds_sssd::check_service();
+
+    mutex_create("FINISH_STEP1");
+
+    mutex_wait("389DS_READY_2");
+    services::389ds_sssd::check_service();
+}
+
+sub post_fail_hook {
+    upload_logs("/var/log/messages");
+    upload_logs("/etc/sssd/sssd.conf");
+}
+
+1;


### PR DESCRIPTION
To test 389ds before and after migration, use 389ds client to
connect with 389ds server before and after migration

- Related ticket: https://progress.opensuse.org/issues/101085
- Verification run: 
](https://openqa.suse.de/tests/7704170#)
https://openqa.suse.de/tests/7704171#