### PR TITLE
Add ssh key to known hosts

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -99,6 +99,9 @@ sub run {
         $instance->wait_for_guestregister();
     }
 
+    # Ensure the ssh public key is in the known hosts file for any upcoming connections
+    assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
+
     assert_script_run("cd $root_dir");
     assert_script_run('curl ' . data_url('publiccloud/restart_instance.sh') . ' -o restart_instance.sh');
     assert_script_run('curl ' . data_url('publiccloud/log_instance.sh') . ' -o log_instance.sh');


### PR DESCRIPTION
Add the ssh public key to the known hosts file to ensure, subsequent ssh
calls are not running into authentication trouble.

This fixes poo#106840

- Related ticket: https://progress.opensuse.org/issues/106840
- Verification run: [15-SP4 Azure](http://duck-norris.qam.suse.de/t8187) (is past the [previous failing point](https://openqa.suse.de/tests/8149249/modules/run_ltp/steps/157))
