### PR TITLE
Rename LTP variables with prefix for the corresponding module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -250,7 +250,13 @@ sub is_ltp_test {
           || get_var('LTP_COMMAND_FILE'));
 }
 
+sub is_publiccloud_ltp_test {
+    return (get_var('LTP_COMMAND_FILE') && get_var('PUBLIC_CLOUD'));
+}
+
 sub is_kernel_test {
+    # ignore ltp tests in publiccloud
+    return if is_publiccloud_ltp_test();
     return is_ltp_test() ||
       (get_var('QA_TEST_KLP_REPO')
         || get_var('INSTALL_KLP_PRODUCT')

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -47,7 +47,7 @@ sub upload_ltp_logs
 {
     my ($self) = @_;
     my $log_file = Mojo::File::path('ulogs/ltp_log.json');
-    my $ltp_testsuite = get_required_var('COMMAND_FILE');
+    my $ltp_testsuite = get_required_var('LTP_COMMAND_FILE');
 
     upload_logs("$root_dir/ltp_log.raw", log_name => 'ltp_log.raw', failok => 1);
     upload_logs("$root_dir/ltp_log.json", log_name => $log_file->basename, failok => 1);
@@ -128,12 +128,12 @@ sub run {
 
     # Use lib/LTP/WhiteList module to exclude tests
     if (get_var('LTP_KNOWN_ISSUES')) {
-        my $exclude = get_var('COMMAND_EXCLUDE', '');
-        my @skipped_tests = list_skipped_tests($ltp_env, get_required_var('COMMAND_FILE'));
+        my $exclude = get_var('LTP_COMMAND_EXCLUDE', '');
+        my @skipped_tests = list_skipped_tests($ltp_env, get_required_var('LTP_COMMAND_FILE'));
         if (@skipped_tests) {
             $exclude .= '|' if (length($exclude) > 0);
             $exclude .= '^(' . join('|', @skipped_tests) . ')$';
-            set_var('COMMAND_EXCLUDE', $exclude);
+            set_var('LTP_COMMAND_EXCLUDE', $exclude);
         }
     }
 
@@ -155,8 +155,8 @@ sub run {
     my $cmd = 'perl -I runltp-ng runltp-ng/runltp-ng ';
     $cmd .= '--logname=ltp_log --verbose ';
     $cmd .= '--timeout=1200 ';
-    $cmd .= '--run ' . get_required_var('COMMAND_FILE') . ' ';
-    $cmd .= '--exclude \'' . get_required_var('COMMAND_EXCLUDE') . '\' ';
+    $cmd .= '--run ' . get_required_var('LTP_COMMAND_FILE') . ' ';
+    $cmd .= '--exclude \'' . get_required_var('LTP_COMMAND_EXCLUDE') . '\' ';
     $cmd .= '--backend=ssh';
     $cmd .= ':user=' . $instance->username;
     $cmd .= ':key_file=' . $instance->ssh_key;
@@ -208,11 +208,11 @@ and connect to the CSP instance using SSH. This is done via the run_ltp_ssh.pl s
 
 =head1 Configuration
 
-=head2 COMMAND_FILE
+=head2 LTP_COMMAND_FILE
 
 The LTP test command file (e.g. syscalls, cve)
 
-=head2 COMMAND_EXCLUDE
+=head2 LTP_COMMAND_EXCLUDE
 
 This regex is used to exclude tests from command file.
 

--- a/variables.md
+++ b/variables.md
@@ -36,8 +36,6 @@ CLUSTER_TYPES | string | false | Set the type of cluster that have to be analyze
 CONTAINER_RUNTIME | string | | Container runtime to be used, e.g.  `docker`, `podman`, or both `podman,docker`.
 CONTAINERS_NO_SUSE_OS | boolean | false | Used by main_containers to see if the host is different than SLE or openSUSE.
 CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.
-COMMAND_FILE | string | | The LTP test command file (e.g. syscalls, cve)
-COMMAND_EXCLUDE | string | | This regex is used to exclude tests from LTP command file.
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.
@@ -96,6 +94,8 @@ LIVECD | boolean | false | Indicates live image being used.
 LIVE_INSTALLATION | boolean | false | If set, boots the live media and starts the builtin NET installer.
 LIVE_UPGRADE | boolean | false | If set, boots the live media and starts the builtin NET installer in upgrade mode.
 LIVETEST | boolean | false | Indicates test of live system.
+LTP_COMMAND_FILE | string | | The LTP test command file (e.g. syscalls, cve)
+LTP_COMMAND_EXCLUDE | string | | This regex is used to exclude tests from LTP command file.
 LTP_KNOWN_ISSUES | string | | Used to specify a url for a json file with well known LTP issues. If an error occur which is listed, then the result is overwritten with softfailure.
 LTP_REPO | string | | The repo which will be added and is used to install LTP package.
 LTP_RUN_NG_BRANCH | string | | Define the branch of the LTP_RUN_NG_REPO.


### PR DESCRIPTION
following the name convention that kernel modules uses and for the sake of sanity between those which are used for the same exact purpose.
that also will make the variable more specific. for instance
COMMAND_EXCLUDE - LTP_COMMAND_EXCLUDE
COMMAND_FILE - LTP_COMMAND_FILE

- Related ticket: https://progress.opensuse.org/issues/98334
- Verification run: https://openqa.suse.de/t7719617
https://openqa.suse.de/tests/7725754 for d7c99b0d659e9e17ae910bd4f6848adb72d631d9