### PR TITLE
Fix minimal+base staging

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -34,6 +34,7 @@ use Installation::Partitioner::LibstorageNG::v4_3::GuidedSetup::SelectHardDisksC
 use Installation::Partitioner::LibstorageNG::GuidedSetupController;
 use Installation::Partitioner::LibstorageNG::v4_3::ExpertPartitionerController;
 use Installation::PerformingInstallation::PerformingInstallationController;
+use Installation::SecurityConfiguration::SecurityConfigurationController;
 use Installation::SSHKeyImport::SSHKeyImportController;
 use Installation::SystemProbing::EncryptedVolumeActivationController;
 use Installation::SystemRole::SystemRoleController;
@@ -191,6 +192,10 @@ sub get_performing_installation {
 
 sub get_ssh_import_settings {
     return Installation::SSHKeyImport::SSHKeyImportController->new();
+}
+
+sub get_security_configuration {
+    return Installation::SecurityConfiguration::SecurityConfigurationController->new();
 }
 
 1;

--- a/lib/Installation/InstallationSettings/InstallationSettingsController.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsController.pm
@@ -56,6 +56,11 @@ sub access_booting_options {
     $self->get_installation_settings_page()->access_booting_options();
 }
 
+sub access_security_options {
+    my ($self) = @_;
+    $self->get_installation_settings_page()->access_security_options();
+}
+
 sub access_ssh_import_options {
     my ($self) = @_;
     $self->get_installation_settings_page()->access_ssh_import_options();

--- a/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
@@ -82,6 +82,11 @@ sub access_booting_options {
     $self->{txt_overview}->activate_link('bootloader_stuff');
 }
 
+sub access_security_options {
+    my ($self) = @_;
+    $self->{txt_overview}->activate_link('security');
+}
+
 sub access_ssh_import_options {
     my ($self) = @_;
     $self->{txt_overview}->activate_link('ssh_import');

--- a/lib/Installation/SecurityConfiguration/SecurityConfigurationController.pm
+++ b/lib/Installation/SecurityConfiguration/SecurityConfigurationController.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces business actions for the
+#          Security Configuration page in the installer.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::SecurityConfiguration::SecurityConfigurationController;
+use strict;
+use warnings;
+use Installation::SecurityConfiguration::SecurityConfigurationPage;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{SecurityConfigurationPage} = Installation::SecurityConfiguration::SecurityConfigurationPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_security_configuration_page {
+    my ($self) = @_;
+    die "Security Configuration page is not displayed" unless $self->{SecurityConfigurationPage}->is_shown();
+    return $self->{SecurityConfigurationPage};
+}
+
+sub select_security_module {
+    my ($self, $module) = @_;
+    $self->get_security_configuration_page()->select_security_module($module);
+    $self->get_security_configuration_page()->press_next();
+}
+
+1;

--- a/lib/Installation/SecurityConfiguration/SecurityConfigurationPage.pm
+++ b/lib/Installation/SecurityConfiguration/SecurityConfigurationPage.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act on the
+#          Security Configuration page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::SecurityConfiguration::SecurityConfigurationPage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub init {
+    my $self = shift;
+    $self->SUPER::init();
+    $self->{cmb_security_module} = $self->{app}->combobox({id => '"Installation::Widgets::LSMSelector"'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{cmb_security_module}->exist();
+}
+
+sub select_security_module {
+    my ($self, $module) = @_;
+    return $self->{cmb_security_module}->select($module);
+}
+
+1;

--- a/schedule/staging/minimal+base@64bit-staging.yaml
+++ b/schedule/staging/minimal+base@64bit-staging.yaml
@@ -4,28 +4,32 @@ description:    >
   Select a minimal textmode installation by starting with the default and unselecting all patterns
   except for "base" and "minimal". Not to be confused with the new system role "minimal" introduced with SLE15.
 vars:
-  PATTERNS: base,minimal
+  DESKTOP: textmode
+  PATTERNS: base,enhanced_base
+  YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
-  - installation/welcome
-  - installation/accept_license
-  - installation/scc_registration
-  - installation/addon_products_sle
-  - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_finish
-  - installation/installer_timezone
-  - installation/user_settings
-  - installation/user_settings_root
-  - installation/resolve_dependency_issues
+  - installation/setup_libyui
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/skip_module_registration
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_text_mode
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
   - installation/select_patterns
-  - installation/installation_overview
-  - installation/disable_grub_timeout
-  - installation/start_install
-  - installation/await_install
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/security/select_security_module_none
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
-  - installation/grub_test
+  - installation/performing_installation/confirm_reboot
+  - installation/handle_reboot
   - installation/first_boot
   - console/system_prepare
   - console/check_network

--- a/tests/installation/security/select_security_module_none.pm
+++ b/tests/installation/security/select_security_module_none.pm
@@ -1,0 +1,19 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Select 'None' Major Linux Security Module in Security Configuration
+# in the installer.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    $testapi::distri->get_installation_settings()->access_security_options();
+    $testapi::distri->get_security_configuration()->select_security_module('None');
+}
+
+1;


### PR DESCRIPTION
Adapt minimal+base to [SLE-21042](https://jira.suse.com/browse/SLE-21042) in staging. As we still want to keep minimal the scenario, instead of avoiding unselect the pattern, it is better to change security configuration.

- Related ticket: [poo#106822](https://progress.opensuse.org/issues/106822)
- Verification run: [minimal+base @ staging](https://openqa.suse.de/tests/8177913)
