### PR TITLE
Add support for Shanghai time zone

### DIFF
--- a/tests/installation/installer_timezone.pm
+++ b/tests/installation/installer_timezone.pm
@@ -24,6 +24,11 @@ sub run {
         send_key_until_needlematch("timezone-Asia", "up", 20, 1);
         send_key 'tab';
         send_key_until_needlematch("timezone-beijing", "down", 20, 1);
+    } elsif (check_var('TIMEZONE', 'shanghai')) {
+        send_key_until_needlematch("timezone-Asia", "up", 20, 1);
+        send_key 'tab';
+        send_key "end";
+        send_key_until_needlematch("timezone-shanghai", "up", 100, 1);
     }
     # Unpredictable hotkey on kde live distri, click button. See bsc#1045798
     if (noupdatestep_is_applicable() && get_var("LIVECD")) {


### PR DESCRIPTION
In the PBOffline test of SAP HANA perf, we need to add support for Shanghai time zone when installing the operating system.
- Related ticket: https://progress.opensuse.org/issues/104814
- Verification run: http://openqa.qa2.suse.asia/tests/43405#step/installer_timezone/29
