### PR TITLE
Softfail bsc#1195156 also for GCE and EC2

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -189,11 +189,7 @@ sub wait_for_guestregister
             $self->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
             $out = $self->run_ssh_command(cmd => 'sudo systemctl status guestregister', proceed_on_failure => 1, quiet => 1);
             record_info("guestregister failed", $out, result => 'fail');
-            if (is_azure) {
-                record_soft_failure("bsc#1195156");
-            } else {
-                die("guestregister failed");
-            }
+            record_soft_failure("bsc#1195156");
             return time() - $start_time;
         } elsif ($out eq 'active') {
             $self->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');


### PR DESCRIPTION
bsc#1195156 is now also an issue for GCE and EC2, so mark this failure
as softfailure for all CSP.

- Related ticket: https://progress.opensuse.org/issues/106341
- Verification run: http://duck-norris.qam.suse.de/t8168 (`prepare_instance` passes)
