### PR TITLE
Clean up the duplicated variables between provider and basetest

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -16,8 +16,10 @@ use testapi qw(is_serial_terminal :DEFAULT);
 use utils qw(script_output_retry);
 use publiccloud::azure_client;
 
-has tenantid => undef;
-has subscription => undef;
+has tenantid => sub { get_var('PUBLIC_CLOUD_AZURE_TENANT_ID') };
+has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };
+has region => sub { get_var('PUBLIC_CLOUD_REGION', 'westeurope') };
+has username => sub { get_var('PUBLIC_CLOUD_USER', 'azureuser') };
 has resource_group => 'openqa-upload';
 has storage_account => 'openqa';
 has container => 'sle-images';

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -46,12 +46,7 @@ sub provider_factory {
             );
         }
         elsif ($args{service} eq 'EC2') {
-            $provider = publiccloud::ec2->new(
-                key_id => get_var('PUBLIC_CLOUD_KEY_ID'),
-                key_secret => get_var('PUBLIC_CLOUD_KEY_SECRET'),
-                region => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1'),
-                username => get_var('PUBLIC_CLOUD_USER', 'ec2-user')
-            );
+            $provider = publiccloud::ec2->new();
         }
         else {
             die('Unknown service given');
@@ -71,14 +66,7 @@ sub provider_factory {
             );
         }
         elsif ($args{service} eq 'AVM') {
-            $provider = publiccloud::azure->new(
-                key_id => get_var('PUBLIC_CLOUD_KEY_ID'),
-                key_secret => get_var('PUBLIC_CLOUD_KEY_SECRET'),
-                region => get_var('PUBLIC_CLOUD_REGION', 'westeurope'),
-                tenantid => get_var('PUBLIC_CLOUD_AZURE_TENANT_ID'),
-                subscription => get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID'),
-                username => get_var('PUBLIC_CLOUD_USER', 'azureuser')
-            );
+            $provider = publiccloud::azure->new();
         } else {
             die('Unknown service given');
         }
@@ -99,17 +87,7 @@ sub provider_factory {
             );
         }
         elsif ($args{service} eq 'GCE') {
-            $provider = publiccloud::gce->new(
-                account => get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT'),
-                service_acount_name => get_var('PUBLIC_CLOUD_GOOGLE_SERVICE_ACCOUNT'),
-                project_id => get_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID'),
-                private_key_id => get_var('PUBLIC_CLOUD_KEY_ID'),
-                private_key => get_var('PUBLIC_CLOUD_KEY'),
-                client_id => get_var('PUBLIC_CLOUD_GOOGLE_CLIENT_ID'),
-                region => get_var('PUBLIC_CLOUD_REGION', 'europe-west1-b'),
-                storage_name => get_var('PUBLIC_CLOUD_GOOGLE_STORAGE', 'openqa-storage'),
-                username => get_var('PUBLIC_CLOUD_USER', 'susetest')
-            );
+            $provider = publiccloud::gce->new();
         }
         else {
             die('Unknown service given');

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -14,6 +14,8 @@ use testapi;
 use publiccloud::utils "is_byos";
 use publiccloud::aws_client;
 
+has region => sub { get_var('PUBLIC_CLOUD_REGION', 'eu-central-1') };
+has username => sub { get_var('PUBLIC_CLOUD_USER', 'ec2-user') };
 has ssh_key => undef;
 has ssh_key_file => undef;
 has provider_client => undef;

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -16,14 +16,16 @@ use Mojo::JSON 'decode_json';
 use testapi;
 use utils;
 
-has storage_name => undef;
-has provider_client => undef;
-has project_id => undef;
-has account => undef;
-has service_acount_name => undef;
-has private_key_id => undef;
-has private_key => undef;
-has client_id => undef;
+has storage_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_STORAGE', 'openqa-storage') };
+has provider_client => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
+has project_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID') };
+has account => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
+has service_acount_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_SERVICE_ACCOUNT') };
+has private_key_id => sub { get_var('PUBLIC_CLOUD_KEY_ID') };
+has private_key => sub { get_var('PUBLIC_CLOUD_KEY') };
+has client_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_CLIENT_ID') };
+has region => sub { get_var('PUBLIC_CLOUD_REGION', 'europe-west1-b') };
+has username => sub { get_var('PUBLIC_CLOUD_USER', 'susetest') };
 
 sub init {
     my ($self, %params) = @_;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -22,10 +22,8 @@ use mmapi;
 use constant TERRAFORM_DIR => '/root/terraform';
 use constant TERRAFORM_TIMEOUT => 30 * 60;
 
-has key_id => undef;
-has key_secret => undef;
-has region => undef;
-has username => undef;
+has key_id => sub { get_var('PUBLIC_CLOUD_KEY_ID') };
+has key_secret => sub { get_var('PUBLIC_CLOUD_KEY_SECRET') };
 has prefix => 'openqa';
 has terraform_env_prepared => 0;
 has terraform_applied => 0;


### PR DESCRIPTION
In the code we have extra complexity in order to flexibility that
we don't need.

This PR clean up the duplicated variables between provider and basetest

- Related ticket: https://progress.opensuse.org/issues/103386
- Verification runs:
Amazon: http://openqa.suse.de/tests/7984874
Azure: http://openqa.suse.de/tests/7984868
Google: http://openqa.suse.de/tests/7984871
EKS : http://openqa.suse.de/tests/7985164

