### PR TITLE
xfstests: Group file change name in upstream

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -184,7 +184,7 @@ sub exclude_grouplist {
     foreach my $group_name (@GROUPLIST) {
         next if ($group_name !~ /^\!/);
         $group_name = substr($group_name, 1);
-        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$test_folder/group | awk '{printf \"$test_folder/\"}{printf \$1}{printf \",\"}' > tmp.group";
+        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$test_folder/group.list | awk '{printf \"$test_folder/\"}{printf \$1}{printf \",\"}' > tmp.group";
         script_run($cmd);
         $cmd = "cat tmp.group";
         my %tmp_list = map { $_ => 1 } split(/,/, substr(script_output($cmd), 0, -1));
@@ -202,7 +202,7 @@ sub include_grouplist {
     my $test_folder = $TEST_RANGES =~ /generic/ ? "generic" : $FSTYPE;
     foreach my $group_name (@GROUPLIST) {
         next if ($group_name =~ /^\!/);
-        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$test_folder/group | awk '{printf \"$test_folder/\"}{printf \$1}{printf \",\"}' > tmp.group";
+        my $cmd = "awk '/$group_name/' $INST_DIR/tests/$test_folder/group.list | awk '{printf \"$test_folder/\"}{printf \$1}{printf \",\"}' > tmp.group";
         script_run($cmd);
         $cmd = "cat tmp.group";
         my $tests = substr(script_output($cmd), 0, -1);


### PR DESCRIPTION
In xfstests upstream, there is a group file rename from group to group.list. And group file create during build.[1] Then we update name to adapt this change.

[1] xfstests git tag: 17f6ac8eccb4d3f974aa74350b63e186c092ea16
    fstests: automatically generate group files
    
    Now that we've moved the group membership details into the test case
    files themselves, automatically generate the group files during build.
    The autogenerated files are named "group.list" instead of "group" to
    avoid conflicts between generated and (stale) SCM files as everyone
    rebases.

- Verification run: 
- Before this PR group tests not enabled only triggered 1 test: https://openqa.suse.de/tests/7806579
- After this PR group enabled a lot of tests: https://openqa.suse.de/tests/7863592