### PR TITLE
x11/keyboard_layout_gdm: Wait longer for reboot

### DIFF
--- a/tests/x11/keyboard_layout_gdm.pm
+++ b/tests/x11/keyboard_layout_gdm.pm
@@ -19,7 +19,7 @@ sub reboot {
     my ($self, %args) = @_;
     $args{setnologin} //= 0;
     power_action('reboot', textmode => 1);
-    $self->wait_boot(nologin => $args{setnologin}, forcenologin => $args{setnologin});
+    $self->wait_boot(nologin => $args{setnologin}, forcenologin => $args{setnologin}, bootloader_time => 300);
 }
 
 sub run {


### PR DESCRIPTION
Sometimes the SUT can take forever to reboot... le't wait a bit more for now.