### PR TITLE
Enable validate_btrfs on JeOS

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -82,7 +82,7 @@ sub load_host_tests_docker {
         loadtest 'containers/registry' if is_x86_64;
         loadtest 'containers/docker_compose';
     }
-    loadtest 'containers/validate_btrfs' if (is_x86_64 && !is_jeos);
+    loadtest 'containers/validate_btrfs' if (is_x86_64);    # works currently only for x86_64, more are coming (poo#103977)
 }
 
 


### PR DESCRIPTION
Re-enable the previously disabled validate_btrfs test on JeOS.

- Related ticket: https://progress.opensuse.org/issues/102377
- Verification run: [Tumbleweed](http://duck-norris.qam.suse.de/tests/7957#step/validate_btrfs/220) | [Leap 15.3](http://duck-norris.qam.suse.de/tests/7956#step/validate_btrfs/220)

Note: There is no container test running on SLE JeOS at the moment, so nothing to be done there.
