### PR TITLE
Do not die on basic bootloader checking for uefi guest

### DIFF
--- a/tests/virt_autotest/uefi_guest_verification.pm
+++ b/tests/virt_autotest/uefi_guest_verification.pm
@@ -52,7 +52,7 @@ sub check_guest_bootloader {
     record_info("Basic bootloader checking on $guest_name", "efibootmgr -v and mokutil --sb-state should return successfully");
     my $ssh_command_prefix = "ssh -vvv -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
     script_retry("$ssh_command_prefix root\@$guest_name efibootmgr -v");
-    script_retry("$ssh_command_prefix root\@$guest_name mokutil --sb-state");
+    script_retry("$ssh_command_prefix root\@$guest_name mokutil --sb-state", die => 0);
     return $self;
 }
 


### PR DESCRIPTION
* **The** secureboot support checking is done by the fucntion check_guest_secure_boot in test module tests/virt_autotest/uefi_guest_verification.pm.
* **The** check_guest_bootloader function in test module tests/virt_autotest/uefi_guest_verification.pm does not check whether uefi guest has secureboot enabled or not. It just outputs basic information about bootloader for the uefi guest, especially moktuil --sb-state command. 
* **Current** [failure](https://openqa.suse.de/tests/7977117#step/uefi_guest_verification/53) happened with Xen virtual machine is because the guest starts reporting 'The system doesn't support Secure Boot' which returns error instead of 'Secureboot disabled' if moktuil --sb-state command is fired up.
* **This** new behavior is correct according to SLES Virtualization Document ["Installing UEFI Support"](https://susedoc.github.io/doc-sle/main/single-html/SLES-virtualization/#sec-vt-installation-ovmf)
* **So** we change to use die => 0 with script_retry("$ssh_command_prefix root\@$guest_name mokutil --sb-state");

* **Verification Runs:**
  * [uefi-gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/7983953)
  * [uefi-gi-guest_sles12sp5-on-host_developing-xen](https://openqa.suse.de/tests/7983955)
  * [uefi-gi-guest_sles15sp3-on-host_developing-xen](https://openqa.suse.de/tests/7983959)
  * [uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/7988845)
  * [uefi-gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.suse.de/tests/7988846)
  * [uefi-gi-guest_sles15sp3-on-host_developing-kvm](https://openqa.suse.de/tests/7988850)
  * [uefi-gi-guest_developing-on-host_sles15sp3-xen](https://openqa.suse.de/tests/7988849)
  * [uefi-gi-guest_developing-on-host_sles12sp5-xen](https://openqa.suse.de/tests/7988847)
  * [uefi-gi-guest_sles12sp5-on-host_developing-kvm](https://openqa.suse.de/tests/7988851)
  * [uefi-gi-guest_developing-on-host_sles15sp3-kvm](https://openqa.suse.de/tests/7988881)



