### PR TITLE
Modify cursor position for grub2.06 in xen-pv

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -305,7 +305,17 @@ sub run {
         }
         enter_cmd "echo e > \$pty";    # edit
 
-        my $max = (!is_jeos) ? 2 : (is_sle '<15-sp1') ? 4 : 13;
+        # move the cursor position in grub2 in order to append kernel command arguments
+        my $max = 2;
+        if (is_jeos) {
+            if (is_sle '<15-sp1') {
+                $max = 4;
+            } elsif (is_sle '15-sp4+') {
+                $max = 9;
+            } else {
+                $max = 13;
+            }
+        }
         enter_cmd "echo -en '\\033[B' > \$pty" for (1 .. $max);    # $max-times key down
         enter_cmd "echo -en '\\033[K' > \$pty";    # end of line
 


### PR DESCRIPTION
As the grub2 config has been slightly modified. The line with kernel
executable has a different position compared to previous service packs.
Leading to [screen
resolution](https://openqa.suse.de/tests/7758842#step/firstrun/9)
misconfiguration in sle15sp4 (only xen pv test suites).

#### Verification runs:
* [sle-15-SP2-JeOS-for-kvm-and-xen-Updates-x86_64-Build20211130-1-jeos-filesystem@svirt-xen-pv](http://kepler.suse.cz/tests/9283#step/firstrun/1)
* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20211130-1-jeos-filesystem@svirt-xen-pv](http://kepler.suse.cz/tests/9282#step/firstrun/1)
* [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build150400.1.156-jeos-filesystem@svirt-xen-pv](http://kepler.suse.cz/tests/9281#step/firstrun/1)