### PR TITLE
Update installation_node_dev yaml scheduler adjusting to 15sp4

### DIFF
--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -16,6 +16,10 @@ conditional_schedule:
         - installation/bootloader_uefi
       x86_64:
         - installation/bootloader
+  user_settings_root:
+    VERSION:
+      15-SP4:
+        - installation/user_settings_root
   systemrole_dev:
     HPC:
       installation_dev:
@@ -31,9 +35,8 @@ schedule:
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
+  - '{{user_settings_root}}'
   - '{{systemrole_dev}}'
-  - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview


### PR DESCRIPTION
i havent found the scheduler in any other job but i added a conditional module
for the 15sp4. some other minor adjustement too, as the `installation/hostname_inst`
doesnt look to be needed.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: http://aquarius.suse.cz/tests/7693
