### PR TITLE
Adjust the openssl hash check return message

### DIFF
--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -1,6 +1,6 @@
 # openssl fips test
 #
-# Copyright 2016-2020 SUSE LLC
+# Copyright 2016-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Test description: In fips mode, openssl only works with the FIPS
@@ -13,7 +13,7 @@
 #          the cases to verify opessl hash, cipher, or public key algorithms
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#44834, poo#64649, poo#64842
+# Tags: poo#44834, poo#64649, poo#64842, poo#104184
 
 use base "consoletest";
 use testapi;
@@ -40,10 +40,14 @@ sub run {
     # Remove md2 and sha, and add rmd160 and md5-sha1 from invalid hash check in fips mode
     my @invalid_hash = ("md4", "md5", "mdc2", "rmd160", "ripemd160", "whirlpool", "md5-sha1");
     for my $hash (@invalid_hash) {
-        validate_script_output "openssl dgst -$hash $tmp_file 2>&1 || true", sub { m/disabled for fips|disabled for FIPS|unknown option|Unknown digest|dgst: Unrecognized flag/ };
+        validate_script_output "openssl dgst -$hash $tmp_file 2>&1 || true", sub { m/$hash is not a known digest|unknown option|Unknown digest|dgst: Unrecognized flag/ };
     }
 
     script_run 'rm -f $tmp_file';
+}
+
+sub test_flags {
+    return {fatal => 0, always_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
Description:
Currently openssl just check disabled for fips|disabled for FIPS message, it leads to miss check the error which mentioned in bsc#1193859, thus tying to adjust the openssl hash check return message to "`$hash is not a known digest`" to avoid the defect.

- Related ticket: https://progress.opensuse.org/issues/104184
- Needles: NA
- Verification run: 
  (SP4) https://openqa.suse.de/tests/7893275#step/openssl_fips_hash/17
  (SP3) https://openqa.suse.de/tests/7893278#step/openssl_fips_hash/35
  (Currently there is a bug to track https://bugzilla.suse.com/show_bug.cgi?id=1193859 the error)