### PR TITLE
Update expected warning list for Xen HVM

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -168,7 +168,7 @@
     "bsc#1187613": {
         "description": "kernel: Grant table initialized",
         "products": {
-            "sle": ["15-SP2", "15-SP3"]
+            "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
[Bug 1187613 - [xen] kernel: Grant table initialized](https://bugzilla.suse.com/show_bug.cgi?id=1187613)

- Failure: https://openqa.suse.de/tests/7758850#step/journal_check/5
