### PR TITLE
Change to use yaml scheduler for TW virtualization test suites

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_kvm_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_kvm_hvm_x86_64.xml
@@ -24,7 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-DVD-x86_64-Snapshot12345</guest_installation_media>
+    <guest_installation_media>http://download.opensuse.org/tumbleweed/repo/oss</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings></guest_boot_settings>
     <guest_secure_boot></guest_secure_boot>

--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_hvm_x86_64.xml
@@ -24,7 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-DVD-x86_64-Snapshot12345</guest_installation_media>
+    <guest_installation_media>http://download.opensuse.org/tumbleweed/repo/oss</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings></guest_boot_settings>
     <guest_secure_boot></guest_secure_boot>

--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_pv_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_pv_x86_64.xml
@@ -24,7 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=hvc0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-DVD-x86_64-Snapshot12345</guest_installation_media>
+    <guest_installation_media>http://download.opensuse.org/tumbleweed/repo/oss</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings></guest_boot_settings>
     <guest_secure_boot></guest_secure_boot>
@@ -53,7 +53,7 @@
     <guest_filesystem></guest_filesystem>
     <guest_sound></guest_sound>
     <guest_watchdog></guest_watchdog>
-    <guest_video>cirrus</guest_video>
+    <guest_video>xen</guest_video>
     <guest_smartcard></guest_smartcard>
     <guest_redirdev></guest_redirdev>
     <guest_memballoon></guest_memballoon>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
@@ -142,7 +142,7 @@
   </timezone>
   <user_defaults>
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive/>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
@@ -142,7 +142,7 @@
   </timezone>
   <user_defaults>
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive/>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
@@ -142,7 +142,7 @@
   </timezone>
   <user_defaults>
     <expire/>
-    <group>500</group>
+    <group>100</group>
     <groups/>
     <home>/home</home>
     <inactive/>

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -315,21 +315,6 @@ elsif (get_var('SECURITY_TEST')) {
     prepare_target();
     load_security_tests;
 }
-elsif (get_var('VIRT_AUTOTEST')) {
-    prepare_target() unless get_var('IPMI_DO_NOT_RESTART_HOST');
-    loadtest "virt_autotest/switch_to_ssh_and_install_hypervisor";
-    loadtest "virt_autotest/reboot_and_wait_up_normal" unless get_var('IPMI_DO_NOT_RESTART_HOST');
-    loadtest "virt_autotest/unified_guest_installation" unless get_var('SKIP_GUEST_INSTALL');
-    loadtest "virt_autotest/set_config_as_glue";
-    if (get_var('ENABLE_VIR_NET')) {
-        loadtest "virt_autotest/libvirt_virtual_network_init";
-        loadtest "virt_autotest/libvirt_host_bridge_virtual_network";
-        loadtest "virt_autotest/libvirt_nated_virtual_network";
-    }
-    loadtest "virt_autotest/sriov_network_card_pci_passthrough" if get_var('ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH');
-    loadtest "virtualization/universal/hotplugging" if get_var('ENABLE_HOTPLUGGING');
-    loadtest "virtualization/universal/storage" if get_var('ENABLE_STORAGE');
-}
 elsif (get_var('XFSTESTS')) {
     prepare_target();
     if (check_var('XFSTESTS', 'installation')) {

--- a/schedule/virt_autotest/virt-guest-installation.yaml
+++ b/schedule/virt_autotest/virt-guest-installation.yaml
@@ -1,0 +1,68 @@
+name:           virt-guest-installation
+description:    >
+    Maintainer: jcao@suse.com
+    Virtualization guest installation tests including extended feature tests schedule
+schedule:
+    - '{{install_and_bootup}}'
+    - virt_autotest/switch_to_ssh_and_install_hypervisor
+    - '{{reboot}}'
+    - '{{install_guest}}'
+    - virt_autotest/set_config_as_glue
+    - '{{virtual_network_test}}'
+    - '{{sriov_network_card_pci_passthrough_test}}'
+    - '{{hotplugging_test}}'
+    - '{{storage_test}}'
+conditional_schedule:
+    install_and_bootup:
+        DO_NOT_INSTALL_HOST:
+            0:
+                - '{{bootup}}'
+                - installation/welcome
+                - installation/online_repos
+                - installation/installation_mode
+                - installation/system_role
+                - installation/partitioning
+                - installation/partitioning_firstdisk
+                - installation/partitioning_finish
+                - installation/installer_timezone
+                - installation/user_settings
+                - installation/resolve_dependency_issues
+                - installation/installation_overview
+                - installation/disable_grub_graphics
+                - installation/start_install
+                - installation/await_install
+                - installation/reboot_after_installation
+                - boot/reconnect_mgmt_console
+                - installation/first_boot
+    reboot:
+        DO_NOT_INSTALL_HOST:
+            0:
+                - virt_autotest/reboot_and_wait_up_normal
+    install_guest:
+        SKIP_GUEST_INSTALL:
+            0:
+                - virt_autotest/unified_guest_installation
+    virtual_network_test:
+        ENABLE_VIR_NET:
+            1:
+                - virt_autotest/libvirt_virtual_network_init
+                - virt_autotest/libvirt_host_bridge_virtual_network
+                - virt_autotest/libvirt_nated_virtual_network
+    sriov_network_card_pci_passthrough_test:
+        ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH:
+            1:
+                - virt_autotest/sriov_network_card_pci_passthrough
+    hotplugging_test:
+        ENABLE_HOTPLUGGING:
+            1:
+                - virtualization/universal/hotplugging
+    storage_test:
+        ENABLE_STORAGE:
+            1:
+                - virtualization/universal/storage
+    bootup:
+        IPXE:
+            1:
+                - installation/ipxe_install
+            0:
+                - boot/boot_from_pxe


### PR DESCRIPTION
- Use yaml scheduler instead of main.pm to schedule tests.
- Use DO_NOT_INSTALL_HOST rather than IPMI_DO_NOT_RESTART_HOST to skip host installation
- Support both ipxe bootup and pxe bootup to install host
- Install guest with media from http://download.opensuse.org/tumbleweed/repo/oss
- Fix some minor issues in guest autoyast control files
- Improve a little about needle match in host login

Related ticket: https://progress.opensuse.org/issues/96374

Verification run: 
[kvm PXE installation](http://10.67.129.54/tests/93) 
[kvm PXE installation without host installation & skip guest installation](http://10.67.129.54/tests/94)
[xen iPXE installation](http://10.67.129.54/tests/95)

@alice-suse @xguo @waynechen55 @nanzhg  @pdostal  Could you help review?