### PR TITLE
Handle network difference between s390x and x86_64, aarch64

### DIFF
--- a/schedule/security/cc_netfilter_netfilebt.yaml
+++ b/schedule/security/cc_netfilter_netfilebt.yaml
@@ -27,26 +27,26 @@ conditional_schedule:
 test_data:
     server:
         first_interface:
-            netcard: eth0.0
+            netcard: 0
             mac_addr: 00:11:11:11:11:00
             ipv4: 192.168.0.1/24
             ipv6: fd00::1
             route: fd00::2
         second_interface:
-            netcard: eth0.1
+            netcard: 1
             mac_addr: 00:11:11:11:11:01
             ipv4: 192.168.1.1/24
             ipv6: fd00:1::1
             route: fd00:1::2
     client:
         first_interface:
-            netcard: eth0.0
+            netcard: 0
             mac_addr: 00:11:11:11:11:10
             ipv4: 192.168.0.2/24
             ipv6: fd00::2
             route: fd00::1
         second_interface:
-            netcard: eth0.1
+            netcard: 1
             mac_addr: 00:11:11:11:11:11
             ipv4: 192.168.1.2/24
             ipv6: fd00:1::2


### PR DESCRIPTION
CC test suites 'netfilter' and 'netfilebt' need multi-machine test
environment. For s390x, we already setup a new netdev 'eth1' for this.
So we need to distinguish that.

Relate: https://progress.opensuse.org/issues/101914
Verify run:
https://openqa.suse.de/tests/7999782#  (s390x)
https://openqa.suse.de/tests/7999780#  (x86_64)
https://openqa.suse.de/tests/7999840# (aarch64)