### PR TITLE
x11/remote_desktop/xrdp_client: Disable H.264/AVC by default

### DIFF
--- a/tests/x11/remote_desktop/xrdp_client.pm
+++ b/tests/x11/remote_desktop/xrdp_client.pm
@@ -29,8 +29,11 @@ sub run {
     # Disable Remmina news before launch Remmina
     x11_start_program('xterm');
     my $pref_dir = '~/.config/remmina';
-    assert_script_run "mkdir $pref_dir";
+    assert_script_run "mkdir -p $pref_dir";
     assert_script_run 'echo -e "[remmina_news]\\nperiodic_rmnews_last_get=$(date +%s)" >> ' . $pref_dir . '/remmina.pref';
+    # Using H.264 is the default option, but we don't support that out of the box, so choose RemoteFX instead.
+    # (Disabling this using the UI is cumbersome, tab handling is broken, doesn't scroll)
+    assert_script_run 'echo -e "[remmina]\\ncolordepth=0" >> ' . $pref_dir . '/remmina.pref';
     enter_cmd "exit";
 
     # Start Remmina and login the remote server


### PR DESCRIPTION
We can't ship FreeRDP with H.264 support out of the box, but Remmina uses that
as default. After authentication, Remmina shows a message that a non-AVC color
depth needs to be chosen, so do that by writing into the settings file.

- Verification run: https://openqa.opensuse.org/tests/2076144
