### PR TITLE
Fix ssh port timeout issue and mac addr conflict issue in swtpm tests

### DIFF
--- a/data/swtpm/70-persistent-net.rules_uefi
+++ b/data/swtpm/70-persistent-net.rules_uefi
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="52:54:00:95:27:54", ATTR{type}=="1",  NAME=""

--- a/data/swtpm/ssh_port_chk_script
+++ b/data/swtpm/ssh_port_chk_script
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ip_addr=""
-for (( i = 0; i < 90; i++ )); do
+for (( i = 0; i < 200; i++ )); do
     ip_addr=`ip n | awk ' /192\\.168/ {print $1}'`
     if [[ -n "$ip_addr" ]] && nc -zvw2 $ip_addr 22 2>/dev/null; then
          echo "the vm's ssh port is online"
@@ -12,5 +12,5 @@ for (( i = 0; i < 90; i++ )); do
         sleep 1
     fi
 done
-echo "the ssh service is still offline after waiting 90s"
+echo "the ssh service is still offline after waiting 200s"
 exit 2

--- a/data/swtpm/swtpm_uefi.xml
+++ b/data/swtpm/swtpm_uefi.xml
@@ -37,7 +37,7 @@
       <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
     </disk>
     <interface type='network'>
-      <mac address='52:54:00:95:27:53'/>
+      <mac address='52:54:00:95:27:54'/>
       <source network='default'/>
       <model type='virtio'/>
       <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>

--- a/lib/swtpmtest.pm
+++ b/lib/swtpmtest.pm
@@ -86,7 +86,7 @@ sub swtpm_verify {
 
     # Check the vm guest is up via listening to the port 22
     assert_script_run("wget --quiet " . data_url("swtpm/ssh_port_chk_script") . " -P $image_path");
-    assert_script_run("bash $image_path/ssh_port_chk_script");
+    assert_script_run("bash $image_path/ssh_port_chk_script", timeout => 200);
 
     # Login to the vm and run the commands to check tpm device
     my $user = 'root';

--- a/lib/swtpmtest.pm
+++ b/lib/swtpmtest.pm
@@ -3,7 +3,7 @@
 #
 # Summary: Base module for swtpm test cases
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81256, tc#1768671
+# Tags: poo#81256, tc#1768671, poo#102849
 
 package swtpmtest;
 

--- a/tests/security/create_swtpm_hdd/build_hdd.pm
+++ b/tests/security/create_swtpm_hdd/build_hdd.pm
@@ -7,7 +7,7 @@
 #          at the same time, install some required packages.
 #
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81256, tc#1768671, poo#93835
+# Tags: poo#81256, tc#1768671, poo#93835, poo#102933
 
 use base 'opensusebasetest';
 use strict;
@@ -33,9 +33,11 @@ sub run {
 
     # Define a new udev rule file to keep the NIC name persistent across OS rebooting
     my $udev_rule_file = '/etc/udev/rules.d/70-persistent-net.rules';
-    my $mac_addr = get_var("NICMAC");
+    my $mac_addr = get_var('NICMAC');
     my $nic_name = script_output("grep $mac_addr /sys/class/net/*/address |cut -d / -f 5");
-    assert_script_run("wget --quiet " . data_url("swtpm/70-persistent-net.rules") . " -O $udev_rule_file");
+    my $net_rule = 'swtpm/70-persistent-net.rules';
+    $net_rule .= '_uefi' if (get_var('UEFI'));
+    assert_script_run("wget --quiet " . data_url("$net_rule") . " -O $udev_rule_file");
     assert_script_run("sed -i 's/NAME=\"\"/ NAME=\"$nic_name\"/' $udev_rule_file");
 
     # Permit ssh login as root


### PR DESCRIPTION
- Related ticket:
 https://progress.opensuse.org/issues/102849
 https://progress.opensuse.org/issues/102933
- Needles: n/a
- Verification run: 
Create-swtpm-hdd: 
  https://openqa.suse.de/tests/7734361
  https://openqa.suse.de/tests/7734362
Swtpm-verify:
 https://openqa.suse.de/tests/7738821
 https://openqa.suse.de/tests/7738814