### PR TITLE
installation/enable_selinux: Adapt to YaST UI changes

### DIFF
--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use base 'y2_installbase';
 use testapi;
+use version_utils 'is_microos';
 
 sub run {
     my $textmode = check_var('VIDEOMODE', 'text');
@@ -28,9 +29,21 @@ sub run {
         send_key 'ret';
     }
 
-    send_key 'alt-m';
-    send_key_until_needlematch 'security-selinux-enforcing', 'down';
-    send_key 'ret' if $textmode;
+    if (is_microos('<5.3')) {
+        # Combobox for SELinux specifically
+        send_key 'alt-m';
+        send_key_until_needlematch 'security-selinux-enforcing', 'down';
+        send_key 'ret' if $textmode;
+    } else {
+        # Select SELinux first
+        send_key 'alt-s';
+        send_key_until_needlematch 'security-module-selinux', 'up';
+        send_key 'ret' if $textmode;
+        # Switch it into enforcing mode
+        send_key 'alt-u';
+        send_key_until_needlematch 'security-selinux-enforcing', 'down';
+        send_key 'ret' if $textmode;
+    }
 
     send_key $cmd{ok};
 

--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -47,7 +47,8 @@ sub run {
 
     send_key $cmd{ok};
 
-    # yast needs some time to think
+    # Make sure the overview is fully loaded and not being recalculated
+    wait_still_screen(3);
     assert_screen 'installation-settings-overview-loaded';
 }
 


### PR DESCRIPTION
Tumbleweed and presumably 15-SP4/15.4 have a separate combo box for selecting
between SELinux and AppApparmor now which needs to be interacted with first.
The module is only used on SLE Micro and TW as of now, so add that condition
only for now.

- Related ticket: https://progress.opensuse.org/issues/104541
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/762
- Verification run: http://10.160.67.85/tests/1170#step/enable_selinux/16
