### PR TITLE
Schedule select security module none

### DIFF
--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
   - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/security/select_security_module_none
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -24,6 +24,7 @@ schedule:
   - installation/authentication/default_user_simple_pwd
   - installation/select_patterns
   - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/security/select_security_module_none
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation


### PR DESCRIPTION
Schedule the module that selects `None` in security configuration

- Related ticket: https://progress.opensuse.org/issues/106822
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/overview?build=ge0r%2Fos-autoinst-distri-opensuse%23apparmor-issue&version=15-SP4&distri=sle
