### PR TITLE
Don't disable updates on installation via QAM_MINIMAL

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -156,10 +156,6 @@ if (is_sle('15+')) {
 diag('default desktop: ' . default_desktop);
 set_var('DESKTOP', get_var('DESKTOP', default_desktop));
 
-# don't want updates, as we don't test it or rely on it in any tests, if is executed during installation
-# For released products we want install updates during installation, only in minimal workflow disable
-set_var('DISABLE_SLE_UPDATES', get_var('DISABLE_SLE_UPDATES', get_var('QAM_MINIMAL')));
-
 # set remote connection variable for s390x, svirt and ipmi
 set_var('REMOTE_CONNECTION', 'vnc') if get_var('BACKEND', '') =~ /s390x|svirt|ipmi/;
 

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -33,6 +33,8 @@ sub run {
     if (check_var('MACHINE', 'uefi')) {
         zypper_call('up grub2 grub2-x86_64-efi kernel-default');
     }
+    # do zypper update bsc#1165180
+    zypper_call('up zypper');
 
     capture_state('before');
 

--- a/variables.md
+++ b/variables.md
@@ -42,7 +42,7 @@ DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dep
 DEV_IMAGE | boolean | false | This setting is used to set veriables properly when SDK or Development-Tools are required.
 DISABLE_ONLINE_REPOS | boolean | false | Enables `installation/disable_online_repos` test module, relevant for openSUSE only. Test module explicitly disables online repos not to be used during installation.
 DISABLE_SECUREBOOT | boolean | false | Disable secureboot in firmware of the SUT or in hypervisor's guest VM settings
-DISABLE_SLE_UPDATES | boolean | false | Disables online updates for the installation. Is true if `QAM_MINIMAL` is true for SLE.
+DISABLE_SLE_UPDATES | boolean | false | Disables online updates for the installation.
 DISTRI | string | | Defines distribution. Possible values: `sle`, `opensuse`, `microos`.
 DOCRUN | boolean | false |
 DUALBOOT | boolean | false | Enables dual boot configuration during the installation.
@@ -189,6 +189,7 @@ PUBLIC_CLOUD_USER | string | "" | The public cloud instance system user.
 PKGMGR_ACTION_AT_EXIT | string | "" | Set the default behavior of the package manager when package installation has finished. Possible actions are: close, restart, summary. If PKGMGR_ACTION_AT_EXIT is not set in openQA, test module will read the default value from /etc/sysconfig/yast2.
 PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
 QA_TESTSUITE | string | | Comma or semicolon separated a list of the automation cases' name, and these cases will be installed and triggered if you call "start_testrun" function from qa_run.pm
+QAM_MINIMAL | string | "full" or "small" | Full is adding patterns x11, gnome-basic, base, apparmor in minimal/install_patterns test. Small is just base.
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
 REBOOT_TIMEOUT | integer | 0 | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
 REGISTRY | string | docker.io | Registry to pull third-party container images from


### PR DESCRIPTION
I don't think QAM_MINIMAL should silently disable updates.
QAM_MINIMAL is affecting patterns.

- Related ticket: https://progress.opensuse.org/issues/104799
- Verification run:
https://dzedro.suse.cz/tests/20567 minimal with DISABLE_SLE_UPDATES=1
https://dzedro.suse.cz/tests/20566 full with DISABLE_SLE_UPDATES=1