### PR TITLE
Collect y2logs when error during installation occurs

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1502,7 +1502,11 @@ sub show_tasks_in_blocked_state {
         send_key 'alt-sysrq-w';
         # info will be sent to serial tty
         wait_serial(qr/sysrq\s*:\s+show\s+blocked\s+state/i);
-        send_key 'ret';    # ensure clean shell prompt
+
+        # If the 'An error occured during the installation.' OK popup has popped up,
+        # do not press the 'return' key, because it will result in all ttys logging out.
+        send_key 'ret' unless (check_screen 'linuxrc-install-fail');
+
     }
 }
 


### PR DESCRIPTION
When the 'An error occured during the installation.' OK popup occurs, sending return (and as a result hitting the OK button) will result in all ttys logging out.
This results in post_fail_hooks failing and logs not being saved, because any console accessed from that point onward has already been logged out.
So sending return should be avoided in the case of the installation error OK popup, in order for the post_fail_hooks to not fail.

- Related ticket: https://progress.opensuse.org/issues/102662
- Needles: No needles
- Verification run: http://10.163.41.154/tests/3846#downloads (the logs have been uploaded, including y2logs)


Notes: 
* [video](https://w3.suse.de/~ggkioulis/return_key_logs_out.mkv) where hitting return on installation error popup logs out all ttys
* this PR depends on [Do not die when uploading the widgets json](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14022#pullrequestreview-855366170)

