### PR TITLE
Soft-fail rhythmbox

### DIFF
--- a/tests/x11/rhythmbox.pm
+++ b/tests/x11/rhythmbox.pm
@@ -12,8 +12,16 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use utils "zypper_call";
+use x11utils 'start_root_shell_in_xterm';
 
 sub run {
+    if (!script_run "rpm -q libtdb1") {
+        record_soft_failure("Missing dependency for rhythmbox - bsc#1195510");
+        start_root_shell_in_xterm();
+        zypper_call "in libtdb1";
+        enter_cmd "killall xterm";
+    }
     x11_start_program('rhythmbox');
     send_key "alt-f4";
 }


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1195510
- Needles: N/A
- Verification run: [sle12sp5](https://openqa.suse.de/tests/8100470#step/rhythmbox/18)
I found that this module runs only in 12sp5