### PR TITLE
restart_firefox: Assert firefox screen before pressing kb shortcuts

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -614,6 +614,7 @@ sub restart_firefox {
     enter_cmd "$cmd";
     enter_cmd "firefox $url >>firefox.log 2>&1 &";
     $self->firefox_check_default;
+    assert_screen 'firefox-url-loaded';
 }
 
 sub firefox_check_default {

--- a/tests/x11/firefox/firefox_downloading.pm
+++ b/tests/x11/firefox/firefox_downloading.pm
@@ -72,6 +72,7 @@ sub dl_pause {
 # firefox 60.2 does not have option or shortcut to cancel only button
 sub dl_cancel {
     assert_and_click('firefox-downloading-cancel-button');
+    wait_still_screen(2, 4);
 }
 
 sub dl_resume {


### PR DESCRIPTION
- Fail:
https://openqa.suse.de/tests/8004846#step/firefox_private/22
https://openqa.suse.de/tests/8002897#step/firefox_downloading/70
- Verification run:
https://openqa.suse.de/tests/8005998
https://openqa.suse.de/tests/8006148
