### PR TITLE
Fix remove test user failed on s390x

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -190,6 +190,7 @@ sub full_users_check {
         # so we have to change this test to logout and login new user.
         if (is_s390x) {
             logout_and_login($newUser, $pwd4newUser);
+            handle_logout;
         }
         else {
             switch_users;


### PR DESCRIPTION
We need logout the test user before remove the test user account. 

- Related ticket: https://progress.opensuse.org/issues/104436
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/7916053#   # online 15SP3
                            https://openqa.nue.suse.com/tests/7916182#step/check_upgraded_service/80  # online 15SP2
