### PR TITLE
svirt: Skip asset upload if os-autoinst implements it

### DIFF
--- a/tests/shutdown/svirt_upload_assets.pm
+++ b/tests/shutdown/svirt_upload_assets.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils 'is_vmware';
+use backend::svirt ();
 
 sub extract_assets {
     my ($args) = @_;
@@ -38,6 +39,8 @@ sub extract_assets {
 }
 
 sub run {
+    # Skip if the os-autoinst backend implements this feature
+    return 1 if defined &backend::svirt::do_extract_assets;
     # Not implemented on VMware
     return 1 if is_vmware;
     # connect to VIRSH_HOSTNAME screen and upload asset from there


### PR DESCRIPTION
See: https://progress.opensuse.org/issues/104520