### PR TITLE
wicked: Skip WEP tests if hostapd does not support WEP

### DIFF
--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -317,6 +317,13 @@ sub assert_sta_connected {
     die("This should never reached!");
 }
 
+sub hostapd_can_wep {
+    my ($self) = @_;
+    $self->write_cfg('/tmp/check_wep.conf', 'wep_key0=123456789a');
+    my $s = script_output('hostapd /tmp/check_wep.conf', proceed_on_failure => 1);
+    return $s !~ m/unknown configuration item 'wep_key0'/i;
+}
+
 sub hostapd_start {
     my ($self, $config, %args) = @_;
     $args{name} //= 'hostapd';

--- a/tests/wicked/wlan/sut/t09_wep.pm
+++ b/tests/wicked/wlan/sut/t09_wep.pm
@@ -175,4 +175,17 @@ has ifcfg_wlan => sub { [
         )
 ] };
 
+sub run {
+    my ($self, @args) = @_;
+
+    if (!$self->hostapd_can_wep()) {
+        record_info('SKIP',
+            'Skip test, cause installed hostapd does not support WEP',
+            result => 'softfail');
+        $self->result('skip');
+        return;
+    }
+    $self->SUPER::run(@args);
+}
+
 1;


### PR DESCRIPTION
With hostapd 2.10, hostapd doesn't support WEP by default. So a test
will not work. WEP is so deprecated, that we do not wanna make more work
on it and just silently skip these tests.

- Verification run: http://openqa.wicked.suse.de/tests/47975#step/t09_wep/7
