### PR TITLE
Fix login prompt can not be caught issue

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1407,6 +1407,7 @@ sub reconnect_mgmt_console {
                     susefirewall2_to_firewalld();
                 }
             }
+            reset_consoles;
             select_console('x11', await_console => 0);
         }
     }


### PR DESCRIPTION
This issue happened since the original root console hasn't log out which cause the module of 'login' can't catch the login prompt, we can add reset_consoles after test finish on previous root console so that the next select_console will activate the console.

- Related ticket: https://progress.opensuse.org/issues/102500
- Needles: N/A
- Verification run:  https://openqa.nue.suse.com/tests/7733229#step/login/1
                   To avoid regression : https://openqa.nue.suse.com/tests/7733747
                                                     https://openqa.nue.suse.com/tests/7733759