### PR TITLE
PoC for enhanced YAML scheduler

### DIFF
--- a/lib/scheduler2.pm
+++ b/lib/scheduler2.pm
@@ -1,0 +1,37 @@
+#! /usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use File::Basename;
+use YAML::PP;
+use YAML::PP::Schema::Include;
+use YAML::PP::Common 'PRESERVE_ORDER';
+
+my $root_project_dir = dirname(__FILE__) . '/../';
+my $include = YAML::PP::Schema::Include->new(paths => ($root_project_dir));
+my $ypp = YAML::PP->new(
+    schema => ['Core', $include, 'Merge'],
+    preserve => PRESERVE_ORDER
+);
+$include->yp($ypp);
+
+my $YAML_SCHEDULE_DEFAULTS = 'schedule/yast2/defaults/sle-15-sp4-x86_64-svirt-xen-pv.yaml';
+my $YAML_SCHEDULE_BASE_ON = 'guided+gnome+part_val';
+my $YAML_SCHEDULE = 'schedule/yast2/ext4.yaml';
+
+my $schedule_defaults = $ypp->load_file($root_project_dir . $YAML_SCHEDULE_DEFAULTS);
+my $base_on = $schedule_defaults->{$YAML_SCHEDULE_BASE_ON};
+my $schedule = $ypp->load_file($root_project_dir . $YAML_SCHEDULE);
+
+my @overriden_schedule = ();
+for my $k (keys %$base_on) {
+    if (exists $schedule->{schedule}{$k}) {
+        push @overriden_schedule, $schedule->{schedule}{$k}->@*;
+    }
+    else {
+        push @overriden_schedule, $base_on->{$k}->@*;
+    }
+}
+print $ypp->dump_string(\@overriden_schedule);
+

--- a/schedule/yast2/btrfs.yaml
+++ b/schedule/yast2/btrfs.yaml
@@ -1,0 +1,8 @@
+name:           btrfs
+description:    >
+  Validate default installation with btrfs and libstorage-ng.
+vars:
+  # DESKTOP: gnome
+  FILESYSTEM: btrfs
+  YUI_REST_API: 1
+schedule:

--- a/schedule/yast2/defaults/opensuse.yaml
+++ b/schedule/yast2/defaults/opensuse.yaml
@@ -1,0 +1,106 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  disable_online_repos: &disable_online_repos
+  - installation/online_repos/disable_online_repos
+  installation_mode: &installation_mode
+  - installation/installation_mode
+  logpackages: &logpackages
+  - installation/logpackages
+  system_role: &system_role []
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout  
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  install: &install 
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  grub: &handle_reboot
+  - installation/handle_reboot
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  license_agreement: *license_agreement
+  disable_online_repos: *disable_online_repos
+  installation_mode: *installation_mode
+  logpackages: *logpackages
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_booting: *installation_settings_booting
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  grub: *handle_reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+gnome: &guided+gnome
+  <<: *guided
+  system_role:
+  - installation/system_role/select_role_desktop_with_GNOME
+
+guided+kde: &guided+kde
+  <<: *guided
+  system_role:
+  - installation/system_role/select_role_desktop_with_KDE_plasma
+
+guided+server: &guided+server
+  <<: *guided
+  system_role:
+  - installation/system_role/select_role_server
+
+guided+gnome+no_autologin: &guided+gnome+no_autologin
+  <<: *guided+gnome
+  local_user: 
+  - installation/authentication/disable_autologin
+
+# validation
+guided+gnome+no_autologin+part_val:
+  <<: *guided+gnome+no_autologin
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space
+  - console/validate_read_write
+
+guided+server+part_val:
+  <<: *guided+server
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space
+  - console/validate_read_write
+
+guided+kde+btrfs_val:
+  <<: *guided+kde
+  system_validation:
+  - console/validate_no_cow_attribute
+  - console/verify_no_separate_home
+  - console/validate_subvolumes

--- a/schedule/yast2/defaults/sle-15-sp4-aarch64.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-aarch64.yaml
@@ -1,0 +1,95 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  grub: &handle_reboot
+  - installation/handle_reboot
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_booting: *installation_settings_booting
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  grub: *handle_reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+gnome: &guided+gnome
+  <<: *guided
+  extension_and_module_selection:
+  - installation/module_registration/register_module_desktop
+  system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+
+# validations
+guided+gnome+part_val:
+  <<: *guided+gnome
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space
+
+guided+gnome+btrfs_val:
+  <<: *guided+gnome
+  system_validation:
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/hibernation_disabled
+  - console/validate_product_installed_SLES
+  - console/validate_no_cow_attribute
+  - console/verify_separate_home
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices

--- a/schedule/yast2/defaults/sle-15-sp4-ppc64le-pvm.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-ppc64le-pvm.yaml
@@ -1,0 +1,92 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_plymouth
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  installation_settings_security: &installation_settings_security
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  grub: &handle_reboot
+  - installation/handle_reboot
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_booting: *installation_settings_booting
+  installation_settings_security: *installation_settings_security
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  grub: *handle_reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+part_val:
+  <<: *guided
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space
+  - console/validate_read_write
+
+guided+btrfs_val:
+  <<: *guided
+  system_validation:
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/hibernation_disabled
+  - console/validate_product_installed_SLES
+  - console/verify_separate_home
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices

--- a/schedule/yast2/defaults/sle-15-sp4-ppc64le-qemu.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-ppc64le-qemu.yaml
@@ -1,0 +1,95 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  grub: &handle_reboot
+  - installation/handle_reboot
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_booting: *installation_settings_booting
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  grub: *handle_reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+gnome: &guided+gnome
+  <<: *guided
+  extension_and_module_selection:
+  - installation/module_registration/register_module_desktop
+  system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+
+# validations
+guided+gnome+part_val:
+  <<: *guided+gnome
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space   
+
+guided+gnome+btrfs_val:
+  <<: *guided+gnome
+  system_validation:
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/hibernation_disabled
+  - console/validate_product_installed_SLES
+  - console/validate_no_cow_attribute
+  - console/verify_separate_home
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices

--- a/schedule/yast2/defaults/sle-15-sp4-s390x-zkvm.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-s390x-zkvm.yaml
@@ -1,0 +1,101 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  installation_settings_security: &installation_settings_security
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  grub: &handle_reboot
+  - installation/handle_reboot
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_booting: *installation_settings_booting
+  installation_settings_security: *installation_settings_security
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  grub: *handle_reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+gnome: &guided+gnome
+  <<: *guided
+  extension_and_module_selection:
+  - installation/module_registration/register_module_desktop
+  system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+
+# validations
+guided+gnome+part_val:
+  <<: *guided+gnome
+  system_validation:
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space
+  - console/validate_read_write
+
+guided+gnome+btrfs_val:
+  <<: *guided+gnome
+  system_validation:
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/hibernation_disabled
+  - console/validate_product_installed_SLES
+  - console/validate_no_cow_attribute
+  - console/verify_separate_home
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices

--- a/schedule/yast2/defaults/sle-15-sp4-s390x-zvm.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-s390x-zvm.yaml
@@ -1,0 +1,100 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  disk_activation: &disk_activation
+  - installation/disk_activation/select_configure_dasd_disks
+  - installation/disk_activation/configure_dasd
+  - installation/disk_activation/finish_disk_activation
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  installation_settings_security: &installation_settings_security
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  - installation/handle_reboot  
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  disk_activation: *disk_activation
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_booting: *installation_settings_booting
+  installation_settings_security: *installation_settings_security
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+# validation
+guided+gnome: &guided+gnome
+  <<: *guided
+  extension_and_module_selection:
+  - installation/module_registration/register_module_desktop
+  system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  
+guided+part_val:
+  <<: *guided
+  system_validation:
+  - console/validate_partition_table_via_parted
+  - console/validate_blockdevices
+
+guided+gnome+btrfs_val:
+  <<: *guided+gnome
+  system_validation:
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/hibernation_disabled
+  - console/validate_product_installed_SLES
+  - console/validate_no_cow_attribute
+  - console/verify_no_separate_home

--- a/schedule/yast2/defaults/sle-15-sp4-x86_64-ipmi.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-x86_64-ipmi.yaml
@@ -1,0 +1,96 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_software: &installation_settings_software
+  - installation/installation_settings/validate_default_target
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  grub: &handle_reboot
+  - installation/handle_reboot
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks:
+  - installation/partitioning/guided_setup/select_disks
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_software: *installation_settings_software
+  installation_settings_booting: *installation_settings_booting
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  grub: *handle_reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+gnome: &guided+gnome
+  <<: *guided
+  extension_and_module_selection:
+  - installation/module_registration/register_module_desktop
+  system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+
+guided+gnome+part_val:
+  <<: *guided+gnome
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space   
+
+guided+gnome+btrfs_val:
+  <<: *guided+gnome
+  system_validation:
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/hibernation_enabled
+  - console/validate_product_installed_SLES
+  - console/validate_no_cow_attribute
+  - console/verify_separate_home

--- a/schedule/yast2/defaults/sle-15-sp4-x86_64-qemu.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-x86_64-qemu.yaml
@@ -1,0 +1,98 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_software: &installation_settings_software
+  - installation/installation_settings/validate_default_target
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  grub: &handle_reboot
+  - installation/handle_reboot
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_software: *installation_settings_software
+  installation_settings_booting: *installation_settings_booting
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  grub: *handle_reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+gnome: &guided+gnome
+  <<: *guided
+  extension_and_module_selection:
+  - installation/module_registration/register_module_desktop
+  system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+
+# validations
+guided+gnome+part_val:
+  <<: *guided+gnome
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space   
+
+guided+gnome+btrfs_val:
+  <<: *guided+gnome
+  system_validation:
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - console/hibernation_enabled
+  - console/validate_product_installed_SLES
+  - console/validate_no_cow_attribute
+  - console/verify_separate_home
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices

--- a/schedule/yast2/defaults/sle-15-sp4-x86_64-svirt-xen-hvm.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-x86_64-svirt-xen-hvm.yaml
@@ -1,0 +1,87 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+    - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_booting: &installation_settings_booting
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  installation_settings_security: &installation_settings_security
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port  
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  grub: &handle_reboot
+  - installation/handle_reboot
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_booting: *installation_settings_booting
+  installation_settings_security: *installation_settings_security
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  grub: *handle_reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+gnome: &guided+gnome
+  <<: *guided
+  extension_and_module_selection:
+  - installation/module_registration/register_module_desktop
+  system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+
+guided+gnome+part_val:
+  <<: *guided+gnome
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space
+  - console/validate_read_write

--- a/schedule/yast2/defaults/sle-15-sp4-x86_64-svirt-xen-pv.yaml
+++ b/schedule/yast2/defaults/sle-15-sp4-x86_64-svirt-xen-pv.yaml
@@ -1,0 +1,82 @@
+---
+default: &default
+  bootloader: &bootloader
+  - installation/bootloader_start
+  setup_libyui: &setup_libyui
+  - installation/setup_libyui
+  product_selection: &product_selection
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  license_agreement: &license_agreement
+  - installation/licensing/accept_license
+  registration: &registration
+  - installation/registration/register_via_scc
+  extension_and_module_selection: &extension_and_module_selection
+  - installation/module_registration/skip_module_registration.pm
+  add_on_product: &add_on_product
+  - installation/add_on_product/skip_install_addons
+  system_role: &system_role
+  - installation/system_role/accept_selected_role_text_mode
+  accept_proposed_layout: &accept_proposed_layout
+  - installation/partitioning/accept_proposed_layout
+  clock_and_timezone: &clock_and_timezone
+  - installation/clock_and_timezone/accept_timezone_configuration
+  local_user: &local_user
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  installation_settings_security: &installation_settings_security
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+  install: &install
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
+  install_logs: &install_logs
+  - installation/logs_from_installation_system
+  reboot: &reboot
+  - installation/reboot_after_installation
+  first_login: &first_login
+  - installation/first_boot
+  system_validation: &system_validation []
+
+guided: &guided
+  bootloader: *bootloader
+  setup_libyui: *setup_libyui
+  product_selection: *product_selection
+  license_agreement: *license_agreement
+  registration: *registration
+  extension_and_module_selection: *extension_and_module_selection
+  add_on_product: *add_on_product
+  system_role: *system_role
+  select_guided_setup:
+  - installation/partitioning/select_guided_setup
+  select_hard_disks: []
+  partitioning_scheme:
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  filesystem_options:
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  accept_proposed_layout: *accept_proposed_layout
+  clock_and_timezone: *clock_and_timezone
+  local_user: *local_user
+  installation_settings_security: *installation_settings_security
+  install: *install
+  install_logs: *install_logs
+  reboot: *reboot
+  first_login: *first_login
+  system_validation: *system_validation
+
+guided+gnome: &guided+gnome
+  <<: *guided
+  extension_and_module_selection:
+  - installation/module_registration/register_module_desktop
+  system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+
+guided+gnome+part_val:
+  <<: *guided+gnome
+  system_validation: 
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/validate_free_space
+  - console/validate_read_write  

--- a/schedule/yast2/ext4.yaml
+++ b/schedule/yast2/ext4.yaml
@@ -1,0 +1,15 @@
+---
+name:           ext4
+description:    >
+  Test for ext4 filesystem.
+vars:
+  # DESKTOP: gnome
+  YUI_REST_API: 1
+schedule:
+  filesystem_options:
+  - installation/partitioning/guided_setup/select_filesystem_option_ext4
+test_data:
+  guided_partitioning:
+    filesystem_options:
+      root_filesystem_type: ext4
+  <<: !include test_data/yast/ext4/ext4_no_separate_home.yaml


### PR DESCRIPTION
- Related ticket: [poo#105043](https://progress.opensuse.org/issues/105043)

### Motivation
- Main motivation is to improve the maintenance and scalability of test suite, for example if we search for some module frequently used in installation in `/schedule/yast/` we can easily find 150 hits. It should be better to have one single place where to make a modification.
 In YaST group in openQA we have introduced more granularity in our test, which allow us and anyone to dissect better the problem in case of failures (no more modules doing conditions and behaving differently depending on env variables) but the costs of that is to have different steps during installation, therefore it means more schedules files and more repetition as well.
- Explore the possibility to have only one schedule per test suite (Factory First approach). `main.pm` offered the possibility to do that somehow, it broke tests from other teams and introduce too many conditional logic to schedule a test, but it didn't have that separation between openSUSE and SLE. When a better solution was introduced, current yaml scheduler mechanism, despite teams efforts to cover openSUSE as much as possible, the schedules would differ so much that there has been a split in files and in logic. The idea is simple, try to test the same among products but still be flexible and allow some differences.

### Composition
This Proof of Concept consists of:
- 1 executable file `scheduler2` which you can run in your machine and try things out on your own.
- 2 schedules migrated to new mechanism, btrfs and ext4, which they are selected due to they are multi-architecture, multiproduct and even run in text mode and graphical mode, to make things more interesting.
- 1 base file per each combination of distri,version,architecture,virtualization, etc. following the structure in job group yaml.
- [MR for Job group](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/392) to see a draft of the integration.

### Description
Each test suite is configure in Job group yaml, avoiding to have any sort of conditions in yaml schedules, why to move that complexity there when was already in Job group yaml? In that way all the path are in sync and we don't have to update for example that something change per architecture in both sides. We will just have a file with a name reflecting exact environment, so we can set it like this for a given test suite, for instance: `YAML_SCHEDULE_DEFAULTS=schedule/yast2/defaults/sle-15-sp4-aarch64.yaml`

Each environment file contains some combinations of flows represented by keys, for example `default` is equivalent to go next, next, next, etc. in corresponding architecture, accepting all the defaults. `guided` represents the same default plus the default flow that we do if entering in the guided setup, meaning by default we install btrfs. If gnome is needed `guided+gnome` would be a combination of both. In order to point to an specific flow (or hash in that file) we will use `YAML_SCHEDULE_BASE_ON` on Job group yaml.

Once we have our base flow for our environment we just need to override some steps in a schedule file to represent what is really specific and unique of our test suite. We will point to this file with existing setting `YAML_SCHEDULE`.

For some test suite, for example in powerVM we know that is different and we never set a desktop, so selecting a different `YAML_SCHEDULE_BASE_ON` allows us to still have the same test suite.
Same idea for having a test suite in text mode, this mode as we test it is not default, needs to be set at the beginning  and changes some defaults like autologin, but with this setting we can modify that behavior.

For validations, ideally we would expect unique validations for those unique steps in the test suite, for example, if the only step different in one test suite is that ext4 is set as filesystem, the only validation required would be to check that filesystem after installation. Right now there is a big mess, where we have been reusing test suite that are multi architecture to put very different test modules to check different things. Therefore this validations should not be part of this environment variables and should be moved to some default test suites, but for now it could remain there as different flows.

### Further details
`PRESERVE_ORDER` is a nice `YAML::PP` feature which allows to keep the order of the keys without the need sequences of maps, because having just maps makes things easier as we have merge maps `<<:` . In general the whole idea is base on using YAML:PP as much as possible so the processing of the schedule programmatically is easier later.

YAML anchors and references ( `&` and `*`) do not work among different files by YAML specification, so when reusing parts in the environment files we can only use them locally in those files, if we use `!include` even with or without `<<:` those cannot be accessed. For that reason might be still some repetition among environment files.

There are two ways (or technical ways with YAML) to create flows in and environment file:
 - By Overriding, when the steps from which we want to override are the same and we just need to change one more steps which could be closed together or in any part of the schedule, for example, when we want gnome in sle we need two insertion, one for registering the module and another for selecting the system role gnome (only available after registering that module).
 - By composition: This happen when you need more granularity and inside one existing steps the flow is different. Of course in this case there is the possibility to have a different test (there is not need to force to have one test if makes things easier to have more than one). Another option is to use all the anchors from some other flow (hash key inside an env file), reference them and add those extra steps. A good example is when in ipmi for guided partitioning we have an extra screen to select disk. With this way we still don't need to change the test itself.
 In this case the test is empty because the flow itself is a default, we could call it a default guided partitioning. I wanted to probe that one test is possible but it might be strange to have an empty test. On the other hand, the env file can be configure in openQA to be displayed with a link and once tester get used to go `by configuration` it shouldn't be that surprising.
 
I pointed this settings in the schedule script to all the possibilities you can see in the merge request and it returns a list which corresponds with the schedules in OSD and O3 (I think I only exclude one test, validate default target which should be in some default test suite instead but the rest is the same):
```
my $YAML_SCHEDULE_DEFAULTS
my $YAML_SCHEDULE_BASE_ON
my $YAML_SCHEDULE
```
Now it is your time to have some fun trying :) and provide some feedback.
 
 




