### PR TITLE
Add ebpf test into openQA

### DIFF
--- a/schedule/security/ebpf.yaml
+++ b/schedule/security/ebpf.yaml
@@ -1,0 +1,15 @@
+name: ebpf
+description:    >
+    This is for ebpf test
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - security/ebpf/disable_unprivileged_ebpf
+    - security/ebpf/check_cap_bpf
+conditional_schedule:
+    bootloader:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+            ppc64le:
+                - installation/bootloader

--- a/tests/security/ebpf/check_cap_bpf.pm
+++ b/tests/security/ebpf/check_cap_bpf.pm
@@ -1,0 +1,28 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test 'CAP_BPF' capability is available:
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#103932, tc#1769831
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $f_tcpdump = '/usr/sbin/tcpdump';
+    my $capability = 'cap_bpf';
+
+    select_console 'root-console';
+
+    # Install packages
+    zypper_call('in libcap-progs tcpdump');
+
+    assert_script_run("getcap $f_tcpdump");
+    assert_script_run("setcap $capability+eip $f_tcpdump");
+    validate_script_output("getcap $f_tcpdump", sub { m/.*$capability.*/ });
+}
+
+1;

--- a/tests/security/ebpf/disable_unprivileged_ebpf.pm
+++ b/tests/security/ebpf/disable_unprivileged_ebpf.pm
@@ -1,0 +1,72 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test 'Unprivileged eBPF usage has been disabled,
+#          the setting can be changed by the `root` user':
+#          '# Verify the eBPF should be disabled unprivileged eBPF by default'
+#          '# Verify re-enable unprivileged eBPF temporarily using "systemctl"'
+#          '# Verify re-enable unprivileged eBPF temporarily using status file'
+#          '# Verify re-enable unprivileged eBPF persistently using config file'
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#103932, tc#1769831
+
+use base 'opensusebasetest';
+use power_action_utils "power_action";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Utils::Backends 'is_pvm';
+
+sub reboot_and_check {
+    my ($self, $status) = @_;
+    my $f_unpriv_bpf_disabled = '/proc/sys/kernel/unprivileged_bpf_disabled';
+
+    # Reboot and verify the eBPF status
+    power_action("reboot", textmode => 1);
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
+    select_console 'root-console';
+    validate_script_output("cat $f_unpriv_bpf_disabled", sub { m/$status/ });
+}
+
+sub run {
+    my ($self) = @_;
+    my $f_unpriv_bpf_disabled = '/proc/sys/kernel/unprivileged_bpf_disabled';
+    my $sysctl_conf = '/etc/sysctl.conf';
+
+    select_console 'root-console';
+
+    # Verify the eBPF status: OS should be disabled unprivileged eBPF by default
+    validate_script_output("cat $f_unpriv_bpf_disabled", sub { m/2/ });
+
+    # Re-enable unprivileged eBPF temporarily using 'systemctl'
+    validate_script_output('sysctl kernel.unprivileged_bpf_disabled=0', sub { m/kernel.unprivileged_bpf_disabled = 0/ });
+    # Verify the eBPF status: should be enabled unprivileged eBPF
+    validate_script_output("cat $f_unpriv_bpf_disabled", sub { m/0/ });
+
+    # Reboot, verify the eBPF status: should be disabled unprivileged eBPF again
+    $self->reboot_and_check('2');
+
+    # Re-enable unprivileged eBPF temporarily using "$f_unpriv_bpf_disabled"
+    assert_script_run("echo -n 0 > $f_unpriv_bpf_disabled");
+    # Verify the eBPF status: should be enabled unprivileged eBPF
+    validate_script_output("cat $f_unpriv_bpf_disabled", sub { m/0/ });
+
+    # Reboot, verify the eBPF status: should be disabled unprivileged eBPF again
+    $self->reboot_and_check('2');
+
+    # Re-enable unprivileged eBPF persistently
+    assert_script_run("echo 'kernel.unprivileged_bpf_disabled = 0' >> $sysctl_conf");
+    # Verify the eBPF status: should be enabled unprivileged eBPF
+    validate_script_output("cat $f_unpriv_bpf_disabled", sub { m/2/ });
+
+    # Reboot, verify the eBPF status: should be enabled unprivileged eBPF
+    $self->reboot_and_check('0');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Add ebpf test into openQA

poo#103932 - [sle][security][sle15sp4][feature][automation] SLE-SLE-22587 - QA: Disable unprivileged eBPF due to security issues

Failed test case can be tracked by a known bug.
TW openQA run will be added by @ShawnHa0.

- Related ticket: https://progress.opensuse.org/issues/103932
- Needles: NA
- Verification run:
  x86_64: https://openqa.suse.de/tests/7871309
  ppc64le: https://openqa.suse.de/tests/7882524
  s390x: https://openqa.suse.de/tests/7871377
  aarch64: https://openqa.suse.de/tests/7871376