### PR TITLE
Fix sync timeout for sap migration

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -59,6 +59,9 @@ sub patching_sle {
         # Update origin system on zVM that is controlled by autoyast profile and reboot is done by end of autoyast installation
         # So we skip reboot here after fully patched on zVM to reduce times of reconnection to s390x
         if (!get_var('UPGRADE_ON_ZVM')) {
+            # Sometimes update package 'polkit' will cause GDM restart, so after
+            # update patches we'd better to select_console to make test robust.
+            select_console 'root-console';
             # Perform sync ahead of reboot to flush filesystem buffers
             assert_script_run 'sync', 600;
             # Open gdm debug info for poo#45236, this issue happen sometimes in openqa env


### PR DESCRIPTION
The sync timeout for the GDM restarted when updated 'polkit', so after update patches we'd better to select_console to make test robust.

- Related ticket: https://progress.opensuse.org/issues/97310
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/7882530#step/patch_sle/49  # The later failure in start_install is for package conflict issue, no relationship with the fix.
