### PR TITLE
Default location for PHP session.save_path changed

### DIFF
--- a/data/apparmor/usr.sbin.httpd-prefork
+++ b/data/apparmor/usr.sbin.httpd-prefork
@@ -69,6 +69,7 @@
 
     /proc/meminfo r,
     /srv/www/htdocs/adminer/** r,
+    /tmp/** rwk,
     /tmp/adminer.invalid rwk,
     /var/lib/php7/** rwk,
     /var/log/apache2/access_log w,


### PR DESCRIPTION
The session.save_path in php{7,8} has changed in Tumbleweed to the upstream PHP default (= unset, defaulting to /tmp).

See https://bugzilla.opensuse.org/show_bug.cgi?id=1194414 and https://bugzilla.opensuse.org/show_bug.cgi?id=1194544