### PR TITLE
lib/repo_tools: Use new repo name convention for Leap 15.4+

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -462,7 +462,9 @@ sub generate_version {
     my $dist = get_required_var('DISTRI');
     my $version = get_required_var('VERSION');
     $separator //= '_';
-    if (is_sle) {
+    if (is_leap(">=15.4")) {
+        return $version;
+    } elsif (is_sle) {
         $dist = 'SLE';
         $version =~ s/-/$separator/;
     } elsif (is_tumbleweed) {


### PR DESCRIPTION
Since 15.3+, the new convention (and default in OBS) is to just use the version
number to indicate that it's usable for both Leap and SLE.

Currently used by:
* https://download.opensuse.org/repositories/home:/asmorodskyi/
* http://download.opensuse.org/repositories/benchmark:/ltp:/devel/