### PR TITLE
Update Lynis baseline for x86_64

### DIFF
--- a/data/lynis/baseline-lynis-audit-system-nocolors-Tumbleweed-x86_64-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-Tumbleweed-x86_64-gnome
@@ -1,5 +1,5 @@
 
-[ Lynis 3.0.5 ]
+[ Lynis 3.0.6 ]
 
 ################################################################################
   Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
@@ -17,11 +17,11 @@
 [2C- Checking profiles...[37C [ DONE ]
 
   ---------------------------------------------------
-  Program version:           3.0.5
+  Program version:           3.0.6
   Operating system:          Linux
   Operating system name:     openSUSE
-  Operating system version:  20210703
-  Kernel version:            5.12.13
+  Operating system version:  20211129
+  Kernel version:            5.15.5
   Hardware platform:         x86_64
   Hostname:                  susetest
   ---------------------------------------------------
@@ -49,65 +49,24 @@
 [0C [0C
 [2C- Plugins enabled[42C [ NONE ]
 
-=================================================================
-
-  Exception found!
-
-  Function/test:  [GetHostID]
-  Message:        Can't create hostid (no MAC addresses found)
-
-  Help improving the Lynis community with your feedback!
-
-  Steps:
-  - Ensure you are running the latest version (/usr/bin/lynis update check)
-  - If so, create a GitHub issue at https://github.com/CISOfy/lynis
-  - Include relevant parts of the log file or configuration file
-
-  Thanks!
-
-=================================================================
-
-
-=================================================================
-
-  Exception found!
-
-  Function/test:  [GetHostID]
-  Message:        Can't create HOSTID, command ip not found
-
-  Help improving the Lynis community with your feedback!
-
-  Steps:
-  - Ensure you are running the latest version (/usr/bin/lynis update check)
-  - If so, create a GitHub issue at https://github.com/CISOfy/lynis
-  - Include relevant parts of the log file or configuration file
-
-  Thanks!
-
-=================================================================
-
-
 [+] Boot and services
 ------------------------------------
-
-  [WARNING]: Test CORE-1000 had a long execution: 19.703842 seconds
-
 [2C- Service Manager[42C [ systemd ]
 [2C- Checking UEFI boot[39C [ DISABLED ]
 [2C- Checking presence GRUB2[34C [ FOUND ]
 [4C- Checking for password protection[23C [ NONE ]
 [2C- Check running services (systemctl)[23C [ DONE ]
-[8CResult: found 32 running services[20C
+[8CResult: found 33 running services[20C
 [2C- Check enabled services at boot (systemctl)[15C [ DONE ]
 [8CResult: found 26 enabled services[20C
 [2C- Check startup files (permissions)[24C [ OK ]
 [2C- Running 'systemd-analyze security'[23C
 [8C- ModemManager.service:[30C [ MEDIUM ]
 [8C- NetworkManager.service:[28C [ EXPOSED ]
-[8C- accounts-daemon.service:[27C [ UNSAFE ]
+[8C- accounts-daemon.service:[27C [ EXPOSED ]
 [8C- after-local.service:[31C [ UNSAFE ]
 [8C- alsa-state.service:[32C [ UNSAFE ]
-[8C- appstream-sync-cache.service:[22C [ UNSAFE ]
+[8C- appstream-sync-cache.service:[22C [ MEDIUM ]
 [8C- auditd.service:[36C [ EXPOSED ]
 [8C- avahi-daemon.service:[30C [ UNSAFE ]
 [8C- chronyd.service:[35C [ EXPOSED ]
@@ -123,15 +82,17 @@
 [8C- getty@tty1.service:[32C [ UNSAFE ]
 [8C- getty@tty6.service:[32C [ UNSAFE ]
 [8C- getty@tty7.service:[32C [ UNSAFE ]
-[8C- gpm.service:[39C [ UNSAFE ]
+[8C- gpm.service:[39C [ EXPOSED ]
 [8C- haveged.service:[35C [ MEDIUM ]
 [8C- irqbalance.service:[32C [ MEDIUM ]
+[8C- lvm2-lvmpolld.service:[29C [ UNSAFE ]
 [8C- mcelog.service:[36C [ UNSAFE ]
 [8C- nscd.service:[38C [ UNSAFE ]
-[8C- pcscd.service:[37C [ UNSAFE ]
+[8C- pcscd.service:[37C [ EXPOSED ]
 [8C- plymouth-start.service:[28C [ UNSAFE ]
 [8C- polkit.service:[36C [ UNSAFE ]
 [8C- postfix.service:[35C [ UNSAFE ]
+[8C- power-profiles-daemon.service:[21C [ EXPOSED ]
 [8C- rc-local.service:[34C [ UNSAFE ]
 [8C- rescue.service:[36C [ UNSAFE ]
 [8C- rtkit-daemon.service:[30C [ MEDIUM ]
@@ -140,7 +101,7 @@
 [8C- serial-getty@ttyS0.service:[24C [ UNSAFE ]
 [8C- serial-getty@ttyS1.service:[24C [ UNSAFE ]
 [8C- serial-getty@ttyS2.service:[24C [ UNSAFE ]
-[8C- smartd.service:[36C [ UNSAFE ]
+[8C- smartd.service:[36C [ EXPOSED ]
 [8C- snapperd.service:[34C [ MEDIUM ]
 [8C- sshd.service:[38C [ UNSAFE ]
 [8C- systemd-ask-password-console.service:[14C [ UNSAFE ]
@@ -151,6 +112,7 @@
 [8C- systemd-rfkill.service:[28C [ UNSAFE ]
 [8C- systemd-timesyncd.service:[25C [ PROTECTED ]
 [8C- systemd-udevd.service:[29C [ MEDIUM ]
+[8C- tuned.service:[37C [ UNSAFE ]
 [8C- udisks2.service:[35C [ UNSAFE ]
 [8C- upower.service:[36C [ PROTECTED ]
 [8C- user@0.service:[36C [ UNSAFE ]
@@ -165,7 +127,7 @@
 [2C- Checking kernel version and release[22C [ DONE ]
 [2C- Checking kernel type[37C [ DONE ]
 [2C- Checking loaded kernel modules[27C [ DONE ]
-[6CFound 102 active modules[31C
+[6CFound 86 active modules[32C
 [2C- Checking Linux kernel configuration file[17C [ FOUND ]
 [2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
 [2C- Checking core dumps configuration[24C
@@ -174,7 +136,7 @@
 [4C- 'hard' configuration in security/limits.conf[11C [ DEFAULT ]
 [4C- 'soft' configuration in security/limits.conf[11C [ DEFAULT ]
 [4C- Checking setuid core dumps configuration[15C [ DISABLED ]
-[2C- Check if reboot is needed[32C [ NO ]
+[2C- Check if reboot is needed[32C [ YES ]
 
 [+] Memory and Processes
 ------------------------------------
@@ -282,10 +244,10 @@
 [4C- Searching RPM package manager[26C [ FOUND ]
 [6C- Querying RPM package manager[25C
 
-  [WARNING]: Test PKGS-7308 had a long execution: 24.410926 seconds
+  [WARNING]: Test PKGS-7308 had a long execution: 23.399025 seconds
 
 
-  [WARNING]: Test PKGS-7328 had a long execution: 14.423750 seconds
+  [WARNING]: Test PKGS-7328 had a long execution: 12.376914 seconds
 
 [2C- Using Zypper to find vulnerable packages[17C [ NONE ]
 [2C- Checking package audit tool[30C [ INSTALLED ]
@@ -453,7 +415,7 @@
 [2C- Checking accounting information[26C [ NOT FOUND ]
 [2C- Checking sysstat accounting data[25C [ NOT FOUND ]
 [2C- Checking auditd[42C [ ENABLED ]
-[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit rules[35C [ SUGGESTION ]
 [4C- Checking audit configuration file[22C [ OK ]
 [4C- Checking auditd log file[31C [ FOUND ]
 
@@ -481,7 +443,7 @@
 ------------------------------------
 [2C- Checking presence AppArmor[31C [ FOUND ]
 [4C- Checking AppArmor status[31C [ ENABLED ]
-[8CFound 96 unconfined processes[24C
+[8CFound 95 unconfined processes[24C
 [2C- Checking presence SELinux[32C [ NOT FOUND ]
 [2C- Checking presence TOMOYO Linux[27C [ NOT FOUND ]
 [2C- Checking presence grsecurity[29C [ NOT FOUND ]
@@ -506,7 +468,7 @@
 [+] File Permissions
 ------------------------------------
 [2C- Starting file permissions check[26C
-[4CFile: /boot/grub2/grub.cfg[31C [ OK ]
+[4CFile: /boot/grub2/grub.cfg[31C [ SUGGESTION ]
 [4CFile: /etc/cron.deny[37C [ OK ]
 [4CFile: /etc/crontab[39C [ OK ]
 [4CFile: /etc/group[41C [ OK ]
@@ -515,7 +477,6 @@
 [4CFile: /etc/hosts.deny[36C [ OK ]
 [4CFile: /etc/issue[41C [ SUGGESTION ]
 [4CFile: /etc/issue.net[37C [ OK ]
-[4CFile: /etc/motd[42C [ OK ]
 [4CFile: /etc/passwd[40C [ OK ]
 [4CFile: /etc/passwd-[39C [ OK ]
 [4CFile: /etc/hosts.equiv[35C [ OK ]
@@ -548,7 +509,6 @@
 [4C- kernel.modules_disabled (exp: 1)[23C [ DIFFERENT ]
 [4C- kernel.perf_event_paranoid (exp: 3)[20C [ DIFFERENT ]
 [4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
-[4C- kernel.suid_dumpable (exp: 0)[26C [ OK ]
 [4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
 [4C- kernel.unprivileged_bpf_disabled (exp: 1)[14C [ DIFFERENT ]
 [4C- net.core.bpf_jit_harden (exp: 2)[23C [ DIFFERENT ]
@@ -588,13 +548,15 @@
 
   [WARNING]: Deprecated function used (logtext)
 
-[4CWarning: Package iio-sensor-proxy-3.1-1.1.x86_64 installs an unknown D-BUS autostart/system service: net.hadess.SensorProxy.conf[0C [ WARNING ]
-[4CWarning: Package bluez-5.58-1.5.x86_64 installs an unknown D-BUS autostart/system service: org.bluez.service[0C [ WARNING ]
-[4CWarning: Package flatpak-1.11.2-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.Flatpak.SystemHelper.service[0C [ WARNING ]
-[4CWarning: Package bolt-0.9.1-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.bolt.service[0C [ WARNING ]
-[4CWarning: Package fwupd-1.5.8-1.3.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.fwupd.service[0C [ WARNING ]
-[4CWarning: Package systemd-248.3-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
-[4CWarning: Package snapper-0.9.0-6.1.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+[4CWarning: Package power-profiles-daemon-0.10.1-2.1.x86_64 installs an unknown D-BUS autostart/system service: net.hadess.PowerProfiles.conf[0C [ WARNING ]
+[4CWarning: Package iio-sensor-proxy-3.3-1.1.x86_64 installs an unknown D-BUS autostart/system service: net.hadess.SensorProxy.conf[0C [ WARNING ]
+[4CWarning: Package power-profiles-daemon-0.10.1-2.1.x86_64 installs an unknown D-BUS autostart/system service: net.hadess.PowerProfiles.service[0C [ WARNING ]
+[4CWarning: Package bluez-5.62-1.3.x86_64 installs an unknown D-BUS autostart/system service: org.bluez.service[0C [ WARNING ]
+[4CWarning: Package flatpak-1.12.2-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.Flatpak.SystemHelper.service[0C [ WARNING ]
+[4CWarning: Package bolt-0.9.1-2.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.bolt.service[0C [ WARNING ]
+[4CWarning: Package fwupd-1.6.4-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.fwupd.service[0C [ WARNING ]
+[4CWarning: Package systemd-249.7-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.9.0-7.1.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
 
   [WARNING]: Deprecated function used (wait_for_keypress)
 
@@ -621,7 +583,7 @@
 
   [WARNING]: Deprecated function used (logtext)
 
-[4CNo bad RPATH usage found in 7973 executables[13C [ OK ]
+[4CNo bad RPATH usage found in 8179 executables[13C [ OK ]
 
   [WARNING]: Deprecated function used (wait_for_keypress)
 
@@ -629,7 +591,7 @@
 [+] File systems
 ------------------------------------
 
-  [WARNING]: Test BINARY-1000 had a long execution: 63.736589 seconds
+  [WARNING]: Test BINARY-1000 had a long execution: 62.374736 seconds
 
 [2C- Starting look-up of symlinks in /tmp...[18C
 
@@ -683,18 +645,25 @@
 
 ================================================================================
 
-  -[ Lynis 3.0.5 Results ]-
+  -[ Lynis 3.0.6 Results ]-
 
-  Warnings (2):
+  Warnings (3):
   ----------------------------
+  ! Reboot of system is most likely needed [KRNL-5830] 
+    - Solution : reboot
+      https://cisofy.com/lynis/controls/KRNL-5830/
+
   ! Couldn't find 2 responsive nameservers [NETW-2705] 
       https://cisofy.com/lynis/controls/NETW-2705/
 
   ! iptables module(s) loaded, but no rules active [FIRE-4512] 
       https://cisofy.com/lynis/controls/FIRE-4512/
 
-  Suggestions (40):
+  Suggestions (42):
   ----------------------------
+  * This release is more than 4 months old. Check the website or GitHub to see if there is an update available. [LYNIS] 
+      https://cisofy.com/lynis/controls/LYNIS/
+
   * Set a password on GRUB boot loader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
       https://cisofy.com/lynis/controls/BOOT-5122/
 
@@ -809,6 +778,9 @@
   * Enable sysstat to collect accounting (no results) [ACCT-9626] 
       https://cisofy.com/lynis/controls/ACCT-9626/
 
+  * Audit daemon is enabled with an empty ruleset. Disable the daemon or define rules [ACCT-9630] 
+      https://cisofy.com/lynis/controls/ACCT-9630/
+
   * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
       https://cisofy.com/lynis/controls/FINT-4350/
 
@@ -842,8 +814,8 @@
 
   Lynis security scan details:
 
-  Hardening index : 82 [################    ]
-  Tests performed : 263
+  Hardening index : 81 [################    ]
+  Tests performed : 264
   Plugins enabled : 0
 
   Components:
@@ -873,7 +845,7 @@
 
 ================================================================================
 
-  Lynis 3.0.5
+  Lynis 3.0.6
 
   Auditing, system hardening, and compliance for UNIX-based systems
   (Linux, macOS, BSD, and others)

--- a/data/lynis/baseline-lynis-audit-system-nocolors-Tumbleweed-x86_64-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-Tumbleweed-x86_64-textmode
@@ -1,5 +1,5 @@
 
-[ Lynis 3.0.5 ]
+[ Lynis 3.0.6 ]
 
 ################################################################################
   Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
@@ -17,11 +17,11 @@
 [2C- Checking profiles...[37C [ DONE ]
 
   ---------------------------------------------------
-  Program version:           3.0.5
+  Program version:           3.0.6
   Operating system:          Linux
   Operating system name:     openSUSE
-  Operating system version:  20210703
-  Kernel version:            5.12.13
+  Operating system version:  20211129
+  Kernel version:            5.15.5
   Hardware platform:         x86_64
   Hostname:                  susetest
   ---------------------------------------------------
@@ -49,49 +49,8 @@
 [0C [0C
 [2C- Plugins enabled[42C [ NONE ]
 
-=================================================================
-
-  Exception found!
-
-  Function/test:  [GetHostID]
-  Message:        Can't create hostid (no MAC addresses found)
-
-  Help improving the Lynis community with your feedback!
-
-  Steps:
-  - Ensure you are running the latest version (/usr/bin/lynis update check)
-  - If so, create a GitHub issue at https://github.com/CISOfy/lynis
-  - Include relevant parts of the log file or configuration file
-
-  Thanks!
-
-=================================================================
-
-
-=================================================================
-
-  Exception found!
-
-  Function/test:  [GetHostID]
-  Message:        Can't create HOSTID, command ip not found
-
-  Help improving the Lynis community with your feedback!
-
-  Steps:
-  - Ensure you are running the latest version (/usr/bin/lynis update check)
-  - If so, create a GitHub issue at https://github.com/CISOfy/lynis
-  - Include relevant parts of the log file or configuration file
-
-  Thanks!
-
-=================================================================
-
-
 [+] Boot and services
 ------------------------------------
-
-  [WARNING]: Test CORE-1000 had a long execution: 17.226488 seconds
-
 [2C- Service Manager[42C [ systemd ]
 [2C- Checking UEFI boot[39C [ DISABLED ]
 [2C- Checking presence GRUB2[34C [ FOUND ]
@@ -99,7 +58,7 @@
 [2C- Check running services (systemctl)[23C [ DONE ]
 [8CResult: found 24 running services[20C
 [2C- Check enabled services at boot (systemctl)[15C [ DONE ]
-[8CResult: found 25 enabled services[20C
+[8CResult: found 24 enabled services[20C
 [2C- Check startup files (permissions)[24C [ OK ]
 [2C- Running 'systemd-analyze security'[23C
 [8C- after-local.service:[31C [ UNSAFE ]
@@ -129,7 +88,7 @@
 [8C- serial-getty@ttyS0.service:[24C [ UNSAFE ]
 [8C- serial-getty@ttyS1.service:[24C [ UNSAFE ]
 [8C- serial-getty@ttyS2.service:[24C [ UNSAFE ]
-[8C- smartd.service:[36C [ UNSAFE ]
+[8C- smartd.service:[36C [ EXPOSED ]
 [8C- snapperd.service:[34C [ MEDIUM ]
 [8C- sshd.service:[38C [ UNSAFE ]
 [8C- systemd-ask-password-console.service:[14C [ UNSAFE ]
@@ -155,7 +114,7 @@
 [2C- Checking kernel version and release[22C [ DONE ]
 [2C- Checking kernel type[37C [ DONE ]
 [2C- Checking loaded kernel modules[27C [ DONE ]
-[6CFound 101 active modules[31C
+[6CFound 86 active modules[32C
 [2C- Checking Linux kernel configuration file[17C [ FOUND ]
 [2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
 [2C- Checking core dumps configuration[24C
@@ -164,7 +123,7 @@
 [4C- 'hard' configuration in security/limits.conf[11C [ DEFAULT ]
 [4C- 'soft' configuration in security/limits.conf[11C [ DEFAULT ]
 [4C- Checking setuid core dumps configuration[15C [ DISABLED ]
-[2C- Check if reboot is needed[32C [ NO ]
+[2C- Check if reboot is needed[32C [ YES ]
 
 [+] Memory and Processes
 ------------------------------------
@@ -431,7 +390,7 @@
 [2C- Checking accounting information[26C [ NOT FOUND ]
 [2C- Checking sysstat accounting data[25C [ NOT FOUND ]
 [2C- Checking auditd[42C [ ENABLED ]
-[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit rules[35C [ SUGGESTION ]
 [4C- Checking audit configuration file[22C [ OK ]
 [4C- Checking auditd log file[31C [ FOUND ]
 
@@ -483,7 +442,7 @@
 [+] File Permissions
 ------------------------------------
 [2C- Starting file permissions check[26C
-[4CFile: /boot/grub2/grub.cfg[31C [ OK ]
+[4CFile: /boot/grub2/grub.cfg[31C [ SUGGESTION ]
 [4CFile: /etc/cron.deny[37C [ OK ]
 [4CFile: /etc/crontab[39C [ OK ]
 [4CFile: /etc/group[41C [ OK ]
@@ -492,7 +451,6 @@
 [4CFile: /etc/hosts.deny[36C [ OK ]
 [4CFile: /etc/issue[41C [ SUGGESTION ]
 [4CFile: /etc/issue.net[37C [ OK ]
-[4CFile: /etc/motd[42C [ OK ]
 [4CFile: /etc/passwd[40C [ OK ]
 [4CFile: /etc/passwd-[39C [ OK ]
 [4CFile: /etc/hosts.equiv[35C [ OK ]
@@ -525,7 +483,6 @@
 [4C- kernel.modules_disabled (exp: 1)[23C [ DIFFERENT ]
 [4C- kernel.perf_event_paranoid (exp: 3)[20C [ DIFFERENT ]
 [4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
-[4C- kernel.suid_dumpable (exp: 0)[26C [ OK ]
 [4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
 [4C- kernel.unprivileged_bpf_disabled (exp: 1)[14C [ DIFFERENT ]
 [4C- net.core.bpf_jit_harden (exp: 2)[23C [ DIFFERENT ]
@@ -565,8 +522,8 @@
 
   [WARNING]: Deprecated function used (logtext)
 
-[4CWarning: Package systemd-248.3-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
-[4CWarning: Package snapper-0.9.0-6.1.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
+[4CWarning: Package systemd-249.7-1.1.x86_64 installs an unknown D-BUS autostart/system service: org.freedesktop.timesync1.service[0C [ WARNING ]
+[4CWarning: Package snapper-0.9.0-7.1.x86_64 installs an unknown D-BUS autostart/system service: org.opensuse.Snapper.service[0C [ WARNING ]
 
   [WARNING]: Deprecated function used (wait_for_keypress)
 
@@ -593,7 +550,7 @@
 
   [WARNING]: Deprecated function used (logtext)
 
-[4CNo bad RPATH usage found in 4262 executables[13C [ OK ]
+[4CNo bad RPATH usage found in 4355 executables[13C [ OK ]
 
   [WARNING]: Deprecated function used (wait_for_keypress)
 
@@ -601,7 +558,7 @@
 [+] File systems
 ------------------------------------
 
-  [WARNING]: Test BINARY-1000 had a long execution: 30.047560 seconds
+  [WARNING]: Test BINARY-1000 had a long execution: 31.845813 seconds
 
 [2C- Starting look-up of symlinks in /tmp...[18C
 
@@ -654,18 +611,25 @@
 
 ================================================================================
 
-  -[ Lynis 3.0.5 Results ]-
+  -[ Lynis 3.0.6 Results ]-
 
-  Warnings (2):
+  Warnings (3):
   ----------------------------
+  ! Reboot of system is most likely needed [KRNL-5830] 
+    - Solution : reboot
+      https://cisofy.com/lynis/controls/KRNL-5830/
+
   ! Couldn't find 2 responsive nameservers [NETW-2705] 
       https://cisofy.com/lynis/controls/NETW-2705/
 
   ! iptables module(s) loaded, but no rules active [FIRE-4512] 
       https://cisofy.com/lynis/controls/FIRE-4512/
 
-  Suggestions (39):
+  Suggestions (41):
   ----------------------------
+  * This release is more than 4 months old. Check the website or GitHub to see if there is an update available. [LYNIS] 
+      https://cisofy.com/lynis/controls/LYNIS/
+
   * Set a password on GRUB boot loader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
       https://cisofy.com/lynis/controls/BOOT-5122/
 
@@ -777,6 +741,9 @@
   * Enable sysstat to collect accounting (no results) [ACCT-9626] 
       https://cisofy.com/lynis/controls/ACCT-9626/
 
+  * Audit daemon is enabled with an empty ruleset. Disable the daemon or define rules [ACCT-9630] 
+      https://cisofy.com/lynis/controls/ACCT-9630/
+
   * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
       https://cisofy.com/lynis/controls/FINT-4350/
 
@@ -810,7 +777,7 @@
 
   Lynis security scan details:
 
-  Hardening index : 81 [################    ]
+  Hardening index : 80 [################    ]
   Tests performed : 259
   Plugins enabled : 0
 
@@ -841,7 +808,7 @@
 
 ================================================================================
 
-  Lynis 3.0.5
+  Lynis 3.0.6
 
   Auditing, system hardening, and compliance for UNIX-based systems
   (Linux, macOS, BSD, and others)


### PR DESCRIPTION
New issues:
* Audit missing rules: boo#1191614#c2, fix is submitted
* False positive in reboot detection:
  https://github.com/CISOfy/lynis/issues/1241
* Insecure grub.cfg permissions: boo#1189644

CC @lilyeyes

Verification runs:
* gnome: https://openqa.opensuse.org/tests/2064154
* textmode: https://openqa.opensuse.org/tests/2064153

