### PR TITLE
Set current version for the installed dev_tools in ibtest

### DIFF
--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -3,7 +3,7 @@ description:    >
     The master node for the infiniband testsuite (hpc-testing)
 vars:
     DESKTOP: textmode
-    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/15.4/devel:tools.repo
     GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1


### PR DESCRIPTION
Currently test is running against 15.4 but it uses 15.2 repo.
I might have missed something and i need to impove this later on

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


