### PR TITLE
Improve libyui REST API timeout before MAX_JOB_TIME

### DIFF
--- a/lib/Installation/PerformingInstallation/PerformingInstallationController.pm
+++ b/lib/Installation/PerformingInstallation/PerformingInstallationController.pm
@@ -52,11 +52,10 @@ sub get_system_reboot_with_timeout_popup {
 }
 
 sub wait_installation_popup {
-    my ($self, $timeout) = @_;
+    my ($self, $args) = @_;
     YuiRestClient::Wait::wait_until(object => sub {
-            return $self->{AbstractOKPopup}->is_shown();
-        }, timeout => $timeout,
-        message => 'System reboot popup did not appear');
+            $self->{AbstractOKPopup}->is_shown({timeout => 0});
+    }, %$args);
 }
 
 sub confirm_reboot {

--- a/lib/Installation/Popups/AbstractOKPopup.pm
+++ b/lib/Installation/Popups/AbstractOKPopup.pm
@@ -26,8 +26,8 @@ sub init {
 }
 
 sub is_shown {
-    my ($self) = @_;
-    return $self->{btn_ok}->exist();
+    my ($self, $args) = @_;
+    return $self->{btn_ok}->exist($args);
 }
 
 sub press_ok {

--- a/lib/YuiRestClient/App.pm
+++ b/lib/YuiRestClient/App.pm
@@ -62,7 +62,7 @@ sub check_connection {
 
     YuiRestClient::Logger->get_instance()->debug("Check connection to the app by url: $uri");
     YuiRestClient::Wait::wait_until(object => sub {
-            my $response = YuiRestClient::Http::HttpClient::http_get($uri);
+            my $response = YuiRestClient::Http::HttpClient::http_get(uri => $uri);
             return $response->json if $response;
         },
         message => "Connection to YUI REST server failed",

--- a/lib/YuiRestClient/Http/HttpClient.pm
+++ b/lib/YuiRestClient/Http/HttpClient.pm
@@ -10,8 +10,10 @@ use YuiRestClient::Logger;
 my $ua = Mojo::UserAgent->new;
 
 sub http_get {
-    my $url = Mojo::URL->new(shift);
-    sleep(1);
+    my (%args) = @_;
+    $args{add_delay} //= 1;
+    my $url = Mojo::URL->new($args{uri});
+    sleep(1) if $args{add_delay};
     my $res = $ua->get($url)->result;
     return $res if $res->is_success;
     # Die if non OK response code
@@ -20,8 +22,10 @@ sub http_get {
 }
 
 sub http_post {
-    my $url = Mojo::URL->new(shift);
-    sleep(1);
+    my (%args) = @_;
+    $args{add_delay} //= 1;
+    my $url = Mojo::URL->new($args{uri});
+    sleep(1) if $args{add_delay};
     my $res = $ua->post($url)->result;
     return $res if $res->is_success;
     # Die if non OK response code

--- a/lib/YuiRestClient/Http/WidgetController.pm
+++ b/lib/YuiRestClient/Http/WidgetController.pm
@@ -42,26 +42,31 @@ sub set_port {
 
 sub find {
     my ($self, $args) = @_;
+    my $timeout = $args->{timeout} // $self->{timeout};
+    my $interval = $args->{interval} // $self->{interval};
 
     my $uri = YuiRestClient::Http::HttpClient::compose_uri(
         host => $self->{host},
         port => $self->{port},
         path => $self->{api_version} . '/widgets',
-        params => $args
+        params => $args->{filter}
     );
 
     YuiRestClient::Logger->get_instance()->debug('Finding widget by url: ' . $uri);
 
     YuiRestClient::Wait::wait_until(object => sub {
-            my $response = YuiRestClient::Http::HttpClient::http_get($uri);
+            my $response = YuiRestClient::Http::HttpClient::http_get(
+                uri => $uri, add_delay => $timeout);
             return $response->json if $response; },
-        timeout => $self->{timeout},
-        interval => $self->{interval}
+        timeout => $timeout,
+        interval => $interval
     );
 }
 
 sub send_action {
     my ($self, $args) = @_;
+    my $timeout = $args->{timeout} // $self->{timeout};
+    my $interval = $args->{interval} // $self->{interval};
 
     my $uri = YuiRestClient::Http::HttpClient::compose_uri(
         host => $self->{host},
@@ -73,10 +78,11 @@ sub send_action {
     YuiRestClient::Logger->get_instance()->debug('Sending action to widget by url: ' . $uri);
 
     YuiRestClient::Wait::wait_until(object => sub {
-            my $response = YuiRestClient::Http::HttpClient::http_post($uri);
+            my $response = YuiRestClient::Http::HttpClient::http_post(
+                uri => $uri, add_delay => $timeout);
             return $response if $response; },
-        timeout => $self->{timeout},
-        interval => $self->{interval}
+        timeout => $timeout,
+        interval => $interval
     );
 }
 

--- a/lib/YuiRestClient/Widget/Base.pm
+++ b/lib/YuiRestClient/Widget/Base.pm
@@ -26,9 +26,9 @@ sub action {
 }
 
 sub exist {
-    my ($self) = @_;
+    my ($self, $args) = @_;
 
-    eval { $self->find_widgets() };
+    eval { $self->find_widgets($args) };
     return 0 if $@;
     return 1;
 }
@@ -46,17 +46,21 @@ sub property {
 }
 
 sub find_widgets {
-    my ($self) = @_;
+    my ($self, $args) = @_;
 
     $self->resolve_filter() unless $self->{filter}->is_resolved();
-    return $self->{widget_controller}->find($self->{filter}->get_filter());
+    return $self->{widget_controller}->find({
+            filter => $self->{filter}->get_filter(),
+            timeout => $args->{timeout},
+            interval => $args->{interval}
+    });
 }
 
 sub resolve_filter {
-    my ($self) = @_;
+    my ($self, $args) = @_;
 
     # get json with widgets according to current filter (which does not include regex)
-    my $json = $self->{widget_controller}->find($self->{filter}->get_filter());
+    my $json = $self->{widget_controller}->find({filter => $self->{filter}->get_filter()});
     # replace regex by found value in the filter
     $self->{filter}->resolve($json);
 }

--- a/tests/installation/performing_installation/perform_installation.pm
+++ b/tests/installation/performing_installation/perform_installation.pm
@@ -19,14 +19,15 @@ sub run {
 
     $performing_install->get_performing_installation_page();
 
-    # 2750 represents a huge timeout of 5500 seconds for installation to succeed
-    my $timeout = 2750 * get_var('TIMEOUT_SCALE', 1);
-    $performing_install->wait_installation_popup($timeout);
+    my $timeout = 2400 * get_var('TIMEOUT_SCALE', 1);
+    $performing_install->wait_installation_popup({
+            timeout => $timeout,
+            interval => 2,
+            message => 'System reboot popup did not appear'});
 
     assert_matches(qr/The system will reboot now/,
         $performing_install->get_system_reboot_popup()->text(),
         'System reboot popup is not displayed');
-
 }
 
 1;


### PR DESCRIPTION
Once we hit MAX_JOB_TIME is game over, there is not chance to run code in post_fail_hooks by design.
As the process of performing installation requires a short interval to check due to sometimes we need to stop the reboot timeout in less than 10 seconds, creating a screenshot for each check is not possible, it would be too many of them.

What we can do is to avoid reaching that MAX_JOB_TIME waiting for the widget to exist only because we use a `wait_until` inside another `wait_until`. By passing `timeout=0` to the methods which are executed in the inner block we can exit earlier from this long wait and get a proper error before hitting the maximum time set for the job. Also we measure the time instead of using a counter.

Additionally we can avoid to double the sleep time that we introduced for safety at the beginning of development with libyui REST API for this particular cases with zero timeout. For other cases this delay should be there, otherwise it fails due to some screen are not completed loaded and we don't check it properly in early code with new libyui REST API development.

- Related ticket: [poo#106850](https://progress.opensuse.org/issues/106850)
- Verification run: 
  - [sle](https://openqa.suse.de/tests/overview?version=15-SP4&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23improve_perform_install)
  - [faking error with wrong id and 30'' timeout](https://openqa.suse.de/tests/8265116#step/access_beta_distribution/2)