### PR TITLE
Press "Ok" to reboot system after installation with libyui-rest-api

### DIFF
--- a/lib/Installation/PerformingInstallation/PerformingInstallationController.pm
+++ b/lib/Installation/PerformingInstallation/PerformingInstallationController.pm
@@ -59,6 +59,11 @@ sub wait_installation_popup {
         message => 'System reboot popup did not appear');
 }
 
+sub confirm_reboot {
+    my ($self) = @_;
+    $self->get_system_reboot_popup()->press_ok();
+}
+
 sub stop_timeout_system_reboot_now {
     my ($self) = @_;
     $self->get_system_reboot_with_timeout_popup->press_stop();

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@pvm.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@pvm.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
@@ -29,7 +29,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -25,6 +25,6 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -38,6 +38,6 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/btrfs/btrfs+warnings@pvm.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@pvm.yaml
@@ -39,6 +39,6 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
@@ -41,6 +41,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@ipmi.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng@s390x.yaml
@@ -31,7 +31,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng_s390x_zvm.yaml
@@ -34,7 +34,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - boot/reconnect_mgmt_console
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage_spvm.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/clone_system/clone_system_pvm.yaml
+++ b/schedule/yast/clone_system/clone_system_pvm.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
 test_data:

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -34,7 +34,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
@@ -38,7 +38,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
 test_data:

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_user_login_textmode

--- a/schedule/yast/encryption/activate_encrypted_volume.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
 test_data:

--- a/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
 test_data:

--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -39,7 +39,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -34,7 +34,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -36,7 +36,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm_sle_15.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
@@ -31,7 +31,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/boot_encrypt
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/start_install
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
@@ -33,7 +33,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/boot_encrypt
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x-disk-activation.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_parted

--- a/schedule/yast/ext4/ext4@yast-s390x.yaml
+++ b/schedule/yast/ext4/ext4@yast-s390x.yaml
@@ -33,7 +33,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-hvm.yaml
@@ -30,7 +30,9 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/ext4/ext4@yast-xen-pv.yaml
+++ b/schedule/yast/ext4/ext4@yast-xen-pv.yaml
@@ -32,7 +32,9 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid
   - console/validate_blockdevices

--- a/schedule/yast/ext4/ext4@yast.yaml
+++ b/schedule/yast/ext4/ext4@yast.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/ext4/ext4@yast_spvm.yaml
+++ b/schedule/yast/ext4/ext4@yast_spvm.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_fstab

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_mirror_repos

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
@@ -30,7 +30,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/lvm_multipath.yaml
+++ b/schedule/yast/lvm_multipath.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_multipath

--- a/schedule/yast/lvm_multipath_encrypted.yaml
+++ b/schedule/yast/lvm_multipath_encrypted.yaml
@@ -34,7 +34,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -29,7 +29,9 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -29,7 +29,9 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/first_boot
   - console/validate_lvm_raid1
 test_data:

--- a/schedule/yast/minimal+base/minimal+base@pvm.yaml
+++ b/schedule/yast/minimal+base/minimal+base@pvm.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/minimal+base/minimal+base@svirt-xen-hvm.yaml
+++ b/schedule/yast/minimal+base/minimal+base@svirt-xen-hvm.yaml
@@ -30,7 +30,9 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -36,7 +36,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -32,7 +32,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
@@ -33,7 +33,9 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/first_boot
   - console/system_prepare
   - console/prepare_test_data

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
@@ -30,7 +30,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -26,7 +26,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - '{{stop_timeout_system_reboot_now}}'
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_modify_existing_partition

--- a/schedule/yast/msdos/msdos.yaml
+++ b/schedule/yast/msdos/msdos.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - '{{logs_from_installation_system}}'
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_parted

--- a/schedule/yast/msdos/msdos@pvm.yaml
+++ b/schedule/yast/msdos/msdos@pvm.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_parted

--- a/schedule/yast/msdos/msdos@s390x.yaml
+++ b/schedule/yast/msdos/msdos@s390x.yaml
@@ -27,7 +27,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_parted

--- a/schedule/yast/msdos/msdos@svirt-hyperv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-hyperv.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_parted

--- a/schedule/yast/msdos/msdos@svirt-xen-hvm.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-hvm.yaml
@@ -25,7 +25,9 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_parted

--- a/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
@@ -25,7 +25,9 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/first_boot
   - console/validate_partition_table_via_parted
   - console/validate_blockdevices

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/nvme.yaml
+++ b/schedule/yast/nvme.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/opensuse/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/opensuse/btrfs/btrfs+warnings.yaml
@@ -36,7 +36,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   # On Tumbleweed process Welcome pop-up screen

--- a/schedule/yast/opensuse/btrfs/btrfs.yaml
+++ b/schedule/yast/opensuse/btrfs/btrfs.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_no_cow_attribute

--- a/schedule/yast/opensuse/btrfs/btrfs_textmode.yaml
+++ b/schedule/yast/opensuse/btrfs/btrfs_textmode.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_no_cow_attribute

--- a/schedule/yast/opensuse/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/opensuse/encryption/crypt_no_lvm.yaml
@@ -38,7 +38,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/opensuse/encryption/cryptlvm.yaml
+++ b/schedule/yast/opensuse/encryption/cryptlvm.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/opensuse/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/opensuse/encryption/lvm_encrypt_separate_boot.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/opensuse/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/opensuse/encryption/lvm_full_encrypt.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/boot_encrypt
   - installation/first_boot

--- a/schedule/yast/opensuse/ext3/ext3_textmode.yaml
+++ b/schedule/yast/opensuse/ext3/ext3_textmode.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/opensuse/ext4/ext4.yaml
+++ b/schedule/yast/opensuse/ext4/ext4.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/opensuse/ext4/ext4_textmode.yaml
+++ b/schedule/yast/opensuse/ext4/ext4_textmode.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/opensuse/gpt.yaml
+++ b/schedule/yast/opensuse/gpt.yaml
@@ -28,7 +28,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/opensuse/lvm/lvm.yaml
+++ b/schedule/yast/opensuse/lvm/lvm.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_lvm

--- a/schedule/yast/opensuse/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/opensuse/lvm/lvm_thin_provisioning.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   # On Tumbleweed process Welcome pop-up screen

--- a/schedule/yast/opensuse/lvm_raid1/lvm+raid1.yaml
+++ b/schedule/yast/opensuse/lvm_raid1/lvm+raid1.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_lvm_raid1

--- a/schedule/yast/opensuse/modify_existing_partition.yaml
+++ b/schedule/yast/opensuse/modify_existing_partition.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_modify_existing_partition

--- a/schedule/yast/opensuse/nvme.yaml
+++ b/schedule/yast/opensuse/nvme.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - installation/opensuse_welcome

--- a/schedule/yast/opensuse/raid/raid0_gpt.yaml
+++ b/schedule/yast/opensuse/raid/raid0_gpt.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/opensuse/raid/raid10_gpt.yaml
+++ b/schedule/yast/opensuse/raid/raid10_gpt.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/opensuse/raid/raid1_gpt.yaml
+++ b/schedule/yast/opensuse/raid/raid1_gpt.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/opensuse/raid/raid5_gpt.yaml
+++ b/schedule/yast/opensuse/raid/raid5_gpt.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/opensuse/separate_usr_partition.yaml
+++ b/schedule/yast/opensuse/separate_usr_partition.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/opensuse/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/opensuse/transactional_server/create_hdd_transactional_server.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/opensuse/transactional_server/transactional_server.yaml
+++ b/schedule/yast/opensuse/transactional_server/transactional_server.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/opensuse/xfs/xfs.yaml
+++ b/schedule/yast/opensuse/xfs/xfs.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/opensuse/xfs/xfs_textmode.yaml
+++ b/schedule/yast/opensuse/xfs/xfs_textmode.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/opensuse/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/opensuse/yast_no_self_update/yast_no_self_update.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - installation/opensuse_welcome

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
   - console/upload_asset
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_md_raid

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_md_raid

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_md_raid

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_md_raid

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_md_raid

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/exit_startshell
   - installation/grub_test
   - installation/first_boot

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_first_disk_selection

--- a/schedule/yast/select_disk/select_disk@pvm.yaml
+++ b/schedule/yast/select_disk/select_disk@pvm.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_first_disk_selection

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
@@ -39,7 +39,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -38,7 +38,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -36,7 +36,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/integration_services

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
@@ -35,7 +35,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
@@ -31,7 +31,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -27,7 +27,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/hostname

--- a/schedule/yast/skip_registration/skip_registration_pvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration_pvm.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
+++ b/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - installation/addon_products_via_SCC_yast2_ncurses

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/textmode/textmode@pvm.yaml
+++ b/schedule/yast/textmode/textmode@pvm.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/textmode/textmode@s390x_svirt.yaml
+++ b/schedule/yast/textmode/textmode@s390x_svirt.yaml
@@ -26,7 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/textmode/textmode@s390x_zVM.yaml
+++ b/schedule/yast/textmode/textmode@s390x_zVM.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/textmode/textmode@svirt-xen.yaml
+++ b/schedule/yast/textmode/textmode@svirt-xen.yaml
@@ -26,7 +26,9 @@ schedule:
   - installation/performing_installation/perform_installation
   - '{{stop_reboot_timeout}}'
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/first_boot
   - console/system_prepare
   - console/prepare_test_data

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -32,7 +32,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -28,7 +28,7 @@ schedule:
     - installation/confirm_installation
     - installation/performing_installation/perform_installation
     - installation/logs_from_installation_system
-    - installation/reboot_after_installation
+    - installation/performing_installation/confirm_reboot
     - installation/handle_reboot
     - installation/first_boot
     - console/hostname

--- a/schedule/yast/transactional_server/create_hdd_transactional_server@pvm.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server@pvm.yaml
@@ -30,7 +30,7 @@ schedule:
     - installation/confirm_installation
     - installation/performing_installation/perform_installation
     - installation/logs_from_installation_system
-    - installation/reboot_after_installation
+    - installation/performing_installation/confirm_reboot
     - installation/handle_reboot
     - installation/first_boot
     - console/hostname

--- a/schedule/yast/transactional_server/create_hdd_transactional_server@s390x.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server@s390x.yaml
@@ -30,7 +30,8 @@ schedule:
     - installation/performing_installation/perform_installation
     - installation/performing_installation/stop_timeout_system_reboot_now
     - installation/logs_from_installation_system
-    - installation/reboot_after_installation
+    - installation/performing_installation/confirm_reboot
+    - installation/performing_installation/reconnect_after_reboot
     - installation/handle_reboot
     - installation/first_boot
     - console/hostname

--- a/schedule/yast/usb_install.yaml
+++ b/schedule/yast/usb_install.yaml
@@ -25,7 +25,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/grub_test
   - installation/first_boot
   - console/system_prepare

--- a/schedule/yast/xfs/xfs.yaml
+++ b/schedule/yast/xfs/xfs.yaml
@@ -31,7 +31,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - '{{validate_partition_table}}'

--- a/schedule/yast/xfs/xfs@s390x_svirt.yaml
+++ b/schedule/yast/xfs/xfs@s390x_svirt.yaml
@@ -33,7 +33,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/xfs/xfs@s390x_zVM.yaml
+++ b/schedule/yast/xfs/xfs@s390x_zVM.yaml
@@ -36,7 +36,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_parted

--- a/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
@@ -33,7 +33,9 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/grub_test
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
@@ -33,7 +33,9 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid
   - console/validate_blockdevices

--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -33,7 +33,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_partition_table_via_blkid

--- a/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
@@ -29,6 +29,6 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/yast_no_self_update/yast_no_self_update@s390x.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update@s390x.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
@@ -29,6 +29,6 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -29,6 +29,6 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/yast_self_update/yast_self_update@s390x.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update@s390x.yaml
@@ -32,6 +32,7 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
@@ -29,6 +29,6 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -35,7 +35,8 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_zfcp

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -70,6 +70,7 @@ sub run {
     # We don't change network setup here, so should work
     # We don't parse logs unless it's detect_yast2_failures scenario
     $self->save_upload_y2logs(no_ntwrk_recovery => 1, skip_logs_investigation => !get_var('ASSERT_Y2LOGS'));
+    select_console 'installation' unless get_var('REMOTE_CONTROLLER');
 }
 
 sub test_flags {

--- a/tests/installation/performing_installation/confirm_reboot.pm
+++ b/tests/installation/performing_installation/confirm_reboot.pm
@@ -1,0 +1,18 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Confirm system reboot by pressing "OK" button
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    $testapi::distri->get_performing_installation()->confirm_reboot();
+}
+
+1;

--- a/tests/installation/performing_installation/reconnect_after_reboot.pm
+++ b/tests/installation/performing_installation/reconnect_after_reboot.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: VNC connection to SUT (the 'sut' console) is terminated via svirt backend on XEN and s390x
+# and it is required to re-connect *after* the restart, otherwise the job end up with stalled
+# VNC connection.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use power_action_utils qw(prepare_system_shutdown assert_shutdown_and_restore_system);
+
+sub run {
+    prepare_system_shutdown;
+    assert_shutdown_and_restore_system('reboot', 180);
+}
+
+1;

--- a/tests/installation/performing_installation/update_virsh_config_to_boot_from_hd.pm
+++ b/tests/installation/performing_installation/update_virsh_config_to_boot_from_hd.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Update virsh config to boot from HD. Used on svirt.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my $svirt = console('svirt');
+    $svirt->change_domain_element(os => boot => {dev => 'hd'});
+}
+
+1;


### PR DESCRIPTION
The PR adds test module to press "Ok" after system installation.
Also the commit adds test modules that are needed to process reboot
after the "Ok" button is pressed on the systems where it is needed (e.g.
xen, svirt-s390x).

Also it updates yaml schedules accordingly.

- Related ticket: https://progress.opensuse.org/issues/98961
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=81.1_oorlov&groupid=96
