### PR TITLE
Fix STIG & AppArmor failure

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 SUSE LLC
+# Copyright 2017-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Base module for AppArmor test cases
@@ -73,7 +73,7 @@ sub aa_tmp_prof_prepare {
     if ($type == 0) {
         assert_script_run "mkdir $prof_dir_tmp";
         assert_script_run "cp -r $prof_dir/{tunables,abstractions} $prof_dir_tmp/";
-        if (!(is_sle('<16') or is_leap('<16.0'))) {    # apparmor >= 3.0
+        if (!(is_sle('<15-SP4') or is_leap('<16.0'))) {    # apparmor >= 3.0
             assert_script_run "cp -r $prof_dir/abi $prof_dir/disable $prof_dir_tmp/";
         }
         if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95

--- a/lib/stigtest.pm
+++ b/lib/stigtest.pm
@@ -57,7 +57,9 @@ sub upload_logs_reports
     }
     upload_logs("$f_stdout") if script_run "! [[ -e $f_stdout ]]";
     upload_logs("$f_stderr") if script_run "! [[ -e $f_stderr ]]";
-    upload_logs("$f_report") if script_run "! [[ -e $f_report ]]";
+    if (get_var('UPLOAD_REPORT_HTML')) {
+        upload_logs("$f_report", timeout => 600) if script_run "! [[ -e $f_report ]]";
+    }
 }
 
 1;

--- a/tests/security/stig/oscap_xccdf_eval_remote.pm
+++ b/tests/security/stig/oscap_xccdf_eval_remote.pm
@@ -11,7 +11,8 @@ use warnings;
 use testapi;
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings);
-use power_action_utils "power_action";
+use power_action_utils 'power_action';
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -19,6 +20,7 @@ sub run {
 
     add_grub_cmdline_settings('ignore_loglevel', update_grub => 1);
     power_action('reboot', textmode => 1);
+    reconnect_mgmt_console if is_pvm;
     $self->wait_boot(textmode => 1);
 
     select_console 'root-console';


### PR DESCRIPTION
Fix STIG & AppArmor failure.

See poo for more details:
  poo#105334 - [sle][security][sle15sp4] test fails in oscap_xccdf_eval_remote from reconnect_mgmt_console fail in pvm
  poo#105467 - [sle][security][sle15sp4] test fails in aa_autodep: "abi" dir should be copied for testing sen setup
  poo#105717 - [sle][security][sle15sp4]automate testing of scap-security-guide: optionally upload "report.html" and fix upload timed out on ppc64le

- Related ticket:
  https://progress.opensuse.org/issues/105467
  https://progress.opensuse.org/issues/105334
  https://progress.opensuse.org/issues/105717 
- Needles: NA
- Verification run:
  SLE apparmor: https://openqa.suse.de/tests/8039738
  SLE stig x86_64: https://openqa.suse.de/tests/8065258
  SLE stig ppc64: https://openqa.suse.de/tests/8065264
  TW apparmor: https://openqa.opensuse.org/tests/2160877
  