### PR TITLE
Enable textmode_svirt tests with yaml schedule

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1100,8 +1100,6 @@ sub load_consoletests {
     loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
-    # This is a temporary solution for enabling open-vm-tools tests, will use YAML job template instead.
-    loadtest 'virt_autotest/esxi_open_vm_tools' if is_vmware && get_var('OPEN_VM_TOOLS');
 
     if (get_var('IBM_TESTS')) {
         # prepare tarballs for the testcase

--- a/schedule/virt_autotest/textmode_svirt.yaml
+++ b/schedule/virt_autotest/textmode_svirt.yaml
@@ -1,0 +1,51 @@
+name:           textmode_svirt
+description:    >
+    Maintainer: nan.zhang@suse.com
+    Textmode installation with integration services and open-vm-tools test modules
+schedule:
+    - installation/isosize
+    - '{{bootloader}}'
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/add_serial_console
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/grub_test
+    - installation/first_boot
+    - console/system_prepare
+    - console/check_network
+    - console/system_state
+    - console/integration_services
+    - '{{open_vm_tools}}'
+conditional_schedule:
+    bootloader:
+        VIRSH_VMM_FAMILY:
+            vmware:
+                - installation/bootloader_svirt
+                - '{{uefi}}'
+            hyperv:
+                - installation/bootloader_hyperv
+                - '{{uefi}}'
+    uefi:
+        UEFI:
+            1:
+                - installation/bootloader_uefi
+            0:
+                - installation/bootloader
+    open_vm_tools:
+        VIRSH_VMM_FAMILY:
+            vmware:
+                - virt_autotest/esxi_open_vm_tools


### PR DESCRIPTION
Textmode related tests will be replaced and run with yaml job template. And additional job parameter will be appended to the test suite "textmode_svirt": YAML_SCHEDULE=schedule/virt_autotest/textmode_svirt.yaml

- Related ticket: https://progress.opensuse.org/issues/106185
- Verification run: 
    textmode_svirt@svirt-hyperv: https://openqa.nue.suse.com/tests/8119694
    textmode_svirt@svirt-hyperv-uefi: https://openqa.nue.suse.com/tests/8123889
    textmode_svirt@svirt-hyperv2012r2: https://openqa.nue.suse.com/tests/8119693
    textmode_svirt@svirt-hyperv2012r2-uefi: https://openqa.nue.suse.com/tests/8123944
    textmode_svirt@svirt-hyperv2016: https://openqa.nue.suse.com/tests/8119692
    textmode_svirt@svirt-hyperv2016-uefi: https://openqa.nue.suse.com/tests/8123871
    textmode_svirt@svirt-vmware65: https://openqa.nue.suse.com/tests/8117124
    textmode_svirt@svirt-vmware67: http://10.67.129.66/tests/369