### PR TITLE
Add workaround for yast2_apparmor failures

### DIFF
--- a/tests/security/yast2_apparmor/manually_add_profile.pm
+++ b/tests/security/yast2_apparmor/manually_add_profile.pm
@@ -38,11 +38,16 @@ sub run {
     # Enter "Manually Add Profile" to generate a profile for a program
     # "marked as a program that should not have its own profile",
     # it should be failed
-    assert_and_click("AppArmor-Manually-Add-Profile", timeout => 60);
+    assert_and_click("AppArmor-Manually-Add-Profile", timeout => 90);
     assert_and_click("AppArmor-Launch", timeout => 60);
     send_key_until_needlematch("AppArmor-Chose-a-program-to-generate-a-profile", "alt-n", 30, 3);
     type_string("$test_file");
     assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
+    if (!check_screen("AppArmor-generate-a-profile-Error")) {
+        assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
+        record_soft_failure("bsc#1190295, add workaround to click 'Open' again");
+        send_key "tab";
+    }
     assert_screen("AppArmor-generate-a-profile-Error");
     # Exit "yast2 apparmor"
     wait_screen_change { send_key "alt-o" };
@@ -58,7 +63,13 @@ sub run {
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_bk");
     assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
-    assert_screen("AppArmor-Scan-system-log");
+    if (!check_screen("AppArmor-Scan-system-log")) {
+        assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
+        record_soft_failure("bsc#1190295, add workaround to click 'Open' again");
+        send_key "tab";
+    }
+
+    send_key_until_needlematch("AppArmor-Scan-system-log", "tab", 2, 2);
     # Scan systemlog
     send_key "alt-s";
     assert_screen("AppArmor-Scan-system-log");
@@ -76,14 +87,23 @@ sub run {
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_vsftpd");
     assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
-    assert_screen("AppArmor-Inactive-local-profile");
+    if (!check_screen("AppArmor-Inactive-local-profile")) {
+        assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
+        record_soft_failure("bsc#1190295, add workaround to click 'Open' again");
+        send_key "tab";
+    }
+    mouse_click("right");
+    send_key_until_needlematch("AppArmor-Inactive-local-profile", "tab", 2, 2);
+    send_key "tab";
+
     # Check "View Profile"
-    send_key "alt-v";
-    assert_screen("AppArmor-View-Profile");
+    assert_and_click("AppArmor-View-Profile-clickview");
+    send_key_until_needlematch("AppArmor-View-Profile", "tab", 2, 2);
     send_key "alt-o";
-    assert_screen("AppArmor-Inactive-local-profile");
+    send_key_until_needlematch("AppArmor-Inactive-local-profile", "tab", 2, 2);
     # Check "Use Profile"
     send_key "alt-u";
+    mouse_click("right");
     assert_screen("AppArmor-Scan-system-log");
     # Exit "yast2 apparmor"
     wait_screen_change { send_key "alt-f" };

--- a/tests/security/yast2_apparmor/scan_audit_logs.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs.pm
@@ -34,6 +34,10 @@ sub run {
     # Enter "Scan Audit logs" and check there should no records
     assert_and_click("AppArmor-Scan-Audit-logs", timeout => 120);
     assert_and_click("AppArmor-Launch", timeout => 60);
+    if (!check_screen("AppArmor-Scan-Audit-logs-no-records")) {
+        assert_and_click("AppArmor-Launch", timeout => 60);
+        record_soft_failure("bsc#1190292, add workaround to click 'Launch' again");
+    }
     assert_screen("AppArmor-Scan-Audit-logs-no-records");
     # Exit "yast2 apparmor"
     wait_screen_change { send_key "alt-o" };
@@ -50,11 +54,7 @@ sub run {
     # E.g., comment out specific entries from profile, then run corresponding programs to generate audit records
     assert_script_run("cp $test_profile $test_profile_bk");
     assert_script_run("sed -i -e 's/$entry/#$entry/' $test_profile");
-    if (is_sle) {
-        validate_script_output("grep '##' $test_profile", sub { m/#$entry/ });
-    } else {
-        validate_script_output("grep '#' $test_profile", sub { m/#$entry/ });
-    }
+    validate_script_output("grep '#' $test_profile", sub { m/#$entry/ });
     assert_script_run("$test_file");
     validate_script_output("grep 'DENIED' $audit_log", sub { m/type=AVC.*msg=audit.*apparmor=.*DENIED.*profile=.*nscd.*comm=.*nscd.*/ });
 
@@ -66,36 +66,43 @@ sub run {
     # Enter "Scan Audit logs" and check there should have records
     assert_and_click("AppArmor-Scan-Audit-logs", timeout => 120);
     assert_and_click("AppArmor-Launch", timeout => 60);
+    if (!check_screen("AppArmor-Scan-Audit-logs-scan-records")) {
+        assert_and_click("AppArmor-Launch", timeout => 60);
+        record_soft_failure("bsc#1190292, add workaround to click 'Launch' again");
+    }
     assert_screen("AppArmor-Scan-Audit-logs-scan-records");
 
     # Audit the entry
     send_key "alt-u";
-    assert_screen("AppArmor-Scan-Audit-logs-audit");
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-audit", "tab", 2, 2);
     send_key "alt-u";
-    assert_screen("AppArmor-Scan-Audit-logs-scan-records");
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-scan-records", "tab", 2, 2);
 
     # Allow the entry
     send_key "alt-a";
-    assert_screen("AppArmor-Scan-Audit-logs-allow");
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-allow", "tab", 2, 2);
 
     # View changes
     send_key "alt-v";
-    assert_screen("AppArmor-Scan-Audit-logs-view-changes");
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-view-changes", "tab", 2, 2);
     send_key "alt-o";
 
     # View changes b/w clean profile
     send_key "alt-i";
-    assert_screen("AppArmor-Scan-Audit-logs-view-changes-clean-profile");
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-view-changes-clean-profile", "tab", 2, 2);
     send_key "alt-o";
 
     # Abort: no
     send_key "alt-a";
-    assert_screen("AppArmor-Scan-Audit-logs-abort");
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-abort", "tab", 2, 2);
     send_key "alt-n";
+    mouse_click("right");
     assert_screen("AppArmor-Scan-Audit-logs-allow");
 
     # Save changes
     send_key "alt-s";
+    mouse_click("right");
+    assert_and_click("AppArmor-Scan-Audit-logs-save");
     assert_screen("AppArmor-Scan-Audit-logs-saved");
     send_key "alt-o";
 

--- a/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
+++ b/tests/security/yast2_apparmor/settings_disable_enable_apparmor.pm
@@ -24,19 +24,23 @@ sub run {
     send_key "alt-e";
     assert_screen("AppArmor-Settings-Disable-Apparmor");
     wait_screen_change { send_key "alt-q" };
+    type_string("\n");
+    send_key "ctrl-c";
     enter_cmd("systemctl status apparmor | tee ");
     assert_screen("AppArmor_Inactive");
 
     # Enable apparmor service and check
     enter_cmd("yast2 apparmor &");
-    assert_screen("AppArmor-Configuration-Settings", timeout => 120);
+    assert_screen("AppArmor-Configuration-Settings", timeout => 180);
     assert_and_click("AppArmor-Launch", timeout => 60);
     assert_screen("AppArmor-Settings-Disable-Apparmor");
     send_key "alt-e";
     assert_screen("AppArmor-Settings-Enable-Apparmor");
     wait_screen_change { send_key "alt-q" };
     # Handle exception: the cursor disappears for no reason sometimes
+    mouse_click("left");
     type_string("\n");
+    send_key "ctrl-c";
     clear_console;
     assert_screen("root-console-x11");
     enter_cmd("systemctl status apparmor | tee ");


### PR DESCRIPTION
Add workaround for yast2_apparmor failures due to bsc#1190292 & bsc#1190295

- Related ticket:
  https://progress.opensuse.org/issues/104322
  https://progress.opensuse.org/issues/104319
  https://progress.opensuse.org/issues/98853
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: 
 x86_64: https://openqa.suse.de/tests/7918457
 s390x: https://openqa.suse.de/tests/7918634
 ppc64le: https://openqa.suse.de/tests/7918455
 aarch64: https://openqa.suse.de/tests/7918717