### PR TITLE
Public Cloud: use http URL for LTP repo

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -83,7 +83,7 @@ sub upload_ltp_logs
 sub run {
     my ($self, $args) = @_;
     my $arch = check_var('PUBLIC_CLOUD_ARCH', 'arm64') ? 'aarch64' : 'x86_64';
-    my $ltp_repo = get_var('LTP_REPO', 'https://download.opensuse.org/repositories/benchmark:/ltp:/devel/' . generate_version("_") . '/');
+    my $ltp_repo = get_var('LTP_REPO', 'http://download.opensuse.org/repositories/benchmark:/ltp:/devel/' . generate_version("_") . '/');
     my $provider;
     my $instance;
 


### PR DESCRIPTION
This will help avoid this error:
`Error message: Protocol "http" not supported or disabled in libcurl`
which happens quite often lately.

Example: https://openqa.suse.de/tests/7853629#next_previous

VR: http://fromm.arch.suse.de/tests/5303

