### PR TITLE
Wait for keyboard layout to be selected on page load

### DIFF
--- a/lib/Installation/LanguageKeyboard/LanguageKeyboardController.pm
+++ b/lib/Installation/LanguageKeyboard/LanguageKeyboardController.pm
@@ -45,4 +45,11 @@ sub get_keyboard_test {
     $self->get_language_keyboard_page()->get_keyboard_test();
 }
 
+sub wait_for_keyboard_layout_to_be_selected {
+    my ($self, $keyboard_layout) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->get_language_keyboard_page()->get_keyboard_layout() eq $keyboard_layout;
+    });
+}
+
 1;

--- a/lib/Installation/LanguageKeyboard/LanguageKeyboardPage.pm
+++ b/lib/Installation/LanguageKeyboard/LanguageKeyboardPage.pm
@@ -44,6 +44,11 @@ sub enter_keyboard_test {
     type_string $test;
 }
 
+sub get_keyboard_layout {
+    my ($self) = @_;
+    $self->{cb_keyboard_layout}->value();
+}
+
 sub get_keyboard_test {
     my ($self) = @_;
     $self->{tb_keyboard_test}->value();

--- a/tests/installation/language_keyboard/switch_keyboard_layout.pm
+++ b/tests/installation/language_keyboard/switch_keyboard_layout.pm
@@ -11,6 +11,8 @@ use Test::Assert ':all';
 
 sub run {
     my $language_keyboard = $testapi::distri->get_language_keyboard();
+    # wait for the English (US) to be pre-selected as on slow architectures it takes some time
+    $language_keyboard->wait_for_keyboard_layout_to_be_selected('English (US)');
     $language_keyboard->switch_keyboard_layout('French');
     $language_keyboard->enter_keyboard_test('azerty');
     my $keyboard_test = $language_keyboard->get_keyboard_test();


### PR DESCRIPTION
When Product Selection Page is loaded, it takes some time for "English
(US)" to be selected. If during that period of time, another layout is
selected via LibyuiClient, it is not recognized by the system.

The commit ensures, "English (US)" is selected and then proceeds with
the further steps in the test.

- Related ticket: https://progress.opensuse.org/issues/103314
- Verification run: https://openqa.suse.de/tests/7851162
