### PR TITLE
ZFCP activation via libyui

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -14,6 +14,9 @@ use warnings FATAL => 'all';
 use parent 'susedistribution';
 use Installation::AuthenticationForRoot::AuthenticationForRootController;
 use Installation::ClockAndTimeZone::ClockAndTimeZoneController;
+use Installation::DiskActivation::DiskActivationController;
+use Installation::DiskActivation::ConfiguredZFCPDevicesController;
+use Installation::DiskActivation::AddZFCPDeviceController;
 use Installation::LanguageKeyboard::LanguageKeyboardController;
 use Installation::License::Opensuse::Firstboot::LicenseAgreementController;
 use Installation::License::Opensuse::LicenseAgreementController;
@@ -163,5 +166,16 @@ sub get_encrypted_volume_activation {
     return Installation::SystemProbing::EncryptedVolumeActivationController->new();
 }
 
+sub get_disk_activation {
+    return Installation::DiskActivation::DiskActivationController->new();
+}
+
+sub get_configured_zfcp_devices {
+    return Installation::DiskActivation::ConfiguredZFCPDevicesController->new();
+}
+
+sub get_add_new_zfcp_device {
+    return Installation::DiskActivation::AddZFCPDeviceController->new();
+}
 
 1;

--- a/lib/Installation/DiskActivation/AddZFCPDeviceController.pm
+++ b/lib/Installation/DiskActivation/AddZFCPDeviceController.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act on the Add ZFCP Device page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::DiskActivation::AddZFCPDeviceController;
+use strict;
+use warnings;
+use Installation::DiskActivation::AddZFCPDevicePage;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{AddZFCPDevicePage} = Installation::DiskActivation::AddZFCPDevicePage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_add_zfcp_device_page {
+    my ($self) = @_;
+    die "Add ZFCP Device Page is not displayed" unless $self->{AddZFCPDevicePage}->is_shown();
+    return $self->{AddZFCPDevicePage};
+}
+
+sub configure {
+    my ($self, $args) = @_;
+    $self->get_add_zfcp_device_page()->set_channel($args->{channel});
+    $self->get_add_zfcp_device_page()->press_next();
+}
+
+1;

--- a/lib/Installation/DiskActivation/AddZFCPDevicePage.pm
+++ b/lib/Installation/DiskActivation/AddZFCPDevicePage.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to the Add New ZFCP Device dialog
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::DiskActivation::AddZFCPDevicePage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub init {
+    my ($self, $args) = @_;
+    $self->SUPER::init($args);
+    $self->{cmb_channel} = $self->{app}->combobox({id => 'channel'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{cmb_channel}->exist();
+}
+
+sub set_channel {
+    my ($self, $channel) = @_;
+    return $self->{cmb_channel}->set($channel);
+}
+
+1;

--- a/lib/Installation/DiskActivation/ConfiguredZFCPDevicesController.pm
+++ b/lib/Installation/DiskActivation/ConfiguredZFCPDevicesController.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act on the Configure ZFCP devices page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::DiskActivation::ConfiguredZFCPDevicesController;
+use strict;
+use warnings;
+use Installation::DiskActivation::ConfiguredZFCPDevicesPage;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{ZFCPConfigurationPage} = Installation::DiskActivation::ConfiguredZFCPDevicesPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_zfcp_configuration_page {
+    my ($self) = @_;
+    die "Configured ZFCP devices page is not displayed" unless $self->{ZFCPConfigurationPage}->is_shown();
+    return $self->{ZFCPConfigurationPage};
+}
+
+sub get_devices {
+    my ($self) = @_;
+    return $self->get_zfcp_configuration_page()->get_devices();
+}
+
+sub add {
+    my ($self) = @_;
+    $self->get_zfcp_configuration_page()->press_add();
+}
+
+sub accept_devices {
+    my ($self) = @_;
+    $self->get_zfcp_configuration_page()->press_next();
+}
+
+
+1;

--- a/lib/Installation/DiskActivation/ConfiguredZFCPDevicesPage.pm
+++ b/lib/Installation/DiskActivation/ConfiguredZFCPDevicesPage.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to the Configured ZFCP dialog
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::DiskActivation::ConfiguredZFCPDevicesPage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub init {
+    my ($self, $args) = @_;
+    $self->SUPER::init($args);
+    $self->{btn_filter} = $self->{app}->button({id => 'filter'});
+    $self->{btn_add} = $self->{app}->button({id => 'add'});
+    $self->{txt_min_chan} = $self->{app}->textbox({id => 'min_chan'});
+    $self->{txt_max_chan} = $self->{app}->textbox({id => 'max_chan'});
+    $self->{tbl_devices} = $self->{app}->table({id => 'table'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{btn_add}->exist();
+}
+
+sub press_add {
+    my ($self) = @_;
+    return $self->{btn_add}->click();
+}
+
+sub get_devices {
+    my ($self) = @_;
+    return $self->{tbl_devices}->items();
+}
+
+1;

--- a/lib/Installation/DiskActivation/DiskActivationController.pm
+++ b/lib/Installation/DiskActivation/DiskActivationController.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act on the Disk Activation page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::DiskActivation::DiskActivationController;
+use strict;
+use warnings;
+use Installation::DiskActivation::DiskActivationPage;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{DiskActivationPage} = Installation::DiskActivation::DiskActivationPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_disk_activation_page {
+    my ($self) = @_;
+    die "Disk Activation Page is not displayed" unless $self->{DiskActivationPage}->is_shown();
+    return $self->{DiskActivationPage};
+}
+
+sub configure_dasd_disks {
+    my ($self) = @_;
+    $self->get_disk_activation_page()->press_dasd();
+}
+
+sub configure_zfcp_disks {
+    my ($self) = @_;
+    $self->get_disk_activation_page()->press_zfcp();
+}
+
+sub configure_iscsi_disks {
+    my ($self) = @_;
+    $self->get_disk_activation_page()->press_iscsi();
+}
+
+sub accept_disks_configuration {
+    my ($self) = @_;
+    $self->get_disk_activation_page()->press_next();
+}
+
+1;

--- a/lib/Installation/DiskActivation/DiskActivationPage.pm
+++ b/lib/Installation/DiskActivation/DiskActivationPage.pm
@@ -1,0 +1,45 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act on the Disk Activation page
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::DiskActivation::DiskActivationPage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub init {
+    my ($self, $args) = @_;
+    $self->SUPER::init($args);
+    $self->{btn_conf_dasd} = $self->{app}->button({id => 'dasd'});
+    $self->{btn_conf_zfcp} = $self->{app}->button({id => 'zfcp'});
+    $self->{btn_conf_iscsi} = $self->{app}->button({id => 'iscsi'});
+    $self->{btn_net_conf} = $self->{app}->button({id => 'network'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{btn_net_conf}->exist();
+}
+
+sub press_dasd {
+    my ($self) = @_;
+    return $self->{btn_conf_dasd}->click();
+}
+
+sub press_zfcp {
+    my ($self) = @_;
+    return $self->{btn_conf_zfcp}->click();
+}
+
+sub press_iscsi {
+    my ($self) = @_;
+    return $self->{btn_conf_iscsi}->click();
+}
+
+1;

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -1,5 +1,5 @@
-name:           zfcp
-description:    >
+name: zfcp
+description: >
   Test installation on machine with zfcp multipath disk.
   Only tests succesful detection of multipath and installation.
   No functional testing of multipath itself.
@@ -12,7 +12,11 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - installation/disk_activation
+  - installation/disk_activation/select_configure_zfcp_disks
+  - installation/disk_activation/select_add_zfcp_device
+  - installation/disk_activation/configure_zfcp_device
+  - installation/disk_activation/accept_configured_zfcp_devices
+  - installation/disk_activation/finish_disk_activation
   - installation/activate_multipath
   - installation/registration/register_via_scc
   - installation/module_selection/select_module_desktop

--- a/tests/installation/disk_activation/accept_configured_zfcp_devices.pm
+++ b/tests/installation/disk_activation/accept_configured_zfcp_devices.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This test module handles ZFCP disk activation
+#          through libyui-rest-client.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    my $zfcp_configuration_overview = $testapi::distri->get_configured_zfcp_devices();
+    $zfcp_configuration_overview->accept_devices();
+}
+
+1;

--- a/tests/installation/disk_activation/configure_zfcp_device.pm
+++ b/tests/installation/disk_activation/configure_zfcp_device.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This test module handles ZFCP disk activation
+#          through libyui-rest-client.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    my $zfcp_add_disk = $testapi::distri->get_add_new_zfcp_device();
+    $zfcp_add_disk->configure({channel => '0.0.fa00'});
+}
+
+1;

--- a/tests/installation/disk_activation/finish_disk_activation.pm
+++ b/tests/installation/disk_activation/finish_disk_activation.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This test module handles ZFCP disk activation
+#          through libyui-rest-client.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    my $disk_activation = $testapi::distri->get_disk_activation();
+    $disk_activation->accept_disks_configuration();
+}
+
+1;

--- a/tests/installation/disk_activation/select_add_zfcp_device.pm
+++ b/tests/installation/disk_activation/select_add_zfcp_device.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This test module handles ZFCP disk activation
+#          through libyui-rest-client.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    my $zfcp_configuration_overview = $testapi::distri->get_configured_zfcp_devices();
+    $zfcp_configuration_overview->add();
+}
+
+1;

--- a/tests/installation/disk_activation/select_configure_zfcp_disks.pm
+++ b/tests/installation/disk_activation/select_configure_zfcp_disks.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This test module handles ZFCP disk activation
+#          through libyui-rest-client.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    my $disk_activation = $testapi::distri->get_disk_activation();
+    $disk_activation->configure_zfcp_disks();
+}
+
+1;


### PR DESCRIPTION
Activate ZFCP disks via libyui

- Related ticket: https://progress.opensuse.org/issues/98967
- Needles: n.a.
- Verification run: https://openqa.suse.de/tests/7755204