### PR TITLE
Fix rpcinfo failed to show nfs on s390x

### DIFF
--- a/lib/services/rpcbind.pm
+++ b/lib/services/rpcbind.pm
@@ -57,12 +57,21 @@ sub check_enabled {
 sub check_service {
     common_service_action('rpcbind.socket', $service_type, 'is-enabled');
     common_service_action('rpcbind.socket', $service_type, 'is-active');
+    common_service_action($nfs_server, $service_type, 'is-enabled');
+    common_service_action($nfs_server, $service_type, 'is-active');
 }
 
 sub check_function {
     assert_script_run("rpcinfo");
     # Wait for updated rpcinfo.
     sleep(5);
+    if (script_run('rpcinfo | grep nfs') != 0) {
+        record_soft_failure('bsc#1193028', "rpcinfo can not get nfs info in time on s390x");
+        for (1 .. 10) {
+            last if (script_run('rpcinfo | grep nfs') == 0);
+            sleep 5;
+        }
+    }
     assert_script_run('rpcinfo | grep nfs');
     assert_script_run('mkdir -p /tmp/nfs');
     assert_script_run('mount -t nfs localhost:/rpcbindtest /tmp/nfs');


### PR DESCRIPTION
On s390x, the rpcinfo command sometimes failed to show the NFS information,
so we need to try more times.

Related ticket: https://progress.opensuse.org/issues/101475
Needles: N/A
Verification run:
https://openqa.nue.suse.com/tests/7748331
https://openqa.nue.suse.com/tests/7748332
https://openqa.nue.suse.com/tests/7748333

on Maintence:

Maintenance 15sp3
https://openqa.nue.suse.com/tests/7894069
https://openqa.nue.suse.com/t7893742
https://openqa.nue.suse.com/t7893743

maintenance 12sp5
https://openqa.nue.suse.com/t7897933
https://openqa.nue.suse.com/t7897934
https://openqa.nue.suse.com/t7897935