### PR TITLE
validate_btrfs: fix regex to make 9% a valid usage level

### DIFF
--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -39,7 +39,7 @@ sub _sanity_test_btrfs {
     assert_script_run "btrfs fi df $dev_path/btrfs/";
     assert_script_run "ls -td $dev_path/btrfs/subvolumes/* | head -n 1 > $btrfs_head";
     # Ensure the var partition has at least 10% free space
-    validate_script_output "df -h | grep var", sub { m/\/dev\/x?[v,s]d[a-z].+ [0-8][0-9]?%/ };
+    validate_script_output "df -h | grep var", sub { m/\/dev\/x?[v,s]d[a-z].+ [1-8]?[0-9]%/ };
 }
 
 sub _test_btrfs_balancing {


### PR DESCRIPTION
Fix issue introduced with https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13860

- Related ticket: https://progress.opensuse.org/issues/104559
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2119621
