### PR TITLE
PC: Measure basic networking and record time of important steps

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -324,4 +324,21 @@ sub get_state
     return $self->provider->get_state_from_instance($self, @_);
 }
 
+=head2 network_speed_test
+
+    network_speed_test();
+
+Test the network speed.
+=cut
+sub network_speed_test() {
+    my ($self, %args) = @_;
+    # Curl stats output format
+    my $write_out = 'time_namelookup:\t%{time_namelookup} s\ntime_connect:\t\t%{time_connect} s\ntime_appconnect:\t%{time_appconnect} s\ntime_pretransfer:\t%{time_pretransfer} s\ntime_redirect:\t\t%{time_redirect} s\ntime_starttransfer:\t%{time_starttransfer} s\ntime_total:\t\t%{time_total} s\n';
+    # PC RMT server domain name
+    my $rmt_host = "smt-" . lc(get_required_var('PUBLIC_CLOUD_PROVIDER')) . ".susecloud.net";
+    $self->run_ssh_command(cmd => "grep '$rmt_host' /etc/hosts", proceed_on_failure => 1);
+    record_info("ping 1.1.1.1", $self->run_ssh_command(cmd => "ping -c30 1.1.1.1", proceed_on_failure => 1, timeout => 600));
+    record_info("curl $rmt_host", $self->run_ssh_command(cmd => "curl -w '$write_out' -o /dev/null -v https://$rmt_host/", proceed_on_failure => 1));
+}
+
 1;

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -55,6 +55,7 @@ sub register_addon {
     my $arch = get_var('PUBLIC_CLOUD_ARCH') // "x86_64";
     $arch = "aarch64" if ($arch eq "arm64");
     record_info($addon, "Going to register '$addon' addon");
+    my $cmd_time = time();
     if ($addon =~ /ltss/) {
         ssh_add_suseconnect_product($remote, get_addon_fullname($addon), '${VERSION_ID}', $arch, "-r " . get_required_var('SCC_REGCODE_LTSS'));
     } elsif (is_sle('<15') && $addon =~ /tcm|wsm|contm|asmm|pcm/) {
@@ -64,6 +65,7 @@ sub register_addon {
     } else {
         ssh_add_suseconnect_product($remote, get_addon_fullname($addon), undef, $arch);
     }
+    record_info('SUSEConnect time', 'The command SUSEConnect -r ' . get_addon_fullname($addon) . ' took ' . (time() - $cmd_time) . ' seconds.');
 }
 
 sub registercloudguest {
@@ -95,7 +97,9 @@ sub registercloudguest {
     # Check what version of registercloudguest binary we use
     $instance->run_ssh_command(cmd => "sudo rpm -qa cloud-regionsrv-client", proceed_on_failure => 1);
     # Register the system
+    my $cmd_time = time();
     $instance->retry_ssh_command(cmd => "sudo registercloudguest -r $regcode", timeout => 420, retry => 3);
+    record_info('registercloudguest time', 'The command registercloudguest took ' . (time() - $cmd_time) . ' seconds.');
 }
 
 # Check if we are a BYOS test run

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -22,8 +22,14 @@ sub run {
 
     my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
 
-    $args->{my_instance}->retry_ssh_command(cmd => "sudo zypper -n ref", timeout => 240, retry => 6);
+    my $cmd_time = time();
+    my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;
+    $args->{my_instance}->retry_ssh_command(cmd => "sudo zypper -n ref", timeout => $ref_timeout, retry => 6, delay => 60);
+    record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');
+    record_soft_failure('bsc#1195382', 'bsc#1195382 - Considerable decrease of zypper performance and increase of registration times') if ((time() - $cmd_time) > 240);
+
     ssh_fully_patch_system($remote);
+
     $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
 }
 

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -78,6 +78,8 @@ sub run {
     assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
     $instance->ssh_opts("");
 
+    $instance->network_speed_test();
+
     # ssh-tunnel settings
     prepare_ssh_tunnel($instance) if (get_var('TUNNELED'));
 }


### PR DESCRIPTION
 * We need to better see how long some important commands run.
 * It is hard to measure the network with unregistered product - this is just first attempt.

- Related ticket: [bsc#1195382](https://bugzilla.suse.com/show_bug.cgi?id=1195382) [poo#105969](https://progress.opensuse.org/issues/105969)
- Verification run: TBD
