### PR TITLE
Select 'None' LSM when AppArmor pattern is not selected

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -16,7 +16,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_microos is_sle_micro is_upgrade);
+use version_utils qw(is_microos is_sle_micro is_upgrade is_sle);
 use Utils::Backends qw(is_remote_backend is_hyperv);
 use Test::Assert ':all';
 
@@ -73,6 +73,17 @@ sub check_default_target {
     $self->validate_default_target($expected_target);
 }
 
+sub set_linux_security_to_none {
+    send_key_until_needlematch 'security-section-selected', 'tab', 25;
+    send_key 'ret';
+    assert_screen 'security-configuration', 120;
+    send_key 'alt-s';
+    send_key 'pgup';
+    assert_screen 'lsm-selected-none';
+    send_key 'alt-o';
+    assert_screen 'installation-settings-overview-loaded', 120;
+}
+
 sub run {
     my ($self) = shift;
     # overview-generation
@@ -90,6 +101,7 @@ sub run {
                 assert_screen 'inst-xen-pattern';
             }
         }
+        set_linux_security_to_none if (check_var('LINUX_SECURITY_MODULE', 'none') && is_sle('>=15-SP4'));
         ensure_ssh_unblocked;
         $self->check_default_target();
     }


### PR DESCRIPTION
The installation proposal contains a conflict, the "Major Linux Security Module" option says "Activate AppArmor". So then it is OK to require the AppArmor pattern to be installed.

The commit makes explicit selection of "None" LSM in case AppArmor is disabled.

- Verification run: https://openqa.suse.de/tests/8204765
