### PR TITLE
Move container registry helpers function to each client

### DIFF
--- a/lib/publiccloud/k8s_provider.pm
+++ b/lib/publiccloud/k8s_provider.pm
@@ -12,10 +12,8 @@ use Mojo::Base -base;
 use testapi;
 use mmapi 'get_current_job_id';
 
-
 has region => undef;
 has resource_name => sub { get_var('PUBLIC_CLOUD_RESOURCE_NAME', 'openqa-vm') };
-has container_registry => sub { get_var("PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY", 'suse-qec-testing') };
 has provider_client => undef;
 
 sub init {
@@ -30,14 +28,19 @@ sub init {
                 region => $self->region,
                 service => $service
             ));
-        $self->provider_client->init();
     }
     elsif ($provider eq 'GCE') {
-        # TODO
+        die('Not implemented yet');
     }
     elsif ($provider eq 'AZURE') {
-        # TODO
+        die('Not implemented yet');
     }
+    else {
+        die("Invalid provider");
+    }
+
+
+    $self->provider_client->init();
 }
 
 =head2 get_container_registry_prefix
@@ -45,18 +48,16 @@ Get the full registry prefix URL (based on the account and region) to push conta
 =cut
 sub get_container_registry_prefix {
     my ($self) = @_;
-    my $region = $self->region;
-    my $full_name_prefix = sprintf('%s.dkr.ecr.%s.amazonaws.com', $self->provider_client->aws_account_id, $region);
-    return $full_name_prefix;
+    return $self->provider_client->get_container_registry_prefix();
 }
 
 =head2 get_container_image_full_name
-Get the full name for a container image in ECR registry
+Returns the full name of the container image in ECR registry
+C<tag> Tag of the container
 =cut
 sub get_container_image_full_name {
     my ($self, $tag) = @_;
-    my $full_name_prefix = $self->get_container_registry_prefix();
-    return "$full_name_prefix/" . $self->container_registry . ":$tag";
+    return $self->provider_client->get_container_image_full_name($tag);
 }
 
 =head2 get_default_tag

--- a/tests/containers/run_container_in_eks.pm
+++ b/tests/containers/run_container_in_eks.pm
@@ -62,7 +62,7 @@ sub cleanup {
     record_info('Cleanup', 'Deleting kubectl job and image.');
     assert_script_run("kubectl delete job " . $self->{job_name});
     assert_script_run("aws ecr batch-delete-image --repository-name "
-          . $self->{provider}->container_registry
+          . $self->{provider}->provider_client->container_registry
           . " --image-ids imageTag="
           . $self->{image_tag});
 }


### PR DESCRIPTION
The container registry helpers behavior depends on the
provider is being testing. So it's necessary to move them
to the provider clients

- Related ticket: https://progress.opensuse.org/issues/101497
- Verification run: 
-- http://copland.arch.suse.de/tests/581 (GKE)
-- http://copland.arch.suse.de/tests/580 (EKS)
