### PR TITLE
lib/main_common: Don't run enable_usb_repo on JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1150,7 +1150,7 @@ sub load_consoletests {
     loadtest "console/check_system_info" if (is_sle && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
     # Enable installation repo from the usb, unless we boot from USB, but don't use it
     # for the installation, like in case of LiveCDs and when using http/smb/ftp mirror
-    if (check_var('USBBOOT', 1) && !is_livecd && !get_var('NETBOOT')) {
+    if (check_var('USBBOOT', 1) && !(is_jeos || is_livecd) && !get_var('NETBOOT')) {
         loadtest 'console/enable_usb_repo';
     }
 


### PR DESCRIPTION
There is no installation medium attached.

- Verification run: https://openqa.opensuse.org/tests/2162938