### PR TITLE
Clean up variables between provider and client

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -14,10 +14,10 @@ use publiccloud::vault;
 
 use constant CREDENTIALS_FILE => '/root/amazon_credentials';
 
-has key_id => undef;
-has key_secret => undef;
+has key_id => sub { get_var('PUBLIC_CLOUD_KEY_ID') };
+has key_secret => sub { get_var('PUBLIC_CLOUD_KEY_SECRET') };
 has security_token => undef;
-has region => undef;
+has region => sub { get_var('PUBLIC_CLOUD_REGION', 'eu-central-1') };
 has vault => undef;
 has aws_account_id => undef;
 has service => undef;

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -16,16 +16,11 @@ use testapi qw(is_serial_terminal :DEFAULT);
 use utils qw(script_output_retry);
 use publiccloud::azure_client;
 
-has tenantid => sub { get_var('PUBLIC_CLOUD_AZURE_TENANT_ID') };
-has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };
-has region => sub { get_var('PUBLIC_CLOUD_REGION', 'westeurope') };
-has username => sub { get_var('PUBLIC_CLOUD_USER', 'azureuser') };
 has resource_group => 'openqa-upload';
 has storage_account => 'openqa';
 has container => 'sle-images';
 has lease_id => undef;
 has vault => undef;
-has provider_client => undef;
 
 sub init {
     my ($self) = @_;
@@ -97,10 +92,10 @@ sub create_resources {
     my ($self) = @_;
     my $timeout = 60 * 5;
     record_info('INFO', 'Create resource group ' . $self->resource_group);
-    assert_script_run('az group create --name ' . $self->resource_group . ' -l ' . $self->region, $timeout);
+    assert_script_run('az group create --name ' . $self->resource_group . ' -l ' . $self->provider_client->region, $timeout);
     record_info('INFO', 'Create storage account ' . $self->storage_account);
     assert_script_run('az storage account create --resource-group ' . $self->resource_group . ' -l '
-          . $self->region . ' --name ' . $self->storage_account . ' --kind Storage --sku Standard_LRS', $timeout);
+          . $self->provider_client->region . ' --name ' . $self->storage_account . ' --kind Storage --sku Standard_LRS', $timeout);
     my $key = $self->get_storage_account_keys($self->resource_group, $self->storage_account);
     record_info('INFO', 'Create storage container ' . $self->container);
     assert_script_run('az storage container create --account-name ' . $self->storage_account

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -30,12 +30,7 @@ has provider_client => undef;
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->provider_client(publiccloud::azure_client->new(
-            key_id => $self->key_id,
-            key_secret => $self->key_secret,
-            subscription => $self->subscription,
-            tenantid => $self->tenantid,
-            region => $self->region));
+    $self->provider_client(publiccloud::azure_client->new());
     $self->provider_client->init();
 }
 

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -13,11 +13,13 @@ use testapi;
 use utils;
 use publiccloud::vault;
 
-has key_id => undef;
-has key_secret => undef;
-has subscription => undef;
-has tenantid => undef;
-has region => undef;
+has key_id => sub { get_var('PUBLIC_CLOUD_KEY_ID') };
+has key_secret => sub { get_var('PUBLIC_CLOUD_KEY_SECRET') };
+has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };
+has tenantid => sub { get_var('PUBLIC_CLOUD_AZURE_TENANT_ID') };
+has region => sub { get_var('PUBLIC_CLOUD_REGION', 'westeurope') };
+has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };
+
 has vault => undef;
 has container_registry => sub { get_var('PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY', 'suseqectesting') };
 

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -19,6 +19,7 @@ has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };
 has tenantid => sub { get_var('PUBLIC_CLOUD_AZURE_TENANT_ID') };
 has region => sub { get_var('PUBLIC_CLOUD_REGION', 'westeurope') };
 has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };
+has username => sub { get_var('PUBLIC_CLOUD_USER', 'azureuser') };
 
 has vault => undef;
 has container_registry => sub { get_var('PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY', 'suseqectesting') };

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -23,10 +23,7 @@ has provider_client => undef;
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->provider_client(publiccloud::aws_client->new(
-            key_id => $self->key_id,
-            key_secret => $self->key_secret,
-            region => $self->region));
+    $self->provider_client(publiccloud::aws_client->new());
     $self->provider_client->init();
 }
 

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -14,11 +14,9 @@ use testapi;
 use publiccloud::utils "is_byos";
 use publiccloud::aws_client;
 
-has region => sub { get_var('PUBLIC_CLOUD_REGION', 'eu-central-1') };
 has username => sub { get_var('PUBLIC_CLOUD_USER', 'ec2-user') };
 has ssh_key => undef;
 has ssh_key_file => undef;
-has provider_client => undef;
 
 sub init {
     my ($self) = @_;
@@ -108,7 +106,7 @@ sub upload_img {
             'eu-west-1-byos-arm64' => 'ami-02eae5be24d203db3',
         };
 
-        my $ami_id_key = $self->region;
+        my $ami_id_key = $self->provider_client->region;
         $ami_id_key .= '-byos' if is_byos();
         $ami_id_key .= '-arm64' if check_var('PUBLIC_CLOUD_ARCH', 'arm64');
         $helper_ami_id = $ami_id_hash->{$ami_id_key} if exists($ami_id_hash->{$ami_id_key});
@@ -136,7 +134,7 @@ sub upload_img {
           . (is_byos() ? '' : '--use-root-swap ')
           . '--ena-support '
           . "--verbose "
-          . "--regions '" . $self->region . "' "
+          . "--regions '" . $self->provider_client->region . "' "
           . "--ssh-key-pair '" . $self->ssh_key . "' "
           . "--private-key-file " . $self->ssh_key_file . " "
           . "-d 'OpenQA upload image' "

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -16,17 +16,6 @@ use Mojo::JSON 'decode_json';
 use testapi;
 use utils;
 
-has storage_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_STORAGE', 'openqa-storage') };
-has provider_client => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
-has project_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID') };
-has account => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
-has service_acount_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_SERVICE_ACCOUNT') };
-has private_key_id => sub { get_var('PUBLIC_CLOUD_KEY_ID') };
-has private_key => sub { get_var('PUBLIC_CLOUD_KEY') };
-has client_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_CLIENT_ID') };
-has region => sub { get_var('PUBLIC_CLOUD_REGION', 'europe-west1-b') };
-has username => sub { get_var('PUBLIC_CLOUD_USER', 'susetest') };
-
 sub init {
     my ($self, %params) = @_;
     $self->SUPER::init();
@@ -57,7 +46,7 @@ sub find_img {
 sub upload_img {
     my ($self, $file) = @_;
     my $img_name = $self->file2name($file);
-    my $uri = $self->storage_name . '/' . $file;
+    my $uri = $self->provider_client->storage_name . '/' . $file;
     my $guest_os_features = get_var('PUBLIC_CLOUD_GCE_UPLOAD_GUEST_FEATURES', 'MULTI_IP_SUBNET,UEFI_COMPATIBLE,VIRTIO_SCSI_MULTIQUEUE');
 
     assert_script_run("gsutil cp '$file' 'gs://$uri'", timeout => 60 * 60);
@@ -85,7 +74,7 @@ sub img_proof {
 
 sub terraform_apply {
     my ($self, %args) = @_;
-    $args{project} //= $self->project_id;
+    $args{project} //= $self->provider_client->project_id;
     $args{confidential_compute} = get_var("PUBLIC_CLOUD_CONFIDENTIAL_VM", 0);
     return $self->SUPER::terraform_apply(%args);
 }

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -30,15 +30,7 @@ has username => sub { get_var('PUBLIC_CLOUD_USER', 'susetest') };
 sub init {
     my ($self, %params) = @_;
     $self->SUPER::init();
-    $self->provider_client(publiccloud::gcp_client->new(
-            region => $self->region,
-            account => $self->account,
-            service_acount_name => $self->service_acount_name,
-            project_id => $self->project_id,
-            private_key_id => $self->private_key_id,
-            private_key => $self->private_key,
-            client_id => $self->client_id
-    ));
+    $self->provider_client(publiccloud::gcp_client->new());
     $self->provider_client->init();
 }
 

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -18,7 +18,6 @@ use Mojo::JSON 'decode_json';
 use constant CREDENTIALS_FILE => '/root/google_credentials.json';
 
 has storage_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_STORAGE', 'openqa-storage') };
-has provider_client => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
 has project_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID') };
 has account => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
 has service_acount_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_SERVICE_ACCOUNT') };
@@ -26,6 +25,8 @@ has private_key_id => sub { get_var('PUBLIC_CLOUD_KEY_ID') };
 has private_key => sub { get_var('PUBLIC_CLOUD_KEY') };
 has client_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_CLIENT_ID') };
 has gcr_zone => sub { get_var('PUBLIC_CLOUD_GCR_ZONE', 'eu.gcr.io') };
+has region => sub { get_var('PUBLIC_CLOUD_REGION', 'europe-west1-b') };
+has username => sub { get_var('PUBLIC_CLOUD_USER', 'susetest') };
 has vault_gcp_role_index => undef;
 has vault => undef;
 

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -17,20 +17,20 @@ use Mojo::JSON 'decode_json';
 
 use constant CREDENTIALS_FILE => '/root/google_credentials.json';
 
-has account => undef;
-has project_id => undef;
-has private_key_id => undef;
-has private_key => undef;
-has service_acount_name => undef;
-has client_id => undef;
+has storage_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_STORAGE', 'openqa-storage') };
+has provider_client => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
+has project_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID') };
+has account => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
+has service_acount_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_SERVICE_ACCOUNT') };
+has private_key_id => sub { get_var('PUBLIC_CLOUD_KEY_ID') };
+has private_key => sub { get_var('PUBLIC_CLOUD_KEY') };
+has client_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_CLIENT_ID') };
+has gcr_zone => sub { get_var('PUBLIC_CLOUD_GCR_ZONE', 'eu.gcr.io') };
 has vault_gcp_role_index => undef;
-has gcr_zone => undef;
 has vault => undef;
 
 sub init {
     my ($self) = @_;
-
-    $self->gcr_zone(get_var('PUBLIC_CLOUD_GCR_ZONE', 'eu.gcr.io'));
 
     $self->vault(publiccloud::vault->new());
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -11,7 +11,6 @@ package publiccloud::provider;
 use testapi qw(is_serial_terminal :DEFAULT);
 use Mojo::Base -base;
 use publiccloud::instance;
-use publiccloud::vault;
 use Carp;
 use List::Util qw(max);
 use Data::Dumper;
@@ -22,13 +21,11 @@ use mmapi;
 use constant TERRAFORM_DIR => '/root/terraform';
 use constant TERRAFORM_TIMEOUT => 30 * 60;
 
-has key_id => sub { get_var('PUBLIC_CLOUD_KEY_ID') };
-has key_secret => sub { get_var('PUBLIC_CLOUD_KEY_SECRET') };
 has prefix => 'openqa';
 has terraform_env_prepared => 0;
 has terraform_applied => 0;
 has resource_name => sub { get_var('PUBLIC_CLOUD_RESOURCE_NAME', 'openqa-vm') };
-has vault => undef;
+has provider_client => undef;
 
 =head1 METHODS
 
@@ -178,7 +175,7 @@ sub run_img_proof {
     my $cmd = 'img-proof --no-color test ' . $args{provider};
     $cmd .= ' --debug ';
     $cmd .= "--distro " . $args{distro} . " ";
-    $cmd .= '--region "' . $self->region . '" ';
+    $cmd .= '--region "' . $self->provider_client->region . '" ';
     $cmd .= '--results-dir "' . $args{results_dir} . '" ';
     $cmd .= '--no-cleanup ';
     $cmd .= '--collect-vm-info ';
@@ -355,7 +352,7 @@ sub terraform_apply {
         my $ha_sap_repo = get_var('HA_SAP_REPO') ? get_var('HA_SAP_REPO') . '/SLE_' . $sle_version : '';
         file_content_replace('terraform.tfvars',
             q(%MACHINE_TYPE%) => $instance_type,
-            q(%REGION%) => $self->region,
+            q(%REGION%) => $self->provider_client->region,
             q(%HANA_BUCKET%) => $sap_media,
             q(%SLE_IMAGE%) => $image,
             q(%SCC_REGCODE_SLES4SAP%) => $sap_regcode,
@@ -382,7 +379,7 @@ sub terraform_apply {
         $cmd .= "-var 'image_id=" . $image . "' " if ($image);
         $cmd .= "-var 'instance_count=" . $args{count} . "' ";
         $cmd .= "-var 'type=" . $instance_type . "' ";
-        $cmd .= "-var 'region=" . $self->region . "' ";
+        $cmd .= "-var 'region=" . $self->provider_client->region . "' ";
         $cmd .= "-var 'name=" . $self->resource_name . "' ";
         $cmd .= "-var 'project=" . $args{project} . "' " if $args{project};
         $cmd .= "-var 'enable_confidential_vm=true' " if $args{confidential_compute};
@@ -437,10 +434,10 @@ sub terraform_apply {
         my $instance = publiccloud::instance->new(
             public_ip => @{$ips}[$i],
             instance_id => @{$vms}[$i],
-            username => $self->username,
+            username => $self->provider_client->username,
             ssh_key => $ssh_private_key_file,
             image_id => $image,
-            region => $self->region,
+            region => $self->provider_client->region,
             type => $instance_type,
             provider => $self
         );
@@ -470,7 +467,7 @@ sub terraform_destroy {
     else {
         assert_script_run('cd ' . TERRAFORM_DIR);
         # Add region variable also to `terraform destroy` (poo#63604) -- needed by AWS.
-        $cmd = sprintf(q(terraform destroy -no-color -auto-approve -var 'region=%s'), $self->region);
+        $cmd = sprintf(q(terraform destroy -no-color -auto-approve -var 'region=%s'), $self->provider_client->region);
     }
     # Retry 3 times with considerable delay. This has been introduced due to poo#95932 (RetryableError)
     # terraform keeps track of the allocated and destroyed resources, so its safe to run this multiple times.


### PR DESCRIPTION
In the code we have extra complexity in order to flexibility that
we don't need.

This PR clean up the duplicated variables between provider and clients

- Related ticket: https://progress.opensuse.org/issues/103386
-Verification run:
http://openqa.suse.de/t8001314 (AWS) OK
http://openqa.suse.de/tests/8005346 (EKS) OK
https://openqa.suse.de/tests/8001313 (Azure) OK
https://openqa.suse.de/tests/8001313 (Google) OK