### PR TITLE
Avoid failures due to un-refreshed screen & bsc#1192992 workaround

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -21,7 +21,7 @@ use version_utils;
 use main_common 'opensuse_welcome_applicable';
 use isotovideo;
 use IO::Socket::INET;
-use x11utils qw(handle_login ensure_unlocked_desktop);
+use x11utils qw(handle_login ensure_unlocked_desktop handle_additional_polkit_windows);
 
 # Base class for all openSUSE tests
 
@@ -969,17 +969,6 @@ sub handle_broken_autologin_boo1102563 {
     wait_screen_change { send_key 'alt-f4' };
 }
 
-sub handle_additional_polkit_windows {
-    record_soft_failure 'bsc#1177446 - Polkit popup appears at first login, again';
-    wait_still_screen(3);
-    ensure_unlocked_desktop;
-    # deal with potential followup authentication window which is not
-    # actually a login screen but polkit asking for modification to system
-    # repositories
-    wait_still_screen(3);
-    ensure_unlocked_desktop;
-}
-
 =head2 wait_boot_past_bootloader
 
  wait_boot_past_bootloader([, textmode => $textmode] [,ready_time => $ready_time] [, nologin => $nologin] [, forcenologin => $forcenologin]);
@@ -1034,7 +1023,7 @@ sub wait_boot_past_bootloader {
         push(@tags, 'guest-disable-display');
     }
     # bsc#1177446 - Polkit popup appears at first login, again
-    if (is_sle && !is_sle('<=15-SP1')) {
+    if (is_sle && !is_sle('<=15-SP1') && is_s390x) {
         push(@tags, 'authentication-required-user-settings');
     }
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -888,7 +888,6 @@ sub console_selected {
     # x11 needs special handling because we can not easily know if screen is
     # locked, display manager is waiting for login, etc.
     if ($args{tags} =~ /x11/) {
-        wait_still_screen;
         return ensure_unlocked_desktop;
     }
     assert_screen($args{tags}, no_wait => 1, timeout => $args{timeout});

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -65,6 +65,10 @@ all possible options should be handled within loop to get unlocked desktop
 sub ensure_unlocked_desktop {
     my $counter = 10;
 
+    # press key to update screen, wait shortly before and after to not match cached screen
+    wait_still_screen(3);
+    send_key 'ctrl';
+    wait_still_screen(3);
     while ($counter--) {
         my @tags = qw(displaymanager displaymanager-password-prompt generic-desktop screenlock screenlock-password authentication-required-user-settings authentication-required-modify-system guest-disabled-display oh-no-something-has-gone-wrong);
         push(@tags, 'blackscreen') if get_var("DESKTOP") =~ /minimalx|xfce/;    # Only xscreensaver and xfce have a blackscreen as screenlock

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -17,6 +17,7 @@ our @EXPORT = qw(
   desktop_runner_hotkey
   ensure_unlocked_desktop
   ensure_fullscreen
+  handle_additional_polkit_windows
   handle_login
   handle_logout
   handle_relogin
@@ -182,6 +183,29 @@ sub ensure_fullscreen {
     }
 }
 
+sub handle_additional_polkit_windows {
+    my $mypwd = shift // $testapi::password;
+    if (match_has_tag('authentication-required-user-settings')) {
+        # for S390x testing, since they are not using qemu built-in vnc, it is
+        # expected that polkit authentication window can open for first time login.
+        # see bsc#1177446 for more information.
+        record_soft_failure 'bsc#1192992 - multiple authentication due to repositories refresh on s390x';
+        wait_still_screen(5);
+        my $counter = 5;
+        while (check_screen('authentication-required-user-settings', 10) && $counter) {
+            type_password($mypwd);
+            send_key 'ret';
+            wait_still_screen(2, 4);
+            $counter--;
+        }
+    }
+    if (match_has_tag('authentication-required-modify-system')) {
+        type_password($mypwd);
+        send_key 'ret';
+        wait_still_screen(2, 4);
+    }
+}
+
 =head2 handle_login
 
  handle_login($myuser, $user_selected);
@@ -234,14 +258,7 @@ sub handle_login {
     type_password($mypwd);
     send_key 'ret';
     wait_still_screen;
-    # for S390x testing, since they are not using qemu built-in vnc, it is
-    # expected that polkit authentication window can open for first time login.
-    # see bsc#1177446 for more information.
-    if (check_screen([qw(authentication-required-user-settings authentication-required-modify-system)], 10)) {
-        type_password($mypwd);
-        send_key 'ret';
-        wait_still_screen;
-    }
+    handle_additional_polkit_windows($mypwd) if check_screen([qw(authentication-required-user-settings authentication-required-modify-system)], 15);
     assert_screen([qw(generic-desktop gnome-activities opensuse-welcome)], 180);
     if (match_has_tag('gnome-activities')) {
         send_key_until_needlematch [qw(generic-desktop opensuse-welcome)], 'esc';

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -67,9 +67,10 @@ sub ensure_unlocked_desktop {
     my $counter = 10;
 
     # press key to update screen, wait shortly before and after to not match cached screen
-    wait_still_screen(3);
+    my $wait_time = get_var('UPGRADE') ? 10 : 3;
+    wait_still_screen($wait_time);
     send_key 'ctrl';
-    wait_still_screen(3);
+    wait_still_screen($wait_time);
     while ($counter--) {
         my @tags = qw(displaymanager displaymanager-password-prompt generic-desktop screenlock screenlock-password authentication-required-user-settings authentication-required-modify-system guest-disabled-display oh-no-something-has-gone-wrong);
         push(@tags, 'blackscreen') if get_var("DESKTOP") =~ /minimalx|xfce/;    # Only xscreensaver and xfce have a blackscreen as screenlock


### PR DESCRIPTION
- Related ticket:
https://progress.opensuse.org/issues/101292
https://progress.opensuse.org/issues/102638
https://progress.opensuse.org/issues/102020
- Verification run:
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=x11 15 SP4
https://openqa.suse.de/tests/overview?distri=sle&version=15&build=x11 15 GA consoletest_finish failures are related to another issue
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=x11 15 SP2 consoletest_finish failures are related to another issue
https://openqa.opensuse.org/tests/overview?distri=opensuse&build=x11&version=Tumbleweed TW
