### PR TITLE
Implement RPi hardware tests for SLE JeOS

### DIFF
--- a/data/generalhw_scripts/power_on_off_shelly.sh
+++ b/data/generalhw_scripts/power_on_off_shelly.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script can operate shelly wifi switch plugs
+# See https://shelly-api-docs.shelly.cloud/gen1/#shelly-plug-plugs-relay-0
+
+# Check number of args
+if [ "$#" -ne 2 ] ; then
+	echo "Invalid number of arguments."
+	echo "Usage: $0 IP/HOSTNAME on|off"
+	exit 1
+fi
+
+shelly_ip=$1
+state=$2
+
+res=$(curl -s "http://${shelly_ip}/relay/0?turn=${state}")
+if ! echo "$res" | grep -q "ison" ; then
+	exit 1
+fi

--- a/schedule/jeos/sle/rpi/create_hdd_rpi.yaml
+++ b/schedule/jeos/sle/rpi/create_hdd_rpi.yaml
@@ -1,0 +1,7 @@
+---
+description: 'Prepare rpi image to do dhcp and ssh. Maintainer: dheidler.'
+name: 'create_hdd_rpi@aarch64 ( qemu )'
+schedule:
+  - jeos/firstrun
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/jeos/sle/rpi/jeos-realhw.yaml
+++ b/schedule/jeos/sle/rpi/jeos-realhw.yaml
@@ -1,0 +1,21 @@
+---
+description: 'Real HW RPi test suite. Maintainer: dheidler.'
+name: 'jeos-realhw@aarch64'
+schedule:
+  - jeos/prepare_firstboot
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/ntp_client
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/suseconnect_scc
+  - jeos/rpi_wifi
+  - jeos/rpi_bluetooth
+  - console/consoletest_setup
+  - console/salt
+  - console/nginx
+  - console/dns_srv
+  - console/postgresql_server
+  - console/hostname
+  - console/curl_https
+  - console/rsync

--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: chrony ntp
@@ -18,7 +18,7 @@ sub run {
 
     assert_script_run 'timedatectl';
 
-    if (is_sle) {
+    if (is_sle() && !check_var('FLAVOR', 'JeOS-for-RaspberryPi')) {
         systemctl 'enable chronyd';
         systemctl 'start chronyd';
         # bsc#1179022 avoid '503 No such source' error while chrony does pick responding sources after start

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2015-2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Configure JeOS
@@ -120,6 +120,11 @@ sub run {
     if (is_sle) {
         assert_screen 'jeos-please-register';
         send_key 'ret';
+
+        if (is_generalhw) {
+            assert_screen 'jeos-please-configure-wifi';
+            send_key 'n';
+        }
     }
 
     # Our current Hyper-V host and it's spindles are quite slow. Especially
@@ -156,9 +161,12 @@ sub run {
 
     verify_user_info(user_is_root => 1);
 
-    # Create user account
-    assert_script_run "useradd -m $username -c '$realname'";
-    assert_script_run "echo $username:$password | chpasswd";
+    # Create user account, if image doesn't already contain user
+    # (which is the case for SLE images that were already prepared by openQA)
+    if (script_run("getent passwd $username") != 0) {
+        assert_script_run "useradd -m $username -c '$realname'";
+        assert_script_run "echo $username:$password | chpasswd";
+    }
 
     ensure_serialdev_permissions;
 

--- a/tests/jeos/prepare_firstboot.pm
+++ b/tests/jeos/prepare_firstboot.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Enable jeos-firstboot as required by openQA testsuite
@@ -11,7 +11,7 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 use utils 'zypper_call';
-use version_utils 'is_leap';
+use version_utils qw(is_leap is_sle);
 use Utils::Backends;
 
 sub run {
@@ -27,8 +27,12 @@ sub run {
         # Run jeos-firstboot manually and do not reboot as we use SSH
         $reboot_for_jeos_firstboot = 0;
 
-        # Handle default credentials for ssh login
-        $testapi::password = $default_password;
+        if (!is_sle()) {
+            # Handle default credentials for ssh login
+            # On SLE we use an image preprocessed by openQA where the default
+            # $testapi::password was set
+            $testapi::password = $default_password;
+        }
         # 'root-ssh' console will wait for SUT to be reachable from ssh
         select_console('root-ssh');
     }

--- a/tests/jeos/rpi_bluetooth.pm
+++ b/tests/jeos/rpi_bluetooth.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check RPi bluetooth: Do a scan and check if we see
+#          the openQA-worker device.
+# Maintainer: qe-core team <qe-core@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+# This requires a discoverable bluetooth device in range:
+#===========================
+#/etc/bluetooth/main.conf:
+#[Policy]
+#AutoEnable=true
+#[General]
+#DiscoverableTimeout = 0
+#Name = openQA-worker
+#===========================
+
+sub run {
+    my ($self) = @_;
+
+    zypper_call 'in bluez';
+    systemctl 'start bluetooth';
+    systemctl 'status bluetooth';
+    assert_script_run 'rfkill list';
+    assert_script_run 'bluetoothctl show';
+    assert_script_run '(echo "power on"; sleep 5; echo "scan on"; sleep 30; echo "devices") | bluetoothctl | tee /dev/stderr | grep openQA-worker';
+    assert_script_run 'bluetoothctl show';
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->save_and_upload_log('dmesg', 'dmesg.log');
+    $self->save_and_upload_log('journalctl -b', 'journal.log');
+}
+
+1;

--- a/tests/jeos/rpi_wifi.pm
+++ b/tests/jeos/rpi_wifi.pm
@@ -1,0 +1,52 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check RPi Wifi: Connect to openQA-worker wifi and do a ping.
+#          PSK is set via RPI_WIFI_PSK and ping target via RPI_WIFI_WORKER_IP.
+# Maintainer: qe-core team <qe-core@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+
+    assert_script_run 'ip l';
+    assert_script_run 'ip a';
+    assert_script_run 'rfkill list';
+    assert_script_run 'ip l set wlan0 up';
+    # This would be a more modern approach but
+    # iw is not installed by default:
+    # iw dev wlan0 scan | grep -e "^\(BSS\|\sSSID:\)"
+    assert_script_run 'iwlist wlan0 scan | grep -e "^\s*\(Cell\|Frequency\|Quality\|ESSID\)"';
+    assert_script_run 'ip l set wlan0 down';
+
+    select_console 'root-console';
+    enter_cmd 'jeos-config raspberrywifi';
+    assert_screen 'jeos-rpiwifi-select';
+
+    # press key until openQA-worker wifi is selected
+    send_key_until_needlematch('jeos-rpwifi-select-list-workerwifi-selected', 'o');
+    send_key 'ret';
+
+    assert_screen 'jeos-rpiwifi-select-auth-mode-wpapsk';
+    send_key 'ret';
+
+    assert_screen 'jeos-rpiwifi-enter-psk';
+    enter_cmd(get_required_var('RPI_WIFI_PSK'));
+
+    assert_screen 'text-logged-in-root';
+    assert_script_run 'ip a';
+    assert_script_run('ping -c1 ' . get_required_var('RPI_WIFI_WORKER_IP'));
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->save_and_upload_log('cat /etc/sysconfig/network/ifcfg-wlan0', 'ifcfg-wlan0.txt');
+}
+
+1;


### PR DESCRIPTION
SLE doesn't do DHCP and SSH with a default pw (like openSUSE does)
so this test needs to rely on a preprocessed image.
This image is generated by openQA using qemu backend
via `create_hdd_rpi.yaml`.

The SUT RPi is connected to an as sd card multiplexer
which is also connected to the worker via USB, so the worker
can flash that image onto the sdcard and then switch
the sdcard back to the SUT.
The SUT RPi is power cycled from the worker using a wifi power plug.

https://progress.opensuse.org/issues/105852