### PR TITLE
Remove disk_activation from textmode@pvm

### DIFF
--- a/schedule/yast/textmode/textmode@pvm.yaml
+++ b/schedule/yast/textmode/textmode@pvm.yaml
@@ -10,7 +10,6 @@ schedule:
   - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
-  - installation/disk_activation
   - installation/registration/register_via_scc
   - installation/module_selection/skip_module_selection
   - installation/add_on_product/skip_install_addons


### PR DESCRIPTION
The disk_activation test module was mistakenly added to the schedule, so
the commit removes it.

- Verification run: https://openqa.suse.de/tests/7802628
