### PR TITLE
Update dracut to version 055

### DIFF
--- a/schedule/functional/extra_tests_dracut.yaml
+++ b/schedule/functional/extra_tests_dracut.yaml
@@ -6,4 +6,5 @@ schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
     - console/dracut
+    - console/dracut_enhanced
     - console/coredump_collect


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/104907
- Needles: *not applicable*
- Verification runs:
    **Build 95.1:** [x86_64](https://openqa.suse.de/tests/8128899#step/dracut/15) | [aarch64](https://openqa.suse.de/tests/8124978#step/dracut/15) | [s390x](https://openqa.suse.de/tests/8125822#step/dracut/3) | [ppc64le](https://openqa.suse.de/tests/8125463#step/dracut/15)