### PR TITLE
pynfs: Add SATT15 and WRT18 as known issues + all test passed

### DIFF
--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -50,11 +50,15 @@ sub display_results {
 
         my $targs = OpenQA::Test::RunArgs->new();
         $targs->{data} = $test;
-        autotest::loadtest("tests/nfs/pynfs_failed.pm", name => $test->{code}, run_args => $targs);
+        autotest::loadtest("tests/nfs/pynfs_result.pm", name => $test->{code}, run_args => $targs);
         $fail = 1;
     }
 
-    record_info('ALL PASSED') if (!$fail);
+    if (!$fail) {
+        my $targs = OpenQA::Test::RunArgs->new();
+        $targs->{all_passed} = 'ALL TESTS PASSED';
+        autotest::loadtest("tests/nfs/pynfs_result.pm", name => $targs->{all_passed}, run_args => $targs);
+    }
 }
 
 sub upload_cthon04_log {

--- a/tests/nfs/pynfs_result.pm
+++ b/tests/nfs/pynfs_result.pm
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 use base 'opensusebasetest';
 use testapi;
+use version_utils qw(is_sle is_leap);
 
 sub run {
     my ($self, $args) = @_;
@@ -19,20 +20,25 @@ sub run {
     }
 
     my $data = $args->{data};
-    my $msg;
+    my $test = $data->{code};
+    my $message = $data->{failure}->{message};
+    my $is_v4 = get_required_var('PYNFS') eq 'nfs4.0';
+    my $log = "$message\n\n$data->{failure}->{err}";
 
     record_info('INFO', "name: $data->{name}\nclassname: $data->{classname}\ntime: $data->{time}\n");
 
     die 'failure does not exist' unless (exists($data->{failure}));
 
-    $msg = "$data->{failure}->{message}\n\n$data->{failure}->{err}";
 
-    if ($data->{code} eq 'LOCK24' && $data->{failure}->{message} eq
+    if ($test eq 'LOCK24' && $message eq
         'OP_LOCK should return NFS4_OK, instead got NFS4ERR_BAD_SEQID') {
-        $self->record_soft_failure_result("LOCK24 failure is known, verriding to softfail: bsc#1192211\n\n" . $msg);
+        $self->record_soft_failure_result("LOCK24 failure is known, verriding to softfail: bsc#1192211\n\n" . $log);
+    } elsif (($test eq 'SATT15' || $test eq 'WRT18') && $is_v4 && (is_sle('<=15-sp3') or is_leap('<=15.3')) &&
+        $message eq 'consecutive SETATTR(mode)\'s don\'t all change change attribute') {
+        $self->record_soft_failure_result("$test failure is known, verriding to softfail: bsc#1192210\n\n" . $log);
     } else {
         $self->{result} = 'fail';
-        record_info('ERROR', $msg);
+        record_info('ERROR', $log);
     }
 }
 

--- a/tests/nfs/pynfs_result.pm
+++ b/tests/nfs/pynfs_result.pm
@@ -13,6 +13,12 @@ use Data::Dumper;
 
 sub run {
     my ($self, $args) = @_;
+
+    if (defined($args->{all_passed})) {
+        record_info($args->{all_passed});
+        return;
+    }
+
     my $data = $args->{data};
     my $msg;
 

--- a/tests/nfs/pynfs_result.pm
+++ b/tests/nfs/pynfs_result.pm
@@ -9,7 +9,6 @@ use strict;
 use warnings;
 use base 'opensusebasetest';
 use testapi;
-use Data::Dumper;
 
 sub run {
     my ($self, $args) = @_;


### PR DESCRIPTION
2 pynfs improvements
- Mark SATT15 and WRT18 as known failures on <= 15.3
- Explicitly notify that all tests passed

Verification run:

- SATT15 and WRT18
http://quasar.suse.cz/tests/8331#step/WRT18/2

- All test passed:
http://quasar.suse.cz/tests/8334