### PR TITLE
Add more test cases for SELinux

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2378,6 +2378,8 @@ sub load_security_tests_selinux {
     loadtest "security/selinux/restorecon";
     loadtest "security/selinux/chcon";
     loadtest "security/selinux/chcat";
+    loadtest "security/selinux/set_get_enforce";
+    loadtest "security/selinux/selinuxexeccon";
 }
 
 sub load_security_tests_cc_audit_test {

--- a/lib/selinuxtest.pm
+++ b/lib/selinuxtest.pm
@@ -110,9 +110,6 @@ sub set_sestatus {
     my $selinux_config_file = '/etc/selinux/config';
     $self->select_serial_terminal;
 
-    # SELinux by default
-    validate_script_output('sestatus', sub { m/SELinux status: .*disabled/ });
-
     # workaround for 'selinux-auto-relabel' in case: auto relabel then trigger reboot
     my $results = script_run("zypper --non-interactive se selinux-autorelabel");
     if (!$results) {

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -1,9 +1,10 @@
-# Copyright 2018-2021 SUSE LLC
+# Copyright 2018-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# Summary: Setup environment for selinux tests
+# Summary: Setup environment for selinux tests,
+#          check SELinux status by default via 'sestatus/selinuxenabled'
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#40358
+# Tags: poo#40358, poo#105202, tc#1769801
 
 use base 'opensusebasetest';
 use strict;
@@ -17,59 +18,66 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    # program 'sestatus' can be found in policycoreutils pkgs
+    # Program 'sestatus' can be found in policycoreutils pkgs
     zypper_call("in policycoreutils");
-    # program 'semanage' is in policycoreutils-python-utils pkgs on TW
+    # Program 'semanage' is in policycoreutils-python-utils pkgs on TW
     if (is_tumbleweed) {
-        zypper_call("in policycoreutils-python-utils");
+        zypper_call('in policycoreutils-python-utils');
     }
     if (!is_sle('>=15')) {
         assert_script_run('zypper -n in policycoreutils-python');
     }
 
-    # install as many as SELinux related packages
+    # Install as many as SELinux related packages
     my @pkgs = (
-        "selinux-tools", "libselinux-devel", "libselinux1", "python3-selinux", "libsepol1", "libsepol-devel",
-        "libsemanage1", "libsemanage-devel", "checkpolicy", "mcstrans", "restorecond", "setools-console",
-        "setools-devel", "setools-java", "setools-libs", "setools-tcl"
+        'selinux-tools', 'libselinux-devel', 'libselinux1', 'python3-selinux', 'libsepol1', 'libsepol-devel',
+        'libsemanage1', 'libsemanage-devel', 'checkpolicy', 'mcstrans', 'restorecond', 'setools-console',
+        'setools-devel', 'setools-java', 'setools-libs', 'setools-tcl'
     );
     foreach my $pkg (@pkgs) {
         my $results = script_run("zypper --non-interactive se $pkg");
         if ($results) {
-            record_info("WARNING", "Package $pkg is missing, zypper search returns: $results");
+            record_info('WARNING', "Package $pkg is missing, zypper search returns: $results");
         }
         else {
             zypper_call("in $pkg");
         }
     }
     if (is_x86_64) {
-        zypper_call("in libselinux1-32bit");
+        zypper_call('in libselinux1-32bit');
     }
 
-    # for opensuse, e.g, Tumbleweed install selinux_policy pkgs as needed
-    # for sle15 and sle15+ "selinux-policy-*" pkgs will not be released
+    # For opensuse, e.g, Tumbleweed install selinux_policy pkgs as needed
+    # For sle15 and sle15+ "selinux-policy-*" pkgs will not be released
     # NOTE: have to install "selinux-policy-minimum-*" pkg due to this bug: bsc#1108949
-    # install policy packages separately due to this bug: bsc#1177675
+    # Install policy packages separately due to this bug: bsc#1177675
     if (is_sle('>=15')) {
         my @files
-          = ("selinux-policy-20200219-3.6.noarch.rpm", "selinux-policy-minimum-20200219-3.6.noarch.rpm", "selinux-policy-devel-20200219-3.20.noarch.rpm");
+          = ('selinux-policy-20200219-3.6.noarch.rpm', 'selinux-policy-minimum-20200219-3.6.noarch.rpm', 'selinux-policy-devel-20200219-3.20.noarch.rpm');
         foreach my $file (@files) {
-            assert_script_run "wget --quiet " . data_url("selinux/$file");
+            assert_script_run 'wget --quiet ' . data_url("selinux/$file");
             assert_script_run("rpm -ivh --nosignature --nodeps --noplugins $file");
         }
     }
     elsif (!is_sle && !is_leap) {
-        my @files = ("selinux-policy", "selinux-policy-minimum", "selinux-policy-devel");
+        my @files = ('selinux-policy', 'selinux-policy-minimum', 'selinux-policy-devel');
         foreach my $file (@files) {
             zypper_call("in $file");
         }
     } else {
-        zypper_call("in selinux-policy-minimum");
+        zypper_call('in selinux-policy-minimum');
     }
 
-    # record the pkgs' version for reference
-    my $results = script_output("zypper se -s selinux-policy");
-    record_info("Pkg_ver", "SELinux policy packages' version is: $results");
+    # Record the pkgs' version for reference
+    my $results = script_output('zypper se -s selinux policy');
+    record_info('Pkg_ver', "SELinux packages' version is: $results");
+
+    # Check SELinux status by default, it should be disabled
+    # 'selinuxenabled' exits with status 0 if SELinux is enabled and 1 if it is not enabled
+    validate_script_output('sestatus', sub { m/SELinux status: .*disabled/ });
+    if (script_run('selinuxenabled') == 0) {
+        $self->result('fail');
+    }
 }
 
 sub test_flags {

--- a/tests/security/selinux/selinuxexeccon.pm
+++ b/tests/security/selinux/selinuxexeccon.pm
@@ -1,0 +1,24 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test '# selinuxexeccon' command works,
+#          report process context for command from the current context
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#105202, tc#1769801
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+
+    # Report the SELinux process context for this command from the current context
+    validate_script_output('selinuxexeccon /usr/bin/passwd', sub { m/.*_u:.*_r:.*_t:s.*:c.*/ });
+}
+
+1;

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: FSFAP
 
 #
-# Summary: Test "sestatus" command gets the right status of a system running SELinux
+# Summary: Test 'sestatus/selinuxenabled' commands get the right status of a system running SELinux
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#40358, tc#1682592
+# Tags: poo#40358, tc#1682592, poo#105202, tc#1769801
 
 use base 'selinuxtest';
 use strict;
@@ -17,7 +17,10 @@ use utils;
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
-    $self->set_sestatus("permissive", "minimum");
+    $self->set_sestatus('permissive', 'minimum');
+
+    # Check SELinux status: 'selinuxenabled' exits with status 0 if SELinux is enabled and 1 if it is not enabled
+    assert_script_run('selinuxenabled');
 }
 
 sub test_flags {

--- a/tests/security/selinux/set_get_enforce.pm
+++ b/tests/security/selinux/set_get_enforce.pm
@@ -1,0 +1,60 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test '# setenforce/getenforce' commands work
+#          # setenforce - modify the mode SELinux is running in
+#          #   - usage:  setenforce [ Enforcing | Permissive | 1 | 0 ]
+#          # getenforce - reports whether SELinux is enforcing, permissive, or disabled
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#105202, tc#1769801
+
+use base 'opensusebasetest';
+use power_action_utils "power_action";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Utils::Backends 'is_pvm';
+
+sub run {
+    my ($self) = @_;
+    my $mode_old = 'Enforcing';
+    my $mode_new = 'Permissive';
+
+    $self->select_serial_terminal;
+
+    # Get the current SELinux policy mode
+    $mode_old = script_output('getenforce');
+
+    # Set to 'Permissive' mode
+    $mode_new = 'Permissive';
+    assert_script_run("setenforce $mode_new");
+    assert_script_run('setenforce 0');
+    validate_script_output('getenforce', sub { m/$mode_new/ });
+
+    # Reboot
+    power_action("reboot", textmode => 1);
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
+    $self->select_serial_terminal;
+
+    # Check the mode after reboot, the mode returns to original one
+    validate_script_output('getenforce', sub { m/$mode_old/ });
+
+    # Set to 'Enforcing' mode
+    $mode_new = 'Enforcing';
+    assert_script_run("setenforce $mode_new");
+    assert_script_run('setenforce 1');
+    validate_script_output('getenforce', sub { m/$mode_new/ });
+
+    # Reboot
+    power_action("reboot", textmode => 1);
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
+    $self->select_serial_terminal;
+
+    # Check the mode after reboot, the mode returns to original one
+    validate_script_output('getenforce', sub { m/$mode_old/ });
+}
+
+1;


### PR DESCRIPTION
Add more test cases for SELinux.

Added 'setenforce', 'getenforce', 'selinuxexeccon' and 'selinuxenabled' testings.

- Related ticket: https://progress.opensuse.org/issues/105202
- Needles: NA
- Verification run:
  x86_64 (TW): https://openqa.opensuse.org/tests/2156754
  SLE: There is a blocker bsc#1194806 on SLE so no VR for SLE atm but I think the results might be the same with TW.
