### PR TITLE
Add python3 support for sleperf framework on SLE 12

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -28,6 +28,9 @@ sub install_pkg {
 
     # Install qa_lib_ctcs2 package to fix dependency issue
     zypper_call("install qa_lib_ctcs2");
+    if (get_var('VERSION') =~ /^12/) {
+        zypper_call("install python3");
+    }
 }
 
 sub extract_settings_qaset_config {


### PR DESCRIPTION
sleperf framework needs python3 after updating, but no python3 on SLE 12 in default, so we haveto install python3 on SLE 12 when deploying sleperf.

- Related ticket: https://progress.opensuse.org/issues/104820
- Needles: http://openqa.qa2.suse.asia/tests/43400#step/install_qatestset/23
- Verification run: http://openqa.qa2.suse.asia/tests/43400
