### PR TITLE
Remove useless prj3 workaroun on dst host

### DIFF
--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -30,22 +30,9 @@ sub run {
     #Refer to bsc#1191511 for more details
     $self->reset_unprivileged_userfaultfd if (is_sle('>=15-SP4') && is_kvm_host);
 
-    #workaround for weird mount failure
-    $self->workaround_for_reverse_lock("SRC_IP", 3600);
-    my $src_ip = $self->get_var_from_child("SRC_IP");
-    my $src_user = $self->get_var_from_child("SRC_USER");
-    my $src_pass = $self->get_var_from_child("SRC_PASS");
-    my $hypervisor = (is_xen_host) ? 'xen' : 'kvm';
-    my $args = "-d $src_ip -v $hypervisor -u $src_user -p $src_pass";
-    my $pre_test_cmd = "/usr/share/qa/virtautolib/lib/guest_migrate.sh " . $args;
-    enter_cmd("$pre_test_cmd ");
-    save_screenshot;
-    send_key("ctrl-c");
-    save_screenshot;
-    #workaround end
 
     # clean up logs from prevous tests
-    script_run('[ -d /var/log/qa/ctcs2/ ] && rm -rf /var/log/qa/ctcs2/', die_on_timeout => 0);
+    script_run('[ -d /var/log/qa/ctcs2/ ] && rm -rf /var/log/qa/ctcs2/');
     script_run('[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/');
     script_run('[ -d /tmp/prj3_migrate_admin_log/ ] && rm -rf /tmp/prj3_migrate_admin_log/');
 
@@ -58,7 +45,7 @@ sub run {
 
     #upload logs
     my $xen_logs = "";
-    if ($hypervisor =~ /XEN/im) {
+    if (is_xen_host) {
         $xen_logs = "/var/lib/xen/dump /tmp/xl-dmesg.log";
         script_run("xl dmesg > /tmp/xl-dmesg.log");
         #separate the xen logs from other virt logs because it needs to be remained or xen service will fail to start


### PR DESCRIPTION
The workround to pre-run guest migration from destination host to get around nfs problem has not been needed any more. Also It leads to the timeout of removing the ctcs log directory. 

- Related ticket: https://progress.opensuse.org/issues/106913
- Verification run: 
[virt-guest-migration-sles12sp5-from-sles12sp5-to-developing-xen](https://openqa.nue.suse.com/tests/8206161)
[virt-guest-migration-sles15sp3-from-sles15sp3-to-developing-xen](https://openqa.nue.suse.com/tests/8205979)