### PR TITLE
[virt_autotest] fix up die_on_timeout warning for s390x test

### DIFF
--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -108,7 +108,11 @@ sub run {
     my $self = shift;
     my $timeout = get_var('MAX_TEST_TIME', '36000') + 10;
     my $upload_log_name = 'guest-upgrade-logs';
-    script_run("echo \"Debug info: max_test_time is $timeout\"");
+    # Add new option die_on_timeout=>0 to adapt API script_run() new behavior change
+    # Refer to poo#105720 for more details
+    my %args = ();
+    $args{die_on_timeout} = 0;
+    script_run("echo \"Debug info: max_test_time is $timeout\"", %args);
     # Modify source configuration file sources.* of virtauto-data pkg on host
     # to use openqa daily build installer repo and module repo for guests,
     # and it will be copied into guests to be used during guest upgrade test
@@ -116,7 +120,7 @@ sub run {
 
     $self->{'package_name'} = 'Guest Upgrade Test';
     if (is_s390x) {
-        script_run "[ -d /var/log/qa/ctcs2 ] && rm -r /var/log/qa/ctcs2 ; [ -d /var/lib/libvirt/images/prj4_guest_upgrade ] && rm -r /var/lib/libvirt/images/prj4_guest_upgrade /tmp/full_guest_upgrade_test-* /tmp/kill_zypper_procs-* /tmp/update-guest-*";
+        script_run "[ -d /var/log/qa/ctcs2 ] && rm -r /var/log/qa/ctcs2 ; [ -d /var/lib/libvirt/images/prj4_guest_upgrade ] && rm -r /var/lib/libvirt/images/prj4_guest_upgrade /tmp/full_guest_upgrade_test-* /tmp/kill_zypper_procs-* /tmp/update-guest-*", %args;
     }
     else {
         $self->execute_script_run("[ -d /var/log/qa/ctcs2 ] && rm -r /var/log/qa/ctcs2 ; [ -d /tmp/prj4_guest_upgrade ] && rm -r /tmp/prj4_guest_upgrade", 30);
@@ -126,20 +130,24 @@ sub run {
     if (is_s390x) {
         #upload s390x_guest_upgrade_test.log
         upload_asset("/tmp/s390x_guest_upgrade_test.log", 1, 1);
-        script_run "rm -rf /tmp/s390x_guest_upgrade_test.log";
+        script_run "rm -rf /tmp/s390x_guest_upgrade_test.log", %args;
     }
 
 }
 
 sub post_fail_hook {
     my ($self) = @_;
+    # Add new option die_on_timeout=>0 to adapt API script_run() new behavior change
+    # Refer to poo#105720 for more details
+    my %args = ();
+    $args{die_on_timeout} = 0;
 
     $self->SUPER::post_fail_hook;
 
     if (is_s390x) {
         #upload s390x_guest_upgrade_test.log
         upload_asset("/tmp/s390x_guest_upgrade_test.log", 1, 1);
-        script_run "rm -rf /tmp/s390x_guest_upgrade_test.log";
+        script_run "rm -rf /tmp/s390x_guest_upgrade_test.log", %args;
     }
 }
 

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -61,9 +61,13 @@ sub run {
     #workaround of bsc#1177790
     #disable DNSSEC validation as it is turned on by default but the forwarders donnot support it, refer to bsc#1177790
     if (is_sle('>=12-sp5')) {
-        script_run "sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf";
-        script_run "grep 'dnssec-validation' /etc/named.conf";
-        script_run "systemctl restart named";
+        # Add new option die_on_timeout=>0 to adapt API script_run() new behavior change
+        # Refer to poo#105720 for more details
+        my %args = ();
+        $args{die_on_timeout} = 0;
+        script_run "sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf", %args;
+        script_run "grep 'dnssec-validation' /etc/named.conf", %args;
+        script_run "systemctl restart named", %args;
         save_screenshot;
     }
 

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -254,9 +254,13 @@ sub post_fail_hook {
 
     #FOR S390X LPAR
     if (is_s390x) {
+        # Add new option die_on_timeout=>0 to adapt API script_run() new behavior change
+        # Refer to poo#105720 for more details
+        my %args = ();
+        $args{die_on_timeout} = 0;
         #collect and upload supportconfig log from S390X LPAR
         upload_system_log::upload_supportconfig_log();
-        script_run "rm -rf scc_*";
+        script_run "rm -rf scc_*", %args;
         return;
     }
 


### PR DESCRIPTION
It is the enhancement PR. Try to keep the ole behavior - use with die_on_timeout => 0 during call API script_run() for s390x test.  
Refer to the latest OSD s390x tests, figure out some die_on_timeout warning due to call OSD Test API testapi::script_run() as below:
```
[2022-01-15T22:32:37.287745+01:00] [warn] !!! testapi::script_run: DEPRECATED call of script_run() in tests/virt_autotest/update_package.pm:64 add die_on_timeout => ? to the call or set
$distri->{script_run_die_on_timeout} to avoid this warning
[2021-12-31T03:22:25.020023+01:00] [warn] !!! testapi::script_run: DEPRECATED call of script_run() in tests/virt_autotest/update_package.pm:64 add die_on_timeout => ? to avoid this warning
```

According to the PR[#1807](https://github.com/os-autoinst/os-autoinst/pull/1807) testapi: Add die_on_timeout option to testapi::script::run().
Try to preserve the old behavior by adding a new argument - die_on_timeout => 0
Adjust to OpenQA API has added a new script_run() parameter(i.e die_on_timeout) to control how the function handles command timeout for OSD s390x tests

- Related ticket: https://progress.opensuse.org/issues/105720
- Verification run: 
s390x guest installation
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/8065510#)
[gi-guest_developing-on-host_sles15sp3-kvm](https://openqa.suse.de/tests/8065509#)
[gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.suse.de/tests/8065266#)
[gi-guest_sles12sp5-on-host_developing-kvm](https://openqa.suse.de/tests/8065511#)
[gi-guest_sles15sp3-on-host_developing-kvm](https://openqa.suse.de/tests/8065512#)
s390x guest upgrade
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](https://openqa.suse.de/tests/8065520#)
prj4_guest_upgrade_sles15sp3_on_sles15sp3-kvm
