### PR TITLE
Rerun the test cases in CC which usually fail randomly

### DIFF
--- a/tests/security/cc/audit_tools.pm
+++ b/tests/security/cc/audit_tools.pm
@@ -5,14 +5,14 @@
 #
 # Summary: Run 'audit-tools' test case of 'audit-test' test suite
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#94450
+# Tags: poo#94450, poo#106816
 
 use base 'consoletest';
 use strict;
 use warnings;
 use testapi;
 use utils;
-use audit_test qw(run_testcase compare_run_log);
+use audit_test qw(run_testcase compare_run_log rerun_fail_cases);
 
 sub run {
     my ($self) = shift;
@@ -21,6 +21,9 @@ sub run {
 
     # Run test case
     run_testcase('audit-tools');
+
+    # Rerun randomly fail cases
+    rerun_fail_cases();
 
     # Compare current test results with baseline
     my $result = compare_run_log('audit-tools');

--- a/tests/security/cc/filter.pm
+++ b/tests/security/cc/filter.pm
@@ -5,14 +5,14 @@
 #
 # Summary: Run 'filter' test case of 'audit-test' test suite
 # Maintainer: rfan1 <richard.fan@suse.com>, Liu Xiaojing <xiaojing.liu@suse.com>
-# Tags: poo#95464
+# Tags: poo#95464, poo#106735
 
 use base 'consoletest';
 use strict;
 use warnings;
 use testapi;
 use utils;
-use audit_test qw(run_testcase compare_run_log);
+use audit_test qw(run_testcase compare_run_log rerun_fail_cases);
 
 sub run {
     my ($self) = shift;
@@ -20,6 +20,9 @@ sub run {
     select_console 'root-console';
 
     run_testcase('filter', (make => 1, timeout => 180));
+
+    # Rerun randomly fail cases
+    rerun_fail_cases();
 
     # Compare current test results with baseline
     my $result = compare_run_log('filter');

--- a/tests/security/cc/syscalls.pm
+++ b/tests/security/cc/syscalls.pm
@@ -5,14 +5,14 @@
 #
 # Summary: Run 'syscalls' test case of 'audit-test' test suite
 # Maintainer: rfan1 <richard.fan@suse.com>, Liu Xiaojing <xiaojing.liu@suse.com>
-# Tags: poo#94684
+# Tags: poo#94684, poo#106736
 
 use base 'consoletest';
 use strict;
 use warnings;
 use testapi;
 use utils;
-use audit_test qw(run_testcase compare_run_log);
+use audit_test qw(run_testcase compare_run_log rerun_fail_cases);
 
 sub run {
     my ($self) = shift;
@@ -25,6 +25,9 @@ sub run {
 
     # Run test case
     run_testcase('syscalls', (make => 1, timeout => 720));
+
+    # Rerun randomly fail cases
+    rerun_fail_cases();
 
     # Compare current test results with baseline
     my $result = compare_run_log('syscalls');


### PR DESCRIPTION
Some test cases in CC usually fail with unknown reason. But they pass in
the manual test, so we rerun them to see if they could pass in openQA.

Relate: https://progress.opensuse.org/issues/106735

Verify run: https://openqa.suse.de/tests/8206210  (s390x)
https://openqa.suse.de/tests/8206189  (aarch64)
https://openqa.suse.de/tests/8206209  (x86_64)
https://openqa.suse.de/tests/8216229  (s390x)