### PR TITLE
Public Cloud: Specify 30G boot disk for Azure

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -182,9 +182,12 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
   }
 
   os_disk {
-    name              = "${var.name}-${element(random_id.service.*.hex, count.index)}-osdisk"
+    name                 = "${var.name}-${element(random_id.service.*.hex, count.index)}-osdisk"
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
+    # SLE images are 30G by default. Uncomment this line in case we need to increase the disk size
+    # note: value can not be decreased because 30 GB is minimum allowed by Azure
+    # disk_size_gb         = 30
   }
 
   source_image_id =  var.image_id != "" ? azurerm_image.image.0.id : null


### PR DESCRIPTION
Our SLES images are usually 30G by default:

```
Error: Code="OperationNotAllowed" Message="The specified disk size 20 GB is smaller than the size of the corresponding disk in the VM image: 30 GB. This is not allowed. Please choose equal or greater size or do not specify an explicit size." Target="osDisk.diskSizeGB"
```

As one cannot decreese the disk size this is the minimal value.
This is not the case for EC2 and GCE see 60f1490 merged in #13766

- Verification run: [SLES15-SP2-Azure-x86_64](http://pdostal-server.suse.cz/tests/12908)
