### PR TITLE
Add variable for resource group name

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -350,6 +350,8 @@ sub terraform_apply {
         my $sap_regcode = get_required_var('SCC_REGCODE_SLES4SAP');
         my $storage_account_name = get_var('STORAGE_ACCOUNT_NAME');
         my $storage_account_key = get_var('STORAGE_ACCOUNT_KEY');
+        # Enable specifying resource group name to allow running multiple tests simultaneously
+        my $resource_group = get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qashapopenqa');
         my $sle_version = get_var('FORCED_DEPLOY_REPO_VERSION') ? get_var('FORCED_DEPLOY_REPO_VERSION') : get_var('VERSION');
         $sle_version =~ s/-/_/g;
         my $ha_sap_repo = get_var('HA_SAP_REPO') ? get_var('HA_SAP_REPO') . '/SLE_' . $sle_version : '';
@@ -365,7 +367,7 @@ sub terraform_apply {
             q(%SLE_VERSION%) => $sle_version
         );
         upload_logs(TERRAFORM_DIR . "/$cloud_name/terraform.tfvars", failok => 1);
-        assert_script_run('terraform workspace new qashapopenqa -no-color', $terraform_timeout);
+        assert_script_run("terraform workspace new $resource_group -no-color", $terraform_timeout);
     }
     else {
         assert_script_run('cd ' . TERRAFORM_DIR);

--- a/variables.md
+++ b/variables.md
@@ -170,6 +170,7 @@ PUBLIC_CLOUD_PROVIDER | string | "" | The type of the CSP (e.g. AZURE, EC2, GCE)
 PUBLIC_CLOUD_QAM | boolean | false | Previously used to recognize maintenance jobs - now deprecated - should be removed.
 PUBLIC_CLOUD_REBOOT_TIMEOUT | integer | 600 | Number of seconds we wait for instance to reboot.
 PUBLIC_CLOUD_REGION | string | "" | The region to use. (default-azure: westeurope, default-ec2: eu-central-1, default-gcp: europe-west1).
+PUBLIC_CLOUD_RESOURCE_GROUP | string | "qashapopenqa" | Allows to specify resource group name on SLES4SAP PC tests.
 PUBLIC_CLOUD_RESOURCE_NAME | string | "openqa-vm" | The name we use when creating our VM.
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Debug variable used to run test without maintenance updates repository being applied.
 PUBLIC_CLOUD_SERVICE_ACCOUNT | string | "" | GCE only, used to specify the service account.


### PR DESCRIPTION
jsc#TEAM-5355 Currently there is only static value for resource group 
name 'qashapopenqa'. This causes multiple tests running at the same 
time to fail as the resource group is already taken. This PR 
introduces variable 'PUBLIC_CLOUD_RESOURCE_GROUP' for SLES4SAP tests, 
which allows to change RG name. Existing value 'qashapopenqa' remains 
as default. 

- Related ticket: https://jira.suse.com/browse/TEAM-5355
- Verification run: https://mordor.suse.cz/tests/1978#step/sles4sap/150
