### PR TITLE
Replace publiccloud::utils::is_publiccloud() by version_utils::is_public_cloud()

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -8,7 +8,8 @@ use strict;
 use warnings;
 use testapi;
 use known_bugs;
-use publiccloud::utils qw(select_host_console is_publiccloud);
+use version_utils 'is_public_cloud';
+use publiccloud::utils 'select_host_console';
 
 =head1 consoletest
 
@@ -45,7 +46,7 @@ sub post_fail_hook {
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
     $self->export_logs_desktop;
 
-    if (is_publiccloud()) {
+    if (is_public_cloud()) {
         select_host_console(force => 1);
 
         # Destroy the public cloud instance in case of fatal test failure

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -15,11 +15,11 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils;
+use version_utils qw(is_sle is_public_cloud);
 use publiccloud::ssh_interactive;
 use registration;
 
-our @EXPORT = qw(select_host_console is_publiccloud is_byos is_ondemand is_ec2 is_azure is_gce registercloudguest register_addon);
+our @EXPORT = qw(select_host_console is_byos is_ondemand is_ec2 is_azure is_gce registercloudguest register_addon);
 
 # Select console on the test host, if force is set, the interactive session will
 # be destroyed. If called in TUNNELED environment, this function die.
@@ -95,35 +95,31 @@ sub registercloudguest {
     $instance->retry_ssh_command(cmd => "sudo registercloudguest -r $regcode", timeout => 420, retry => 3);
 }
 
-sub is_publiccloud() {
-    return (get_var('PUBLIC_CLOUD') == 1);
-}
-
 # Check if we are a BYOS test run
 sub is_byos() {
-    return is_publiccloud && get_var('FLAVOR') =~ 'BYOS';
+    return is_public_cloud && get_var('FLAVOR') =~ 'BYOS';
 }
 
 # Check if we are a OnDemand test run
 sub is_ondemand() {
     # By convention OnDemand images are not marked explicitly.
     # Check all the other flavors, and if they don't match, it must be on_demand.
-    return is_publiccloud && (!is_byos());    # When introducing new flavors, add checks here accordingly.
+    return is_public_cloud && (!is_byos());    # When introducing new flavors, add checks here accordingly.
 }
 
 # Check if we are on an AWS test run
 sub is_ec2() {
-    return is_publiccloud && check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    return is_public_cloud && check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 }
 
 # Check if we are on an Azure test run
 sub is_azure() {
-    return is_publiccloud && check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    return is_public_cloud && check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
 }
 
 # Check if we are on an GCP test run
 sub is_gce() {
-    return is_publiccloud && check_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
+    return is_public_cloud && check_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
 }
 
 1;

--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -19,8 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
-use version_utils 'is_sle';
-use publiccloud::utils qw(is_publiccloud);
+use version_utils qw(is_sle is_public_cloud);
 
 sub sudo_with_pw {
     my ($command, %args) = @_;
@@ -58,7 +57,7 @@ sub run {
     # on publiccloud the root password is not yet set
     # note: due to security reasons, the root password must be reset afterwards
     my $password = $testapi::password;
-    assert_script_run("echo -e '$password\n$password' | passwd root") if is_publiccloud;
+    assert_script_run("echo -e '$password\n$password' | passwd root") if is_public_cloud;
     select_console 'user-console';
     # check if password is required
     assert_script_run 'sudo -K && ! timeout 5 sudo id -un';
@@ -108,7 +107,7 @@ sub post_run_hook {
     # remove test user
     assert_script_run 'userdel -r sudo_test && groupdel sudo_group';
     # remove root password on publiccloud again
-    assert_script_run("passwd root --lock") if is_publiccloud;
+    assert_script_run("passwd root --lock") if is_public_cloud;
 }
 
 1;


### PR DESCRIPTION
in `version_utils.pm`:
```perl
sub is_public_cloud {
  return get_var('PUBLIC_CLOUD');
}
```
in `publiccloud/utils.pm`:
```perl
sub is_publiccloud() {
  return (get_var('PUBLIC_CLOUD') == 1);
}
```

- Related ticket: [poo#105247](https://progress.opensuse.org/issues/105247)
- Verification run: [15-SP3-consoletests](http://pdostal-server.suse.cz/tests/13099)
