### PR TITLE
Fix for problems in disable_boot_menu_timeout.pm

### DIFF
--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/authentication/default_user_simple_pwd
   - installation/installation_overview
   - installation/bootloader_settings/disable_plymouth
-  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system

--- a/schedule/yast/remote_ssh/remote_ssh_controller_sle15.yaml
+++ b/schedule/yast/remote_ssh/remote_ssh_controller_sle15.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
-  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation

--- a/schedule/yast/remote_vnc/remote_vnc_controller.yaml
+++ b/schedule/yast/remote_vnc/remote_vnc_controller.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/user_settings
   - installation/user_settings_root
   - installation/installation_overview
-  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/reboot_after_installation

--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
-  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system

--- a/schedule/yast/ssh-x.yaml
+++ b/schedule/yast/ssh-x.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/user_settings_root
   - installation/select_patterns
   - installation/installation_overview
-  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
   - installation/logs_from_installation_system


### PR DESCRIPTION
- Module was called from YAML schedules that don't use
  setup_libyui
- YAML schedules reverted back to disable_grub_timeout

- Related ticket: https://progress.opensuse.org/issues/102780
- Needles: n.a.
- Verification run: https://openqa.suse.de/tests/7718210
