### PR TITLE
Switch deprecated config item for haproxy

### DIFF
--- a/data/ha/haproxy.cfg.template
+++ b/data/ha/haproxy.cfg.template
@@ -16,7 +16,7 @@ defaults
 
 frontend LB
   bind %VIP_IP%:8080
-  reqadd X-Forwarded-Proto:\ http
+  http-request add-header X-Forwarded-Proto http
   default_backend LB
 
 backend LB


### PR DESCRIPTION
Haproxy rest fails because of deprecated config item 'reqadd'. This 
option is replaced by 'http-request add-header'. Option 'reqadd' is 
not recommended to use since haproxy 1.5.

- Verification run: https://mordor.suse.cz/tests/2854#dependencies
