### PR TITLE
Revert "Merge pull request #13666 from pdostal/firewalled_containers"

### DIFF
--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -9,9 +9,8 @@
 package containers::docker;
 use Mojo::Base 'containers::engine';
 use testapi;
-use containers::utils qw(registry_url get_docker_version check_runtime_version container_ip);
+use containers::utils qw(registry_url);
 use containers::common qw(install_docker_when_needed);
-use version_utils qw(is_sle is_leap);
 use utils qw(systemctl file_content_replace);
 use version_utils qw(get_os_release);
 has runtime => 'docker';
@@ -31,46 +30,6 @@ sub configure_insecure_registries {
     assert_script_run('cat /etc/docker/daemon.json');
     systemctl('restart docker');
     record_info "setup $self->runtime", "deamon.json ready";
-}
-
-sub check_containers_firewall {
-    record_info "firewall", "Checking that firewall is enabled, properly configured and containers can reach the Internet";
-    my $container_name = 'sut_container';
-    my $docker_version = get_docker_version();
-    systemctl('is-active firewalld');
-    my $running = script_output qq(docker ps -q | wc -l);
-    validate_script_output('ip a s docker0', sub { /state DOWN/ }) if $running == 0;
-    # Docker zone is created for docker version >= 20.10 (Tumbleweed), but it
-    # is backported to docker 19 for SLE15-SP3 and for Leap 15.3
-    if (check_runtime_version($docker_version, ">=20.10") || is_sle('>=15-sp3') || is_leap(">=15.3")) {
-        assert_script_run "firewall-cmd --list-all --zone=docker";
-        validate_script_output "firewall-cmd --list-interfaces --zone=docker", sub { /docker0/ };
-        validate_script_output "firewall-cmd --get-active-zones", sub { /docker/ };
-    }
-    # Rules applied before DOCKER. Default is to listen to all tcp connections
-    # ex. output: "1           0        0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0"
-    validate_script_output "iptables -L DOCKER-USER -nvx --line-numbers", sub { /1.+all.+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0/ };
-
-    # Run container in the background
-    assert_script_run "docker run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine');
-    my $container_ip = container_ip($container_name, 'docker');
-
-    # Each running container should have added a new entry to the DOCKER zone.
-    # ex. output: "1           0        0 ACCEPT     tcp  --  !docker0 docker0  0.0.0.0/0            172.17.0.2           tcp dpt:1234"
-    validate_script_output "iptables -L DOCKER -nvx --line-numbers", sub { /1.+ACCEPT.+!docker0 docker0.+$container_ip\s+tcp dpt:1234/ };
-
-    # Connectivity to host check
-    my $default_route = script_output "docker run " . registry_url('alpine') . " ip route show default | awk \'/default/ {print \$3}\'";
-    assert_script_run "docker run --rm " . registry_url('alpine') . " ping -c3 " . $default_route;
-
-    # Cross-container connectivity check
-    assert_script_run "docker run --rm " . registry_url('alpine') . " ping -c3 " . $container_ip;
-
-    # Outisde connectivity check
-    assert_script_run "docker run --rm " . registry_url('alpine') . " wget google.com";
-
-    # Kill the container running on background
-    assert_script_run "docker kill $container_name ";
 }
 
 1;

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -9,10 +9,9 @@
 package containers::podman;
 use Mojo::Base 'containers::engine';
 use testapi;
-use containers::utils qw(registry_url container_ip);
+use containers::utils qw(registry_url);
 use containers::common qw(install_podman_when_needed);
 use utils qw(file_content_replace);
-use Utils::Systemd 'systemctl';
 use version_utils qw(get_os_release);
 has runtime => "podman";
 
@@ -29,40 +28,6 @@ sub configure_insecure_registries {
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
     file_content_replace("/etc/containers/registries.conf", REGISTRY => $registry);
-}
-
-sub check_containers_firewall {
-    my ($runtime) = @_;
-    record_info "firewall", "Checking that firewall is enabled, properly configured and containers can reach the Internet";
-    my $container_name = 'sut_container';
-    systemctl('is-active firewalld');
-
-    # cni-podman0 interface is created when running the first container
-    assert_script_run "podman pull " . registry_url('alpine');
-    assert_script_run "podman run --rm " . registry_url('alpine');
-    validate_script_output('ip a s cni-podman0', sub { /,UP/ });
-
-    # Run container in the background
-    assert_script_run "podman pull " . registry_url('alpine');
-    assert_script_run "podman run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine');
-    my $container_ip = container_ip $container_name, 'podman';
-
-    # Cheking rules of specific running container
-    validate_script_output("iptables -vn -t nat -L PREROUTING", sub { /CNI-HOSTPORT-DNAT/ });
-    validate_script_output("iptables -vn -t nat -L POSTROUTING", sub { /CNI-HOSTPORT-MASQ/ });
-
-    # Connectivity to host check
-    my $default_route = script_output "podman run " . registry_url('alpine') . " ip route show default | awk \'/default/ {print \$3}\'";
-    assert_script_run "podman run --rm " . registry_url('alpine') . " ping -c3 " . $default_route;
-
-    # Cross-container connectivity check
-    assert_script_run "podman run --rm " . registry_url('alpine') . " ping -c3 " . $container_ip;
-
-    # Outside connectivity check
-    assert_script_run "podman run --rm " . registry_url('alpine') . " wget google.com";
-
-    # Kill the container running on background
-    assert_script_run "podman kill $container_name";
 }
 
 1;

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -20,7 +20,7 @@ use warnings;
 use version_utils;
 use Mojo::Util 'trim';
 
-our @EXPORT = qw(test_seccomp basic_container_tests get_vars can_build_sle_base
+our @EXPORT = qw(test_seccomp basic_container_tests get_vars can_build_sle_base check_docker_firewall
   get_docker_version check_runtime_version container_ip registry_url);
 
 sub test_seccomp {
@@ -38,6 +38,29 @@ sub test_seccomp {
     else {
         record_info('seccomp', 'Docker Engine supports seccomp');
     }
+}
+
+sub check_docker_firewall {
+    my $container_name = 'sut_container';
+    my $docker_version = get_docker_version();
+    systemctl('is-active firewalld');
+    my $running = script_output qq(docker ps -q | wc -l);
+    validate_script_output('ip a s docker0', sub { /state DOWN/ }) if $running == 0;
+    # Docker zone is created for docker version >= 20.10 (Tumbleweed), but it
+    # is backported to docker 19 for SLE15-SP3 and for Leap 15.3
+    if (check_runtime_version($docker_version, ">=20.10") || is_sle('>=15-sp3') || is_leap(">=15.3")) {
+        assert_script_run "firewall-cmd --list-all --zone=docker";
+        validate_script_output "firewall-cmd --list-interfaces --zone=docker", sub { /docker0/ };
+    }
+    # Rules applied before DOCKER. Default is to listen to all tcp connections
+    # ex. output: "1           0        0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0"
+    validate_script_output "iptables -L DOCKER-USER -nvx --line-numbers", sub { /1.+all.+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0/ };
+    assert_script_run "docker run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine');
+    my $container_ip = container_ip($container_name, 'docker');
+    # Each running container should have added a new entry to the DOCKER zone.
+    # ex. output: "1           0        0 ACCEPT     tcp  --  !docker0 docker0  0.0.0.0/0            172.17.0.2           tcp dpt:1234"
+    validate_script_output "iptables -L DOCKER -nvx --line-numbers", sub { /1.+ACCEPT.+!docker0 docker0.+$container_ip\s+tcp dpt:1234/ };
+    assert_script_run "docker kill $container_name ";
 }
 
 sub get_docker_version {

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -22,15 +22,10 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use utils;
-use version_utils;
 use registration;
 use containers::common;
 use containers::utils;
 use containers::container_images;
-use publiccloud::utils;
-use Utils::Systemd qw(systemctl disable_and_stop_service);
-
-my $stop_firewall = 0;    # Post-run flag to stop the firewall (failsafe)
 
 sub run {
     my ($self) = @_;
@@ -38,13 +33,6 @@ sub run {
 
     my $dir = "/root/DockerTest";
     my $podman = $self->containers_factory('podman');
-
-    if ($self->firewall() eq 'firewalld') {
-        zypper_call('in ' . $self->firewall()) if (is_publiccloud || is_jeos);
-        systemctl('restart ' . $self->firewall());
-        $stop_firewall = 1;
-        $podman->check_containers_firewall();
-    }
 
     # Run basic runtime tests
     basic_container_tests(runtime => $podman->runtime);
@@ -57,23 +45,10 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    cleanup($self->firewall());
     select_console 'log-console';
     script_run "podman version | tee /dev/$serialdev";
     script_run "podman info --debug | tee /dev/$serialdev";
     $self->SUPER::post_fail_hook;
-}
-
-sub post_run_hook {
-    my $self = shift;
-    cleanup($self->firewall());
-    $self->SUPER::post_run_hook;
-}
-
-# must ensure firewalld is stopped, if it is only enabled in this test (e.g. publiccloud test runs)
-sub cleanup() {
-    my $firewall = shift;
-    disable_and_stop_service($firewall) if $stop_firewall;
 }
 
 1;


### PR DESCRIPTION
This reverts commit 1ff355921f1967b120220b42e12dbafee0f27aa8, reversing
changes made to d3863075911098aa87cf0cf86f46efa829524360.

#13666 did not take into account that the primary openSUSE users of podman, MicroOS and Kubic, do not use firewalld

There was not any vertification runs on MicroOS or Kubic, despite their status as the primary users of podman on openSUSE

Therefore the test that assumes its presence broke all test runs on MicroOS and Kubic

And given MicroOS and Kubic are core parts of the Tumbleweed development process, including staging, this blocked all Factory development.
