### PR TITLE
ai_ml: Use test repos when tested on top of JeOS

### DIFF
--- a/schedule/ai_ml.yaml
+++ b/schedule/ai_ml.yaml
@@ -19,3 +19,7 @@ conditional_schedule:
       generalhw:
         - jeos/prepare_firstboot
         - jeos/firstrun
+        - update/zypper_clear_repos
+        - console/zypper_ar
+        - console/zypper_ref
+        - console/zypper_lr


### PR DESCRIPTION
to avoid mismatch between packages on JeOS image and packages from repos.
- Verification run: jeos_extra_tests_ai_ml@RPi4: https://openqa.opensuse.org/t2099715