### PR TITLE
Fixes for PR#13811 (revert back to needles for test suites without libyui)

### DIFF
--- a/schedule/yast/opensuse/remote_ssh_controller.yaml
+++ b/schedule/yast/opensuse/remote_ssh_controller.yaml
@@ -7,7 +7,7 @@ schedule:
  - support_server/setup
  - remote/remote_controller
  - installation/welcome
- - installation/online_repos/disable_online_repos
+ - installation/online_repos
  - installation/installation_mode
  - installation/system_role
  - installation/partitioning

--- a/schedule/yast/opensuse/remote_vnc/remote_vnc_controller.yaml
+++ b/schedule/yast/opensuse/remote_vnc/remote_vnc_controller.yaml
@@ -7,7 +7,7 @@ schedule:
  - support_server/setup
  - remote/remote_controller
  - installation/welcome
- - installation/online_repos/disable_online_repos
+ - installation/online_repos
  - installation/installation_mode
  - installation/system_role
  - installation/partitioning


### PR DESCRIPTION
- 2 YAML files reverted back to needling tests because libyui
  is not available.

- Related ticket: https://progress.opensuse.org/issues/102188
- Needles: -
- Verification run: https://openqa.opensuse.org/tests/2083317