### PR TITLE
Use dummy IPs instead of NTP pools

### DIFF
--- a/lib/services/ntpd.pm
+++ b/lib/services/ntpd.pm
@@ -25,11 +25,20 @@ sub install_service {
 # This will be used by QAM ntp test.
 sub check_config {
     my $server_count = script_output 'ntpq -p | tail -n +3 | wc -l';
-    assert_script_run 'echo "server 3.europe.pool.ntp.org" >> /etc/ntp.conf';
-    assert_script_run 'echo "server 2.europe.pool.ntp.org" >> /etc/ntp.conf';
+    record_info 'Servers', "Default ntp servers defined: $server_count";
+    assert_script_run 'cp /etc/ntp.conf /etc/ntp.conf.bkp';
+    assert_script_run 'echo "server 172.16.12.34" >> /etc/ntp.conf';
+    assert_script_run 'echo "server 172.16.21.43" >> /etc/ntp.conf';
     common_service_action($service_name, $service_type, 'restart');
     assert_script_run 'ntpq -p';
-    $server_count + 2 <= script_output 'ntpq -p | tail -n +3 | wc -l' or die "Configuration not loaded";
+    for (my $i = 0; $i < 5; $i++) {
+        if ($server_count + 2 <= script_output('ntpq -pn | tail -n +3 | wc -l')) {
+            record_info 'Config', "$i ... 6 servers found";
+            return;
+        }
+        sleep 30;
+    }
+    die "Configuration not loaded";
 }
 
 sub config_service {

--- a/tests/console/ntp.pm
+++ b/tests/console/ntp.pm
@@ -15,7 +15,7 @@ use utils;
 use services::ntpd;
 
 sub run {
-    select_console 'root-console';
+    shift->select_serial_terminal;
     services::ntpd::install_service();
     services::ntpd::enable_service();
     services::ntpd::start_service();
@@ -23,6 +23,17 @@ sub run {
     services::ntpd::config_service();
     services::ntpd::check_service();
     services::ntpd::check_function();
+}
+
+sub post_fail_hook {
+    assert_script_run 'cp /etc/ntp.conf.bkp /etc/ntp.conf' if (script_run('test -f /etc/ntp.conf.bkp') == 0);
+    upload_logs '/var/log/ntp';
+    shift->save_and_upload_log('journalctl --no-pager -o short-precise', 'journalctl.txt');
+}
+
+sub post_run_hook {
+    assert_script_run 'cp /etc/ntp.conf.bkp /etc/ntp.conf' if (script_run('test -f /etc/ntp.conf.bkp') == 0);
+
 }
 
 1;


### PR DESCRIPTION
In order to verify successful updates of NTP configuration, it is enough to
use dummy IPs instead of real NTP pools.

According to Reinhard's findings test should not mix NTP pools as NTP
client might filter out duplicated address.

- [ntp dies after restart](https://progress.opensuse.org/issues/102047)