### PR TITLE
JeOS: OpenStack test automation kick off

### DIFF
--- a/data/jeos/clouds.yaml
+++ b/data/jeos/clouds.yaml
@@ -1,0 +1,13 @@
+clouds:
+  mycloud:
+    region_name: CustomRegion
+    auth:
+      auth_url: %OPENSTACK_AUTH_URI%
+      username: %OPENSTACK_USER%
+      password: %OPENSTACK_PASSWORD%
+      project_name: %OPENSTACK_PROJECT_NAME%
+      project_id: %OPENSTACK_PROJECT_ID%
+      user_domain_name: default
+    interface: public
+    identity_api_version: 3
+    cacert: /root/SUSE_Trust_Root.crt.pem

--- a/data/jeos/mn_jeos.cloud-init
+++ b/data/jeos/mn_jeos.cloud-init
@@ -1,0 +1,24 @@
+#cloud-config
+
+# set locale
+locale: en_US.UTF-8
+
+# set timezone
+timezone: UTC
+
+# set root password and create bernhard user
+chpasswd:
+  list: |
+    root:%PASSWORD%
+    bernhard:%PASSWORD%
+  expire: False
+
+# (1)   set keymap
+# (2-3) set it the way jeos-firstboot does
+runcmd:
+ - localectl set-keymap us
+ - sed -i -e "s/^KEYTABLE=.*/KEYTABLE=\"us\"/" /etc/sysconfig/keyboard
+ - sed -i -e "s/^RC_LANG=.*/RC_LANG=\"en_US.UTF-8\"/" /etc/sysconfig/language
+
+system_info:
+  distro: sles

--- a/data/publiccloud/terraform/openstack.tf
+++ b/data/publiccloud/terraform/openstack.tf
@@ -1,0 +1,107 @@
+terraform {
+  required_providers {
+    openstack = {
+      version = ">= 0.14.0"
+      source = "terraform-provider-openstack/openstack"
+    }
+    random = {
+      version = "= 3.1.0"
+      source = "hashicorp/random"
+    }
+    external = {
+      version = "= 2.1.0"
+      source = "hashicorp/external"
+    }
+  }
+}
+
+provider "openstack" {
+    cloud = "mycloud"
+}
+
+variable "name" {
+    default = "openqa-vm"
+}
+
+variable "keypair" {
+    description = "Public Key to be injected to the instance"
+    type        = string
+    default     = ""
+}
+
+variable "image_id" {
+    description = "Image ID to boot the instance"
+    type        = string
+    default     = ""
+}
+
+variable "secgroup" {
+    description = "Security group to be used"
+    type        = string
+    default     = "icmp_ssh"
+}
+
+variable "type" {
+    description = "Flavor (cpu, ram) to boot the instance"
+    type        = string
+    default     = "m1.small"
+}
+
+variable "instance_count" {
+    default = "1"
+}
+
+variable "tags" {
+    type = map(string)
+    default = {}
+}
+
+variable "region" {
+    default = "CustomRegion"
+}
+
+
+resource "random_id" "service" {
+    count = var.instance_count
+    keepers = {
+        name = var.name
+    }
+    byte_length = 8
+}
+
+data "template_file" "cloudinit_jeos" {
+    template = file("/root/mn_jeos.cloud-init")
+}
+
+resource "openstack_compute_instance_v2" "openqa_instance" {
+    count           = var.instance_count
+    name            = "${var.name}-${element(random_id.service.*.hex, count.index)}"
+    image_id        = var.image_id
+    flavor_name     = var.type
+    key_pair        = var.keypair
+    security_groups = [var.secgroup]
+    region          = var.region
+    user_data       = data.template_file.cloudinit_jeos.rendered
+    network {
+        name = "fixed"
+    }
+}
+
+resource "openstack_networking_floatingip_v2" "floating_ip" {
+    count = var.instance_count
+    pool  = "floating"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "floating_ip" {
+    count = var.instance_count
+    floating_ip = openstack_networking_floatingip_v2.floating_ip[count.index].address
+    instance_id = openstack_compute_instance_v2.openqa_instance[count.index].id
+}
+
+output "vm_name" {
+    value = openstack_compute_instance_v2.openqa_instance.*.name
+}
+
+output "public_ip" {
+    value = openstack_networking_floatingip_v2.floating_ip.*.address
+}

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -569,36 +569,46 @@ sub load_system_role_tests {
     }
 }
 sub load_jeos_tests {
-    if ((is_arm || is_aarch64) && is_opensuse()) {
-        # Enable jeos-firstboot, due to boo#1020019
+    if (get_var('JEOS_OPENSTACK')) {
+        loadtest 'boot/boot_to_desktop';
+        if (get_var('JEOS_OPENSTACK_UPLOAD_IMG')) {
+            loadtest "publiccloud/upload_image";
+        }
+        elsif (get_var('JEOS_OPENSTACK_CHECK_BOOT')) {
+            loadtest "jeos/openstack_check_boot";
+        }
+    } else {
+        if ((is_arm || is_aarch64) && is_opensuse()) {
+            # Enable jeos-firstboot, due to boo#1020019
+            load_boot_tests();
+            loadtest "jeos/prepare_firstboot";
+        }
         load_boot_tests();
-        loadtest "jeos/prepare_firstboot";
-    }
-    load_boot_tests();
-    loadtest "jeos/firstrun";
-    loadtest "jeos/record_machine_id";
-    loadtest "console/system_prepare" if is_sle;
-    loadtest "console/force_scheduled_tasks";
-    unless (get_var('INSTALL_LTP')) {
-        loadtest "jeos/grub2_gfxmode";
-        loadtest "jeos/diskusage";
-        loadtest "jeos/build_key";
-        loadtest "console/prjconf_excluded_rpms";
-    }
-    unless (get_var('CONTAINER_RUNTIME')) {
-        loadtest "console/journal_check";
-        loadtest "microos/libzypp_config";
-    }
-    if (is_sle) {
-        loadtest "console/suseconnect_scc";
-        loadtest "jeos/efi_tid" if (get_var('UEFI') && is_sle('=12-sp5'));
-    }
+        loadtest "jeos/firstrun";
+        loadtest "jeos/record_machine_id";
+        loadtest "console/system_prepare" if is_sle;
+        loadtest "console/force_scheduled_tasks";
+        unless (get_var('INSTALL_LTP')) {
+            loadtest "jeos/grub2_gfxmode";
+            loadtest "jeos/diskusage";
+            loadtest "jeos/build_key";
+            loadtest "console/prjconf_excluded_rpms";
+        }
+        unless (get_var('CONTAINER_RUNTIME')) {
+            loadtest "console/journal_check";
+            loadtest "microos/libzypp_config";
+        }
+        if (is_sle) {
+            loadtest "console/suseconnect_scc";
+            loadtest "jeos/efi_tid" if (get_var('UEFI') && is_sle('=12-sp5'));
+        }
 
-    loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
-    replace_opensuse_repos_tests if is_repo_replacement_required;
-    loadtest 'console/verify_efi_mok' if get_var 'CHECK_MOK_IMPORT';
-    # zypper_ref needs to run on jeos-containers. the is_sle is required otherwise is scheduled twice on o3
-    loadtest "console/zypper_ref" if (get_var('CONTAINER_RUNTIME') && is_sle);
+        loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+        replace_opensuse_repos_tests if is_repo_replacement_required;
+        loadtest 'console/verify_efi_mok' if get_var 'CHECK_MOK_IMPORT';
+        # zypper_ref needs to run on jeos-containers. the is_sle is required otherwise is scheduled twice on o3
+        loadtest "console/zypper_ref" if (get_var('CONTAINER_RUNTIME') && is_sle);
+    }
 }
 
 sub installzdupstep_is_applicable {

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -17,6 +17,7 @@ use publiccloud::ecr;
 use publiccloud::gce;
 use publiccloud::gcr;
 use publiccloud::acr;
+use publiccloud::openstack;
 use strict;
 use warnings;
 
@@ -92,6 +93,9 @@ sub provider_factory {
         else {
             die('Unknown service given');
         }
+    }
+    elsif ($args{provider} eq 'OPENSTACK') {
+        $provider = publiccloud::openstack->new();
     }
     else {
         die('Unknown PUBLIC_CLOUD_PROVIDER given');

--- a/lib/publiccloud/openstack.pm
+++ b/lib/publiccloud/openstack.pm
@@ -1,0 +1,99 @@
+# SUSE's openQA tests
+#
+# Copyright 2018 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Helper class for OpenStack
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+package publiccloud::openstack;
+use Mojo::Base 'publiccloud::provider';
+use Mojo::JSON 'decode_json';
+use testapi;
+use publiccloud::openstack_client;
+
+has ssh_key => undef;
+has ssh_key_name => undef;
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->provider_client(publiccloud::openstack_client->new());
+    $self->provider_client->init();
+}
+
+sub find_img {
+    my ($self, $name) = @_;
+    ($name) = $name =~ m/([^\/]+)$/;
+    $name =~ s/\.qcow2$//;
+    my $out = script_output("openstack image show $name -f json | jq -r '.id'", proceed_on_failure => 1);
+
+    if ($out !~ /Could not find resource|No Image found/) {
+        return $out;
+    }
+    return;
+}
+
+sub create_keypair {
+    my ($self, $prefix) = @_;
+
+    return $self->ssh_key if ($self->ssh_key);
+
+    for my $i (0 .. 9) {
+        my $key_name = $prefix . "_" . $i;
+        my $cmd = "openstack keypair create --public-key /root/.ssh/id_rsa.pub $key_name";
+        my $ret = script_run($cmd, timeout => 300);
+        if (defined($ret) && $ret == 0) {
+            $self->ssh_key_name($key_name);
+            return $key_name;
+        }
+    }
+    die("Create key-pair failed");
+}
+
+sub delete_keypair {
+    my $self = shift;
+    my $name = shift || $self->ssh_key_name;
+
+    return unless $name;
+
+    assert_script_run("openstack keypair delete " . $name);
+    $self->ssh_key(undef);
+}
+
+sub upload_img {
+    my ($self, $file) = @_;
+
+    my ($img_name) = $file =~ /([^\/]+)$/;
+    $img_name =~ s/\.qcow2$//;
+    assert_script_run("openstack image create"
+          . " --disk-format qcow2"
+          . " --container-format bare"
+          . " --file $file $img_name", timeout => 60 * 60);
+
+    my $image_id = $self->find_img($img_name);
+    die("Cannot find image after upload!") unless $image_id;
+    record_info('INFO', "Image ID: $image_id");
+    return $image_id;
+}
+
+sub terraform_apply {
+    my ($self, %args) = @_;
+    $args{vars} //= {};
+
+    my $keypair = $self->create_keypair($self->prefix . time);
+    my $secgroup = get_var("OPENSTACK_SECGROUP");
+    $args{vars}->{keypair} = $keypair;
+    $args{vars}->{secgroup} = $secgroup;
+    return $self->SUPER::terraform_apply(%args);
+}
+
+sub cleanup {
+    my ($self) = @_;
+    $self->terraform_destroy() if ($self->terraform_applied);
+    $self->delete_keypair();
+    $self->provider_client->cleanup();
+}
+
+1;

--- a/lib/publiccloud/openstack_client.pm
+++ b/lib/publiccloud/openstack_client.pm
@@ -1,0 +1,80 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Helper class for OpenStack connection and authentication
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+package publiccloud::openstack_client;
+use Mojo::Base -base;
+use testapi;
+use utils qw(file_content_replace);
+
+use constant {
+    OS_CONFIG_FILE => '/root/.config/openstack/clouds.yaml',
+    CLOUD_INIT_FILE => '/root/mn_jeos.cloud-init'
+};
+
+has auth_uri => sub { get_required_var('OPENSTACK_AUTH_URI') };
+has project_name => sub { get_required_var('OPENSTACK_PROJECT_NAME') };
+has project_id => sub { get_required_var('OPENSTACK_PROJECT_ID') };
+has region => sub { get_var('OPENSTACK_REGION', 'CustomRegion') };
+has username => sub { get_var('OPENSTACK_USER', 'sles') };
+
+sub _check_credentials {
+    my ($self) = @_;
+    my $max_tries = 6;
+
+    for my $i (1 .. $max_tries) {
+        my $out = script_output('openstack image list', 300, proceed_on_failure => 1);
+        record_info('cli check', $out);
+        # There are multiple possible error messages, e.g.:
+        #   The request you have made requires authentication
+        #   Failed to discover available identity versions
+        #   Missing value auth-url required for auth plugin password
+        #   Cloud mycloud was not found
+        #   Could not find a suitable TLS CA certificate bundle, invalid path
+        # But if the command succeeds, it will return an ASCII table with 3 columns: ID, Name, Status
+        return 1 if ($out =~ /\| ID.*| Name.*| Status.*|/m);
+        sleep 30;
+    }
+    return;
+}
+
+sub init {
+    my ($self, %params) = @_;
+
+    assert_script_run('mkdir -p /root/.config/openstack');
+    assert_script_run('curl ' . data_url("jeos/clouds.yaml") . ' -o ' . OS_CONFIG_FILE);
+    assert_script_run('curl ' . data_url("jeos/mn_jeos.cloud-init") . ' -o ' . CLOUD_INIT_FILE);
+
+    # terraform complains if the certificate is in /usr/share/pki/trust/anchors/
+    #    "Error: Error parsing CA Cert from /usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem"
+    # but it works if it's in root directory
+    assert_script_run('cp /usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem /root/SUSE_Trust_Root.crt.pem');
+
+    my $user = get_required_var('_SECRET_OPENSTACK_CLOUD_USER');
+    my $password = get_required_var('_SECRET_OPENSTACK_CLOUD_PASSWORD');
+
+    file_content_replace(OS_CONFIG_FILE,
+        q(%OPENSTACK_USER%) => $user,
+        q(%OPENSTACK_PASSWORD%) => $password,
+        q(%OPENSTACK_AUTH_URI%) => $self->auth_uri,
+        q(%OPENSTACK_PROJECT_NAME%) => $self->project_name,
+        q(%OPENSTACK_PROJECT_ID%) => $self->project_id);
+
+    file_content_replace(CLOUD_INIT_FILE, q(%PASSWORD%) => $testapi::password);
+
+    assert_script_run('chmod 644 ' . OS_CONFIG_FILE);
+    assert_script_run('export OS_CLOUD=mycloud');
+
+    die('Credentials are invalid') unless ($self->_check_credentials());
+}
+
+sub cleanup {
+    my ($self) = @_;
+}
+
+1;

--- a/tests/jeos/openstack_check_boot.pm
+++ b/tests/jeos/openstack_check_boot.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright 2019 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: JeOS OpenStack image validation
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal();
+
+    my $provider = $self->provider_factory();
+    my $instance = $provider->create_instance();
+
+    record_info('Uname', $instance->run_ssh_command(cmd => q(uname -a)));
+    $instance->run_ssh_command(cmd => 'sudo journalctl -b > /tmp/journalctl_b.txt', no_quote => 1);
+    upload_logs('/tmp/journalctl_b.txt');
+}
+
+1;

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -15,6 +15,7 @@ use utils;
 use publiccloud::ec2;
 use publiccloud::azure;
 use publiccloud::gce;
+use publiccloud::openstack;
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
This expands Public Cloud libraries to support OpenStack based clouds.
The motivation is to automate JeOS OpenStack image validation for
each milestone.

https://progress.opensuse.org/issues/90704

- [upload_image](http://fromm.arch.suse.de/tests/5579) (parent job)
- [check boot](http://fromm.arch.suse.de/tests/5580) (one of the children tests that will come later)
