### PR TITLE
Need more time to match gnome-setting on ARM

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -740,7 +740,8 @@ sub start_gnome_settings {
 
     if (!$is_sle_12_sp1 || $settings_menu_loaded) {
         assert_and_click 'settings';
-        assert_screen 'gnome-settings';
+        my $timeout = (check_var('ARCH', 'aarch64')) ? '180' : '30';
+        assert_screen 'gnome-settings', $timeout;
     }
 }
 


### PR DESCRIPTION
 Through manual test on ARM, I found after click the 'setting' it will show the desktop firstly then show the gnome-setting, it is slow on ARM, so we need wait more time to catch the gnome-setting.

- Related ticket: https://progress.opensuse.org/issues/102494
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/7714299#step/install_service/342