### PR TITLE
Remove 254 from lsblk excluding list in partitioning_smalldisk_storageng

### DIFF
--- a/tests/installation/partitioning_smalldisk_storageng.pm
+++ b/tests/installation/partitioning_smalldisk_storageng.pm
@@ -29,7 +29,7 @@ sub run {
         select_console 'root-console';
     }
     my $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME -d -e 7,11,254 -b | sort -n | awk '(NR == 1) {print $2}')]"/;
-    $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME,TYPE -e 7,11,254 -b | grep 'mpath' | sort -n | awk '(NR == 1) {print $2}')]"/
+    $lsblkcmd = q/echo "[$(lsblk -n -l -o SIZE,NAME,TYPE -e 7,11 -b | grep 'mpath' | sort -n | awk '(NR == 1) {print $2}')]"/
       if (get_var('MULTIPATH') and (get_var('MULTIPATH_CONFIRM') !~ /\bNO\b/i));
     my $output = script_output $lsblkcmd;
     $output =~ /\[([\w\.]+)\]/;


### PR DESCRIPTION
After revisiting the result in 15SP3, removing major node 254 from
lsblk excluding list in partitioning_smalldisk_storageng will help to
identify multi path device in more products.

refer to the discussion in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13991#issuecomment-1014447950 

- Verification run: http://openqa.qa2.suse.asia/tests/43599
