### PR TITLE
Fix product shortcuts for SLES4SAP 15-SP4+

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -65,8 +65,7 @@ sub get_product_shortcuts {
             : is_aarch64() ? 's'
             : 'i',
             sled => 'x',
-            sles4sap => is_ppc64le() ? (is_sle('15-SP4+') ? 'U' : 'i')
-            : (is_sle('15-SP4+') && is_x86_64() && !is_quarterly_iso()) ? 'i'
+            sles4sap => is_ppc64le() ? 'i'
             : (is_sle('15-SP2+') && is_x86_64() && !is_quarterly_iso()) ? 't'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
Fix product shortcuts for SLES4SAP 15-SP4+

- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x

Failing tests:
- ppc64le: https://openqa.suse.de/tests/7983599#step/welcome/4
- x86_64: https://openqa.suse.de/tests/7981003#step/welcome/6

Verification runs:
- ppc64le: http://openqa.suse.de/t7985451
- x86_64: http://openqa.suse.de/t7985453