### PR TITLE
Increase needle timeout for yast2 nfs4 client

### DIFF
--- a/tests/console/yast2_nfs4_client.pm
+++ b/tests/console/yast2_nfs4_client.pm
@@ -50,7 +50,7 @@ sub run {
     #
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nfs-client');
 
-    assert_screen 'yast2-nfs-client-shares';
+    assert_screen 'yast2-nfs-client-shares', 90;
     send_key 'alt-a';
     assert_screen 'yast2-nfs-client-add';
     # Enable NFSv4


### PR DESCRIPTION
Increase the timeout for `yast2-nfs-client-shares` 

- Related ticket: No ticket
- Needles: No needle
- Verification run: https://openqa.suse.de/tests/8205051#details
