### PR TITLE
Transactional: increase timeout for first trup_call

### DIFF
--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -78,7 +78,7 @@ sub run {
         record_info 'Update #1', 'Add repository and update - snapshot #2';
         # openSUSE does not need additional repo
         zypper_call 'ar utt.repo' unless is_opensuse;
-        trup_call 'cleanup up';
+        trup_call 'cleanup up', timeout => 300;
         check_reboot_changes;
         check_package(stage => 'up');
 


### PR DESCRIPTION
There are some sporadic timeouts in this call. The default timeout
is 180s, so 300s should avoid those sporadic failures.

Failures history can be seen here: https://openqa.suse.de/tests/8101929#next_previous (~50% of the times)

- Related ticket: https://progress.opensuse.org/issues/105936

VRs: (10 / 10 green)
- http://openqa.suse.de/t8104028
- http://openqa.suse.de/t8104029
- http://openqa.suse.de/t8104030
- http://openqa.suse.de/t8104031
- http://openqa.suse.de/t8104032
- http://openqa.suse.de/t8104033
- http://openqa.suse.de/t8104035
- http://openqa.suse.de/t8104036
- http://openqa.suse.de/t8104037
- http://openqa.suse.de/t8104038