### PR TITLE
xfstests: enable some options to debug softlockup

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -387,9 +387,16 @@ sub umount_xfstests_dev {
     }
 }
 
+sub config_debug_option {
+    script_run('echo 1 > /proc/sys/kernel/softlockup_all_cpu_backtrace');    # on detection capture more debug information
+    script_run('echo 1 > /proc/sys/kernel/softlockup_panic');    # panic when softlockup
+}
+
 sub run {
     my $self = shift;
     select_console('root-console');
+
+    config_debug_option;
 
     # Get wrapper
     assert_script_run("curl -o $TEST_WRAPPER " . data_url('xfstests/wrapper.sh'));

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -390,6 +390,11 @@ sub umount_xfstests_dev {
 sub config_debug_option {
     script_run('echo 1 > /proc/sys/kernel/softlockup_all_cpu_backtrace');    # on detection capture more debug information
     script_run('echo 1 > /proc/sys/kernel/softlockup_panic');    # panic when softlockup
+    if (get_var('XFSTESTS_DEBUG')) {
+        # e.g. XFSTESTS_DEBUG could be one or more parameter in following
+        # [hardlockup_panic hung_task_panic panic_on_io_nmi panic_on_oops panic_on_rcu_stall...]
+        script_run("echo 1 > /proc/sys/kernel/$_ ") foreach (split ' ', get_var('XFSTESTS_DEBUG'));
+    }
 }
 
 sub run {


### PR DESCRIPTION
in commit 4d72297: Enable following options to debug softlockup issue in xfstests:
kernel.softlockup_all_cpu_backtrace=1
kernel.softlockup_panic=1

in commit c1cb33c: Add more panic type control by openqa parameter XFSTESTS_DEBUG, they are not enable by default to avoid misunderstanding happen when xfstests got a panic. It use only in debug. XFSTESTS_DEBUG could use in clone job and add this parameter to get more log. It could be one or more in following:
[hardlockup_panic hung_task_panic panic_on_io_nmi panic_on_oops panic_on_rcu_stall...]

- Verification run: 
- Single run a issue case: https://openqa.suse.de/tests/7964739#step/run/23
- Trigger a full group test: https://openqa.suse.de/tests/7964813

Compare difference:
Before set kernel.softlockup_panic=1: https://openqa.suse.de/tests/7924858#step/run/1125
After set kernel.softlockup_panic=1: https://openqa.suse.de/tests/7964813#step/run/1137