### PR TITLE
Implement tpm2 tests using swtpm device

### DIFF
--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_ecdsa_operation.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_ecdsa_operation.pm
@@ -38,8 +38,4 @@ sub run {
     assert_script_run "cd";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_info.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_info.pm
@@ -25,8 +25,4 @@ sub run {
     };
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_random_data.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_random_data.pm
@@ -21,8 +21,4 @@ sub run {
     validate_script_output "openssl rand -engine tpm2tss -hex 10  2>&1", sub { m/engine\s\"tpm2tss\"\sset/ };
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_rsa_operation.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_rsa_operation.pm
@@ -46,8 +46,4 @@ sub run {
     assert_script_run "cd";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_self_sign.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_self_sign.pm
@@ -44,8 +44,4 @@ expect {
     assert_script_run "cd";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/tpm2/tpm2_tools/tpm2_tools_auth.pm
+++ b/tests/security/tpm2/tpm2_tools/tpm2_tools_auth.pm
@@ -1,11 +1,11 @@
-# Copyright 2020 SUSE LLC
+# Copyright 2020-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Per TPM2 stack, we would like to add the tpm2-tools tests,
 #          from sles15sp2, update tpm2.0-tools to the stable 4 release
 #          this test module will cover auth tests.
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#64905, tc#1742297
+# Tags: poo#64905, poo#105732, tc#1742297
 
 use strict;
 use warnings;
@@ -23,45 +23,45 @@ sub run {
     my $key_pub = "key.pub";
     my $key_name = "key.name";
     my $ket_ctx = "key.ctx";
+
+    my $tpm_suffix = '';
+    $tpm_suffix = '-T tabrmd' if (get_var('QEMUTPM', 0) != 1 || get_var('QEMUTPM_VER', '') ne '2.0');
+
     assert_script_run "mkdir $test_dir";
     assert_script_run "cd $test_dir";
-    assert_script_run "tpm2_createprimary -Q -C o -c $prim_ctx -T tabrmd";
-    assert_script_run "tpm2_create -Q -g sha256 -G aes -u $key_pub -r $key_priv -C $prim_ctx -T tabrmd";
-    assert_script_run "tpm2_load -C $prim_ctx -u $key_pub -r $key_priv -n $key_name -c $ket_ctx -T tabrmd";
-    assert_script_run "tpm2_changeauth -c $ket_ctx -C $prim_ctx -r $key_priv newkeyauth -T tabrmd";
-    assert_script_run "tpm2_clear -T tabrmd";
+    assert_script_run "tpm2_createprimary -Q -C o -c $prim_ctx $tpm_suffix";
+    assert_script_run "tpm2_create -Q -g sha256 -G aes -u $key_pub -r $key_priv -C $prim_ctx $tpm_suffix";
+    assert_script_run "tpm2_load -C $prim_ctx -u $key_pub -r $key_priv -n $key_name -c $ket_ctx $tpm_suffix";
+    assert_script_run "tpm2_changeauth -c $ket_ctx -C $prim_ctx -r $key_priv newkeyauth $tpm_suffix";
+    assert_script_run "tpm2_clear $tpm_suffix";
 
     # Modify authorization for a NV Index Requires Extended Session Support
     my $ses_ctx = "session.ctx";
-    assert_script_run "tpm2_startauthsession -S $ses_ctx -T tabrmd";
-    assert_script_run "tpm2_policycommandcode -S $ses_ctx -L policy.nvchange TPM2_CC_NV_ChangeAuth -T tabrmd";
+    assert_script_run "tpm2_startauthsession -S $ses_ctx $tpm_suffix";
+    assert_script_run "tpm2_policycommandcode -S $ses_ctx -L policy.nvchange TPM2_CC_NV_ChangeAuth $tpm_suffix";
 
     # TPM2_CC_NV_ChangeAuth
     my $nv_val = "0x1500015";
-    assert_script_run "tpm2_flushcontext $ses_ctx -T tabrmd";
-    assert_script_run "tpm2_nvdefine $nv_val -C o -s 32 -a \"authread|authwrite\" -L policy.nvchange -T tabrmd";
-    assert_script_run "tpm2_startauthsession --policy-session -S $ses_ctx -T tabrmd";
-    assert_script_run "tpm2_policycommandcode -S $ses_ctx -L policy.nvchange TPM2_CC_NV_ChangeAuth -T tabrmd";
-    assert_script_run "tpm2_changeauth -p session:$ses_ctx -c $nv_val newindexauth -T tabrmd";
-    assert_script_run "tpm2_clear -T tabrmd";
+    assert_script_run "tpm2_flushcontext $ses_ctx $tpm_suffix";
+    assert_script_run "tpm2_nvdefine $nv_val -C o -s 32 -a \"authread|authwrite\" -L policy.nvchange $tpm_suffix";
+    assert_script_run "tpm2_startauthsession --policy-session -S $ses_ctx $tpm_suffix";
+    assert_script_run "tpm2_policycommandcode -S $ses_ctx -L policy.nvchange TPM2_CC_NV_ChangeAuth $tpm_suffix";
+    assert_script_run "tpm2_changeauth -p session:$ses_ctx -c $nv_val newindexauth $tpm_suffix";
+    assert_script_run "tpm2_clear $tpm_suffix";
 
     # Tpm2_changeauth - Configures authorization values for the various hierarchies, NV indices
     # Set owner, endorsement and lockout authorizations to $new_pass
     my $new_pass = "newpass";
     my $newer_pass = "newerpass";
-    assert_script_run "tpm2_changeauth -c owner $new_pass -T tabrmd";
-    assert_script_run "tpm2_changeauth -c endorsement $new_pass -T tabrmd";
-    assert_script_run "tpm2_changeauth -c lockout $new_pass -T tabrmd";
+    assert_script_run "tpm2_changeauth -c owner $new_pass $tpm_suffix";
+    assert_script_run "tpm2_changeauth -c endorsement $new_pass $tpm_suffix";
+    assert_script_run "tpm2_changeauth -c lockout $new_pass $tpm_suffix";
 
     # Change owner, endorsement and lockout authorizations
-    assert_script_run "tpm2_changeauth -c o -p $new_pass $newer_pass -T tabrmd";
-    assert_script_run "tpm2_changeauth -c e -p $new_pass $newer_pass -T tabrmd";
-    assert_script_run "tpm2_changeauth -c l -p $new_pass $newer_pass -T tabrmd";
+    assert_script_run "tpm2_changeauth -c o -p $new_pass $newer_pass $tpm_suffix";
+    assert_script_run "tpm2_changeauth -c e -p $new_pass $newer_pass $tpm_suffix";
+    assert_script_run "tpm2_changeauth -c l -p $new_pass $newer_pass $tpm_suffix";
     assert_script_run "cd";
-}
-
-sub test_flags {
-    return {always_rollback => 1};
 }
 
 1;

--- a/tests/security/tpm2/tpm2_tools/tpm2_tools_encrypt.pm
+++ b/tests/security/tpm2/tpm2_tools/tpm2_tools_encrypt.pm
@@ -1,11 +1,11 @@
-# Copyright 2020 SUSE LLC
+# Copyright 2020-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Per TPM2 stack, we would like to add the tpm2-tools tests,
 #          from sles15sp2, update tpm2.0-tools to the stable 4 release
 #          this test module will cover encrypt and decrypt tests.
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#64905, tc#1742297
+# Tags: poo#64905, poo#105732, tc#1742297
 
 use strict;
 use warnings;
@@ -16,49 +16,49 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
+    my $tpm_suffix = '';
+    $tpm_suffix = '-T tabrmd' if (get_var('QEMUTPM', 0) != 1 || get_var('QEMUTPM_VER', '') ne '2.0');
+
     # Write/Read data to/from a Non-Volatile (NV) index
     my $test_dir = "tpm2_tools_encrypt";
     my $test_file = "nv.test_w";
     assert_script_run "mkdir $test_dir";
     assert_script_run "cd $test_dir";
-    assert_script_run "tpm2_nvdefine -Q  1 -C o -s 32 -a \"ownerread|policywrite|ownerwrite\" -T tabrmd";
-    validate_script_output "tpm2_nvreadpublic -T tabrmd", sub { m/0x1000001/ };
+    assert_script_run "tpm2_nvdefine -Q  1 -C o -s 32 -a \"ownerread|policywrite|ownerwrite\" $tpm_suffix";
+    validate_script_output "tpm2_nvreadpublic $tpm_suffix", sub { m/0x1000001/ };
     assert_script_run "echo \"please123abc\" > $test_file";
-    assert_script_run "tpm2_nvwrite -Q  1 -C o -i $test_file -T tabrmd";
-    assert_script_run "tpm2_nvread -Q  1 -C o -s 32 -o 0 -T tabrmd";
+    assert_script_run "tpm2_nvwrite -Q  1 -C o -i $test_file $tpm_suffix";
+    assert_script_run "tpm2_nvread -Q  1 -C o -s 32 -o 0 $tpm_suffix";
 
     # tpm2_nvundefine(1) - Delete a Non-Volatile (NV) index
-    assert_script_run "tpm2_nvundefine -Q  1 -C o -T tabrmd";
-    validate_script_output "tpm2_nvreadpublic -T tabrmd|wc -l", sub { m/0/ };
+    assert_script_run "tpm2_nvundefine -Q  1 -C o $tpm_suffix";
+    validate_script_output "tpm2_nvreadpublic $tpm_suffix|wc -l", sub { m/0/ };
 
     # Create an ECC primary object
     my $context_out = "context.out";
     my $key_priv = "key.priv";
     my $key_pub = "key.pub";
     my $key_ctx = "key.ctx";
-    assert_script_run "tpm2_createprimary -C o -g sha256 -G ecc -c $context_out -T tabrmd";
+
+    assert_script_run "tpm2_createprimary -C o -g sha256 -G ecc -c $context_out $tpm_suffix";
 
     # tpm2_create(1) - Create a child objec
-    assert_script_run "tpm2_create -C $context_out -G rsa2048:rsaes -u $key_pub -r $key_priv -T tabrmd";
+    assert_script_run "tpm2_create -C $context_out -G rsa2048:rsaes -u $key_pub -r $key_priv $tpm_suffix";
 
     # tpm2_load(1) - Load both the private and public portions of an object into the TPM
-    assert_script_run "tpm2_load  -C $context_out -u $key_pub -r $key_priv -c $key_ctx -T tabrmd";
+    assert_script_run "tpm2_load  -C $context_out -u $key_pub -r $key_priv -c $key_ctx $tpm_suffix";
 
     # Encrypt using RSA
     my $msg_dat = "msg.dat";
     my $msg_enc = "msg.enc";
     assert_script_run "echo \"my message\" > $msg_dat";
-    assert_script_run "tpm2_rsaencrypt -c $key_ctx -o $msg_enc $msg_dat -T tabrmd";
+    assert_script_run "tpm2_rsaencrypt -c $key_ctx -o $msg_enc $msg_dat $tpm_suffix";
 
     # Decrypt using RSA
     my $msg_ptext = "msg.ptext";
-    assert_script_run "tpm2_rsadecrypt -c $key_ctx -o $msg_ptext $msg_enc -T tabrmd";
+    assert_script_run "tpm2_rsadecrypt -c $key_ctx -o $msg_ptext $msg_enc $tpm_suffix";
     assert_script_run "diff $msg_dat $msg_ptext";
     assert_script_run "cd";
-}
-
-sub test_flags {
-    return {always_rollback => 1};
 }
 
 1;

--- a/tests/security/tpm2/tpm2_tools/tpm2_tools_self_contain_tool.pm
+++ b/tests/security/tpm2/tpm2_tools/tpm2_tools_self_contain_tool.pm
@@ -1,11 +1,11 @@
-# Copyright 2020 SUSE LLC
+# Copyright 2020-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Per TPM2 stack, we would like to add the tpm2-tools tests,
 #          from sles15sp2, update tpm2.0-tools to the stable 4 release
 #          this test module will cover self contained tool.
 # Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#64905, tc#1742297
+# Tags: poo#64905, poo#105732, tc#1742297
 
 use strict;
 use warnings;
@@ -16,10 +16,13 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
+    my $tpm_suffix = '';
+    $tpm_suffix = '-T tabrmd' if (get_var('QEMUTPM', 0) != 1 || get_var('QEMUTPM_VER', '') ne '2.0');
+
     # Display PCR values
     validate_script_output "systemctl status tpm2-abrmd.service", sub { m/Active:\sactive/ };
     # List the supported PCR
-    validate_script_output "tpm2_pcrread -T tabrmd", sub {
+    validate_script_output "tpm2_pcrread $tpm_suffix", sub {
         m/
              sha1.*
              sha256.*
@@ -32,37 +35,33 @@ sub run {
     my $test_file = "random.out";
     assert_script_run "mkdir $test_dir";
     assert_script_run "cd $test_dir";
-    assert_script_run "tpm2_getrandom -o $test_file 64 -T tabrmd";
+    assert_script_run "tpm2_getrandom -o $test_file 64 $tpm_suffix";
     validate_script_output "ls -l $test_file|awk '{print $5}'", sub { m/64/ };
 
     # Hash a file with sha1 hash algorithm and save the hash and ticket to a file
     my $test_data = "data.txt";
     my $hash_file = "ticket.bin";
     assert_script_run "echo test > $test_data";
-    assert_script_run "tpm2_hash -C e -g sha1 -t $hash_file $test_data -T tabrmd";
+    assert_script_run "tpm2_hash -C e -g sha1 -t $hash_file $test_data $tpm_suffix";
 
     # Define a TPM Non-Volatile (NV) index
     my $nv_val = "0x1500016";
-    validate_script_output "tpm2_nvdefine $nv_val -C 0x40000001 -s 32 -a 0x2000A -T tabrmd", sub { m/nv-index:\s$nv_val/ };
+    validate_script_output "tpm2_nvdefine $nv_val -C 0x40000001 -s 32 -a 0x2000A $tpm_suffix", sub { m/nv-index:\s$nv_val/ };
 
     # Display all defined Non-Volatile (NV)s indices
-    validate_script_output "tpm2_nvreadpublic -T tabrmd", sub {
+    validate_script_output "tpm2_nvreadpublic $tpm_suffix", sub {
         m/
              value:\s0xA000200.*
              size:\s32.*/sx
     };
 
     # Undefine the nv index
-    assert_script_run "tpm2_nvundefine $nv_val -T tabrmd";
+    assert_script_run "tpm2_nvundefine $nv_val $tpm_suffix";
 
     # Clears lockout, endorsement and owner hierarchy authorization values
-    assert_script_run "tpm2_clear -T tabrmd";
-    validate_script_output "tpm2_nvreadpublic -T tabrmd|wc -l", sub { m/0/ };
+    assert_script_run "tpm2_clear $tpm_suffix";
+    validate_script_output "tpm2_nvreadpublic $tpm_suffix|wc -l", sub { m/0/ };
     assert_script_run "cd";
-}
-
-sub test_flags {
-    return {always_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
Currently, we use IBM's Software TPM 2.0 to emulate TPM "device".
now,we have an alternative method to test tpm2 in qemu env which
uses swtpm device.


- Related ticket: https://progress.opensuse.org/issues/105732
- Needles: n/a
- Verification run: 
https://openqa.suse.de/tests/8157351            -SLE
https://openqa.opensuse.org/tests/2189468 -TW
- Regression test:
https://openqa.suse.de/tests/8168760           -SLE
https://openqa.opensuse.org/tests/2189459 -TW