### PR TITLE
Increase timeout for zypper ref

### DIFF
--- a/tests/console/cleanup_qam_testrepos.pm
+++ b/tests/console/cleanup_qam_testrepos.pm
@@ -30,7 +30,7 @@ sub get_repo_aliases() {
 
 sub run {
     my $self = shift;
-    return if (script_run('zypper -n ref') == 0);    # If all repos are OK we don't have to do anything
+    return if (script_retry('zypper -n ref', timeout => (is_public_cloud ? 1200 : 300), retry => 3, delay => 30) == 0); # If all repos are OK we don't have to do anything
     my $behav = get_var('QAM_TESTREPO_FAIL') // "fail";
     # Check all repositories if they are valid
     foreach my $repo (get_repo_aliases()) {


### PR DESCRIPTION
Increase the duration for zypper ref to avoid timeout issues and add two
retries to account for network issues.

- Related ticket: https://progress.opensuse.org/issues/105419
- Verification run: http://duck-norris.qam.suse.de/tests/8076#step/cleanup_qam_testrepos/6
