### PR TITLE
Update label for Encrypted Device dialog

### DIFF
--- a/lib/Installation/SystemProbing/EncryptedVolumeActivationPage.pm
+++ b/lib/Installation/SystemProbing/EncryptedVolumeActivationPage.pm
@@ -20,7 +20,7 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{lbl_vol_activation} = $self->{app}->label({label => 'Encrypted Volume Activation'});
+    $self->{lbl_vol_activation} = $self->{app}->label({label => 'Encrypted Device'});
     $self->{tb_password} = $self->{app}->textbox({id => 'password'});
     $self->{btn_ok} = $self->{app}->button({id => 'accept'});
     $self->{btn_cancel} = $self->{app}->button({id => 'cancel'});


### PR DESCRIPTION
The dialog was updated and the label was changed.

The commit adjusts the existing label to correspond the change.

- Verification run: https://openqa.suse.de/tests/8014611
