### PR TITLE
SLE Micro: add more tests in container suites

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -191,6 +191,21 @@ our %images_uri = (
             released => sub { 'registry.suse.com/suse/sle15:15.3' },
             totest => sub { },
             available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
+        '5.0' => {
+            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
+            totest => sub { },
+            available_arch => ['x86_64', 'aarch64', 's390x']
+        },
+        '5.1' => {
+            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
+            totest => sub { },
+            available_arch => ['x86_64', 'aarch64', 's390x']
+        },
+        '5.2' => {
+            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
+            totest => sub { },
+            available_arch => ['x86_64', 'aarch64', 's390x']
         }
     },
     microos => {

--- a/schedule/sle-micro/containers.yaml
+++ b/schedule/sle-micro/containers.yaml
@@ -31,6 +31,8 @@ schedule:
   - '{{maintenance}}'
   - '{{selinux}}'
   - microos/toolbox
-  - containers/podman_3rd_party_images
   - containers/podman
   - containers/podman_image
+  - containers/podman_3rd_party_images
+  - containers/podman_firewall
+  - containers/rootless_podman

--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -59,7 +59,7 @@ sub run {
 
 
     record_info 'Test', "Rootless toolbox as $user";
-    select_console 'user-console';
+    my $console = select_console 'user-console';
     my $uid = script_output 'id -u';
     validate_script_output 'toolbox -u id', sub { m/uid=${uid}\(${user}\)/ }, timeout => 180;
     die "$user shouldn't have access to /etc/passwd!" if (script_run('toolbox -u touch /etc/passwd') == 0);
@@ -69,6 +69,9 @@ sub run {
     assert_script_run 'toolbox -r touch /etc/passwd', fail_message => 'Root should have access to /etc/passwd!';
     assert_script_run 'podman ps -a';
     clean_container_host(runtime => 'podman');
+
+    enter_cmd "exit";
+    $console->reset;
 
     # Back to root
     select_console 'root-console';


### PR DESCRIPTION
Reasoning:
- Add more podman coverage in SLE Micro/MicroOS.
- Related ticket: https://jira.suse.com/browse/SLE-22715 (podman maintenance update)

TBD: add tests for openSUSE too.

[SLE Micro 5.2](https://openqa.suse.de/tests/overview?distri=sle-micro&version=5.2&build=jlausuch%2Fos-autoinst-distri-opensuse%23sle_micro_containers)
[SLE Micro 5.1](https://openqa.suse.de/tests/overview?build=jlausuch%2Fos-autoinst-distri-opensuse%23sle_micro_containers&distri=sle-micro&version=5.1)
[SLE Micro 5.0](https://openqa.suse.de/tests/overview?build=jlausuch%2Fos-autoinst-distri-opensuse%23sle_micro_containers&version=5.0&distri=sle-micro)