### PR TITLE
Turn off screen saver to avoid lock screen

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -6,7 +6,7 @@ check service status or service function before and after migration
 
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2021-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: check service status before and after migration.
@@ -37,6 +37,7 @@ use services::firewall;
 use services::libvirtd;
 use kdump_utils;
 use version_utils 'is_sle';
+use x11utils;
 
 our @EXPORT = qw(
   $default_services
@@ -236,6 +237,15 @@ sub install_services {
     my ($service) = @_;
     # turn off lmod shell debug information
     assert_script_run('echo export LMOD_SH_DBG_ON=1 >> /etc/bash.bashrc.local');
+    # turn off screen saver
+    if (check_var('DESKTOP', 'gnome')) {
+        if (is_s390x) {
+            turn_off_gnome_screensaver;
+        }
+        else {
+            turn_off_gnome_screensaver_for_running_gdm;
+        }
+    }
     # On ppc64le, sometime the console font will be distorted into pseudo graphics characters.
     # we need to reset the console font. As it impacted all the console services, added this command to bashrc file
     assert_script_run('echo /usr/lib/systemd/systemd-vconsole-setup >> /etc/bash.bashrc.local') if is_ppc64le;

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2021-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Package for users service test
@@ -152,15 +152,6 @@ sub full_users_check {
     # reset consoles before select x11 console will make the connect operation
     # more stable on s390x
     reset_consoles if is_s390x;
-    if (check_var('DESKTOP', 'gnome')) {
-        if (is_s390x) {
-            turn_off_gnome_screensaver;
-        }
-        else {
-            select_console 'root-console';
-            turn_off_gnome_screensaver_for_gdm;
-        }
-    }
     select_console 'x11', await_console => 0;
     wait_still_screen 15;
     ensure_unlocked_desktop;

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package x11utils;
@@ -29,6 +29,7 @@ our @EXPORT = qw(
   turn_off_plasma_screenlocker
   turn_off_gnome_screensaver
   turn_off_gnome_screensaver_for_gdm
+  turn_off_gnome_screensaver_for_running_gdm
   turn_off_gnome_suspend
   turn_off_gnome_show_banner
   untick_welcome_on_next_startup
@@ -406,6 +407,18 @@ a command prompt, for example an xterm window.
 =cut
 sub turn_off_gnome_screensaver_for_gdm {
     script_run 'sudo -u gdm dbus-launch gsettings set org.gnome.desktop.session idle-delay 0';
+}
+
+=head2 turn_off_gnome_screensaver_for_running_gdm
+
+turn_off_gnome_screensaver_for_running_gdm()
+
+Disable screensaver in gnome for running gdm. The function should be run under root. To be called
+from a command prompt, for example an xterm window.
+
+=cut
+sub turn_off_gnome_screensaver_for_running_gdm {
+    script_run 'su gdm -s /bin/bash -c "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u gdm)/bus gsettings set org.gnome.desktop.session idle-delay 0"';
 }
 
 =head2 turn_off_gnome_suspend


### PR DESCRIPTION
We need turn off screen saver to avoid lock screen, the setting for running gdm work for all arches and we need set it early so that the setting will take effect.

- Related ticket: https://progress.opensuse.org/issues/104074
- Needles: N/A
- Verification run: 
  http://openqa.nue.suse.com/tests/7922030#step/install_service/299  # aarch64 sles15sp3
  http://openqa.nue.suse.com/tests/7922033#step/check_upgraded_service/68 # x86_64 sles15sp1
  https://openqa.nue.suse.com/tests/7939098#step/install_service/197  # ppc64le sles15sp2
  https://openqa.nue.suse.com/tests/7939091#live                                 # s390x 15sp3
