### PR TITLE
Handle polkit-agent-helper-1 not setuid root in CC

### DIFF
--- a/tests/security/cc/polkit_tests.pm
+++ b/tests/security/cc/polkit_tests.pm
@@ -21,15 +21,6 @@ sub run {
 
     # PASSWD is needed by polkit_success
     script_run("export PASSWD=$testapi::password");
-
-    # In cc role based system,polkit-agent-helper-1 needs to be setuid root.
-    # Authentication is required to set the statically configured local
-    # hostname, as well as the pretty hostname.
-    my $results = script_run("journalctl -u dracut-pre-pivot | grep 'crypto checks done'");
-    if (!$results) {
-        assert_script_run('chmod u+s /usr/lib/polkit-1/polkit-agent-helper-1');
-    }
-
     run_testcase('polkit-tests');
 
     # Compare current test results with baseline


### PR DESCRIPTION
In cc setup, 'polkit-agent-helper-1' file is not setuid root
by default, then it will impact our polkit tests, current
workaround is "chmod u+s" for this file in our openQA test code.
it is a not good way to change the default file permission to
pass the test, so enhance our test code to handle it.

BTW, the code change is done in cc  test code already: 
https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/44

- Related ticket: https://progress.opensuse.org/issues/104001
- Needles: n/a
- Verification run:https://openqa.suse.de/tests/7882522 [x86_64]
There is no need to run the VR on aarch64 and s390x, since the change is common one and not x86_64 only