### PR TITLE
Do not skip installation of FIPS pattern for SLED

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1938,10 +1938,6 @@ sub install_patterns {
         if (($pt =~ /sap_server/) && is_sle('=11-SP4')) {
             next;
         }
-        # skip the installation of "fips" for SLED cases, poo#98745.
-        if (($pt =~ /fips/) && check_var('SLE_PRODUCT', 'sled')) {
-            next;
-        }
         # if pattern is common-criteria and PATTERNS is all, skip, poo#73645
         next if (($pt =~ /common-criteria/) && check_var('PATTERNS', 'all'));
         zypper_call("in -t pattern $pt", timeout => 1800);


### PR DESCRIPTION
FIPS pattern is moved to basesystem module, so it is available on
SLED. While some of the dependency packages were in server application
module, there would be some dependency issues when installing FIPS on
SLED. Because FIPS is only supported on SLES, we skipped installing it
on SLED. While FIPS developer think they should move all dependency
packages to basesystem module and it should be no problem if installing
it on SLED, see bsc#1191024 for more details. Now this pr will not skip
the FIPS pattern installation for SLED.
- Related ticket: https://progress.opensuse.org/issues/102140
- Needles: n/a
- Verification run: https://openqa.nue.suse.com/tests/7850223#step/patch_sle/102
