### PR TITLE
nvme_checks: Do not use 'nmve show-regs' in smoke-test scenario

### DIFF
--- a/tests/console/nvme_checks.pm
+++ b/tests/console/nvme_checks.pm
@@ -56,9 +56,6 @@ sub _exercise_nvme_commands_and_validate_output {
     # lbads = LBA Data Size, in terms of a power of two, so LBA data size is 2⁹ = 512 bytes
     # rp = Relative Performance, the lower the better
     validate_script_output("nvme id-ns /dev/$nvm_test_data->{nvm_disk} --namespace-id=$nvm_test_data->{nvm_ns}", sub { m/lbaf\s+0\s+:\s+ms:0\s+lbads:9\s+rp:0\s\(in use\)/ });
-    # show registers
-    my $ret_code = script_run("nvme show-regs -H /dev/$nvm_test_data->{nvm_disk}");
-    record_info "bsc#1175217 - not permitted shared memory access to get registers" if ($ret_code > 0);
 }
 
 sub _issue_read_command_and_compare_with_dd {


### PR DESCRIPTION
'nvme show-regs' accesses the raw registers via mapping IO space to
userspace. Today most distros enable CONFIG_IO_STRICT_DEVMEM which
prevents this operation. This can be overwritten by the kernel command
line option 'iomem=relaxed'. But this is not recommended for
production systems.

Hence using 'nvme show-regs' in a smoke-test for production images is
not particular useful. There are other nvme-cli commands which qualify
for smoke-tests but not this one. Remove it.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

