### PR TITLE
Disable online repos for openSUSE Tumbleweed

### DIFF
--- a/lib/Installation/Popups/YesNoPopup.pm
+++ b/lib/Installation/Popups/YesNoPopup.pm
@@ -22,7 +22,7 @@ sub new {
 sub init {
     my $self = shift;
     $self->{btn_yes} = $self->{app}->button({id => 'yes'});
-    $self->{btn_no} = $self->{app}->button({id => 'no'});
+    $self->{btn_no} = $self->{app}->button({id => qr/^(no|no_button)$/});
     $self->{lbl_warning} = $self->{app}->label({type => 'YLabel'});
     return $self;
 }

--- a/schedule/yast/opensuse/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/opensuse/btrfs/btrfs+warnings.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma

--- a/schedule/yast/opensuse/btrfs/btrfs.yaml
+++ b/schedule/yast/opensuse/btrfs/btrfs.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma

--- a/schedule/yast/opensuse/btrfs/btrfs_textmode.yaml
+++ b/schedule/yast/opensuse/btrfs/btrfs_textmode.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server

--- a/schedule/yast/opensuse/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/opensuse/encryption/crypt_no_lvm.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_generic_desktop

--- a/schedule/yast/opensuse/encryption/cryptlvm.yaml
+++ b/schedule/yast/opensuse/encryption/cryptlvm.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_generic_desktop

--- a/schedule/yast/opensuse/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/opensuse/encryption/lvm_encrypt_separate_boot.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server

--- a/schedule/yast/opensuse/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/opensuse/encryption/lvm_full_encrypt.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_GNOME

--- a/schedule/yast/opensuse/ext3/ext3_textmode.yaml
+++ b/schedule/yast/opensuse/ext3/ext3_textmode.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server

--- a/schedule/yast/opensuse/ext4/ext4.yaml
+++ b/schedule/yast/opensuse/ext4/ext4.yaml
@@ -15,7 +15,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_GNOME

--- a/schedule/yast/opensuse/ext4/ext4_textmode.yaml
+++ b/schedule/yast/opensuse/ext4/ext4_textmode.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server

--- a/schedule/yast/opensuse/gpt.yaml
+++ b/schedule/yast/opensuse/gpt.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_generic_desktop

--- a/schedule/yast/opensuse/installer_extended/installer_extended.yaml
+++ b/schedule/yast/opensuse/installer_extended/installer_extended.yaml
@@ -11,7 +11,7 @@ schedule:
   - '{{access_beta_distribution}}'
   - '{{switch_keyboard_layout}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma

--- a/schedule/yast/opensuse/lvm/lvm.yaml
+++ b/schedule/yast/opensuse/lvm/lvm.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_generic_desktop

--- a/schedule/yast/opensuse/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/opensuse/lvm/lvm_thin_provisioning.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/validate_no_system_role_selected

--- a/schedule/yast/opensuse/lvm_raid1/lvm+raid1.yaml
+++ b/schedule/yast/opensuse/lvm_raid1/lvm+raid1.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/validate_no_system_role_selected

--- a/schedule/yast/opensuse/modify_existing_partition.yaml
+++ b/schedule/yast/opensuse/modify_existing_partition.yaml
@@ -13,7 +13,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server

--- a/schedule/yast/opensuse/nvme.yaml
+++ b/schedule/yast/opensuse/nvme.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_GNOME

--- a/schedule/yast/opensuse/raid/raid0_gpt.yaml
+++ b/schedule/yast/opensuse/raid/raid0_gpt.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_generic_desktop

--- a/schedule/yast/opensuse/raid/raid10_gpt.yaml
+++ b/schedule/yast/opensuse/raid/raid10_gpt.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma

--- a/schedule/yast/opensuse/raid/raid1_gpt.yaml
+++ b/schedule/yast/opensuse/raid/raid1_gpt.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_generic_desktop

--- a/schedule/yast/opensuse/raid/raid5_gpt.yaml
+++ b/schedule/yast/opensuse/raid/raid5_gpt.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma

--- a/schedule/yast/opensuse/remote_ssh_controller.yaml
+++ b/schedule/yast/opensuse/remote_ssh_controller.yaml
@@ -7,7 +7,7 @@ schedule:
  - support_server/setup
  - remote/remote_controller
  - installation/welcome
- - installation/online_repos
+ - installation/online_repos/disable_online_repos
  - installation/installation_mode
  - installation/system_role
  - installation/partitioning

--- a/schedule/yast/opensuse/remote_vnc/remote_vnc_controller.yaml
+++ b/schedule/yast/opensuse/remote_vnc/remote_vnc_controller.yaml
@@ -7,7 +7,7 @@ schedule:
  - support_server/setup
  - remote/remote_controller
  - installation/welcome
- - installation/online_repos
+ - installation/online_repos/disable_online_repos
  - installation/installation_mode
  - installation/system_role
  - installation/partitioning

--- a/schedule/yast/opensuse/select_disk/select_disk.yaml
+++ b/schedule/yast/opensuse/select_disk/select_disk.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma

--- a/schedule/yast/opensuse/separate_usr_partition.yaml
+++ b/schedule/yast/opensuse/separate_usr_partition.yaml
@@ -10,7 +10,7 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/welcome
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_generic_desktop

--- a/schedule/yast/opensuse/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/opensuse/transactional_server/create_hdd_transactional_server.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/validate_no_system_role_selected

--- a/schedule/yast/opensuse/transactional_server/transactional_server.yaml
+++ b/schedule/yast/opensuse/transactional_server/transactional_server.yaml
@@ -12,7 +12,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/validate_no_system_role_selected

--- a/schedule/yast/opensuse/xfs/xfs.yaml
+++ b/schedule/yast/opensuse/xfs/xfs.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_GNOME

--- a/schedule/yast/opensuse/xfs/xfs_textmode.yaml
+++ b/schedule/yast/opensuse/xfs/xfs_textmode.yaml
@@ -16,7 +16,7 @@ schedule:
   - installation/setup_libyui
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_server

--- a/schedule/yast/opensuse/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/opensuse/yast_no_self_update/yast_no_self_update.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/validate_no_self_update
   - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
-  - installation/online_repos
+  - installation/online_repos/disable_online_repos
   - installation/installation_mode
   - installation/logpackages
   - installation/system_role/select_role_desktop_with_KDE_plasma

--- a/tests/installation/online_repos/disable_online_repos.pm
+++ b/tests/installation/online_repos/disable_online_repos.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This test module answers the popup for configuring
+#          online repos with no.
+
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    my $online_repos_popup = $testapi::distri->get_yes_no_popup_controller();
+    $online_repos_popup->decline();
+}
+
+1;


### PR DESCRIPTION
Disable the use of online repos by declining the popup.

- Related ticket: https://progress.opensuse.org/issues/102188
- Needles: not needed because using libyui
- Verification run: https://openqa.opensuse.org/tests/overview?build=rakoenig_disable_online_repos
