### PR TITLE
Fix upgrade_select for new popup dialog

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright 2012-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Select existing partition(s) for upgrade
@@ -12,7 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'assert_screen_with_soft_timeout';
-use version_utils qw(is_sle is_opensuse);
+use version_utils qw(is_sle is_opensuse is_leap);
 
 sub run {
     if (get_var('ENCRYPT')) {
@@ -23,8 +23,10 @@ sub run {
             send_key 'alt-p';    # provide password
             assert_screen "upgrade-enter-password";
         }
-        type_password;
-        send_key $cmd{ok};
+        type_password();
+        send_key is_sle('<=15-SP4') || is_leap('<=15.4') ?
+          $cmd{ok} :
+          'alt-d';
     }
 
     # hardware detection and waiting for updates from suse.com can take a while


### PR DESCRIPTION
Fix shortcut according to [new popup developed](https://github.com/yast/yast-storage-ng/pull/1271). Provide branching for SLE and Leap as we don't know exactly when this change will apply there, so it can be edit there.

- Related tickets: [poo#104926](https://progress.opensuse.org/issues/104926) 
- Verification run: [openSUSE](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=jknphy%2Fos-autoinst-distri-opensuse%23fix_upgrade_select)
