### PR TITLE
Merge podman and docker image based tests into one module

### DIFF
--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -11,21 +11,21 @@ use containers::docker;
 use containers::podman;
 use Mojo::Base 'opensusebasetest';
 
+has engine => undef;
 sub containers_factory {
-    my ($self, $runtime) = @_;
-    my $engine;
+    my ($self, $runargs) = @_;
 
-    if ($runtime eq 'docker') {
-        $engine = containers::docker->new();
+    if (defined $runargs->{docker}) {
+        $self->engine(containers::docker->new());
     }
-    elsif ($runtime eq 'podman') {
-        $engine = containers::podman->new();
+    elsif (defined $runargs->{podman}) {
+        $self->engine(containers::podman->new());
     }
     else {
-        die("Unknown runtime $runtime. Only 'docker' and 'podman' are allowed.");
+        die("Unknown runtime $self->engine. Only 'docker' and 'podman' are allowed.");
     }
-    $engine->init();
-    return $engine;
+    $self->engine->init();
+    return $self->engine;
 }
 
 1;

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -41,11 +41,15 @@ sub is_ubuntu_host {
 }
 
 sub load_image_tests_podman {
-    loadtest 'containers/podman_image';
+    my $engine_args = OpenQA::Test::RunArgs->new();
+    $engine_args->{podman} = 1;
+    loadtest 'containers/image_test', name => 'podman_images', run_args => $engine_args;
 }
 
 sub load_image_tests_docker {
-    loadtest 'containers/docker_image';
+    my $engine_args = OpenQA::Test::RunArgs->new();
+    $engine_args->{docker} = 1;
+    loadtest 'containers/image_test', name => 'docker_images', run_args => $engine_args;
     # container_diff package is not avaiable for <=15 in aarch64
     # Also, we don't want to run it on 3rd party hosts
     unless ((is_sle("<=15") and is_aarch64) || get_var('CONTAINERS_NO_SUSE_OS')) {
@@ -55,9 +59,11 @@ sub load_image_tests_docker {
 
 sub load_host_tests_podman {
     if (is_leap('15.1+') || is_tumbleweed || is_sle("15-sp1+")) {
+        my $engine_args = OpenQA::Test::RunArgs->new();
+        $engine_args->{podman} = 1;
         # podman package is only available as of 15-SP1
         loadtest 'containers/podman';
-        loadtest 'containers/podman_image';
+        loadtest 'containers/image_test', name => 'podman_images', run_args => $engine_args;
         loadtest 'containers/podman_3rd_party_images';
         loadtest 'containers/podman_firewall';
         loadtest 'containers/buildah';
@@ -66,8 +72,10 @@ sub load_host_tests_podman {
 }
 
 sub load_host_tests_docker {
+    my $engine_args = OpenQA::Test::RunArgs->new();
+    $engine_args->{docker} = 1;
     loadtest 'containers/docker';
-    loadtest 'containers/docker_image';
+    loadtest 'containers/image_test', name => 'docker_images', run_args => $engine_args;
     loadtest 'containers/docker_3rd_party_images';
     loadtest 'containers/docker_firewall';
     unless (is_sle("<=15") && is_aarch64) {

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -65,7 +65,9 @@ sub load_feature_tests {
     elsif (check_var 'SYSTEM_ROLE', 'container-host') {
         loadtest 'microos/toolbox';
         loadtest 'containers/podman';
-        loadtest 'containers/podman_image';
+        my $engine_args = OpenQA::Test::RunArgs->new();
+        $engine_args->{podman} = 1;
+        loadtest 'containers/image_test', name => 'podman_images', run_args => $engine_args;
     }
 }
 

--- a/tests/containers/image_test.pm
+++ b/tests/containers/image_test.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright 2020-2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: containers
+# Summary: Test installation and running of the container image from the registry for this snapshot.
+# This module is unified to run independented the host os.
+
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use containers::common;
+use containers::container_images;
+use containers::urls 'get_suse_container_urls';
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal();
+    my $engine = $self->containers_factory($self->{run_args});
+
+    scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE'));
+
+    # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGE_VERSIONS
+    my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
+
+    for my $version (split(/,/, $versions)) {
+        my ($untested_images, $released_images) = get_suse_container_urls(version => $version);
+        my $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
+        for my $iname (@{$images_to_test}) {
+            record_info "IMAGE", "Testing image: $iname";
+            test_container_image(image => $iname, runtime => $engine);
+            test_rpm_db_backend(image => $iname, runtime => $engine);
+            my $beta = $version eq get_var('VERSION') ? get_var('BETA', 0) : 0;
+            test_opensuse_based_image(image => $iname, runtime => $engine, version => $version, beta => $beta);
+        }
+    }
+    scc_restore_docker_image_credentials() if defined $self->{run_args}->{docker};
+    $engine->cleanup_system_host();
+}
+
+1;


### PR DESCRIPTION
Leverage `TestArgs` to pass an attribute which defines which container engine should be initialized for each case.
Because each engine has separate function which load the module, each `TestArgs` is also separate instance which means
that the modules works also when they both scheduled in the same job.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/101210
- Verification run: 
