### PR TITLE
Drop alt from kb shortcut for cert settings

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -697,6 +697,8 @@ sub exit_firefox_common {
         # confirm "save&quit"
         send_key "ret";
     }
+    # wait a sec because xterm-without-focus can match while firefox is being closed
+    wait_still_screen 2;
     assert_screen [qw(xterm-left-open xterm-without-focus)];
     if (match_has_tag 'xterm-without-focus') {
         # focus it

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -684,8 +684,8 @@ sub firefox_open_url {
 }
 
 sub firefox_preferences {
-    send_key_until_needlematch 'firefox-edit-menu', 'alt-e', 3, 15;
-    send_key_until_needlematch 'firefox-preferences', 'n', 3, 15;
+    send_key_until_needlematch 'firefox-edit-menu', 'alt-e', 5, 5;
+    send_key_until_needlematch 'firefox-preferences', 'n', 5, 5;
 }
 
 sub exit_firefox_common {

--- a/tests/x11/firefox/firefox_ssl.pm
+++ b/tests/x11/firefox/firefox_ssl.pm
@@ -54,8 +54,9 @@ sub run {
     type_string "hong";
     send_key "down";
 
+    send_key 'tab';
     sleep 1;
-    send_key "alt-shift-e";
+    send_key "shift-e";
 
     sleep 1;
     send_key "spc";


### PR DESCRIPTION
Alt can call firefox edit menu instead 'Edit trust CA' button
Tab to select buttons and then press shortcut for 'Edit trust CA'

- Related ticket: https://progress.opensuse.org/issues/101367
- Verification run:
https://openqa.suse.de/tests/7965413 15 SP4 wayland 
https://openqa.suse.de/tests/7965414 15 SP4 x11
https://openqa.suse.de/tests/7965356 15 SP3 SLED
https://openqa.suse.de/tests/7965357 15 SP3 SLES
https://openqa.suse.de/tests/7965157 15 SP2
https://openqa.suse.de/tests/7965156 15 SP1
https://openqa.suse.de/tests/7965155 15 GA
https://openqa.suse.de/tests/7965154 12 SP5
https://openqa.suse.de/tests/7965153 12 SP4
https://openqa.suse.de/tests/7965152 12 SP3
https://openqa.suse.de/tests/7965151 12 SP2