### PR TITLE
Add mariadb multiple instance configuration in ppc64le

### DIFF
--- a/tests/console/mariadb_srv.pm
+++ b/tests/console/mariadb_srv.pm
@@ -42,7 +42,7 @@ sub run {
 
     # Test multiple instance configuration
     # It is not supported in sle12sp2 and sle12sp3
-    if (!is_sle('<=12-SP3') && !is_ppc64le && !is_ppc64) {
+    if (!is_sle('<=12-SP3')) {
         assert_script_run "touch /etc/mynode{1,2}.cnf";
         assert_script_run "curl " . data_url('console/mariadb/mynode1.cnf') . " -o /etc/mynode1.cnf";
         assert_script_run "curl " . data_url('console/mariadb/mynode2.cnf') . " -o /etc/mynode2.cnf";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/99558
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: [TW ppc64le](https://openqa.opensuse.org/tests/2147514#step/mariadb_srv/48) | [TW ppc64](https://openqa.opensuse.org/tests/2148026#step/mariadb_srv/48)
