### PR TITLE
Fix rhythmbox test

### DIFF
--- a/tests/x11/rhythmbox.pm
+++ b/tests/x11/rhythmbox.pm
@@ -16,12 +16,12 @@ use utils "zypper_call";
 use x11utils 'start_root_shell_in_xterm';
 
 sub run {
+    start_root_shell_in_xterm();
     if (!script_run "rpm -q libtdb1") {
         record_soft_failure("Missing dependency for rhythmbox - bsc#1195510");
-        start_root_shell_in_xterm();
         zypper_call "in libtdb1";
-        enter_cmd "killall xterm";
     }
+    enter_cmd "killall xterm";
     x11_start_program('rhythmbox');
     send_key "alt-f4";
 }

--- a/tests/x11/rhythmbox.pm
+++ b/tests/x11/rhythmbox.pm
@@ -16,12 +16,6 @@ use utils "zypper_call";
 use x11utils 'start_root_shell_in_xterm';
 
 sub run {
-    start_root_shell_in_xterm();
-    if (!script_run "rpm -q libtdb1") {
-        record_soft_failure("Missing dependency for rhythmbox - bsc#1195510");
-        zypper_call "in libtdb1";
-    }
-    enter_cmd "killall xterm";
     x11_start_program('rhythmbox');
     send_key "alt-f4";
 }


### PR DESCRIPTION
need to open a shell to check for dependency. Was working before due to
previous behavior of script_run timeout.

- Related ticket: https://progress.opensuse.org/issues/106636
- Needles:no needles
- Verification run: https://openqa.suse.de/tests/8178095
