### PR TITLE
Retry 'host' command to acquire IP address

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -204,8 +204,15 @@ Returns 0 on failure.
 
 sub get_ip {
     my $node_hostname = shift;
-    my $node_ip = get_var('USE_SUPPORT_SERVER') ? script_output "host -t A $node_hostname" :
-      script_output "awk 'BEGIN {RET=1} /$node_hostname/ {print \$1; RET=0; exit} END {exit RET}' /etc/hosts";
+    my $node_ip;
+
+    if (get_var('USE_SUPPORT_SERVER')) {
+        $node_ip = script_output_retry("host -t A $node_hostname", retry => 3, delay => 5);
+    }
+    else {
+        $node_ip = script_output("awk 'BEGIN {RET=1} /$node_hostname/ {print \$1; RET=0; exit} END {exit RET}' /etc/hosts");
+    }
+
     return _just_the_ip($node_ip);
 }
 


### PR DESCRIPTION
There are sporadic failures on different aarch64 based cluster tests 
caused by command 'host' not being able to get an IP address on first 
try. This PR makes the command being re-tried 2 times before failing.

- Related ticket: https://jira.suse.com/browse/TEAM-5203
- Verification run: 
- https://mordor.suse.cz/tests/2783#step/drbd_passive/3
- https://mordor.suse.cz/tests/2780#step/drbd_passive/3
