### PR TITLE
Enable bci-tests on Ubuntu and CentOS

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -27,22 +27,29 @@ use testapi;
 
 
 sub packages_to_install {
-    my $host_version = get_required_var('HOST_VERSION');
-    $host_version =~ s/-SP/./;
+    my ($version, $sp, $host_distri) = @_;
     my $arch = get_required_var('ARCH');
-
     # common packages
-    my @packages = ('git-core', 'python3', 'python3-devel', 'gcc');
-    if ($host_version eq "12.5") {
-        push @packages, 'python36-pip';
-    } elsif ($host_version eq '15') {
-        assert_script_run("SUSEConnect -p PackageHub/15/$arch");
-        push @packages, ('go1.10', 'skopeo');
-    } elsif ($host_version =~ /15\./) {
-        # Desktop module is needed for SDK module, which is required for installing go
-        assert_script_run("SUSEConnect -p sle-module-desktop-applications/$host_version/$arch");
-        assert_script_run("SUSEConnect -p sle-module-development-tools/$host_version/$arch");
-        push @packages, ('go', 'skopeo');
+    my @packages = ('git-core', 'python3', 'gcc');
+    if ($host_distri eq 'ubuntu') {
+        push @packages, ('python3-dev', 'python3-pip', 'golang');
+    } elsif ($host_distri eq 'centos') {
+        push @packages, ('python3-devel', 'python3-pip', 'golang');
+    } elsif ($host_distri eq 'sles') {
+        my $version = "$version.$sp";
+        push @packages, 'python3-devel';
+        if ($version eq "12.5") {
+            push @packages, 'python36-pip';
+        } elsif ($version eq '15.0') {
+            # On SLES15 go needs to be installed from packagehub. On later SLES it comes from the SDK module
+            assert_script_run("SUSEConnect -p PackageHub/15/$arch");
+            push @packages, ('go1.10', 'skopeo');
+        } else {
+            # Desktop module is needed for SDK module, which is required for installing go
+            assert_script_run("SUSEConnect -p sle-module-desktop-applications/$version/$arch");
+            assert_script_run("SUSEConnect -p sle-module-development-tools/$version/$arch");
+            push @packages, ('go', 'skopeo');
+        }
     } else {
         die("Host is not supported for running BCI tests.");
     }
@@ -57,9 +64,11 @@ sub run {
     my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
     my $bci_tests_branch = get_var('BCI_TESTS_BRANCH');
 
-    ensure_ca_certificates_suse_installed;
+    my ($version, $sp, $host_distri) = get_os_release;
 
-    my ($running_version, $sp, $host_distri) = get_os_release;
+    # Our Ubuntu and CentOS images have the SUSE_Trust_Root.crt already installed
+    ensure_ca_certificates_suse_installed unless ($host_distri =~ /ubuntu|centos/);
+
     if ($engine eq 'podman') {
         install_podman_when_needed($host_distri);
         install_buildah_when_needed($host_distri);
@@ -72,13 +81,29 @@ sub run {
     }
 
     record_info('Install', 'Install needed packages');
-    my @packages = packages_to_install();
-    foreach my $pkg (@packages) {
-        record_info('pkg', $pkg);
-        zypper_call("--quiet in $pkg", timeout => 300);
+    my @packages = packages_to_install($version, $sp, $host_distri);
+    if ($host_distri eq 'ubuntu') {
+        assert_script_run("apt-get update", timeout => 600);
+        foreach my $pkg (@packages) {
+            assert_script_run("apt-get -y install $pkg", timeout => 300);
+        }
+        assert_script_run('pip3 --quiet install --upgrade pip', timeout => 600);
+        assert_script_run("pip3 --quiet install tox", timeout => 600);
+    } elsif ($host_distri eq 'centos') {
+        assert_script_run("yum update -y --allowerasing", timeout => 600);
+        foreach my $pkg (@packages) {
+            assert_script_run("yum install -y $pkg", timeout => 300);
+        }
+        assert_script_run('pip3 --quiet install --upgrade pip', timeout => 600);
+        assert_script_run("pip3 --quiet install tox", timeout => 600);
+    } elsif ($host_distri eq 'sles') {
+        zypper_call("--quiet up", timeout => 600);
+        foreach my $pkg (@packages) {
+            zypper_call("--quiet in $pkg", timeout => 300);
+        }
+        assert_script_run('pip3.6 --quiet install --upgrade pip', timeout => 600);
+        assert_script_run("pip3.6 --quiet install tox --ignore-installed six", timeout => 600);
     }
-    assert_script_run('pip3.6 --quiet install --upgrade pip', timeout => 600);
-    assert_script_run("pip3.6 --quiet install tox --ignore-installed six", timeout => 600);
 
     record_info('Clone', "Clone BCI tests repository: $bci_tests_repo");
     my $branch = $bci_tests_branch ? "-b $bci_tests_branch" : '';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/98183


[VRs](http://fromm.arch.suse.de/tests/overview?distri=sle&version=15-SP3&build=17.8.36&groupid=41&test=bci_on_centos_8_host_docker&test=bci_on_centos_8_host_podman&test=bci_on_ubuntu_20.04_host_docker&test=bci_on_ubuntu_20.04_host_podman)
