### PR TITLE
Add patch_sle after installation finished on zVM

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -129,7 +129,7 @@ sub deregister_dropped_modules {
 # https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-online.html#sec-upgrade-online-zypper
 sub disable_installation_repos {
     if (is_s390x) {
-        zypper_call "mr -d `zypper lr -u | awk '/ftp:.*?openqa.suse.de|10.160.0.100/ {print \$1}'`";
+        zypper_call "mr -d `zypper lr -u | awk '/ftp:.*?openqa.suse.de|10.160.0.207|10.160.0.100/ {print \$1}'`";
     }
     else {
         zypper_call "mr -d -l";

--- a/schedule/install/sles15_s390_install.yaml
+++ b/schedule/install/sles15_s390_install.yaml
@@ -1,0 +1,47 @@
+name:           sles15_s390_install
+description:    >
+    This is prepare install task before migration.
+schedule:
+  - installation/bootloader_s390
+  - installation/welcome
+  - installation/accept_license
+  - installation/disk_activation
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - '{{partitioning_filesystem}}'
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - '{{resolve_dependency}}'
+  - '{{select_patterns}}'
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - console/scc_deregistration
+  - update/patch_sle
+  - '{{install_service_test}}'
+conditional_schedule:
+  install_service_test:
+    REGRESSIONTEST:
+      1:
+        - installation/install_service
+  select_patterns:
+    PATTERNS:
+      all:
+        - installation/select_patterns
+  resolve_dependency:
+    RESOLVE_DEPENDENCY:
+      1:
+        - installation/resolve_dependency_issues
+  partitioning_filesystem:
+    SET_FILESYSTEM:
+      1:
+        - installation/partitioning_filesystem


### PR DESCRIPTION
We need add patch_sle after installation finished on zVM to do update and de-register modules to make migration process run well on z/VM.

- Related ticket: https://progress.opensuse.org/issues/103155
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/7761758#step/start_install/2  #the failure is for bsc#1193215
