### PR TITLE
Fix container schedule for MicroOS

### DIFF
--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -63,9 +63,12 @@ sub load_feature_tests {
         loadtest 'console/kubeadm';
     }
     elsif (check_var 'SYSTEM_ROLE', 'container-host') {
+        my $args = OpenQA::Test::RunArgs->new();
+        my $runtime = get_required_var('CONTAINER_RUNTIME');
+        $args->{runtime} = $runtime;
         loadtest 'microos/toolbox';
         loadtest 'containers/podman';
-        loadtest 'containers/podman_image';
+        loadtest('containers/image', run_args => $args, name => "image_$runtime");
     }
 }
 


### PR DESCRIPTION
This fixes the regression caused by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14231
I proposed to run some VRs in O3, but forgot to propose MicroOS which follows its own schedule file... which IMO we should change for this things not to happen. It would be nice that ANY container job (in OSD/O3, SLES, TW, Leap, SLE Micro, MicroOS, etc) uses the same schedule `main_containers.pm`.
