### PR TITLE
Use the full option name for --cleanup instead of the abbreviated --clean

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -238,7 +238,7 @@ variable set.
 =cut
 sub cleanup_registration {
     # Remove registration from the system
-    assert_script_run 'SUSEConnect --clean';
+    assert_script_run 'SUSEConnect --cleanup';
     # Define proxy SCC if provided
     my $proxyscc = get_var('SCC_URL');
     assert_script_run "echo \"url: $proxyscc\" > /etc/SUSEConnect" if $proxyscc;


### PR DESCRIPTION
The new Go version of `SUSEConnect` doesn't support abbreviated option names, so use `--cleanup` instead of `--clean` in the command line.

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1195003

Failing test: https://openqa.suse.de/tests/8011466