### PR TITLE
xfstests: Mark skip test as pass and enrich summary info

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -61,7 +61,7 @@ sub analyze_result {
             my $test_time = $3;
             (my $test_path = $test_name) =~ s/-/\//;
             $test_num += 1;
-            $test_range = $test_range . $test_path . "\n";
+            $test_range = $test_range . $test_path . " ... ... " . $test_status . " ($test_time seconds)" . "\n";
             $test_path = '/opt/log/' . $test_path;
             bmwqemu::fctinfo("$test_name");
             if ($test_status =~ /FAILED|SKIPPED/) {

--- a/tests/xfstests/xfstests_failed.pm
+++ b/tests/xfstests/xfstests_failed.pm
@@ -22,7 +22,7 @@ sub run {
         record_info('dmesg', "$args->{dmesg}");
     }
     else {
-        $self->{result} = 'softfail';
+        $self->{result} = 'skip';
     }
 }
 


### PR DESCRIPTION
To make pass rate comparable between beta1 and other milestone. Change to mark skip to skip tests instead of softfail. And skip cases could also been distinguished. Because only fail and skip case could show in result.
Also enrich summary a little bit with some status information.

- Verification run: https://openqa.suse.de/tests/7939131
