### PR TITLE
Remove softfailure for bsc#1180605

### DIFF
--- a/tests/console/python_scientific.pm
+++ b/tests/console/python_scientific.pm
@@ -13,7 +13,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_tumbleweed);
 
 sub run_python_script {
     my $script = shift;
@@ -23,11 +23,9 @@ sub run_python_script {
     assert_script_run("chmod a+rx '$script'");
     assert_script_run("./$script 2>&1 | tee $logfile");
     if (script_run("grep 'Softfail' $logfile") == 0) {
-        # bsc#1180605 is only relevant for SLE and will be hopefully solved soon by a package update
-        # since there is no timeframe when this happens, we ignore this bsc for sle completely for now
-        # Note: Remove 'is_sle' when available in PackageHub
-        if (script_run("grep 'Softfail' $logfile | grep 'bsc#1180605'") == 0 && (is_sle)) {
-            record_info("scipy-fft", "scipy-fft module not available for SLE <= 15-SP2");
+        # Except for Tumbleweed, scipy is still outdated and bsc#1180605 is therefore triggered
+        if ((script_run("grep 'Softfail' $logfile | grep 'bsc#1180605'") == 0) && (!is_tumbleweed)) {
+            record_info("scipy-fft", "scipy-fft module not available", result => 'softfail');
         } else {
             my $failmsg = script_output("grep 'Softfail' '$logfile'");
             record_soft_failure("$failmsg");


### PR DESCRIPTION
The softfailure for bsc#1180605 is still triggered and it does not look
like this is going to be solved anytime soon.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1180605
- Verification run: [SLES 15-SP3](http://duck-norris.qam.suse.de/t8022) | [Tumbleweed](http://duck-norris.qam.suse.de/t8023)
