### PR TITLE
Increase timeout in log collection for broken links

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -195,7 +195,7 @@ sub problem_detection {
     $self->save_and_upload_log(
 "find / -type d \\( -path /proc -o -path /run -o -path /.snapshots -o -path /var \\) -prune -o -xtype l -exec ls -l --color=always {} \\; -exec rpmquery -f {} \\;",
         "broken-symlinks.txt",
-        {screenshot => 1, noupload => 1});
+        {screenshot => 1, noupload => 1, timeout => 60});
     clear_console;
 
     # Binaries with missing libraries


### PR DESCRIPTION
Fix for instance lack of yast logs here https://openqa.suse.de/tests/8179636 where in logs we have:
```
post_fail_hook failed: command 'find / -type d \( -path /proc -o -path /run -o -path /.snapshots -o -path /var \) -prune -o -xtype l -exec ls -l --color=always {} \; -exec rpmquery -f {} \; | tee broken-symlinks.txt' timed out at /usr/lib/os-autoinst/testapi.pm line 1038.
```
- Related ticket:  [poo#106850](https://progress.opensuse.org/issues/106850)
- Verification run: https://openqa.suse.de/tests/8189745
