### PR TITLE
check_default_network_manager: JeOS is (so far) using wicked in all cases

### DIFF
--- a/tests/console/check_default_network_manager.pm
+++ b/tests/console/check_default_network_manager.pm
@@ -37,16 +37,16 @@ sub run {
     my $unexpected = 'wicked';
     my $reason = 'networking';
 
-    if (is_sle) {
+    if (is_jeos) {
+        $expected = 'wicked';
+        $unexpected = 'NetworkManager';
+        $reason = 'JeOS';
+    }
+    elsif (is_sle) {
         if (is_server) {
             $expected = 'wicked';
             $unexpected = 'NetworkManager';
             $reason = 'SLES';
-        }
-        elsif (is_jeos) {
-            $expected = 'wicked';
-            $unexpected = 'NetworkManager';
-            $reason = 'JeOS';
         }
         else {
             $reason = 'SLED';


### PR DESCRIPTION
JeOS firstboot would need some major rework before this can be toggled to
also use NetworkManager (or potentially systemd-networkd)

- Related ticket: https://progress.opensuse.org/issues/105298
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2162916
