### PR TITLE
Schedule isosize only once per architecture in YaST

### DIFF
--- a/schedule/yast/autoyast/autoyast_ext4.yaml
+++ b/schedule/yast/autoyast/autoyast_ext4.yaml
@@ -10,7 +10,6 @@ vars:
   FILESYSTEM: ext4
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast/autoyast_gnome.yaml
+++ b/schedule/yast/autoyast/autoyast_gnome.yaml
@@ -9,7 +9,6 @@ vars:
   DESKTOP: gnome
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast/autoyast_installonly.yaml
+++ b/schedule/yast/autoyast/autoyast_installonly.yaml
@@ -8,7 +8,6 @@ vars:
   AUTOYAST_PREPARE_PROFILE: '1'
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast/autoyast_keyboard_layout.yaml
+++ b/schedule/yast/autoyast/autoyast_keyboard_layout.yaml
@@ -10,7 +10,6 @@ vars:
   INSTALL_KEYBOARD_LAYOUT: cz
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader
   - autoyast/installation
   - locale/keymap_or_locale

--- a/schedule/yast/autoyast_bcache.yaml
+++ b/schedule/yast/autoyast_bcache.yaml
@@ -11,7 +11,6 @@ vars:
   NUMDISKS: 2
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast_btrfs.yaml
+++ b/schedule/yast/autoyast_btrfs.yaml
@@ -11,7 +11,6 @@ vars:
   FILESYSTEM: btrfs
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast_disk_as_md_member.yaml
+++ b/schedule/yast/autoyast_disk_as_md_member.yaml
@@ -7,7 +7,6 @@ vars:
   AUTOYAST_CONFIRM: 1
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast_disk_as_pv.yaml
+++ b/schedule/yast/autoyast_disk_as_pv.yaml
@@ -10,7 +10,6 @@ vars:
   AUTOYAST_PREPARE_PROFILE: 1
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast_home_encrypted.yaml
+++ b/schedule/yast/autoyast_home_encrypted.yaml
@@ -4,7 +4,6 @@ description: |
   Gnome installation with separate /home partition encrypted
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - installation/boot_encrypt

--- a/schedule/yast/autoyast_invalid_default_target.yaml
+++ b/schedule/yast/autoyast_invalid_default_target.yaml
@@ -10,7 +10,6 @@ vars:
   AUTOYAST_PREPARE_PROFILE: 1
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -9,7 +9,6 @@ vars:
   QEMURAM: 2048
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - installation/boot_encrypt

--- a/schedule/yast/autoyast_nfs_share.yaml
+++ b/schedule/yast/autoyast_nfs_share.yaml
@@ -7,7 +7,6 @@ vars:
   DESKTOP: textmode
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - installation/first_boot

--- a/schedule/yast/autoyast_non_existing_graphical_target.yaml
+++ b/schedule/yast/autoyast_non_existing_graphical_target.yaml
@@ -15,7 +15,6 @@ vars:
   AUTOYAST_PREPARE_PROFILE: 1
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - console/verify_default_target

--- a/schedule/yast/autoyast_non_secure_boot.yaml
+++ b/schedule/yast/autoyast_non_secure_boot.yaml
@@ -8,7 +8,6 @@ vars:
   EXTRABOOTPARAMS: startshell=1
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - installation/verify_secure_boot_bios
   - autoyast/installation

--- a/schedule/yast/autoyast_resize_luks2.yaml
+++ b/schedule/yast/autoyast_resize_luks2.yaml
@@ -10,7 +10,6 @@ vars:
   EXTRABOOTPARAMS: startshell=1
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/pre_partitioning
   - autoyast/installation

--- a/schedule/yast/autoyast_salt_formulas.yaml
+++ b/schedule/yast/autoyast_salt_formulas.yaml
@@ -10,7 +10,6 @@ vars:
   SALT_FORMULAS_PATH: yast2/salt.tar.gz
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast_systemd_timesync.yaml
+++ b/schedule/yast/autoyast_systemd_timesync.yaml
@@ -8,7 +8,6 @@ vars:
   NTP_SERVER_ADDRESS: cz.pool.ntp.org
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
+++ b/schedule/yast/btrfs/btrfs_sle_libstorage-ng.yaml
@@ -6,8 +6,6 @@ vars:
   FILESYSTEM: btrfs
   YUI_REST_API: 1
 schedule:
-  # Called on BACKEND: qemu
-  - '{{isosize}}'
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
@@ -55,10 +53,6 @@ conditional_schedule:
         - console/hibernation_disabled
       x86_64:
         - console/hibernation_enabled
-  isosize:
-    BACKEND:
-      qemu:
-        - installation/isosize
   disk_activation:
     BACKEND:
       s390x:

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -12,7 +12,6 @@ vars:
   SCC_ADDONS: base,serverapp,desktop
   YUI_REST_API: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -5,7 +5,6 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -9,7 +9,6 @@ vars:
   NICTYPE: user
   YUI_REST_API: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution

--- a/schedule/yast/opensuse/autoyast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/opensuse/autoyast/autoyast_multi_btrfs.yaml
@@ -8,7 +8,6 @@ vars:
   NUMDISKS: '4'
 schedule:
   - autoyast/prepare_profile
-  - installation/isosize
   - installation/bootloader_start
   - autoyast/installation
   - installation/boot_encrypt

--- a/schedule/yast/opensuse/installer_extended/installer_extended.yaml
+++ b/schedule/yast/opensuse/installer_extended/installer_extended.yaml
@@ -6,6 +6,7 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
+  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - '{{access_beta_distribution}}'

--- a/schedule/yast/opensuse/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/opensuse/lvm/lvm_thin_provisioning.yaml
@@ -8,7 +8,6 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - '{{access_beta_distribution}}'

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -11,7 +11,6 @@ vars:
   EXTRABOOTPARAMS: startshell=1
   YUI_REST_API: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/validation/repo_inst
   - installation/setup_libyui

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -6,7 +6,6 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
@@ -6,7 +6,6 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution

--- a/schedule/yast/yast_hostname/yast_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname.yaml
@@ -7,7 +7,6 @@ vars:
   EXIT_AFTER_START_INSTALL: '1'
   YUI_REST_API: 1
 schedule:
-  - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution


### PR DESCRIPTION
This test module is scheduled everywhere only in Online medium, when the check should be done just once per architecture, i.e: https://openqa.suse.de/tests/7935989#step/isosize/1

This PR makes isosize to be running only once per architecture (left in installer_extended and xfs for xen machines).

- Related ticket: https://progress.opensuse.org/issues/104850
- Verification run: o3 to check that after it is added to installer_extended, hte test is still passing: https://openqa.opensuse.org/tests/2167209