### PR TITLE
Increase timeout for aarch64 in apache_ssl

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -1,6 +1,6 @@
 # SUSE's Apache tests
 #
-# Copyright 2016-2020 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 =head1 Apache tests
@@ -12,13 +12,12 @@ package apachetest;
 
 use base Exporter;
 use Exporter;
-
 use strict;
 use warnings;
-
 use testapi;
 use utils;
 use version_utils qw(is_sle is_leap check_version is_tumbleweed);
+use Utils::Architectures qw(is_aarch64);
 
 our @EXPORT = qw(setup_apache2 setup_pgsqldb destroy_pgsqldb test_pgsql test_mysql postgresql_cleanup);
 # Setup apache2 service in different mode: SSL, NSS, NSSFIPS, PHP7
@@ -57,7 +56,8 @@ sub setup_apache2 {
     }
 
     # Make sure the packages are installed
-    zypper_call("--no-gpg-checks in @packages");
+    my $timeout = is_aarch64 ? 1200 : 300;
+    zypper_call("--no-gpg-checks in @packages", timeout => $timeout);
 
     # Enable php7
     if ($mode eq "PHP7") {

--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -1,13 +1,13 @@
 # SUSE's Apache+SSL tests
 #
-# Copyright 2016-2020 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Enable SSL module on Apache2 server
 #          calls setup_apache2 with mode = SSL (lib/apachetest.pm)
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#65375, poo#67309
+# Tags: poo#65375, poo#67309, poo#101782
 
 use base "consoletest";
 use testapi;


### PR DESCRIPTION
apache_ssl:  Increase the Test timeout in aarch64 while packages installation

- Related ticket: https://progress.opensuse.org/issues/101782
- Needles: NA
- Verification run: 
 https://openqa.suse.de/tests/7810154 (aarch64)
 https://openqa.suse.de/t7810161 (s390x)
 https://openqa.suse.de/tests/7810160 (x86_64)