### PR TITLE
Remove unsupported ftp protocol

### DIFF
--- a/tests/x11/firefox/firefox_urlsprotocols.pm
+++ b/tests/x11/firefox/firefox_urlsprotocols.pm
@@ -29,7 +29,6 @@ sub run {
     my %sites_url = (
         http => "http://httpbin.org/html",
         https => "https://www.google.com/",
-        ftp => "ftp://mirror.suse.cz/",
         local => "file:///usr/share/w3m/w3mhelp.html"
     );
 


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/104949
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/7983557#step/firefox_urlsprotocols/31
