### PR TITLE
Upload basic logs prior to the full problem detection logs

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -492,9 +492,8 @@ sub export_logs {
     save_screenshot;
     show_oom_info;
     $self->remount_tmp_if_ro;
-    $self->problem_detection;
-
     $self->export_logs_basic;
+    $self->problem_detection;
 
     # Just after the setup: let's see the network configuration
     $self->save_and_upload_log("ip addr show", "/tmp/ip-addr-show.log");


### PR DESCRIPTION
basic_logs contains loadavg - we want to get this 'as soon as possible'
to the point where the error actually occurred. If we get this only
after collecting all other logs, a few minutes have passed, which has
a great chance to make the numbers appear much lower than what is
interesting for us.
