### PR TITLE
Make sure non-root user can access serialdev

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1259,7 +1259,8 @@ sub ensure_serialdev_permissions {
     else {
         # when serial getty is started, it changes the group of serialdev from dialout to tty (but doesn't change it back when stopped)
         # let's make sure that both will work
-        assert_script_run "chown $testapi::username /dev/$testapi::serialdev && usermod -a -G tty,dialout,\$(stat -c %G /dev/$testapi::serialdev) $testapi::username";
+        # based on bsc#1195620, let's restore file permission to '620'
+        assert_script_run "chmod 620 /dev/$testapi::serialdev && chown $testapi::username /dev/$testapi::serialdev && usermod -a -G tty,dialout,\$(stat -c %G /dev/$testapi::serialdev) $testapi::username";
     }
 }
 


### PR DESCRIPTION
The code changes are for s390x platform only, we did not see the issue on other
platform for now.

- Related ticket: https://progress.opensuse.org/issues/106020
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/8114055
