### PR TITLE
Remove python test files after running the tests

### DIFF
--- a/tests/console/python_scientific.pm
+++ b/tests/console/python_scientific.pm
@@ -48,12 +48,18 @@ sub run {
 
 sub post_fail_hook {
     my $self = shift;
+    $self->cleanup();
     $self->SUPER::post_fail_hook;
 }
 
 sub post_run_hook {
     my $self = shift;
+    $self->cleanup();
     $self->SUPER::post_run_hook;
+}
+
+sub cleanup {
+    script_run('rm -f python3-numpy-test.py python3-scipy-test.py');
 }
 
 1;


### PR DESCRIPTION
Signed-off-by: Avinesh Kumar <akumar@suse.de>

Removing the test files after test execution is finished.

- Related ticket: https://progress.opensuse.org/issues/103350
- Verification run: 
  [SLE15-SP4](https://openqa.suse.de/tests/7767276#)
  [SLE15-SP3](http://d462.qam.suse.de/tests/59)
