### PR TITLE
console/verify_no_separate_home: Use findmnt to get source devices

### DIFF
--- a/tests/console/verify_no_separate_home.pm
+++ b/tests/console/verify_no_separate_home.pm
@@ -12,15 +12,14 @@ use base "consoletest";
 use strict;
 use warnings FATAL => 'all';
 use testapi;
+use Test::Assert 'assert_equals';
 
 sub run {
     select_console 'root-console';
 
-    assert_script_run("! lsblk -n | grep '/home'",
-        fail_message => "Fail!\n
-        Expected: /home is NOT on separate partition/volume.\n
-        Actual: /home is on separate partition/volume."
-    );
+    my $root_device = script_output("findmnt -nrvo SOURCE -T /");
+    my $home_device = script_output("findmnt -nrvo SOURCE -T /home");
+    assert_equals($root_device, $home_device, "/home is on a separate partition");
 }
 
 1;


### PR DESCRIPTION
Use findmnt to query the source device for the given mountpoints and
compare them. lsblk focuses mainly on devices, and with the new MOUNTPOINT(s)
column behaviour, doing the check is harder.

- Related ticket: https://progress.opensuse.org/issues/102795
- Verification run: https://openqa.opensuse.org/tests/2057135 (WIP)
