### PR TITLE
Set security module to None in minimal installation

### DIFF
--- a/schedule/yast/minimal+base/minimal+base@svirt-xen-hvm.yaml
+++ b/schedule/yast/minimal+base/minimal+base@svirt-xen-hvm.yaml
@@ -26,6 +26,7 @@ schedule:
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
   - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/security/select_security_module_none
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -31,6 +31,7 @@ schedule:
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
   - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/security/select_security_module_none
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation

--- a/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
   - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/security/select_security_module_none
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation

--- a/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
@@ -28,6 +28,7 @@ schedule:
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
   - installation/installation_settings/validate_default_target
+  - installation/security/select_security_module_none
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation


### PR DESCRIPTION
- Related ticket: [poo#106822](https://progress.opensuse.org/issues/106822)
