### PR TITLE
Fixes issues performing installation libyui-rest-api

### DIFF
--- a/lib/Installation/Popups/AbstractOKPopup.pm
+++ b/lib/Installation/Popups/AbstractOKPopup.pm
@@ -3,11 +3,11 @@
 # Copyright 2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: The module provides interface to act on the Performing Installation
-#          Page.
+# Summary: The abstract class introduces methods to handle
+# an abstract OK popup with unknown content.
 # Maintainer: QE YaST <qa-sle-yast@suse.de>
 
-package Installation::PerformingInstallation::PerformingInstallationPage;
+package Installation::Popups::AbstractOKPopup;
 use strict;
 use warnings;
 
@@ -21,13 +21,18 @@ sub new {
 
 sub init {
     my $self = shift;
-    $self->{pba_total_packages} = $self->{app}->progressbar({id => 'progressTotal'});
+    $self->{btn_ok} = $self->{app}->button({id => 'ok'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{pba_total_packages}->exist();
+    return $self->{btn_ok}->exist();
+}
+
+sub press_ok {
+    my ($self) = @_;
+    $self->{btn_ok}->click();
 }
 
 1;

--- a/lib/Installation/Popups/OKPopup.pm
+++ b/lib/Installation/Popups/OKPopup.pm
@@ -10,35 +10,24 @@
 package Installation::Popups::OKPopup;
 use strict;
 use warnings;
-
-sub new {
-    my ($class, $args) = @_;
-    my $self = bless {
-        app => $args->{app}
-    }, $class;
-    return $self->init();
-}
+use parent 'Installation::Popups::AbstractOKPopup';
 
 sub init {
     my $self = shift;
-    $self->{rt_warning} = $self->{app}->label({type => 'YRichText'});
-    $self->{btn_ok} = $self->{app}->button({id => 'ok'});
+    $self->SUPER::init();
+    $self->{rtx_warning} = $self->{app}->richtext({type => 'YRichText'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{btn_ok}->exist();
+    return $self->SUPER::is_shown() &&
+      $self->{rtx_warning}->exist();
 }
 
 sub text {
     my ($self) = @_;
-    return $self->{rt_warning}->text();
-}
-
-sub press_ok {
-    my ($self) = @_;
-    $self->{btn_ok}->click();
+    return $self->{rtx_warning}->text();
 }
 
 1;

--- a/lib/Installation/Popups/OKStopPopup.pm
+++ b/lib/Installation/Popups/OKStopPopup.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces methods to handle an OK/Stop
+# popup containing the message in YRichText Widget.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Popups::OKStopPopup;
+use strict;
+use warnings;
+use parent 'Installation::Popups::OKPopup';
+
+sub init {
+    my $self = shift;
+    $self->SUPER::init();
+    $self->{lbl_counter} = $self->{app}->label({id => '__timeout_label'});
+    $self->{btn_stop} = $self->{app}->button({id => '__stop'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{btn_stop}->exist();
+}
+
+sub press_stop {
+    my ($self) = @_;
+    $self->{btn_stop}->click();
+}
+
+1;

--- a/schedule/yast/addon_module_ftp/addon_module_ftp@s390x.yaml
+++ b/schedule/yast/addon_module_ftp/addon_module_ftp@s390x.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/addon_module_http/addon_module_http@s390x.yaml
+++ b/schedule/yast/addon_module_http/addon_module_http@s390x.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
@@ -40,6 +40,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@s390x.yaml
@@ -31,6 +31,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -33,6 +33,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - boot/reconnect_mgmt_console

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
@@ -31,6 +31,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/boot_encrypt

--- a/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
@@ -33,6 +33,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/boot_encrypt

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -31,6 +31,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/first_boot

--- a/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
@@ -30,6 +30,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -28,6 +28,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/first_boot

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -35,6 +35,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -31,6 +31,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/first_boot

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
@@ -30,6 +30,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/msdos/msdos@s390x.yaml
+++ b/schedule/yast/msdos/msdos@s390x.yaml
@@ -25,6 +25,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
@@ -24,6 +24,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/reboot_after_installation
   - installation/first_boot
   - console/validate_partition_table_via_parted

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -36,6 +36,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -35,6 +35,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/textmode/textmode@svirt-xen.yaml
+++ b/schedule/yast/textmode/textmode@svirt-xen.yaml
@@ -25,6 +25,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/first_boot

--- a/schedule/yast/transactional_server/create_hdd_transactional_server@s390x.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server@s390x.yaml
@@ -29,6 +29,7 @@ schedule:
     - installation/launch_installation
     - installation/confirm_installation
     - installation/performing_installation/perform_installation
+    - installation/performing_installation/stop_timeout_system_reboot_now
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
     - installation/handle_reboot

--- a/schedule/yast/xfs/xfs@s390x_svirt.yaml
+++ b/schedule/yast/xfs/xfs@s390x_svirt.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/xfs/xfs@s390x_zVM.yaml
+++ b/schedule/yast/xfs/xfs@s390x_zVM.yaml
@@ -35,6 +35,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/first_boot

--- a/schedule/yast/yast_no_self_update/yast_no_self_update@s390x.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update@s390x.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/yast_self_update/yast_self_update@s390x.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update@s390x.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -33,6 +33,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot

--- a/tests/installation/performing_installation/perform_installation.pm
+++ b/tests/installation/performing_installation/perform_installation.pm
@@ -3,7 +3,7 @@
 # Copyright 2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Wait for the installation to be finished.
+# Summary: Wait for the installation to be finished successfully.
 # Use TIMEOUT_SCALE so expected installation time can be adjusted
 # for slower architectures.
 # Maintainer: QE YaST <qa-sle-yast@suse.de>
@@ -12,12 +12,21 @@ use strict;
 use warnings;
 use base 'y2_installbase';
 use testapi 'get_var';
+use Test::Assert ':all';
 
 sub run {
-    # Estimated timeout of 5500 seconds (we need to fix the client in order
-    # to introduce here the right value, because of that we set the half of it)
+    my $performing_install = $testapi::distri->get_performing_installation();
+
+    $performing_install->get_performing_installation_page();
+
+    # 2750 represents a huge timeout of 5500 seconds for installation to succeed
     my $timeout = 2750 * get_var('TIMEOUT_SCALE', 1);
-    $testapi::distri->get_performing_installation()->perform($timeout);
+    $performing_install->wait_installation_popup($timeout);
+
+    assert_matches(qr/The system will reboot now/,
+        $performing_install->get_system_reboot_popup()->text(),
+        'System reboot popup is not displayed');
+
 }
 
 1;

--- a/tests/installation/performing_installation/stop_timeout_system_reboot_now.pm
+++ b/tests/installation/performing_installation/stop_timeout_system_reboot_now.pm
@@ -1,0 +1,17 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Stop timeout for system reboot now.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    $testapi::distri->get_performing_installation()->stop_timeout_system_reboot_now();
+}
+
+1;


### PR DESCRIPTION
- Description: This PR contains missing logic when performing installation using client libyui-rest-api:
  - Assert dialog for system reboot so it can detect errors at the end of the installation, where we could find another kind of dialog or the same kind of dialog with different content.
  - Stop timeout for system reboot in s390x with qt. 
- Related ticket: [poo#98958](https://progress.opensuse.org/issues/98958)
- Verification run: [SLE](https://openqa.suse.de/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%23fixes_perform_install&version=15-SP4&distri=sle) | [openSUSE](https://openqa.opensuse.org/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%23fixes_perform_install&version=Tumbleweed&distri=opensuse)