### PR TITLE
bsc#1195156 for all SLES versions

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -184,7 +184,7 @@ sub wait_for_guestregister
         } elsif ($out eq 'failed') {
             $out = $self->run_ssh_command(cmd => 'sudo systemctl status guestregister', proceed_on_failure => 1, quiet => 1);
             record_info("guestregister failed", $out, result => 'fail');
-            if ((is_sle("=12-SP5") && is_azure) || (is_sle("=15-SP2") && is_azure)) {
+            if (is_azure) {
                 record_soft_failure("bsc#1195156");
             } else {
                 die("guestregister failed");


### PR DESCRIPTION
Adapt the softfailure for bsc#1195156 to be valid for all SLES versions.

- Verification run: http://duck-norris.qam.suse.de/t8066
