### PR TITLE
Add timeout for apparmor aa autodep test

### DIFF
--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -12,7 +12,7 @@
 # - Disable temporarily created nscd profile
 # - Cleanup temporary profiles
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#36889, poo#45803
+# Tags: poo#36889, poo#45803, poo#106002
 
 use base 'apparmortest';
 use strict;
@@ -55,7 +55,7 @@ sub run {
                 key => 'c',
             },
         ],
-        60
+        90
     );
 
     # Output generated profiles list to serial console


### PR DESCRIPTION
On aarch64 platform, due to lower performance of the test
machine, in apparmor test, aa autodep command may need more
time to get return, so add some wait time.

Currently, only aarch64 platform hit the issue, and the code change should not impact other platforms.
then skip the VRs on other platforms.

- Related ticket: https://progress.opensuse.org/issues/106002
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/8116583
