### PR TITLE
Add test module Audit: autrace.pm

### DIFF
--- a/schedule/security/audit.yaml
+++ b/schedule/security/audit.yaml
@@ -1,0 +1,7 @@
+name: audit
+description:    >
+    Audit test for sle and Tumbleweed
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/audit/autrace

--- a/tests/security/audit/autrace.pm
+++ b/tests/security/audit/autrace.pm
@@ -1,0 +1,66 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-Later
+#
+# Summary: Verify the "autrace" utility traces individual processes in a fashion similar to strace.
+#          The output of autrace is logged to the audit log.
+# Maintainer: llzhao <llzhao@suse.com>, shawnhao <weixuan.hao@suse.com>
+# Tags: poo#81772
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub get_pid {
+    # Call this fuction to extract pid from autrace output in command line
+    my $tmp_output = '/tmp/out';
+    my $tmp_backup = '/tmp/backup';
+    script_run("tail -1 $tmp_output > $tmp_backup");
+    script_run("awk -F\\' '{print \$2}' $tmp_backup > $tmp_output");
+    my $pid = script_output("cat $tmp_output | cut -d ' ' -f 4");
+    return ($pid);
+}
+
+sub run {
+    my $audit_log = '/var/log/audit/audit.log';
+    my $tmp_output = '/tmp/out';
+
+    select_console 'root-console';
+
+    # Install related packages and start audit service
+    zypper_call('in audit libaudit1');
+    assert_script_run('systemctl start auditd');
+
+    # Use autrace to trace an individual process, output will be logged to audit log
+    script_run('autrace /bin/ls /tmp');
+    record_info('autrace_output: ', 'autrace will report error here as expected');
+
+    # Delete all existing rules
+    assert_script_run('auditctl -D');
+
+    # Clear original audit log
+    assert_script_run("echo '' > $audit_log");
+
+    # Trace process again and record the pid
+    assert_script_run("autrace /bin/ls > $tmp_output");
+    my $pid = get_pid();
+
+    # Run ausearch with the pid
+    assert_script_run("ausearch -i -p $pid");
+
+    # Clear log again
+    assert_script_run("echo '' > $audit_log");
+
+    # Try resource usage mode and record the pid
+    assert_script_run("autrace -r /bin/ls > $tmp_output");
+    $pid = get_pid();
+
+    # Query audit daemon logs by pid and generate audit reports about files
+    assert_script_run("ausearch --start recent -p $pid --raw | aureport --file --summary");
+
+    # Query audit daemon logs by pid and generate audit reports about hosts
+    assert_script_run("ausearch --start recent -p $pid --raw | aureport --host --summary");
+}
+
+1;


### PR DESCRIPTION
Verify the "autrace" utility traces individual processes in a fashion similar to strace. The output of autrace is logged to the audit log

- Related ticket: https://progress.opensuse.org/issues/81772
- Needles: N/A
- Verification run: 
  - O3: https://openqa.opensuse.org/tests/2156163#
  - OSD: https://openqa.suse.de/tests/8033223#
