### PR TITLE
Update IBM TSS to the latest version

### DIFF
--- a/schedule/security/ibmtss.yaml
+++ b/schedule/security/ibmtss.yaml
@@ -1,0 +1,8 @@
+name: ibm_tss_version_check
+description:    >
+    This is for ibm tss version check on aarch64
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/ibmtss/version_check
+    - security/ibmtss/ibmtss_basic_function

--- a/tests/security/ibmtss/ibmtss_basic_function.pm
+++ b/tests/security/ibmtss/ibmtss_basic_function.pm
@@ -1,0 +1,67 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Update IBM's Trusted Computing Group Software Stack (TSS) to the latest version.
+#          IBM has tested x86_64, s390x and ppc64le, we only need cover aarch64
+#          This test module covers basic function test
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#101088, poo#102792, tc#1769800
+
+use base 'opensusebasetest';
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use version_utils 'is_sle';
+use registration 'add_suseconnect_product';
+
+sub run {
+    my $self = shift;
+
+    select_console('root-console');
+    # Install required develop packages
+    if (is_sle('>=15')) {
+        add_suseconnect_product('sle-module-desktop-applications');
+        add_suseconnect_product('sle-module-development-tools');
+    }
+    zypper_call('in -t pattern devel_basis');
+    zypper_call('in openssl-devel');
+
+    # Install emulated tpm server
+    zypper_call('in ibmswtpm2');
+
+    # Swith to root console to start tpm server in backaround
+    my $tpm_spid;
+    if (is_sle) {
+        $tpm_spid = background_script_run('/usr/lib/ibmtss/tpm_server');
+    }
+    else {
+        $tpm_spid = background_script_run('/usr/libexec/ibmtss/tpm_server');
+    }
+
+    # Download the test script, which is imported from link 'https://git.code.sf.net/p/ibmtpm20tss/tssi'
+    $self->select_serial_terminal;
+
+    assert_script_run('git clone https://git.code.sf.net/p/ibmtpm20tss/tss ibmtpm20tss-tss', timeout => 240);
+    assert_script_run('cd ibmtpm20tss-tss/utils');
+    assert_script_run('make -f makefiletpmc', timeout => 120);
+
+    # Modify the script to use the binaries installed in current system
+    assert_script_run q(sed -i 's/^PREFIX=.*/PREFIX=tss/g' reg.sh);
+
+    # Run the script
+    assert_script_run('export TPM_INTERFACE_TYPE=socsim');
+    my $tsslog = '/tmp/tss.log';
+    script_run("./reg.sh | tee $tsslog", timeout => 120);
+    upload_logs("$tsslog");
+
+    # Check the test result
+    assert_script_run("cat $tsslog | grep 'Success - 0 Tests 0 Warnings'");
+
+    # Clean up
+    assert_script_run('cd; rm -rf ibmtpm20tss-tss');
+    assert_script_run("kill -9 $tpm_spid");
+}
+
+1;

--- a/tests/security/ibmtss/version_check.pm
+++ b/tests/security/ibmtss/version_check.pm
@@ -1,0 +1,26 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Update IBM's Trusted Computing Group Software Stack (TSS) to the latest version.
+#          IBM has tested x86_64, s390x and ppc64le, we only need cover aarch64
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#101088, poo#102792, tc#1769800
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    zypper_call('in ibmtss');
+    my $tagert_ver = 1.6.0;
+    my $current_ver = script_output("rpm -q --qf '%{version}\n' ibmtss");
+    record_info("Current ibmtss package version: $current_ver");
+    die 'The package version is not updated yet, please check with developer' if ($current_ver < $tagert_ver);
+}
+
+1;


### PR DESCRIPTION
Update IBM's Trusted Computing Group Software Stack (TSS)
to the latest version. we need to check the package version
and run basic function tests to communicate with tpm server.

- Related ticket: https://progress.opensuse.org/issues/102792
- Needles: n/a
- Verification run: 
https://openqa.opensuse.org/tests/2056279 - TW
https://openqa.suse.de/tests/7740843            - SLE
