### PR TITLE
Move sys_param_check testkit location to a setting

### DIFF
--- a/tests/sles4sap/sys_param_check.pm
+++ b/tests/sles4sap/sys_param_check.pm
@@ -6,6 +6,8 @@
 # Summary: Check the sles4sap "from scratch" settings (without saptune/sapconf) using the robot framework.
 #          This test is configured to be used with a 2 GB RAM system.
 #          Some values depend of the hardware configuration.
+#          External robotfw testkit is supplied in the SYS_PARAM_CHECK_TEST setting. Defaults to
+#          qa-css-hq.qa.suse.de/robot.tar.gz.
 # Maintainer: Julien Adamek <jadamek@suse.com>
 
 use base "sles4sap";
@@ -45,10 +47,11 @@ sub run {
     my $robot_fw_version = '3.2.2';
     my $test_repo = "/robot/tests/sles-" . get_var('VERSION');
     my $robot_tar = "robot.tar.gz";
+    my $testkit = get_var('SYS_PARAM_CHECK_TEST', "qa-css-hq.qa.suse.de/$robot_tar");
     my $python_bin = is_sle('15+') ? 'python3' : 'python';
 
     # Download and prepare the test environment
-    assert_script_run "cd /; curl -f -v qa-css-hq.qa.suse.de/$robot_tar -o $robot_tar";
+    assert_script_run "cd /; curl -f -v \"$testkit\" -o $robot_tar";
     assert_script_run "tar -xzf $robot_tar";
 
     # Install the robot framework


### PR DESCRIPTION
Currently the `sys_param_check.pm` test module downloads the external robotfw testkit from a server hard-coded in the module. This commit moves this hard-coded value to the **SYS_PARAM_CHECK_TEST** setting, leaving the current value as the default.

- Related ticket: N/A
- Needles: N/A
- Verification runs: [12-SP5](http://mango.qa.suse.de/tests/4784), [15-SP3](http://mango.qa.suse.de/tests/4782) & [15-SP4](http://mango.qa.suse.de/tests/4786). Failure in 15-SP4 is known ( [bsc#1191396](https://bugzilla.suse.com/show_bug.cgi?id=1191396) ) and unrelated to this PR.
