### PR TITLE
Add required arg to script_run of ibtest module

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1387,8 +1387,8 @@ sub prepare_disks {
     #exclude device 254(zram) as wipefs fails on /dev/zram1 in openSUSE
     my $disks = script_output('lsblk -n -l -o NAME -d -e 7,11,254');
     for my $d (split('\n', $disks)) {
-        script_run "wipefs -af /dev/$d";
-        script_run "sync";
+        script_run "wipefs -af /dev/$d", die_on_timeout => 1;
+        script_run "sync", die_on_timeout => 1;
         if (get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_CANCEL_EXISTING')) {
             create_encrypted_part(disk => $d);
             if (get_var('ETC_PASSWD') && get_var('ETC_SHADOW')) {
@@ -1399,11 +1399,11 @@ sub prepare_disks {
             }
         }
         else {
-            script_run "parted /dev/$d mklabel gpt";
-            script_run "sync";
+            script_run "parted /dev/$d mklabel gpt", die_on_timeout => 1;
+            script_run "sync", die_on_timeout => 1;
         }
     }
-    script_run "lsblk";
+    script_run "lsblk", die_on_timeout => 1;
 }
 
 1;

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -69,7 +69,7 @@ Returns if can ping worker host gateway
 sub can_upload_logs {
     my ($gw) = @_;
     $gw ||= testapi::host_ip();
-    return (script_run('ping -c 1 ' . $gw) == 0);
+    return (script_run('ping -c 1 ' . $gw, die_on_timeout => 1) == 0);
 }
 
 

--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -119,9 +119,9 @@ sub save_upload_y2logs {
 
     # Try to recover network if cannot reach gw and upload logs if everything works
     if (can_upload_logs() || (!$args{no_ntwrk_recovery} && recover_network())) {
-        script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';
+        script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs', die_on_timeout => 0;
         my $filename = "/tmp/y2logs$args{suffix}.tar" . get_available_compression();
-        script_run "save_y2logs $filename", 180;
+        script_run "save_y2logs $filename", 180, die_on_timeout => 0;
         upload_logs($filename, failok => 1);
     } else {    # Redirect logs content to serial
         script_run("journalctl -b --no-pager -o short-precise > /dev/$serialdev");

--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -141,7 +141,7 @@ sub verify_license_translations {
 sub get_available_compression {
     my %extensions = (bzip2 => '.bz2', gzip => '.gz', xz => '.xz');
     foreach my $binary (sort keys %extensions) {
-        return $extensions{$binary} unless script_run("type $binary");
+        return $extensions{$binary} unless script_run("type $binary", die_on_timeout => 0);
     }
     return "";
 }

--- a/tests/kernel/ibtests.pm
+++ b/tests/kernel/ibtests.pm
@@ -117,7 +117,7 @@ sub run {
     barrier_wait('IBTEST_SETUP');
 
     # create a ssh key if we don't have one
-    script_run('[ ! -f /root/.ssh/id_rsa ] && ssh-keygen -b 2048 -t rsa -q -N "" -f /root/.ssh/id_rsa');
+    script_run('[ ! -f /root/.ssh/id_rsa ] && ssh-keygen -b 2048 -t rsa -q -N "" -f /root/.ssh/id_rsa', die_on_timeout => 1);
     # distribute the ssh key to the machines
     exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$master");
     script_run("/usr/bin/clear");


### PR DESCRIPTION
Add die_on_timeout argument to `script_run` to remove warning message in the autoinst-logs.
Log entry appears like _testapi::script_run: DEPRECATED call of script_run() in tests/console/suseconnect_scc.pm:30 add `die_on_timeout => ?` to avoid this warning_

per perlpod: -1 is the default, 0 avoids the warning, 1 throw an exception, if timeout expires.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


❯ openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14013 https://openqa.suse.de/tests/7972720
Github oauth token provided, performing authenticated requests
Created job #7984856: sle-15-SP4-Online-x86_64-Build79.1-ibtest-master@ipmi-64bit-mlx_con5 -> https://openqa.suse.de/t7984856
