### PR TITLE
Fix two issues in pc xfs tests

### DIFF
--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -68,6 +68,8 @@ sub create_config {
     assert_script_run("echo 'export SCRATCH_MNT=$mnt_scratch' >> $CONFIG_FILE");
     assert_script_run("echo 'export TEST_DEV=${device}1' >> $CONFIG_FILE");
     assert_script_run("echo 'export SCRATCH_DEV=${device}2' >> $CONFIG_FILE");
+    # Ensure reflink is enabled (required for several tests)
+    assert_script_run("echo 'MKFS_OPTIONS=\"-m reflink=1\"' >> $CONFIG_FILE");
 }
 
 

--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -61,7 +61,7 @@ sub create_config {
     my ($device, $mnt_xfs, $mnt_scratch) = @_;
 
     ## Version required by xfstests/partition.pm
-    script_run('(rpm -qa xfsprogs xfsdump btrfsprogs kernel-default xfstests; uname -r; rpm -qi kernel-default) | tee /opt/version.log');
+    script_run('(rpm -qa xfsprogs xfsdump btrfsprogs kernel-default xfstests dbench; uname -r; rpm -qi kernel-default) | tee /opt/version.log');
 
     ## Profile config file containing device and mount point definitions
     assert_script_run("echo 'export TEST_DIR=$mnt_xfs' >> $CONFIG_FILE");


### PR DESCRIPTION
Fix two issues with new xfstests:

* Add `reflink` option to the preparation step (otherwise some tests are skipped)
* Add `dbench` to zypper install, required for some tests

- Related ticket: https://progress.opensuse.org/issues/60179
- Verification run: http://duck-norris.qam.suse.de/tests/7855
