### PR TITLE
Assert screen to make sure the grub2 page has shown up

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -265,6 +265,8 @@ sub boot_local_disk {
 sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
+    # assert needle to make sure grub2 page show up
+    assert_screen('grub2-page', 60);
     # assert needle to avoid send down key early in grub_test_snapshot.
     if (get_var('OFW') || is_pvm || check_var('SLE_PRODUCT', 'hpc')) {
         send_key_until_needlematch('snap-default', 'down', 60, 5);


### PR DESCRIPTION
Assert screen to make sure the grub2 page has shown up

- Related ticket: https://progress.opensuse.org/issues/106939
- Verification run: https://openqa.suse.de/tests/8202487#step/grub_test_snapshot/7
x86_64:  http://openqa.suse.de/t8202672
ppc64le: http://openqa.suse.de/t8202675
aarch64: http://openqa.suse.de/t8202676
sles12+:
http://openqa.suse.de/t8206229
http://openqa.suse.de/t8206230
http://openqa.suse.de/t8206231
HPC:
https://openqa.suse.de/tests/8216050
https://openqa.suse.de/tests/8216057