### PR TITLE
wicked: retry on set ip of bss

### DIFF
--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -335,7 +335,9 @@ sub hostapd_start {
     ## Check for multi BSS setup
     my @bsss = $config =~ (/^bss=(.*)$/gm);
     for my $bss (@bsss) {
-        $self->netns_exec('ip addr add dev ' . $bss . ' ' . $self->ref_ip(bss => $bss, netmask => 1));
+        $self->retry(sub {
+                $self->netns_exec('ip addr add dev ' . $bss . ' ' . $self->ref_ip(bss => $bss, netmask => 1));
+        });
         $self->restart_dhcp_server(bss => $bss) if ($self->use_dhcp());
     }
 }


### PR DESCRIPTION
This catch errors like this: http://openqa.wicked.suse.de/tests/44478/#step/t10_multi_networks_priority/8 

Which just happen if we try to set an IP on an interface which isn't added from hostapd till now...

- Verification run: http://openqa.wicked.suse.de/t44575
