### PR TITLE
install_ltp: HPC is used on 12-SP4 aarch64 due to LTSS support

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -111,7 +111,11 @@ sub add_custom_grub_entries {
     my $cfg_old = 'grub.cfg.old';
     my $distro = "openSUSE" . ' \\?' . get_required_var('VERSION');
 
-    if (check_var('SLE_PRODUCT', 'slert')) {
+    # LTSS is supported only on aarch64 HPC 12-SP4
+    if (check_var('VERSION', '12-SP4') && check_var('ARCH', 'aarch64')) {
+        $distro = 'SLE-HPC' . ' \\?' . get_required_var('VERSION');
+    }
+    elsif (check_var('SLE_PRODUCT', 'slert')) {
         $distro = "SLE_RT" . ' \\?' . get_required_var('VERSION');
     }
     elsif (is_sle()) {


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/7853189#step/install_ltp/155
- Verification run: https://openqa.suse.de/tests/overview?build=4.12.14-29.1.geb513f7&groupid=214&version=12-SP4&distri=sle