### PR TITLE
Install SUSEConnect when system role is common criteria

### DIFF
--- a/tests/security/cc/cc_audit_test_setup.pm
+++ b/tests/security/cc/cc_audit_test_setup.pm
@@ -5,7 +5,7 @@
 #
 # Summary: Setup 'audit-test' test environment of a system with needed packages
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#93441
+# Tags: poo#93441, poo#104070
 
 use base 'consoletest';
 use strict;
@@ -23,6 +23,10 @@ sub run {
 
     select_console 'root-console';
 
+    if (script_run('which SUSEConnect') != 0) {
+        record_soft_failure('bsc#1193782', 'SUSEConnect is not installed when system role is common criteria');
+        zypper_call('in SUSEConnect');
+    }
     # Add needed modules
     add_suseconnect_product('sle-module-legacy');
     add_suseconnect_product('sle-module-desktop-applications');


### PR DESCRIPTION
In the last build [74.1], when system role is common criteria, the
package SUSEConnect is not installed. This caused all CC test cases
failed. So we need to install this package as a workaround and need to
confirm if it is by design.

Related: https://progress.opensuse.org/issues/104070

Verify run: https://openqa.suse.de/tests/7862983