### PR TITLE
Use die_on_timeout=>0 in lib/sles4sap when required

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -300,7 +300,7 @@ sub prepare_profile {
 
     if ($has_saptune) {
         assert_script_run "saptune daemon start";
-        my $ret = script_run "saptune solution verify $profile";
+        my $ret = script_run("saptune solution verify $profile", die_on_timeout => 0);
         if (!defined $ret) {
             # Command timed out. 'saptune daemon start' could have caused the SUT to
             # move out of root-console, so select root-console and try again


### PR DESCRIPTION
PR #14027 introduces a change in `script_run()` that makes it fail whenever a timeout with the SUT occurs, modifying the previous behavior when the call would have returned `undef`. When the previous behavior is expected, the call must include `die_on_timeout => 0`. This PR fixes the one call to `script_run()` in `lib/sles4sap` that relies on an undef return value.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/4801#step/hana_install/27 & http://mango.qa.suse.de/tests/4803#step/netweaver_install/14
