### PR TITLE
Fix SUSEConnect cleanup test

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -238,7 +238,7 @@ variable set.
 =cut
 sub cleanup_registration {
     # Remove registration from the system
-    assert_script_run 'SUSEConnect --clean';
+    assert_script_run 'SUSEConnect --cleanup';
     # Define proxy SCC if provided
     my $proxyscc = get_var('SCC_URL');
     assert_script_run "echo \"url: $proxyscc\" > /etc/SUSEConnect" if $proxyscc;


### PR DESCRIPTION
Abbreviated flags are not supported by Go version of SUSEConnect, that
is started being used instead of Ruby version.

- Verification run: https://openqa.suse.de/tests/8014715
