### PR TITLE
Add a module to import users with restapi in installer

### DIFF
--- a/lib/Installation/LocalUser/LocalUserController.pm
+++ b/lib/Installation/LocalUser/LocalUserController.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2021-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: The class introduces business actions for Local user dialog
@@ -11,6 +11,7 @@ package Installation::LocalUser::LocalUserController;
 use strict;
 use warnings;
 use Installation::LocalUser::LocalUserPage;
+use Installation::LocalUser::SelectUsersPage;
 use Installation::Popups::YesNoPopup;
 use YuiRestClient;
 
@@ -23,6 +24,7 @@ sub new {
 sub init {
     my ($self, $args) = @_;
     $self->{LocalUserPage} = Installation::LocalUser::LocalUserPage->new({app => YuiRestClient::get_app()});
+    $self->{SelectUsersPage} = Installation::LocalUser::SelectUsersPage->new({app => YuiRestClient::get_app()});
     $self->{WeakPasswordWarning} = Installation::Popups::YesNoPopup->new({app => YuiRestClient::get_app()});
     return $self;
 }
@@ -31,6 +33,12 @@ sub get_local_user_page {
     my ($self) = @_;
     die 'Local User page is not displayed' unless $self->{LocalUserPage}->is_shown();
     return $self->{LocalUserPage};
+}
+
+sub get_select_users_page {
+    my ($self) = @_;
+    die 'User selection pop-up is not displayed' unless $self->{SelectUsersPage}->is_shown();
+    return $self->{SelectUsersPage};
 }
 
 sub get_weak_password_warning {
@@ -72,6 +80,15 @@ sub is_autologin {
 sub is_use_same_password_for_admin {
     my ($self) = @_;
     $self->get_local_user_page()->has_use_same_password_for_admin_checked();
+}
+
+sub import_existing_users {
+    my ($self) = @_;
+    $self->get_local_user_page()->select_import_users();
+    $self->get_local_user_page()->choose_users_to_import();
+    $self->get_select_users_page()->select_all();
+    $self->get_select_users_page()->press_ok();
+    $self->get_local_user_page()->press_next();
 }
 
 1;

--- a/lib/Installation/LocalUser/LocalUserPage.pm
+++ b/lib/Installation/LocalUser/LocalUserPage.pm
@@ -3,11 +3,12 @@
 # Copyright 2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: The module provides interface to act with Local User page
+# Summary: The class provides interface to act with Local User page
 #
 # Maintainer: QE YaST <qa-sle-yast@suse.de>
 
 package Installation::LocalUser::LocalUserPage;
+use parent 'Installation::Navigation::NavigationBase';
 use strict;
 use warnings;
 
@@ -21,12 +22,15 @@ sub new {
 
 sub init {
     my ($self) = @_;
+    $self->SUPER::init();
     $self->{tb_confirm_password} = $self->{app}->textbox({id => 'pw2'});
     $self->{tb_full_name} = $self->{app}->textbox({id => 'full_name'});
     $self->{tb_username} = $self->{app}->textbox({id => 'username'});
     $self->{tb_password} = $self->{app}->textbox({id => 'pw1'});
     $self->{ch_autologin} = $self->{app}->checkbox({id => 'autologin'});
     $self->{ch_use_for_admin} = $self->{app}->checkbox({id => 'root_pw'});
+    $self->{rb_import_users} = $self->{app}->radiobutton({id => 'import'});
+    $self->{btn_choose_users} = $self->{app}->button({id => 'choose_users'});
     return $self;
 }
 
@@ -74,6 +78,16 @@ sub select_use_this_password_for_admin {
 sub has_use_same_password_for_admin_checked {
     my ($self) = @_;
     return $self->{ch_use_for_admin}->is_checked();
+}
+
+sub select_import_users {
+    my ($self) = @_;
+    return $self->{rb_import_users}->select();
+}
+
+sub choose_users_to_import {
+    my ($self) = @_;
+    return $self->{btn_choose_users}->click();
 }
 
 1;

--- a/lib/Installation/LocalUser/SelectUsersPage.pm
+++ b/lib/Installation/LocalUser/SelectUsersPage.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles the pop-up that allows to select users from previous installation.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::LocalUser::SelectUsersPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->{ch_select_all} = $self->{app}->checkbox({id => 'all'});
+    $self->{btn_ok} = $self->{app}->button({id => 'ok'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{ch_select_all}->exist();
+}
+
+sub select_all {
+    my ($self) = @_;
+    return $self->{ch_select_all}->check();
+}
+
+sub press_ok {
+    my ($self) = @_;
+    return $self->{btn_ok}->click();
+}
+
+1;

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/hostname_inst
-  - installation/user_import
+  - installation/authentication/import_users
   - installation/authentication/root_simple_pwd
   - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/partitioning/encrypt_lvm_reuse_existing
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/user_import
+  - installation/authentication/import_users
   - installation/authentication/root_simple_pwd
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port

--- a/tests/installation/authentication/import_users.pm
+++ b/tests/installation/authentication/import_users.pm
@@ -1,0 +1,18 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Import user(s) from previous installation
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    $testapi::distri->get_local_user()->import_existing_users();
+}
+
+1;


### PR DESCRIPTION
Replaces the module users_import by one that uses libyui-rest-api.

- Related ticket: https://progress.opensuse.org/issues/104791

- Verification run: http://waaa-amazing.suse.cz/tests/16127
https://openqa.suse.de/tests/overview?build=JRivrain/os-autoinst-distri-opensuse%2314009