### PR TITLE
Containers: simpler output validation for container-suseconnect-zypp lm

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -174,7 +174,7 @@ sub test_opensuse_based_image {
                 my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
                 validate_script_output("$runtime run --entrypoint $plugin -i $image -v", sub { m/container-suseconnect version .*/ });
                 validate_script_output("$runtime run --entrypoint $plugin -i $image lp", sub { m/.*All available products.*/ });
-                validate_script_output("$runtime run --entrypoint $plugin -i $image lm", sub { m/.*Installed product.*\n.*Registration server set to.*\nAll available modules.*/ });
+                validate_script_output("$runtime run --entrypoint $plugin -i $image lm", sub { m/.*All available modules.*/ });
             }
         } else {
             record_info "non-SLE host", "This host ($host_id) does not support zypper service";


### PR DESCRIPTION
For some reason, the command:
`podman run --entrypoint /usr/lib/zypp/plugins/services/container-suseconnect-zypp -i registry.suse.com/suse/sle15:15.3 lp`
prints the following lines to stderr:

`2022/01/10 19:10:16 Installed product: SLES-15.3-x86_64`
`2022/01/10 19:10:16 Registration server set to https://scc.suse.com`


And the next line is regular stdout:
`All available modules:`

This output validation works normally, but it fails on VMWare, HyperV and Xen, I guess due to how the serial output is treated in those backends.

We just need the string "All available modules" to be validated.

Example of error:
https://openqa.suse.de/tests/7958422#step/podman_image/84

- Verification runs: 
https://openqa.suse.de/tests/7958514#step/podman_image/84
https://openqa.suse.de/tests/7958515#step/podman_image/84


