### PR TITLE
Revert "Fix product shortcuts for SLES4SAP 15-SP4+ (#14026)"

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -65,7 +65,8 @@ sub get_product_shortcuts {
             : is_aarch64() ? 's'
             : 'i',
             sled => 'x',
-            sles4sap => is_ppc64le() ? 'i'
+            sles4sap => is_ppc64le() ? (is_sle('15-SP4+') ? 'U' : 'i')
+            : (is_sle('15-SP4+') && is_x86_64() && !is_quarterly_iso()) ? 'i'
             : (is_sle('15-SP2+') && is_x86_64() && !is_quarterly_iso()) ? 't'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
Revert https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14026

Failing tests:
https://openqa.suse.de/tests/8009393
https://openqa.suse.de/tests/8009395