### PR TITLE
Disable openssl-nodejs single with exp cert

### DIFF
--- a/data/console/test_openssl_nodejs.sh
+++ b/data/console/test_openssl_nodejs.sh
@@ -154,6 +154,8 @@ skip_test=(
   ["14.15.1-6.3.1 test/sequential/test-tls-session-timeout.js SLE_12_SP5"]="skip"
   ["10.22.1-1.27.1 test/parallel/test-crypto-dh.js SLE_15"]="skip"
   ["10.22.1-1.27.1 test/parallel/test-crypto-dh.js SLE_15_SP1"]="skip"
+  ["10.24.1-1.36.1 test/parallel/test-tls-passphrase.js SLE_15"]="skip"
+  ["10.24.1-1.36.1 test/parallel/test-tls-passphrase.js SLE_15_SP1"]="skip"
 )
 
 # Common flags to use on each test


### PR DESCRIPTION

Disable openssl-nodejs single with expired certertificate


- Related ticket: https://progress.opensuse.org/issues/103002
- Needles: no needles
- Verification run:
  - 15-GA https://openqa.suse.de/tests/7761910#step/openssl_nodejs/9
  - 15-SP1 https://openqa.suse.de/tests/7761923#step/openssl_nodejs/9 
