### PR TITLE
Bugfix for disable_plymouth.pm

### DIFF
--- a/tests/installation/bootloader_settings/disable_plymouth.pm
+++ b/tests/installation/bootloader_settings/disable_plymouth.pm
@@ -12,7 +12,7 @@ use warnings;
 use base 'y2_installbase';
 
 sub run {
-    $testapi::distri->get_overview_controller()->access_booting_options();
+    $testapi::distri->get_installation_settings()->access_booting_options();
     $testapi::distri->get_bootloader_settings()->disable_plymouth();
 }
 


### PR DESCRIPTION
- test code was refering to get_overview_controller which
   was renamed to get_installation_settings.

- Related ticket: https://progress.opensuse.org/issues/102813
- Needles: n.a.
- Verification run: https://openqa.suse.de/tests/7717876