### PR TITLE
pynfs: Show failed and skipped tests

### DIFF
--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -10,27 +10,46 @@ package generate_report;
 use strict;
 use warnings;
 use base 'opensusebasetest';
-use File::Basename;
+use Mojo::JSON;
 use testapi;
 use upload_system_log;
 
-sub upload_pynfs_log {
+sub display_results {
     my $self = shift;
+    my $skip = "";
+    my $pass = "";
+
     my $folder = get_required_var('PYNFS');
 
     assert_script_run("cd ~/pynfs/$folder");
+    upload_logs('results.json', failok => 1);
 
-    upload_logs('result-raw.txt', failok => 1);
+    my $content = script_output('cat results.json');
+    my $results = Mojo::JSON::decode_json($content);
 
-    script_run('../showresults.py result-raw.txt > result-analysis.txt');
-    upload_logs('result-analysis.txt', failok => 1);
+    die 'failed to parse results.json' unless $results;
+    die 'results.json is not array' unless (ref($results->{testcase}) eq 'ARRAY');
 
-    script_run('../showresults.py --hidepass result-raw.txt > result-fail.txt');
-    upload_logs('result-fail.txt', failok => 1);
+    record_info('Results', "failures: $results->{failures}\nskipped: $results->{skipped}\ntime: $results->{time}");
 
-    if (script_output("cat result-fail.txt | grep 'Of those:.*Failed' | sed 's/.*, \\([0-9]\\+\\) Failed,.*/\\1/'") gt 0) {
-        $self->result("fail");
-        record_info("failed tests", script_output('cat result-fail.txt'), result => 'fail');
+    for my $test (@{$results->{testcase}}) {
+        if (exists($test->{skipped})) {
+            $skip .= "$test->{code}\n";
+        } elsif (!exists($test->{failure})) {
+            $pass .= "$test->{code}\n";
+        }
+    }
+
+    record_info('Passed', $pass);
+    record_info('Skipped', $skip);
+
+    for my $test (@{$results->{testcase}}) {
+        bmwqemu::fctinfo("code: $test->{code}");
+        next unless (exists($test->{failure}));
+
+        my $targs = OpenQA::Test::RunArgs->new();
+        $targs->{data} = $test;
+        autotest::loadtest("tests/nfs/pynfs_failed.pm", name => $test->{code}, run_args => $targs);
     }
 }
 
@@ -76,12 +95,16 @@ sub run {
     $self->select_serial_terminal;
 
     if (get_var("PYNFS")) {
-        $self->upload_pynfs_log();
+        $self->display_results();
     }
     elsif (get_var("CTHON04")) {
         $self->upload_cthon04_log();
     }
     upload_system_logs();
+}
+
+sub test_flags {
+    return {no_rollback => 1};
 }
 
 1;

--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -101,6 +101,8 @@ sub run {
         $self->upload_cthon04_log();
     }
     upload_system_logs();
+
+    autotest::loadtest("tests/shutdown/shutdown.pm");
 }
 
 sub test_flags {

--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -97,4 +97,8 @@ sub run {
     setup_nfs_server(get_var("NFSVERSION"));
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;

--- a/tests/nfs/pynfs_failed.pm
+++ b/tests/nfs/pynfs_failed.pm
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright 2021 SUSE LLC
+#
+# Summary: Print failed test info
+# Maintainer: Petr Vorel <pvorel@suse.cz>
+
+use 5.018;
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+use Data::Dumper;
+
+sub run {
+    my ($self, $args) = @_;
+    my $data = $args->{data};
+
+    record_info('INFO', "name: $data->{name}\nclassname: $data->{classname}\ntime: $data->{time}\n");
+
+    die 'failure does not exist' unless (exists($data->{failure}));
+
+    $self->{result} = 'fail';
+    record_info('ERROR', "$data->{failure}->{message}\n\n$data->{failure}->{err}\n");
+}
+
+sub test_flags {
+    return {no_rollback => 1, fatal => 0};
+}
+
+1;

--- a/tests/nfs/run.pm
+++ b/tests/nfs/run.pm
@@ -21,7 +21,7 @@ sub pynfs_server_test_all {
     my $folder = get_required_var('PYNFS');
 
     assert_script_run("cd ./$folder");
-    script_run('./testserver.py -v --rundeps --hidepass --outfile result-raw.txt --maketree localhost:/exportdir all', 3600);
+    script_run('./testserver.py -v --rundeps --hidepass --json results.json --maketree localhost:/exportdir all', 3600);
 }
 
 sub run {


### PR DESCRIPTION
Generate list of failed and skipped tests at the end of testing from test output. This helps easier to track failed and skipped ests.

NOTE: we don't print passed tests, because total number is really high (currently 677).

Use JSON format for results for easier parsing. This requires pynfs with commits from May 2021:
* 92c13d7 ("server: Allow to print JSON format")
* 107c1e5 ("server: Add test code to JSON and XML output")

Signed-off-by: Petr Vorel <pvorel@suse.cz>

Verification run:
- single failure: http://quasar.suse.cz/tests/7811#step/LOCK24/2 http://quasar.suse.cz/tests/7812#step/LOCK24/2
- more failures (older release): http://quasar.suse.cz/tests/7851
- no failures: http://quasar.suse.cz/tests/7814 http://quasar.suse.cz/tests/7813

NOTE: I also had version which showed also skipped: http://quasar.suse.cz/tests/7793, but that's IMHO useless (there is a list just before testing).

**UPDATE**: not merging, because there is alternative implementation from @lansuse: **https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13801**