### PR TITLE
Fix autofs test

### DIFF
--- a/lib/autofs_utils.pm
+++ b/lib/autofs_utils.pm
@@ -23,6 +23,7 @@ my $test_mount_dir = '/mnt/test_autofs_local';
 my $file_to_mount = '/tmp/test-iso.iso';
 my $test_conf_file_content = "iso -fstype=auto,ro :$file_to_mount";
 my $service_type = 'Systemd';
+my $autofs_sys_conf_file = '/etc/sysconfig/autofs';
 
 =head2 setup_autofs_server
 
@@ -42,6 +43,7 @@ sub setup_autofs_server {
     assert_script_run("grep '$args{test_conf_file}' $args{autofs_map_file}");
     assert_script_run("echo $args{test_conf_file_content} > $args{test_conf_file}", fail_message => "File $args{test_conf_file} could not be created");
     assert_script_run("grep '$args{test_conf_file_content}' $args{test_conf_file}");
+    assert_script_run(q{sed -i_bk 's|AUTOFS_OPTIONS=""|AUTOFS_OPTIONS="--debug"|' } . $autofs_sys_conf_file);
 }
 
 =head2 check_autofs_service

--- a/tests/network/autofs_server.pm
+++ b/tests/network/autofs_server.pm
@@ -50,6 +50,7 @@ sub run {
         zypper_call('modifyrepo -e 1');
         zypper_call('ref');
     }
+
     # autofs
     zypper_call('in nfs-kernel-server');
     assert_script_run "mkdir -p $test_share_dir";
@@ -60,10 +61,11 @@ sub run {
 
     # nfsidmap
     assert_script_run "echo N > /sys/module/nfsd/parameters/nfs4_disable_idmapping";
-    zypper_call('in nfsidmap');
+    is_opensuse ? zypper_call('in libnfsidmap1') : zypper_call('in nfsidmap');
     systemctl 'restart nfs-idmapd';
     assert_script_run "nfsidmap -c || true";
     assert_script_run "useradd -m tux";
+    assert_script_run "chmod -R 755 $nfsidmap_share_dir";
     assert_script_run "echo Hi tux > $nfsidmap_share_dir/tux.txt";
     assert_script_run "chown tux:users $nfsidmap_share_dir/tux.txt";
     assert_script_run "echo '/home/tux *(ro)' >> /etc/exports";
@@ -74,5 +76,4 @@ sub run {
     barrier_wait 'AUTOFS_SUITE_READY';
     barrier_wait 'AUTOFS_FINISHED';
 }
-
 1;


### PR DESCRIPTION
Parameter no_subtree_check in  autofs map file is resulting the error as 'unknown parameter', so avoid using the parameter and enabled debug log in autofs configuration. 

- Related ticket: https://progress.opensuse.org/issues/102251
- Needles: NO
- Verification run: 
> SLE15 SP4 : [autofs_server](http://10.161.229.147/tests/1891#step/autofs_server/1) | [autofs_client](http://10.161.229.147/tests/1892#step/autofs_client/1)
> SLE15 SP3 : [autofs_server](http://10.161.229.147/tests/1885#step/autofs_server/1) | [autofs_client](http://10.161.229.147/tests/1886#step/autofs_client/1)
> SLE15 SP2 : [autofs_server](http://10.161.229.147/tests/1893#step/autofs_server/1) | [autofs_client](http://10.161.229.147/tests/1894#step/autofs_client/1)
> SLE12 SP4 : [autofs_server](http://10.161.229.147/tests/1889#step/autofs_server/1) | [autofs_client](http://10.161.229.147/tests/1890#step/autofs_client/1)
> SLE12 SP3 : [autofs_server](http://10.161.229.147/tests/1887#step/autofs_server/1) | [autofs_client](http://10.161.229.147/tests/1888#step/autofs_client/1)
> Tumbleweed : [autofs_server](http://10.161.229.147/tests/1911#step/autofs_server/1) | [autofs_client](http://10.161.229.147/tests/1912#step/autofs_client/1)