### PR TITLE
Fix textmode key shortcuts in product selection

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -65,8 +65,8 @@ sub get_product_shortcuts {
             : is_aarch64() ? 's'
             : 'i',
             sled => 'x',
-            sles4sap => is_ppc64le() ? 'i'
-            : (is_sle('15-SP2+') && is_x86_64() && !is_quarterly_iso()) ? 't'
+            sles4sap => is_ppc64le() ? 'u'
+            : (is_sle('15-SP2+') && is_x86_64() && !is_quarterly_iso()) ? 'i'
             : 'p',
             hpc => is_x86_64() ? 'g' : 'u',
             rt => is_x86_64() ? 't' : undef


### PR DESCRIPTION
I could not find any textmode sles4sap tests on older versions than 15-SP4

- Fail: https://openqa.suse.de/tests/8195354#step/accept_license/2 https://openqa.suse.de/tests/8195293#step/accept_license/1
- Verification run:
https://openqa.suse.de/tests/8202819#step/welcome/6 x86_64
https://openqa.suse.de/tests/8202821#step/welcome/6 ppc64le