### PR TITLE
slem5.1: Ensure booting RT kernel

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -11,7 +11,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_microos is_selfinstall);
+use version_utils qw(is_microos is_selfinstall is_rt);
 use power_action_utils 'power_action';
 use Utils::Architectures qw(is_aarch64);
 
@@ -43,8 +43,7 @@ sub microos_reboot {
     # No grub bootloader on xen-pv
     # grub2 needle is unreliable (stalls during timeout) - poo#28648
     assert_screen 'grub2', 300;
-    send_key('ret') if match_has_tag('grub2');
-
+    send_key('ret') if get_var('DISABLE_GRUB_TIMEOUT');
     microos_login;
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -347,7 +347,7 @@ sub is_sles4sap_standard {
 Returns true if called on a real time system
 =cut
 sub is_rt {
-    return check_var('SLE_PRODUCT', 'rt');
+    return (check_var('SLE_PRODUCT', 'rt') || get_var('FLAVOR') =~ /rt/i);
 }
 
 =head2 is_hpc

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -28,10 +28,15 @@ conditional_schedule:
     SLE_MICRO_K3S:
       '1':
         - containers/k3s_cli_check
+  rt:
+    FLAVOR:
+      'MicroOS-Image-RT':
+        - rt/rt_is_realtime
 
 schedule:
   - '{{boot}}'
   - transactional/host_config
+  - '{{rt}}'
   - '{{registration}}'
   - '{{maintenance}}'
   - '{{selinux}}'

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -15,6 +15,7 @@ use warnings;
 use testapi;
 use transactional qw(process_reboot);
 use bootloader_setup qw(change_grub_config);
+use version_utils qw(is_rt is_sle_micro);
 
 sub run {
     select_console 'root-console';
@@ -24,8 +25,9 @@ sub run {
     my $extrabootparams = get_var('EXTRABOOTPARAMS');
     change_grub_config('=\"[^\"]*', "& $extrabootparams", 'GRUB_CMDLINE_LINUX_DEFAULT') if $extrabootparams;
     change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT') if $disable_grub_timeout;
+    change_grub_config('=0', '="1>2"', 'GRUB_DEFAULT') if (is_rt && is_sle_micro('<5.2'));
 
-    if ($disable_grub_timeout or $extrabootparams) {
+    if ($disable_grub_timeout or $extrabootparams or (is_rt && is_sle_micro('<5.2'))) {
         record_info('GRUB', script_output('cat /etc/default/grub'));
         assert_script_run('transactional-update grub.cfg');
         process_reboot(trigger => 1);
@@ -35,7 +37,7 @@ sub run {
 }
 
 sub test_flags {
-    return {no_rollback => 1};
+    return {no_rollback => 1, fatal => is_rt ? 1 : 0, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
Slem5.1 comes with 2 kernels pre-installed in case of *Default-RT-Image*
flavor. Unfortunately, grub2 to is set to boot from the first record in
grub menu which kernel-default. Removal of kernel-default cannot be done
without removing kernel-rt at the same time.

- Related ticket: [SLE Micro RT - Boot RT kernel instead of default one](https://progress.opensuse.org/issues/102723)
- Verification runs: http://kepler.suse.cz/tests/13788#step/host_config/12
  * [microos-Tumbleweed-MicroOS-Image-Kubic-kubeadm-x86_64-Build20220219-kubeadm@64bit-2G ](http://kepler.suse.cz/tests/13791)
  * [microos-Tumbleweed-MicroOS-Image-ContainerHost-x86_64-Build20220219-container-host@64bit](http://kepler.suse.cz/tests/13790)
  * [ microos-Tumbleweed-MicroOS-Image-x86_64-Build20220219-microos@64bit](http://kepler.suse.cz/tests/13789)
