### PR TITLE
jeos-firstboot: New initial configuration screen 

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -70,8 +70,18 @@ sub run {
 
     # JeOS on generalhw
     mouse_hide;
+    # https://github.com/openSUSE/jeos-firstboot/pull/82 welcome dialog is shown on all consoles
+    # and configuration continues on console where *Start* has been pressed
+    unless (is_leap('<=15.4') || is_sle('<=15-sp4')) {
+        assert_screen 'jeos-init-config-screen', 300;
+        # Without this 'ret' sometimes won't get to the dialog
+        wait_still_screen;
+        send_key 'ret';
+    }
+
     # kiwi-templates-JeOS images (sle, opensuse x86_64 only) are build w/o translations
     # jeos-firstboot >= 0.0+git20200827.e920a15 locale warning dialog has been removed
+    # TO BE REMOVED *soon*; keep only else part
     if ((is_sle('15+') && is_sle('<15-sp3')) || (is_leap('<15.3') && is_x86_64)) {
         assert_screen 'jeos-lang-notice', 300;
         # Without this 'ret' sometimes won't get to the dialog


### PR DESCRIPTION
- [Jeos firstrun has a new welcome screen](https://progress.opensuse.org/issues/105286)
- openSUSE/jeos-firstboot#82
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/759
- Verification runs:
  * [TW](http://kepler.suse.cz/tests/10540#step/firstrun/1)
  * [sle12sp5](http://kepler.suse.cz/tests/10541#live)
  * [opensuse-15.3-JeOS-for-kvm-and-xen](http://kepler.suse.cz/tests/10543#)
