### PR TITLE
Parallel guests install

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -192,11 +192,10 @@ sub create_guest {
         $virtinstall .= " --events on_reboot=$on_reboot" unless ($on_reboot eq '');
         $virtinstall .= " --extra-args '$extra_args'" unless ($extra_args eq '');
         record_info("$name", "Creating $name guests:\n$virtinstall");
-        # HOTFIX: Run installation sequentially due to poo#101256
-        assert_script_run("$virtinstall >> ~/virt-install_$name.txt 2>&1", timeout => 2700);
-        ## wait for initrd to ensure the installation is starting
-        # Note: This is not needed for sequential installation but left here, for when we will work on parallel installation again.
-        #script_retry("grep -B99 -A99 'initrd' ~/virt-install_$name.txt", delay => 15, retry => 12, die => 0);
+        script_run "$virtinstall >> ~/virt-install_$name.txt 2>&1 & true";    # true required because & terminator is not allowed
+
+        # wait for initrd to ensure the installation is starting
+        script_retry("grep -B99 -A99 'initrd' ~/virt-install_$name.txt", delay => 15, retry => 12, die => 0);
     } else {
         die "unsupported create_guest method '$method'";
     }

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -101,21 +101,15 @@ sub run {
     add_guest_to_hosts $_, $virt_autotest::common::guests{$_}->{ip} foreach (keys %virt_autotest::common::guests);
     assert_script_run "cat /etc/hosts";
 
-    ##########################################################################################################
-    ## The following block has been commented because it is only required for parallel guest installation.  ##
-    ## For now we had to switch back to sequential guest installation (See poo#101542), however the code    ##
-    ## is intentionally kept here for when we enable parallel guest installation again.                     ##
-    ## Note: Double commented comments (##) remain comments!                                                ##
-    ##########################################################################################################
-    ## Wait for guests to finish installation
-    ## script_run("wait", timeout => 1200);
-    ##script_retry("! ps x | grep -v 'grep' | grep 'virt-install'", retry => 120, delay => 10);
-    ## Unfortunately this doesn't cover the second step of the installation, where ssh is available
-    ##my $sleep_delay = 1200;
-    ##$sleep_delay = 1800 if (is_xen_host);    # XEN has more guests
-    ##sleep($sleep_delay);                     # XXX Get rid of this sleep!
-    ##start_guests();
-    ##record_info("guests installed", "Guest installation completed");
+    # Wait for guests to finish installation
+    # script_run("wait", timeout => 1200);
+    # script_retry("! ps x | grep -v 'grep' | grep 'virt-install'", retry => 120, delay => 10);
+    # Unfortunately this doesn't cover the second step of the installation, where ssh is available
+    my $sleep_delay = 1200;
+    $sleep_delay = 1800 if (is_xen_host);    # XEN has more guests
+    sleep($sleep_delay);    # XXX Get rid of this sleep!
+    start_guests();
+    record_info("guests installed", "Guest installation completed");
 
     # Adding the PCI bridges requires the guests to be shutdown
     record_info("shutdown guests", "Shutting down all guests");


### PR DESCRIPTION
The network issues seems to be resolve and tests run a lot more stable, reverting back to parallel install of guests to run tests faster. The root cause of the network problem is still unknown.

- Related ticket: https://progress.opensuse.org/issues/101256
- Needles: N/A
- Verification run: [XEN](http://openqa.qam.suse.cz/tests/31608#) and [KVM](http://openqa.qam.suse.cz/tests/31619)
