### PR TITLE
Exclude user_gui_login from gnome test starting from hdd

### DIFF
--- a/schedule/functional/gnome.yaml
+++ b/schedule/functional/gnome.yaml
@@ -29,7 +29,6 @@ schedule:
     - console/system_state
     - console/prepare_test_data
     - console/consoletest_setup
-    - x11/user_gui_login
     - x11/desktop_runner
     - x11/xterm
     - x11/sshxterm


### PR DESCRIPTION
see https://progress.opensuse.org/issues/107095
will provide verification test later
