### PR TITLE
install_ltp: Use zypper_call() for installing deps

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -84,7 +84,8 @@ sub install_runtime_dependencies {
       xfsprogs
     );
     for my $dep (@maybe_deps) {
-        script_run('zypper -n -t in ' . $dep . ' | tee');
+        # ignore failures due to missing packages (exit code 104)
+        zypper_call("in $dep", exitcode => [0, 104]);
     }
 }
 
@@ -96,7 +97,8 @@ sub install_debugging_tools {
       strace
     );
     for my $dep (@maybe_deps) {
-        script_run('zypper -n -t in ' . $dep . ' | tee');
+        # ignore failures due to missing packages (exit code 104)
+        zypper_call("in $dep", exitcode => [0, 104]);
     }
 }
 
@@ -125,7 +127,8 @@ sub install_runtime_dependencies_network {
       xinetd
     );
     for my $dep (@maybe_deps) {
-        script_run('zypper -n -t in ' . $dep . ' | tee');
+        # ignore failures due to missing packages (exit code 104)
+        zypper_call("in $dep", exitcode => [0, 104]);
     }
 }
 
@@ -165,7 +168,8 @@ sub install_build_dependencies {
       libtirpc-devel-32bit
     );
     for my $dep (@maybe_deps) {
-        script_run('zypper -n -t in ' . $dep . ' | tee');
+        # ignore failures due to missing packages (exit code 104)
+        zypper_call("in $dep", exitcode => [0, 104]);
     }
 }
 


### PR DESCRIPTION
The default `script_run()` timeout is often not enough to install packages. Since PR #14027 got merged, this would cause the whole install_ltp job to fail. Switch package installation to `zypper_call()` with better default timeout and extended error handling.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - aarch64: https://openqa.suse.de/tests/8117178
  - x86_64: https://openqa.suse.de/tests/8117177
