### PR TITLE
Fix double interval while using wait_until

### DIFF
--- a/lib/YuiRestClient/Http/HttpClient.pm
+++ b/lib/YuiRestClient/Http/HttpClient.pm
@@ -5,28 +5,19 @@ use strict;
 use warnings;
 
 use Mojo::UserAgent;
-use YuiRestClient::Logger;
 
 my $ua = Mojo::UserAgent->new;
 
 sub http_get {
     my $url = Mojo::URL->new(shift);
-    sleep(1);
     my $res = $ua->get($url)->result;
-    return $res if $res->is_success;
-    # Die if non OK response code
-    YuiRestClient::Logger->get_instance()->error('Widget not found by url: ' . $url);
-    die $res->message . "\n" . $res->body . "\n$url";
+    return $res;
 }
 
 sub http_post {
     my $url = Mojo::URL->new(shift);
-    sleep(1);
     my $res = $ua->post($url)->result;
-    return $res if $res->is_success;
-    # Die if non OK response code
-    YuiRestClient::Logger->get_instance()->error('Widget not found by url: ' . $url);
-    die $res->message . "\n" . $res->body . "\n$url";
+    return $res;
 }
 
 sub compose_uri {
@@ -82,17 +73,9 @@ Uses Mojo::UserAgent for HTTP protocol.
 
 =head2 Class and object methods
 
-B<http_get($url)> - perform a HTTP/GET to the specified URL
+B<http_get($url)> - perform a HTTP/GET to the specified URL and returns HTTP response
 
-If the GET is successful (HTTP 200) then the data that was retrieved will be 
-returned. If HTTP errors occur the method will log a "Widget not found by url" 
-error message and then die with the error message returned by the server.
-
-B<http_post($url)> - perform a HTTP/POST to the specified URL
-
-If the POST is successful (HTTP 200) then the data that was retrieved will be 
-returned. If HTTP errors occur the method will log a "Widget not found by url" 
-error message and then die with the error message returned by the server.
+B<http_post($url)> - perform a HTTP/POST to the specified URL and returns HTTP response
 
 B<compose_url(%args)> - compose an URL using the named parameter list 
 

--- a/lib/YuiRestClient/Wait.pm
+++ b/lib/YuiRestClient/Wait.pm
@@ -3,7 +3,7 @@
 package YuiRestClient::Wait;
 use strict;
 use warnings;
-
+use DateTime;
 
 sub wait_until {
     my (%args) = @_;
@@ -12,10 +12,12 @@ sub wait_until {
     $args{message} //= '';
 
     die "No object passed to the method" unless $args{object};
-
-    my $counter = abs(int($args{timeout} / $args{interval}));
     my $result;
-    while (--$counter >= 0) {
+    # if timeout is 0, just execute the passed expression once
+    return eval { $args{object}->() } if $args{timeout} == 0;
+
+    my $end_time = DateTime->now()->clone->add(seconds => $args{timeout});
+    while ($end_time->compare(DateTime->now()) > 0) {
         eval { $result = $args{object}->() };
         return $result if $result;
         sleep($args{interval});


### PR DESCRIPTION
The interval was doubled while using wait_until function. It happened
because http requests already wrapped with wait_until function. In case
wait_until is used to wait for some events happened to widgets, the
interval that is specified in this wait_until become summarized with the
interval, that is used in WidgetController to send http requests.

The commit makes wait until to be dependent on time, but not on counter.
So, if it is set to wait two seconds, it will check current time, and
wait for two seconds from it, instead of just using counter increment.

Another change that helped to avoid double timeout is removal of "sleep"
from http_get and http_post. That was hard coded to wait 1 second for
each HTTP request.

- Related ticket: https://progress.opensuse.org/issues/103548
- VRs: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=70.1_oorlov&groupid=96