### PR TITLE
Disable soft fail record for 390 auth popup case

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -193,7 +193,12 @@ sub handle_additional_polkit_windows {
         # for S390x testing, since they are not using qemu built-in vnc, it is
         # expected that polkit authentication window can open for first time login.
         # see bsc#1177446 for more information.
-        record_soft_failure 'bsc#1192992 - multiple authentication due to repositories refresh on s390x';
+        # Base latest feedback of bsc#1192992,authentication should never open if is_sle  >= 15SP4
+        if (is_sle('>=15-sp4')) {
+            record_soft_failure 'bsc#1192992 - authentication should never open if is_sle >= 15SP4';
+        } else {
+            record_info('authentication open for first time login');
+        }
         wait_still_screen(5);
         my $counter = 5;
         while (check_screen('authentication-required-user-settings', 10) && $counter) {
@@ -201,6 +206,9 @@ sub handle_additional_polkit_windows {
             send_key 'ret';
             wait_still_screen(2, 4);
             $counter--;
+            if ($counter < 4) {
+                record_soft_failure 'bsc#1192992 - multiple authentication due to repositories refresh on s390x';
+            }
         }
     }
     if (match_has_tag('authentication-required-modify-system')) {


### PR DESCRIPTION
Disable soft fail record for 390 auth popup case, base feedback on bsc#1192992, if version < 15sp4, the auth popup window is normal behavior.

- Related ticket: https://progress.opensuse.org/issues/105178
- Needles: na
- Verification run: http://openqa.suse.de/tests/8039597#step/first_boot/6
