### PR TITLE
Implement keylime test into openQA

### DIFF
--- a/schedule/security/keylime.yaml
+++ b/schedule/security/keylime.yaml
@@ -1,0 +1,8 @@
+name: keylime
+description:    >
+    This is for keylime tests
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/tpm2/tpm2_env_setup
+    - security/tpm2/keylime/keylime

--- a/tests/security/tpm2/keylime/keylime.pm
+++ b/tests/security/tpm2/keylime/keylime.pm
@@ -1,0 +1,44 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Add the keylime package (attestation)
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#106870, tc#1769823
+
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+use utils qw(zypper_call systemctl);
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Install keylime packages
+    zypper_call('in keylime-config keylime-firewalld keylime-agent keylime-tpm_cert_store keylime-registrar keylime-verifier', timeout => 240);
+
+    # Copy the keylime configuration file to /etc if not there
+    script_run("f=/etc/keylime.conf; [ ! -f \$f ] && cp /usr\$f \$f");
+
+    # Record the keylime packages' version for reference
+    my $pkgs_version = script_output('rpm -qa | grep keylime');
+    record_info("keylime packages version", "Current keylime packages' version:\n $pkgs_version");
+
+    # Make sure 'keylime_verifier' and 'keylime_registrar' services can be started successfully
+    systemctl('restart keylime_verifier.service');
+    systemctl('is-active keylime_verifier.service');
+    systemctl('restart keylime_registrar.service');
+    systemctl('is-active keylime_registrar.service');
+
+    # As test purpose, we will start keylime agent on single node
+    # So setting the 'receive_revocation_ip' and 'registrar_ip' to
+    # 127.0.0.1
+    assert_script_run q(sed -i 's/^registrar_ip = <REMOTE_IP>/registrar_ip = 127.0.0.1/' /etc/keylime.conf);
+    assert_script_run q(sed -i 's/^receive_revocation_ip = <REMOTE_IP>/receive_revocation_ip = 127.0.0.1/' /etc/keylime.conf);
+    systemctl('restart keylime_agent.service');
+    systemctl('is-active keylime_agent.service');
+}
+
+1;


### PR DESCRIPTION
Add the keylime attestation package.
Reference: https://github.com/keylime/keylime
Upstream status: Accepted (keylime >= 6.1.0)


- Related ticket: https://progress.opensuse.org/issues/106870
- Needles: n/a/
- Verification run: 

x86_64:
https://openqa.suse.de/tests/8178338# -SLE
https://openqa.opensuse.org/tests/2191560# -TW

aarch64:
https://openqa.suse.de/tests/8184248# -SLE
https://openqa.opensuse.org/tests/2193283# -TW