### PR TITLE
Public Cloud: run_ltp.pm Use zypper -n and remove -q and -y

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -117,8 +117,8 @@ sub run {
         $instance->run_ssh_command(cmd => 'sudo zypper --no-gpg-checks --gpg-auto-import-keys -q in -y ' . $remote_rpm_path, timeout => 600);
     }
     else {
-        $instance->run_ssh_command(cmd => 'sudo zypper -q addrepo -fG ' . $ltp_repo . ' ltp_repo', timeout => 600);
-        $instance->run_ssh_command(cmd => 'sudo zypper -q in -y ltp', timeout => 600);
+        $instance->run_ssh_command(cmd => 'sudo zypper -n addrepo -fG ' . $ltp_repo . ' ltp_repo', timeout => 600);
+        $instance->run_ssh_command(cmd => 'sudo zypper -n in ltp', timeout => 600);
     }
 
     download_whitelist();


### PR DESCRIPTION
We need the `zypper` output - that's why I remove the `-q` parameter.
It is also preferable to use `-n` global parameter in scripts then `in -y`.

- Verification run: [Failed](http://pdostal-server.suse.cz/tests/13181) (Not related to this PR), [Passed](http://pdostal-server.suse.cz/tests/13191)
