### PR TITLE
Extract schedule for modify_existing_partition@s390x

### DIFF
--- a/schedule/yast/modify_existing_partition/modify_existing_partition.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition.yaml
@@ -1,0 +1,33 @@
+---
+name: modify_existing_partition
+description: >
+  Installation where we modify some pre-existing partitions. Must depend on some
+  create_hdd test suite.
+vars:
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/skip_module_registration
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_text_mode
+  - installation/partitioning/modify_existing_partition
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/handle_reboot
+  - installation/first_boot
+  - console/validate_modify_existing_partition
+test_data:
+  <<: !include test_data/yast/modify_existing_partition/modify_existing_partition.yaml

--- a/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
@@ -24,16 +24,12 @@ schedule:
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
-  - '{{stop_timeout_system_reboot_now}}'
+  - installation/performing_installation/stop_timeout_system_reboot_now
   - installation/logs_from_installation_system
   - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
   - installation/handle_reboot
   - installation/first_boot
   - console/validate_modify_existing_partition
-conditional_schedule:
-  stop_timeout_system_reboot_now:
-    ARCH:
-      s390x:
-        - installation/performing_installation/stop_timeout_system_reboot_now
 test_data:
   <<: !include test_data/yast/modify_existing_partition/modify_existing_partition.yaml


### PR DESCRIPTION
s390x requires additional steps that are not needed on qemu. The commit
separates schedules for s390x and qemu.

- Verification runs: 
   - s390x: https://openqa.suse.de/tests/8191444
   - x86_64: https://openqa.suse.de/tests/8191449

**MR for Job Group settings should be merged as well:** https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/397 