### PR TITLE
Add regression test for python-flake8 package

### DIFF
--- a/data/python/sample.py
+++ b/data/python/sample.py
@@ -1,0 +1,13 @@
+# Sample python file for flake8 test
+
+#An incorrectly formatted comment - pycodestyle E265
+
+# Unused import - pyflakes F401
+import os
+
+
+def sample_print():
+    print("A sample python program")
+
+
+sample_print()

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -85,6 +85,7 @@ conditional_schedule:
                 - console/parsec
                 - console/systemd_rpm_macros
                 - console/vsftpd
+                - console/python_flake8
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -7,6 +7,7 @@ schedule:
     - boot/boot_to_desktop
     - console/add_phub_extension
     - console/python_scientific
+    - console/python_flake8
     - '{{wpa_supplicant}}'
     - console/vmstat
     - console/sssd_389ds_functional

--- a/schedule/qam/common/mau-extratests-phub.yaml
+++ b/schedule/qam/common/mau-extratests-phub.yaml
@@ -16,12 +16,16 @@ conditional_schedule:
     VERSION:
       15-SP3:
         - '{{sle15_x86_64}}'
+        - console/python_flake8
       15-SP2:
         - '{{sle15_x86_64}}'
+        - console/python_flake8
       15-SP1:
         - '{{sle15_x86_64}}'
+        - console/python_flake8
       15:
         - '{{sle15_x86_64}}'
+        - console/python_flake8
   sle15_x86_64:
     ARCH:
       x86_64:

--- a/tests/console/python_flake8.pm
+++ b/tests/console/python_flake8.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright (C) 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+# Summary: Regression test for python-flake8
+# Maintainer: QE-Core <qe-core@suse.de>
+
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Make sure that python-flake8 is installed.
+    # On SLE, this requires phub extenstion
+    zypper_call 'in python3-flake8';
+
+    # Test case 1: check if flake8 is functional
+    assert_script_run('mkdir /tmp/empty_dir');
+    assert_script_run('flake8 /tmp/empty_dir');
+
+    # Test case 2: check if flake8 is working as expected
+    assert_script_run('curl -O ' . data_url("python/sample.py"));
+    validate_script_output('flake8 --exit-zero sample.py', sub { m/E265 block comment should start with '# '/ && m/F401 'os' imported but unused/ });
+    script_run('rm sample.py');
+    script_run('rmdir /tmp/empty_dir');
+}
+
+1;


### PR DESCRIPTION
Running flake8 on a sample python file and validating the
expected formatting errors.

- Related ticket: https://progress.opensuse.org/issues/102431
- Verification runs: 
SLE15-SP4 - [x86_64](https://openqa.suse.de/tests/7749078), [ppc64le](https://openqa.suse.de/tests/7749079), [aarch64](https://openqa.suse.de/tests/7749080)
[SLE15-SP3](https://openqa.suse.de/tests/7748923)
[SLE15-SP2](https://openqa.suse.de/tests/7748924)
[SLE15-SP1](https://openqa.suse.de/tests/7751918)
[SLE15](https://openqa.suse.de/tests/7748926)
[Tumbleweed](https://openqa.opensuse.org/tests/2058118)