### PR TITLE
console/salt: switch to serial terminal

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -27,8 +27,9 @@ use version_utils qw(is_jeos is_opensuse);
 use registration 'add_suseconnect_product';
 
 sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
     if (is_jeos && !is_opensuse) {
-        select_console 'root-console';
         my $version = get_required_var('VERSION') =~ s/([0-9]+).*/$1/r;
         if ($version == '12') {
             add_suseconnect_product('sle-module-adv-systems-management', $version);
@@ -39,7 +40,6 @@ sub run {
         }
     }
 
-    select_console 'root-console';
     quit_packagekit;
     zypper_call('in salt-master salt-minion');
     my $cmd = <<'EOF';


### PR DESCRIPTION
Avoid or reduce probability of missing characters by moving the test to use serial console.

https://openqa.suse.de/tests/7856323#step/salt/18

* [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20211214-jeos@64bit_virtio](https://openqa.opensuse.org/tests/2086733)
* [opensuse-Tumbleweed-NET-x86_64-Build20211214-minimalx@64bit](https://openqa.opensuse.org/tests/2086734)
* [sle-15-SP4-Online-x86_64-Build74.1-default@svirt-xen-pv](https://openqa.suse.de/tests/7866279)
* [sle-15-SP4-Online-x86_64-Build74.1-textmode+role_xen@64bit](https://openqa.suse.de/tests/7866278)
