### PR TITLE
vagrant: allow vagrant some time to stop

### DIFF
--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -22,7 +22,7 @@ sub run_test_per_provider {
     run_vagrant_cmd("up $boxname --provider $provider", timeout => 1200);
 
     # test if the box survives a reboot
-    run_vagrant_cmd('halt');
+    run_vagrant_cmd('halt', timeout => 300);
     run_vagrant_cmd("up $boxname", timeout => 1200);
 
     run_vagrant_cmd("destroy -f $boxname");


### PR DESCRIPTION
Seems most of the vagrant test seems actually to work by now, but we wait too long to 'shut it down'

- Related ticket: https://progress.opensuse.org/issues/99057
- Needles: N/A
- Verification run: [Vagrant/Tumbleweed](https://openqa.opensuse.org/tests/2077910)
