### PR TITLE
Do not die when uploading the widgets json

### DIFF
--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -145,11 +145,16 @@ Save screenshot and upload widgets json file.
 sub upload_widgets_json {
     save_screenshot;
     if (get_var('YUI_REST_API')) {
-        my $json_content = to_json(YuiRestClient::get_app()->check_connection());
-        my $json_path = $autotest::current_test->{name} . '-widgets.json';
-        save_tmp_file($json_path, $json_content);
-        make_path('ulogs');
-        copy(hashed_string($json_path), "ulogs/$json_path");
+        my $json_content;
+        eval { $json_content = to_json(YuiRestClient::get_app()->check_connection()) };
+        if ($json_content) {
+            my $json_path = $autotest::current_test->{name} . '-widgets.json';
+            save_tmp_file($json_path, $json_content);
+            make_path('ulogs');
+            copy(hashed_string($json_path), "ulogs/$json_path");
+        } else {
+            record_info('rest-api down', 'widgets.json not uploaded because libyui-rest-api server is down.');
+        }
     }
 }
 


### PR DESCRIPTION
Pass a proceed_on_failure argument to wait_until in order to control whether the function should die on failure or just return a value.

- Related ticket: https://progress.opensuse.org/issues/102662
- Needles: No needles
- Verification run:
* [Before](http://10.163.41.154/tests/3831#details) | [After](http://10.163.41.154/tests/3855#step/skip_install_addons/5) (y2 logs and the rest of the logs have been uploaded, except for widgets.json because the rest-api is down)
* [Failure without installation error](http://10.163.41.154/tests/3856#), just to show that all logs uploaded ok (including widgets) when postfail hooks run without issue during a regular failure.