### PR TITLE
Set correct order of modules on installation_node_dev scheduling

### DIFF
--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -35,8 +35,8 @@ schedule:
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
-  - '{{user_settings_root}}'
   - '{{systemrole_dev}}'
+  - '{{user_settings_root}}'
   - installation/resolve_dependency_issues
   - installation/select_patterns
   - installation/installation_overview


### PR DESCRIPTION
Somehow the previous fix passed but the order of the user_settings and user_settings_root was wrong.
The root is never set before the normal user.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

http://aquarius.suse.cz/tests/7762