### PR TITLE
Add pam and btrfsmaintenance module into migration group

### DIFF
--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -78,6 +78,8 @@ conditional_schedule:
         - console/upgrade_snapshots
         - console/x_vt
         - console/zypper_lr
+        - console/pam
+        - console/btrfsmaintenance
         - console/cpio
         - console/java
         - console/check_system_info

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -63,6 +63,8 @@ conditional_schedule:
         - console/hostname
         - console/x_vt
         - console/zypper_lr
+        - console/pam
+        - console/btrfsmaintenance
         - console/cpio
         - console/java
         - console/check_system_info

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -76,6 +76,8 @@ conditional_schedule:
         - console/upgrade_snapshots
         - console/x_vt
         - console/zypper_lr
+        - console/pam
+        - console/btrfsmaintenance
         - console/cpio
         - console/java
         - console/check_system_info

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -76,6 +76,8 @@ conditional_schedule:
         - console/upgrade_snapshots
         - console/x_vt
         - console/zypper_lr
+        - console/pam
+        - console/btrfsmaintenance
         - console/cpio
         - console/java
         - console/check_system_info

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -64,6 +64,8 @@ conditional_schedule:
         - console/textinfo
         - console/hostname
         - console/zypper_lr
+        - console/pam
+        - console/btrfsmaintenance
         - console/cpio
         - console/java
         - console/check_system_info

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -57,6 +57,8 @@ conditional_schedule:
         - console/textinfo
         - console/hostname
         - console/zypper_lr
+        - console/pam
+        - console/btrfsmaintenance
         - console/cpio
         - console/java
         - console/check_system_info

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -71,6 +71,8 @@ conditional_schedule:
         - console/upgrade_snapshots
         - console/x_vt
         - console/zypper_lr
+        - console/pam
+        - console/btrfsmaintenance
         - console/java
         - console/cpio
         - console/check_system_info

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -60,6 +60,8 @@ conditional_schedule:
         - console/upgrade_snapshots
         - console/x_vt
         - console/zypper_lr
+        - console/pam
+        - console/btrfsmaintenance
         - console/cpio
         - console/java
         - console/check_system_info


### PR DESCRIPTION
 Add pam and btrfsmaintenance module into migration group 

- Related ticket: https://progress.opensuse.org/issues/104452
- Needles: na
- Verification run: 
390
http://openqa.suse.de/t7950035
x86
http://openqa.suse.de/tests/7947545
power:
http://openqa.suse.de/tests/7949811
aarch:
http://openqa.suse.de/tests/7972454