### PR TITLE
xfstests: Add record_info of xfstests config file

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -211,6 +211,7 @@ sub create_loop_device_by_rootsize {
 sub set_config {
     my $self = shift;
     script_run("echo 'export KEEP_DMESG=yes' >> $CONFIG_FILE");
+    record_info('Config file', script_output("cat $CONFIG_FILE"));
 }
 
 sub post_env_info {
@@ -300,7 +301,6 @@ sub run {
         }
     }
     set_config;
-    upload_logs($CONFIG_FILE, timeout => 60, log_name => basename($CONFIG_FILE));
 }
 
 sub test_flags {


### PR DESCRIPTION
Add record_info of xfstests config file instead of uploading. As record_info is easy to read and faster and more space efficient than uploading.


- Related ticket: https://progress.opensuse.org/issues/104874
- Needles: N/A
- Verification run: http://10.67.133.102/tests/540#step/partition/60
