### PR TITLE
[virt_autotest] Fix up timeout problem called virt_utils::repl_module_in_sourcefile

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -152,7 +152,7 @@ sub repl_module_in_sourcefile {
         upload_asset "/usr/share/qa/virtautolib/data/sources.de", 1, 1;
     }
     else {
-        assert_script_run($command);
+        assert_script_run($command, timeout => 120);
         save_screenshot;
         assert_script_run("grep Module $source_file -r");
         save_screenshot;


### PR DESCRIPTION
Fix up timeout problem during guest_upgrade_run test called virt_utils::repl_module_in_sourcefile

- Related ticket: https://progress.opensuse.org/issues/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
