### PR TITLE
Fix pidgin failure on aarch64

### DIFF
--- a/tests/x11/pidgin/prep_pidgin.pm
+++ b/tests/x11/pidgin/prep_pidgin.pm
@@ -11,7 +11,7 @@
 # - Bring pidgin up (can be hidden on tray)
 # - Enable showoffline and check
 # - Exit pidgin
-# Maintainer: Chingkai <chuchingkai@gmail.com>
+# Maintainer: Grace Wang <grace.wang@suse.com>
 
 use base "x11test";
 use strict;


### PR DESCRIPTION
Use a workaround for IP blacklisted on Libera

- Related ticket: https://progress.opensuse.org/issues/102653
- Needles: pidgin-SASL-only-error
- Verification run: 
> On regular aarch64 without IP BLACKLISTED: https://openqa.opensuse.org/tests/2072412#
> On aarch64 with IP BLACKLISTED: https://openqa.opensuse.org/tests/2076068#
(New) https://openqa.opensuse.org/tests/2077646
