### PR TITLE
Add GnuTLS_FORCE_FIPS_MODE parameter into fips_setup

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 SUSE LLC
+# Copyright 2016-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Package: patterns-server-enterprise-fips
@@ -6,8 +6,9 @@
 #          Installation check - verify the setup of FIPS installation
 #          ENV mode - selected by FIPS_ENV_MODE
 #          Global mode - setup fips=1 in kernel command line
+#
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#39071
+# Tags: poo#39071, poo#105591
 
 use strict;
 use warnings;
@@ -46,7 +47,7 @@ sub run {
     if (get_var("FIPS_ENV_MODE")) {
         die 'FIPS kernel mode is required for this test!' if check_var('SECURITY_TEST', 'crypt_kernel');
         zypper_call('in -t pattern fips');
-        foreach my $env ('OPENSSL_FIPS', 'OPENSSL_FORCE_FIPS_MODE', 'LIBGCRYPT_FORCE_FIPS_MODE', 'NSS_FIPS') {
+        foreach my $env ('OPENSSL_FIPS', 'OPENSSL_FORCE_FIPS_MODE', 'LIBGCRYPT_FORCE_FIPS_MODE', 'NSS_FIPS', 'GnuTLS_FORCE_FIPS_MODE') {
             assert_script_run "echo 'export $env=1' >> /etc/bash.bashrc";
         }
 


### PR DESCRIPTION
GnuTLS_FORCE_FIPS_MODE parameter is already supported and add into
fips_setup for the basic configuration for ENV mode.

- Related ticket: https://progress.opensuse.org/issues/105591
- Reference: https://confluence.suse.com/display/FIPS/GnuTLS+and+Libnettele+testing+in+FIPS+mode
- Verification run: http://openqa.suse.de/tests/8047844#step/fips_setup/17
