### PR TITLE
Revert upload_asset deletion

### DIFF
--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -26,6 +26,7 @@ schedule:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
+  - console/upload_asset
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot

--- a/test_data/yast/raid/raid0_gpt_bios_boot.yaml
+++ b/test_data/yast/raid/raid0_gpt_bios_boot.yaml
@@ -1,4 +1,5 @@
 <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+asset_files: "/var/log/YaST2/y2log*"
 mds:
   - raid_level: 0
     name: md0

--- a/tests/console/upload_asset.pm
+++ b/tests/console/upload_asset.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Compresses files, as given in test data and upload the compressed file as asset.
+# test data example:
+# test_data:
+#   asset_files: "/dir1/file1 /dir2/file2"
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler "get_test_suite_data";
+
+sub run {
+    select_console 'root-console';
+    my $files_to_upload = get_test_suite_data()->{asset_files};
+    assert_script_run("tar -cvf asset_files.tar $files_to_upload", fail_message => "Failed to compress file(s)");
+    upload_asset("asset_files.tar");
+}
+
+1;


### PR DESCRIPTION
detect_yast2_failures is using the asset which is uploaded.
Please, check https://openqa.suse.de/tests/8126491#dependencies

- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14161
