### PR TITLE
Wait before connecting ISCSI

### DIFF
--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -59,6 +59,8 @@ sub run {
     wait_still_screen 3;
     send_key 'alt-n';    # Next
 
+    # Sometimes client connection does not work immediately
+    wait_still_screen 10;
     # Select target with internal IP first?
     assert_screen 'iscsi-client-target-list';
     send_key 'alt-e';    # connEct


### PR DESCRIPTION
Various ARM basec cluster tests tend to fail sporadically while 
attempting to connect ISCSI devices due to network related issues. 
Increasing wait time before connection to 10s fixes to issue. This PR 
adds 10 s wait time before connection attempt.

- Related ticket: https://jira.suse.com/browse/TEAM-5809
- Verification run: 
https://openqa.suse.de/tests/8206357#dependencies
https://openqa.suse.de/tests/8191446#step/iscsi_client/12
https://openqa.suse.de/tests/8191347#step/iscsi_client/12