### PR TITLE
Containers: Test podman and docker with firewall and check connectivity

### DIFF
--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -9,9 +9,10 @@
 package containers::podman;
 use Mojo::Base 'containers::engine';
 use testapi;
-use containers::utils qw(registry_url);
+use containers::utils qw(registry_url container_ip);
 use containers::common qw(install_podman_when_needed);
 use utils qw(file_content_replace);
+use Utils::Systemd 'systemctl';
 use version_utils qw(get_os_release);
 has runtime => "podman";
 
@@ -28,6 +29,29 @@ sub configure_insecure_registries {
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
     file_content_replace("/etc/containers/registries.conf", REGISTRY => $registry);
+}
+
+sub check_containers_connectivity {
+    record_info "connectivity", "Checking that containers can connect to the host, to each other and outside of the host";
+    my $container_name = 'sut_container';
+
+    # Run container in the background
+    assert_script_run "podman pull " . registry_url('alpine');
+    assert_script_run "podman run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
+    my $container_ip = container_ip $container_name, 'podman';
+
+    # Connectivity to host check
+    my $default_route = script_output "podman run " . registry_url('alpine') . " ip route show default | awk \'/default/ {print \$3}\'";
+    assert_script_run "podman run --rm " . registry_url('alpine') . " ping -c3 " . $default_route;
+
+    # Cross-container connectivity check
+    assert_script_run "podman run --rm " . registry_url('alpine') . " ping -c3 " . $container_ip;
+
+    # Outside connectivity check
+    assert_script_run "podman run --rm " . registry_url('alpine') . " wget google.com";
+
+    # Kill the container running on background
+    assert_script_run "podman kill $container_name";
 }
 
 1;

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -20,7 +20,7 @@ use warnings;
 use version_utils;
 use Mojo::Util 'trim';
 
-our @EXPORT = qw(test_seccomp basic_container_tests get_vars can_build_sle_base check_docker_firewall
+our @EXPORT = qw(test_seccomp basic_container_tests get_vars can_build_sle_base
   get_docker_version check_runtime_version container_ip registry_url);
 
 sub test_seccomp {
@@ -38,29 +38,6 @@ sub test_seccomp {
     else {
         record_info('seccomp', 'Docker Engine supports seccomp');
     }
-}
-
-sub check_docker_firewall {
-    my $container_name = 'sut_container';
-    my $docker_version = get_docker_version();
-    systemctl('is-active firewalld');
-    my $running = script_output qq(docker ps -q | wc -l);
-    validate_script_output('ip a s docker0', sub { /state DOWN/ }) if $running == 0;
-    # Docker zone is created for docker version >= 20.10 (Tumbleweed), but it
-    # is backported to docker 19 for SLE15-SP3 and for Leap 15.3
-    if (check_runtime_version($docker_version, ">=20.10") || is_sle('>=15-sp3') || is_leap(">=15.3")) {
-        assert_script_run "firewall-cmd --list-all --zone=docker";
-        validate_script_output "firewall-cmd --list-interfaces --zone=docker", sub { /docker0/ };
-    }
-    # Rules applied before DOCKER. Default is to listen to all tcp connections
-    # ex. output: "1           0        0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0"
-    validate_script_output "iptables -L DOCKER-USER -nvx --line-numbers", sub { /1.+all.+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0/ };
-    assert_script_run "docker run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine');
-    my $container_ip = container_ip($container_name, 'docker');
-    # Each running container should have added a new entry to the DOCKER zone.
-    # ex. output: "1           0        0 ACCEPT     tcp  --  !docker0 docker0  0.0.0.0/0            172.17.0.2           tcp dpt:1234"
-    validate_script_output "iptables -L DOCKER -nvx --line-numbers", sub { /1.+ACCEPT.+!docker0 docker0.+$container_ip\s+tcp dpt:1234/ };
-    assert_script_run "docker kill $container_name ";
 }
 
 sub get_docker_version {

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -59,6 +59,7 @@ sub load_host_tests_podman {
         loadtest 'containers/podman';
         loadtest 'containers/podman_image';
         loadtest 'containers/podman_3rd_party_images';
+        loadtest 'containers/podman_firewall';
         loadtest 'containers/buildah';
         loadtest 'containers/rootless_podman';
     }
@@ -68,6 +69,7 @@ sub load_host_tests_docker {
     loadtest 'containers/docker';
     loadtest 'containers/docker_image';
     loadtest 'containers/docker_3rd_party_images';
+    loadtest 'containers/docker_firewall';
     unless (is_sle("<=15") && is_aarch64) {
         # these 2 packages are not avaiable for <=15 (aarch64 only)
         # zypper-docker is not available in factory

--- a/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
+++ b/schedule/jeos/sle/jeos-container-engines_and_tools.yaml
@@ -30,12 +30,14 @@ schedule:
     - console/zypper_ref
     - containers/podman
     - containers/podman_image
+    - containers/podman_3rd_party_images
+    - containers/podman_firewall
+    - containers/rootless_podman
     - containers/buildah
     - containers/docker
     - containers/docker_runc
     - containers/docker_image
     - containers/docker_3rd_party_images
-    - containers/podman_3rd_party_images
+    - containers/docker_firewall
     - containers/registry
     - containers/zypper_docker
-    - containers/rootless_podman

--- a/tests/containers/docker_firewall.pm
+++ b/tests/containers/docker_firewall.pm
@@ -1,0 +1,85 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: docker firewalld
+# Summary: Test docker with enabled firewall
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use utils 'script_retry';
+use version_utils qw(is_sle is_leap);
+use containers::utils qw(registry_url container_ip);
+use Utils::Systemd 'systemctl';
+
+my $stop_firewall = 0;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $engine = $self->containers_factory('docker');
+    my $container_name = 'sut_container';
+
+    # Test firewall only on systems where it's installed
+    die('Firewall is not present.') unless ($self->firewall() == 'firewalld' && script_run('which ' . $self->firewall()) == 0);
+
+    # Start firewall if it was not running before
+    if (script_run('systemctl is-active ' . $self->firewall()) != 0) {
+        systemctl('start ' . $self->firewall());
+        systemctl('restart docker');
+        $stop_firewall = 1;
+    }
+
+    # Network interface docker0 is DOWN when no containers are running
+    die 'No containers should be running!' if (script_output('docker ps -q | wc -l') != 0);
+    validate_script_output('ip a s docker0', sub { /state DOWN/ });
+
+    # Docker zone is created for docker version >= 20.10 (Tumbleweed), but it
+    # is backported to docker 19 for SLE15-SP3 and for Leap 15.3
+    unless (is_sle('<15-sp3') || is_leap("<15.3")) {
+        assert_script_run "firewall-cmd --list-all --zone=docker";
+        validate_script_output "firewall-cmd --list-interfaces --zone=docker", sub { /docker0/ };
+        validate_script_output "firewall-cmd --get-active-zones", sub { /docker/ };
+    }
+    # Rules applied before DOCKER. Default is to listen to all tcp connections
+    # ex. output: "1           0        0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0"
+    validate_script_output "iptables -L DOCKER-USER -nvx --line-numbers", sub { /1.+all.+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0/ };
+
+    # Run container in the background
+    assert_script_run "docker run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
+    my $container_ip = container_ip($container_name, 'docker');
+
+    # Each running container should have added a new entry to the DOCKER zone.
+    # ex. output: "1           0        0 ACCEPT     tcp  --  !docker0 docker0  0.0.0.0/0            172.17.0.2           tcp dpt:1234"
+    validate_script_output "iptables -L DOCKER -nvx --line-numbers", sub { /1.+ACCEPT.+!docker0 docker0.+$container_ip\s+tcp dpt:1234/ };
+
+    # Kill the container running on background (this may take some time)
+    assert_script_run "docker kill $container_name ";
+    script_retry "docker ps -q | wc -l | grep 0", delay => 5, retry => 12;
+
+    # Test the connectivity of Docker containers
+    $engine->check_containers_connectivity();
+
+    # Stop the firewall if it was started by this test module
+    if ($stop_firewall == 1) {
+        systemctl('stop ' . $self->firewall());
+        systemctl('restart docker');
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    # Stop the firewall if it was started by this test module
+    if ($stop_firewall == 1) {
+        systemctl('stop ' . $self->firewall());
+        systemctl('restart docker');
+    }
+
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/containers/podman.pm
+++ b/tests/containers/podman.pm
@@ -34,6 +34,9 @@ sub run {
     my $dir = "/root/DockerTest";
     my $podman = $self->containers_factory('podman');
 
+    # Test the connectivity of Docker containers
+    $podman->check_containers_connectivity();
+
     # Run basic runtime tests
     basic_container_tests(runtime => $podman->runtime);
     # Build an image from Dockerfile and run it

--- a/tests/containers/podman_firewall.pm
+++ b/tests/containers/podman_firewall.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: podman firewalld
+# Summary: Test podman with enabled firewall
+# Maintainer: qac team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use utils 'script_retry';
+use containers::utils qw(registry_url container_ip);
+use Utils::Systemd 'systemctl';
+
+my $stop_firewall = 0;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $podman = $self->containers_factory('podman');
+    my $container_name = 'sut_container';
+
+    # Test firewall only on systems where it's installed
+    die('Firewall is not present.') unless ($self->firewall() == 'firewalld' && script_run('which ' . $self->firewall()) == 0);
+
+    # Start firewall if it was not running before
+    if (script_run('systemctl is-active ' . $self->firewall()) != 0) {
+        systemctl('start ' . $self->firewall());
+        $stop_firewall = 1;
+    }
+
+    # cni-podman0 interface is created when running the first container
+    assert_script_run "podman pull " . registry_url('alpine');
+    assert_script_run "podman run --rm " . registry_url('alpine');
+    validate_script_output('ip a s cni-podman0', sub { /,UP/ });
+
+    # Run container in the background
+    assert_script_run "podman pull " . registry_url('alpine');
+    assert_script_run "podman run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
+
+    # Cheking rules of specific running container
+    validate_script_output("iptables -vn -t nat -L PREROUTING", sub { /CNI-HOSTPORT-DNAT/ });
+    validate_script_output("iptables -vn -t nat -L POSTROUTING", sub { /CNI-HOSTPORT-MASQ/ });
+
+    # Kill the container running on background (this may take some time)
+    assert_script_run "podman kill $container_name ";
+    script_retry "podman ps -q | wc -l | grep 0", delay => 5, retry => 12;
+
+    # Test the connectivity of Podman containers
+    $podman->check_containers_connectivity();
+
+    # Stop the firewall if it was started by this test module
+    systemctl('stop ' . $self->firewall()) if $stop_firewall;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    # Stop the firewall if it was started by this test module
+    systemctl('stop ' . $self->firewall()) if $stop_firewall;
+
+    $self->SUPER::post_fail_hook;
+}
+
+1;


### PR DESCRIPTION
This pull request:
 * Extends `check_docker_firewall()` also for Podman
 * Introduces `check_container_connectivity()`
 * Introduced `podman_firewall` and `docker_firewall` test modules

This restores 3ac053b introduced in #13666 reverted by #13744 due to bug

- Related ticket: [poo#94132](https://progress.opensuse.org/issues/94132)
- Verification run: The verification runs have been updated: [SLE12-SP3-Docker](http://pdostal-server.suse.cz/tests/12979), [MicroOS-ContainerHost](http://pdostal-server.suse.cz/tests/12976), [JeOS15-SP3-Containers](http://pdostal-server.suse.cz/tests/12977), [SLE15-SP3-Podman](http://pdostal-server.suse.cz/tests/12978), [SLE15-SP3-Docker](http://pdostal-server.suse.cz/tests/12962), [Tumbleweed-Docker](http://pdostal-server.suse.cz/tests/12974), [Tumbleweed-Podman](http://pdostal-server.suse.cz/tests/12963)
