### PR TITLE
wicked: Fix wlan testsuite with custom RPM package

### DIFF
--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -162,16 +162,14 @@ sub stop_dhcp_server {
     assert_script_run(sprintf('test -e %s && kill $(cat %s) || true', $pidfile, $pidfile));
 }
 
-sub before_test {
+sub prepare_sut {
     my $self = shift // wicked::wlan->new();
-    $self->prepare_packages();
     $self->prepare_phys();
     $self->prepare_freeradius_server();
     $self->adopt_apparmor();
 }
 
 sub prepare_packages {
-    my $self = shift;
     if (is_sle()) {
         set_var('QA_HEAD_REPO', 'http://download.suse.de/ibs/QA:/Head/' . generate_version('-')) unless (get_var('QA_HEAD_REPO'));
         add_qa_head_repo();

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -133,9 +133,8 @@ sub run {
             zypper_ar($repo_url . generate_version('_') . '/', name => 'wicked_maintainers', no_gpg_check => 1, priority => 60);
             $package_list .= ' ndisc6';
         }
-        if (check_var('WICKED', 'wlan')) {
-            wicked::wlan::before_test();
-        }
+        wicked::wlan::prepare_packages() if (check_var('WICKED', 'wlan'));
+
         $package_list .= ' openvswitch iputils';
         $package_list .= ' libteam-tools libteamdctl0 ' if check_var('WICKED', 'advanced') || check_var('WICKED', 'aggregate');
         $package_list .= ' gcc' if check_var('WICKED', 'advanced');
@@ -143,6 +142,7 @@ sub run {
         $self->reset_wicked();
         $self->reboot() if $need_reboot;
         record_info('PKG', script_output(q(rpm -qa 'wicked*' --qf '%{NAME}\n' | sort | uniq | xargs rpm -qi)));
+        wicked::wlan::prepare_sut() if (check_var('WICKED', 'wlan'));
     }
 }
 


### PR DESCRIPTION
The wicked::wlan::before_test() calls wicked::wlan::prepare_phys() which create
the network namespace and load the hwsim module. But these are not boot
save, so a reboot remove these settings...

- Verification run: http://openqa.wicked.suse.de/t46777
