### PR TITLE
[virt_autotest] fix up timeout failure from s390x update_package test

### DIFF
--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -108,7 +108,12 @@ sub run {
     my $self = shift;
     my $timeout = get_var('MAX_TEST_TIME', '36000') + 10;
     my $upload_log_name = 'guest-upgrade-logs';
-    script_run("echo \"Debug info: max_test_time is $timeout\"");
+    if (is_s390x) {
+        #ues die_on_timeout=> 0 as workaround for s390x test during call script_run, refer to poo#106765
+        script_run("echo \"Debug info: max_test_time is $timeout\"", die_on_timeout => 0);
+    } else {
+        script_run("echo \"Debug info: max_test_time is $timeout\"");
+    }
     # Modify source configuration file sources.* of virtauto-data pkg on host
     # to use openqa daily build installer repo and module repo for guests,
     # and it will be copied into guests to be used during guest upgrade test
@@ -116,7 +121,8 @@ sub run {
 
     $self->{'package_name'} = 'Guest Upgrade Test';
     if (is_s390x) {
-        script_run "[ -d /var/log/qa/ctcs2 ] && rm -r /var/log/qa/ctcs2 ; [ -d /var/lib/libvirt/images/prj4_guest_upgrade ] && rm -r /var/lib/libvirt/images/prj4_guest_upgrade /tmp/full_guest_upgrade_test-* /tmp/kill_zypper_procs-* /tmp/update-guest-*";
+        #ues die_on_timeout=> 0 as workaround for s390x test during call script_run, refer to poo#106765
+        script_run "[ -d /var/log/qa/ctcs2 ] && rm -r /var/log/qa/ctcs2 ; [ -d /var/lib/libvirt/images/prj4_guest_upgrade ] && rm -r /var/lib/libvirt/images/prj4_guest_upgrade /tmp/full_guest_upgrade_test-* /tmp/kill_zypper_procs-* /tmp/update-guest-*", die_on_timeout => 0;
     }
     else {
         $self->execute_script_run("[ -d /var/log/qa/ctcs2 ] && rm -r /var/log/qa/ctcs2 ; [ -d /tmp/prj4_guest_upgrade ] && rm -r /tmp/prj4_guest_upgrade", 30);
@@ -126,7 +132,8 @@ sub run {
     if (is_s390x) {
         #upload s390x_guest_upgrade_test.log
         upload_asset("/tmp/s390x_guest_upgrade_test.log", 1, 1);
-        script_run "rm -rf /tmp/s390x_guest_upgrade_test.log";
+        #ues die_on_timeout=> 0 as workaround for s390x test during call script_run, refer to poo#106765
+        script_run "rm -rf /tmp/s390x_guest_upgrade_test.log", die_on_timeout => 0;
     }
 
 }
@@ -139,7 +146,8 @@ sub post_fail_hook {
     if (is_s390x) {
         #upload s390x_guest_upgrade_test.log
         upload_asset("/tmp/s390x_guest_upgrade_test.log", 1, 1);
-        script_run "rm -rf /tmp/s390x_guest_upgrade_test.log";
+        #ues die_on_timeout=> 0 as workaround for s390x test during call script_run, refer to poo#106765
+        script_run "rm -rf /tmp/s390x_guest_upgrade_test.log", die_on_timeout => 0;
     }
 }
 

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -61,9 +61,16 @@ sub run {
     #workaround of bsc#1177790
     #disable DNSSEC validation as it is turned on by default but the forwarders donnot support it, refer to bsc#1177790
     if (is_sle('>=12-sp5')) {
-        script_run "sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf";
-        script_run "grep 'dnssec-validation' /etc/named.conf";
-        script_run "systemctl restart named";
+        #ues die_on_timeout=> 0 as workaround for s390x test during call script_run, refer to poo#106765
+        my %args = ();
+        if (is_s390x) {
+            $args{die_on_timeout} = 0;
+        } else {
+            $args{die_on_timeout} = 1;
+        }
+        script_run "sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf", %args;
+        script_run "grep 'dnssec-validation' /etc/named.conf", %args;
+        script_run "systemctl restart named", %args;
         save_screenshot;
     }
 


### PR DESCRIPTION
According to the new change from script_run() ,  die_on_timeout=> 1 as the default option. Refer to the latest osd s390x results, figure out this default option do not work very well for s390x during call script_run(). 
Use with die_on_timeout=> 0, keep the old behavior, as the workaround for s390x during call script_run(). refer to [poo#106765](https://progress.opensuse.org/issues/106765) for more details. 
- Related ticket: https://progress.opensuse.org/issues/106765
- Verification run: 
s390x
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/8186575#)
[gi-guest_sles12sp5-on-host_developing-kvm](http://openqa.suse.de/t8189434)
[gi-guest_sles15sp3-on-host_developing-kvm](http://openqa.suse.de/t8189435)
[gi-guest_developing-on-host_sles12sp5-kvm](http://openqa.suse.de/t8189432)
[gi-guest_developing-on-host_sles15sp3-kvm](http://openqa.suse.de/t8189433)
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](https://openqa.suse.de/tests/8189604#)
[prj4_guest_upgrade_sles15sp3_on_sles15sp3-kvm](https://openqa.suse.de/tests/8186598#)
x86
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/8206014#)
aarch64
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](https://openqa.suse.de/tests/8189608#)