### PR TITLE
Implement SSH host key handling based on libyui

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -34,6 +34,7 @@ use Installation::Partitioner::LibstorageNG::v4_3::GuidedSetup::SelectHardDisksC
 use Installation::Partitioner::LibstorageNG::GuidedSetupController;
 use Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerController;
 use Installation::PerformingInstallation::PerformingInstallationController;
+use Installation::SSHKeyImport::SSHKeyImportController;
 use Installation::SystemProbing::EncryptedVolumeActivationController;
 use Installation::SystemRole::SystemRoleController;
 use Installation::Popups::OKPopupController;
@@ -186,6 +187,10 @@ sub get_dasd_disk_management {
 
 sub get_performing_installation {
     return Installation::PerformingInstallation::PerformingInstallationController->new();
+}
+
+sub get_ssh_import_settings {
+    return Installation::SSHKeyImport::SSHKeyImportController->new();
 }
 
 1;

--- a/lib/Installation/InstallationSettings/InstallationSettingsController.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsController.pm
@@ -47,6 +47,11 @@ sub access_booting_options {
     $self->get_installation_settings_page()->access_booting_options();
 }
 
+sub access_ssh_import_options {
+    my ($self) = @_;
+    $self->get_installation_settings_page()->access_ssh_import_options();
+}
+
 sub install {
     my ($self) = @_;
     $self->get_installation_settings_page()->press_install();

--- a/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
@@ -70,6 +70,11 @@ sub access_booting_options {
     $self->{txt_overview}->activate_link('bootloader_stuff');
 }
 
+sub access_ssh_import_options {
+    my ($self) = @_;
+    $self->{txt_overview}->activate_link('ssh_import');
+}
+
 sub press_install {
     my ($self) = @_;
     return $self->{btn_install}->click();

--- a/lib/Installation/SSHKeyImport/SSHKeyImportController.pm
+++ b/lib/Installation/SSHKeyImport/SSHKeyImportController.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces business actions for the
+#          Import SSH Host Keys ad Configruation page
+#          of the installer.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::SSHKeyImport::SSHKeyImportController;
+use strict;
+use warnings;
+use Installation::SSHKeyImport::SSHKeyImportPage;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{SSHImportPage} = Installation::SSHKeyImport::SSHKeyImportPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_ssh_import_page {
+    my ($self) = @_;
+    die "Import SSH Host Keys and Configuration page is not displayed" unless $self->{SSHImportPage}->is_shown();
+    return $self->{SSHImportPage};
+}
+
+sub enable_ssh_import {
+    my ($self) = @_;
+    return $self->get_ssh_import_page()->enable_ssh_import();
+}
+
+sub disable_ssh_import {
+    my ($self) = @_;
+    return $self->get_ssh_import_page()->disable_ssh_import();
+}
+
+sub accept {
+    my ($self) = @_;
+    return $self->get_ssh_import_page()->press_accept();
+}
+
+1;

--- a/lib/Installation/SSHKeyImport/SSHKeyImportPage.pm
+++ b/lib/Installation/SSHKeyImport/SSHKeyImportPage.pm
@@ -1,0 +1,54 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act on the
+#          Import SSH Host Keys and Configuration page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::SSHKeyImport::SSHKeyImportPage;
+use strict;
+use warnings;
+use YuiRestClient::Wait;
+use testapi 'save_screenshot';
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{cb_import} = $self->{app}->checkbox({id => 'import_ssh_key'});
+    $self->{cb_copy_config} = $self->{app}->checkbox({id => 'copy_config'});
+    $self->{btn_accept} = $self->{app}->button({id => 'accept'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    my $is_shown = $self->{cb_import}->exist();
+    save_screenshot if $is_shown;
+    return $is_shown;
+}
+
+sub enable_ssh_import {
+    my ($self) = @_;
+    return $self->{cb_import}->check();
+}
+
+sub disable_ssh_import {
+    my ($self) = @_;
+    return $self->{cb_import}->uncheck();
+}
+
+sub press_accept {
+    my ($self) = @_;
+    return $self->{btn_accept}->click();
+}
+
+1;

--- a/schedule/yast/ssh_keys/do_not_import_ssh_keys.yaml
+++ b/schedule/yast/ssh_keys/do_not_import_ssh_keys.yaml
@@ -1,0 +1,37 @@
+---
+name:           import_ssh_keys
+description:    >
+  Test import of SSH keys from previous installation
+vars:
+  SCC_REGISTER: 'none'
+  ADDONS: all-packages
+  YUI_REST_API: 1
+schedule:
+  - boot/boot_to_desktop
+  - x11/ssh_key_check
+  - x11/reboot_and_install
+  - installation/setup_libyui
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_module_desktop
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/hostname_inst
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/ssh_host_key_settings/do_not_import_ssh_host_keys
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - installation/ssh_host_key_settings/verify_ssh_key_not_imported
+  - shutdown/shutdown

--- a/schedule/yast/ssh_keys/import_ssh_keys.yaml
+++ b/schedule/yast/ssh_keys/import_ssh_keys.yaml
@@ -1,0 +1,37 @@
+---
+name:           import_ssh_keys
+description:    >
+  Test import of SSH keys from previous installation
+vars:
+  SCC_REGISTER: 'none'
+  ADDONS: all-packages
+  YUI_REST_API: 1
+schedule:
+  - boot/boot_to_desktop
+  - x11/ssh_key_check
+  - x11/reboot_and_install
+  - installation/setup_libyui
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_module_desktop
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/hostname_inst
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/ssh_host_key_settings/import_ssh_host_keys
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - installation/ssh_host_key_settings/verify_ssh_key_imported
+  - shutdown/shutdown

--- a/tests/installation/ssh_host_key_settings/do_not_import_ssh_host_keys.pm
+++ b/tests/installation/ssh_host_key_settings/do_not_import_ssh_host_keys.pm
@@ -1,0 +1,19 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Disable import SSH host keys
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    $testapi::distri->get_installation_settings()->access_ssh_import_options();
+    $testapi::distri->get_ssh_import_settings()->disable_ssh_import();
+    $testapi::distri->get_ssh_import_settings()->accept();
+}
+
+1;

--- a/tests/installation/ssh_host_key_settings/import_ssh_host_keys.pm
+++ b/tests/installation/ssh_host_key_settings/import_ssh_host_keys.pm
@@ -1,0 +1,19 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enable import SSH host keys
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    $testapi::distri->get_installation_settings()->access_ssh_import_options();
+    $testapi::distri->get_ssh_import_settings()->enable_ssh_import();
+    $testapi::distri->get_ssh_import_settings()->accept();
+}
+
+1;

--- a/tests/installation/ssh_host_key_settings/verify_ssh_key_imported.pm
+++ b/tests/installation/ssh_host_key_settings/verify_ssh_key_imported.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: verify that SSH host key got imported.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    x11_start_program('xterm -geometry 150x45+5+5', target_match => 'xterm');
+    become_root;
+    script_run 'cd /etc/ssh';
+    enter_cmd "cat /etc/ssh/ssh_host_key | tee /dev/$serialdev";
+    wait_serial "SSHHOSTKEYFILE", 5 || die "/etc/ssh/ssh_host_key content doesn't match";
+    enter_cmd "cat /etc/ssh/ssh_host_key.pub | tee /dev/$serialdev";
+    wait_serial "SSHHOSTPUBKEYFILE", 5 || die "/etc/ssh/ssh_host_key.pub content doesn't match";
+    script_run "md5sum * | tee /dev/$serialdev";
+    enter_cmd "killall xterm";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/installation/ssh_host_key_settings/verify_ssh_key_not_imported.pm
+++ b/tests/installation/ssh_host_key_settings/verify_ssh_key_not_imported.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: verify that SSH host key dit not got imported.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    x11_start_program('xterm -geometry 150x45+5+5', target_match => 'xterm');
+    become_root;
+    script_run 'cd /etc/ssh';
+    enter_cmd "cat /etc/ssh/ssh_host_key | tee /dev/$serialdev";
+    wait_serial "SSHHOSTKEYFILE", 5, 1 || die "/etc/ssh/ssh_host_key content does match";
+    enter_cmd "cat /etc/ssh/ssh_host_key.pub | tee /dev/$serialdev";
+    wait_serial "SSHHOSTPUBKEYFILE", 5, 1 || die "/etc/ssh/ssh_host_key.pub content does match";
+    script_run "md5sum * | tee /dev/$serialdev";
+    enter_cmd "killall xterm";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Testsuites are mirgrated from main.pm based execution to YAML based schedule.

- Related ticket: https://progress.opensuse.org/issues/102317
- Needles: not needed
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=rakoenig_ssh_keys&groupid=96