### PR TITLE
Automate testing of scap-security-guide

### DIFF
--- a/lib/stigtest.pm
+++ b/lib/stigtest.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Base module for STIG test cases
+# Maintainer: llzhao <llzhao@suse.com>
+
+package stigtest;
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+use base 'opensusebasetest';
+
+our @EXPORT = qw(
+  $profile_ID
+  $f_ssg_sle_ds
+  $f_stdout
+  $f_stderr
+  $f_report
+  $remediated
+  set_ds_file
+  upload_logs_reports
+);
+
+# The file names of scap logs and reports
+our $f_stdout = 'stdout';
+our $f_stderr = 'stderr';
+our $f_report = 'report.html';
+
+# Set default value for 'scap-security-guide' ds file
+our $f_ssg_sle_ds = '/usr/share/xml/scap/ssg/content/ssg-sle12-ds.xml';
+
+# Profile ID
+our $profile_ID = 'xccdf_org.ssgproject.content_profile_stig';
+
+# The OS status of remediation: '0', not remediatd; '1', remediated
+our $remediated = 0;
+
+# Set value for 'scap-security-guide' ds file
+sub set_ds_file {
+    # Set the ds file for separate product, e.g.,
+    # for SLE15 the ds file is "ssg-sle15-ds.xml";
+    # for SLE12 the ds file is "ssg-sle12-ds.xml"
+    my $version = get_required_var('VERSION') =~ s/([0-9]+).*/$1/r;
+    $f_ssg_sle_ds = '/usr/share/xml/scap/ssg/content/ssg-sle' . "$version" . '-ds.xml';
+}
+
+sub upload_logs_reports
+{
+    # Upload logs & ouputs for reference
+    my $files = script_output('ls | grep "^ssg-sle.*.xml"');
+    foreach my $file (split("\n", $files)) {
+        upload_logs("$file");
+    }
+    upload_logs("$f_stdout") if script_run "! [[ -e $f_stdout ]]";
+    upload_logs("$f_stderr") if script_run "! [[ -e $f_stderr ]]";
+    upload_logs("$f_report") if script_run "! [[ -e $f_report ]]";
+}
+
+1;

--- a/schedule/security/stig.yaml
+++ b/schedule/security/stig.yaml
@@ -1,0 +1,19 @@
+name: stig
+description:    >
+    This is for stig test
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - security/stig/oscap_security_guide_setup
+    - security/stig/oscap_xccdf_eval
+    - security/stig/oscap_xccdf_eval_remote
+    - security/stig/oscap_xccdf_remediate
+      # Do evaluate again after remediate
+    - security/stig/oscap_xccdf_eval
+conditional_schedule:
+    bootloader:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+            ppc64le:
+                - installation/bootloader

--- a/tests/security/stig/oscap_security_guide_setup.pm
+++ b/tests/security/stig/oscap_security_guide_setup.pm
@@ -1,0 +1,38 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test 'stig' hardening in the 'scap-security-guide' works: setup environment
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#93886, poo#104943
+
+use base 'stigtest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    # Install packages
+    zypper_call('in openscap-utils scap-security-guide', timeout => 180);
+
+    # Record the pkgs' version for reference
+    my $out = script_output("zypper se -s openscap-utils scap-security-guide");
+    record_info("Pkg_ver", "openscap security guide packages' version: $out");
+
+    # Set ds file
+    $self->set_ds_file();
+
+    # Check the ds file information for reference
+    my $f_ssg_sle_ds = $stigtest::f_ssg_sle_ds;
+    $out = script_output("oscap info $f_ssg_sle_ds");
+    record_info("Info", "\"# oscap info $f_ssg_sle_ds\" returns: $out");
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/security/stig/oscap_xccdf_eval.pm
+++ b/tests/security/stig/oscap_xccdf_eval.pm
@@ -1,0 +1,52 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test 'stig' hardening in the 'scap-security-guide': detection mode
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#93886, poo#104943
+
+use base 'stigtest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    # Get ds file and profile ID
+    my $f_ssg_sle_ds = $stigtest::f_ssg_sle_ds;
+    my $profile_ID = $stigtest::profile_ID;
+    my $f_stdout = $stigtest::f_stdout;
+    my $f_stderr = $stigtest::f_stderr;
+    my $f_report = $stigtest::f_report;
+
+    # Verify detection mode
+    my $ret = script_run("oscap xccdf eval --profile $profile_ID --oval-results --report $f_report $f_ssg_sle_ds > $f_stdout 2> $f_stderr", timeout => 300);
+    if ($ret == 0) {
+        record_info('PASS');
+    } elsif ($ret == 1 || $ret == 2) {
+        record_info("errno=$ret", "# oscap xccdf eval --profile \"$profile_ID\" returns: $ret");
+        # Note: the system is not fully compliant before remediation so some fails are permitted
+        # For a new installed OS the first time remediate can permit fail
+        if ($stigtest::remediated == 0) {
+            $stigtest::remediated = 1;
+            record_info('non remediated', 'before remediation some fails are permitted');
+        } else {
+            $self->result('fail');
+            record_info('remediated', 'after remediation fails are not permitted');
+        }
+    } else {
+        $self->result('fail');
+    }
+
+    # Upload logs & ouputs for reference
+    $self->upload_logs_reports();
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/security/stig/oscap_xccdf_eval_remote.pm
+++ b/tests/security/stig/oscap_xccdf_eval_remote.pm
@@ -1,0 +1,49 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test 'stig' hardening in the 'scap-security-guide': detection mode with remote
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#93886, poo#104943
+
+use base 'stigtest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use bootloader_setup qw(add_grub_cmdline_settings);
+use power_action_utils "power_action";
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    add_grub_cmdline_settings('ignore_loglevel', update_grub => 1);
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(textmode => 1);
+
+    select_console 'root-console';
+
+    # Get ds file and profile ID
+    my $f_ssg_sle_ds = $stigtest::f_ssg_sle_ds;
+    my $profile_ID = $stigtest::profile_ID;
+    my $f_stdout = $stigtest::f_stdout;
+    my $f_stderr = $stigtest::f_stderr;
+    my $f_report = $stigtest::f_report;
+
+    # Verify detection mode with remote
+    my $ret = script_run("oscap xccdf eval --profile $profile_ID --oval-results --fetch-remote-resources --report $f_report $f_ssg_sle_ds > $f_stdout 2> $f_stderr", timeout => 3000);
+    record_info("Return=$ret", "# oscap xccdf eval --fetch-remote-resources --profile $profile_ID\" returns: $ret");
+    if ($ret == 137) {
+        record_info('bsc#1194724');
+        $self->result('fail');
+    }
+
+    # Upload logs & ouputs for reference
+    $self->upload_logs_reports();
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/security/stig/oscap_xccdf_remediate.pm
+++ b/tests/security/stig/oscap_xccdf_remediate.pm
@@ -1,0 +1,42 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test 'stig' hardening in the 'scap-security-guide': mitigation mode
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#93886, poo#104943
+
+use base 'stigtest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    # Get ds file and profile ID, etc.
+    my $f_ssg_sle_ds = $stigtest::f_ssg_sle_ds;
+    my $profile_ID = $stigtest::profile_ID;
+    my $f_stdout = $stigtest::f_stdout;
+    my $f_stderr = $stigtest::f_stderr;
+    my $f_report = $stigtest::f_report;
+
+    # Verify mitigation mode
+    my $ret = script_run("oscap xccdf eval --profile $profile_ID --remediate --oval-results --report $f_report $f_ssg_sle_ds > $f_stdout 2> $f_stderr", timeout => 300);
+    record_info("Return=$ret", "# oscap xccdf eval --profile $profile_ID --remediate\" returns: $ret");
+    if ($ret) {
+        $self->result('fail');
+        record_info('bsc#1194676', 'remediation should be succeeded');
+    }
+
+    # Upload logs & ouputs for reference
+    $self->upload_logs_reports();
+}
+
+sub test_flags {
+    # Do not rollback as next test module will be run on this test environments
+    return {milestone => 1, always_rollback => 0};
+}
+
+1;


### PR DESCRIPTION
Automate testing of scap-security-guide: add '# oscap "eval" / "eval remote" / "remediate" / "eval after remediate"' into openQA

poo#93886 - [sle][security][sle15sp4]automate testing of scap-security-guide
poo#104943 - [sle][security][sle15sp4]automate testing of scap-security-guide: run '# oscap "eval" / "eval remote" / "remediate" / "eval after remediate"'

Note: the failure can be tracked by known product issue: bsc#1194676

- Related ticket:
  https://progress.opensuse.org/issues/104943
  https://progress.opensuse.org/issues/93886
- Needles: NA
- Verification run:
  x86_64: https://openqa.suse.de/tests/7983379
  s390x: https://openqa.suse.de/tests/7983467
  aarch64: https://openqa.suse.de/tests/7983465
  ppc64le: https://openqa.suse.de/tests/7983582 (wip, still has issue)
