### PR TITLE
ovs MM test: Change ping_check output to debug failure

### DIFF
--- a/lib/console/ovs_utils.pm
+++ b/lib/console/ovs_utils.pm
@@ -31,17 +31,19 @@ sub ping_check {
     my $client_ip = shift;
     my $vpn = shift;
     assert_script_run("cd");
-    assert_script_run "(ping -c 20 $vpn &>/dev/null &)";
+    assert_script_run "(ping -c 20 $vpn &>ping.log &)";
     if ($vpn eq "192.0.0.2") {
-        assert_script_run("tcpdump -ni any net -c 10 $client_ip > check.log");
+        assert_script_run("tcpdump -ni any net -c 20 $client_ip > check.log", 300);
+        assert_script_run('cat check.log');
         assert_script_run("grep 'IP $server_ip > $client_ip: ESP' check.log");
     }
     else {
-        assert_script_run("tcpdump -ni any net -c 10 $server_ip > check.log");
+        assert_script_run("tcpdump -ni any net -c 20 $server_ip > check.log", 300);
+        assert_script_run('cat check.log');
         assert_script_run("grep 'IP $client_ip > $server_ip: ESP' check.log");
     }
     assert_script_run("pkill ping");
-    assert_script_run("ping -c 5 $vpn");
-    assert_script_run("rm check.log");
+    assert_script_run('cat ping.log');
+    assert_script_run("rm ping.log check.log");
 }
 1;

--- a/tests/console/ovs_client.pm
+++ b/tests/console/ovs_client.pm
@@ -59,6 +59,7 @@ sub run {
     # Set IPsec tunnel using pre-shared key
     assert_script_run("ovs-vsctl add-port br-ipsec tun -- set interface tun type=gre options:remote_ip=$server_ip options:psk=swordfish");
     systemctl 'restart openvswitch-ipsec';
+    systemctl 'status openvswitch-ipsec';
 
     # Wait till both hosts have finished the IPsec setup
     barrier_wait 'ipsec_done';
@@ -91,6 +92,7 @@ sub run {
     assert_script_run("ovs-vsctl set Open_vSwitch . other_config:certificate=/etc/keys/host_2-cert.pem other_config:private_key=/etc/keys/host_2-privkey.pem");
     assert_script_run("ovs-vsctl add-port br-ipsec tun -- set interface tun type=gre options:remote_ip=$server_ip options:remote_cert=/etc/keys/host_1-cert.pem");
     systemctl 'restart openvswitch-ipsec';
+    systemctl 'status openvswitch-ipsec';
 
     barrier_wait 'ipsec1_done';
     ping_check("$server_ip", "$client_ip", "$server_vpn");
@@ -121,6 +123,7 @@ sub run {
     assert_script_run("ovs-vsctl set Open_vSwitch . other_config:certificate=/etc/keys/host_2-cert.pem other_config:private_key=/etc/keys/host_2-privkey.pem other_config:ca_cert=/etc/keys/cacert.pem");
     assert_script_run("ovs-vsctl add-port br-ipsec tun -- set interface tun type=gre options:remote_ip=$server_ip options:remote_name=host_1");
     systemctl 'restart openvswitch-ipsec';
+    systemctl 'status openvswitch-ipsec';
 
     barrier_wait 'ipsec2_done';
     ping_check("$server_ip", "$client_ip", "$server_vpn");

--- a/tests/console/ovs_server.pm
+++ b/tests/console/ovs_server.pm
@@ -71,6 +71,7 @@ sub run {
     # Setup IPsec tunnel using pre-shared keys
     assert_script_run("ovs-vsctl add-port br-ipsec tun -- set interface tun type=gre options:remote_ip=$client_ip options:psk=swordfish");
     systemctl 'restart openvswitch-ipsec';
+    systemctl 'status openvswitch-ipsec';
 
     # Wait for the client host to setup the IPsec tunnel
     barrier_wait 'ipsec_done';
@@ -104,6 +105,7 @@ sub run {
     assert_script_run("ovs-vsctl set Open_vSwitch . other_config:certificate=/etc/keys/host_1-cert.pem other_config:private_key=/etc/keys/host_1-privkey.pem");
     assert_script_run("ovs-vsctl add-port br-ipsec tun -- set interface tun type=gre options:remote_ip=$client_ip options:remote_cert=/etc/keys/host_2-cert.pem");
     systemctl 'restart openvswitch-ipsec';
+    systemctl 'status openvswitch-ipsec';
 
     # Wait for the client host to setup the IPsec tunnel
     barrier_wait 'ipsec1_done';
@@ -147,6 +149,7 @@ sub run {
     assert_script_run("ovs-vsctl set Open_vSwitch . other_config:certificate=/etc/keys/host_1-cert.pem other_config:private_key=/etc/keys/host_1-privkey.pem other_config:ca_cert=/etc/keys/cacert.pem");
     assert_script_run("ovs-vsctl add-port br-ipsec tun -- set interface tun type=gre options:remote_ip=$client_ip options:remote_name=host_2");
     systemctl 'restart openvswitch-ipsec';
+    systemctl 'status openvswitch-ipsec';
 
     barrier_wait 'ipsec2_done';
 


### PR DESCRIPTION
console::ovs_utils::ping_check failure is happening very often.
I could reproduce the failure on my openQA instance, so it's most likely
not related to MM/network problems.

After debugging the issue I think tcpdump does collect 10 lines which are
related to ovs setup. [1]
For example in one failed run tcpdump is run at 10:49:22 and done at 10:49:24,
it's pretty fast but still does not contain expected ESP message.
When I added systemctl status openvswitch-ipsec after restart I could not
reproduce the fail. The command added some time for ovs to setup the interface.
I increased also lines collected with tcpdump to 20, to avoid non-ESP log. [2]
If that is not good enough wait or check, so tunnel is established,
should be added so tcpdump log is not filled with non-ESP data.
I print also output of ping and tcpdump for better understanding what happens
in case of failure.
Dropped ping after ping, tdpcumb, grep check. No reason to do ping again.

[1] https://networklessons.com/cisco/ccie-routing-switching/ipsec-internet-protocol-security
There are two phases to build an IPsec tunnel:
    IKE phase 1
    IKE phase 2

In IKE phase 1, two peers will negotiate about the encryption, authentication,
hashing and other protocols that they want to use and some other parameters
that are required. In this phase, an ISAKMP (Internet Security Association
and Key Management Protocol) session is established. This is also called
the ISAKMP tunnel or IKE phase 1 tunnel.
...

[2]
09:05:52.336827 IP 10.0.2.102.500 > 10.0.2.101.500: isakmp: parent_sa ikev2_init[I]
09:05:52.339276 IP 10.0.2.101.500 > 10.0.2.102.500: isakmp: parent_sa ikev2_init[R]
09:05:52.340725 IP 10.0.2.102.4500 > 10.0.2.101.4500: NONESP-encap: isakmp: child_sa  ikev2_auth[I]
09:05:52.380277 IP 10.0.2.101.4500 > 10.0.2.102.4500: NONESP-encap: isakmp: child_sa  ikev2_auth[R]
09:05:52.427883 IP 10.0.2.101.500 > 10.0.2.102.500: isakmp: parent_sa ikev2_init[I]
09:05:52.429362 IP 10.0.2.102.500 > 10.0.2.101.500: isakmp: parent_sa ikev2_init[R]
09:05:52.430898 IP 10.0.2.101.4500 > 10.0.2.102.4500: NONESP-encap: isakmp: child_sa  ikev2_auth[I]
09:05:52.432026 IP 10.0.2.102.4500 > 10.0.2.101.4500: NONESP-encap: isakmp: child_sa  ikev2_auth[R]
09:05:52.432043 IP 10.0.2.102.4500 > 10.0.2.101.4500: NONESP-encap: isakmp: child_sa  inf2[I]
09:05:52.433683 IP 10.0.2.101.4500 > 10.0.2.102.4500: NONESP-encap: isakmp: child_sa  inf2[R]

- Fail:
https://openqa.suse.de/tests/7982564#step/ovs_client/51 15 SP3
https://openqa.suse.de/tests/7977288#step/ovs_server/50 15 SP4
- Verification run:
https://openqa.suse.de/tests/7986039 15 SP4
https://openqa.suse.de/tests/7986041 15 SP3
https://openqa.suse.de/tests/7986043 15 SP2
