### PR TITLE
libnettle8: Check support for ED448 signature

### DIFF
--- a/schedule/jeos/sle/fips.yaml
+++ b/schedule/jeos/sle/fips.yaml
@@ -30,7 +30,7 @@ schedule:
     - console/consoletest_setup
     - fips/fips_setup
     - console/openssl_alpn
-      #    - fips/openssl/openssl_fips_alglist
+      #   - fips/openssl/openssl_fips_alglist
     - fips/openssl/openssl_fips_hash
     - fips/openssl/openssl_fips_cipher
     - fips/openssl/dirmngr_setup


### PR DESCRIPTION
- [failure](https://openqa.suse.de/tests/7739057#step/gnutls_base_check/10)
- VRs:
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates](http://kepler.suse.cz/tests/9031#step/gnutls_base_check/4)
  * [sle-15-SP4-JeOS-for-kvm-and-xen](http://kepler.suse.cz/tests/9030#step/gnutls_base_check/9)
  * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen](http://kepler.suse.cz/tests/9032#)