### PR TITLE
firefox: Drop unused arg for flash test and disable screensaver

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2096,6 +2096,7 @@ sub load_common_x11 {
     elsif (check_var("REGRESSION", "firefox")) {
         loadtest "boot/boot_to_desktop";
         loadtest "x11/window_system";
+        loadtest 'x11/disable_screensaver';
         load_x11_webbrowser();
     }
     elsif (check_var('REGRESSION', 'remote')) {

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -659,7 +659,7 @@ sub firefox_check_popups {
 }
 
 sub firefox_open_url {
-    my ($self, $url, $do_not_check_loaded_url) = @_;
+    my ($self, $url) = @_;
     my $counter = 1;
     while (1) {
         # make sure firefox window is focused
@@ -677,10 +677,7 @@ sub firefox_open_url {
     }
     enter_cmd_slow "$url";
     wait_still_screen 2, 4;
-    # this is because of adobe flash, screensaver will activate sooner than the page
-    unless ($do_not_check_loaded_url) {
-        assert_screen 'firefox-url-loaded', 300;
-    }
+    send_key_until_needlematch 'firefox-url-loaded', 'f5', 3, 90;
 }
 
 sub firefox_preferences {

--- a/schedule/qam/12-SP2/qam-regression-firefox.yaml
+++ b/schedule/qam/12-SP2/qam-regression-firefox.yaml
@@ -3,6 +3,7 @@ name: qam-regression-firefox
 schedule:
 - boot/boot_to_desktop
 - x11/window_system
+- x11/disable_screensaver
 - x11/firefox/firefox_smoke
 - x11/firefox/firefox_urlsprotocols
 - x11/firefox/firefox_downloading

--- a/schedule/qam/12-SP3/qam-regression-firefox.yaml
+++ b/schedule/qam/12-SP3/qam-regression-firefox.yaml
@@ -3,6 +3,7 @@ name: qam-regression-firefox
 schedule:
 - boot/boot_to_desktop
 - x11/window_system
+- x11/disable_screensaver
 - x11/firefox/firefox_smoke
 - x11/firefox/firefox_urlsprotocols
 - x11/firefox/firefox_downloading

--- a/schedule/qam/12-SP4/qam-regression-firefox.yaml
+++ b/schedule/qam/12-SP4/qam-regression-firefox.yaml
@@ -3,6 +3,7 @@ name: qam-regression-firefox
 schedule:
 - boot/boot_to_desktop
 - x11/window_system
+- x11/disable_screensaver
 - x11/firefox/firefox_smoke
 - x11/firefox/firefox_urlsprotocols
 - x11/firefox/firefox_downloading

--- a/schedule/qam/12-SP5/qam-regression-firefox.yaml
+++ b/schedule/qam/12-SP5/qam-regression-firefox.yaml
@@ -3,6 +3,7 @@ name: qam-regression-firefox
 schedule:
 - boot/boot_to_desktop
 - x11/window_system
+- x11/disable_screensaver
 - x11/firefox/firefox_smoke
 - x11/firefox/firefox_urlsprotocols
 - x11/firefox/firefox_downloading

--- a/schedule/qam/15-SP1/qam-regression-firefox.yaml
+++ b/schedule/qam/15-SP1/qam-regression-firefox.yaml
@@ -3,6 +3,7 @@ name: qam-regression-firefox
 schedule:
 - boot/boot_to_desktop
 - x11/window_system
+- x11/disable_screensaver
 - x11/firefox/firefox_smoke
 - x11/firefox/firefox_urlsprotocols
 - x11/firefox/firefox_downloading

--- a/schedule/qam/15-SP2/qam-regression-firefox.yaml
+++ b/schedule/qam/15-SP2/qam-regression-firefox.yaml
@@ -3,6 +3,7 @@ name: qam-regression-firefox
 schedule:
 - boot/boot_to_desktop
 - x11/window_system
+- x11/disable_screensaver
 - x11/firefox/firefox_smoke
 - x11/firefox/firefox_urlsprotocols
 - x11/firefox/firefox_downloading

--- a/schedule/qam/15-SP3/qam-regression-firefox.yaml
+++ b/schedule/qam/15-SP3/qam-regression-firefox.yaml
@@ -3,6 +3,7 @@ name: qam-regression-firefox
 schedule:
 - boot/boot_to_desktop
 - x11/window_system
+- x11/disable_screensaver
 - x11/firefox/firefox_smoke
 - x11/firefox/firefox_urlsprotocols
 - x11/firefox/firefox_downloading

--- a/schedule/qam/15/qam-regression-firefox.yaml
+++ b/schedule/qam/15/qam-regression-firefox.yaml
@@ -3,6 +3,7 @@ name: qam-regression-firefox
 schedule:
 - boot/boot_to_desktop
 - x11/window_system
+- x11/disable_screensaver
 - x11/firefox/firefox_smoke
 - x11/firefox/firefox_urlsprotocols
 - x11/firefox/firefox_downloading


### PR DESCRIPTION
First I tried to add workaround for stuck download list screen, but looks like disabled screensaver does decrease fail rate. :crossed_fingers: 

- Fail:
https://openqa.suse.de/tests/7979019#step/firefox_downloading/82
https://openqa.suse.de/tests/7986627#step/firefox_pdf/13
https://openqa.suse.de/tests/7986604#step/firefox_downloading/80
- Verification run:
https://openqa.suse.de/tests/7993911 SLED 15 SP4
https://openqa.suse.de/tests/7993993 SLED 15 SP3
https://openqa.suse.de/tests/7993994 SLES 15 SP3
