### PR TITLE
Configurable timeout for prepare_test_data

### DIFF
--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -20,8 +20,10 @@ use warnings;
 sub run {
     is_ipmi ? use_ssh_serial_console : select_console 'root-console';
 
+    my $timeout = get_var('PREPARE_TEST_DATA_TIMEOUT', 300);
+
     select_console 'user-console';
-    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " | cpio -id", timeout => 300;
+    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " | cpio -id", timeout => $timeout;
     script_run "ls -al data";
 }
 

--- a/variables.md
+++ b/variables.md
@@ -245,3 +245,4 @@ ZFCP_ADAPTERS | string | | Comma separated list of available ZFCP adapters in th
 LINUXRC_BOOT | boolean | true | To be used only in scenarios where we are booting an installed system from the installer medium (for example, a DVD) with the menu option "Boot Linux System" (not "boot From Hard Disk"). This option uses linuxrc.
 ZYPPER_WHITELISTED_ORPHANS | string | empty | Whitelist expected orphaned packages, do not fail if any are found. Upgrade scenarios are expecting orphans by default. Used by console/orphaned_packages_check.pm
 PUBLIC_CLOUD_CONTAINER_IMAGES_REPO | string | | The Container images repository in CSP
+PREPARE_TEST_DATA_TIMEOUT | integer | 300 | Download assets in the prepare_test_data module timeout


### PR DESCRIPTION
Sometimes the amount of data to the test is big and the curl downloading
process is interrupted by the timeout

https://progress.opensuse.org/issues/102569

- Related ticket: https://progress.opensuse.org/issues/103119
- Verification run: https://openqa.suse.de/tests/7748904
