### PR TITLE
Force test failure when terraform destroy fails

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -489,7 +489,11 @@ sub terraform_destroy {
         assert_script_run('cd ' . TERRAFORM_DIR);
         $self->on_terraform_destroy_timeout();
     }
-    record_info('ERROR', 'Terraform exited with ' . $ret, result => 'fail') if ($ret != 0);
+
+    if ($ret != 0) {
+        record_info('ERROR', 'Terraform exited with ' . $ret, result => 'fail');
+        die('Terraform destroy failed');
+    }
 }
 
 =head2 terraform_param_tags


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/104952
Verification run: 
- http://openqa.suse.de/t7984933
- https://openqa.suse.de/tests/7984921 (this test introduces a delivered die to ensure that test fails, I introduced a delivery die for this test at the end of terraform_destroy subrutine only for testing purposes)