### PR TITLE
Enlarge timeout of java test

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -67,7 +67,7 @@ sub run {
         assert_script_run './test_java.sh --transactional-server';
     }
     else {
-        assert_script_run './test_java.sh';
+        assert_script_run("./test_java.sh", timeout => 180);
     }
     # if !QAM test suite then cleanup test suite environment
     unless (is_updates_tests || is_opensuse || is_migration_tests) {


### PR DESCRIPTION
Enlarge timeout of java test

- Related ticket: https://progress.opensuse.org/issues/104742
- Needles: na
- Verification run: 
http://openqa.suse.de/tests/7999710#
https://openqa.suse.de/tests/7999710#