### PR TITLE
Use publiccloud::utils::registercloudguest() in publiccloud/storage_perf.pm test module

### DIFF
--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -13,7 +13,7 @@ use testapi;
 use utils;
 use db_utils;
 use Mojo::JSON;
-use publiccloud::utils "is_byos";
+use publiccloud::utils qw(is_byos registercloudguest);
 
 use constant NUMJOBS => 4;
 use constant IODEPTH => 4;


### PR DESCRIPTION
In `publiccloud/storage_perf.pm` we call `publiccloud::utils::registercloudguest()` which was not available.

- Error: [sle-15-SP4-EC2-BYOS-publiccloud_fio](https://openqa.suse.de/tests/8021544)
- Verification run: [sle-15-SP4-EC2-BYOS-publiccloud_fio](http://pdostal-server.suse.cz/tests/13101#details)
