### PR TITLE
pynfs: Add soft failure

### DIFF
--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -18,6 +18,7 @@ sub display_results {
     my $self = shift;
     my $skip = "";
     my $pass = "";
+    my $fail = 0;
 
     my $folder = get_required_var('PYNFS');
 
@@ -50,7 +51,10 @@ sub display_results {
         my $targs = OpenQA::Test::RunArgs->new();
         $targs->{data} = $test;
         autotest::loadtest("tests/nfs/pynfs_failed.pm", name => $test->{code}, run_args => $targs);
+        $fail = 1;
     }
+
+    record_info('ALL PASSED') if (!$fail);
 }
 
 sub upload_cthon04_log {

--- a/tests/nfs/pynfs_failed.pm
+++ b/tests/nfs/pynfs_failed.pm
@@ -14,13 +14,21 @@ use Data::Dumper;
 sub run {
     my ($self, $args) = @_;
     my $data = $args->{data};
+    my $msg;
 
     record_info('INFO', "name: $data->{name}\nclassname: $data->{classname}\ntime: $data->{time}\n");
 
     die 'failure does not exist' unless (exists($data->{failure}));
 
-    $self->{result} = 'fail';
-    record_info('ERROR', "$data->{failure}->{message}\n\n$data->{failure}->{err}\n");
+    $msg = "$data->{failure}->{message}\n\n$data->{failure}->{err}";
+
+    if ($data->{code} eq 'LOCK24' && $data->{failure}->{message} eq
+        'OP_LOCK should return NFS4_OK, instead got NFS4ERR_BAD_SEQID') {
+        $self->record_soft_failure_result("LOCK24 failure is known, verriding to softfail: bsc#1192211\n\n" . $msg);
+    } else {
+        $self->{result} = 'fail';
+        record_info('ERROR', $msg);
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
bsc#1192211 (needed as tests are using `autotest::loadtest()`).

verification run:
- http://quasar.suse.cz/tests/7972#step/LOCK24/2 http://quasar.suse.cz/tests/7971#step/LOCK24/2 (soft failure)
- http://quasar.suse.cz/tests/7973#step/generate_report/18 (all passed)