### PR TITLE
Handle dasd activation via libyui-rest-api

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -17,6 +17,7 @@ use Installation::ClockAndTimeZone::ClockAndTimeZoneController;
 use Installation::DiskActivation::DiskActivationController;
 use Installation::DiskActivation::ConfiguredZFCPDevicesController;
 use Installation::DiskActivation::AddZFCPDeviceController;
+use Installation::DiskActivation::DASDDiskManagementController;
 use Installation::LanguageKeyboard::LanguageKeyboardController;
 use Installation::License::Opensuse::Firstboot::LicenseAgreementController;
 use Installation::License::Opensuse::LicenseAgreementController;
@@ -176,6 +177,10 @@ sub get_configured_zfcp_devices {
 
 sub get_add_new_zfcp_device {
     return Installation::DiskActivation::AddZFCPDeviceController->new();
+}
+
+sub get_dasd_disk_management {
+    return Installation::DiskActivation::DASDDiskManagementController->new();
 }
 
 1;

--- a/lib/Installation/DiskActivation/DASDDiskManagementController.pm
+++ b/lib/Installation/DiskActivation/DASDDiskManagementController.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This class introduces business actions for DASD Disk Management page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::DiskActivation::DASDDiskManagementController;
+use strict;
+use warnings;
+use Installation::DiskActivation::DASDDiskManagementPage;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{DASDDiskManagementPage} = Installation::DiskActivation::DASDDiskManagementPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_dasd_disk_management_page {
+    my ($self) = @_;
+    die "DASD Disk Management page is not displayed" unless $self->{DASDDiskManagementPage}->is_shown();
+    return $self->{DASDDiskManagementPage};
+}
+
+sub filter_channel {
+    my ($self, $channel) = @_;
+    $self->get_dasd_disk_management_page()->enter_minimum_channel($channel);
+    $self->get_dasd_disk_management_page()->enter_maximum_channel($channel);
+    $self->get_dasd_disk_management_page()->press_filter_button();
+}
+
+sub activate_device {
+    my ($self, $channel) = @_;
+    $self->get_dasd_disk_management_page()->select_device($channel);
+    $self->get_dasd_disk_management_page()->perform_action_activate();
+}
+
+sub accept_configuration {
+    my ($self) = @_;
+    $self->get_dasd_disk_management_page()->press_next();
+}
+
+1;

--- a/lib/Installation/DiskActivation/DASDDiskManagementPage.pm
+++ b/lib/Installation/DiskActivation/DASDDiskManagementPage.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles DASD Disk Management page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::DiskActivation::DASDDiskManagementPage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->{tbx_minimum_channel} = $self->{app}->textbox({id => 'min_chan'});
+    $self->{tbx_maximum_channel} = $self->{app}->textbox({id => 'max_chan'});
+    $self->{btn_filter} = $self->{app}->button({id => 'filter'});
+    $self->{tbl_devices} = $self->{app}->table({id => 'table'});
+    $self->{mco_operation} = $self->{app}->menucollection({id => 'operation'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{mco_operation}->exist();
+}
+
+sub enter_minimum_channel {
+    my ($self, $channel) = @_;
+    return $self->{tbx_minimum_channel}->set($channel);
+}
+
+sub enter_maximum_channel {
+    my ($self, $channel) = @_;
+    return $self->{tbx_maximum_channel}->set($channel);
+}
+
+sub press_filter_button {
+    my ($self) = @_;
+    return $self->{btn_filter}->click();
+}
+
+sub get_devices {
+    my ($self) = @_;
+    return $self->{tbl_devices}->items();
+}
+
+sub select_device {
+    my ($self, $channel) = @_;
+    return $self->{tbl_devices}->select(value => $channel);
+}
+
+sub perform_action_activate {
+    my ($self) = @_;
+    $self->{mco_operation}->select('Activate');
+}
+
+1;

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -11,7 +11,9 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - installation/disk_activation
+  - installation/disk_activation/select_configure_dasd_disks
+  - installation/disk_activation/configure_dasd
+  - installation/disk_activation/finish_disk_activation
   - installation/registration/register_via_scc
   - installation/module_selection/select_module_desktop
   - installation/add_on_product/skip_install_addons

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -12,7 +12,9 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - installation/disk_activation
+  - installation/disk_activation/select_configure_dasd_disks
+  - installation/disk_activation/configure_dasd
+  - installation/disk_activation/finish_disk_activation
   - installation/registration/register_via_scc
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -16,7 +16,9 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - installation/disk_activation
+  - installation/disk_activation/select_configure_dasd_disks
+  - installation/disk_activation/configure_dasd
+  - installation/disk_activation/finish_disk_activation
   - installation/registration/register_via_scc
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -20,7 +20,9 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - installation/disk_activation
+  - installation/disk_activation/select_configure_dasd_disks
+  - installation/disk_activation/configure_dasd
+  - installation/disk_activation/finish_disk_activation
   - installation/registration/skip_registration
   - installation/addon_products_sle
   - installation/system_role/accept_selected_role_SLES_with_GNOME

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -10,7 +10,6 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - '{{disk_activation}}'
   - installation/registration/register_via_scc
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons

--- a/schedule/yast/textmode/textmode@s390x.yaml
+++ b/schedule/yast/textmode/textmode@s390x.yaml
@@ -10,7 +10,9 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - installation/disk_activation
+  - installation/disk_activation/select_configure_dasd_disks
+  - installation/disk_activation/configure_dasd
+  - installation/disk_activation/finish_disk_activation
   - installation/registration/register_via_scc
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons

--- a/schedule/yast/xfs/xfs.yaml
+++ b/schedule/yast/xfs/xfs.yaml
@@ -13,8 +13,6 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  # Called only on BACKEND: s390x
-  - '{{disk_activation}}'
   - installation/registration/register_via_scc
   - installation/module_selection/select_module_desktop
   - installation/add_on_product/skip_install_addons
@@ -43,10 +41,6 @@ schedule:
   - console/validate_free_space
   - console/validate_read_write
 conditional_schedule:
-  disk_activation:
-    BACKEND:
-      s390x:
-        - installation/disk_activation
   hostname_inst:
     BACKEND:
       qemu:

--- a/schedule/yast/xfs/xfs@svirt-s390x.yaml
+++ b/schedule/yast/xfs/xfs@svirt-s390x.yaml
@@ -13,7 +13,9 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - installation/disk_activation
+  - installation/disk_activation/select_configure_dasd_disks
+  - installation/disk_activation/configure_dasd
+  - installation/disk_activation/finish_disk_activation
   - installation/registration/register_via_scc
   - installation/module_selection/select_module_desktop
   - installation/add_on_product/skip_install_addons

--- a/tests/installation/disk_activation/configure_dasd.pm
+++ b/tests/installation/disk_activation/configure_dasd.pm
@@ -1,0 +1,19 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Activates a device in DASD disk management page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    my $dasd_disk_management = $testapi::distri->get_dasd_disk_management();
+    $dasd_disk_management->activate_device('0.0.0150');
+    $dasd_disk_management->accept_configuration();
+}
+
+1;

--- a/tests/installation/disk_activation/select_configure_dasd_disks.pm
+++ b/tests/installation/disk_activation/select_configure_dasd_disks.pm
@@ -1,0 +1,18 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Selects DASD disk configuration in disk activation page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    my $disk_activation = $testapi::distri->get_disk_activation();
+    $disk_activation->configure_dasd_disks();
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/98970
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/overview?build=ge0r%2Fos-autoinst-distri-opensuse%23activate_dasd&distri=sle&version=15-SP4
