### PR TITLE
Remove workaround for poo#88247

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -178,7 +178,6 @@ sub full_users_check {
         logout_and_login;
         # for poo#88247, it is hard to deal with the authorization of bernhard in
         # following migration process, we have to restore current user's password.
-        record_soft_failure("poo#88247, it is hard to deal with the authorization of bernhard in following migration process, we have to restore current users password");
         restore_passwd;
     }
     else {


### PR DESCRIPTION
We don't need to record soft failure any more since we changed test suite to verify password with new added user 'test' while not the default user.

- Related ticket: https://progress.opensuse.org/issues/103821
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/7849900#step/install_service/126