### PR TITLE
Add sle-module-certifications to available modules

### DIFF
--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -75,6 +75,7 @@ test_data:
     - sle-module-live-patching
     - sle-we
     - sle-module-basesystem
+    - sle-module-certifications
     - sle-module-containers
     - sle-module-desktop-applications
     - sle-module-development-tools

--- a/schedule/yast/installer_extended/installer_extended@pvm.yaml
+++ b/schedule/yast/installer_extended/installer_extended@pvm.yaml
@@ -73,6 +73,7 @@ test_data:
     - sle-module-live-patching
     - sle-we
     - sle-module-basesystem
+    - sle-module-certifications
     - sle-module-containers
     - sle-module-desktop-applications
     - sle-module-development-tools

--- a/schedule/yast/installer_extended/installer_extended@s390x.yaml
+++ b/schedule/yast/installer_extended/installer_extended@s390x.yaml
@@ -74,6 +74,7 @@ test_data:
     - sle-module-live-patching
     - sle-we
     - sle-module-basesystem
+    - sle-module-certifications
     - sle-module-containers
     - sle-module-desktop-applications
     - sle-module-development-tools

--- a/test_data/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/test_data/yast/installer_extended/installer_extended_aarch64.yaml
@@ -30,6 +30,7 @@ beta_text: 'You are accessing our Beta Distribution'
 modules:
   - sle-ha
   - sle-module-basesystem
+  - sle-module-certifications
   - sle-module-containers
   - sle-module-desktop-applications
   - sle-module-development-tools

--- a/test_data/yast/installer_extended/installer_extended_ppc64le_s390x.yaml
+++ b/test_data/yast/installer_extended/installer_extended_ppc64le_s390x.yaml
@@ -31,6 +31,7 @@ modules:
   - sle-ha
   - sle-module-live-patching
   - sle-module-basesystem
+  - sle-module-certifications
   - sle-module-containers
   - sle-module-desktop-applications
   - sle-module-development-tools


### PR DESCRIPTION
The module sle-module-certifications is not expected, resulting in failures of `verify_module_selection.pm` such as [this one](https://openqa.suse.de/tests/7923087#step/verify_module_selection/2)

- Related ticket: No ticket
- Needles: No needles
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle&build=ge0r%2Fos-autoinst-distri-opensuse%23add_sle-module-certifications&version=15-SP4