### PR TITLE
 wicked: Check for coredumps after each test 

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -849,6 +849,48 @@ sub check_logs {
     }
 }
 
+sub coredumpctl_has_debug {
+    my ($self) = @_;
+    $self->{systemd_ver} = script_output('rpm -q --qf "%{VERSION}" systemd') unless $self->{systemd_ver};
+    return check_version('>=249', $self->{systemd_ver});
+}
+
+sub prepare_coredump {
+    my $self = shift;
+    zypper_call('--quiet in systemd-coredump');
+    zypper_call('--quiet in gdb', exitcode => [104, 0]) if ($self->has_coredump_with_debug());
+
+    if (script_run('sysctl kernel.core_pattern | grep systemd-coredump') != 0) {
+        my $core_pattern = 'kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %e';
+        assert_script_run("sysctl -w '$core_pattern'");
+        assert_script_run("echo '$core_pattern' > /etc/sysctl.d/50-coredump.conf");
+    }
+
+    assert_script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend)" ]');
+    for my $pkg (qw(wicked-debuginfo wicked-debugsource)) {
+        if (script_run("zypper search $pkg") == 0) {
+            zypper_call("in --force -y --force-resolution $pkg");
+        }
+    }
+}
+
+sub check_coredump {
+    my $self = shift;
+    return if (script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend)" ]') == 0);
+
+    my @core_pids = split(/\s+/, script_output(q(coredumpctl list --no-pager --no-legend | perl -ne '$_ =~ m/ ([0-9]+) / && print $1 .$/')));
+    for my $pid (@core_pids) {
+        my $core;
+        if ($self->coredumpctl_has_debug() && script_run('command -v gdb') == 0 && script_run('rpm -q --qf "" wicked-debuginfo') == 0) {
+            $core = script_output(qq(coredumpctl debug $pid --debugger-arguments='-quiet -ex "set pagination off" -ex "set debuginfod off" -ex bt -ex quit'));
+        } else {
+            $core = script_output(qq(coredumpctl info $pid));
+        }
+        record_info('CORE DUMP', $core, result => 'fail');
+        $self->result('fail');
+    }
+}
+
 sub reboot {
     my ($self) = @_;
     $self->check_logs();
@@ -866,6 +908,7 @@ sub post_run {
         $self->upload_log_file('/tmp/' . $self->{name} . '_tcpdump.pcap');
     }
     $self->check_logs();
+    $self->check_coredump();
     $self->upload_wicked_logs('post');
 }
 

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -40,7 +40,6 @@ sub run {
         systemctl("stop " . opensusebasetest::firewall);
         systemctl("disable " . opensusebasetest::firewall);
     }
-    assert_script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend)" ]');
     record_info('INFO', 'Setting debug level for wicked logs');
     file_content_replace('/etc/sysconfig/network/config', '--sed-modifier' => 'g', '^WICKED_DEBUG=.*' => 'WICKED_DEBUG="all"', '^WICKED_LOG_LEVEL=.*' => 'WICKED_LOG_LEVEL="debug2"');
     #preparing directories for holding config files
@@ -108,7 +107,7 @@ sub run {
                 zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/$version/SUSE:CA.repo");
                 zypper_call("in ca-certificates-suse");
             }
-            zypper_ar($wicked_repo, params => '-n wicked_repo', no_gpg_check => 1);
+            zypper_ar($wicked_repo, priority => 10, params => '-n wicked_repo', no_gpg_check => 1);
             my ($resolv_options, $repo_id) = (' --allow-vendor-change  --allow-downgrade ', 'wicked_repo');
             $resolv_options = ' --oldpackage' if (is_sle('<15'));
             ($repo_id) = ($wicked_repo =~ m!(^.*/)!s) if (is_sle('<=12-sp1'));
@@ -139,6 +138,7 @@ sub run {
             $package_list .= ' ndisc6';
         }
         wicked::wlan::prepare_packages() if (check_var('WICKED', 'wlan'));
+        $self->prepare_coredump();
 
         $package_list .= ' openvswitch iputils';
         $package_list .= ' libteam-tools libteamdctl0 ' if check_var('WICKED', 'advanced') || check_var('WICKED', 'aggregate');


### PR DESCRIPTION
1) Install systemd-cordump
2) Set sysctl kernel.core_pattern
3) Install wicked-debuginfo and wicked-debugsource, if available
4) Check after each test for new coredumps and print decoded output.
5) Fail the test if coredump exists

- Related ticket: https://gitlab.suse.de/wicked-maintainers/wicked-ci/-/issues/10
- Verification run: 
  - tumbleweed (systemd >= 249) http://openqa.wicked.suse.de/tests/50153#step/t01_open_static_ip/18
  - tumbleweed without debug-info http://openqa.wicked.suse.de/tests/50217#step/t01_open_static_ip/18
  - LEAP (systemd < 249)  http://openqa.wicked.suse.de/tests/50149#step/t01_open_static_ip/18
  - SLE-15-SP4 no core https://openqa.suse.de/t8174160
  - SLE-15-SP4 https://openqa.suse.de/tests/8174981#step/t01_open_static_ip/18
