### PR TITLE
Add username to aws_client

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -22,6 +22,7 @@ has vault => undef;
 has aws_account_id => undef;
 has service => undef;
 has container_registry => sub { get_var("PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY", 'suse-qec-testing') };
+has username => sub { get_var('PUBLIC_CLOUD_USER', 'ec2-user') };
 
 sub vault_create_credentials {
     my ($self) = @_;

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -14,7 +14,6 @@ use testapi;
 use publiccloud::utils "is_byos";
 use publiccloud::aws_client;
 
-has username => sub { get_var('PUBLIC_CLOUD_USER', 'ec2-user') };
 has ssh_key => undef;
 has ssh_key_file => undef;
 
@@ -141,7 +140,7 @@ sub upload_img {
           . "--wait-count 3 "
           . "--ec2-ami '" . $helper_ami_id . "' "
           . "--type '" . $instance_type . "' "
-          . "--user '" . $self->username . "' "
+          . "--user '" . $self->provider_client->username . "' "
           . ($sec_group ? "--security-group-ids '" . $sec_group . "' " : '')
           . ($vpc_subnet ? "--vpc-subnet-id '" . $vpc_subnet . "' " : '')
           . "'$file'",


### PR DESCRIPTION
Now username is defined in EC2 but must be in aws_client

- Related ticket: https://progress.opensuse.org/issues/103386
- Verification run: 
