### PR TITLE
Skip host_configuration for JeOS container tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -81,7 +81,6 @@ sub load_host_tests_docker {
         loadtest 'containers/docker_compose';
     }
     loadtest 'containers/validate_btrfs' if (is_x86_64 && !is_jeos);
-    loadtest "containers/container_diff" if (is_opensuse());
 }
 
 
@@ -94,7 +93,7 @@ sub load_container_tests {
 
     if (is_container_image_test()) {
         # Container Image tests
-        loadtest 'containers/host_configuration' unless (is_res_host || is_ubuntu_host);
+        loadtest 'containers/host_configuration' unless (is_res_host || is_ubuntu_host || is_jeos);
         load_image_tests_podman() if ($runtime =~ 'podman');
         load_image_tests_docker() if ($runtime =~ 'docker');
     } else {


### PR DESCRIPTION
This is just to skip this unnecessary module in JeOS container tests, e.g. https://openqa.opensuse.org/tests/2056841#step/host_configuration/1

Also, skip container_diff for host tests:
We have now split host tests from image tests, so this test doesn't
make sense any more in host tests as it compares released image
from totest image.



VR:
https://openqa.opensuse.org/tests/2056867
https://openqa.opensuse.org/tests/2056868