### PR TITLE
Skip double checking xen kernel on first reboot after host upgrade

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -103,6 +103,7 @@ sub login_to_console {
     }
 
     if (!get_var("reboot_for_upgrade_step")) {
+        set_var("first_reboot_after_upgrade", "no") if (check_var("first_reboot_after_upgrade", "yes"));
         if (is_xen_host) {
             #send key 'up' to stop grub timer counting down, to be more robust to select xen
             send_key 'up';
@@ -147,6 +148,7 @@ sub login_to_console {
         }
         #setup vars
         set_var("reboot_for_upgrade_step", undef);
+        set_var("first_reboot_after_upgrade", "yes");
         set_var("after_upgrade", "yes");
     }
     save_screenshot;
@@ -166,7 +168,7 @@ sub login_to_console {
     # use console based on ssh to avoid unstable ipmi
     use_ssh_serial_console;
     # double-check xen role for xen host
-    double_check_xen_role if is_xen_host;
+    double_check_xen_role if (is_xen_host and (!check_var("first_reboot_after_upgrade", "yes")));
 }
 
 sub run {


### PR DESCRIPTION
* **Host** upgrade test suites will boot info the default grub2 entry on the first reboot after finishing upgrade, namely the grub2 kvm boot entry. So the double_check_xen_role function will fail definitely on this occasion. Please refer to [failure1](https://openqa.suse.de/tests/8196691#step/reboot_and_wait_up_upgrade/1) and [failure2](https://openqa.suse.de/tests/8177648#step/reboot_and_wait_up_upgrade/50)
* **Introducing** first_reboot_after_upgrade parameter to record first reboot and also help combat this issue which will be set to "yes" immediately after host upgrade finishes and will be set back to "no" afterwards.

* **double_check_xen_role** is only called on xen host and at steps that are not first reboot after host upgrade.

* **Verification runs:**
  * [guest installation kvm](https://openqa.suse.de/tests/8200502)
  * [guest installation xen](https://openqa.suse.de/tests/8202762)
  * [online host upgrade kvm](https://openqa.suse.de/tests/8200517)
  * [online host upgrade xen](https://openqa.suse.de/tests/8200515)
  * [offline host upgrade kvm](https://openqa.suse.de/tests/8200731)
  * [offline host upgrade xen](https://openqa.suse.de/tests/8200732)