### PR TITLE
Add ltss repos in ltss guest VM

### DIFF
--- a/tests/virtualization/universal/register_guests.pm
+++ b/tests/virtualization/universal/register_guests.pm
@@ -16,13 +16,20 @@ use version_utils;
 sub run_test {
     my ($self) = @_;
     # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
-    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
+    # $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
+    select_console 'root-console';
+    my %ltss_products = @{get_var_array("LTSS_REGCODES_SECRET")};
 
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "Registrating $guest against SMT";
         my ($sles_running_version, $sles_running_sp) = get_os_release("ssh root\@$guest");
+        my $version_id = $sles_running_sp != 0 ? "$sles_running_version.$sles_running_sp" : $sles_running_version;
         if ($sles_running_version >= 12) {
             assert_script_run("ssh root\@$guest SUSEConnect -r " . get_var('SCC_REGCODE') . " -e " . get_var("SCC_EMAIL"));
+            #it's safe to wait a few seconds to perform next register.
+            sleep 10;
+            assert_script_run("ssh root\@$guest SUSEConnect -p SLES-LTSS/$version_id/x86_64 -r " . $ltss_products{"$version_id"}) if ($ltss_products{"$version_id"});
+            sleep 10;
         }
         assert_script_run("ssh root\@$guest zypper -n ref");
         # Perhaps check the return values?


### PR DESCRIPTION
Logic:
1. Check if the guest OS is ltss by checking ltss scc code is present. (Each sle version has its own ltss code)
2.  Register ltss scc repo if guest OS is ltss.

This requires a hash to store ltss code. The hash should not be made public in github.
Therefore, it can be placed nowhere but job settings.  A variable below can be easily converted to hash

LTSS_PRODUCTS_CODES="15.1,INTERNAL-USE-xxxxxx,15,INTERNAL-USE-ONLY-yyyyyyy,12.4,INTERNAL-USE-ONLY-cccccc,12.3,INTERNAL-USE-ONLY-dddddd".

See the job settings of VR below for "LTSS_PRODUCTS_CODES" example.

- Related ticket: https://progress.opensuse.org/issues/106793
- Needles: no
- Verification run: 
- sles12sp4 kvm: http://openqa.qam.suse.cz/tests/37180#step/register_guests/8
- sles15 xen: http://openqa.qam.suse.cz/tests/37201#step/register_guests/20
- sles15sp1 kvm: http://openqa.qam.suse.cz/tests/37263#step/register_guests/8
- sle15SP2 kvm: http://openqa.qam.suse.cz/tests/37495#step/register_guests/19      VR after change suggested by reviewers