### PR TITLE
install_ltp: Remove libopenssl-devel-32bit dependency on SLE-12

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -163,10 +163,14 @@ sub install_build_dependencies {
       libmnl-devel
       libnuma-devel
       libnuma-devel-32bit
-      libopenssl-devel-32bit
       libselinux-devel-32bit
       libtirpc-devel-32bit
     );
+
+    # libopenssl-devel-32bit is blocked by dependency mess on SLE-12 and we
+    # don't use it anyway...
+    push @maybe_deps, 'libopenssl-devel-32bit' if !is_sle('<15');
+
     for my $dep (@maybe_deps) {
         # ignore failures due to missing packages (exit code 104)
         zypper_call("in $dep", exitcode => [0, 104]);


### PR DESCRIPTION
PR #14199 has revealed a dependency conflict which has been preventing the installation of libopenssl-devel-32bit on SLE-12: https://openqa.suse.de/tests/8121776#step/install_ltp/76

We don't run any 32bit LTP tests in maintenance so the package is not needed.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - SLE-12SP4: https://openqa.suse.de/tests/8129244
  - SLE-15GA: https://openqa.suse.de/tests/8129247
  - SLE-15SP1: https://openqa.suse.de/tests/8129248
