### PR TITLE
Adjust pvm test to new apparmor pattern

### DIFF
--- a/schedule/yast/minimal+base/minimal+base@pvm.yaml
+++ b/schedule/yast/minimal+base/minimal+base@pvm.yaml
@@ -26,6 +26,7 @@ schedule:
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
   - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/security/select_security_module_none
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation


### PR DESCRIPTION
Add the `select_security_module_none` module to the ppc64le-hmc testsuite (so that it does not fail in [confirm_installation](https://openqa.suse.de/tests/8204110#step/confirm_installation/2) ).

- Related ticket: No ticket
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/8205049#step/confirm_installation/1
