### PR TITLE
Fail if guestregister fails

### DIFF
--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -23,7 +23,6 @@ sub run {
     my ($self, $args) = @_;
     # Preserve args for post_fail_hook
     $self->{provider} = $args->{my_provider};
-    select_console 'root-console';
 
     script_run("hostname -f");
     assert_script_run("uname -a");


### PR DESCRIPTION
Mark failures in guestregister as test failures instead of softfailures.

- Related ticket: https://progress.opensuse.org/issues/105597
- Verification runs: [15-SP3 Azure BYOS](http://duck-norris.qam.suse.de/tests/8062) | [15-SP3 Azure Basic](http://duck-norris.qam.suse.de/tests/8055) | [15-SP3 EC2-ARM](http://duck-norris.qam.suse.de/tests/8056) | [15-SP3 EC2 BYOS](http://duck-norris.qam.suse.de/tests/8057) | [15-SP3 GCE](http://duck-norris.qam.suse.de/tests/8058) | [15-SP1 GCE BYOS](http://duck-norris.qam.suse.de/tests/8059) | [12-SP5 Azure BYOS](http://duck-norris.qam.suse.de/tests/8065) | [12-SP5 GCE](http://duck-norris.qam.suse.de/tests/8061)
