### PR TITLE
Containers: specify swap partition size for HDD creation

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -172,6 +172,7 @@
           <format config:type="boolean">true</format>
           <fstopt>defaults</fstopt>
           <mount>swap</mount>
+          <size>2G</size>
         </partition>
         <partition>
           <mountby config:type="symbol">device</mountby>


### PR DESCRIPTION
If size is  not specified, the installation will assign 50% for swap
and 50% for root partition, which is not very efficient and we found
problems in tests complaining about no space left on the device.
The idea with this change is to limit the swap partition to 2GB 
only and the rest will go to the root partition.

VRs:
HDD Creation: http://fromm.arch.suse.de/tests/4529
TEST run: [28G](http://fromm.arch.suse.de/tests/4530#step/bci_prepare/9) vs [15GB](http://fromm.arch.suse.de/tests/4525#step/bci_prepare/9)

VRs on OSD for ALL jobs: https://openqa.suse.de/tests/overview?flavor=Container-Host&groupid=377&build=GM