### PR TITLE
MariaDB srv: increase timeout of service start

### DIFF
--- a/tests/console/mariadb_srv.pm
+++ b/tests/console/mariadb_srv.pm
@@ -37,7 +37,7 @@ sub run {
         assert_script_run "sed -i 's|resolveip=\"\$bindir/resolveip\"|resolveip=\"/usr/bin/resolveip\"|' /usr/bin/${mariadb}_install_db";
     }
     systemctl "status $mariadb", expect_false => 1, fail_message => 'mariadb should be disabled by default';
-    systemctl "start $mariadb";
+    systemctl "start $mariadb", timeout => 300;
     systemctl "is-active $mariadb";
 
     # Test multiple instance configuration


### PR DESCRIPTION
The command times out sporadically. It won't harm to have a more
flexible timeout.

Example of timeouts:
https://openqa.suse.de/tests/7806609#step/mariadb_srv/11
https://openqa.suse.de/tests/7806613#step/mariadb_srv/11

VRs:
https://openqa.suse.de/tests/7817559
https://openqa.suse.de/tests/7817558