### PR TITLE
Fix is_sle condition in main_containers

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -61,7 +61,7 @@ sub load_host_tests_podman {
         loadtest 'containers/podman_3rd_party_images';
         loadtest 'containers/podman_firewall';
         loadtest 'containers/buildah';
-        loadtest 'containers/rootless_podman' unless is_sle("15-sp1");    # https://github.com/containers/podman/issues/5732#issuecomment-610222293
+        loadtest 'containers/rootless_podman' unless is_sle('=15-sp1');    # https://github.com/containers/podman/issues/5732#issuecomment-610222293
     }
 }
 


### PR DESCRIPTION
This fixes the error introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13985

`Unsupported version parameter for check_version: '15-sp1' at sle/lib/version_utils.pm line 188.`

error: https://openqa.suse.de/tests/7965416
VR: https://openqa.suse.de/tests/7965417



