### PR TITLE
Fix can't upload logs in yast2_migration,start_install and zypper migration

### DIFF
--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -110,7 +110,7 @@ sub save_system_logs {
 sub save_upload_y2logs {
     my ($self, %args) = @_;
 
-    return if (get_var('NOLOGS'));
+    return if (get_var('NOLOGS') || get_var('Y2LOGS_UPLOADED'));
     $args{suffix} //= '';
 
     # Do not test/recover network if collect from installation system, as it won't work anyway with current approach

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -288,6 +288,8 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
+    $self->save_upload_y2logs;
+    set_var('Y2LOGS_UPLOADED', 1);
     $self->save_and_upload_log('journalctl -b -o short-precise', '/tmp/journal.log', {screenshot => 1});
     $self->export_logs_desktop;
     $self->SUPER::post_fail_hook;

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -165,10 +165,11 @@ sub run {
 
 sub post_fail_hook {
     my $self = shift;
-    $self->SUPER::post_fail_hook;
     $self->select_serial_terminal;
     script_run("pkill zypper");
+    upload_logs '/var/log/zypper.log';
     $self->upload_solvertestcase_logs();
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
In zypper_migration, yast2_migration and start_install, when something breaks
the upgrade process, such as conflicts, system errors, we need to get the yast2log
or zypper.log to quickly file bugs or tickets.

- Related ticket: https://progress.opensuse.org/issues/92875
- Needles: N/A
- Verification run: 
zypper_migraion:

https://openqa.nue.suse.com/tests/7843071/file/zypper_migration-zypper.log 
https://openqa.nue.suse.com/tests/7850224/file/zypper_migration-zypper.log

yast2_migration:
https://openqa.nue.suse.com/tests/7810102 
https://openqa.nue.suse.com/tests/7810071 
start_install:
https://openqa.nue.suse.com/t7850096 has log "https://openqa.nue.suse.com/tests/7850096/file/start_install-y2logs.tar.bz2"
https://openqa.nue.suse.com/t7850097 has log "https://openqa.nue.suse.com/tests/7850097/file/start_install-y2logs.tar.bz2"