### PR TITLE
|WIP] Remove password possibility workaround for s390x

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -121,7 +121,6 @@ sub run {
     }
     # on s390 we might need to install additional packages depending on the installation method
     if (is_s390x) {
-        ssh_password_possibility();
         push(@tags, 'additional-packages');
     }
     # For poo#64228, we need ensure the timeout value less than the MAX_JOB_TIME


### PR DESCRIPTION
openSUSE Tumbleweed has got a test issue during the reboot after await_install for the s390x architecture.
We have added a workaround for the password possibility for s390x in July. I remove this workaround for the test case.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1193889
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: 
