### PR TITLE
Remove unnecessary guest start and on_reboot check

### DIFF
--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -65,14 +65,6 @@ sub run {
         }
     }
 
-    ## Our test setup requires guests to restart when the machine is rebooted.
-    ## Ensure every guest has <on_reboot>restart</on_reboot>
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        if (script_run("! virsh dumpxml $guest | grep 'on_reboot' | grep -v 'restart'") != 0) {
-            record_info("$guest bsc#1153028", "Setting on_reboot=restart failed for $guest");
-        }
-    }
-
     script_run 'history -a';
     assert_script_run('cat ~/virt-install*', 30);
     script_run('xl dmesg |grep -i "fail\|error" |grep -vi Loglevel') if (is_xen_host());

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -108,7 +108,6 @@ sub run {
     my $sleep_delay = 1200;
     $sleep_delay = 1800 if (is_xen_host);    # XEN has more guests
     sleep($sleep_delay);    # XXX Get rid of this sleep!
-    start_guests();
     record_info("guests installed", "Guest installation completed");
 
     # Adding the PCI bridges requires the guests to be shutdown


### PR DESCRIPTION
Remove unnecessary on_reboot check and guest start in Guest install code (prepare_guests.pm,  waitfor_guests.pm)

- Related ticket: https://progress.opensuse.org/issues/104508
- Needles: no
- Verification run: 
- sles12sp4 xen: http://openqa.qam.suse.cz/tests/34860
- sles12sp4 kvm:  http://openqa.qam.suse.cz/tests/34989
- sles12sp3 xen: http://openqa.qam.suse.cz/tests/35035
- sles15sp3 kvm: http://openqa.qam.suse.cz/tests/overview?distri=sle&version=15-SP3&build=%3Atony1234%3A&groupid=154