### PR TITLE
Validate output retry

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -172,8 +172,8 @@ sub test_opensuse_based_image {
                 # we set --entrypoint specifically to the zypper plugin to avoid bsc#1192941
                 my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
                 validate_script_output("$runtime run --entrypoint $plugin -i $image -v", sub { m/container-suseconnect version .*/ }, timeout => 180);
-                validate_script_output("$runtime run --entrypoint $plugin -i $image lp", sub { m/.*All available products.*/ }, timeout => 180);
-                validate_script_output("$runtime run --entrypoint $plugin -i $image lm", sub { m/.*All available modules.*/ }, timeout => 180);
+                validate_script_output_retry("$runtime run --entrypoint $plugin -i $image lp", sub { m/.*All available products.*/ }, retry => 5, delay => 60, timeout => 300);
+                validate_script_output_retry("$runtime run --entrypoint $plugin -i $image lm", sub { m/.*All available modules.*/ }, retry => 5, delay => 60, timeout => 300);
             }
         } else {
             record_info "non-SLE host", "This host ($host_id) does not support zypper service";

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -86,6 +86,7 @@ our @EXPORT = qw(
   install_patterns
   common_service_action
   script_output_retry
+  validate_script_output_retry
   get_secureboot_status
   assert_secureboot_status
   susefirewall2_to_firewalld
@@ -1663,6 +1664,55 @@ sub script_output_retry {
     die("Waiting for Godot: $cmd") if $die;
 }
 
+
+=head2 validate_script_output_retry
+
+ validate_script_output_retry($cmd, $check, [retry => $retry], [delay => $delay], [timeout => $timeout]);
+
+Repeat command until validate_script_output succeeds or die. Return the output of the command on success.
+
+C<$retry> refers to the number of retries and defaults to C<10>.
+
+C<$delay> is the time between retries and defaults to C<30>.
+
+If the command doesn't succeed after C<$retry> retries,
+this function will die.
+
+Example:
+
+ validate_script_output_retry('ping -c1 -W1 machine', m/1 packets transmitted/, retry => 5, delay => 60);
+
+=cut
+sub validate_script_output_retry {
+    my ($cmd, $check, %args) = @_;
+    $args{retry} //= 10;
+    $args{delay} //= 30;
+    $args{timeout} //= 90;
+    $args{proceed_on_failure} //= 1;
+    my $retry = delete $args{retry};
+    my $delay = delete $args{delay};
+    my $timeout = delete $args{timeout};
+    my $ret;
+    my $exec = "timeout --foreground --kill-after 5s ${timeout}s";
+    # Exclamation mark needs to be moved before the timeout command, if present
+    if (substr($cmd, 0, 1) eq "!") {
+        $cmd = substr($cmd, 1);
+        $cmd =~ s/^\s+//;    # left trim spaces after the exclamation mark
+        $exec = "! $exec";
+    }
+    $exec = "$exec $cmd";
+    $timeout += 8;    # timeout for script_run must be larger than for the 'timeout ...' command
+
+    for (1 .. $retry) {
+        eval { $ret = validate_script_output($exec, $check, $timeout, %args); };
+        return $ret if (defined($ret));
+        record_info("Retry", "validate_script_output failed or timed out. Retrying...");
+        sleep $delay;
+    }
+    die("Can't validate output after $retry retries");
+}
+
+
 =head2 script_run_interactive
 
  script_run_interactive($cmd, $prompt, $timeout);
@@ -1764,12 +1814,12 @@ sub create_btrfs_subvolume {
     assert_script_run("rm -fr /tmp/arm64-efi/");
 }
 
-=head2 create_raid_loop_device 
-    
+=head2 create_raid_loop_device
+
  create_raid_loop_device([raid_type => $raid_type], [device_num => $device_num], [file_size => $file_size]);
 
 Create a raid array over loop devices.
-Raid type is C<$raid_type>, using C<$device_num> number of loop device, 
+Raid type is C<$raid_type>, using C<$device_num> number of loop device,
 with the size of each device being C<$file_size> megabytes.
 
 Example to create a RAID C<5> array over C<3> loop devices, C<200> Mb each:

--- a/t/05_utils_auxiliary.t
+++ b/t/05_utils_auxiliary.t
@@ -33,4 +33,25 @@ subtest 'script_retry' => sub {
     dies_ok { script_retry('sleep 10', retry => 1, delay => 0, timeout => 1) } 'script_retry(sleep) is expected to die';
 };
 
+
+subtest 'validate_script_output_retry' => sub {
+    my $module = Test::MockModule->new('testapi');
+
+    my $basetest = Test::MockModule->new('basetest');
+    $basetest->noop('record_resultfile');
+    $autotest::current_test = new basetest;
+
+    $module->mock('script_output', sub { 'foo' });
+    lives_ok { validate_script_output_retry('echo foo', qr/foo/, retry => 2) } 'Do not throw exception';
+    throws_ok { validate_script_output_retry('echo foo', qr/bar/, retry => 2, delay => 0) } qr/validate output/, 'Exception thrown';
+
+    my @results;
+    $module->mock('script_output', sub { shift @results });
+
+    @results = qw(1 2 3 foo);
+    lives_ok { validate_script_output_retry('echo foo', qr/foo/, retry => 4, delay => 0) } 'Success on 4th retry';
+    @results = qw(1 2 3 foo);
+    throws_ok { validate_script_output_retry('echo foo', qr/foo/, retry => 3, delay => 0) } qr/validate output/, 'Not enough retries';
+};
+
 done_testing;


### PR DESCRIPTION
Allow running validate_script_output with given number of retries,
similar to script_retry. It's basically the same function but
giving the chance to run the command $retry times with $delay
waiting time between them. This might be useful for commands
that are not 100% stable due to network issues and we need to try
2 or 3 times until it works.

- Related ticket: https://progress.opensuse.org/issues/107062
VR: https://openqa.suse.de/tests/8203396#
