### PR TITLE
Check if snapper support disable-used-space or not

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2066,7 +2066,9 @@ sub cleanup_disk_space {
 
     record_soft_failure "bsc#1192331", "Low diskspace on Filesystem root";
 
-    my @snap_lists = split /\n/, script_output("snapper list --disable-used-space | grep important= | grep -v single | awk \'{print \$1}\'");
+    my $ret = script_run("snapper --help | grep disable-used-space");
+    my $disable = $ret ? '' : '--disable-used-space';
+    my @snap_lists = split /\n/, script_output("snapper list $disable | grep important= | grep -v single | awk \'{print \$1}\'");
     foreach my $snapid (@snap_lists) {
         assert_script_run("snapper delete -s $snapid", timeout => 120) if ($snapid > 3);
     }


### PR DESCRIPTION
In sle12sp5 the snapper list does not support --disable-used-space option, so we'd check if the 
system supports it or not before issue 'snapper list --disable-used-space'.

- Related ticket: https://progress.opensuse.org/issues/103275
- Needles: N/A
- Verification run: 
   https://openqa.nue.suse.com/tests/7761735
   https://openqa.nue.suse.com/tests/7761736

  more 12sp3/4 verify jobs
   https://openqa.nue.suse.com/tests/7766466
   https://openqa.nue.suse.com/tests/7766300
   https://openqa.nue.suse.com/tests/7766301