### PR TITLE
SLE Micro: make scc registration optional in autoyast profile

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro.xml.ep
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  % if ($check_var->('SCC_REGISTER', 'installation')) {
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
     <reg_code>{{SCC_REGCODE}}</reg_code>
     <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
+  % }
   <bootloader>
     <global>
       <timeout config:type="integer">-1</timeout>


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/105058 https://progress.opensuse.org/issues/104394
- Verification run:  https://openqa.suse.de/tests/8001315

