### PR TITLE
wicked: When log-check failed, show only error message in openqa UI

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -13,6 +13,7 @@ use utils qw(systemctl file_content_replace zypper_call);
 use network_utils;
 use lockapi;
 use testapi qw(is_serial_terminal :DEFAULT);
+use bmwqemu;
 use serial_terminal;
 use Carp;
 use Mojo::File 'path';
@@ -766,12 +767,13 @@ sub check_logs {
         }
         my $out = trim(script_output($cmd, proceed_on_failure => 1));
         if (length($out) > 0) {
-            my $msg = "$cmd\n\n$out\n\n";
+            my $msg = "wicked check logs failed:\n$cmd\n\n$out\n\n";
             $msg .= "Use WICKED_CHECK_LOG_EXCLUDE to change filter!\n";
             $msg .= "  WICKED_CHECK_LOG_EXCLUDE=$exclude_var\n";
             $msg .= '  WICKED_CHECK_LOG_EXCLUDE_' . $self->{name} . "=$exclude_test_var\n";
             $msg .= "Control if test fail with WICKED_CHECK_LOG_FAIL default off.\n";
-            record_info('LOG-ERROR', $msg, result => 'fail');
+            bmwqemu::fctwarn($msg);
+            record_info('LOG-ERROR', $out, result => 'fail');
             $self->result('fail') if get_var(WICKED_CHECK_LOG_FAIL => 0) && $self->{name} ne 'before_test';
         }
     }


### PR DESCRIPTION
autoinst-log.txt looks like:
```
[0m[31m[2022-02-15T11:24:39.132880+01:00] [warn] !!! wickedbase::check_logs: wicked check logs failed:
  journalctl -q -p 3 -x -u wickedd-nanny
  
  Feb 15 05:17:24 install wickedd-nanny[511]: device eth1: device has been deleted
  
  Use WICKED_CHECK_LOG_EXCLUDE to change filter!
    WICKED_CHECK_LOG_EXCLUDE=do_not_match_any
    WICKED_CHECK_LOG_EXCLUDE_t08_bonding_ab_miimon=
  Control if test fail with WICKED_CHECK_LOG_FAIL default off.
  
[0m[2022-02-15T11:24:39.133147+01:00] [debug] lib/wickedbase.pm:830 called wickedbase::post_run -> lib/wickedbase.pm:798 called wickedbase::check_logs -> lib/wickedbase.pm:776 called testapi::record_info
```

- Verification run: http://openqa.wicked.suse.de/tests/49681
