### PR TITLE
Fix disks selection in Clone partition

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ClonePartitionsDialog.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ClonePartitionsDialog.pm
@@ -41,7 +41,7 @@ sub select_disks {
     foreach my $disk (@disks) {
         # Find list item which matches wanted disk
         if (my ($lst_item) = grep $_ =~ $disk, @available) {
-            $self->{lst_target_disks}->select($lst_item);
+            $self->{lst_target_disks}->check($lst_item);
         }
         else {
             die "$disk cannot be found in the list of target disks";
@@ -56,7 +56,7 @@ sub select_all_disks {
     my @disks = $self->{lst_target_disks}->items();
     #Select all disks
     foreach my $disk (@disks) {
-        $self->{lst_target_disks}->select($disk);
+        $self->{lst_target_disks}->check($disk);
     }
     return $self;
 }

--- a/lib/YuiRestClient/Widget/SelectionBox.pm
+++ b/lib/YuiRestClient/Widget/SelectionBox.pm
@@ -87,13 +87,14 @@ Handles a selection box.
 
 B<select($item)> - Select item in a SelectionBox object.
 
+This action puts the item in focus (i.e highlights it), but does not check a checkbox associated with the item.
 The item is identified by its label.
 
-B<check($item)> - Select item in a SelectionBox object.
+B<check($item)> - Check checkbox for an item in a SelectionBox object.
 
 The item is identified by its label.
 
-B<uncheck($item)> - Unselect item in a SelectionBox object.
+B<uncheck($item)> - Uncheck checkbox for an item in a SelectionBox object.
 
 The item is identified by its label.
 


### PR DESCRIPTION
There was a fix of an issue in libyui for YMultiSelectionBox.
Previously, checkboxes may be selected with both 'select' and 'check'
actions, that was incorrect. After the fix, 'select' action highlights
element in list and 'check' action checks a checkbox. Link to the PR
with fix: https://github.com/libyui/libyui/pull/58

The commit updates testing framework to use 'check' action to select
disks in 'Clone partition layout' dialog.

Fixes https://openqa.suse.de/tests/7729237#step/raid_gpt/4

- Verification runs: 
   - staging: https://openqa.suse.de/tests/7736071
   - YaST job group (to confirm that it works on older version of libyui): https://openqa.suse.de/tests/7736072
