### PR TITLE
lib/containers/{docker,podman}: Don't interpret warnings as IP address

### DIFF
--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -41,7 +41,7 @@ sub check_containers_connectivity {
     my $container_ip = container_ip($container_name, 'docker');
 
     # Connectivity to host check
-    my $default_route = script_output "docker run " . registry_url('alpine') . " ip route show default | awk \'/default/ {print \$3}\'";
+    my $default_route = script_output "docker run " . registry_url('alpine') . " ip route show default 2>/dev/null | awk \'/default/ {print \$3}\'";
     assert_script_run "docker run --rm " . registry_url('alpine') . " ping -c3 " . $default_route;
 
     # Cross-container connectivity check

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -41,7 +41,7 @@ sub check_containers_connectivity {
     my $container_ip = container_ip $container_name, 'podman';
 
     # Connectivity to host check
-    my $default_route = script_output "podman run " . registry_url('alpine') . " ip route show default | awk \'/default/ {print \$3}\'";
+    my $default_route = script_output "podman run " . registry_url('alpine') . " ip route show default 2>/dev/null | awk \'/default/ {print \$3}\'";
     assert_script_run "podman run --rm " . registry_url('alpine') . " ping -c3 " . $default_route;
 
     # Cross-container connectivity check


### PR DESCRIPTION
podman can print warnings like these to stderr:
WARN[0001] Path "/etc/SUSEConnect" from "/etc/containers/mounts.conf" doesn't exist, skipping
WARN[0001] Path "/etc/zypp/credentials.d/SCCcredentials" from "/etc/containers/mounts.conf" doesn't exist, skipping

Those bypass the pipe and get straight into the serial output captured by
openQA, ending up in the IP address: https://openqa.opensuse.org/tests/2145758

- Verification run: https://openqa.opensuse.org/tests/2147521#live
