### PR TITLE
Wait for Installation Settings screen to be loaded

### DIFF
--- a/lib/Installation/InstallationSettings/InstallationSettingsController.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsController.pm
@@ -29,7 +29,16 @@ sub init {
 sub get_installation_settings_page {
     my ($self) = @_;
     die "Installation Settings Page is not displayed" unless $self->{InstallationSettingsPage}->is_shown();
+    die "Overview content on Installation Settings Page is not loaded completely" unless $self->{InstallationSettingsPage}->is_loaded_completely();
     return $self->{InstallationSettingsPage};
+}
+
+sub wait_for_overview_content_to_be_loaded {
+    my ($self) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            my $overview_content = $self->get_installation_settings_page()->get_overview_content();
+            return ($overview_content =~ m/SSH port will be/);
+    }, timeout => 60, message => "Overview content is not loaded.");
 }
 
 sub enable_ssh_service {

--- a/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
@@ -57,6 +57,18 @@ sub is_shown {
     return $self->{txt_overview}->exist();
 }
 
+sub is_loaded_completely {
+    my ($self) = @_;
+    my $result;
+    eval {
+        $result = YuiRestClient::Wait::wait_until(object => sub {
+                my $overview_content = $self->get_overview_content();
+                return ($overview_content =~ m/SSH port will be/);
+        }, timeout => 60, message => "Overview content is not loaded.");
+    };
+    $result ? 1 : 0;
+}
+
 sub open_ssh_port {
     my ($self) = @_;
     YuiRestClient::Wait::wait_until(object => sub {


### PR DESCRIPTION
validate_ssh_service_enabled test module checked that Installation
Screen is loaded by ensuring that widget with "id=proposal" is shown on
the screen. Then 'assert_true' is called immediately and it failed,
because the content of 'proposal' widget was not loaded.

The commit ensures that the the content is loaded before validating that
the port is opened.

- Related issue: https://progress.opensuse.org/issues/104703
- Verification run: https://openqa.suse.de/tests/7965573
