### PR TITLE
Fix partitioning_smalldisk_storageng checking multipath issue

### DIFF
--- a/tests/installation/partitioning_smalldisk_storageng.pm
+++ b/tests/installation/partitioning_smalldisk_storageng.pm
@@ -29,7 +29,7 @@ sub run {
         select_console 'root-console';
     }
     my $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME -d -e 7,11,254 -b | sort -n | awk '(NR == 1) {print $2}')]"/;
-    $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME,TYPE -e 7,11,254 -b | sort -n | awk '($3 == "mpath" && NR == 1) {print $2}')]"/
+    $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME,TYPE -e 7,11,254 -b | grep 'mpath' | sort -n | awk '(NR == 1) {print $2}')]"/
       if (get_var('MULTIPATH') and (get_var('MULTIPATH_CONFIRM') !~ /\bNO\b/i));
     my $output = script_output $lsblkcmd;
     $output =~ /\[([\w\.]+)\]/;


### PR DESCRIPTION
The commit#007d818 adding 254 in lsblk excluding list causes multipath
device be ignored because it is also using 254 in some product version.
For safety, modify the filter express as grep 'mpath'.

- Related ticket: https://progress.opensuse.org/issues/104817
- Needles: N/A
- Verification run: http://openqa.qa2.suse.asia/tests/43368
