### PR TITLE
Deregister product with SUSEConnect instead of zypper

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -107,8 +107,8 @@ sub deregister_dropped_modules {
         if ($name eq 'ltss') {
             if (check_var('SLE_PRODUCT', 'hpc')) {
                 remove_suseconnect_product('SLE_HPC-LTSS');
-            } elsif (is_sle('15+') && check_var('SLE_PRODUCT', 'sles')) {
-                remove_suseconnect_product('SLES-LTSS');
+            } elsif ((is_sle('12+') && check_var('SLE_PRODUCT', 'sles')) || (check_var('SLE_PRODUCT', 'sles4sap'))) {
+                remove_suseconnect_product('SLES-LTSS');    # sles4sap also uses SLES-LTSS as its ltss
             } else {
                 zypper_call 'rm -t product SLES-LTSS';
                 zypper_call 'rm sles-ltss-release-POOL';


### PR DESCRIPTION
In the sle12spx cases, removing ltss still use zypper, which can not
remove the ltss clean, the ltss repos are not removed. So this pr
will replace it by using SUSEConnect.

- Related ticket: https://progress.opensuse.org/issues/104667
- Needles: N/A
- Verification run: 
sles12spx:
https://openqa.nue.suse.com/tests/7950807#step/patch_sle/108
https://openqa.nue.suse.com/tests/7950808#step/patch_sle/145
https://openqa.nue.suse.com/tests/7967980#step/patch_sle/135
https://openqa.nue.suse.com/tests/7967981#step/patch_sle/37
sles15spx:
https://openqa.nue.suse.com/tests/7950809#step/patch_sle/120
https://openqa.nue.suse.com/tests/7950810#step/patch_sle/224
sle-hpc-15spx:
https://openqa.nue.suse.com/tests/7950811#step/zypper_patch/14
https://openqa.nue.suse.com/tests/7950812#step/patch_sle/217
sles+ha12spx:
https://openqa.nue.suse.com/tests/7950805#step/patch_sle/86
sles+ha15spx:
https://openqa.nue.suse.com/tests/7950825#step/patch_sle/87
sles4sap12spx:
https://openqa.nue.suse.com/tests/7950806#step/patch_sle/71
https://openqa.nue.suse.com/tests/7950824#step/patch_sle/73