### PR TITLE
kdump: Increase timeout for final kdump configuration

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -183,7 +183,7 @@ sub activate_kdump {
     if ($expect_restart_info == 1) {
         my @tags = qw(yast2-kdump-restart-info os-prober-warning);
         do {
-            assert_screen(\@tags, timeout => 90);
+            assert_screen(\@tags, timeout => 180);
             handle_warning_install_os_prober() if match_has_tag('os-prober-warning');
         } until (match_has_tag('yast2-kdump-restart-info'));
         send_key('alt-o');


### PR DESCRIPTION
Fix poo#106098: Timeout 90s is not enough during yast configuration, we
need to set it to same value 180s like it is in command line setup.

- Related ticket: https://progress.opensuse.org/issues/106098
- Needles: none
- Verification run:  https://openqa.suse.de/tests/8114327
