### PR TITLE
slem5.2: Another bugrefs (wicked and aarch64 kernel)

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -55,7 +55,7 @@
     "bsc#1022527": {
         "description": ".*wickedd.*ni_process_reap.*blocking waitpid.*",
         "products": {
-            "sle-micro": [ "5.0", "5.1" ],
+            "sle-micro": [ "5.0", "5.1", "5.2" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
             "sle": ["15-SP2", "15-SP3", "15-SP4", "12-SP5"]
@@ -97,7 +97,7 @@
     "bsc#1178033": {
         "description": "kernel: ITS@0x8080000: Unable to locate ITS domain handle",
         "products": {
-            "sle-micro": [ "5.0", "5.1" ],
+            "sle-micro": [ "5.0", "5.1", "5.2" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
             "sle": ["15-SP2", "15-SP3", "15-SP4"]
@@ -175,7 +175,7 @@
     "bsc#1032323": {
         "description": "Initialization of hypfs failed|The hardware system does not support hypfs",
         "products": {
-            "sle-micro": [ "5.1" ]
+            "sle-micro": [ "5.1", "5.2" ]
         },
         "type": "bug"
     },
@@ -300,7 +300,7 @@
     "ssh-connection-close-by-remote": {
         "description": "error: kex_exchange_identification: Connection closed by remote host",
         "products": {
-            "sle-micro": [ "5.0", "5.1" ],
+            "sle-micro": [ "5.0", "5.1", "5.2" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
             "sle": ["15-SP2", "15-SP3"]


### PR DESCRIPTION
- Verification runs:
  * [sle-micro-5.2-DVD-B-Staging-x86_64-BuildB.15.1-sle-micro_installation+update@uefi](http://kepler.suse.cz/tests/10525#live) 
  * [sle-micro-5.2-DVD-B-Staging-x86_64-BuildB.15.1-sle-micro_installation+update@64bit](http://kepler.suse.cz/tests/10524#live)
  * [sle-micro-5.2-MicroOS-Image-aarch64](https://openqa.suse.de/tests/7991481#) 
  * [sle-micro-5.2-MicroOS-Image-aarch64](https://openqa.suse.de/tests/7991470#) 