### PR TITLE
Fix yast2_lan_restart for SLE 15 SP1

### DIFF
--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -85,7 +85,7 @@ sub change_hw_device_name {
 sub run {
     initialize_y2lan;
     verify_network_configuration;    # check simple access to Overview tab
-    my $service_status_after_conf = (is_sle('<=15')) ? 'no_restart_or_reload' : 'reload';
+    my $service_status_after_conf = (is_sle('<=15-SP1')) ? 'no_restart_or_reload' : 'reload';
     if ($backend eq "svirt") {
         verify_network_configuration(\&check_network_settings_tabs, $service_status_after_conf);
     }


### PR DESCRIPTION
The test is used in maintenance job group and was false positive before
the build 20220122-1.

The test expected that the network will be reloaded which is incorrect,
as NO changes were made in the config.

This commit updates the test to expect that no reload or restart of
network is happened as this seems to be fixed by the update.

- Related ticket: https://progress.opensuse.org/issues/105358
- Verification run: https://openqa.suse.de/tests/8095955
