### PR TITLE
wpa_supplicant: Poll connection state on WPA_PSK

### DIFF
--- a/data/wpa_supplicant/hostapd.conf
+++ b/data/wpa_supplicant/hostapd.conf
@@ -1,23 +1,23 @@
 interface=wlan0
 driver=nl80211
 country_code=DE
-ssid=FBI Surveillance Van 3
 channel=1
-hw_mode=b
-bss=wlan0_0
-ssid=FBI Surveillance Van 4
 hw_mode=g
-channel=2
+ieee80211n=1
+macaddr_acl=0
+beacon_int=100
+bssid=02:DE:AD:BE:EF:01
+ssid=FBI Surveillance Van 3
+
+bss=wlan0_0
+bssid=02:DE:AD:BE:EF:02
+ssid=FBI Surveillance Van 4
+
 bss=wlan0_1
+bssid=02:DE:AD:BE:EF:03
 ssid=Tony's Ice Cream Shop
-hw_mode=a
-channel=0
 wpa=3
 wpa_key_mgmt=WPA-PSK
 wpa_pairwise=TKIP CCMP
 wpa_passphrase=EatMoreIceCream
-auth_algs=3
-
-beacon_int=15
-macaddr_acl=0
 auth_algs=3

--- a/data/wpa_supplicant/hostapd.sh
+++ b/data/wpa_supplicant/hostapd.sh
@@ -9,7 +9,7 @@ ip link | grep "wlan0" > /dev/null
 
 echo "Starting hostapd ... "
 # hostapd starts the wifi hotspot on wlan0
-hostapd hostapd.conf >> hostapd.log &
+hostapd -t hostapd.conf >> hostapd.log &
 hostapd_pid=$!
 timeout 30s grep -q 'wlan0: AP-ENABLED ' <(tail -f hostapd.log)
 ip addr add 192.168.200.1/24 dev wlan0

--- a/data/wpa_supplicant/wpa_supplicant_test.sh
+++ b/data/wpa_supplicant/wpa_supplicant_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function prepare() {
-	modprobe mac80211_hwsim
+	modprobe mac80211_hwsim radios=2
 	# Ensure there are no other processes running that disturb this test
 	systemctl disable --now wpa_supplicant || true
 	killall wpa_supplicant 2>/dev/null || true
@@ -14,7 +14,8 @@ function cleanup() {
 		kill $hostapd_pid
 	fi
 	modprobe -r mac80211_hwsim
-	rm -f wifi_scan.txt networks.txt status.txt hostapd.com dnsmasq.log dhclinet.log
+	[ -e dhclient.pid ] && kill $(cat dhclient.pid) 
+	rm -f wifi_scan.txt networks.txt status.txt hostapd.com dnsmasq.log dhclinet.log dhclient.pid dhclient.lease
 	rm -f /etc/sysconfig/network/ifcfg-wlan1
 	wpa_cli -i wlan1 terminate >/dev/null 2>/dev/null
 	ip netns pids wifi_master | xargs kill
@@ -40,6 +41,7 @@ prepare
 
 # Prepare files that are used as communication channel
 touch hostapd.log
+touch wpa_supplicant.log
 touch hostapd.com
 # We put the hostapd in a separate network namespace
 ip netns add wifi_master
@@ -53,14 +55,19 @@ echo "Waiting for hostapd to start ..."
 timeout 30s grep -q 'wlan0: AP-ENABLED ' <(tail -f hostapd.log)
 
 echo "Testing for wifi networks to show up ... "
-wpa_supplicant -B -i wlan1 -c wpa_supplicant1.conf
+wpa_supplicant -B -i wlan1 -t -dd -f wpa_supplicant.log -c wpa_supplicant1.conf
 wpa_cli -i wlan1 list_networks > networks.txt
 GREP "FBI Surveillance Van 3" networks.txt
 GREP "FBI Surveillance Van 4" networks.txt
 echo "Scanning for wifi networks ... "
 wpa_cli -i wlan1 scan
-# Wait until the results show up
-sleep 20
+for (( i=0; i < 20 ; i++)) ; do
+    sleep 1;
+    echo "wait for scan_results..."
+    if [ $(wpa_cli -i wlan1 scan_result | wc -l) -gt 3 ]; then
+        break;
+    fi
+done
 wpa_cli -i wlan1 scan_result > wifi_scan.txt
 GREP "Tony's Ice Cream Shop" wifi_scan.txt
 GREP "FBI Surveillance Van 3" wifi_scan.txt
@@ -81,12 +88,18 @@ ip addr del 192.168.201.2/24 dev wlan1
 echo "Connecting to WPA2 wifi networks ... "
 wpa_cli -i wlan1 terminate
 sleep 2
-wpa_supplicant -B -i wlan1 -c wpa_supplicant2.conf
+wpa_supplicant -B -i wlan1 -t -dd -f wpa_supplicant.log -c wpa_supplicant2.conf
 # Wait until connected
-sleep 5
+for (( i=0; i < 20 ; i++)) ; do
+    sleep 1;
+    echo "wait for wpa_supplicant connected..."
+    if wpa_cli -i wlan1 status | grep 'wpa_state=COMPLETED'; then
+        break;
+    fi
+done
 # Apply static IP configuration (dhcp comes next)
 ip addr add 192.168.202.2/24 dev wlan1
-wpa_cli -i wlan1 status > status.txt 
+wpa_cli -i wlan1 status | tee status.txt 
 GREP "ssid=Tony's Ice Cream Shop" status.txt
 GREP "pairwise_cipher=CCMP" status.txt
 GREP "group_cipher=TKIP" status.txt
@@ -95,15 +108,29 @@ GREP "wpa_state=COMPLETED" status.txt
 ping -c 4 192.168.202.1
 ip addr del 192.168.202.2/24 dev wlan1
 
-echo "Checking wicked/dhcp on wifi interface ... "
+echo "Checking dhcp on wifi interface ... "
 echo 'start dnsmasq' >>hostapd.com
-cp ifcfg-wlan1-dhcp /etc/sysconfig/network/ifcfg-wlan1
-echo "Restarting wicked ... "
-systemctl restart wicked
-sleep 20
-systemctl status wicked
-echo "starting wicked ... "
-wicked --debug all ifup wlan1 --timeout 60 > wicked.log 2>&1
+if systemctl is-active wickedd >& /dev/null; then
+    echo "use wicked"
+    cp ifcfg-wlan1-dhcp /etc/sysconfig/network/ifcfg-wlan1
+    echo "Restarting wicked ... "
+    systemctl restart wicked
+    sleep 20
+    systemctl status wicked
+    echo "starting wicked ... "
+    wicked --debug all ifup wlan1 --timeout 60 > wicked.log 2>&1
+else
+    echo "use dhclient"
+    touch dhclient.lease
+    dhclient -pf dhclient.pid -lf dhclient.lease wlan1
+    for (( i=0; i < 20 ; i++)) ; do
+        echo "wait for DHCP lease..."
+        sleep 1;
+        if grep -P 'fixed-address\s+192.168.202.[12]\d\d' dhclient.lease; then
+            break
+        fi
+    done
+fi
 echo "Assigned ip address(es):"
 ip a show dev wlan1 | grep inet
 ping -c 4 192.168.202.1

--- a/tests/console/wpa_supplicant.pm
+++ b/tests/console/wpa_supplicant.pm
@@ -50,6 +50,7 @@ sub post_fail_hook {
     upload_logs("wicked.log") if (script_run("stat wicked.log") == 0);
     upload_logs("wpa-supplicant_test.txt") if (script_run("stat wpa-supplicant_test.txt") == 0);
     upload_logs("hostapd.log") if (script_run("stat hostapd.log") == 0);
+    upload_logs("wpa_supplicant.log") if (script_run("stat wpa_supplicant.log") == 0);
 }
 
 1;


### PR DESCRIPTION
This is a fix for https://bugzilla.suse.com/show_bug.cgi?id=1194811 as
connection to WPA_PSK takes slightly longer on ppc64le.

Replace fix sleep's with polling for state.

Change the hostapd.conf to use only one phy configuration, as it
isn't supported to use different phy settings via multi-bss.

Fix test if network.service isn't wicked.

- Verification run: https://openqa.opensuse.org/t2162340