### PR TITLE
Check partitioning summary using Mojo::DOM

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/SuggestedPartitioningController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/SuggestedPartitioningController.pm
@@ -37,4 +37,9 @@ sub select_guided_setup {
     return $self->get_suggested_partitioning_page()->select_guided_setup();
 }
 
+sub get_partitioning_changes_summary {
+    my ($self) = @_;
+    return $self->get_suggested_partitioning_page()->get_text_summary();
+}
+
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/SuggestedPartitioningPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/SuggestedPartitioningPage.pm
@@ -21,14 +21,19 @@ sub new {
 
 sub init {
     my $self = shift;
-    $self->{summary} = $self->{app}->richtext({id => 'summary'});
+    $self->{rtx_summary} = $self->{app}->richtext({id => 'summary'});
     $self->{btn_guided_setup} = $self->{app}->button({id => 'guided'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{summary}->exist();
+    return $self->{rtx_summary}->exist();
+}
+
+sub get_text_summary() {
+    my ($self) = @_;
+    return $self->{rtx_summary}->text();
 }
 
 sub select_guided_setup {

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -17,7 +17,7 @@ schedule:
   - installation/system_probing/activate_encrypted_volume
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/encrypt_lvm_reuse_existing
+  - installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/import_users
@@ -31,3 +31,10 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+test_data:
+  partitioning_deletion_entries:
+    - 'Delete btrfs on /dev/system/root'
+    - 'Delete swap on /dev/system/swap'
+    - 'Delete xfs on /dev/system/home'
+    - 'Delete volume group system'
+    - 'Delete partition'

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -21,7 +21,7 @@ schedule:
   - installation/system_probing/activate_encrypted_volume
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/encrypt_lvm_reuse_existing
+  - installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/import_users
@@ -37,3 +37,5 @@ schedule:
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_user_login_textmode
+test_data:
+  <<: !include test_data/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml

--- a/schedule/yast/encryption/activate_encrypted_volume.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume.yaml
@@ -17,7 +17,7 @@ schedule:
   - console/validate_encrypted_volume_activation
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/encrypt_lvm_reuse_existing
+  - installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root

--- a/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume_spvm.yaml
@@ -20,7 +20,7 @@ schedule:
   - console/validate_encrypted_volume_activation
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/encrypt_lvm_reuse_existing
+  - installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted
   - installation/partitioning/accept_proposed_layout
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
@@ -45,3 +45,6 @@ test_data:
       cipher: 'aes-xts-plain64'
       key_location: 'dm-crypt'
       mode: 'read/write'
+  partitioning_deletion_entries:
+    - 'Delete partition'
+    - 'Delete GPT'

--- a/test_data/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/test_data/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -1,0 +1,3 @@
+partitioning_deletion_entries:
+  - 'Delete partition'
+  - 'Delete GPT'

--- a/test_data/yast/encryption/activate_encrypted_volume.yaml
+++ b/test_data/yast/encryption/activate_encrypted_volume.yaml
@@ -6,3 +6,9 @@ device_status:
     cipher: 'aes-xts-plain64'
     key_location: 'dm-crypt'
     mode: 'read/write'
+partitioning_deletion_entries:
+  - 'Delete btrfs on /dev/system/root'
+  - 'Delete swap on /dev/system/swap'
+  - 'Delete xfs on /dev/system/home'
+  - 'Delete volume group system'
+  - 'Delete partition'

--- a/tests/installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted.pm
+++ b/tests/installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The test module reuses the partition that was created with LVM on
+# previous installation and verifies that the encrypted partition and the
+# relevant mount points are marked for deletion in the partitioning list.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings;
+use Test::Assert qw(assert_matches);
+use List::MoreUtils qw(pairwise);
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my $test_data = get_test_suite_data();
+    my @expected_strings = @{$test_data->{partitioning_deletion_entries}};
+
+    my $partitioner = $testapi::distri->get_suggested_partitioning();
+    my $text = $partitioner->get_partitioning_changes_summary();
+    my @deletion_entries = Mojo::DOM->new($text)->find('b')->map('text')->each;
+
+    if (scalar @deletion_entries ne scalar @expected_strings) {
+        die "Number of partitioning deletion entries do not match the provided test data.";
+    }
+
+    pairwise {
+        assert_matches(qr/$a/, $b, "Expected entry /$a/ not found in suggested partitioner's deletion entry $b");
+    } @expected_strings, @deletion_entries;
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;


### PR DESCRIPTION
Until now the partitioning summary was tested using a needle, in order to check that all mount points of the encrypted disk partition of the previous installation were deleted.
This check is now done by parsing the partitioning summary using Mojo::DOM

- Related ticket: https://progress.opensuse.org/issues/102131
- Needles: No needles
- Verification runs: https://openqa.suse.de/tests/overview?build=ge0r%2Fos-autoinst-distri-opensuse%23parse_volumes&distri=sle&version=15-SP4
