### PR TITLE
Add missing module for required installation step

### DIFF
--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -20,6 +20,8 @@ conditional_schedule:
     VERSION:
       15-SP2:
         - installation/user_settings_root
+      15-SP4:
+        - installation/user_settings_root
 schedule:
   - installation/isosize
   - '{{bootloader}}'


### PR DESCRIPTION
15SP4 asks to set up the root password before continue. The yaml scheduler is missing condition
which will schedule the `user_settings_root` module.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: http://aquarius.suse.cz/tests/7690
