### PR TITLE
wip[virt_autotest] workaround DRM for HyperV

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -410,7 +410,8 @@ sub uefi_bootmenu_params {
 # Returns kernel framebuffer configuration we have to
 # explicitly set on Hyper-V to get 1024x768 resolution.
 sub get_hyperv_fb_video_resolution {
-    return 'video=hyperv_fb:1024x768';
+	#return 'video=hyperv_drmdrmfb:1024x768';
+    return ' ';
 }
 
 
@@ -1075,7 +1076,8 @@ sub zkvm_add_interface {
 sub set_framebuffer_resolution {
     my $video;
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        $video = 'video=hyperv_fb:1024x768';
+        #$video = 'video=hyperv_drmdrmfb:1024x768';
+        $video = ' ';
     }
     elsif (check_var('VIRSH_VMM_TYPE', 'linux')) {
         $video = 'xen-fbfront.video=32,1024,768 xen-kbdfront.ptr_size=1024,768';

--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -221,6 +221,9 @@ sub run {
 
     hyperv_cmd("$ps Set-VMProcessor $name -Count $cpucount");
 
+    #DEBUG
+    #hyperv_cmd("$ps Set-VMVideo -VMName $name -ResolutionType Single -HorizontalResolution 1024 -VerticalResolution 768") if $winserver eq '2012r2';
+
     if (get_var('UEFI')) {
         if ($winserver eq '2012r2' || get_var('DISABLE_SECUREBOOT')) {
             hyperv_cmd("$ps Set-VMFirmware $name -EnableSecureBoot Off");


### PR DESCRIPTION
Try to just only use with video=1024x768 instead of` video=hyperv_fb` kernel option during 15-SP4 guest installation on HyperV server. 
refer to https://jira.suse.com/browse/SLE-19748 and https://bugzilla.suse.com/show_bug.cgi?id=1195266 for more details.

- Verification run: 
WIP