### PR TITLE
Fix erratic behavior of setting up the network on windows

### DIFF
--- a/schedule/sles4sap/remote_desktop/sles4sap_remote_desktop_windows_client.yaml
+++ b/schedule/sles4sap/remote_desktop/sles4sap_remote_desktop_windows_client.yaml
@@ -3,13 +3,10 @@ name: sles4sap_remote_desktop_windows_client
 description: >
   Remote Desktop Protocol (RDP) test from a Windows client.
 vars:
-  BOOTFROM: c
   NETWORKS: fixed
   REGRESSION: remote
   REMOTE_DESKTOP_TYPE: win_client
-  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
-  # HDD_1: windows-10-x86_64-1511@64bit_win.qcow2
 schedule:
-  - x11/remote_desktop/windows_client_boot
+  - wsl/boot_windows
   - x11/remote_desktop/windows_network_setup
   - x11/remote_desktop/windows_client_remotelogin


### PR DESCRIPTION
This fix uses the windows from wsl/boot_windows as base.
Due to the issue that the network adapter is sometimes (possibly
depending on the worker setup?) named "Ethernet" and sometimes
"Ethernet 2" there is the need to first find the name and use that
to actually set up the network.
This fix implements that.
For that, powershell cmdlets are used instead of netsh.

- Related issue: https://openqa.suse.de/tests/7924149#step/windows_network_setup/5
- Needles: https://gitlab.suse.de/bschmidt/os-autoinst-needles-sles/-/merge_requests/2
- Verification run: http://keks.qa.suse.de/tests/386#step/windows_network_setup/21
