### PR TITLE
ovs: Remove count as the ping is killed

### DIFF
--- a/lib/console/ovs_utils.pm
+++ b/lib/console/ovs_utils.pm
@@ -31,7 +31,7 @@ sub ping_check {
     my $client_ip = shift;
     my $vpn = shift;
     assert_script_run("cd");
-    assert_script_run "(ping -c 20 $vpn &>ping.log &)";
+    assert_script_run "(ping $vpn &>ping.log &)";
     if ($vpn eq "192.0.0.2") {
         assert_script_run("tcpdump -ni any net -c 20 $client_ip > check.log", 300);
         assert_script_run('cat check.log');

--- a/lib/console/ovs_utils.pm
+++ b/lib/console/ovs_utils.pm
@@ -33,13 +33,11 @@ sub ping_check {
     assert_script_run("cd");
     assert_script_run "(ping $vpn &>ping.log &)";
     if ($vpn eq "192.0.0.2") {
-        assert_script_run("tcpdump -ni any net -c 20 $client_ip > check.log", 300);
-        assert_script_run('cat check.log');
+        assert_script_run("tcpdump -ni any net -c 20 $client_ip | tee check.log", 300);
         assert_script_run("grep 'IP $server_ip > $client_ip: ESP' check.log");
     }
     else {
-        assert_script_run("tcpdump -ni any net -c 20 $server_ip > check.log", 300);
-        assert_script_run('cat check.log');
+        assert_script_run("tcpdump -ni any net -c 20 $server_ip | tee check.log", 300);
         assert_script_run("grep 'IP $client_ip > $server_ip: ESP' check.log");
     }
     assert_script_run("pkill ping");


### PR DESCRIPTION
It can happen ping is done sooner than 20 packets are collected and then will tcpdump fail

- Fail: https://dzedro.suse.cz/tests/20693#step/ovs_client/48
- Verification run: https://dzedro.suse.cz/tests/20696