### PR TITLE
xfstests: Shorter label to stable under stress

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -31,8 +31,8 @@ use filesystem_utils qw(format_partition);
 # Heartbeat variables
 my $HB_INTVL = get_var('XFSTESTS_HEARTBEAT_INTERVAL') || 30;
 my $HB_TIMEOUT = get_var('XFSTESTS_HEARTBEAT_TIMEOUT') || 200;
-my $HB_PATN = '<heartbeat>';
-my $HB_DONE = '<done>';
+my $HB_PATN = '<h>';    #shorter label <heartbeat> to getting stable under heavy stress
+my $HB_DONE = '<d>';    #shorter label <done> to getting stable under heavy stress
 my $HB_DONE_FILE = '/opt/test.done';
 my $HB_EXIT_FILE = '/opt/test.exit';
 my $HB_SCRIPT = '/opt/heartbeat.sh';
@@ -126,7 +126,9 @@ sub test_wait {
     my $begin = time();
     my ($type, $status) = heartbeat_wait;
     my $delta = time() - $begin;
-    while ($type eq $HB_PATN and $delta < $timeout) {
+    # In case under heavy stress, only match first 2 words in label is enough
+    my $hb_label = substr($HB_PATN, 0, 2);
+    while ($type =~ /$hb_label/ and $delta < $timeout) {
         ($type, $status) = heartbeat_wait;
         $delta = time() - $begin;
     }


### PR DESCRIPTION
xfstests in openqa has a strategy to kill test when it timeout to avoid hanging case. But recently it kill some unnecessary case especially in case their label not match because of under heavy stress in serial. This PR try to enhance this scenario.
- Shorter heartbeat label "heartbeat" to "h", done label "done" to "d"
- Match only first two words in label when checking test not finish to minimal the checking point to make test not stop before timeout

- Verification run: 
http://10.67.133.133/tests/111

And use xfstests_btrfs-btrfs-151-999 to have a try
before: https://openqa.suse.de/tests/7911438
after: https://openqa.suse.de/tests/7916192
