### PR TITLE
Disable root ssh login for cc setup

### DIFF
--- a/tests/security/cc/cc_disable_root_ssh.pm
+++ b/tests/security/cc/cc_disable_root_ssh.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Disable root ssh login due to CC hard requirement
+#          This test is needed on s390x SLE platform only
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#99096
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console "root-console";
+    assert_script_run("sed -i 's/^PermitRootLogin.*\$/#/' /etc/ssh/sshd_config");
+    assert_script_run("echo 'PermitRootLogin no' >> /etc/ssh/sshd_config");
+    assert_script_run("systemctl restart sshd");
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Based on CC test requirement, we may need disable
root ssh login, so introduce this new test module

this change may cause some test failures which need ssh access the 
test machine. so only commit this test module only,  we may need more 
code changes to fit this new design.

- Related ticket: https://progress.opensuse.org/issues/99096
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/8025298#step/trustedprograms/46 
[The failure is by design, and I didn't change the current test logic]
