### PR TITLE
Fail on empty repositories in publiccloud

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -75,8 +75,6 @@ sub run_ssh_command {
     } elsif ($rc_only) {
         # Increase the hard timeout for script_run, otherwise our 'timeout $args{timeout} ...' has no effect
         $args{timeout} += 2;
-        # Pipe both the standard and error output serial for debug purposes
-        $ssh_cmd .= " >/dev/$serialdev 2>&1";
         $args{quiet} = 0;
         $args{die_on_timeout} = 1;
         # Run the command and return only the returncode here

--- a/tests/console/cleanup_qam_testrepos.pm
+++ b/tests/console/cleanup_qam_testrepos.pm
@@ -30,7 +30,6 @@ sub get_repo_aliases() {
 
 sub run {
     my $self = shift;
-    $self->select_serial_terminal;
     return if (script_run('zypper -n ref') == 0);    # If all repos are OK we don't have to do anything
     my $behav = get_var('QAM_TESTREPO_FAIL') // "fail";
     # Check all repositories if they are valid

--- a/tests/publiccloud/register_system.pm
+++ b/tests/publiccloud/register_system.pm
@@ -34,8 +34,8 @@ sub run {
             register_addon($remote, $addon);
         }
     }
-    record_info('LR', $args->{my_instance}->run_ssh_command(cmd => "sudo zypper lr || true"));
-    record_info('LS', $args->{my_instance}->run_ssh_command(cmd => "sudo zypper ls || true"));
+    record_info('repos (lr)', $args->{my_instance}->run_ssh_command(cmd => "sudo zypper lr"));
+    record_info('repos (ls)', $args->{my_instance}->run_ssh_command(cmd => "sudo zypper ls"));
 }
 
 1;


### PR DESCRIPTION
Fail if there are no repositories defined in register_system step on
publiccloud. This is necessary to catch registration errors much
earlier.

- Related ticket: https://progress.opensuse.org/issues/105419
- Verification run: [15-SP3 Azure BYOS](http://duck-norris.qam.suse.de/t8048) | [15-SP3 ARM BYOS](http://duck-norris.qam.suse.de/t8049) | [15-SP3 GCE](http://duck-norris.qam.suse.de/t8050) | [12-SP5 EC2](http://duck-norris.qam.suse.de/t8051)
