### PR TITLE
Containers: exclude ubi9 images on ppc

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -283,6 +283,8 @@ sub get_3rd_party_images {
 
     # - ubi9 images require z14+ s390x machine, they are not ready in OSD yet.
     #     on z13: "Fatal glibc error: CPU lacks VXE support (z14 or later required)".
+    # - ubi9 images require power9+ machine.
+    #     on Power8: "Fatal glibc error: CPU lacks ISA 3.00 support (POWER9 or later required)"
     # - poo#72124 Ubuntu image (occasionally) fails on s390x.
     # - CentOS image not available on s390x.
     push @images, (
@@ -292,14 +294,14 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi9-beta/ubi-init",
         "$ex_reg/library/ubuntu",
         "$ex_reg/library/centos"
-    ) unless is_s390x;
+    ) unless (is_s390x || is_ppc64le);
 
     # RedHat UBI7 images are not built for aarch64
     push @images, (
         "registry.access.redhat.com/ubi7/ubi",
         "registry.access.redhat.com/ubi7/ubi-minimal",
         "registry.access.redhat.com/ubi7/ubi-init"
-    ) unless (is_aarch64 or check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
+    ) unless (is_aarch64 || check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
 
     return (\@images);
 }


### PR DESCRIPTION
Example of the failure: https://openqa.suse.de/tests/7715824#step/podman_3rd_party_images/461
VR: https://openqa.suse.de/tests/7728455
