### PR TITLE
Fix installation_overview because of BSC1167736 for openSUSE Leap on s390x

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -67,7 +67,7 @@ sub check_default_target {
     return if (!get_var('DESKTOP') || get_var('PATTERNS'));
 
     # Set expectations
-    my $expected_target = check_var('DESKTOP', 'textmode*') ? "multi-user" : "graphical";
+    my $expected_target = check_var('DESKTOP', 'textmode' | 'textmode-server' ) ? "multi-user" : "graphical";
 
     $self->validate_default_target($expected_target);
 }

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -67,7 +67,7 @@ sub check_default_target {
     return if (!get_var('DESKTOP') || get_var('PATTERNS'));
 
     # Set expectations
-    my $expected_target = check_var('DESKTOP', 'textmode') ? "multi-user" : "graphical";
+    my $expected_target = check_var('DESKTOP', 'textmode*') ? "multi-user" : "graphical";
 
     $self->validate_default_target($expected_target);
 }

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -67,7 +67,7 @@ sub check_default_target {
     return if (!get_var('DESKTOP') || get_var('PATTERNS'));
 
     # Set expectations
-    my $expected_target = check_var('DESKTOP', 'textmode' | 'textmode-server' ) ? "multi-user" : "graphical";
+    my $expected_target = check_var('DESKTOP', 'textmode' | 'textmode-server') ? "multi-user" : "graphical";
 
     $self->validate_default_target($expected_target);
 }

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -65,7 +65,6 @@ sub check_default_target {
         get_var('REMOTE_CONTROLLER') || (get_var('BACKEND', '') =~ /spvm|pvm_hmc|ipmi/));
     # exclude non-desktop environment and scenarios with edition of package selection (bsc#1167736)
     return if (!get_var('DESKTOP') || get_var('PATTERNS'));
-    return if (get_var 'BSC1167736');
 
     # Set expectations
     my $expected_target = check_var('DESKTOP', 'textmode') ? "multi-user" : "graphical";


### PR DESCRIPTION
The test-suite textmode-server is failing for openSUSE Leap 15.3 and openSUSE Leap 15.4 on s390x because of the SUSE internal bugreport BSC1167736.
This fix in the test should fix this issue by adding textmode-server equal as textmode to the expected_target.

- Related ticket: https://progress.opensuse.org/issues/81685
- Verification run: https://openqa.opensuse.org/t2150725
