### PR TITLE
Mark console/journal_check as non-fatal

### DIFF
--- a/tests/console/journal_check.pm
+++ b/tests/console/journal_check.pm
@@ -98,4 +98,8 @@ sub run {
     $self->result('fail') if $failed;
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
Unrecognized errors in the journal are no reason to abort the test, or roll back
if snapshots are supported.

- Verification run: https://openqa.opensuse.org/tests/2077754
