### PR TITLE
Fix vnc_two_passwords test for aarch64

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -16,7 +16,6 @@
 # - Check if events were recorded by xev
 # - Close all opened windows
 # Maintainer: mkravec <mkravec@suse.com>
-#             Felix Niederwanger <felix.niederwanger@suse.de>
 # Tags: poo#11794
 
 use base "x11test";
@@ -109,6 +108,7 @@ sub run {
     # open xterm for xev
     x11_start_program('xterm');
     send_key "super-right";
+    assert_screen 'vncviewer-console-right';
 
     # Start vncviewer (rw & ro mode) and check if changes are processed by xev
     foreach my $opt (@options) {


### PR DESCRIPTION
On aarch64 the input handling is slower and this requires some more
careful handling and waiting.

- Related ticket: https://progress.opensuse.org/issues/103188
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/760 and https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1592
- Verification run: [Tumbleweed](http://duck-norris.qam.suse.de/tests/8034#step/vnc_two_passwords/23) | [SLES15-SP3](http://duck-norris.qam.suse.de/tests/8033)
