### PR TITLE
Add apparmor in the patterns of the HPC installations

### DIFF
--- a/schedule/hpc/create_hdd_hpc_textmode.yaml
+++ b/schedule/hpc/create_hdd_hpc_textmode.yaml
@@ -7,7 +7,7 @@ description:    >
 vars:
   DESKTOP: textmode
   INSTALLONLY: 1
-  PATTERNS: base,minimal
+  PATTERNS: base,minimal,apparmor
   SLE_PRODUCT: hpc
   HDDSIZEGB: 30
 conditional_schedule:

--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -6,7 +6,7 @@ description:    >
 vars:
   DESKTOP: textmode
   INSTALLONLY: 1
-  PATTERNS: base,minimal
+  PATTERNS: base,minimal,apparmor
   SLE_PRODUCT: hpc
   HDDSIZEGB: 30
 conditional_schedule:

--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -6,7 +6,7 @@ description:    >
 vars:
   DESKTOP: textmode
   INSTALLONLY: 1
-  PATTERNS: base,minimal
+  PATTERNS: base,minimal,apparmor
   SLE_PRODUCT: hpc
   HDDSIZEGB: 30
 conditional_schedule:

--- a/schedule/hpc/single_machine_test.yaml
+++ b/schedule/hpc/single_machine_test.yaml
@@ -5,7 +5,7 @@ description:    >
      all singe machine HPC tests based loaded based on hpctest
 vars:
   DESKTOP: textmode
-  PATTERNS: base,minimal
+  PATTERNS: base,minimal,apparmor
   SLE_PRODUCT: hpc
   HDDSIZEGB: 30
 conditional_schedule:


### PR DESCRIPTION
Due to Major Linux Security Module in the product the installation requires to define apparmor or se linux.
Apparmor is selected by default. With this change and added the require needle the apparmor should not be deselected.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>
