### PR TITLE
Fix the failures in CC syscall test case

### DIFF
--- a/tests/security/cc/audit_remote_libvirt.pm
+++ b/tests/security/cc/audit_remote_libvirt.pm
@@ -51,7 +51,7 @@ sub run {
     run_testcase('audit-remote-libvirt', make => 0, timeout => 120);
 
     # Compare current test results with baseline
-    my $result = compare_run_log('audit_remote_libvirt');
+    my $result = compare_run_log('audit-remote-libvirt');
     $self->result($result);
 }
 

--- a/tests/security/cc/audit_tools.pm
+++ b/tests/security/cc/audit_tools.pm
@@ -23,7 +23,7 @@ sub run {
     run_testcase('audit-tools');
 
     # Compare current test results with baseline
-    my $result = compare_run_log('audit_tools');
+    my $result = compare_run_log('audit-tools');
     $self->result($result);
 }
 

--- a/tests/security/cc/audit_trail_protection.pm
+++ b/tests/security/cc/audit_trail_protection.pm
@@ -22,7 +22,7 @@ sub run {
     run_testcase('audit-trail-protection', (make => 1));
 
     # Compare current test results with baseline
-    my $result = compare_run_log('audit_trail_protection');
+    my $result = compare_run_log('audit-trail-protection');
     $self->result($result);
 }
 

--- a/tests/security/cc/fail_safe.pm
+++ b/tests/security/cc/fail_safe.pm
@@ -23,7 +23,7 @@ sub run {
     run_testcase('fail-safe', make => 1, timeout => 500);
 
     # Compare current test results with baseline
-    my $result = compare_run_log('fail_safe');
+    my $result = compare_run_log('fail-safe');
     $self->result($result);
 }
 

--- a/tests/security/cc/filter.pm
+++ b/tests/security/cc/filter.pm
@@ -19,7 +19,7 @@ sub run {
 
     select_console 'root-console';
 
-    run_testcase('filter', (make => 1));
+    run_testcase('filter', (make => 1, timeout => 180));
 
     # Compare current test results with baseline
     my $result = compare_run_log('filter');

--- a/tests/security/cc/ip_eb_tables.pm
+++ b/tests/security/cc/ip_eb_tables.pm
@@ -53,7 +53,7 @@ sub run {
         assert_script_run("service network restart");
     }
     # Compare current test results with baseline
-    my $result = compare_run_log('ip_eb_tables');
+    my $result = compare_run_log('ip+eb-tables');
     $self->result($result);
 }
 

--- a/tests/security/cc/polkit_tests.pm
+++ b/tests/security/cc/polkit_tests.pm
@@ -24,7 +24,7 @@ sub run {
     run_testcase('polkit-tests');
 
     # Compare current test results with baseline
-    my $result = compare_run_log('polkit_tests');
+    my $result = compare_run_log('polkit-tests');
     $self->result($result);
 }
 

--- a/tests/security/cc/run_net_case.pm
+++ b/tests/security/cc/run_net_case.pm
@@ -55,7 +55,7 @@ sub run {
     # The 8th test case in netfilter sometimes may end with ERROR because of the performance issue. we need to run it again
     assert_script_run('./run.bash 8', timeout => 300) if ($case_name eq 'netfilter' && script_run('egrep "[8].*ERROR" rollup.log') == 0);
     # Upload logs
-    upload_audit_test_logs();
+    upload_audit_test_logs($case_name);
     # Compare current test results with baseline
     $result = compare_run_log($case_name);
 

--- a/tests/security/cc/syscalls.pm
+++ b/tests/security/cc/syscalls.pm
@@ -22,6 +22,7 @@ sub run {
     if (my $pprofile = get_var('PPROFILE')) {
         assert_script_run("export PPROFILE=$pprofile");
     }
+
     # Run test case
     run_testcase('syscalls', (make => 1, timeout => 720));
 


### PR DESCRIPTION
For syscall test, the test cases that need to be run are not the same
in different arches. So we need to compare the result with the correct
one.

Relate: https://progress.opensuse.org/issues/104235
Verify run: 
         https://openqa.suse.de/tests/7929245#  [aarch64]
         https://openqa.suse.de/tests/7929244#  [x86_64]
         https://openqa.suse.de/tests/7929262#   [s390x]
