### PR TITLE
Remove vim from installation tests (functional part)

### DIFF
--- a/schedule/functional/extra_tests_misc.yaml
+++ b/schedule/functional/extra_tests_misc.yaml
@@ -15,6 +15,7 @@ schedule:
     - boot/boot_to_desktop
     - update/zypper_up
     - console/ncurses
+    - console/vim
     - console/iotop
     - console/gd
     - console/journalctlLevels

--- a/schedule/functional/minimal_x.yaml
+++ b/schedule/functional/minimal_x.yaml
@@ -45,7 +45,6 @@ schedule:
     - update/zypper_up
     - console/zypper_in
     - console/zypper_log
-    - console/vim
     - console/firewall_enabled
     - console/sshd
     - console/ssh_cleanup


### PR DESCRIPTION
see https://progress.opensuse.org/issues/95724
Add vim in extra_test_misc
