### PR TITLE
wicked: Fix cleanup of old config files in `wickedbase::reset_wicked()`

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -100,8 +100,8 @@ sub assert_wicked_state {
 sub reset_wicked {
     my $self = @_;
     # Remove any config file and leave the system clean to start tests
-    assert_script_run('find /etc/sysconfig/network/ -name "ifcfg-*" -not -name "ifcfg-lo" -exec rm {} \;');
-    assert_script_run('find /etc/sysconfig/network/ -name "routes" -o -name "ifroute-*" -exec rm {} \;');
+    assert_script_run('find /etc/sysconfig/network/ \( -name "ifcfg-*" -not -name "ifcfg-lo" \) -exec rm {} \;');
+    assert_script_run('find /etc/sysconfig/network/ \( -name "routes" -o -name "ifroute-*" \) -exec rm {} \;');
 
     # Remove any previous manual ip configuration
     my $iface = iface();


### PR DESCRIPTION
Simply check with:
```bash
cd $(mktemp -d)
touch routes ifroute-eth0
find .  -name "routes" -o -name "ifroute-*"  -print
# compared to:
find . \( -name "routes" -o -name "ifroute-*" \) -print
```