### PR TITLE
Replace installation_overview with validate_default_target

### DIFF
--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/enable_autologin
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -28,7 +28,7 @@ schedule:
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/hostname_inst
   - installation/user_import
   - installation/authentication/root_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/activate_encrypted_volume.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/cryptlvm_sle_15.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -26,7 +26,9 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/change_desktop
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/lvm_multipath.yaml
+++ b/schedule/yast/lvm_multipath.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/lvm_multipath_encrypted.yaml
+++ b/schedule/yast/lvm_multipath_encrypted.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -23,7 +23,6 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/select_patterns
-  - installation/installation_overview
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal.yaml
@@ -24,7 +24,7 @@ schedule:
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/msdos/msdos.yaml
+++ b/schedule/yast/msdos/msdos.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - '{{disable_boot_menu_timeout}}'
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/nvme.yaml
+++ b/schedule/yast/nvme.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/select_patterns
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/select_patterns
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/select_patterns
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/select_patterns
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/usb_install.yaml
+++ b/schedule/yast/usb_install.yaml
@@ -20,7 +20,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/xfs/xfs.yaml
+++ b/schedule/yast/xfs/xfs.yaml
@@ -26,7 +26,7 @@ schedule:
   - '{{hostname_inst}}'
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/yast_hostname/yast_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname.yaml
@@ -22,7 +22,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation

--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/hostname_inst
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_overview
+  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation


### PR DESCRIPTION
The installation_overview test module only validated default target in
the test suites that are edited in this commit.

The commit replaces installation_overview test module, that has a lot of
extra logic to only validate default target test module. This makes the
schedule more transparent and easy to maintain.

- Related ticket: https://progress.opensuse.org/issues/103362
- Verification runs: https://openqa.suse.de/tests/overview?build=74.1_install_overview&groupid=96&distri=sle&version=15-SP4
