### PR TITLE
Workaround zypper can't create solverTestCase.tar.bz2

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -514,7 +514,9 @@ Upload C</tmp/solverTestCase.tar.bz2>.
 
 =cut
 sub upload_solvertestcase_logs {
-    script_run("zypper -n patch --debug-solver --with-interactive -l");
+    my $ret = script_run("zypper -n patch --debug-solver --with-interactive -l");
+    # if zypper was not found, we just skip upload solverTestCase.tar.bz2
+    return if $ret != 0;
     script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");
     upload_logs "/tmp/solverTestCase.tar.bz2 ";
 }

--- a/tests/installation/resolve_dependency_issues.pm
+++ b/tests/installation/resolve_dependency_issues.pm
@@ -35,6 +35,10 @@ sub post_fail_hook {
     my $self = shift;
     select_console 'root-console';
     $self->upload_solvertestcase_logs();
+    # workaround to get the y2logs.tar.bz2 at early stage
+    script_run "save_y2logs /tmp/y2logs.tar.bz2";
+    upload_logs "/tmp/y2logs.tar.bz2";
+    set_var('Y2LOGS_UPLOADED', 1);
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
In resolve_dependency_issues, when we hit conflicts and the zypper
--debug-solver will fail for 'zypper: command not found. We can upload the
yast2log for further investigation.

- Related ticket: https://progress.opensuse.org/issues/104497
- Needles: N/A
- Verification run:  
   https://openqa.nue.suse.com/tests/7939141/file/resolve_dependency_issues-y2logs.tar.bz2
  https://openqa.nue.suse.com/tests/7942463/file/resolve_dependency_issues-y2logs.tar.bz2
  https://openqa.nue.suse.com/tests/7946974/file/resolve_dependency_issues-y2logs.tar.bz2
  https://openqa.nue.suse.com/tests/7947344/file/resolve_dependency_issues-y2logs.tar.bz2