### PR TITLE
Public Cloud: Print cloud-regionsrv-client package version

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -176,6 +176,9 @@ sub wait_for_guestregister
     my $start_time = time();
     my $last_info = 0;
 
+    # Check what version of registercloudguest binary we use
+    $self->run_ssh_command(cmd => "sudo rpm -qa cloud-regionsrv-client", proceed_on_failure => 1);
+
     while (time() - $start_time < $args{timeout}) {
         my $out = $self->run_ssh_command(cmd => 'sudo systemctl is-active guestregister', proceed_on_failure => 1, quiet => 1);
         # guestregister is expected to be inactive because it runs only once

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -92,6 +92,9 @@ sub registercloudguest {
         $instance->run_ssh_command(cmd => "sudo zypper -q -n in $install_packages", timeout => 420);
         $instance->run_ssh_command(cmd => "sudo registercloudguest --clean");
     }
+    # Check what version of registercloudguest binary we use
+    $instance->run_ssh_command(cmd => "sudo rpm -qa cloud-regionsrv-client", proceed_on_failure => 1);
+    # Register the system
     $instance->retry_ssh_command(cmd => "sudo registercloudguest -r $regcode", timeout => 420, retry => 3);
 }
 


### PR DESCRIPTION
As `registercloudguest` program is key for public cloud but has no `--version` we fetch the version from the package.

- Verification run: http://pdostal-server.suse.cz/tests/13155#step/prepare_instance/89
