### PR TITLE
In case the tip screen showup slow, add 5s to wait it

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -974,7 +974,7 @@ sub libreoffice_start_program {
     my %start_program_args;
     $start_program_args{timeout} = 100 if get_var('LIVECD') && check_var('MACHINE', 'uefi-usb');
     x11_start_program($program, %start_program_args);
-    if (match_has_tag('ooffice-tip-of-the-day')) {
+    if (check_screen('ooffice-tip-of-the-day', 5)) {
         # Unselect "_S_how tips on startup", select "_O_k"
         send_key "alt-s";
         send_key "alt-o";


### PR DESCRIPTION
In case the tip screen showup slow, add 5s to wait it

- Related ticket: https://progress.opensuse.org/issues/104538
- Verification run: https://openqa.suse.de/tests/7946525#step/ooffice/4