### PR TITLE
Adapt full medium to new welcome screen bsc#1192626

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -519,7 +519,11 @@ Returns true (1) if Product Selection step has to be shown for the certain
 configuration, otherwise returns false (0).
 =cut
 sub has_product_selection {
-    # Possible result of bsc#1192626
+    # Product selection behavior changed for s390 on 15-SP4, so now there's only a single product
+    # and there's no need for the installer to request anything, however for QU this might change
+    # following PR should be used as a reference for when product selection changes again in the
+    # future
+    # https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13880
     my $does_not_have = is_sle('>=15-SP4') && check_var('FLAVOR', 'Full') && is_s390x();
     if (is_sle('15+') && !get_var('UPGRADE')) {
         return 0 if $does_not_have;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -519,7 +519,10 @@ Returns true (1) if Product Selection step has to be shown for the certain
 configuration, otherwise returns false (0).
 =cut
 sub has_product_selection {
+    # Possible result of bsc#1192626
+    my $does_not_have = is_sle('>=15-SP4') && check_var('FLAVOR', 'Full') && is_s390x();
     if (is_sle('15+') && !get_var('UPGRADE')) {
+        return 0 if $does_not_have;
         return (is_sle('>=15-SP1') || !is_s390x()) && !get_var('BASE_VERSION');
     }
 }
@@ -536,10 +539,16 @@ configuration, otherwise returns false (0).
 =cut
 sub has_license_on_welcome_screen {
     return 1 if is_sle_micro;
-    return get_var('HASLICENSE') &&
-      (((is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x())
-        || is_sle('<15')
-        || (is_sle('=15') && is_s390x()));
+    if (get_var('HASLICENSE')) {
+        return 1 if (
+            ((is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x())
+            || is_sle('<15')
+            || (is_sle('=15') && is_s390x())
+            || (is_sle('>=15-SP4') && check_var('FLAVOR', 'Full') && is_s390x())
+        );
+    }
+
+    return 0;
 }
 
 =head2 has_license_to_accept

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -163,6 +163,7 @@ sub run {
 
     # license+lang +product (on sle15)
     # On sle 15 license is on different screen, here select the product
+    # see has_product_selection in case the screen fails again in the future
     if (has_product_selection) {
         assert_screen('select-product');
         my $product = get_required_var('SLE_PRODUCT');


### PR DESCRIPTION
https://build.suse.de/request/show/258526 changed the behavior for the full medium, so now there's no product selection for s390 at all

s390 Full: https://openqa.suse.de/tests/7861118#
x86 Full: https://openqa.suse.de/tests/7861139#