### PR TITLE
Sanitize variable obtained from SUT with script_output

### DIFF
--- a/tests/sles4sap/sys_param_check.pm
+++ b/tests/sles4sap/sys_param_check.pm
@@ -79,7 +79,9 @@ sub run {
     # Execute each test and upload its results
     assert_script_run "cd $test_repo";
     foreach my $robot_test (split /\n/, script_output "ls $test_repo") {
-        record_info("$robot_test", "Starting $robot_test");
+        # Sanitize $robot_test
+        $robot_test =~ s/[\n|\r]//g;
+        record_info("$robot_test", "Starting [$robot_test]");
         script_run "robot --log $robot_test.html --xunit $robot_test.xml $robot_test";
         # Soft fail section - How to add a new one
         # add_softfail("TEST_NAME", "OS_VERSION", "BUG_NUMBER", "PARAMETERS") if ("TEST_NAME" eq "TEST_NAME");


### PR DESCRIPTION
The variable `$robot_test` in the `sles4sap/sys_param_check` test module is assigned with the output of a command in SUT executed with `script_output()`. Even though this works without major issues when **BACKEND=qemu**, it is possible that in different backends strings in the variable can come with unexpected characters.

This PR sanitizes the string, by removing CR & LF.

- Related ticket: N/A
- Needles: N/A
- Verification run: [12-SP5](http://mango.qa.suse.de/tests/4793), [15-SP3](http://mango.qa.suse.de/tests/4795) & [15-SP4](http://mango.qa.suse.de/tests/4794) (failure in 15-SP4 is unrelated to this PR)
