### PR TITLE
Fix cleanup in azure tests

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -295,7 +295,7 @@ This method is called called after each test on failure or success to revoke the
 sub cleanup {
     my ($self) = @_;
     $self->SUPER::cleanup();
-    $self->vault->revoke();
+    $self->provider_client->cleanup();
 }
 
 1;

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -75,4 +75,9 @@ sub vault_create_credentials {
     }
 }
 
+sub cleanup {
+    my ($self) = @_;
+    $self->vault->revoke();
+}
+
 1;


### PR DESCRIPTION
After split the azure connection from the provider appeared a new
bug related with the cleanup

- Related ticket: http://progress.opensuse.org/issues/103419
- Verification run: https://openqa.suse.de/t7821558
