### PR TITLE
Increase the timeout for running trustedprograms tests

### DIFF
--- a/tests/security/cc/trustedprograms.pm
+++ b/tests/security/cc/trustedprograms.pm
@@ -42,7 +42,7 @@ sub run {
 
     select_console 'root-console';
 
-    run_testcase('trustedprograms', (make => 1, timeout => 900));
+    run_testcase('trustedprograms', (make => 1, timeout => 1200));
 
     # Compare current test results with baseline
     my $result = compare_run_log('trustedprograms');


### PR DESCRIPTION
Sometimes the CC test 'trustedprograms' will fail in timeout due to the
aarch64 workers' performance in OSD. So we need to increate the waiting
time to avoid this issue.

Related: https://progress.opensuse.org/issues/103739
Verify run: https://openqa.suse.de/tests/7886357#
