### PR TITLE
Upload cloudregister log also when service did not start

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -206,6 +206,7 @@ sub wait_for_guestregister
         }
         sleep 1;
     }
+    $self->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
     die('guestregister didn\'t end in expected timeout=' . $args{timeout});
 }
 


### PR DESCRIPTION
It can happen that the `guestregister.service` should start but will not.
In that case we also need to upload the `cloudregister` log.

- Related ticket: [poo#105810](https://progress.opensuse.org/issues/105810)
- Error: https://openqa.suse.de/tests/8078024#step/run_ltp/365
- Verification run: http://pdostal-server.suse.cz/tests/13176
