### PR TITLE
JeOS: Leap15.4 & sle15sp4 confirm new config welcome screen

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -72,7 +72,7 @@ sub run {
     mouse_hide;
     # https://github.com/openSUSE/jeos-firstboot/pull/82 welcome dialog is shown on all consoles
     # and configuration continues on console where *Start* has been pressed
-    unless (is_leap('<=15.4') || is_sle('<=15-sp4')) {
+    unless (is_leap('<15.4') || is_sle('<15-sp4')) {
         assert_screen 'jeos-init-config-screen', 300;
         # Without this 'ret' sometimes won't get to the dialog
         wait_still_screen;


### PR DESCRIPTION
Follow up for
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14087

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/761
- Verification runs:
  * [opensuse-15.4-JeOS-for-kvm-and-xen-x86_64-Build5.70-jeos-filesystem@64bit_virtio-2G](http://kepler.suse.cz/tests/10656#step/firstrun/1)
  * [opensuse-15.4-JeOS-for-kvm-and-xen-x86_64-Build5.70-jeos@64bit_virtio-2G](http://kepler.suse.cz/tests/10657#step/firstrun/1)
