### PR TITLE
Fix typo in get_module_registration method

### DIFF
--- a/tests/installation/module_registration/verify_module_registration.pm
+++ b/tests/installation/module_registration/verify_module_registration.pm
@@ -23,7 +23,7 @@ sub run {
       . "\nActual:\n" . join(', ', @modules)
       if arrays_differ(\@expected_modules, \@modules);
     my @expected_registered_modules = @{get_test_suite_data()->{registered_modules}};
-    my @registered_modules = @{$testapi::distri->get_module_resgistration()->get_registered_modules()};
+    my @registered_modules = @{$testapi::distri->get_module_registration()->get_registered_modules()};
     die "Selected modules are not the default ones"
       . "\nExpected:\n" . join(', ', @expected_registered_modules)
       . "\nActual:\n" . join(', ', @registered_modules)


### PR DESCRIPTION
The PR just fixes the typo in method name.

- Verification run: https://openqa.suse.de/tests/8014584
