### PR TITLE
Add tomcat to migration regression check

### DIFF
--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -108,6 +108,7 @@ conditional_schedule:
         - x11/gnome_terminal
         - x11/gedit
         - x11/firefox
+        - x11/tomcat
         - x11/eog
         - x11/gnome_music
         - x11/wireshark

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -99,6 +99,7 @@ conditional_schedule:
         - x11/gnome_terminal
         - x11/gedit
         - x11/firefox
+        - x11/tomcat
         - x11/eog
         - x11/gnome_music
         - x11/wireshark


### PR DESCRIPTION
Add tomcat to migration regression check. In functional group, tomcat
is only tested on x86_64, so I add it to x86_64 migration regression
cases only.

- Related ticket: https://progress.opensuse.org/issues/104460
- Needles: n/a
- Verification run: 
https://openqa.nue.suse.com/tests/7922063#step/tomcat/1
https://openqa.nue.suse.com/tests/7922071#step/tomcat/1
https://openqa.nue.suse.com/tests/8133197#step/tomcat/1
https://openqa.nue.suse.com/tests/8133200#step/tomcat/1