### PR TITLE
Handle additional polkit window in S390x first_boot

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -237,6 +237,11 @@ sub handle_login {
         type_password($mypwd);
         send_key 'ret';
         wait_still_screen;
+        # If there are additional polkit windows, use `esc` to discard them.
+        if (check_screen([qw(authentication-required-user-settings authentication-required-modify-system)], 10)) {
+            record_soft_failure("bsc#1192992");
+            send_key_until_needlematch('generic-desktop', 'esc');
+        }
     }
     assert_screen([qw(generic-desktop gnome-activities opensuse-welcome)], 180);
     if (match_has_tag('gnome-activities')) {


### PR DESCRIPTION
In `first_boot` on S390x platform, there might be additional polkit window after login.  Handle them by sending `esc` key.

@jknphy please review when you have time.

- Related ticket: https://progress.opensuse.org/issues/102020
https://progress.opensuse.org/issues/102740
- Needles: none
- Verification run: https://openqa.suse.de/tests/7732608 https://openqa.suse.de/tests/7732609