### PR TITLE
Remove yast2_lan_restart test module from yast2_gui

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -39,7 +39,6 @@ conditional_schedule:
         - yast2_gui/yast2_hostnames
         - yast2_gui/yast2_network_settings
         - yast2_gui/yast2_lan_ifcfg_errors
-        - x11/yast2_lan_restart
         - yast2_gui/yast2_lan_restart_bridge
         - yast2_gui/yast2_lan_restart_vlan
         - yast2_gui/yast2_lan_restart_bond


### PR DESCRIPTION
The test module is not relevant as it checks wrong behavior.

Please, see the comment:
https://progress.opensuse.org/issues/105358#note-2
