### PR TITLE
Fix brtfs_qgroups

### DIFF
--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -101,7 +101,7 @@ sub run {
         record_soft_failure 'File overwrite test: bsc#1113042 - btrfs is not informed to commit transaction';
     }
     # write some more times to the same file to be sure
-    if (script_run("for c in {1..38}; do $write_chunk; done")) {
+    if (script_run("for c in {1..38}; do $write_chunk; done", die_on_timeout => 0)) {
         record_soft_failure 'File overwrite test: bsc#1113042 - btrfs is not informed to commit transaction';
     }
     assert_script_run 'sync';


### PR DESCRIPTION
do not fail on timeout to match old behavior, before https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14027

This is a quick fix to not break the test. Will keep the ticket open and we can think on a proper solution to avoid the timeout later on.

- Related ticket: https://progress.opensuse.org/issues/106320
- Needles: no needles
- Verification run:  https://openqa.suse.de/t8124373
