### PR TITLE
Remove leftover testing code

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -120,7 +120,6 @@ sub run {
             send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 3);
         }
         elsif (!is_jeos && !is_microos('VMX')) {
-            send_key 'up';
             send_key_until_needlematch('inst-oninstallation', 'down', 10, 3);
         }
     }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/106609
- Verification run: [microos-Tumbleweed-Kubic-DVD-x86_64-Build20220209-container-host@uefi ](http://kepler.suse.cz/tests/12950#)
