### PR TITLE
Prevent change of Apparmor selection when is presented in Patterns

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -101,7 +101,8 @@ sub run {
                 assert_screen 'inst-xen-pattern';
             }
         }
-        set_linux_security_to_none if (check_var('LINUX_SECURITY_MODULE', 'none') && is_sle('>=15-SP4'));
+     # the Installer of 15SP4 requires Apparmor pattern activation by default. If Apparmor not presented in PATTERNS select None for Major Linux Security Module
+        set_linux_security_to_none if (is_sle('>=15-SP4') && !(get_var('PATTERNS') =~ 'default|all|apparmor'));
         ensure_ssh_unblocked;
         $self->check_default_target();
     }


### PR DESCRIPTION
the Installer of 15SP4 requires Apparmor pattern activation by default.
Remove of the unnecessary variable /LINUX_SECURITY_MODULE/. and enable /set_linux_security_to_none/ only when it is missing from the patterns.
In such way, the /set_linux_security_to_none/ will not run when the Apparmor is already selected and there wouldnt be a problem with the installation.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: http://aquarius.suse.cz/tests/7933#
