### PR TITLE
utils::ssh_fully_patch_system() record info how long the zypper patch command took

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -711,11 +711,17 @@ the second run will update the system.
 =cut
 sub ssh_fully_patch_system {
     my $remote = shift;
+
+    my $cmd_time = time();
     # first run, possible update of packager -- exit code 103
     my $ret = script_run("ssh $remote 'sudo zypper -n patch --with-interactive -l'", 1500);
+    record_info('zypper patch', 'The command zypper patch took ' . (time() - $cmd_time) . ' seconds.');
     die "Zypper failed with $ret" if ($ret != 0 && $ret != 102 && $ret != 103);
+
+    $cmd_time = time();
     # second run, full system update
     $ret = script_run("ssh $remote 'sudo zypper -n patch --with-interactive -l'", 6000);
+    record_info('zypper patch', 'The second command zypper patch took ' . (time() - $cmd_time) . ' seconds.');
     die "Zypper failed with $ret" if ($ret != 0 && $ret != 102);
 }
 


### PR DESCRIPTION
- Follows #14182 
- Related ticket: [bsc#1195382](https://bugzilla.suse.com/show_bug.cgi?id=1195382) [poo#105969](https://progress.opensuse.org/issues/105969)
- Verification run: [GCE OnDemand](http://pdostal-server.suse.cz/tests/13234#step/patch_and_reboot/9) [EC2 BYOS](http://pdostal-server.suse.cz/tests/13235#step/patch_and_reboot/9) [Azure BYOS](http://pdostal-server.suse.cz/tests/13238#step/patch_and_reboot/7)
