### PR TITLE
Remove s390x license on welcome screen condition

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -548,7 +548,7 @@ sub has_license_on_welcome_screen {
             ((is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x())
             || is_sle('<15')
             || (is_sle('=15') && is_s390x())
-            || (is_sle('>=15-SP4') && check_var('FLAVOR', 'Full') && is_s390x())
+            || (is_sle('>=15-SP4') && check_var('FLAVOR', 'Full') && is_s390x() && !get_var('UPGRADE'))
         );
     }
 


### PR DESCRIPTION
HA jobs tend to fail on s390x migration tests due to changed welcome 
screen behavior. With the recent changes the behavior is identical to 
other architectures. This PR changes the test not to expect license 
agreemenet on welcome screen for migration based tests.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1192230
- Verification run: 
12SP4: https://openqa.suse.de/tests/8026260
15SP1: https://openqa.suse.de/tests/8026261
15SP3: https://openqa.suse.de/tests/8025612