### PR TITLE
Fix test upload_image due to missing key_id/secret_id

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -19,7 +19,7 @@ has ssh_key_file => undef;
 has provider_client => undef;
 
 sub init {
-    my ($self, %params) = @_;
+    my ($self) = @_;
     $self->SUPER::init();
     $self->provider_client(publiccloud::aws_client->new(
             key_id => $self->key_id,
@@ -127,8 +127,8 @@ sub upload_img {
     # because we passing all needed info via params anyway
     assert_script_run('echo " " > /root/.ec2utils.conf');
 
-    assert_script_run("ec2uploadimg --access-id '" . $self->key_id
-          . "' -s '" . $self->key_secret . "' "
+    assert_script_run("ec2uploadimg --access-id '" . $self->provider_client->key_id
+          . "' -s '" . $self->provider_client->key_secret . "' "
           . "--backing-store ssd "
           . "--grub2 "
           . "--machine '" . $img_arch . "' "
@@ -165,8 +165,8 @@ sub img_proof {
     $args{user} //= 'ec2-user';
     $args{provider} //= 'ec2';
     $args{ssh_private_key_file} //= $self->ssh_key_file;
-    $args{key_id} //= $self->key_id;
-    $args{key_secret} //= $self->key_secret;
+    $args{key_id} //= $self->provider_client->key_id;
+    $args{key_secret} //= $self->provider_client->key_secret;
     $args{key_name} //= $self->ssh_key;
 
     return $self->run_img_proof(%args);

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -19,11 +19,26 @@ use utils;
 has storage_name => undef;
 has provider_client => undef;
 has project_id => undef;
+has account => undef;
+has service_acount_name => undef;
+has private_key_id => undef;
+has private_key => undef;
+has client_id => undef;
 
 sub init {
     my ($self, %params) = @_;
     $self->SUPER::init();
-    $self->provider_client(publiccloud::gcp_client->new(%params));
+    $self->provider_client(publiccloud::gcp_client->new(
+            key_id => $self->key_id,
+            key_secret => $self->key_secret,
+            region => $self->region,
+            account => $self->account,
+            service_acount_name => $self->service_acount_name,
+            project_id => $self->project_id,
+            private_key_id => $self->private_key_id,
+            private_key => $self->private_key,
+            client_id => $self->client_id
+    ));
     $self->provider_client->init();
 }
 
@@ -72,6 +87,8 @@ sub img_proof {
     $args{instance_type} //= 'n1-standard-2';
     $args{user} //= 'susetest';
     $args{provider} //= 'gce';
+    $args{key_id} //= $self->provider_client->key_id;
+    $args{key_secret} //= $self->provider_client->key_secret;
 
     return $self->run_img_proof(%args);
 }


### PR DESCRIPTION
From the split of k8s and provider some tests are in red because
a problem of duplicated variables key_id and key_secret

- Related ticket: https://progress.opensuse.org/issues/102972
- Verification run:
-- https://openqa.suse.de/tests/7767223 (EC2)
-- https://openqa.suse.de/tests/7767244 (GCE)
-- http://copland.arch.suse.de/tests/609 (GKE)
-- http://copland.arch.suse.de/tests/610 (EKS)