### PR TITLE
Fix snapper rollback -d rollback-before-migration timeout

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -32,7 +32,7 @@ sub run {
     script_run("snapper list", 0);
     script_run("cat /etc/os-release", 0);
     # rollback
-    script_run("snapper rollback -d rollback-before-migration");
+    script_run("snapper rollback -d rollback-before-migration", timeout => 120);
     my $ret = script_run("snapper --help | grep disable-used-space");
     my $disable = '';
     $disable = '--disable-used-space' unless $ret;


### PR DESCRIPTION
We need to enlarge the timeout value for snapper rollback to rollback-before-migration.

- Related ticket: https://progress.opensuse.org/issues/106496
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t8134000 
  https://openqa.nue.suse.com/t8139313
  https://openqa.nue.suse.com/tests/8139448
  https://openqa.nue.suse.com/tests/8139449
  https://openqa.nue.suse.com/tests/8139445 
  https://openqa.nue.suse.com/tests/8139444
