### PR TITLE
Apply existing test modules using YuiRestClient to openSUSE YaST schedules

### DIFF
--- a/schedule/yast/opensuse/btrfs/btrfs.yaml
+++ b/schedule/yast/opensuse/btrfs/btrfs.yaml
@@ -19,19 +19,20 @@ schedule:
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma
   - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/accept_default_fs_options
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_no_cow_attribute
   - console/verify_no_separate_home

--- a/schedule/yast/opensuse/btrfs/btrfs_textmode.yaml
+++ b/schedule/yast/opensuse/btrfs/btrfs_textmode.yaml
@@ -19,19 +19,20 @@ schedule:
   - installation/logpackages
   - installation/system_role/select_role_server
   - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/accept_default_fs_options
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_no_cow_attribute
   - console/verify_no_separate_home

--- a/schedule/yast/opensuse/ext3/ext3_textmode.yaml
+++ b/schedule/yast/opensuse/ext3/ext3_textmode.yaml
@@ -4,27 +4,34 @@ description:    >
   Test for ext3 filesystem in text mode.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/welcome
+  - '{{access_beta_distribution}}'
+  - installation/licensing/accept_license
   - installation/online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server
   - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/select_filesystem_option_ext3
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid
   - console/validate_blockdevices

--- a/schedule/yast/opensuse/ext4/ext4.yaml
+++ b/schedule/yast/opensuse/ext4/ext4.yaml
@@ -20,22 +20,22 @@ schedule:
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_GNOME
   - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/select_filesystem_option_ext4
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
-  - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/resolve_dependency_issues
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid
   - console/validate_blockdevices

--- a/schedule/yast/opensuse/ext4/ext4_textmode.yaml
+++ b/schedule/yast/opensuse/ext4/ext4_textmode.yaml
@@ -4,27 +4,34 @@ description:    >
   Test for ext4 filesystem in text mode.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/welcome
+  - '{{access_beta_distribution}}'
+  - installation/licensing/accept_license
   - installation/online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server
   - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/select_filesystem_option_ext4
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid
   - console/validate_blockdevices

--- a/schedule/yast/opensuse/installer_extended/installer_extended.yaml
+++ b/schedule/yast/opensuse/installer_extended/installer_extended.yaml
@@ -15,12 +15,10 @@ schedule:
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma
-  - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/opensuse/select_disk/select_disk.yaml
+++ b/schedule/yast/opensuse/select_disk/select_disk.yaml
@@ -21,19 +21,21 @@ schedule:
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma
   - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
+  - installation/partitioning/guided_setup/select_disks
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/accept_default_fs_options
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_first_disk_selection
 test_data:

--- a/schedule/yast/opensuse/xfs/xfs.yaml
+++ b/schedule/yast/opensuse/xfs/xfs.yaml
@@ -22,22 +22,22 @@ schedule:
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_GNOME
   - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/select_filesystem_option_xfs
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/disable_autologin
   - installation/authentication/default_user_simple_pwd
-  - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/resolve_dependency_issues
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid
   - console/validate_blockdevices

--- a/schedule/yast/opensuse/xfs/xfs_textmode.yaml
+++ b/schedule/yast/opensuse/xfs/xfs_textmode.yaml
@@ -6,27 +6,34 @@ description: >
   that the correct filesystem was installed.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/welcome
+  - '{{access_beta_distribution}}'
+  - installation/licensing/accept_license
   - installation/online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server
   - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/select_filesystem_option_xfs
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid
   - console/validate_blockdevices

--- a/tests/installation/partitioning/guided_setup/select_filesystem_option_ext3.pm
+++ b/tests/installation/partitioning/guided_setup/select_filesystem_option_ext3.pm
@@ -1,0 +1,17 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: The test module selects Ext3 Filesystem for Root Partition on
+# Filesystem Options Screen of Guided Setup.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    $testapi::distri->get_filesystem_options()->select_root_filesystem_type('ext3');
+    $testapi::distri->get_filesystem_options()->go_forward();
+}
+
+1;


### PR DESCRIPTION
The PR replaces old modules that used needles with the new ones that use LibyuiClient in opensuse schedules.

There will be more PRs with similar change. In order to make review easier and avoid mistakes, this PR contains only the test suites where `guided_setup` was used.

- Related ticket: https://progress.opensuse.org/issues/102191
- Verification runs: https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=20211129_oorlov&groupid=38
