### PR TITLE
Improve schedule in cryptlvm & cryptlvm+cancel_existing

### DIFF
--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -18,25 +18,5 @@ schedule:
   - installation/module_registration/register_module_desktop
   - installation/system_probing/cancel_encrypted_volume
   - console/validate_encrypted_partition_not_activated
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup/accept_default_hard_disks_selection
-  - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
-  - installation/partitioning/guided_setup/accept_default_fs_options
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/boot_encrypt
-  - installation/first_boot
 test_data:
   enc_disk_part: vda2

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -18,27 +18,5 @@ schedule:
   - installation/module_registration/skip_module_registration
   - installation/system_probing/cancel_encrypted_volume
   - console/validate_encrypted_partition_not_activated
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup/accept_default_hard_disks_selection
-  - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
-  - installation/partitioning/guided_setup/accept_default_fs_options
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_plymouth
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/handle_reboot
-  - installation/boot_encrypt
-  - installation/first_boot
 test_data:
   enc_disk_part: sda1


### PR DESCRIPTION
There is not point on running the installation after console/validate_encrypted_partition_not_activated in cryptlvm+cancel_existing as we are doing exactly the same than in cryptlvm.

- Related ticket: https://progress.opensuse.org/issues/104793
- Verification run: https://openqa.suse.de/tests/8169464
