### PR TITLE
Add allow vendor change for cases with packagehub and smt

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -1,6 +1,6 @@
 # SLE online migration tests
 #
-# Copyright 2016-2021 SUSE LLC
+# Copyright 2016-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: zypper, transactional-update
@@ -47,7 +47,7 @@ sub run {
     if (is_sle_micro) {
         script_run("(transactional-update migration; echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
     } else {
-        my $option = (is_leap_migration) ? " --allow-vendor-change " : " ";
+        my $option = (is_leap_migration) || (get_var("SCC_ADDONS") =~ /phub/) || (get_var("SMT_URL") =~ /smt/) ? " --allow-vendor-change " : " ";
         script_run("(zypper migration $option; echo ZYPPER-DONE) |& tee /dev/$serialdev", 0);
     }
     # migration process take long time


### PR DESCRIPTION
When performing migration with packagehub in addon list, it would ask
whether agree to change vendor from SUSE to openSUSE for some packages,
which is reasonable because the packages from packagehub are openSUSE 
packages; For smt registration type migration cases, see bsc#1120169 
Comment#4, packagehub will be added to the target modules list. So we 
add --allow-vendor-change for these cases.

- Related ticket: https://progress.opensuse.org/issues/104823
- Verification run:
hpc smt:
https://openqa.nue.suse.com/tests/7985129#step/zypper_migration/9
sles smt:
https://openqa.nue.suse.com/tests/7985135#step/zypper_migration/10
https://openqa.nue.suse.com/tests/7985136#step/zypper_migration/10
https://openqa.nue.suse.com/tests/7985137#step/zypper_migration/10
https://openqa.nue.suse.com/tests/7984934#step/zypper_migration/10
https://openqa.nue.suse.com/tests/7984935#step/zypper_migration/10
https://openqa.nue.suse.com/tests/7984936#step/zypper_migration/8
sles phub:
https://openqa.nue.suse.com/tests/7988974#step/zypper_migration/6
