### PR TITLE
install_ltp: Enable wait for zypper processes running in background

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -40,6 +40,7 @@ our @EXPORT = qw(
   ssh_fully_patch_system
   minimal_patch_system
   zypper_search
+  set_zypper_lock_timeout
   workaround_type_encrypted_passphrase
   is_boot_encrypted
   is_bridged_networking
@@ -760,6 +761,21 @@ sub zypper_search {
     # Remove header from package list
     shift @ret;
     return \@ret;
+}
+
+=head2 set_zypper_lock_timeout
+
+ set_zypper_lock_timeout($timeout);
+
+Set how many seconds zypper will wait for other processes to release
+the system lock. If this function is called without arguments, it'll set
+timeout to 300 seconds.
+
+=cut
+sub set_zypper_lock_timeout {
+    my $timeout = shift // 300;
+
+    script_run("export ZYPP_LOCK_TIMEOUT='$timeout'");
 }
 
 =head2 workaround_type_encrypted_passphrase

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -352,6 +352,7 @@ sub run {
     }
 
     upload_logs('/boot/config-$(uname -r)', failok => 1);
+    set_zypper_lock_timeout(300);
     add_we_repo_if_available;
 
     if ($inst_ltp =~ /git/i) {


### PR DESCRIPTION
install_ltp module has issues on SLERT with a kernel purge service which tries to remove some outdated kernel packages after system boot and blocks the LTP installation process. Make zypper wait for the system lock to be released to fix the issue.

- Related ticket: https://progress.opensuse.org/issues/102089
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/7962042#step/install_ltp/38 (cloned from: https://openqa.suse.de/tests/7961804#step/install_ltp/35)
