### PR TITLE
Update TrouSerS and tpm-tools to the latest version

### DIFF
--- a/schedule/security/tpm_selftest.yaml
+++ b/schedule/security/tpm_selftest.yaml
@@ -1,0 +1,7 @@
+name: Update TrouSerS and tpm-tools
+description:    >
+    Update TrouSerS and tpm-tools to the latest version
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/swtpm/tpm_selftest

--- a/tests/security/swtpm/tpm_selftest.pm
+++ b/tests/security/swtpm/tpm_selftest.pm
@@ -1,0 +1,57 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Update TrouSerS and tpm-tools to the latest version
+#          Make sure your setup has a TPM 1.2 device attached,
+#          both hardware or software devices should be fine
+#          We need only test this feature on aarch64 platform,
+#          However, based on bsc#1193350, test it on x86_64 as
+#          well
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#103644, tc#1769832
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils qw(zypper_call systemctl);
+use Utils::Architectures;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Version check
+    my $pkg_list = {'tpm-tools' => '1.3.9.2', trousers => '0.3.15'};
+    zypper_call("in " . join(' ', keys %$pkg_list));
+    foreach my $pkg (keys %$pkg_list) {
+        my $current_ver = script_output("rpm -q --qf '%{version}\n' $pkg");
+        record_info("$pkg version", "Current '$pkg' version is $current_ver, target version is $pkg_list->{$pkg}");
+        if ($current_ver lt $pkg_list->{$pkg}) {
+            die("The package $pkg is not updated yet, please check with developer");
+        }
+    }
+
+    # Based on bsc#1193350, swtpm 1.2 device is not supported
+    # on arch64 platform any more, so skip the test on aarch64
+    if (!is_aarch64) {
+        # Make sure tpm device can be created
+        assert_script_run('ls -l /dev/tpm*');
+
+        # Make sure 'tcsd' service can be enabled and started successfully
+        systemctl('enable tcsd');
+        systemctl('start tcsd');
+        systemctl('is-active tcsd');
+
+        # Make sure TPM 1.2 device can be recognized and selftest succeeded
+        validate_script_output('tpm_version', sub { m/TPM 1.2 Version/ });
+        validate_script_output('tpm_selftest -l debug', sub { m/tpm_selftest succeeded/ });
+    }
+}
+
+sub post_fail_hook {
+    script_run('dmesg > /var/tmp/dmesg.txt');
+    upload_logs('/var/tmp/dmesg.txt');
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/103644
- Needles: n/a
- Verification run: 
https://openqa.suse.de/tests/7902552 -x86_64_SLE
https://openqa.suse.de/tests/7902542 -aarch64_SLE

TW tests will be next phase due to https://progress.opensuse.org/issues/103683