### PR TITLE
SLE Micro: increase aarch64 linux needle timeout

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -13,12 +13,14 @@ use warnings;
 use testapi;
 use version_utils 'is_microos';
 use power_action_utils 'power_action';
+use Utils::Architectures qw(is_aarch64);
 
 our @EXPORT = qw(microos_reboot microos_login);
 
 # Assert login prompt and login as root
 sub microos_login {
-    assert_screen 'linux-login-microos', 150;
+    my $login_timeout = is_aarch64 ? 300 : 150;
+    assert_screen 'linux-login-microos', $login_timeout;
 
     if (is_microos 'VMX') {
         # FreeRDP is not sending 'Ctrl' as part of 'Ctrl-Alt-Fx', 'Alt-Fx' is fine though.


### PR DESCRIPTION
Looking at the [history of jobs](https://openqa.suse.de/tests/7813779#next_previous), there is ~50% chance of getting a needle stall waiting for login prompt only in aarch64.
This PR increases that timeout to allow those jobs have a bit more time to match the needle.

Related ticket: https://progress.opensuse.org/issues/103194

VRs: 
https://openqa.suse.de/tests/7816067
https://openqa.suse.de/tests/7816068
https://openqa.suse.de/tests/7816069
https://openqa.suse.de/tests/7816070
https://openqa.suse.de/tests/7816071
https://openqa.suse.de/tests/7816072
https://openqa.suse.de/tests/7816073
https://openqa.suse.de/tests/7816079
(100% passed the sporadic timeout)