### PR TITLE
Remove test user need logout firstly

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -186,7 +186,7 @@ sub full_users_check {
         }
         send_key "alt-f4";
         send_key "ret";
-	select_console 'root-console';
+        select_console 'root-console';
         # need remove the added test user after users test
         remove_test_user;
     }

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -102,14 +102,8 @@ sub switch_users {
     # handle welcome screen, when needed
     handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
     handle_gnome_activities;
-    switch_user;
-    send_key "esc";
-    assert_and_click "displaymanager-$username";
-    assert_screen "originUser-login-dm";
-    # for poo#88247, we have to restore current user's password before migration,
-    # so here need to use the original password.
-    type_password(get_required_var('FLAVOR') =~ /Migration/ ? "$password\n" : "$newpwd\n");
-    handle_gnome_activities;
+    handle_logout;
+    wait_still_screen 10;
 }
 
 # restore password to original value
@@ -129,7 +123,6 @@ sub restore_passwd {
 
 # remove test user
 sub remove_test_user {
-    assert_script_run("pkill -KILL -u $newUser");
     assert_script_run("userdel -r $newUser");
 }
 
@@ -193,7 +186,7 @@ sub full_users_check {
         }
         send_key "alt-f4";
         send_key "ret";
-        select_console 'root-console';
+	select_console 'root-console';
         # need remove the added test user after users test
         remove_test_user;
     }


### PR DESCRIPTION
In x11, to remove a user account need logout the user firstly. So update the switch user test from 'login bernhard -> switch to test -> switch to bernhard ->logout bernhard' to 'login bernhard -> switch to test -> logout test'.

- Related ticket: https://progress.opensuse.org/issues/102963
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/7897906#