### PR TITLE
Add NVIDIA compute to the list of expected modules

### DIFF
--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -80,6 +80,7 @@ test_data:
     - sle-module-development-tools
     - sle-module-legacy
     - sle-module-public-cloud
+    - sle-module-NVIDIA-compute
     - PackageHub
     - sle-module-server-applications
     - sle-module-transactional-server

--- a/test_data/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/test_data/yast/installer_extended/installer_extended_aarch64.yaml
@@ -34,6 +34,7 @@ modules:
   - sle-module-desktop-applications
   - sle-module-development-tools
   - sle-module-legacy
+  - sle-module-NVIDIA-compute
   - sle-module-public-cloud
   - PackageHub
   - sle-module-server-applications


### PR DESCRIPTION
on x64 and aarch64 the NVIDIA compute module is added. The commit adds
the module to the list of expected data in installer_extended test
suite.

- Verification run: https://openqa.suse.de/tests/7802236#step/verify_module_selection/1
