### PR TITLE
Validate partition via parted in xfs@s390_zVM

### DIFF
--- a/schedule/yast/xfs/xfs@s390x_zVM.yaml
+++ b/schedule/yast/xfs/xfs@s390x_zVM.yaml
@@ -39,7 +39,7 @@ schedule:
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
-  - console/validate_partition_table_via_blkid
+  - console/validate_partition_table_via_parted
   - console/validate_blockdevices
   - console/validate_free_space
   - console/validate_read_write


### PR DESCRIPTION
After the schedules for xfs s390x_svirt and s390x_zVM were separated,
the validate_partition_table_via_blkd was used for zVM test, that is
incorrect. It should use parted for that validation.

The commit fixes the issue by scheduling the proper test module.

- Verification run: https://openqa.suse.de/tests/7815953
