### PR TITLE
xfstests: several output enhancement

### DIFF
--- a/tests/xfstests/xfstests_failed.pm
+++ b/tests/xfstests/xfstests_failed.pm
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright 2021 SUSE LLC
+#
+# Summary: Print failed test info in xfstests
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use 5.018;
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+
+sub run {
+    my ($self, $args) = @_;
+    my $test_status = $args->{status};
+    record_info('INFO', "name: $args->{name}\ntest result: $test_status\ntime: $args->{time}\n");
+    record_info('output', "$args->{output}");
+    if ($test_status =~ /FAILED/) {
+        $self->{result} = 'fail';
+        record_info('out.bad', "$args->{outbad}");
+        record_info('full', "$args->{fullog}");
+        record_info('dmesg', "$args->{dmesg}");
+    }
+    else {
+        $self->{result} = 'softfail';
+    }
+}
+
+sub test_flags {
+    return {no_rollback => 1, fatal => 0};
+}
+
+sub post_fail_hook {
+    return;
+}
+
+1;


### PR DESCRIPTION
Changes:

1. Abandoned XML:Write to output log which cause o3 tests fail
2. To short the output, shows only Fail and Skip tests, and add summary in the end of generate_report step to show all included tests
3. Show output, out.bad, full log and dmesg info in page
4. Fail tests' names could see in overview page

- Related ticket: https://progress.opensuse.org/issues/104316
- Verification run: 
SLE: http://10.67.133.133/tests/105
- This test include 4 tests 
generic/470 generic/530 generic/531 generic/594
generic/470 is skipped; generic/594 is failed; others two are passed. As see in this page only show skip test as softfail and shows fail test as fail.
- Test in o3 for Tumbleweed: 
https://openqa.opensuse.org/tests/2106799
https://openqa.opensuse.org/tests/2106802