### PR TITLE
SLE Micro: add migration test with live patching enabled

### DIFF
--- a/schedule/sle-micro/migration.yaml
+++ b/schedule/sle-micro/migration.yaml
@@ -2,10 +2,25 @@ name:           sle_micro_containers
 description:    >
     Maintainer: qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
+conditional_schedule:
+  boot:
+    ARCH:
+      's390x':
+        - installation/bootloader_start
+        - boot/boot_to_desktop
+      'x86_64':
+        - microos/disk_boot
+      'aarch64':
+        - microos/disk_boot
+  live_patching:
+    LIVE_PATCHING:
+      '1':
+        - microos/enable_lp_module
 schedule:
-  - microos/disk_boot
+  - '{{boot}}'
   - transactional/host_config
   - console/suseconnect_scc
+  - '{{live_patching}}'
   - transactional/install_updates
   - migration/online_migration/zypper_migration
   - microos/networking

--- a/tests/microos/enable_lp_module.pm
+++ b/tests/microos/enable_lp_module.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright 2020 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enable Live Patching module in SLE Micro
+# Maintainer: qa-c@suse.de
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use transactional;
+use utils qw(zypper_call);
+
+sub run {
+    select_console 'root-console';
+
+    my $arch = get_required_var('ARCH');
+    my $regcode = get_required_var('SCC_REGCODE_LIVE');
+    my $lp_version = get_required_var('LIVE_PATCHING_VERSION');
+    my $extensions = script_output('SUSEConnect --list-extensions');
+
+    record_info('Extensions', $extensions);
+
+    die("Live Patching module shouldn't be enabled by default") if ($extensions =~ m/Live Patching.*Activated/);
+
+    record_info('Register', 'Registering module "sle-module-live-patching"');
+    trup_call("register -p sle-module-live-patching/$lp_version/$arch -r $regcode");
+    check_reboot_changes;
+    $extensions = script_output('SUSEConnect --list-extensions');
+    record_info('SUSEConnect', script_output('SUSEConnect --status-text'));
+    record_info('Extensions', $extensions);
+
+    die('There was a problem activating the Live Patching module') unless ($extensions =~ m/Live Patching.*Activated/);
+    zypper_call('--gpg-auto-import-keys ref');
+
+    # ensure sle-module-live-patching-release is installed
+    assert_script_run('rpm -q sle-module-live-patching-release');
+    if (script_output('zypper patterns --installed-only') !~ 'lp_sles') {
+        record_info('Pattern', 'Installing pattern lp_sles');
+        trup_call('pkg install -t pattern lp_sles');
+        check_reboot_changes;
+    }
+}
+
+1;


### PR DESCRIPTION
Also, enable migration scenarios in 390x arch.


- Related ticket: https://progress.opensuse.org/issues/106639
- VRs:

[With LP disabled](https://openqa.suse.de/tests/8140818)
[With LP enabled](https://openqa.suse.de/tests/8140658#) (expected to fail due to [bsc#1195832](https://bugzilla.suse.com/show_bug.cgi?id=1195832))

