### PR TITLE
Zypper migration: make target regex more flexible

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -64,7 +64,7 @@ sub run {
         if ($out =~ $zypper_migration_target) {
             my $version = get_var("VERSION");
             $version =~ s/-/ /;
-            if ($out =~ /(\d+)\s+\|\s+SUSE Linux Enterprise.*?$version/m) {
+            if ($out =~ /(\d+)\s+\|\s?SUSE Linux Enterprise.*?$version/m) {
                 send_key "$1";
             }
             else {


### PR DESCRIPTION
In SLE Micro, recently the string has changed from

   `1 | SUSE Linux Enterprise ...`

to

   `1 |SUSE Linux Enterprise ...`

The regex expects a space between `|` and `SUSE`, so it fails in some
cases. This commit makes it more flexible, and it will work with
or without space.

- Related ticket: https://openqa.suse.de/tests/8075506
- Verification run: https://openqa.suse.de/tests/8075519#step/zypper_migration/1
