### PR TITLE
Run different test flow in switch_users for migration and desktop test

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -102,8 +102,19 @@ sub switch_users {
     # handle welcome screen, when needed
     handle_welcome_screen(timeout => 120) if (opensuse_welcome_applicable);
     handle_gnome_activities;
-    handle_logout;
-    wait_still_screen 10;
+    # migration test need logout 'test' to remove 'test' account later
+    if (get_required_var('FLAVOR') =~ /Migration/) {
+        handle_logout;
+        wait_still_screen 10;
+    }
+    else {
+        switch_user;
+        send_key "esc";
+        assert_and_click "displaymanager-$username";
+        assert_screen "originUser-login-dm";
+        type_password "$newpwd\n";
+        handle_gnome_activities;
+    }
 }
 
 # restore password to original value


### PR DESCRIPTION
It is different test scenarios for migration and desktop for switch_users, so need add condition to control the scenarios of migration and desktop test.

- Related ticket: https://progress.opensuse.org/issues/104325
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2101912#step/change_password/1  # verify desktop test
                            https://openqa.nue.suse.com/tests/7902448#step/check_upgraded_service/68#   # veriffy migration test
                            
