### PR TITLE
Fix lynis failure by adding Legacy Module

### DIFF
--- a/tests/security/lynis/lynis_setup.pm
+++ b/tests/security/lynis/lynis_setup.pm
@@ -21,6 +21,7 @@ sub run {
     select_console "root-console";
 
     add_suseconnect_product("PackageHub", undef, undef, undef, 300, 1) if is_sle;
+    add_suseconnect_product("sle-module-legacy", undef, undef, undef, 300, 1) if is_sle;
     # Set timeout to 300s as the default 90s is not enough in some situations
     zypper_call("in lynis", timeout => 300);
 


### PR DESCRIPTION
Add Legacy Module (sle-module-legacy) before install 'net-tools-deprecated' package needed by lynis

poo#104073 - [sle][security][sle15sp4] test fails in lynis_setup: 'zypper -n in lynis' failed with code 4, nothing provides 'net-tools-deprecated'

- Related ticket: https://progress.opensuse.org/issues/104073
- Needles: NA
- Verification run: https://openqa.suse.de/tests/7863386 （The soft failure/fail is not introduced by this fix, it dues to another pr ）

I will offer other verification runs later.