### PR TITLE
Adapt validate_blockdevices to newer version of lsblk

### DIFF
--- a/tests/console/validate_blockdevices.pm
+++ b/tests/console/validate_blockdevices.pm
@@ -13,17 +13,27 @@ use base "opensusebasetest";
 use testapi;
 
 use scheduler 'get_test_suite_data';
-use filesystem_utils 'validate_lsblk';
+use filesystem_utils qw(
+  validate_lsblk
+  is_lsblk_able_to_display_mountpoints);
 
 sub run {
     select_console('root-console');
     my $disks = get_test_suite_data()->{disks};
 
+    my $has_mountpoints_col = is_lsblk_able_to_display_mountpoints();
+
     my $errors;
     foreach my $disk (@{$disks}) {
-        $errors .= validate_lsblk(device => $disk, type => 'disk');
+        $errors .= validate_lsblk(
+            device => $disk,
+            type => 'disk',
+            has_mountpoints_col => $has_mountpoints_col);
         foreach my $part (@{$disk->{partitions}}) {
-            $errors .= validate_lsblk(device => $part, type => 'part');
+            $errors .= validate_lsblk(
+                device => $part,
+                type => 'part',
+                has_mountpoints_col => $has_mountpoints_col);
         }
     }
     die "Filesystem validation with lsblk failed:\n$errors" if $errors;


### PR DESCRIPTION
- Related ticket: [poo#102795](https://progress.opensuse.org/issues/102795)
- Verification run: [SLE](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23adapt_lsblk&version=15-SP4) | [openSUSE](https://openqa.opensuse.org/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%23adapt_lsblk&distri=opensuse)
