### PR TITLE
Fix yast2_migration wait import-untrusted-gpg-key timeout

### DIFF
--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -198,7 +198,7 @@ sub run {
     # migration via smt will install packagehub and NVIDIA compute, we need click trust
     # gpg keys; Same with leap to sle migration, need to trust packagehub gpg key.
     if (get_var('SMT_URL') =~ /smt/) {
-        assert_screen 'import-untrusted-gpg-key', 60;
+        assert_screen 'import-untrusted-gpg-key', 180;
         send_key 'alt-t';
         if ((is_x86_64) && (!(is_leap_migration)) || (is_aarch64)) {
             assert_screen 'import-untrusted-gpg-key-nvidia', 300;


### PR DESCRIPTION
On Aarch64 smt test, it can't wait for the import-untrusted-gpg-key
in 60 seconds. We need to wait a little longer to make it shown.

- Related ticket: https://progress.opensuse.org/issues/103245
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/7761552
  https://openqa.nue.suse.com/tests/7761554 