### PR TITLE
Add specific python installation into openvswitch_ssl

### DIFF
--- a/tests/console/openvswitch_ssl.pm
+++ b/tests/console/openvswitch_ssl.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright 2017-2020 SUSE LLC
+# Copyright 2017-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Package: python openvswitch
 # Summary: The test to connect openvswitch to openflow with SSL enabled
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: TC1595181, poo#65375
+# Tags: TC1595181, poo#65375, poo#107134
 
 use base "consoletest";
 use strict;
@@ -17,7 +17,9 @@ use utils;
 
 sub run {
     select_console 'root-console';
-    zypper_call('in python openvswitch');    # Install python2 here since pox scripts need python2
+
+    # Install python here since pox scripts need python
+    zypper_call('in python python-base openvswitch');
 
     # Start openvswitch service
     systemctl('start openvswitch');


### PR DESCRIPTION
Add specific python installation into openvswitch_ssl

python-base and libpython needs to be installed specifically since
dependency is missing as python3 by default

- Related ticket: https://progress.opensuse.org/issues/107134
- Needles: NA
- Verification run: https://openqa.suse.de/t8206911
  The fail would be a new bug: https://openqa.suse.de/tests/8206911#step/openvswitch_ssl/43