### PR TITLE
Duplicate persistent logging in sle15sp4

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -15,7 +15,7 @@
 # - check if journalctl vacuum functions are working
 # - verify FSS log again
 # Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
-#             Sergio Lindo Mansilla <slindomansilla@suse.com>
+#             Martin Loviska <mloviska@suse.com>
 # Tags: bsc#1063066 bsc#1171858
 
 use Mojo::Base qw(consoletest);
@@ -155,8 +155,10 @@ sub run {
             assert_script_run 'rpm -q systemd-logger';
             assert_script_run "rpm -q --conflicts systemd-logger | tee -a /dev/$serialdev | grep syslog";
         }
+    } elsif (is_sle('15-SP4+')) {
+        record_soft_failure 'bsc#1194467 - [Build 150400.3.9] redundant persistent log settings in sle15sp4';
+        script_output(sprintf("test -d %s && ls --almost-all %s", PERSISTENT_LOG_DIR, PERSISTENT_LOG_DIR));
     } else {
-        script_run("journalctl --boot=-1 | grep 'no persistent journal was found'") or die "Persistent journal should not be enabled by default on SLE!\n";
         assert_script_run "mkdir -p ${\ PERSISTENT_LOG_DIR }";
         assert_script_run "systemd-tmpfiles --create --prefix ${\ PERSISTENT_LOG_DIR }";
         # test for installed rsyslog and for imuxsock existance


### PR DESCRIPTION
For persistent logs TW and older <=Leap15.2 used to configure persistent
journald.
In sle the situation is slightly differernt, volatile journald is used together with `rsyslog`.

- Verification runs: 
  * [tw](http://kepler.suse.cz/tests/10442#step/journalctl/18)
  * [opensuse-15.4-DVD-x86_64-Build140.1-extra_tests_textmode@64bit](http://kepler.suse.cz/tests/10445#step/journalctl/16)
  * [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.341-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/10441#step/journalctl/16)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220113-1-jeos-extratest@64bit-virtio-vga](http://kepler.suse.cz/tests/10443#step/journalctl/16)
  * [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build150400.3.9-jeos-extratest@uefi-virtio-vga](http://kepler.suse.cz/tests/10440#step/journalctl/15)
