### PR TITLE
data/virtualization/Vagrantfile: Move IP for VBox into allowed range

### DIFF
--- a/data/virtualization/Vagrantfile
+++ b/data/virtualization/Vagrantfile
@@ -5,7 +5,7 @@ def ip_config(config, provider)
   return unless ENV['BOX_STATIC_IP'] == '1'
 
   if provider == 'virtualbox'
-    ip = '192.168.201.176'
+    ip = '192.168.56.176'
     ip6 = 'fde4:8dba:82e1::c4'
   elsif provider == 'libvirt'
     ip = '192.168.151.101'


### PR DESCRIPTION
VBox 2.1.28+ restricts IPs assigned to host-only networks. By default,
only 192.168.56.0/21 is allowed, so use one in that range.

- Related ticket: https://progress.opensuse.org/issues/99057
- Verification run: https://openqa.opensuse.org/tests/2077968
