### PR TITLE
Add krb5 to migration regression check

### DIFF
--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -90,6 +90,7 @@ conditional_schedule:
         - console/yast2_i
         - console/yast2_bootloader
         - console/firewall_enabled
+        - console/krb5
         - console/sshd
         - console/ssh_cleanup
         - console/mtab

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -75,6 +75,7 @@ conditional_schedule:
         - console/yast2_i
         - console/yast2_bootloader
         - console/firewall_enabled
+        - console/krb5
         - console/sshd
         - console/ssh_cleanup
         - console/mtab

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -88,6 +88,7 @@ conditional_schedule:
         - console/yast2_i
         - console/yast2_bootloader
         - console/firewall_enabled
+        - console/krb5
         - console/sshd
         - console/ssh_cleanup
         - console/mtab

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -88,6 +88,7 @@ conditional_schedule:
         - console/yast2_i
         - console/yast2_bootloader
         - console/firewall_enabled
+        - console/krb5
         - console/sshd
         - console/ssh_cleanup
         - console/mtab

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -76,6 +76,7 @@ conditional_schedule:
         - console/yast2_i
         - console/yast2_bootloader
         - console/firewall_enabled
+        - console/krb5
         - console/sshd
         - console/ssh_cleanup
         - console/mtab

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -69,6 +69,7 @@ conditional_schedule:
         - console/yast2_i
         - console/yast2_bootloader
         - console/firewall_enabled
+        - console/krb5
         - console/sshd
         - console/ssh_cleanup
         - console/mtab

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -85,6 +85,7 @@ conditional_schedule:
         - console/yast2_bootloader
         - console/vim
         - console/firewall_enabled
+        - console/krb5
         - console/sshd
         - console/ssh_cleanup
         - console/mtab

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -74,6 +74,7 @@ conditional_schedule:
         - console/yast2_bootloader
         - console/vim
         - console/firewall_enabled
+        - console/krb5
         - console/sshd
         - console/ssh_cleanup
         - console/mtab


### PR DESCRIPTION
Add krb5 to migration regression check.

- Related ticket: https://progress.opensuse.org/issues/104430
- Needles: N/A
- Verification run: 
x86_64:
https://openqa.nue.suse.com/tests/7939628#step/krb5/1
https://openqa.nue.suse.com/tests/7942884#step/krb5/1
aarch64:
https://openqa.nue.suse.com/tests/7943878#step/krb5/1
https://openqa.nue.suse.com/tests/7943507#step/krb5/1
ppc64le:
https://openqa.nue.suse.com/tests/7943042#step/krb5/1
https://openqa.nue.suse.com/tests/7942880#step/krb5/1
s390x:
https://openqa.nue.suse.com/tests/7942881#step/krb5/1
https://openqa.nue.suse.com/tests/7942882#step/krb5/1

