### PR TITLE
Add soft fail for buildah warning

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -116,6 +116,10 @@ sub install_buildah_when_needed {
             zypper_call('in buildah', timeout => 300);
         }
     }
+    if ((script_output 'buildah info') =~ m/Failed to decode the keys.+ostree_repo/) {
+        assert_script_run "sed -i 's/ostree_repo/#ostree_repo/' /etc/containers/storage.conf";
+        record_soft_failure 'bsc#1189893 - Failed to decode the keys [\"storage.options.ostree_repo\"] from \"/etc/containers/storage.conf\"';
+    }
     record_info('buildah', script_output('buildah info'));
 }
 


### PR DESCRIPTION
Softfail for https://bugzilla.suse.com/show_bug.cgi?id=1189893
which throws the "Failed to decode the keys [\"storage.options.ostree_repo\"] from \"/etc/containers/storage.conf\"

Workaround commenting out the ostree_repo in /etc/containers/storage.conf

- Related ticket: https://progress.opensuse.org/issues/103296
- Verification run: http://aquarius.suse.cz/tests/7417
