### PR TITLE
Add luks2 as crypt_method for AutoYaST validation

### DIFF
--- a/test_data/yast/autoyast/profiles/resize_luks2.yaml
+++ b/test_data/yast/autoyast/profiles/resize_luks2.yaml
@@ -7,5 +7,5 @@ profile:
         disklabel: gpt
         partitions:
           partition:
-            crypt_method: luks1
+            crypt_method: luks2
             size: 5368709120


### PR DESCRIPTION
Fixes: https://openqa.suse.de/tests/7758418#step/verify_cloned_profile/6
Verification run: [autoyast_resize_luks2](https://openqa.suse.de/tests/7762505)
