### PR TITLE
 Distinguish different baseline files from arches in CC audit-test

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -73,12 +73,10 @@ sub upload_audit_test_logs {
     my ($testcase) = @_;
     upload_logs("$current_file");
 
-    # For syscall test case, different arch has different baseline file,
-    # so we need to upload the correct file
-    if ($testcase eq 'syscalls') {
-        $baseline_file = $baseline_file . '.' . get_var('ARCH');
-    }
-    else {
+    # Base line file is ARCH specific in some cases,
+    # so we need to upload the correct file for each platform.
+    $baseline_file = 'baseline_run.log.' . get_var('ARCH');
+    if (script_run("test -e $baseline_file") != 0) {
         $baseline_file = "baseline_run.log";
     }
     upload_logs("$baseline_file", (log_name => "$testcase-baseline_run.log"));


### PR DESCRIPTION
For now in test cases 'syscall' and 'misc', the baseline files are not
the same in different arches. So we need to distinguish them.

Related: https://progress.opensuse.org/issues/105352
Verify run: https://openqa.suse.de/tests/8040938#
     for syscalls: https://openqa.suse.de/tests/8040206#