### PR TITLE
Bump timeout to wait until yast2 users will be opened

### DIFF
--- a/tests/yast2_gui/yast2_users.pm
+++ b/tests/yast2_gui/yast2_users.pm
@@ -15,7 +15,7 @@ use testapi;
 
 sub run {
     select_console 'x11';
-    y2_module_guitest::launch_yast2_module_x11('users', match_timeout => 100);
+    y2_module_guitest::launch_yast2_module_x11('users', match_timeout => 200);
     send_key "alt-o";    # OK => Exit
 }
 


### PR DESCRIPTION
It takes more then 100 seconds on slow archs. The commit increases the
timeout.

- Related ticket: https://progress.opensuse.org/issues/105573
- Verification run: https://openqa.suse.de/tests/8191550
