### PR TITLE
Modify test suite: yast2_apparmor to support Tumbleweeed

### DIFF
--- a/tests/security/yast2_apparmor/scan_audit_logs.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs.pm
@@ -10,13 +10,14 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = shift;
     my $test_file = "/usr/sbin/nscd";
     my $test_profile = "/etc/apparmor.d/usr.sbin.nscd";
     my $test_profile_bk = "/tmp/usr.sbin.nscd";
-    my $entry = '#include <abstractions\/base>';
+    my $entry = 'include <abstractions\/base>';
     my $audit_log = $apparmortest::audit_log;
 
     # Set the testing profile to "enforce" mode
@@ -49,7 +50,11 @@ sub run {
     # E.g., comment out specific entries from profile, then run corresponding programs to generate audit records
     assert_script_run("cp $test_profile $test_profile_bk");
     assert_script_run("sed -i -e 's/$entry/#$entry/' $test_profile");
-    validate_script_output("grep '##' $test_profile", sub { m/#$entry/ });
+    if (is_sle) {
+        validate_script_output("grep '##' $test_profile", sub { m/#$entry/ });
+    } else {
+        validate_script_output("grep '#' $test_profile", sub { m/#$entry/ });
+    }
     assert_script_run("$test_file");
     validate_script_output("grep 'DENIED' $audit_log", sub { m/type=AVC.*msg=audit.*apparmor=.*DENIED.*profile=.*nscd.*comm=.*nscd.*/ });
 


### PR DESCRIPTION
According to Factory First, all test cases should support Tumbleweed.
Added version specification to case scan_audit_logs due to different file content in /etc/apparmor.d/usr.sbin.nscd. In sle, the file content is '#include <abstractions\/base>' while in Tumbleweed is 'include <abstractions\/base>' and it is causing sed command to fail on Tumbleweed.

Note that cases including settings_disable_enable_apparmor, scan_audit_logs and manually_add_profile should fail on sle due to known bugs reported. In addition, settings_disable_enable_apparmor and settings_toggle_profile_mode might fail on Tumbleweed when running yast2_apparmor_setup(), I'm assuming that this might be related to the worker that's running the job since the cases but cases can still pass which proves that the cases are correct (as the verify run). Also case manually_add_profile failed on Tumbleweed due to the same bug as sle.

- Related ticket: https://progress.opensuse.org/issues/102755
- Needles: N/A
- Verification run: 
  - https://openqa.suse.de/tests/7821036#
  - https://openqa.opensuse.org/tests/2078924
