### PR TITLE
Fix send 'alt' key cannot show menu problem

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -23,9 +23,7 @@ sub run() {
 
     $self->start_firefox;
     wait_still_screen;
-    send_key('alt');
-    wait_still_screen;
-    assert_screen('firefox-top-bar-highlighted');
+    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt', 4, 10);
     send_key('h');
     wait_still_screen;
     assert_screen('firefox-help-menu');


### PR DESCRIPTION
At s390x, sometimes only send 'alt' key cannot show menu. Need make
sure the menu can be shown

- Related ticket: https://progress.opensuse.org/issues/102185
- Verification run: https://openqa.suse.de/tests/7766167
http://openqa.suse.de/t7766166
http://openqa.suse.de/t7766165
https://openqa.suse.de/tests/7761607