### PR TITLE
SLE Micro 5.2: Soft Fail bsc#1194903

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -94,6 +94,13 @@
         },
         "type": "bug"
     },
+    "bsc#1194903": {
+        "description": "Failed to start One time configuration for iscsid.service",
+        "products": {
+            "sle-micro": [ "5.2" ]
+        },
+        "type": "bug"
+    },
     "bsc#1178033": {
         "description": "kernel: ITS@0x8080000: Unable to locate ITS domain handle",
         "products": {


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1194903

After a chat with the release manager, we can soft fail this bug.

- Verification run: 
https://openqa.suse.de/tests/8043520
https://openqa.suse.de/tests/8043521

