### PR TITLE
Update pam_u2f to 1.1.1 (or later)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2450,6 +2450,7 @@ sub load_security_tests_pam {
     loadtest "security/pam/pam_config";
     loadtest "security/pam/pam_mount";
     loadtest "security/pam/pam_faillock";
+    loadtest "security/pam/pam_u2f";
 }
 
 sub load_security_tests_create_swtpm_hdd {

--- a/tests/security/pam/pam_faillock.pm
+++ b/tests/security/pam/pam_faillock.pm
@@ -94,4 +94,8 @@ EOF
     assert_script_run("userdel -r $user_name");
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/security/pam/pam_u2f.pm
+++ b/tests/security/pam/pam_u2f.pm
@@ -1,0 +1,56 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Update pam_u2f to 1.1.1 (or later)
+#          Add support to FIDO2 (move from libu2f-host+libu2f-server to libfido2)
+#          Add support to User Verification
+#          Add support to PIN Verification
+#          Add support to Resident Credentials
+#          Add support to SSH credential format
+#          This adds support for FIDO2 (yubikey or other)
+#          with pam and provides additional verifications (User, PIN)
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#104181 tc#1769990
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use base 'consoletest';
+use utils 'zypper_call';
+
+sub run {
+    select_console('root-console');
+    zypper_call('in pam_u2f');
+
+    # Package version check
+    my $target_ver = '1.1.1';
+    my $current_ver = script_output q(pamu2fcfg --version | awk '{print $2}');
+    record_info("Current pam_u2f version is $current_ver, target version is $target_ver");
+    die 'The package version is lower than expected' if ($current_ver lt $target_ver);
+
+    # Package change log check
+    my $change_log = script_output('rpm -q pam_u2f --changelog');
+    if ($change_log =~ m/Add support to FIDO2/
+        && $change_log =~ m/Add support to User Verification/
+        && $change_log =~ m/Add support to PIN Verification/
+        && $change_log =~ m/Add support to Resident Credentials/
+        && $change_log =~ m/Add support to SSH credential format/)
+    {
+        record_info('All required patches are set');
+    }
+    else {
+        die('Not all required patches are set, please check with developer');
+    }
+
+    # 'pamu2fcfg' command test, we don't have available yubikey
+    # However, we can still check this command can work
+    validate_script_output('pamu2fcfg 2>&1 || true', sub { m/No device found. Aborting/ });
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
This new version adds support for FIDO2 (yubikey or other)
with pam and provides additional verifications (User, PIN).

- Related ticket: https://progress.opensuse.org/issues/104181
- Needles: n/a
- Verification run:
https://openqa.opensuse.org/tests/2095729 -TW
https://openqa.suse.de/tests/7893662   -SLE
