### PR TITLE
wicked: Add sysctl testsuite

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -9,14 +9,15 @@
 package wickedbase;
 
 use base 'opensusebasetest';
-use utils qw(systemctl file_content_replace zypper_call);
+use utils qw(systemctl file_content_replace zypper_call random_string);
+use Encode qw(encode_utf8);
 use network_utils;
 use lockapi;
 use testapi qw(is_serial_terminal :DEFAULT);
 use serial_terminal;
 use Carp;
 use Mojo::File 'path';
-use Mojo::Util 'trim';
+use Mojo::Util qw(b64_encode b64_decode trim);
 use Regexp::Common 'net';
 use File::Basename;
 use version_utils 'check_version';
@@ -70,7 +71,21 @@ sub get_wicked_version {
 =cut
 sub check_wicked_version {
     my ($self, $query) = @_;
+    return 1 if get_var('WICKED_SKIP_VERSION_CHECK', 0);
     return check_version($query, $self->get_wicked_version());
+}
+
+sub skip_by_wicked_version
+{
+    my ($self, $v) = @_;
+    $v //= $self->wicked_version;
+
+    if ($v && !$self->check_wicked_version($v)) {
+        $self->result('skip');
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 =head2 assert_wicked_state
@@ -716,6 +731,62 @@ sub check_ipv6 {
     }
 
     die "There were errors during test" if $errors || $dns_failure;
+}
+
+sub lookup {
+    my ($self, $name, $env) = @_;
+    if (exists $env->{$name}) {
+        return $env->{$name};
+    } elsif (my $v = eval { return $self->$name }) {
+        return $v;
+    }
+    die("Failed to lookup '{{$name}}' variable");
+}
+
+=head2 write_cfg
+
+  write_cfg($filename, $content[, env => {}, encode_base64 => 0 ]);
+
+Write all data at once to the file. Replace all ocurance of C<{{name}}>.
+First lookup is the given c<$env> hash and if it doesn't exists
+it try to lookup a member function with the given c<name> and replace the string
+with return value
+
+=cut
+sub write_cfg {
+    my ($self, $filename, $content, %args) = @_;
+    my ($filename_orig, $content_orig);
+    $args{env} //= {};
+    $args{encode_base64} //= 0;
+    my $rand = random_string;
+    # replace variables
+    $content =~ s/\{\{(\w+)\}\}/$self->lookup($1, $args{env})/eg;
+    # unwrap content
+    my ($indent) = $content =~ /^\r?\n?([ ]*)/m;
+    $content =~ s/^$indent//mg;
+    $content =~ s/^[ \t]+$//mg;
+
+    if ($args{encode_base64}) {
+        $content = encode_utf8($content);
+        $content_orig = $content;
+        $filename_orig = $filename;
+        $content = b64_encode($content);
+        $filename .= '.base64';
+    }
+
+    script_output(qq(cat > '$filename' << 'END_OF_CONTENT_$rand'
+$content
+END_OF_CONTENT_$rand
+));
+
+    if ($args{encode_base64}) {
+        $content = $content_orig;
+        assert_script_run("base64 -d '$filename' > '$filename_orig'");
+        assert_script_run("rm '$filename'");
+    }
+
+    record_info(basename($filename), $content);
+    return $content;
 }
 
 sub run_test_shell_script

--- a/tests/wicked/sysctl/sut/t01_sysctl_load_files.pm
+++ b/tests/wicked/sysctl/sut/t01_sysctl_load_files.pm
@@ -1,0 +1,149 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Check the sysctl.d file load order of wicked. It's not like
+#          `sysctl --system` as procps-ng >=3.3.17 changed the
+#          sysctl.d load order like systemd.
+#
+# Maintainer: cfamullaconrad@suse.com
+
+use Mojo::Base 'wickedbase';
+use testapi;
+use autotest ();
+use File::Basename;
+use Mojo::Util qw(trim);
+
+our $wicked_show_config = 'wicked --log-level debug --debug all  show-config all';
+our @sysctl_d = qw(
+  /run/sysctl.d
+  /etc/sysctl.d
+  /usr/local/lib/sysctl.d
+  /usr/lib/sysctl.d
+  /lib/sysctl.d
+);
+
+sub wicked_get_file_order {
+    my $out = script_output($wicked_show_config . ' |& grep "Reading sysctl file"');
+    my @files = ($out =~ m/file\s+'([^']+)'/g);
+    return \@files;
+}
+
+sub wicked_get_file_errors {
+    my $out = script_output($wicked_show_config . ' |& grep "Cannot open"');
+    my @files = ($out =~ m/Cannot open\s+'([^']+)'/g);
+    return \@files;
+}
+
+sub sysctl_emu_file_order {
+    state $boot_sysctl = '/boot/sysctl.conf-' . trim(script_output('uname -r'));
+    my @retval = ($boot_sysctl);
+    my @sysctl_d_files = split(/\r?\n/, script_output("find @sysctl_d -name '*.conf' 2> /dev/null", proceed_on_failure => 1));
+
+    my %sysctl_d;
+    for my $file (@sysctl_d_files) {
+        my $basename = basename($file);
+        $sysctl_d{$basename} = $file unless $sysctl_d{$basename};
+    }
+
+    push @retval, $sysctl_d{$_} foreach (sort keys %sysctl_d);
+    push @retval, '/etc/sysctl.conf' if script_run('test -e /etc/sysctl.conf', die_on_timeout => 1) == 0;
+
+    return \@retval;
+}
+
+sub check_load_order {
+    my $exp_order = shift // sysctl_emu_file_order();
+    my $wicked = wicked_get_file_order;
+
+    unless (join(',', @$exp_order) eq join(',', @$wicked)) {
+        die("wicked load the sysctl files in different order\n" .
+              "expect: @$exp_order\n" .
+              "wicked: @$wicked\n");
+    }
+}
+
+sub check {
+    my ($self, $ctx) = @_;
+
+    check_load_order();
+
+    # Check order of files in sysctl.d directories
+    for my $dir (@sysctl_d) {
+        assert_script_run("mkdir -p $dir && touch $dir/20-test.conf");
+        check_load_order();
+    }
+    for my $dir (reverse @sysctl_d) {
+        assert_script_run("mkdir -p $dir && touch $dir/21-test.conf");
+        check_load_order();
+    }
+
+    for my $dir (@sysctl_d) {
+        assert_script_run("rm -f $dir/20-test.conf");
+        check_load_order();
+    }
+
+    for my $dir (reverse @sysctl_d) {
+        assert_script_run("rm -f $dir/21-test.conf");
+        check_load_order();
+    }
+
+    # Check SUSE special ifsysctl files
+    my $sysctl_order = sysctl_emu_file_order();
+    my $sysctl_f1 = '/etc/sysconfig/network/ifsysctl';
+    my $sysctl_f2 = '/etc/sysconfig/network/ifsysctl-' . $ctx->iface();
+    assert_script_run("touch $sysctl_f1");
+    check_load_order([@$sysctl_order, $sysctl_f1]);
+
+    assert_script_run("touch $sysctl_f2");
+    check_load_order([@$sysctl_order, $sysctl_f1, $sysctl_f2]);
+
+    assert_script_run("rm $sysctl_f1");
+    check_load_order([@$sysctl_order, $sysctl_f2]);
+
+    assert_script_run("rm $sysctl_f2");
+    check_load_order();
+
+    # Check broken symlinks
+    for my $dir (reverse @sysctl_d) {
+        my $file = "$dir/20-test.conf";
+        next if (script_run('test -L /lib', die_on_timeout => 1) == 0);
+        assert_script_run("mkdir -p $dir && ln -s /I_do_not_exists $file");
+        check_load_order();
+        die("Missing broken '$file' in logs") unless grep { $_ eq $file } @{wicked_get_file_order()};
+        die("Missing error message for '$file'") unless grep { $_ eq $file } @{wicked_get_file_errors()};
+    }
+
+    # Exceptional behavior for /etc/sysctl.conf, it is silently ignored
+    my $file = "/etc/sysctl.conf";
+    assert_script_run("rm $file");
+    assert_script_run("ln -s /I_do_not_exists $file");
+    check_load_order();
+    die("Wrongly showing broken '$file' in logs") if grep { $_ eq $file } @{wicked_get_file_order()};
+    die("Wrongly showing missing '$file' in logs") if grep { $_ eq $file } @{wicked_get_file_errors()};
+}
+
+sub setup_interfaces {
+    my ($self, $ctx) = @_;
+
+    $self->write_cfg('/etc/sysconfig/network/ifcfg-' . $ctx->iface(), <<EOT);
+        STARTMODE='hotplug'
+        BOOTPROTO='static'
+EOT
+    $self->wicked_command('ifreload', 'all');
+}
+
+sub run {
+    my ($self, $ctx) = @_;
+    $self->select_serial_terminal();
+
+    return if $self->skip_by_wicked_version('>=0.6.68');
+
+    record_info('sysctl.d', script_output("ls -R @sysctl_d", proceed_on_failure => 1));
+
+    $self->setup_interfaces($ctx);
+    $self->check($ctx);
+}
+
+1;

--- a/tests/wicked/sysctl/sut/t02_sysctl_check_defaults.pm
+++ b/tests/wicked/sysctl/sut/t02_sysctl_check_defaults.pm
@@ -1,0 +1,92 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Compare sysctl values if wicked is loaded and not. And do not allow
+#          differences which are not expected, (e.g. arp_notify=1 which is set
+#          by wicked, if SEND_GRATUITOUS_ARP=auto).
+#
+# Maintainer: cfamullaconrad@suse.com
+
+
+use Mojo::Base 'wickedbase';
+use testapi;
+use List::Util qw(uniq);
+use Mojo::File qw(path);
+
+sub get_diff {
+    my ($t1, $t2, $name1, $name2, $allow_diff) = @_;
+    my %v1 = ($t1 =~ /^([^\s=]+)\s+=\s+([^\s]+)$/gm);
+    my %v2 = ($t2 =~ /^([^\s=]+)\s+=\s+([^\s]+)$/gm);
+    my @diff;
+
+    for my $k (sort keys %v1) {
+        if (exists $v2{$k}) {
+            if ($v2{$k} ne $v1{$k} && !(exists $allow_diff->{$k} && $allow_diff->{$k} eq $v2{$k})) {
+                push @diff, "$k differ got $name2 has '$v2{$k}' expected '$v1{$k}' as $name1";
+            }
+        } else {
+            push @diff, "$k missing in $name2";
+        }
+        delete $v2{$k};
+    }
+    for my $k (sort keys %v2) {
+        push @diff, "$k missing in $name1";
+    }
+
+    return join("\n", @diff);
+}
+
+sub run {
+    my ($self, $ctx) = @_;
+    $self->select_serial_terminal();
+
+    return if $self->skip_by_wicked_version('>=0.6.68');
+
+    my @conf_ipv6 = qw(disable_ipv6 autoconf use_tempaddr accept_ra accept_dad accept_redirects addr_gen_mode stable_secret);
+    my @conf_ipv4 = qw(arp_notify accept_redirects);
+    my $dummy0 = 'dummy0';
+    my @interfaces = ('lo', $ctx->iface(), $dummy0);
+
+    my $cfg = <<EOT;
+STARTMODE='auto'
+BOOTPROTO='static'
+EOT
+
+    $self->write_cfg('/etc/sysconfig/network/ifcfg-' . $ctx->iface(), $cfg);
+    $self->write_cfg("/etc/sysconfig/network/ifcfg-$dummy0", $cfg);
+    $self->wicked_command('ifreload', 'all');
+
+    my @u = sort uniq(@conf_ipv6, @conf_ipv4);
+    my $cmd = <<EOT;
+        for cfg in @u; do
+            echo "############### \$cfg";
+            sysctl -a | grep "\.\$cfg " || true;
+        done
+EOT
+
+    my $out_wicked = script_output($cmd);
+    $self->record_console_test_result("Sysctl Wicked", $out_wicked, result => 'ok');
+
+    mkdir "ulogs";
+    path(sprintf('ulogs/%s_%s@%s_sysctl_wicked.txt', get_var('DISTRI'), get_var('VERSION'), get_var('ARCH')))->spurt($out_wicked);
+
+    # Disable wicked and reboot to get "systemd-sysctl" defaults
+    script_run('systemctl disable --now wicked', die_on_timeout => 1);
+    script_run('systemctl disable --now wickedd', die_on_timeout => 1);
+    $self->reboot();
+
+    assert_script_run('ip link add type dummy');
+    my $out_native = script_output($cmd);
+
+    $self->record_console_test_result("Sysctl Native", $out_native, result => 'ok');
+    path(sprintf('ulogs/%s_%s@%s_sysctl_native.txt', get_var('DISTRI'), get_var('VERSION'), get_var('ARCH')))->spurt($out_native);
+
+    # Wicked set `ipv4.arp_notify = 1` by default.
+    my $except_diff = {'net.ipv4.conf.' . $ctx->iface() . '.arp_notify' => 1};
+    my $diff = get_diff($out_native, $out_wicked, 'native', 'wicked', $except_diff);
+    die("Sysctl of native and wicked defaults are different!\n" . $diff . "\n") if $diff;
+}
+
+1;


### PR DESCRIPTION
The first two basic tests:
 - t01_sysctl_load_files - (check load order of sysctl files)
 - t02_sysctl_check_defaults - (check sysctl defaults)

- Related ticket: https://github.com/openSUSE/wicked/pull/896 https://github.com/openSUSE/wicked/pull/895
- Verification run: 
  - ~http://openqa-3.wicked.suse.de/t74546~
  - ~https://openqa.suse.de/tests/7939462 (SLE-15-SP4)~
