### PR TITLE
Fix script_run timeout in patch_sle

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 SUSE LLC
+# Copyright 2017-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package migration;
@@ -47,7 +47,7 @@ sub setup_sle {
 
     # Enable Y2DEBUG for error debugging
     enter_cmd "echo 'export Y2DEBUG=1' >> /etc/bash.bashrc.local";
-    script_run "source /etc/bash.bashrc.local";
+    script_run("source /etc/bash.bashrc.local", die_on_timeout => 0);
 }
 
 sub setup_migration {


### PR DESCRIPTION
We expect script_run() return undef on command timeout instead of raising an exception, so add argument die_on_timeout => 0.

- Related ticket: https://progress.opensuse.org/issues/106817
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/8183347#step/patch_sle/16