### PR TITLE
Substitute SAP repo to LTSS

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -95,6 +95,8 @@ sub run {
     # Extract module name from repo url.
     my @modules = split(/,/, $repos);
     foreach (@modules) {
+        # substitue SLES_SAP for LTSS repo at this point is SAP ESPOS
+        $_ =~ s/SAP_(\d+(-SP\d)?)/$1-LTSS/;
         next if s{http.*SUSE_Updates_(.*)/?}{$1};
         die 'Modules regex failed. Modules could not be extracted from repos variable.';
     }


### PR DESCRIPTION
SAP is ESPOS so updates are going into Update LTSS repo
e.g. SLES_SAP_15_x86_64 -> SLES_15-LTSS_x86_64

- Related ticket: https://progress.opensuse.org/issues/105843
- Verification run:
https://openqa.suse.de/tests/8090946 15 SP1 x86_64
https://openqa.suse.de/tests/8090945 15 SP1 ppc64le
https://openqa.suse.de/tests/8090951 15 x86_64
