### PR TITLE
Extend time for snapper delete timeout problem

### DIFF
--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -64,7 +64,7 @@ sub run {
     # restore the system after running pam.pm
     assert_script_run("snapaf=\$(snapper create -p -d 'after pam test')");
     assert_script_run("snapper -v undochange \$snapbf..\$snapaf");
-    assert_script_run("snapper delete \$snapaf \$snapbf");
+    assert_script_run("snapper delete \$snapaf \$snapbf", timeout => 180);
     zypper_call('rr qa-head-repo');
     zypper_call('rm bats pam-test');
 


### PR DESCRIPTION
Extend time for snapper delete timeout problem

- Related ticket: https://progress.opensuse.org/issues/105552
- Verification run: http://openqa.suse.de/tests/8177590