### PR TITLE
Fixing perl quotes for correct variable interpolation

### DIFF
--- a/tests/console/zypper_extend.pm
+++ b/tests/console/zypper_extend.pm
@@ -81,7 +81,7 @@ sub run {
 
     #Install specific version of a package
     my $version = script_output q[zypper se -s star |grep " star " | awk 'END {print $6}'];
-    zypper_call 'in -f star-$version';
+    zypper_call "in -f star-$version";
 
     #Install and remove package combination
     zypper_call "in cmake -star";


### PR DESCRIPTION
Signed-off-by: Avinesh Kumar <akumar@suse.de>

- Related ticket: https://progress.opensuse.org/issues/103593
- Verification run: http://d462.qam.suse.de/tests/123
