### PR TITLE
Enhance package version upgrade check logic

### DIFF
--- a/tests/security/ibmtss/version_check.pm
+++ b/tests/security/ibmtss/version_check.pm
@@ -10,17 +10,16 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use utils 'zypper_call';
+use utils qw(zypper_call package_upgrade_check);
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    zypper_call('in ibmtss');
-    my $tagert_ver = '1.6.0';
-    my $current_ver = script_output("rpm -q --qf '%{version}\n' ibmtss");
-    record_info("Current ibmtss package version is $current_ver, target version is $tagert_ver");
-    die 'The package version is not updated yet, please check with developer' if ($current_ver lt $tagert_ver);
+    # Version check
+    my $pkg_list = {ibmtss => '1.6.0'};
+    zypper_call("in " . join(' ', keys %$pkg_list));
+    package_upgrade_check($pkg_list);
 }
 
 1;

--- a/tests/security/pam/pam_u2f.pm
+++ b/tests/security/pam/pam_u2f.pm
@@ -18,17 +18,16 @@ use strict;
 use warnings;
 use testapi;
 use base 'consoletest';
-use utils 'zypper_call';
+use utils qw(zypper_call package_upgrade_check);
 
 sub run {
     select_console('root-console');
     zypper_call('in pam_u2f');
 
     # Package version check
-    my $target_ver = '1.1.1';
-    my $current_ver = script_output q(pamu2fcfg --version | awk '{print $2}');
-    record_info("Current pam_u2f version is $current_ver, target version is $target_ver");
-    die 'The package version is lower than expected' if ($current_ver lt $target_ver);
+    my $pkg_list = {'pam_u2f' => '1.1.1'};
+    zypper_call("in " . join(' ', keys %$pkg_list));
+    package_upgrade_check($pkg_list);
 
     # Package change log check
     my $change_log = script_output('rpm -q pam_u2f --changelog');

--- a/tests/security/smartcard/version_check.pm
+++ b/tests/security/smartcard/version_check.pm
@@ -9,9 +9,9 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use utils;
-use version_utils 'is_sle';
+use utils qw(zypper_call systemctl package_upgrade_check);
 use registration 'add_suseconnect_product';
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
@@ -32,13 +32,7 @@ sub run {
         'pkcs11-helper' => '1.25.1'
     };
     zypper_call("in " . join(' ', keys %$pkg_list));
-    foreach my $pkg (keys %$pkg_list) {
-        my $current_ver = script_output("rpm -q --qf '%{version}\n' $pkg");
-        record_info("Current $pkg version is $current_ver, target version is $pkg_list->{$pkg}");
-        if ($current_ver lt $pkg_list->{$pkg}) {
-            die("The package $pkg is not updated yet, please check with developer");
-        }
-    }
+    package_upgrade_check($pkg_list);
 
     # pcscd service check
     systemctl('enable pcscd');

--- a/tests/security/swtpm/tpm_selftest.pm
+++ b/tests/security/swtpm/tpm_selftest.pm
@@ -14,7 +14,7 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use utils qw(zypper_call systemctl);
+use utils qw(zypper_call systemctl package_upgrade_check);
 use Utils::Architectures;
 
 sub run {
@@ -24,13 +24,7 @@ sub run {
     # Version check
     my $pkg_list = {'tpm-tools' => '1.3.9.2', trousers => '0.3.15'};
     zypper_call("in " . join(' ', keys %$pkg_list));
-    foreach my $pkg (keys %$pkg_list) {
-        my $current_ver = script_output("rpm -q --qf '%{version}\n' $pkg");
-        record_info("$pkg version", "Current '$pkg' version is $current_ver, target version is $pkg_list->{$pkg}");
-        if ($current_ver lt $pkg_list->{$pkg}) {
-            die("The package $pkg is not updated yet, please check with developer");
-        }
-    }
+    package_upgrade_check($pkg_list);
 
     # Based on bsc#1193350, swtpm 1.2 device is not supported
     # on arch64 platform any more, so skip the test on aarch64


### PR DESCRIPTION
We have already had a good function to compare package version,
which is much better than simple string comparing. so enhance
our test code for the existing test modules

- Related ticket: https://progress.opensuse.org/issues/104355
- Needles: n/a
- Verification run: 
https://openqa.suse.de/tests/7918770
https://openqa.suse.de/tests/7918771
https://openqa.suse.de/tests/7918772
https://openqa.suse.de/tests/7918773

Fail the case rather than record_soft_failure:
https://openqa.suse.de/tests/7918501#step/version_check/14
