### PR TITLE
Small fixes of the xfstests

### DIFF
--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -13,6 +13,7 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use version_utils qw(is_sle);
+use registration qw(add_suseconnect_product get_addon_fullname);
 use utils;
 
 # xfstests configuration file, as required by xfstests/run
@@ -28,9 +29,9 @@ sub ensure_user_exists {
 # Install requirements
 sub install_xfstests {
     my ($repo) = @_;
-    # Add filesystem repository, which contains the xfstests
-    zypper_ar($repo, name => "filesystems");
-    zypper_call('in xfsprogs xfsdump btrfsprogs kernel-default xfstests fio');
+    zypper_ar($repo, name => "filesystems");    # Add filesystem repository, which contains the xfstests
+    add_suseconnect_product(get_addon_fullname('phub')) if is_sle;    # packagehub is required for dbench (required for e.g. generic/241)
+    zypper_call('in xfsprogs xfsdump btrfsprogs kernel-default xfstests fio dbench');
     assert_script_run('ln -s /usr/lib/xfstests/ /opt/xfstests');    # xfstests/run expects the tests to be in /opt/xfstests
     record_info("xfstests", script_output("rpm -q xfstests"));
     # Ensure users 'nobody' and 'daemon' exists

--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -48,8 +48,8 @@ sub partition_disk {
     my ($device, $mnt_xfs, $mnt_scratch) = @_;
     # Create test and scratch partitions, both formatted with xfs and mounted to the given mountpoints
     assert_script_run("parted $device --script -- mklabel gpt");
-    assert_script_run("parted -s -a min $device mkpart primary 1MB 75%");
-    assert_script_run("parted -s -a min $device mkpart primary 75% 100%");
+    assert_script_run("parted -s -a min $device mkpart primary 1MB 50%");
+    assert_script_run("parted -s -a min $device mkpart primary 50% 100%");
     assert_script_run("mkfs.xfs -L xfstests ${device}1");
     assert_script_run("mkfs.xfs -L scratch ${device}2");
     assert_script_run("mkdir -p $mnt_xfs $mnt_scratch");


### PR DESCRIPTION
This PR contains two small fixes for the publiccloud xfstests:

* Add `dbench`, required for generic/241
* Set the ratio of the xfstests:scratch partitions to 50:50. Required for generic/312

- Related ticket: https://progress.opensuse.org/issues/60179
- Related merge request: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/535
- Verification run: [xfstests_201-300](http://duck-norris.qam.suse.de/t7927) | [xfstests_301-400](http://duck-norris.qam.suse.de/t7928)
