### PR TITLE
Fix firewalld_policy_objects on Tumbleweed

### DIFF
--- a/tests/network/firewalld_policy_objects.pm
+++ b/tests/network/firewalld_policy_objects.pm
@@ -48,7 +48,7 @@ my $CLI_IP = '10.0.3.102';
 sub set_ip {
     my ($ip, $nic) = @_;
     script_run "arping -w 1 -I $nic $ip";    # check for duplicate IP
-    assert_script_run "echo \"STARTMODE='auto'\nBOOTPROTO='static'\nIPADDR='$ip/24'\nMTU='1458'\" > /etc/sysconfig/network/ifcfg-$nic";
+    assert_script_run "echo -e \"STARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip/24'\\nMTU='1458'\" > /etc/sysconfig/network/ifcfg-$nic";
     assert_script_run "rcnetwork restart";
     assert_script_run "ip addr";
 }


### PR DESCRIPTION
network/firewalld_policy_objects: Workaround bug in --runtime-to-permanent

It fails to write a runtime zone change to the permanent config:
firewalld/firewalld#890

network/firewalld_policy_objects: Escape newlines properly 

Otherwise the serial match fails.

- Related ticket: https://progress.opensuse.org/issues/101990
- Verification run:

firewalld-policy-firewall: https://openqa.opensuse.org/t2058162
firewalld-policy-server: https://openqa.opensuse.org/t2058163
firewalld-policy-client: https://openqa.opensuse.org/t2058164