### PR TITLE
install_ltp: Fix repeated installation from git

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -178,9 +178,10 @@ sub prepare_ltp_git {
 
     $rel = "-b $rel" if ($rel);
 
-    my $ret = script_run("git clone -q --depth 1 $url $rel", timeout => 360);
+    script_run('rm -rf ltp');
+    my $ret = script_run("git clone -q --depth 1 $url $rel ltp", timeout => 360);
     if (!defined($ret) || $ret) {
-        assert_script_run("git clone -q $url $rel", timeout => 360);
+        assert_script_run("git clone -q $url $rel ltp", timeout => 360);
     }
     assert_script_run 'cd ltp';
     assert_script_run 'make autotools';


### PR DESCRIPTION
It fixes problem during git clone:

```
fatal: destination path 'ltp' already exists and is not an empty directory.
```

Error occurs when debugging LTP with reinstalling LTP from git for job which also run LTP tests, i.e. jobs with INSTALL_LTP=git and LTP_COMMAND_FILE=foo when qcow2 image was based on git installation (including LTP_GIT_URL).

While it'd be possible to try to add required remote (if different than presented) and reset git to it, let's use the simplest way, although it takes a bit longer to reclone git again.

Fixes: 26892d4e2 ("ltp: Add option to install selected parts from git")

Verification run: 
- http://quasar.suse.cz/tests/8062

Verify for regression of other methods
- install_ltp installation from git http://quasar.suse.cz/tests/8063
- install_ltp installation from repo http://quasar.suse.cz/tests/8066 http://quasar.suse.cz/tests/8068
