### PR TITLE
Integrate IPSec into openQA

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -33,8 +33,9 @@ our @EXPORT = qw(
 );
 
 our $tmp_dir = '/tmp/';
-our $test_dir = '/usr/local/eal4_testing';
-our $code_repo = get_var('CODE_BASE', 'https://gitlab.suse.de/security/audit-test-sle15/-/archive/master/audit-test-sle15-master.tar');
+our $test_dir = get_var('IPSEC_TEST') ? '/usr/local/ipsec' : '/usr/local/eal4_testing';
+our $default_code_base = get_var('IPSEC_TEST') ? 'https://gitlab.suse.de/QA-APAC-I/ipsec/-/archive/main/ipsec-main.tar' : 'https://gitlab.suse.de/security/audit-test-sle15/-/archive/master/audit-test-sle15-master.tar';
+our $code_repo = get_var('CODE_BASE', $default_code_base);
 my @lines = split(/[\/\.]+/, $code_repo);
 our $testfile_tar = $lines[-2];
 our $mode = get_var('MODE', 64);

--- a/schedule/security/cc_ipsec.yaml
+++ b/schedule/security/cc_ipsec.yaml
@@ -1,0 +1,33 @@
+name: cc_ipsec
+description:    >
+    This is for ipsec test in CC system role
+schedule:
+    - '{{bootloader_zkvm}}'
+    - boot/boot_to_desktop
+    - '{{remove_bridge_network}}'
+    - '{{setup_multimachine}}'
+    - security/cc/cc_audit_test_setup
+    - '{{cc_ipsec}}'
+conditional_schedule:
+    bootloader_zkvm:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    remove_bridge_network:
+        ARCH:
+            aarch64:
+                - security/cc/remove_bridge_network
+            x86_64:
+                - security/cc/remove_bridge_network
+    setup_multimachine:
+        ARCH:
+            aarch64:
+                - network/setup_multimachine
+            x86_64:
+                - network/setup_multimachine
+    cc_ipsec:
+        HOSTNAME:
+            server:
+                - security/cc/ipsec_server
+            client:
+                - security/cc/ipsec_client

--- a/tests/security/cc/ipsec_client.pm
+++ b/tests/security/cc/ipsec_client.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run CC 'ipsec' client case
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#101226
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test;
+use Utils::Architectures;
+use lockapi;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    my $server_ip = get_var('SERVER_IP', '10.0.2.101');
+    my $client_ip = get_var('CLIENT_IP', '10.0.2.102');
+
+    # We don't run setup_multimachine in s390x, but we need to know the server and client's
+    # ip address, so we add a known ip to NETDEV.
+    my $netdev = get_var('NETDEV', 'eth0');
+    assert_script_run("ip addr add $client_ip/24 dev $netdev") if (is_s390x);
+
+    mutex_wait('IPSEC_SERVER_READY');
+
+    assert_script_run("cd $audit_test::test_dir/ipsec_configuration/toe");
+
+    # Setup the ipip tunnel to the IPSec gateway and test it
+    # 192.168.100.1 is configured in the server by ipsec_setup_tunnel_server.sh
+    # We need to check if it's accessible to find the network issue easily.
+    assert_script_run("./ipsec_setup_tunnel_toe.sh start $client_ip $server_ip");
+    assert_script_run('ping -W1 -c1 192.168.100.1');
+
+    # Install IPSec configuration
+    assert_script_run('make install');
+
+    # Test the IPSec connection
+    assert_script_run('ipsec start');
+    assert_script_run('stime=$(date +\'%H:%M:%S\')');
+    assert_script_run('ipsec up ikev2suse');
+
+    # Test the IPSec connection
+    assert_script_run('ping -W1 -c1 192.168.250.1');
+
+    # Search for AUDIT SPD/SAD add records
+    assert_script_run('ausearch -ts $stime | grep --color -e \'MAC_IPSEC_EVENT\' -e \'SPD-add\' -e \'SAD-add\'');
+
+    assert_script_run('stime=$(date +\'%H:%M:%S\')');
+    assert_script_run('ipsec down ikev2suse');
+
+    # Search for AUDIT SPD/SAD delete records
+    assert_script_run('ausearch -ts $stime | grep --color -e \'MAC_IPSEC_EVENT\' -e \'SPD-delete\' -e \'SAD-delete\'');
+
+    # Stop the IPSec service
+    assert_script_run('ipsec stop');
+
+    # Stop the ipip tunnel
+    assert_script_run('./ipsec_setup_tunnel_toe.sh stop');
+
+    # Delete the ip that we added if arch is s390x
+    assert_script_run("ip addr del $client_ip/24 dev $netdev") if (is_s390x);
+}
+
+1;

--- a/tests/security/cc/ipsec_server.pm
+++ b/tests/security/cc/ipsec_server.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run CC 'ipsec' server case
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#101226
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test;
+use Utils::Architectures;
+use lockapi;
+use mmapi 'wait_for_children';
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    my $server_ip = get_var('SERVER_IP', '10.0.2.101');
+    my $client_ip = get_var('CLIENT_IP', '10.0.2.102');
+
+    # We don't run setup_multimachine in s390x, but we need to know the server and client's
+    # ip address, so we add a known ip to NETDEV.
+    my $netdev = get_var('NETDEV', 'eth0');
+    assert_script_run("ip addr add $server_ip/24 dev $netdev") if (is_s390x);
+
+    assert_script_run("cd $audit_test::test_dir/ipsec_configuration/server");
+
+    # Create ipip tunnel to the TOE system
+    assert_script_run("./ipsec_setup_tunnel_server.sh start $server_ip $client_ip");
+
+    # Install IPSec configuration
+    assert_script_run('make install');
+
+    # Start StrongSWAN
+    assert_script_run('systemctl start strongswan');
+
+    mutex_create('IPSEC_SERVER_READY');
+    wait_for_children;
+
+    # Stop StrongSWAN
+    assert_script_run('systemctl stop strongswan');
+
+    # Delete ipip tunnel
+    assert_script_run('./ipsec_setup_tunnel_server.sh stop');
+
+    # Delete the ip that we added if arch is s390x
+    assert_script_run("ip addr del $server_ip/24 dev $netdev") if (is_s390x);
+}
+
+1;


### PR DESCRIPTION
The test steps follows: https://confluence.suse.com/display/CC/CC+Testing+Howto+-+SLES15+SP2#CCTestingHowtoSLES15SP2-ipsectests

Relate: https://progress.opensuse.org/issues/101226
Verification run:
      aarch64: 
            https://openqa.suse.de/tests/7964064#   (client)
            https://openqa.suse.de/tests/7964063#   (server)                       
      x86_64: 
            https://openqa.suse.de/tests/7964060#   (client)
            https://openqa.suse.de/tests/7964059#   (server)
      s390x:
            https://openqa.suse.de/tests/7964062#  (client)
            https://openqa.suse.de/tests/7964061#  (server)