### PR TITLE
wicked: Add defaul log-check exception for nanny

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -747,6 +747,7 @@ sub check_logs {
     $default_exclude .= ',wickedd-dhcp4=unable to confirm lease';
     $default_exclude .= ',wickedd-nanny=: call to org.opensuse.Network.Interface.waitLinkUp\(\) failed: General failure';
     $default_exclude .= ',wickedd-nanny=: call to org.opensuse.Network.Interface.waitLinkUp\(\) failed: Object does not support requested method';
+    $default_exclude .= ',wickedd-nanny=: call to org.opensuse.Network.Interface.linkUp\(\) failed: Object does not support requested method';
     $default_exclude .= ',wickedd-nanny=: failed to bring up device, still continuing';
     $default_exclude .= ',wickedd=error retrieving tap attribute from sysfs';
 


### PR DESCRIPTION
in wicked-ci we have enabled `WICKED_CHECK_LOG_FAIL=>1` and we discovered this message http://openqa.wicked.suse.de/tests/48536#step/t19_teaming_ab_nsna_ping/12 but as for now this isn't treated as an error but can happen once a interface is already gone.

- Verification run: http://openqa.wicked.suse.de/t48775
