### PR TITLE
Add password in s390x consoletest_finish

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -131,6 +131,10 @@ sub ensure_unlocked_desktop {
         if ((match_has_tag 'displaymanager-password-prompt') || (match_has_tag 'screenlock-password')) {
             if ($password ne '') {
                 type_password;
+                # poo#97556
+                send_key 'ret';
+                wait_still_screen;
+
                 assert_screen([qw(locked_screen-typed_password login_screen-typed_password generic-desktop)], timeout => 150);
                 next if match_has_tag 'generic-desktop';
             }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/97556
- Needles: N/A
- Verification run: SLE 15sp4 [s390x](https://openqa.suse.de/tests/8096753#step/consoletest_finish/21) | [x86_64](https://openqa.suse.de/tests/8096754#step/consoletest_finish/13) | [aarch64](https://openqa.suse.de/tests/8096755#step/consoletest_finish/13)
