### PR TITLE
Add wait_for_purge_kernels to avoid RPM lock

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 use testapi;
 use Utils::Architectures;
-use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key quit_packagekit script_retry);
+use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key quit_packagekit script_retry wait_for_purge_kernels);
 use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
@@ -832,6 +832,7 @@ sub scc_deregistration {
     if (is_sle('12-SP1+', get_var($args{version_variable}))) {
         # Need quit packagekit to ensure it won't block to de-register system via SUSEConnect.
         quit_packagekit;
+        wait_for_purge_kernels;
         assert_script_run('SUSEConnect --version');
         my $deregister_ret = script_run('SUSEConnect --de-register --debug > /tmp/SUSEConnect.debug 2>&1', 300);
         if (defined $deregister_ret and $deregister_ret == 104) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -47,6 +47,7 @@ our @EXPORT = qw(
   set_bridged_networking
   assert_screen_with_soft_timeout
   quit_packagekit
+  wait_for_purge_kernels
   systemctl
   addon_decline_license
   addon_license
@@ -974,6 +975,18 @@ This is needed to prevent access conflicts to the RPM database.
 =cut
 sub quit_packagekit {
     script_run("systemctl mask packagekit; systemctl stop packagekit; while pgrep packagekitd; do sleep 1; done");
+}
+
+=head2 wait_for_purge_kernels
+
+ wait_for_purge_kernels();
+
+Wait until purge-kernels is done
+Prevent RPM lock e.g. SUSEConnect fail
+
+=cut
+sub wait_for_purge_kernels {
+    script_run('while pgrep purge-kernels; do sleep 1; done');
 }
 
 =head2 addon_decline_license


### PR DESCRIPTION
Wait for purge-kernels to finish

- Related ticket: https://progress.opensuse.org/issues/103956 https://bugzilla.suse.com/show_bug.cgi?id=1194693
- Verification run:
https://dzedro.suse.cz/tests/20749#step/register_without_ltss/4
https://openqa.suse.de/tests/8082962
https://openqa.suse.de/tests/8082959