### PR TITLE
Fix disk usage check in validate_btrfs

### DIFF
--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -38,7 +38,8 @@ sub _sanity_test_btrfs {
     $rt->build($dockerfile_path, 'huge_image');
     assert_script_run "btrfs fi df $dev_path/btrfs/";
     assert_script_run "ls -td $dev_path/btrfs/subvolumes/* | head -n 1 > $btrfs_head";
-    validate_script_output "df -h |grep var", sub { m/\/dev\/vda.+[1-6]\d?%/ };
+    # Ensure the var partition has at least 10% free space
+    validate_script_output "df -h | grep var", sub { m/\/dev\/x?[v,s]d[a-z].+ [0-8][0-9]?%/ };
 }
 
 sub _test_btrfs_balancing {


### PR DESCRIPTION
The _sanity_test_btrfs routine in `validate_btrfs` check if the disk is
not full, but omits some corner cases. This commit changes the behaviour
to accept all disk filling values below 90%.

- Related ticket: https://progress.opensuse.org/issues/102377
- Verification run: [Tumbleweed](https://openqa.opensuse.org/t2083483) | [SLES15-SP3](https://openqa.suse.de/t7845664) | [SLES15](https://openqa.suse.de/t7845665) | [SLES12-SP5](https://openqa.suse.de/t7845680)
