### PR TITLE
systemd should not require udev 

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1110,6 +1110,7 @@ sub load_consoletests {
     loadtest "console/system_state";
     loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
+    loadtest 'console/systemd_wo_udev' if (is_sle('15-sp4+') || is_leap('15.4+') || is_tumbleweed);
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
 
     if (get_var('IBM_TESTS')) {

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -21,6 +21,10 @@ conditional_schedule:
         UEFI:
             '1':
                 - console/verify_efi_mok
+    udev_dep:
+        VERSION:
+            '15-SP4':
+                - console/systemd_wo_udev
     maintenance:
         FLAVOR:
             'JeOS-for-kvm-and-xen-Updates':
@@ -45,6 +49,7 @@ schedule:
     - console/check_network
     - console/system_state
     - console/consoletest_setup
+    - '{{udev_dep}}'
     - locale/keymap_or_locale
     - console/apache
     - console/dns_srv

--- a/tests/console/systemd_wo_udev.pm
+++ b/tests/console/systemd_wo_udev.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright 2012-2018 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: systemd has no direct dependency for udev package
+# Maintainer: QA-C <qa-c@suse.de>
+# Tags: SLE-21856
+
+use Mojo::Base qw(consoletest);
+use testapi;
+
+sub run {
+    shift->select_serial_terminal;
+    script_run("zypper if --requires systemd | grep udev") or
+      die 'systemd on sle15sp4+, leap15.4+ and TW should have no dependency to udev package!';
+}
+
+sub post_fail_hook {
+    upload_logs('/var/log/zypper.log', failok => 1);
+    upload_logs('/var/log/zypp/history', failok => 1);
+}
+
+1;

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -33,6 +33,7 @@ sub run {
             record_info "IMAGE", "Testing image: $iname";
             test_container_image(image => $iname, runtime => $engine);
             test_rpm_db_backend(image => $iname, runtime => $engine);
+            test_systemd_install(image => $iname, runtime => $engine);
             my $beta = $version eq get_var('VERSION') ? get_var('BETA', 0) : 0;
             test_opensuse_based_image(image => $iname, runtime => $engine, version => $version, beta => $beta);
         }


### PR DESCRIPTION
- motivation: [QA: remove udev dependency in systemd main package](https://jira.suse.com/browse/SLE-21856) and [[SLE-21856] "QA: remove udev dependency in systemd main package"](https://progress.opensuse.org/issues/101530)