### PR TITLE
Unified widget variable naming

### DIFF
--- a/lib/Installation/AuthenticationForRoot/AuthenticationForRootPage.pm
+++ b/lib/Installation/AuthenticationForRoot/AuthenticationForRootPage.pm
@@ -21,19 +21,19 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->{lbl_import_public_ssh_key} = $self->{app}->label({label => 'Import Public SSH Key'});
-    $self->{tb_confirm_password} = $self->{app}->textbox({id => 'pw2'});
-    $self->{tb_password} = $self->{app}->textbox({id => 'pw1'});
+    $self->{txb_confirm_password} = $self->{app}->textbox({id => 'pw2'});
+    $self->{txb_password} = $self->{app}->textbox({id => 'pw1'});
     return $self;
 }
 
 sub enter_password {
     my ($self, $password) = @_;
-    return $self->{tb_password}->set($password);
+    return $self->{txb_password}->set($password);
 }
 
 sub enter_confirm_password {
     my ($self, $password) = @_;
-    return $self->{tb_confirm_password}->set($password);
+    return $self->{txb_confirm_password}->set($password);
 }
 
 sub is_shown {

--- a/lib/Installation/ClockAndTimeZone/ClockAndTimeZonePage.pm
+++ b/lib/Installation/ClockAndTimeZone/ClockAndTimeZonePage.pm
@@ -20,20 +20,20 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{cb_region} = $self->{app}->combobox({id => 'region'});
-    $self->{cb_time_zone} = $self->{app}->combobox({id => 'timezone'});
+    $self->{cmb_region} = $self->{app}->combobox({id => 'region'});
+    $self->{cmb_time_zone} = $self->{app}->combobox({id => 'timezone'});
     $self->{chb_hw_clock} = $self->{app}->checkbox({id => 'hwclock'});
     return $self;
 }
 
 sub get_region {
     my ($self) = @_;
-    return $self->{cb_region}->value();
+    return $self->{cmb_region}->value();
 }
 
 sub get_time_zone {
     my ($self) = @_;
-    return $self->{cb_time_zone}->value();
+    return $self->{cmb_time_zone}->value();
 }
 
 sub is_hw_clock_set_to_UTC {
@@ -43,7 +43,7 @@ sub is_hw_clock_set_to_UTC {
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{cb_time_zone}->exist();
+    return $self->{cmb_time_zone}->exist();
 }
 
 1;

--- a/lib/Installation/DiskActivation/ConfiguredZFCPDevicesPage.pm
+++ b/lib/Installation/DiskActivation/ConfiguredZFCPDevicesPage.pm
@@ -17,8 +17,8 @@ sub init {
     $self->SUPER::init($args);
     $self->{btn_filter} = $self->{app}->button({id => 'filter'});
     $self->{btn_add} = $self->{app}->button({id => 'add'});
-    $self->{txt_min_chan} = $self->{app}->textbox({id => 'min_chan'});
-    $self->{txt_max_chan} = $self->{app}->textbox({id => 'max_chan'});
+    $self->{txb_min_chan} = $self->{app}->textbox({id => 'min_chan'});
+    $self->{txb_max_chan} = $self->{app}->textbox({id => 'max_chan'});
     $self->{tbl_devices} = $self->{app}->table({id => 'table'});
     return $self;
 }

--- a/lib/Installation/DiskActivation/DASDDiskManagementPage.pm
+++ b/lib/Installation/DiskActivation/DASDDiskManagementPage.pm
@@ -14,27 +14,27 @@ use warnings;
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{tbx_minimum_channel} = $self->{app}->textbox({id => 'min_chan'});
-    $self->{tbx_maximum_channel} = $self->{app}->textbox({id => 'max_chan'});
+    $self->{txb_minimum_channel} = $self->{app}->textbox({id => 'min_chan'});
+    $self->{txb_maximum_channel} = $self->{app}->textbox({id => 'max_chan'});
     $self->{btn_filter} = $self->{app}->button({id => 'filter'});
     $self->{tbl_devices} = $self->{app}->table({id => 'table'});
-    $self->{mco_operation} = $self->{app}->menucollection({id => 'operation'});
+    $self->{mnc_operation} = $self->{app}->menucollection({id => 'operation'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{mco_operation}->exist();
+    return $self->{mnc_operation}->exist();
 }
 
 sub enter_minimum_channel {
     my ($self, $channel) = @_;
-    return $self->{tbx_minimum_channel}->set($channel);
+    return $self->{txb_minimum_channel}->set($channel);
 }
 
 sub enter_maximum_channel {
     my ($self, $channel) = @_;
-    return $self->{tbx_maximum_channel}->set($channel);
+    return $self->{txb_maximum_channel}->set($channel);
 }
 
 sub press_filter_button {
@@ -54,7 +54,7 @@ sub select_device {
 
 sub perform_action_activate {
     my ($self) = @_;
-    $self->{mco_operation}->select('Activate');
+    $self->{mnc_operation}->select('Activate');
 }
 
 1;

--- a/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
@@ -22,20 +22,20 @@ sub new {
 sub init {
     my $self = shift;
     $self->{btn_install} = $self->{app}->button({id => 'next'});
-    $self->{txt_overview} = $self->{app}->richtext({id => 'proposal'});
+    $self->{rct_overview} = $self->{app}->richtext({id => 'proposal'});
 
     return $self;
 }
 
 sub get_overview_content {
     my ($self) = @_;
-    return $self->{txt_overview}->text();
+    return $self->{rct_overview}->text();
 }
 
 sub enable_ssh_service {
     my ($self) = @_;
     YuiRestClient::Wait::wait_until(object => sub {
-            $self->{txt_overview}->activate_link('security--enable_sshd');
+            $self->{rct_overview}->activate_link('security--enable_sshd');
             return $self->is_ssh_service_enabled;
     }, message => "'SSH service will be enabled' message is not shown, though SSH service is expected to be enabled.");
 }
@@ -54,7 +54,7 @@ sub is_ssh_port_open {
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{txt_overview}->exist();
+    return $self->{rct_overview}->exist();
 }
 
 sub is_loaded_completely {
@@ -72,24 +72,24 @@ sub is_loaded_completely {
 sub open_ssh_port {
     my ($self) = @_;
     YuiRestClient::Wait::wait_until(object => sub {
-            $self->{txt_overview}->activate_link('security--open_ssh');
+            $self->{rct_overview}->activate_link('security--open_ssh');
             return $self->is_ssh_port_open;
     }, message => "'SSH port will be open' message is not shown, though SSH port is expected to be opened.");
 }
 
 sub access_booting_options {
     my ($self) = @_;
-    $self->{txt_overview}->activate_link('bootloader_stuff');
+    $self->{rct_overview}->activate_link('bootloader_stuff');
 }
 
 sub access_security_options {
     my ($self) = @_;
-    $self->{txt_overview}->activate_link('security');
+    $self->{rct_overview}->activate_link('security');
 }
 
 sub access_ssh_import_options {
     my ($self) = @_;
-    $self->{txt_overview}->activate_link('ssh_import');
+    $self->{rct_overview}->activate_link('ssh_import');
 }
 
 sub press_install {

--- a/lib/Installation/LanguageKeyboard/LanguageKeyboardPage.pm
+++ b/lib/Installation/LanguageKeyboard/LanguageKeyboardPage.pm
@@ -21,37 +21,37 @@ sub new {
 
 sub init {
     my ($self, $args) = @_;
-    $self->{cb_keyboard_layout} = $self->{app}->combobox({id => '"Y2Country::Widgets::KeyboardSelectionCombo"'});
-    $self->{tb_keyboard_test} = $self->{app}->textbox({id => 'keyboard_test'});
+    $self->{cmb_keyboard_layout} = $self->{app}->combobox({id => '"Y2Country::Widgets::KeyboardSelectionCombo"'});
+    $self->{txb_keyboard_test} = $self->{app}->textbox({id => 'keyboard_test'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{cb_keyboard_layout}->exist();
+    return $self->{cmb_keyboard_layout}->exist();
 }
 
 sub switch_keyboard_layout {
     my ($self, $keyboard_layout) = @_;
-    $self->{cb_keyboard_layout}->select($keyboard_layout);
+    $self->{cmb_keyboard_layout}->select($keyboard_layout);
 }
 
 sub enter_keyboard_test {
     my ($self, $test) = @_;
     # text for test layout cannot be set correctly via rest api, so focus
     # is moved to the control with libyui and typing is done with testapi
-    $self->{tb_keyboard_test}->set('');
+    $self->{txb_keyboard_test}->set('');
     type_string $test;
 }
 
 sub get_keyboard_layout {
     my ($self) = @_;
-    $self->{cb_keyboard_layout}->value();
+    $self->{cmb_keyboard_layout}->value();
 }
 
 sub get_keyboard_test {
     my ($self) = @_;
-    $self->{tb_keyboard_test}->value();
+    $self->{txb_keyboard_test}->value();
 }
 
 1;

--- a/lib/Installation/License/LicenseAgreementExplicitPage.pm
+++ b/lib/Installation/License/LicenseAgreementExplicitPage.pm
@@ -15,13 +15,13 @@ use warnings;
 sub init {
     my ($self, $args) = @_;
     $self->SUPER::init($args);
-    $self->{ch_accept_license} = $self->{app}->checkbox($args->{ch_accept_license_filter});
+    $self->{chb_accept_license} = $self->{app}->checkbox($args->{ch_accept_license_filter});
     return $self;
 }
 
 sub check_accept_license {
     my ($self) = @_;
-    return $self->{ch_accept_license}->check();
+    return $self->{chb_accept_license}->check();
 }
 
 1;

--- a/lib/Installation/License/LicenseAgreementPage.pm
+++ b/lib/Installation/License/LicenseAgreementPage.pm
@@ -22,34 +22,34 @@ sub new {
 sub init {
     my ($self, $args) = @_;
     $self->SUPER::init($args);
-    $self->{cb_language} = $self->{app}->combobox($args->{cb_language_filter});
-    $self->{rt_eula} = $self->{app}->richtext($args->{rt_eula_filter});
+    $self->{cmb_language} = $self->{app}->combobox($args->{cmb_language_filter});
+    $self->{rct_eula} = $self->{app}->richtext($args->{rct_eula_filter});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rt_eula}->exist();
+    return $self->{rct_eula}->exist();
 }
 
 sub get_available_languages {
     my ($self) = @_;
-    return $self->{cb_language}->items();
+    return $self->{cmb_language}->items();
 }
 
 sub get_eula_content {
     my ($self) = @_;
-    return $self->{rt_eula}->text();
+    return $self->{rct_eula}->text();
 }
 
 sub get_selected_language {
     my ($self) = @_;
-    return $self->{cb_language}->value();
+    return $self->{cmb_language}->value();
 }
 
 sub select_language {
     my ($self, $item) = @_;
-    return $self->{cb_language}->select($item);
+    return $self->{cmb_language}->select($item);
 }
 
 1;

--- a/lib/Installation/LocalUser/LocalUserPage.pm
+++ b/lib/Installation/LocalUser/LocalUserPage.pm
@@ -24,68 +24,68 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{tb_confirm_password} = $self->{app}->textbox({id => 'pw2'});
-    $self->{tb_full_name} = $self->{app}->textbox({id => 'full_name'});
-    $self->{tb_username} = $self->{app}->textbox({id => 'username'});
-    $self->{tb_password} = $self->{app}->textbox({id => 'pw1'});
-    $self->{ch_autologin} = $self->{app}->checkbox({id => 'autologin'});
-    $self->{ch_use_for_admin} = $self->{app}->checkbox({id => 'root_pw'});
-    $self->{rb_import_users} = $self->{app}->radiobutton({id => 'import'});
+    $self->{txb_confirm_password} = $self->{app}->textbox({id => 'pw2'});
+    $self->{txb_full_name} = $self->{app}->textbox({id => 'full_name'});
+    $self->{txb_username} = $self->{app}->textbox({id => 'username'});
+    $self->{txb_password} = $self->{app}->textbox({id => 'pw1'});
+    $self->{chb_autologin} = $self->{app}->checkbox({id => 'autologin'});
+    $self->{chb_use_for_admin} = $self->{app}->checkbox({id => 'root_pw'});
+    $self->{rdb_import_users} = $self->{app}->radiobutton({id => 'import'});
     $self->{btn_choose_users} = $self->{app}->button({id => 'choose_users'});
     return $self;
 }
 
 sub enter_full_name {
     my ($self, $full_name) = @_;
-    return $self->{tb_full_name}->set($full_name);
+    return $self->{txb_full_name}->set($full_name);
 }
 
 sub enter_username {
     my ($self, $username) = @_;
-    return $self->{tb_username}->set($username);
+    return $self->{txb_username}->set($username);
 }
 
 sub enter_password {
     my ($self, $password) = @_;
-    return $self->{tb_password}->set($password);
+    return $self->{txb_password}->set($password);
 }
 
 sub enter_confirm_password {
     my ($self, $password) = @_;
-    return $self->{tb_confirm_password}->set($password);
+    return $self->{txb_confirm_password}->set($password);
 }
 
 sub is_shown {
     my ($self) = @_;
-    my $is_shown = $self->{tb_full_name}->exist();
+    my $is_shown = $self->{txb_full_name}->exist();
     save_screenshot if $is_shown;
     return $is_shown;
 }
 
 sub set_autologin {
     my ($self, $is_checked) = @_;
-    $self->{ch_autologin}->check() if $is_checked;
-    $self->{ch_autologin}->uncheck() if !$is_checked;
+    $self->{chb_autologin}->check() if $is_checked;
+    $self->{chb_autologin}->uncheck() if !$is_checked;
 }
 
 sub has_autologin_checked {
     my ($self) = @_;
-    $self->{ch_autologin}->is_checked();
+    $self->{chb_autologin}->is_checked();
 }
 
 sub select_use_this_password_for_admin {
     my ($self) = @_;
-    return $self->{ch_use_for_admin}->check();
+    return $self->{chb_use_for_admin}->check();
 }
 
 sub has_use_same_password_for_admin_checked {
     my ($self) = @_;
-    return $self->{ch_use_for_admin}->is_checked();
+    return $self->{chb_use_for_admin}->is_checked();
 }
 
 sub select_import_users {
     my ($self) = @_;
-    return $self->{rb_import_users}->select();
+    return $self->{rdb_import_users}->select();
 }
 
 sub choose_users_to_import {

--- a/lib/Installation/LocalUser/SelectUsersPage.pm
+++ b/lib/Installation/LocalUser/SelectUsersPage.pm
@@ -22,21 +22,21 @@ sub new {
 
 sub init {
     my ($self) = @_;
-    $self->{ch_select_all} = $self->{app}->checkbox({id => 'all'});
+    $self->{chb_select_all} = $self->{app}->checkbox({id => 'all'});
     $self->{btn_ok} = $self->{app}->button({id => 'ok'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    my $is_shown = $self->{ch_select_all}->exist();
+    my $is_shown = $self->{chb_select_all}->exist();
     save_screenshot if $is_shown;
     return $is_shown;
 }
 
 sub select_all {
     my ($self) = @_;
-    return $self->{ch_select_all}->check();
+    return $self->{chb_select_all}->check();
 }
 
 sub press_ok {

--- a/lib/Installation/ModuleRegistration/ModuleRegistrationPage.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegistrationPage.pm
@@ -23,47 +23,47 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{ch_hide_dev_versions} = $self->{app}->checkbox({id => 'filter_devel'});
-    $self->{rt_items} = $self->{app}->richtext({id => 'items'});
-    $self->{rt_item_containers} = 'sle-module-containers';
-    $self->{rt_item_desktop} = 'sle-module-desktop-applications';
-    $self->{rt_item_development} = 'sle-module-development-tools';
-    $self->{rt_item_legacy} = 'sle-module-legacy';
-    $self->{rt_item_transactional} = 'sle-module-transactional-server';
-    $self->{rt_item_web} = 'sle-module-web-scripting';
+    $self->{chb_hide_dev_versions} = $self->{app}->checkbox({id => 'filter_devel'});
+    $self->{rct_items} = $self->{app}->richtext({id => 'items'});
+    $self->{rct_item_containers} = 'sle-module-containers';
+    $self->{rct_item_desktop} = 'sle-module-desktop-applications';
+    $self->{rct_item_development} = 'sle-module-development-tools';
+    $self->{rct_item_legacy} = 'sle-module-legacy';
+    $self->{rct_item_transactional} = 'sle-module-transactional-server';
+    $self->{rct_item_web} = 'sle-module-web-scripting';
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rt_items}->exist();
+    return $self->{rct_items}->exist();
 }
 
 sub get_modules_full_name {
     my ($self) = @_;
-    my @modules = ($self->{rt_items}->text() =~ /<a href="(.*?)">|<a href='(.*?)' /g);
+    my @modules = ($self->{rct_items}->text() =~ /<a href="(.*?)">|<a href='(.*?)' /g);
     @modules = grep defined, @modules;
     return \@modules;
 }
 
 sub get_modules {
     my ($self) = @_;
-    my @modules = ($self->{rt_items}->text() =~ /<a href='?"?(.*?)-\d+/g);
+    my @modules = ($self->{rct_items}->text() =~ /<a href='?"?(.*?)-\d+/g);
     return \@modules;
 }
 
 sub get_registered_modules {
     my ($self) = @_;
-    my @modules = ($self->{rt_items}->text() =~ /<a href='(.*?)-\d+.*inst_checkbox-on|<a href="(.*?)-\d+.*\[x\]/g);
+    my @modules = ($self->{rct_items}->text() =~ /<a href='(.*?)-\d+.*inst_checkbox-on|<a href="(.*?)-\d+.*\[x\]/g);
     @modules = grep defined, @modules;
     return \@modules;
 }
 
 sub register_module {
     my ($self, $module) = @_;
-    my $module_name = $self->{"rt_item_$module"};
+    my $module_name = $self->{"rct_item_$module"};
     my ($module_full_name) = grep { /$module_name/ } $self->get_modules_full_name()->@*;
-    return $self->{rt_items}->activate_link($module_full_name);
+    return $self->{rct_items}->activate_link($module_full_name);
 }
 
 sub register_modules {
@@ -74,7 +74,7 @@ sub register_modules {
 
 sub uncheck_hide_development_versions {
     my ($self) = @_;
-    return $self->{ch_hide_dev_versions}->uncheck();
+    return $self->{chb_hide_dev_versions}->uncheck();
 }
 
 1;

--- a/lib/Installation/ModuleSelection/ModuleSelectionPage.pm
+++ b/lib/Installation/ModuleSelection/ModuleSelectionPage.pm
@@ -23,30 +23,30 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{sbox_addons} = $self->{app}->selectionbox({id => 'addon_repos'});
+    $self->{slb_addons} = $self->{app}->selectionbox({id => 'addon_repos'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{sbox_addons}->exist();
+    return $self->{slb_addons}->exist();
 }
 
 sub get_modules {
     my ($self) = @_;
-    return $self->{sbox_addons}->items();
+    return $self->{slb_addons}->items();
 }
 
 sub get_selected_modules {
     my ($self) = @_;
-    return $self->{sbox_addons}->selected_items();
+    return $self->{slb_addons}->selected_items();
 }
 
 sub select_module {
     my ($self, $module) = @_;
     my @modules = $self->get_modules();
     my ($module_full_name) = grep(/$module/i, @modules);
-    return $self->{sbox_addons}->check($module_full_name);
+    return $self->{slb_addons}->check($module_full_name);
 }
 
 sub select_modules {

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AbstractSizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AbstractSizePage.pm
@@ -18,7 +18,7 @@ use YuiRestClient::Wait;
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{rb_custom_size} = $self->{app}->radiobutton({id => 'custom_size'});
+    $self->{rdb_custom_size} = $self->{app}->radiobutton({id => 'custom_size'});
     return $self;
 }
 
@@ -26,10 +26,10 @@ sub set_custom_size {
     my ($self, $size) = @_;
     if ($size) {
         YuiRestClient::Wait::wait_until(object => sub {
-                return $self->{rb_custom_size}->is_enabled();
+                return $self->{rdb_custom_size}->is_enabled();
         }, message => "Custom size radio button takes too long to be enabled");
-        $self->{rb_custom_size}->select();
-        $self->{tb_size}->set($size);
+        $self->{rdb_custom_size}->select();
+        $self->{txb_size}->set($size);
     }
     $self->press_next();
 }

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AddLogicalVolumePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AddLogicalVolumePage.pm
@@ -25,22 +25,22 @@ sub new {
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{tb_lv_name} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::LvmLvInfo::NameWidget"'});
-    $self->{rb_thin_pool} = $self->{app}->radiobutton({id => 'thin_pool'});
-    $self->{rb_thin_volume} = $self->{app}->radiobutton({id => 'thin'});
+    $self->{txb_lv_name} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::LvmLvInfo::NameWidget"'});
+    $self->{rdb_thin_pool} = $self->{app}->radiobutton({id => 'thin_pool'});
+    $self->{rdb_thin_volume} = $self->{app}->radiobutton({id => 'thin'});
     return $self;
 }
 
 sub enter_name {
     my ($self, $lv_name) = @_;
-    return $self->{tb_lv_name}->set($lv_name);
+    return $self->{txb_lv_name}->set($lv_name);
 }
 
 sub select_type {
     my ($self, $type) = @_;
     my %types = (
-        'thin-pool' => $self->{rb_thin_pool},
-        'thin-volume' => $self->{rb_thin_volume}
+        'thin-pool' => $self->{rdb_thin_pool},
+        'thin-volume' => $self->{rdb_thin_volume}
     );
     return $types{$type}->select();
 }

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/AddVolumeGroupPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/AddVolumeGroupPage.pm
@@ -27,7 +27,7 @@ sub init {
     $self->SUPER::init();
     $self->{btn_add} = $self->{app}->button({id => 'add'});
     $self->{btn_add_all} = $self->{app}->button({id => 'add_all'});
-    $self->{txtbox_vg_name} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::LvmVg::NameWidget"'});
+    $self->{txb_vg_name} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::LvmVg::NameWidget"'});
     $self->{tbl_available_devices} = $self->{app}->table({id => '"unselected"'});
     $self->{tbl_selected_devices} = $self->{app}->table({id => '"selected"'});
 
@@ -51,8 +51,8 @@ sub select_available_device {
 
 sub set_volume_group_name {
     my ($self, $vg_name) = @_;
-    $self->{txtbox_vg_name}->exist();
-    return $self->{txtbox_vg_name}->set($vg_name);
+    $self->{txb_vg_name}->exist();
+    return $self->{txb_vg_name}->set($vg_name);
 }
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/CreatePartitionTablePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/CreatePartitionTablePage.pm
@@ -25,14 +25,14 @@ sub new {
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{rb_msdos_part_table} = $self->{app}->radiobutton({id => '"msdos"'});
-    $self->{rb_gpt_part_table} = $self->{app}->radiobutton({id => '"gpt"'});
+    $self->{rdb_msdos_part_table} = $self->{app}->radiobutton({id => '"msdos"'});
+    $self->{rdb_gpt_part_table} = $self->{app}->radiobutton({id => '"gpt"'});
     return $self;
 }
 
 sub select_partition_table_type {
     my ($self, $table_type) = @_;
-    return ($table_type eq 'msdos') ? $self->{rb_msdos_part_table}->select() : $self->{rb_gpt_part_table}->select();
+    return ($table_type eq 'msdos') ? $self->{rdb_msdos_part_table}->select() : $self->{rdb_gpt_part_table}->select();
 }
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/EncryptPartitionPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/EncryptPartitionPage.pm
@@ -22,8 +22,8 @@ sub new {
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{tb_pass} = $self->{app}->textbox({id => 'pw1'});
-    $self->{tb_pass_reenter} = $self->{app}->textbox({id => 'pw2'});
+    $self->{txb_pass} = $self->{app}->textbox({id => 'pw1'});
+    $self->{txb_pass_reenter} = $self->{app}->textbox({id => 'pw2'});
     return $self;
 }
 
@@ -36,12 +36,12 @@ sub set_encryption {
 
 sub enter_password {
     my ($self, $password) = @_;
-    return $self->{tb_pass}->set($password);
+    return $self->{txb_pass}->set($password);
 }
 
 sub reenter_password {
     my ($self, $password) = @_;
-    return $self->{tb_pass_reenter}->set($password);
+    return $self->{txb_pass_reenter}->set($password);
 }
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ExpertPartitionerPage.pm
@@ -35,10 +35,10 @@ sub init {
     $self->{btn_add_raid} = $self->{app}->button({id => '"Y2Partitioner::Widgets::MdAddButton"'});
     $self->{btn_accept} = $self->{app}->button({label => 'Accept'});
     $self->{btn_cancel} = $self->{app}->button({id => 'abort'});
-    $self->{menu_bar} = $self->{app}->menucollection({id => 'menu_bar'});
+    $self->{mnc_bar} = $self->{app}->menucollection({id => 'menu_bar'});
     $self->{tbl_devices} = $self->{app}->table({id => '"Y2Partitioner::Widgets::ConfigurableBlkDevicesTable"'});
     $self->{tbl_lvm_devices} = $self->{app}->table({id => '"Y2Partitioner::Widgets::LvmDevicesTable"'});
-    $self->{tree_system_view} = $self->{app}->tree({id => '"Y2Partitioner::Widgets::OverviewTree"'});
+    $self->{tre_system_view} = $self->{app}->tree({id => '"Y2Partitioner::Widgets::OverviewTree"'});
     $self->{btn_add_logical_volume} = $self->{app}->tree({id => '"Y2Partitioner::Widgets::LvmLvAddButton"'});
 
     return $self;
@@ -49,26 +49,26 @@ sub is_shown {
     # Check for menu bar to be existing on Expert Partitioner Page.
     # The menu bar is chosen as the element that allows to identify that Expert Partitioner Page is opened,
     # as the page does not have any unique header.
-    $self->{menu_bar}->exist();
+    $self->{mnc_bar}->exist();
 }
 
 sub open_resize_device {
     my ($self) = @_;
-    $self->{menu_bar}->select('&Device|&Resize...');
+    $self->{mnc_bar}->select('&Device|&Resize...');
     return $self;
 }
 
 sub select_create_partition_table {
     my ($self) = @_;
-    $self->{menu_bar}->select('&Device|Create New &Partition Table...');
+    $self->{mnc_bar}->select('&Device|Create New &Partition Table...');
     return $self;
 }
 
 sub select_item_in_system_view_table {
     my ($self, $item) = @_;
 
-    $self->{tree_system_view}->exist();
-    $self->{tree_system_view}->select($item);
+    $self->{tre_system_view}->exist();
+    $self->{tre_system_view}->select($item);
 
     return $self;
 }
@@ -76,14 +76,14 @@ sub select_item_in_system_view_table {
 sub open_clone_partition_dialog {
     my ($self, $disk) = @_;
 
-    $self->{tree_system_view}->exist();
+    $self->{tre_system_view}->exist();
     $self->select_disk($disk) if $disk;
     # Cloning option is disabled if any partition is selected, so selecting disk
     $self->{tbl_devices}->select(row => 0);
     # This is workaround, because row selection doesn't enable clone item in menu bar
     send_key("end");
     send_key("home");
-    $self->{menu_bar}->select('&Device|&Clone Partitions to Another Device...');
+    $self->{mnc_bar}->select('&Device|&Clone Partitions to Another Device...');
     return $self;
 }
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/FstabOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/FstabOptionsPage.pm
@@ -23,7 +23,7 @@ sub new {
 sub init {
     my $self = shift;
     $self->{btn_fstab_options} = $self->{app}->button({id => '"Y2Partitioner::Widgets::FstabOptionsButton"'});
-    $self->{cb_mount_by} = $self->{app}->combobox({id => '"Y2Partitioner::Widgets::MountBy"'});
+    $self->{cmb_mount_by} = $self->{app}->combobox({id => '"Y2Partitioner::Widgets::MountBy"'});
     $self->{btn_ok} = $self->{app}->button({id => 'ok'});
     return $self;
 }
@@ -57,12 +57,12 @@ sub press_fstab_options {
 
 sub set_mount_by {
     my ($self, $mount_by) = @_;
-    return $self->{cb_mount_by}->select($mount_by);
+    return $self->{cmb_mount_by}->select($mount_by);
 }
 
 sub check_default_mount_option {
     my ($self, $default) = @_;
-    my $preselected = $self->{cb_mount_by}->value();
+    my $preselected = $self->{cmb_mount_by}->value();
     die "The default mounting option was expected to be $default, but is $preselected" if ($preselected ne $default);
 }
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetup/PartitioningSchemePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/GuidedSetup/PartitioningSchemePage.pm
@@ -17,8 +17,8 @@ sub init {
     $self->SUPER::init();
     $self->{chb_enable_lvm} = $self->{app}->checkbox({id => 'lvm'});
     $self->{chb_enable_disk_encryption} = $self->{app}->checkbox({id => 'encryption'});
-    $self->{tb_password} = $self->{app}->textbox({id => 'password'});
-    $self->{tb_repeat_password} = $self->{app}->textbox({id => 'repeat_password'});
+    $self->{txb_password} = $self->{app}->textbox({id => 'password'});
+    $self->{txb_repeat_password} = $self->{app}->textbox({id => 'repeat_password'});
     return $self;
 }
 
@@ -39,12 +39,12 @@ sub select_enable_disk_encryption {
 
 sub enter_password {
     my ($self, $password) = @_;
-    return $self->{tb_password}->set($password);
+    return $self->{txb_password}->set($password);
 }
 
 sub enter_confirm_password {
     my ($self, $password) = @_;
-    return $self->{tb_repeat_password}->set($password);
+    return $self->{txb_repeat_password}->set($password);
 }
 
 sub is_shown {

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/LogicalVolumeSizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/LogicalVolumeSizePage.pm
@@ -22,7 +22,7 @@ sub new {
 sub init {
     my ($self) = shift;
     $self->SUPER::init();
-    $self->{tb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::LvmLvSize::CustomSizeInput"'});
+    $self->{txb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::LvmLvSize::CustomSizeInput"'});
     return $self;
 }
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/MsdosPartitionTypePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/MsdosPartitionTypePage.pm
@@ -22,8 +22,8 @@ sub new {
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{rb_primary} = $self->{app}->radiobutton({id => '"primary"'});
-    $self->{rb_extended} = $self->{app}->radiobutton({id => '"extended"'});
+    $self->{rdb_primary} = $self->{app}->radiobutton({id => '"primary"'});
+    $self->{rdb_extended} = $self->{app}->radiobutton({id => '"extended"'});
     return $self;
 }
 
@@ -36,8 +36,8 @@ sub set_type {
 sub select_type {
     my ($self, $type) = @_;
     my %types = (
-        primary => $self->{rb_primary},
-        extended => $self->{rb_extended}
+        primary => $self->{rdb_primary},
+        extended => $self->{rdb_extended}
     );
     return $types{$type}->select();
 }

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/NewPartitionSizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/NewPartitionSizePage.pm
@@ -22,7 +22,7 @@ sub new {
 sub init {
     my ($self) = shift;
     $self->SUPER::init();
-    $self->{tb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::PartitionSize::CustomSizeInput"'});
+    $self->{txb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::PartitionSize::CustomSizeInput"'});
     return $self;
 }
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/PartitionIdFormatMountOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/PartitionIdFormatMountOptionsPage.pm
@@ -23,7 +23,7 @@ sub new {
 sub init {
     my ($self) = shift;
     $self->SUPER::init();
-    $self->{partition_id} = $self->{app}->combobox({id => '"Y2Partitioner::Widgets::PartitionIdComboBox"'});
+    $self->{cmb_partition_id} = $self->{app}->combobox({id => '"Y2Partitioner::Widgets::PartitionIdComboBox"'});
     return $self;
 }
 
@@ -41,7 +41,7 @@ sub select_partition_id {
         'microsoft-reserved' => 'Microsoft Reserved Partition',
         'intel-rst' => 'Intel RST'
     );
-    return $self->{partition_id}->select($partition_ids{$partition_id}) if $partition_ids{$partition_id};
+    return $self->{cmb_partition_id}->select($partition_ids{$partition_id}) if $partition_ids{$partition_id};
     die "Wrong test data provided when selecting partition id.\n" .
       "Avalaible options: linux, linux-swap, linux-lvm, linux-raid, efi, bios-boot, prep-boot, " .
       "windows-data, microsoft-reserved, intel-rst";

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/RaidOptionsPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/RaidOptionsPage.pm
@@ -25,14 +25,14 @@ sub new {
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{cb_chunk_size} = $self->{app}->combobox({id => '"Y2Partitioner::Dialogs::MdOptions::ChunkSize"'});
+    $self->{cmb_chunk_size} = $self->{app}->combobox({id => '"Y2Partitioner::Dialogs::MdOptions::ChunkSize"'});
 
     return $self;
 }
 
 sub select_chunk_size {
     my ($self, $chunk_size) = @_;
-    $self->{cb_chunk_size}->select($chunk_size);
+    $self->{cmb_chunk_size}->select($chunk_size);
 }
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/RaidTypePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/RaidTypePage.pm
@@ -28,16 +28,16 @@ sub init {
     $self->{btn_add} = $self->{app}->button({id => 'add'});
     $self->{btn_add_all} = $self->{app}->button({id => 'add_all'});
 
-    $self->{rb_raid0} = $self->{app}->radiobutton({id => 'raid0'});
-    $self->{rb_raid1} = $self->{app}->radiobutton({id => 'raid1'});
-    $self->{rb_raid5} = $self->{app}->radiobutton({id => 'raid5'});
-    $self->{rb_raid6} = $self->{app}->radiobutton({id => 'raid6'});
-    $self->{rb_raid10} = $self->{app}->radiobutton({id => 'raid10'});
+    $self->{rdb_raid0} = $self->{app}->radiobutton({id => 'raid0'});
+    $self->{rdb_raid1} = $self->{app}->radiobutton({id => 'raid1'});
+    $self->{rdb_raid5} = $self->{app}->radiobutton({id => 'raid5'});
+    $self->{rdb_raid6} = $self->{app}->radiobutton({id => 'raid6'});
+    $self->{rdb_raid10} = $self->{app}->radiobutton({id => 'raid10'});
 
     $self->{tbl_available_devices} = $self->{app}->table({id => '"unselected"'});
     $self->{tbl_selected_devices} = $self->{app}->table({id => '"selected"'});
 
-    $self->{txtbox_raid_name} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::Md::NameEntry"'});
+    $self->{txb_raid_name} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::Md::NameEntry"'});
 
     return $self;
 }
@@ -55,13 +55,13 @@ sub press_add_all_button {
 sub set_raid_level {
     my ($self, $raid_level) = @_;
 
-    my $rb_name = "rb_raid$raid_level";
+    my $rdb_name = "rdb_raid$raid_level";
 
-    die "No control defined for raid level: $raid_level" unless $self->{$rb_name};
-    $self->{$rb_name}->exist();
+    die "No control defined for raid level: $raid_level" unless $self->{$rdb_name};
+    $self->{$rdb_name}->exist();
     YuiRestClient::Wait::wait_until(object => sub {
-            $self->{$rb_name}->select();
-            $self->{$rb_name}->is_selected();
+            $self->{$rdb_name}->select();
+            $self->{$rdb_name}->is_selected();
     });
 }
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/ResizePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/ResizePage.pm
@@ -22,7 +22,7 @@ sub new {
 sub init {
     my ($self) = shift;
     $self->SUPER::init();
-    $self->{tb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::BlkDeviceResize::CustomSizeWidget"'});
+    $self->{txb_size} = $self->{app}->textbox({id => '"Y2Partitioner::Dialogs::BlkDeviceResize::CustomSizeWidget"'});
     return $self;
 }
 

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/RolePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/RolePage.pm
@@ -23,11 +23,11 @@ sub new {
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{rb_operating_system} = $self->{app}->radiobutton({id => 'system'});
-    $self->{rb_data_isv_apps} = $self->{app}->radiobutton({id => 'data'});
-    $self->{rb_swap} = $self->{app}->radiobutton({id => 'swap'});
-    $self->{rb_efi_boot_part} = $self->{app}->radiobutton({id => 'efi_boot'});
-    $self->{rb_raw_volume} = $self->{app}->radiobutton({id => 'raw'});
+    $self->{rdb_operating_system} = $self->{app}->radiobutton({id => 'system'});
+    $self->{rdb_data_isv_apps} = $self->{app}->radiobutton({id => 'data'});
+    $self->{rdb_swap} = $self->{app}->radiobutton({id => 'swap'});
+    $self->{rdb_efi_boot_part} = $self->{app}->radiobutton({id => 'efi_boot'});
+    $self->{rdb_raw_volume} = $self->{app}->radiobutton({id => 'raw'});
     return $self;
 }
 
@@ -40,11 +40,11 @@ sub set_role {
 sub select_role {
     my ($self, $role) = @_;
     my %rb_roles = (
-        'operating-system' => $self->{rb_operating_system},
-        data => $self->{rb_data_isv_apps},
-        swap => $self->{rb_swap},
-        'efi-boot' => $self->{rb_efi_boot_part},
-        'raw-volume' => $self->{rb_raw_volume}
+        'operating-system' => $self->{rdb_operating_system},
+        data => $self->{rdb_data_isv_apps},
+        swap => $self->{rdb_swap},
+        'efi-boot' => $self->{rdb_efi_boot_part},
+        'raw-volume' => $self->{rdb_raw_volume}
     );
     return $rb_roles{$role}->select() if $rb_roles{$role};
     die "Wrong test data provided when selecting role.\n" .

--- a/lib/Installation/Partitioner/LibstorageNG/v4_3/SuggestedPartitioningPage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4_3/SuggestedPartitioningPage.pm
@@ -21,19 +21,19 @@ sub new {
 
 sub init {
     my $self = shift;
-    $self->{rtx_summary} = $self->{app}->richtext({id => 'summary'});
+    $self->{rct_summary} = $self->{app}->richtext({id => 'summary'});
     $self->{btn_guided_setup} = $self->{app}->button({id => 'guided'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rtx_summary}->exist();
+    return $self->{rct_summary}->exist();
 }
 
 sub get_text_summary() {
     my ($self) = @_;
-    return $self->{rtx_summary}->text();
+    return $self->{rct_summary}->text();
 }
 
 sub select_guided_setup {

--- a/lib/Installation/PerformingInstallation/PerformingInstallationPage.pm
+++ b/lib/Installation/PerformingInstallation/PerformingInstallationPage.pm
@@ -22,13 +22,13 @@ sub new {
 
 sub init {
     my $self = shift;
-    $self->{pba_total_packages} = $self->{app}->progressbar({id => 'progressTotal'});
+    $self->{prb_total_packages} = $self->{app}->progressbar({id => 'progressTotal'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    my $is_shown = $self->{pba_total_packages}->exist();
+    my $is_shown = $self->{prb_total_packages}->exist();
     save_screenshot if $is_shown;
     return $is_shown;
 }

--- a/lib/Installation/Popups/OKPopup.pm
+++ b/lib/Installation/Popups/OKPopup.pm
@@ -15,19 +15,19 @@ use parent 'Installation::Popups::AbstractOKPopup';
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{rtx_warning} = $self->{app}->richtext({type => 'YRichText'});
+    $self->{rct_warning} = $self->{app}->richtext({type => 'YRichText'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
     return $self->SUPER::is_shown() &&
-      $self->{rtx_warning}->exist();
+      $self->{rct_warning}->exist();
 }
 
 sub text {
     my ($self) = @_;
-    return $self->{rtx_warning}->text();
+    return $self->{rct_warning}->text();
 }
 
 1;

--- a/lib/Installation/ProductSelection/ProductSelectionPage.pm
+++ b/lib/Installation/ProductSelection/ProductSelectionPage.pm
@@ -22,24 +22,24 @@ sub new {
 sub init {
     my ($self, $args) = @_;
     $self->SUPER::init($args);
-    $self->{rb_SLES} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Linux Enterprise Server 15/});
-    $self->{rb_HPC} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Linux Enterprise High Performance Computing 15/});
-    $self->{rb_SLES_for_SAP} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Linux Enterprise Server for SAP Applications 15/});
-    $self->{rb_SLED} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Linux Enterprise Desktop 15/});
-    $self->{rb_SMGR_Server} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Manager Server/});
-    $self->{rb_SMGR_Proxy} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Manager Proxy/});
-    $self->{rb_SMGR_Retail} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Manager Retail Branch Server/});
+    $self->{rdb_SLES} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Linux Enterprise Server 15/});
+    $self->{rdb_HPC} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Linux Enterprise High Performance Computing 15/});
+    $self->{rdb_SLES_for_SAP} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Linux Enterprise Server for SAP Applications 15/});
+    $self->{rdb_SLED} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Linux Enterprise Desktop 15/});
+    $self->{rdb_SMGR_Server} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Manager Server/});
+    $self->{rdb_SMGR_Proxy} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Manager Proxy/});
+    $self->{rdb_SMGR_Retail} = $self->{app}->radiobutton({type => 'YRadioButton', label => qr/SUSE Manager Retail Branch Server/});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rb_SLES}->exist();
+    return $self->{rdb_SLES}->exist();
 }
 
 sub install_product {
     my ($self, $product) = @_;
-    $self->{"rb_$product"}->select();
+    $self->{"rdb_$product"}->select();
 }
 
 1;

--- a/lib/Installation/Registration/RegistrationPage.pm
+++ b/lib/Installation/Registration/RegistrationPage.pm
@@ -23,30 +23,30 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{rb_skip_registration} = $self->{app}->radiobutton({id => 'skip_registration'});
-    $self->{tb_email} = $self->{app}->textbox({id => 'email'});
-    $self->{tb_reg_code} = $self->{app}->textbox({id => 'reg_code'});
+    $self->{rdb_skip_registration} = $self->{app}->radiobutton({id => 'skip_registration'});
+    $self->{txb_email} = $self->{app}->textbox({id => 'email'});
+    $self->{txb_reg_code} = $self->{app}->textbox({id => 'reg_code'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rb_skip_registration}->exist();
+    return $self->{rdb_skip_registration}->exist();
 }
 
 sub enter_email {
     my ($self, $email) = @_;
-    return $self->{tb_email}->set($email);
+    return $self->{txb_email}->set($email);
 }
 
 sub select_skip_registration {
     my ($self) = @_;
-    $self->{rb_skip_registration}->select();
+    $self->{rdb_skip_registration}->select();
 }
 
 sub enter_reg_code {
     my ($self, $reg_code) = @_;
-    return $self->{tb_reg_code}->set($reg_code);
+    return $self->{txb_reg_code}->set($reg_code);
 }
 
 1;

--- a/lib/Installation/RepositoryURL/RepositoryURLPage.pm
+++ b/lib/Installation/RepositoryURL/RepositoryURLPage.pm
@@ -15,24 +15,24 @@ use warnings;
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{tbx_repo_name} = $self->{app}->textbox({id => 'repo_name'});
-    $self->{tbx_url} = $self->{app}->textbox({id => 'url'});
+    $self->{txb_repo_name} = $self->{app}->textbox({id => 'repo_name'});
+    $self->{txb_url} = $self->{app}->textbox({id => 'url'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{tbx_url}->exist();
+    return $self->{txb_url}->exist();
 }
 
 sub enter_repo_name {
     my ($self, $name) = @_;
-    $self->{tbx_repo_name}->set($name);
+    $self->{txb_repo_name}->set($name);
 }
 
 sub enter_url {
     my ($self, $url) = @_;
-    $self->{tbx_url}->set($url);
+    $self->{txb_url}->set($url);
 }
 
 1;

--- a/lib/Installation/SSHKeyImport/SSHKeyImportPage.pm
+++ b/lib/Installation/SSHKeyImport/SSHKeyImportPage.pm
@@ -23,27 +23,27 @@ sub new {
 
 sub init {
     my $self = shift;
-    $self->{cb_import} = $self->{app}->checkbox({id => 'import_ssh_key'});
-    $self->{cb_copy_config} = $self->{app}->checkbox({id => 'copy_config'});
+    $self->{chb_import} = $self->{app}->checkbox({id => 'import_ssh_key'});
+    $self->{chb_copy_config} = $self->{app}->checkbox({id => 'copy_config'});
     $self->{btn_accept} = $self->{app}->button({id => 'accept'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    my $is_shown = $self->{cb_import}->exist();
+    my $is_shown = $self->{chb_import}->exist();
     save_screenshot if $is_shown;
     return $is_shown;
 }
 
 sub enable_ssh_import {
     my ($self) = @_;
-    return $self->{cb_import}->check();
+    return $self->{chb_import}->check();
 }
 
 sub disable_ssh_import {
     my ($self) = @_;
-    return $self->{cb_import}->uncheck();
+    return $self->{chb_import}->uncheck();
 }
 
 sub press_accept {

--- a/lib/Installation/SystemProbing/EncryptedVolumeActivationPage.pm
+++ b/lib/Installation/SystemProbing/EncryptedVolumeActivationPage.pm
@@ -21,7 +21,7 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->{lbl_vol_activation} = $self->{app}->label({label => 'Encrypted Device'});
-    $self->{tb_password} = $self->{app}->textbox({id => 'password'});
+    $self->{txb_password} = $self->{app}->textbox({id => 'password'});
     $self->{btn_ok} = $self->{app}->button({id => 'accept'});
     $self->{btn_cancel} = $self->{app}->button({id => 'cancel'});
     return $self;
@@ -34,7 +34,7 @@ sub is_shown {
 
 sub enter_password {
     my ($self, $encryption_password) = @_;
-    return $self->{tb_password}->set($encryption_password);
+    return $self->{txb_password}->set($encryption_password);
 }
 
 sub press_ok {

--- a/lib/Installation/SystemRole/SystemRolePage.pm
+++ b/lib/Installation/SystemRole/SystemRolePage.pm
@@ -23,23 +23,23 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{sel_role} = $self->{app}->itemselector({id => 'role_selector'});
+    $self->{its_role} = $self->{app}->itemselector({id => 'role_selector'});
     return $self;
 }
 
 sub get_selected_roles {
     my ($self) = @_;
-    return $self->{sel_role}->selected_items();
+    return $self->{its_role}->selected_items();
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{sel_role}->exist();
+    return $self->{its_role}->exist();
 }
 
 sub select_system_role {
     my ($self, $role) = @_;
-    return $self->{sel_role}->select($role);
+    return $self->{its_role}->select($role);
 }
 
 1;

--- a/lib/YaST/Bootloader/BootCodeOptionsPage.pm
+++ b/lib/YaST/Bootloader/BootCodeOptionsPage.pm
@@ -16,13 +16,13 @@ sub init {
     my ($self) = @_;
     $self->SUPER::init();
     $self->{cmb_bootloader} = $self->{app}->combobox({id => "\"Bootloader::LoaderTypeWidget\""});
-    $self->{cb_write_to_partition} = $self->{app}->checkbox({id => 'boot'});
-    $self->{cb_bootdev} = $self->{app}->checkbox({id => 'mbr'});
-    $self->{cb_custom_boot} = $self->{app}->checkbox({id => 'custom'});
+    $self->{chb_write_to_partition} = $self->{app}->checkbox({id => 'boot'});
+    $self->{chb_bootdev} = $self->{app}->checkbox({id => 'mbr'});
+    $self->{chb_custom_boot} = $self->{app}->checkbox({id => 'custom'});
     $self->{cmb_mbr_flag} = $self->{app}->combobox({id => '"Bootloader::PMBRWidget"'});
-    $self->{cb_trusted_boot} = $self->{app}->checkbox({id => '"Bootloader::TrustedBootWidget"'});
-    $self->{cb_generic_to_mbr} = $self->{app}->checkbox({id => '"Bootloader::GenericMBRWidget"'});
-    $self->{cb_set_active_flag} = $self->{app}->checkbox({id => '"Bootloader::ActivateWidget"'});
+    $self->{chb_trusted_boot} = $self->{app}->checkbox({id => '"Bootloader::TrustedBootWidget"'});
+    $self->{chb_generic_to_mbr} = $self->{app}->checkbox({id => '"Bootloader::GenericMBRWidget"'});
+    $self->{chb_set_active_flag} = $self->{app}->checkbox({id => '"Bootloader::ActivateWidget"'});
     $self->{tab_boot_loader_settings} = $self->{app}->tab({id => '"CWM::DumbTabPager"'});
     $self->{btn_ok} = $self->{app}->button({id => 'next'});
     $self->{btn_cancel} = $self->{app}->button({id => 'abort'});
@@ -41,22 +41,22 @@ sub get_bootloader_type {
 
 sub get_write_to_mbr {
     my ($self) = @_;
-    return $self->{cb_bootdev}->is_checked();
+    return $self->{chb_bootdev}->is_checked();
 }
 
 sub get_write_to_custom {
     my ($self) = @_;
-    return $self->{cb_custom_boot}->is_checked();
+    return $self->{chb_custom_boot}->is_checked();
 }
 
 sub get_trusted_boot_support {
     my ($self) = @_;
-    return $self->{cb_custom_boot}->is_checked();
+    return $self->{chb_custom_boot}->is_checked();
 }
 
 sub get_write_to_partition {
     my ($self) = @_;
-    return $self->{cb_write_to_partition}->is_checked();
+    return $self->{chb_write_to_partition}->is_checked();
 }
 
 sub get_protective_mbr_flag {
@@ -66,27 +66,27 @@ sub get_protective_mbr_flag {
 
 sub get_set_active_flag {
     my ($self) = @_;
-    return $self->{cb_set_active_flag}->is_checked();
+    return $self->{chb_set_active_flag}->is_checked();
 }
 
 sub get_write_generic_to_mbr {
     my ($self) = @_;
-    return $self->{cb_generic_to_mbr}->is_checked();
+    return $self->{chb_generic_to_mbr}->is_checked();
 }
 
 sub check_write_to_partition {
     my ($self) = @_;
-    $self->{cb_write_to_partition}->check();
+    $self->{chb_write_to_partition}->check();
 }
 
 sub check_write_generic_to_mbr {
     my ($self) = @_;
-    $self->{cb_generic_to_mbr}->check();
+    $self->{chb_generic_to_mbr}->check();
 }
 
 sub uncheck_write_to_mbr {
     my ($self) = @_;
-    $self->{cb_bootdev}->uncheck();
+    $self->{chb_bootdev}->uncheck();
 }
 
 sub switch_to_bootloader_options_tab {

--- a/lib/YaST/Bootloader/BootloaderOptionsPage.pm
+++ b/lib/YaST/Bootloader/BootloaderOptionsPage.pm
@@ -15,18 +15,18 @@ use warnings;
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{txt_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::TimeoutWidget\""});
+    $self->{txb_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::TimeoutWidget\""});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    $self->{txt_grub_timeout}->exist();
+    $self->{txb_grub_timeout}->exist();
 }
 
 sub set_grub_timeout {
     my ($self, $timeout) = @_;
-    $self->{txt_grub_timeout}->set($timeout);
+    $self->{txb_grub_timeout}->set($timeout);
 }
 
 1;

--- a/lib/YaST/Bootloader/KernelParametersPage.pm
+++ b/lib/YaST/Bootloader/KernelParametersPage.pm
@@ -15,23 +15,23 @@ use warnings;
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{txt_opt_kernel_param} = $self->{app}->textbox({id => "\"Bootloader::KernelAppendWidget\""});
+    $self->{txb_opt_kernel_param} = $self->{app}->textbox({id => "\"Bootloader::KernelAppendWidget\""});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    $self->{txt_opt_kernel_param}->exist();
+    $self->{txb_opt_kernel_param}->exist();
 }
 
 sub get_optional_kernel_param {
     my ($self) = @_;
-    $self->{txt_opt_kernel_param}->value();
+    $self->{txb_opt_kernel_param}->value();
 }
 
 sub set_optional_kernel_param {
     my ($self, $param) = @_;
-    $self->{txt_opt_kernel_param}->set($param);
+    $self->{txb_opt_kernel_param}->set($param);
 }
 
 1;

--- a/lib/YaST/Firstboot/ConfigurationCompletedPage.pm
+++ b/lib/YaST/Firstboot/ConfigurationCompletedPage.pm
@@ -24,18 +24,18 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{rt_finish_setup} = $self->{app}->richtext({type => 'YRichText'});
+    $self->{rct_finish_setup} = $self->{app}->richtext({type => 'YRichText'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rt_finish_setup}->exist();
+    return $self->{rct_finish_setup}->exist();
 }
 
 sub get_text {
     my ($self) = @_;
-    return $self->{rt_finish_setup}->text();
+    return $self->{rct_finish_setup}->text();
 }
 
 1;

--- a/lib/YaST/Firstboot/HostNamePage.pm
+++ b/lib/YaST/Firstboot/HostNamePage.pm
@@ -24,24 +24,24 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{tb_static_hostname} = $self->{app}->textbox({id => '"HOSTNAME"'});
-    $self->{cb_dhcp_hostname_method} = $self->{app}->combobox({id => '"DHCP_HOSTNAME"'});
+    $self->{txb_static_hostname} = $self->{app}->textbox({id => '"HOSTNAME"'});
+    $self->{cmb_dhcp_hostname_method} = $self->{app}->combobox({id => '"DHCP_HOSTNAME"'});
     return $self;
 }
 
 sub get_static_hostname {
     my ($self) = @_;
-    return $self->{tb_static_hostname}->value();
+    return $self->{txb_static_hostname}->value();
 }
 
 sub get_set_hostname_via_DHCP {
     my ($self) = @_;
-    return $self->{cb_dhcp_hostname_method}->value();
+    return $self->{cmb_dhcp_hostname_method}->value();
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{tb_static_hostname}->exist();
+    return $self->{txb_static_hostname}->exist();
 }
 
 1;

--- a/lib/YaST/Firstboot/KeyboardLayoutPage.pm
+++ b/lib/YaST/Firstboot/KeyboardLayoutPage.pm
@@ -24,18 +24,18 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{isel_keyboard_layout} = $self->{app}->itemselector({id => 'layout_list'});
+    $self->{its_keyboard_layout} = $self->{app}->itemselector({id => 'layout_list'});
     return $self;
 }
 
 sub get_keyboard_layout {
     my ($self) = @_;
-    return ($self->{isel_keyboard_layout}->selected_items())[0];
+    return ($self->{its_keyboard_layout}->selected_items())[0];
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{isel_keyboard_layout}->exist();
+    return $self->{its_keyboard_layout}->exist();
 }
 
 1;

--- a/lib/YaST/Firstboot/LanguageAndKeyboardLayoutPage.pm
+++ b/lib/YaST/Firstboot/LanguageAndKeyboardLayoutPage.pm
@@ -24,24 +24,24 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{cb_keyboard_layout} = $self->{app}->combobox({id => 'keyboard'});
-    $self->{cb_language} = $self->{app}->combobox({id => 'language'});
+    $self->{cmb_keyboard_layout} = $self->{app}->combobox({id => 'keyboard'});
+    $self->{cmb_language} = $self->{app}->combobox({id => 'language'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{cb_language}->exist();
+    return $self->{cmb_language}->exist();
 }
 
 sub get_language {
     my ($self) = @_;
-    return $self->{cb_language}->value();
+    return $self->{cmb_language}->value();
 }
 
 sub get_keyboard_layout {
     my ($self) = @_;
-    return $self->{cb_keyboard_layout}->value();
+    return $self->{cmb_keyboard_layout}->value();
 }
 
 1;

--- a/lib/YaST/Firstboot/NTPConfigurationPage.pm
+++ b/lib/YaST/Firstboot/NTPConfigurationPage.pm
@@ -24,13 +24,13 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{rb_only_manually} = $self->{app}->radiobutton({id => '"never"'});
+    $self->{rdb_only_manually} = $self->{app}->radiobutton({id => '"never"'});
     return $self;
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rb_only_manually}->exist();
+    return $self->{rdb_only_manually}->exist();
 }
 
 1;

--- a/lib/YaST/Firstboot/WelcomePage.pm
+++ b/lib/YaST/Firstboot/WelcomePage.pm
@@ -24,18 +24,18 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    $self->{rt_welcome} = $self->{app}->richtext({id => 'welcome_text'});
+    $self->{rct_welcome} = $self->{app}->richtext({id => 'welcome_text'});
     return $self;
 }
 
 sub get_welcome_text {
     my ($self) = @_;
-    return $self->{rt_welcome}->text();
+    return $self->{rct_welcome}->text();
 }
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rt_welcome}->exist();
+    return $self->{rct_welcome}->exist();
 }
 
 1;

--- a/ui-framework-documentation.md
+++ b/ui-framework-documentation.md
@@ -459,6 +459,39 @@ sub edit_proposal {
 
  edit_proposal({is_lvm => 1, has_separate_home => 1});
 ``` 
+
+### Abbreviated prefixes for YuiRestClient widgets
+
+To avoid confusion identifiers that refer to UI widgets should be prefixed with a three-letter abbreviation for the widget followed by an underscore '_'.
+
+**Building rules for prefixes**
+
+* prefixes have the length of 3 letters, all in lower case
+* all letters are consonants, except you have not enough, then take vowels as well (e.g. the Tab widget transforms to 'tab')
+* if a widget name consists of 2 words in CamelCase type style then the first two characters come from the first word, the 3rd character from the second word
+* avoid repetition of the same letter, therefore it is "btn" for Button and not "btt"
+
+Applying the rules above gives us the following prefixes:
+
+| Prefix | Widget | Example     |
+|--------|--------|-------------|
+| btn    | Button | btn_ok      |
+| chb    | CheckBox | chb_autologin |
+| cmb    | ComboBox | cmb_filesystem |
+| its    | ItemSelector | its_keyboard_layout |
+| lbl    | Label   | lbl_warning | 
+| mnc    | MenuCollection | mnc_operation |
+| prb    | ProgressBar | prb_total_packages |
+| rdb     | RadioButton | rdb_skip_registration |
+| rct     | RichText    | rct_welcome |
+| slb   | SelectionBox | slb_addons | 
+| tbl    | Table        | tbl_devices |
+| txb    | TextBox      | txb_maximum_channel | 
+| tre   | Tree         | tre_system_view |
+| tab    | Tab          | tab_boot_loader_settings |
+
+
+
 ## Getting Started
 
 So, basically a new test requires to have at least one package/class per


### PR DESCRIPTION
Document widget abbrevations in ui-framework-documentation.md. 

The current state is that all "Page" code was revised and variables were renamed according to the ui-framework-documentation.md proposal.. 

- Related ticket: https://progress.opensuse.org/issues/105070
- Needles: n.a.
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=rakoenig_widget_naming&groupid=96
