### PR TITLE
SLE Micro 5.1: soft fail bsc#1195060

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -228,6 +228,13 @@
         },
         "type": "bug"
     },
+    "bsc#1195060": {
+        "description": "Load kdump kernel (early on startup|and initrd)",
+        "products": {
+            "sle-micro": [ "5.1" ]
+        },
+        "type": "bug"
+    },
     "apci-bridge": {
         "description": "fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge|PCI: System does not support PCI",
         "products": {


### PR DESCRIPTION
Need to match the following strings:
`Failed to start Load kdump kernel early on startup`
`Failed to start Load kdump kernel and initrd`
`Load kdump kernel early on startup`
`Load kdump kernel and initrd`


Soft failure, because it blocks maintenance bot.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1195060
- VR: 