### PR TITLE
Add sle-module-python3 to modules list

### DIFF
--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -81,6 +81,7 @@ test_data:
     - sle-module-legacy
     - sle-module-public-cloud
     - sle-module-NVIDIA-compute
+    - sle-module-python3
     - PackageHub
     - sle-module-server-applications
     - sle-module-transactional-server

--- a/schedule/yast/installer_extended/installer_extended@pvm.yaml
+++ b/schedule/yast/installer_extended/installer_extended@pvm.yaml
@@ -78,6 +78,7 @@ test_data:
     - sle-module-development-tools
     - sle-module-legacy
     - sle-module-public-cloud
+    - sle-module-python3
     - PackageHub
     - sle-module-server-applications
     - sle-module-transactional-server

--- a/schedule/yast/installer_extended/installer_extended@s390x.yaml
+++ b/schedule/yast/installer_extended/installer_extended@s390x.yaml
@@ -79,6 +79,7 @@ test_data:
     - sle-module-development-tools
     - sle-module-legacy
     - sle-module-public-cloud
+    - sle-module-python3
     - PackageHub
     - sle-module-server-applications
     - sle-module-transactional-server

--- a/test_data/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/test_data/yast/installer_extended/installer_extended_aarch64.yaml
@@ -37,6 +37,7 @@ modules:
   - sle-module-legacy
   - sle-module-NVIDIA-compute
   - sle-module-public-cloud
+  - sle-module-python3
   - PackageHub
   - sle-module-server-applications
   - sle-module-transactional-server

--- a/test_data/yast/installer_extended/installer_extended_ppc64le_s390x.yaml
+++ b/test_data/yast/installer_extended/installer_extended_ppc64le_s390x.yaml
@@ -37,6 +37,7 @@ modules:
   - sle-module-development-tools
   - sle-module-legacy
   - sle-module-public-cloud
+  - sle-module-python3
   - PackageHub
   - sle-module-server-applications
   - sle-module-transactional-server


### PR DESCRIPTION
Recently added sle-module-python3 has not been added yet in our test data modules list.
Check https://jira.suse.com/browse/SLE-23605 for more info on the python3 module.

- Related ticket: No ticket
- Needles: No needles
- Verification runs: https://openqa.suse.de/tests/overview?build=ge0r%2Fos-autoinst-distri-opensuse%23add_python3_module&version=15-SP4&distri=sle  