### PR TITLE
swtpmtest: Check the SHA256 PCR bank instead of SHA1

### DIFF
--- a/lib/swtpmtest.pm
+++ b/lib/swtpmtest.pm
@@ -30,7 +30,7 @@ my $guestvm_cfg = {
     swtpm_2 => {
         xml_file => {uefi => 'swtpm_uefi_2_0.xml', legacy => 'swtpm_legacy_2_0.xml'},
         version => '2.0',
-        expect_cmd => 'tpm2_pcrread sha1:0',
+        expect_cmd => 'tpm2_pcrread sha256:0',
     },
 };
 


### PR DESCRIPTION
swtpm 0.7.0 only enables SHA256 by default.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1192667
- Verification run: https://openqa.opensuse.org/tests/2062939

CC @rfan1