### PR TITLE
Fix schedules for SLES4SAP WMP tests

### DIFF
--- a/schedule/kernel/sles4sap/setup_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/setup_hana_baremetal.yaml
@@ -1,9 +1,9 @@
 ---
-name: install_sles4sap_dvd
+name: setup_hana_baremetal
 description: >
-  Installation tests for SLES4SAP, use the DVD to boot the installer.
+  Install HANA on a baremetal machine
 
-  Can be used to install sles4sap on baremetal machines using ipxe_install
+
 vars:
   DESKTOP: textmode
   GRUB_TIMEOUT: 300
@@ -12,8 +12,7 @@ vars:
   INSTANCE_ID: '00'
   INSTANCE_TYPE: HBD
   RECLAIM_ROOT: '1'
-  START_AFTER_TEST: sles4sap_online_dvd_gnome
-  WMP_TEST_REPO: https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz
+  START_AFTER_TEST: install_sles4sap_baremetal
 schedule:
   - boot/boot_to_desktop
   - console/system_prepare
@@ -29,8 +28,6 @@ conditional_schedule:
     TEST_SLES4SAP:
       1:
         - sles4sap/hana_install
-        - sles4sap/wmp_setup
-        - sles4sap/wmp_check_process
   scc_deregister:
     SCC_DEREGISTER:
       1:

--- a/schedule/kernel/sles4sap/wmp_simple_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/wmp_simple_hana_baremetal.yaml
@@ -2,7 +2,6 @@
 name: install_sles4sap_dvd
 description: >
   Installation tests for SLES4SAP, use the DVD to boot the installer.
-
   Can be used to install sles4sap on baremetal machines using ipxe_install
 vars:
   DESKTOP: textmode
@@ -12,11 +11,10 @@ vars:
   INSTANCE_ID: '00'
   INSTANCE_TYPE: HBD
   RECLAIM_ROOT: '1'
-  START_AFTER_TEST: sles4sap_online_dvd_gnome
+  START_AFTER_TEST: setup_hana_baremetal
   WMP_TEST_REPO: https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz
 schedule:
   - boot/boot_to_desktop
-  - console/system_prepare
   - '{{test_sles4sap}}'
   - '{{scc_deregister}}'
   - '{{generate_image}}'
@@ -28,7 +26,7 @@ conditional_schedule:
   test_sles4sap:
     TEST_SLES4SAP:
       1:
-        - sles4sap/hana_install
+        - console/system_prepare
         - sles4sap/wmp_setup
         - sles4sap/wmp_check_process
         - kernel/wmp_simple


### PR DESCRIPTION
Seperate HANA installlation from WMP testing, allowing to re-trigger
WMP tests and not having to reinstall the machine, as we have no support
for uninstalling HANA (yet).

- Verification run: 
- http://baremetal-support.qa.suse.de/tests/1630
- http://baremetal-support.qa.suse.de/tests/1631
- http://baremetal-support.qa.suse.de/tests/1632
