### PR TITLE
Simplify container diff check

### DIFF
--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -21,16 +21,15 @@ sub run {
 
     zypper_call("install container-diff") if (script_run("which container-diff") != 0);
 
-    my ($untested_images, $released_images) = get_suse_container_urls();
+    my ($testing_images, $released_images) = get_suse_container_urls();
     # container-diff
-    for my $i (@{$untested_images}) {
-        my $image_file = $untested_images->[$i] =~ s/\/|:/-/gr;
+    for my $i (@{$testing_images}) {
+        my $image_file = $testing_images->[$i] =~ s/\/|:/-/gr;
         my $container_diff_results = "/tmp/container-diff-$image_file.txt";
-        assert_script_run("docker pull $untested_images->[$i]", 360);
+        assert_script_run("docker pull $testing_images->[$i]", 360);
         assert_script_run("docker pull $released_images->[$i]", 360);
-        assert_script_run("container-diff diff daemon://$untested_images->[$i] daemon://$released_images->[$i] --type=rpm --type=file --type=size > $container_diff_results", 300);
+        assert_script_run("container-diff diff daemon://$testing_images->[$i] daemon://$released_images->[$i] --type=rpm --type=file --type=size > $container_diff_results", 300);
         upload_logs("$container_diff_results");
-        ensure_container_rpm_updates("$container_diff_results");
     }
 
     # Clean container


### PR DESCRIPTION
Remove unnecessary container diff check to allow empty container updates
as well.

- Related ticket: https://progress.opensuse.org/issues/105067
- Verification run: https://openqa.opensuse.org/tests/2161400 and https://openqa.suse.de/tests/8041978
