### PR TITLE
Extend supportconfig timeout

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -595,7 +595,7 @@ sub ha_export_logs {
     upload_logs($mdadm_conf, failok => 1);
 
     # supportconfig
-    script_run "supportconfig -g -B $clustername", 180;
+    script_run "supportconfig -g -B $clustername", 300;
     upload_logs("/var/log/nts_$clustername.tgz", failok => 1);
 
     # pacemaker cts log


### PR DESCRIPTION
HA cluster tests tend to fail on 'check_logs' module because of 
'supportconfig' command takes longer than usual and times out. This PR 
extends command timeout from 180s to 300s.

- Verification run:
https://openqa.suse.de/tests/8173326#dependencies
https://openqa.suse.de/tests/8173329#dependencies