### PR TITLE
Migrate vmware test to esxi7 and resolve softfails

### DIFF
--- a/schedule/virtualization/vmware_hyperv.yaml
+++ b/schedule/virtualization/vmware_hyperv.yaml
@@ -4,7 +4,6 @@ description:    >
     Testing Kernel on VMware / Hyper-V SLE hosts
 schedule:
     - support_server/login
-    - support_server/setup
     - virtualization/external/prepare
     - virtualization/universal/ssh_hypervisor_init
     - virtualization/universal/ssh_guests_init

--- a/tests/virtualization/external/prepare.pm
+++ b/tests/virtualization/external/prepare.pm
@@ -15,19 +15,24 @@ use version_utils;
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
-
+    select_console("root-console");
     script_run("SUSEConnect -r " . get_var('SCC_REGCODE'), timeout => 420);
-
     assert_script_run "rm /etc/zypp/repos.d/SUSE_Maintenance* || true";
     assert_script_run "rm /etc/zypp/repos.d/TEST* || true";
     zypper_call '-t in nmap iputils bind-utils', exitcode => [0, 102, 103, 106];
 
     # Fill the current pairs of hostname & address into /etc/hosts file
-    assert_script_run "echo \"\$(dig +short $virt_autotest::common::guests{$_}->{ip}) $_ # virtualization\" >> /etc/hosts" foreach (keys %virt_autotest::common::guests);
+    if (get_var("REGRESSION", '') =~ /vmware/) {
+        foreach my $guest (keys %virt_autotest::common::guests) {
+            my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no root\@esxi7.qa.suse.cz "vim-cmd vmsvc/get.guest \\`vim-cmd vmsvc/getallvms | grep -w $guest|cut -d ' ' -f1\\`|grep -A 1 hostName|grep ipAddress|cut -d '\\"' -f2"));
+            record_info("$ip");
+            assert_script_run(qq(echo "$ip $guest" >> /etc/hosts));
+        }
+    } else {
+        assert_script_run "echo \"\$(dig +short $virt_autotest::common::guests{$_}->{ip}) $_ # virtualization\" >> /etc/hosts" foreach (keys %virt_autotest::common::guests);
+    }
     assert_script_run "cat /etc/hosts";
 }
-
 sub test_flags {
     return {fatal => 1, milestone => 1};
 }


### PR DESCRIPTION
1. Migrate vmware test from esxi6.0 to esxi7.0
2. Using dynamic IP address for VMs instead of static IP.  No need to manually create MAC and set up static IP. Release static IP resource
3. resolve softfails for Vmware and hyperv tests

- Related ticket: https://progress.opensuse.org/issues/104482
- Needles: no
- Verification run: 
sles15: https://openqa.suse.de/tests/overview?distri=sle&build=%3A22662%3A&groupid=322&version=15
sles15sp1: https://openqa.suse.de/tests/overview?build=%3A22660%3A&groupid=322&distri=sle&version=15-SP1
sles12sp3: https://openqa.suse.de/tests/overview?version=12-SP3&distri=sle&groupid=322&build=%3A22643%3A
