### PR TITLE
script_run(): Fail on timeout by default

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -36,6 +36,18 @@ use testapi qw(send_key %cmd assert_screen check_screen check_var click_lastmatc
   wait_still_screen wait_screen_change get_required_var diag);
 
 
+=head2 new
+
+Class constructor
+=cut
+sub new {
+    my ($class) = @_;
+    my $self = $class->SUPER::new(@_);
+
+    $self->{script_run_die_on_timeout} = 1;
+    return $self;
+}
+
 =head2 handle_password_prompt
 
 Types the password in a password prompt


### PR DESCRIPTION
OpenQA API has added a new script_run() parameter to control how the function handles command timeout. Set the default timeout behavior to fail the test module.

This can obviously break things. I'll announce this PR via QE mailing list and leave it open for 3 weeks so that everybody has time to fix their test code.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/7985939 (cloned from https://openqa.suse.de/tests/7969815)