### PR TITLE
Unschedule validate_mutlipath from zfcp testsuite

### DIFF
--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -39,7 +39,8 @@ schedule:
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_zfcp
-  - console/validate_multipath
+    #  Unscheduling due to poo#99267
+    #  - console/validate_multipath
 test_data:
   software:
     packages:


### PR DESCRIPTION
The module validate_multipath has been failing in the zfcp testsuite, due to changes in the fcp infrastructure on the z/VM hypervisor.
After the chages we have two disks attached to the system (an extra 200 GB disk has been added), which results in two WWIDs being displayed in the multipath config. This causes the module to fail because the `$wwid` parameter is supposed
to only contain one value.

- Related ticket: https://progress.opensuse.org/issues/99267
- Needles: No needles
- Verification run: No run
