### PR TITLE
Prevent resource leak in failing terraform apply

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -399,6 +399,7 @@ sub terraform_apply {
 
     script_retry($cmd, timeout => $terraform_timeout, delay => 3, retry => 6);
     my $ret = script_run('terraform apply -no-color -input=false myplan', $terraform_timeout);
+    $self->terraform_applied(1);    # Must happen here to prevent resource leakage
     unless (defined $ret) {
         if (is_serial_terminal()) {
             type_string(qq(\c\\));    # Send QUIT signal
@@ -413,8 +414,6 @@ sub terraform_apply {
         die('Terraform apply failed with timeout');
     }
     die('Terraform exit with ' . $ret) if ($ret != 0);
-
-    $self->terraform_applied(1);
 
     my $output = decode_json(script_output("terraform output -json"));
     my $vms;


### PR DESCRIPTION
Prevent that ressources are leaking if terraform apply fails or times
out.

- Verification run: [15-SP3 GCE consoletests](http://duck-norris.qam.suse.de/t8020) | [15-SP3 GCE imgproof](http://duck-norris.qam.suse.de/t8021) | [15-SP4 SAP](https://openqa.suse.de/tests/8021611#step/sles4sap/142) (failure expected, `terraform destroy` is executed)
