### PR TITLE
update-alternatives: Use find to find symlinks, passed to stat via xargs

### DIFF
--- a/tests/console/update_alternatives.pm
+++ b/tests/console/update_alternatives.pm
@@ -16,7 +16,8 @@ use testapi;
 
 sub run {
     select_console('user-console');
-    assert_script_run('stat -c"%N" -L /etc/alternatives/* >/dev/null');    # call stat on all files in /etc/alternatices an report to stderr broken links
+    # call stat on all files in /etc/alternatices and report to stderr broken links
+    assert_script_run('find /etc/alternatives -type l | xargs -r stat -c"%N" -L >/dev/null');
     save_screenshot;
 }
 


### PR DESCRIPTION
Calling stat /etc/alternatives/* in case of not having a single update-alternative link
installed in the system results in errors (happens, especially in scenarios like JeOS)

- Related ticket: https://progress.opensuse.org/issues/103431
- Needles: N/A
- Verification run:
  * https://openqa.opensuse.org/t2068369 (JeOS, no u-a links present)
  * https://openqa.opensuse.org/t2068369 (TW/DVD, with u-a links present)
