### PR TITLE
Use libyui-based modules instead of welcome

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -3,7 +3,7 @@
 # Copyright 2016-2020 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: common parts on SMT and RMT
+# Summary: common parts on SMT and RMT, and other tools related to repositories.
 # Maintainer: Lemon Li <leli@suse.com>
 
 =head1 repo_tools
@@ -48,6 +48,14 @@ Tools for repositories used by openQA:
 
 =item * generate_version
 
+=item * validate_repo_properties
+
+=item * parse_repo_data
+
+=item * verify_software
+
+=item * validate_install_repo
+
 =back
 
 =cut
@@ -88,6 +96,7 @@ our @EXPORT = qw(
   validate_repo_properties
   parse_repo_data
   verify_software
+  validate_install_repo
 );
 
 =head2 add_qa_head_repo
@@ -590,6 +599,21 @@ sub verify_software {
         return $error;
     }
     return '';
+}
+
+=head2
+
+Verify that install repo C<mirror> corresponds to the one expected one.
+
+=cut
+
+sub validate_install_repo {
+    my $method = uc get_required_var('INSTALL_SOURCE');
+    my $mirror = get_required_var("MIRROR_$method");
+    record_info("$method mirror:", "$mirror");
+    assert_script_run("grep -Pzo \"install url:(.|\\n)*$mirror\" /var/log/linuxrc.log");
+    assert_script_run('grep install=' . $mirror . ' /proc/cmdline');
+    assert_script_run("grep --color=always -e \"^RepoURL: $mirror\" -e \"^ZyppRepoURL: $mirror\" /etc/install.inf");
 }
 
 1;

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -1,10 +1,10 @@
 ---
 name: gnome_install_from_source
 description: >
-   Install default system using the gnome desktop
-   using a remote repository over http or https or samba.
-   Scenario is thought to use Online medium to boot
-   and Full medium for remote repositories.
+  Install default system using the gnome desktop
+  using a remote repository over http or https or samba.
+  Scenario is thought to use Online medium to boot
+  and Full medium for remote repositories.
 vars:
   DESKTOP: gnome
   NETBOOT: 1
@@ -12,7 +12,9 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/welcome
+  - installation/validation/validate_install_repo
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration
   - installation/module_selection/select_module_desktop

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -8,13 +8,14 @@ description: >
 vars:
   DESKTOP: gnome
   VALIDATE_INST_SRC: '1'
-  EXTRABOOTPARAMS: startshell=1
   YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
-  - installation/validation/repo_inst
   - installation/setup_libyui
-  - installation/welcome
+  - installation/validation/repo_inst
+  - installation/validation/validate_install_repo
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_module_desktop
@@ -31,7 +32,6 @@ schedule:
   - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
   - installation/performing_installation/confirm_reboot
-  - installation/exit_startshell
   - installation/grub_test
   - installation/first_boot
   - console/validate_mirror_repos

--- a/tests/installation/validation/repo_inst.pm
+++ b/tests/installation/validation/repo_inst.pm
@@ -10,17 +10,12 @@
 use strict;
 use warnings;
 use base 'y2_installbase';
-use utils 'get_netboot_mirror';
 use testapi;
 
-
 sub run {
-    assert_screen 'startshell', 180;
+    select_console 'install-shell';
     my $arch = get_var('ARCH');
     assert_script_run("grep -Pzo \"instsys url:(.|\\n)*disk:/boot/$arch/root\" /var/log/linuxrc.log");
-    my $mirror = get_netboot_mirror;
-    assert_script_run("grep -Pzo \"install url:(.|\\n)*$mirror\" /var/log/linuxrc.log");
-    enter_cmd "exit";
 }
 
 1;

--- a/tests/installation/validation/validate_install_repo.pm
+++ b/tests/installation/validation/validate_install_repo.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate that install urls matches the expected one.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+use repo_tools 'validate_install_repo';
+
+
+sub run {
+    select_console 'install-shell';
+    validate_install_repo;
+    select_console 'installation';
+}
+
+1;


### PR DESCRIPTION
See https://progress.opensuse.org/issues/104769
Since welcome included some validation of the remote repository,
we had to implement that separately.
Also got rid of startshell in repo_inst.

I decided not to use different modules for validation of repos, as anyway we rely on variable INSTALL_SOURCE which is needed for grub, so I think it's okay to use it in that case, with a record_info to show what is expected.

VRs:
gnome_smb http://waaa-amazing.suse.cz/tests/16197
gnome_http http://waaa-amazing.suse.cz/tests/16198
repo_inst http://waaa-amazing.suse.cz/tests/16199