### PR TITLE
Improve error msg when not using libyui-rest-api

### DIFF
--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -25,6 +25,8 @@ my $host;
 
 sub get_app {
     my (%args) = @_;
+    die "No environment for libyui REST API has been configured.",
+      " Please schedule test module `setup_libyui.pm` in previous steps." unless YuiRestClient::is_libyui_rest_api();
     $app = init_app(%args) unless $app;
     return $app;
 }


### PR DESCRIPTION
When a module that uses libyui-restapi failing on a testsuite that has not set up libyui-rest-api, the resulting error is not very
descriptive.
We improve error message so that reviewers know the exact reason, when such a module fails.

- Related ticket: https://progress.opensuse.org/issues/103917
- Needles: No needles
- Verification run: https://openqa.opensuse.org/tests/2184318#step/disable_online_repos/2
