### PR TITLE
Enlarge timeout for wait yast lan page

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -402,7 +402,7 @@ sub open_yast2_lan {
         return "Controlled by network manager";
     }
 
-    assert_screen [qw(yast2_lan install-susefirewall2 install-firewalld dhcp-popup)], 120;
+    assert_screen [qw(yast2_lan install-susefirewall2 install-firewalld dhcp-popup)], 240;
     handle_dhcp_popup;
 
     if (match_has_tag('install-susefirewall2') || match_has_tag('install-firewalld')) {


### PR DESCRIPTION
Enlarge timeout for wait yast lan page

- Related ticket:https://progress.opensuse.org/issues/104329
- Needles: na
- Verification run: [openqa.mypersonalinstance.de/tests/xyz#step/module/x](http://openqa.suse.de/tests/7909333#step/yast2_lan/13)
