### PR TITLE
Add version_switch_origin_system module to get system version

### DIFF
--- a/schedule/install/offline_spvm_install.yaml
+++ b/schedule/install/offline_spvm_install.yaml
@@ -1,6 +1,8 @@
 name:          offline_spvm_install
 description:    >
     This is prepare install task before migration.
+vars:
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
 schedule:
   - installation/bootloader
   - installation/welcome
@@ -28,6 +30,7 @@ schedule:
   - console/system_prepare
   - console/hostname
   - console/force_scheduled_tasks
+  - migration/version_switch_origin_system
   - update/patch_sle
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown


### PR DESCRIPTION
Add version_switch_origin_system module to get system version.
We need use correct system version.

- Related ticket: https://progress.opensuse.org/issues/104409
- Verification run: https://openqa.suse.de/tests/7918562#step/patch_sle/59
