### PR TITLE
JeOS firstrun: increase timeout for setterm -blank 0

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -142,7 +142,7 @@ sub run {
     }
     # Manually configure root-console as we skipped some parts in root-console's activation
     $testapi::distri->set_standard_prompt('root');
-    assert_script_run('setterm -blank 0');
+    assert_script_run('setterm -blank 0', timeout => 1200);
 
     verify_user_info(user_is_root => 1);
 


### PR DESCRIPTION
Example of failures:
https://openqa.suse.de/tests/7828828#step/firstrun/18
https://openqa.suse.de/tests/7828827#step/firstrun/18

VRs:
http://openqa.suse.de/t7832181
http://openqa.suse.de/t7832182