### PR TITLE
Remove unavailable python2 module from hpc_autoyast

### DIFF
--- a/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
@@ -43,11 +43,13 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
+      % unless ($check_var->('VERSION', '15-SP4')) {
       <addon>
         <name>sle-module-python2</name>
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
+      % }
     </addons>
   </suse_register>
   <bootloader>
@@ -65,17 +67,31 @@
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>
-      <disklabel>msdos</disklabel>
+      <disklabel>gpt</disklabel>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
         <partition>
           <mountby config:type="symbol">device</mountby>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">vfat</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>umask=0002,utf8=true</fstopt>
+          <mount>/boot/efi</mount>
+        </partition>
+        <partition>
+          <mountby config:type="symbol">device</mountby>
+          <create config:type="boolean">true</create>
           <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
           <mount>swap</mount>
         </partition>
         <partition>
           <mountby config:type="symbol">device</mountby>
+          <create config:type="boolean">true</create>
           <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
           <mount>/</mount>
         </partition>
       </partitions>
@@ -94,7 +110,9 @@
       <package>sle-module-basesystem-release</package>
       <package>sle-module-web-scripting-release</package>
       <package>sle-module-hpc-release</package>
+      % unless ($check_var->('VERSION', '15-SP4')) {
       <package>sle-module-python2-release</package>
+      % }
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
@@ -43,11 +43,13 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
+      % unless ($check_var->('VERSION', '15-SP4')) {
       <addon>
         <name>sle-module-python2</name>
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
+      % }
     </addons>
   </suse_register>
   <bootloader>
@@ -65,31 +67,17 @@
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>
-      <disklabel>gpt</disklabel>
+      <disklabel>msdos</disklabel>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
         <partition>
           <mountby config:type="symbol">device</mountby>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">vfat</filesystem>
-          <format config:type="boolean">true</format>
-          <fstopt>umask=0002,utf8=true</fstopt>
-          <mount>/boot/efi</mount>
-        </partition>
-        <partition>
-          <mountby config:type="symbol">device</mountby>
-          <create config:type="boolean">true</create>
           <filesystem config:type="symbol">swap</filesystem>
-          <format config:type="boolean">true</format>
-          <fstopt>defaults</fstopt>
           <mount>swap</mount>
         </partition>
         <partition>
           <mountby config:type="symbol">device</mountby>
-          <create config:type="boolean">true</create>
           <filesystem config:type="symbol">btrfs</filesystem>
-          <format config:type="boolean">true</format>
-          <fstopt>defaults</fstopt>
           <mount>/</mount>
         </partition>
       </partitions>
@@ -108,7 +96,9 @@
       <package>sle-module-basesystem-release</package>
       <package>sle-module-web-scripting-release</package>
       <package>sle-module-hpc-release</package>
+      % unless ($check_var->('VERSION', '15-SP4')) {
       <package>sle-module-python2-release</package>
+      % }
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/schedule/hpc/installation_autoyast.yaml
+++ b/schedule/hpc/installation_autoyast.yaml
@@ -1,7 +1,7 @@
 ---
 name: hpc_installation_autoyast
 vars:
-  AUTOYAST: autoyast_sle15/autoyast_hpc_%ARCH%.xml
+  AUTOYAST: autoyast_sle15/autoyast_hpc_%ARCH%.xml.ep
   AUTOYAST_CONFIRM: 1
   HDDSIZEGB: 30
 schedule:


### PR DESCRIPTION
The sle-module-python2 is not available as module in sle15.
I checked the installed system and python2 comes with the base system.

in this respect the autoyast schema doesnt need the particular sections and they are removed

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: 
❯ openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13964 https://openqa.suse.de/tests/7924123
Github oauth token provided, performing authenticated requests
Created job #7944075: sle-15-SP4-Online-x86_64-Build79.1-hpc_installation_autoyast@64bit -> https://openqa.suse.de/t7944075
❯ openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13964 https://openqa.suse.de/tests/7923022
Github oauth token provided, performing authenticated requests
Created job #7944076: sle-15-SP4-Online-aarch64-Build79.1-hpc_installation_autoyast@aarch64 -> https://openqa.suse.de/t7944076

Update using embperl:
 
❯ openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13964 https://openqa.suse.de/tests/7923022
Github oauth token provided, performing authenticated requests
Created job #7957390: sle-15-SP4-Online-aarch64-Build79.1-hpc_installation_autoyast@aarch64 -> https://openqa.suse.de/t7957390
❯ openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13964 https://openqa.suse.de/tests/7924123
Github oauth token provided, performing authenticated requests
Created job #7957392: sle-15-SP4-Online-x86_64-Build79.1-hpc_installation_autoyast@64bit -> https://openqa.suse.de/t7957392
❯ openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13964 https://openqa.suse.de/tests/7727938
Github oauth token provided, performing authenticated requests
Created job #7957393: sle-15-SP3-Server-DVD-HPC-Incidents-x86_64-Build:21639:netcdf-hpc_installation_autoyast@64bit -> https://openqa.suse.de/t7957393
