### PR TITLE
Fix XFSTESTS_BLACKLIST for publiccloud

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -426,6 +426,8 @@ sub run {
     heartbeat_start;
     my $status_log_content = "";
     foreach my $test (@tests) {
+        # trim testname
+        $test =~ s/^\s+|\s+$//g;
         # Skip tests inside blacklist
         if (exists($BLACKLIST{$test})) {
             next;


### PR DESCRIPTION
Fix the XFSTESTS_BLACKLIST setting for publiccloud, where this setting
was not processed correctly by adding a trim operation on the test name.

- Related ticket: https://progress.opensuse.org/issues/104920
- Verification run: [SLES 15-SP3](http://duck-norris.qam.suse.de/tests/8008) | [PC 15-SP3 GCE](http://duck-norris.qam.suse.de/tests/8009) | [PC 15-SP2 GCE](http://duck-norris.qam.suse.de/tests/8014) | [PC 15-SP1 GCE](http://duck-norris.qam.suse.de/tests/8007) (fails intentionally for `generic/093`) | [PC 12-SP5 GCE](http://duck-norris.qam.suse.de/tests/8013)

Note: PC 15-SP1 GCE fails intentionally to check, if we are not excluding (failing) test runs by accident.