### PR TITLE
Add workaround for test 'ssh04' in s390x

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -14,6 +14,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Architectures;
 use Mojo::File 'path';
 use Mojo::Util 'trim';
 
@@ -161,6 +162,10 @@ sub _parse_results_with_diff_baseline {
         $flag = 'softfail' if ($flag ne 'fail');
     }
     else {
+        if ($name eq 'ssh04' && is_s390x) {
+            record_soft_failure('Test case ssh04 fails in s390x is a known issue, see poo#99096');
+            return 'softfail';
+        }
         record_info($name, $msg, result => 'fail');
         $flag = 'fail';
     }


### PR DESCRIPTION
In CC system role, root login is forbidden. But for openQA test in s390x,
`PermitRootLogin` is set to 'yes' again. So the test case 'ssh04' in
libpam fails in s390x.

Related: https://progress.opensuse.org/issues/99096

Verify run: http://openqa.suse.de/tests/7943027#