### PR TITLE
MicroOS: include systemctl status for cockpit

### DIFF
--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -39,6 +39,7 @@ sub run {
     assert_script_run('curl http://localhost:9090', fail_message => 'Cannot fetch index page');
     assert_script_run('lsof -i :9090', fail_message => 'Port 9090 is not opened!');
     systemctl('is-active cockpit.service');
+    record_info('status', script_output('systemctl status cockpit.service'));
 
 
     # Cockpit should survive a reboot. After reboot cockpit.socket should be
@@ -48,6 +49,7 @@ sub run {
     systemctl('is-enabled cockpit.socket');
     assert_script_run('curl http://localhost:9090', fail_message => 'Cannot fetch index page');
     systemctl('is-active cockpit.service');
+    record_info('status', script_output('systemctl status cockpit.service'));
 }
 
 1;


### PR DESCRIPTION
It could help us make this error more visual in the tests:
`Error generating temporary dummy cert using sscg, falling back to openssl`


[openSUSE](https://openqa.opensuse.org/tests/overview?version=Tumbleweed&distri=microos&build=jlausuch%2Fos-autoinst-distri-opensuse%23microos_cockpit_systemctl)
[SLE Micro](https://openqa.suse.de/tests/overview?distri=sle-micro&version=5.1&build=jlausuch%2Fos-autoinst-distri-opensuse%23microos_cockpit_systemctl)