### PR TITLE
Calculate delay and wait for services

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -52,6 +52,7 @@ sub run {
         barrier_create("DLM_CHECKED_$cluster_name", $num_nodes);
         barrier_create("DRBD_INIT_$cluster_name", $num_nodes);
         barrier_create("DRBD_CREATE_CONF_$cluster_name", $num_nodes);
+        barrier_create("SBD_START_DELAY_$cluster_name", $num_nodes);
         barrier_create("DRBD_ACTIVATE_DEVICE_$cluster_name", $num_nodes);
         barrier_create("DRBD_CREATE_DEVICE_$cluster_name", $num_nodes);
         barrier_create("DRBD_CHECK_ONE_DONE_$cluster_name", $num_nodes);


### PR DESCRIPTION
With newest updates, there is a delay introduced to service start 
after fencing. Current test does not account for that and fails 
because cluster services are not starting. This PR introduces 
mechanism to calculate this delay and waits before starting services.

- Related ticket: https://jira.suse.com/browse/TEAM-5386
- Verification run:
  - Offline migration: https://mordor.suse.cz/tests/2183#dependencies
  - 2node cluster: https://mordor.suse.cz/tests/2145#dependencies
  - 3node cluster: https://mordor.suse.cz/tests/2148#dependencies
  - diskless SBD: https://mordor.suse.cz/tests/2187#dependencies
