### PR TITLE
Add configuration for tidyall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/*.html
 docs/**/*.html
 /script/yaml_generator/env/
 __pycache__/
+.tidyall.d/

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,0 +1,3 @@
+[PerlTidy]
+select = {lib,products,script,tests,t}/**/*.{pl,pm,t}
+argv = --pro=$ROOT/.perltidyrc


### PR DESCRIPTION
A complete initial run when the cache is empty takes 1m34s for me. The old
implementation of tidy takes 1m30s so the cache generation can take roughly 4s.
However any subsequent run is very quick. A no-op run takes only 1.5s.

This is a preparation for an upcoming planned change in os-autoinst using
tidyall as well which will automatically allow the use in
os-autoinst-distri-opensuse. For this see
https://github.com/os-autoinst/os-autoinst/pull/1795

Related progress issue: https://progress.opensuse.org/issues/99678