### PR TITLE
Disable AppArmor for SELinux test cases on TW

### DIFF
--- a/lib/selinuxtest.pm
+++ b/lib/selinuxtest.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020-2021 SUSE LLC
+# Copyright 2020-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Base module for SELinux test cases
@@ -13,7 +13,7 @@ use warnings;
 use testapi;
 use utils;
 use Utils::Backends 'is_pvm';
-use bootloader_setup 'add_grub_cmdline_settings';
+use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
 use power_action_utils 'power_action';
 
 use base "opensusebasetest";
@@ -121,7 +121,8 @@ sub set_sestatus {
 
     # enable SELinux in grub
     die "Need mode 'enforcing' or 'permissive'" unless $mode =~ /enforcing|permissive/;
-    add_grub_cmdline_settings('security=selinux selinux=1 enforcing=' . ($mode eq 'enforcing' ? 1 : 0), update_grub => 1);
+    replace_grub_cmdline_settings('lsm=apparmor', '', update_grub => 1);
+    add_grub_cmdline_settings('lsm=selinux security=selinux selinux=1 enforcing=' . ($mode eq 'enforcing' ? 1 : 0), update_grub => 1);
 
     # control (enable) the status of SELinux on the system, e.g., "enforcing" or "permissive"
     assert_script_run("sed -i -e 's/^SELINUX=/#SELINUX=/' $selinux_config_file");

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2018-2021 SUSE LLC
+# Copyright 2018-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 #
@@ -18,6 +18,10 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     $self->set_sestatus("permissive", "minimum");
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;


### PR DESCRIPTION
Disable AppArmor for SELinux test cases on TW
In recent builds of TW the default value of lsm is set to"apparmor" ("lsm" is one parameter in GRUB_CMDLINE_LINUX_DEFAULT) as "security= is ignored because it is superseded by lsm=".

poo#104542 - [Tumbleweed][security] test fails in sestatus: sed does not disabled apparmor

- Related ticket: https://progress.opensuse.org/issues/104542
- Needles: none
- Verification run:
  TW: https://openqa.opensuse.org/tests/2122901#
  SLES: https://openqa.suse.de/tests/7942483