### PR TITLE
Fix product shortcuts for SLES4SAP 15-SP4+

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -65,7 +65,8 @@ sub get_product_shortcuts {
             : is_aarch64() ? 's'
             : 'i',
             sled => 'x',
-            sles4sap => is_ppc64le() ? 'i'
+            sles4sap => is_ppc64le() ? (is_sle('15-SP4+') ? 'U' : 'i')
+            : (is_sle('15-SP4+') && is_x86_64() && !is_quarterly_iso()) ? 'i'
             : (is_sle('15-SP2+') && is_x86_64() && !is_quarterly_iso()) ? 't'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
Fix annoying bug introduced by bsc#1192517 on sles4sap_online_dvd_textmode tests.

- Needles: -
- Verification runs:

x86_64:
Failing test: https://openqa.suse.de/tests/7804587
Verification run: https://openqa.suse.de/tests/7936496

ppc64le:
Failing test: https://openqa.suse.de/tests/7812402
Verification run: https://openqa.suse.de/tests/7936593