### PR TITLE
Fix script_run timed out and install semanage

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -407,7 +407,7 @@ Disable screensaver in gnome. To be called from a command prompt, for example an
 
 =cut
 sub turn_off_gnome_screensaver {
-    script_run 'gsettings set org.gnome.desktop.session idle-delay 0';
+    script_run 'gsettings set org.gnome.desktop.session idle-delay 0', die_on_timeout => 0, timeout => 90;
 }
 
 =head2 turn_off_gnome_screensaver_for_gdm

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -20,8 +20,8 @@ sub run {
 
     # Program 'sestatus' can be found in policycoreutils pkgs
     zypper_call("in policycoreutils");
-    # Program 'semanage' is in policycoreutils-python-utils pkgs on TW
-    if (is_tumbleweed) {
+    # Program 'semanage' is in policycoreutils-python-utils pkgs on TW and SLES 15-SP4
+    if (is_tumbleweed || is_sle('>=15-SP4')) {
         zypper_call('in policycoreutils-python-utils');
     }
     if (!is_sle('>=15')) {
@@ -32,7 +32,7 @@ sub run {
     my @pkgs = (
         'selinux-tools', 'libselinux-devel', 'libselinux1', 'python3-selinux', 'libsepol1', 'libsepol-devel',
         'libsemanage1', 'libsemanage-devel', 'checkpolicy', 'mcstrans', 'restorecond', 'setools-console',
-        'setools-devel', 'setools-java', 'setools-libs', 'setools-tcl'
+        'setools-devel', 'setools-java', 'setools-libs', 'setools-tcl', 'policycoreutils-python-utils'
     );
     foreach my $pkg (@pkgs) {
         my $results = script_run("zypper --non-interactive se $pkg");


### PR DESCRIPTION
Set die_on_timeout=0 when invoking script_run;
Install policycoreutils-python-utils pkg for semanage

poo#106802 - [sle][security][sle15sp4] test fails in apache2_changehat: command 'gsettings set org.gnome.desktop.session idle-delay 0' timed out
poo#104932 - [sle][security][sle15sp4] selinux: test fails in enforcing_mode_setup due to semanage command-not-found

- Related ticket:
   https://progress.opensuse.org/issues/106802
   https://progress.opensuse.org/issues/104932
- Needles: NA
- Verification run:
  selinux: https://openqa.suse.de/tests/8184457#details the failure can be tracked by product bug, see "Comments"
  apparmor_profile: https://openqa.suse.de/tests/8184426#