### PR TITLE
Build a kernel on sle15sp4

### DIFF
--- a/tests/kernel/build_git_kernel.pm
+++ b/tests/kernel/build_git_kernel.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: git-core ncurses-devel gcc flex bison libelf-devel libopenssl-devel
@@ -8,11 +8,9 @@
 # Summary: build, install and boot a custom, upstream kernel tree
 #          from an arbitrary git tree
 #
-# Maintainer: Michael Moese <mmoese@suse.de>
+# Maintainer: Michael Moese <mmoese@suse.de>, Yiannis Bonatakis <ybonatakis@suse.com>
 
-use base 'opensusebasetest';
-use strict;
-use warnings;
+use Mojo::Base qw(opensusebasetest);
 use testapi;
 use utils;
 use power_action_utils 'power_action';
@@ -28,21 +26,29 @@ sub run {
     zypper_call('in bc git-core ncurses-devel gcc flex bison libelf-devel libopenssl-devel');
     # git clone takes a long time due to slow network connection
     assert_script_run("git clone --depth 1 --single-branch --branch $git_branch $git_tree linux", 7200);
-
     assert_script_run('cd linux');
     assert_script_run('zcat /proc/config.gz > .config');
-    assert_script_run('make olddefconfig');
 
-    assert_script_run('make -j `nproc` | tee /tmp/kernelbuild.log', 3600);
-    assert_script_run("sed -i 's/allow_unsupported_modules 0/allow_unsupported_modules 1/g' /etc/modprobe.d/10-unsupported-modules.conf");
-    assert_script_run('make install modules_install');
-    assert_script_run('mkinitrd -f iscsi,md,multipath,lvm,lvm2,ifup,fcoe,dcbd');
+    assert_script_run("sed -i 's/CONFIG_MODULE_SIG_KEY=.*/CONFIG_MODULE_SIG_KEY=\"\"/' .config");
+    assert_script_run("sed -i 's/CONFIG_SYSTEM_TRUSTED_KEYRING=.*/CONFIG_SYSTEM_TRUSTED_KEYRING=n/' .config");
+    assert_script_run("sed -i 's/CONFIG_DEBUG_INFO_BTF=y/# CONFIG_DEBUG_INFO_BTF=y/' .config");
+
+    assert_script_run('make olddefconfig');
+    assert_script_run('make -j `nproc` 2>&1 | tee /tmp/kernelbuild.log', 3600);
+    assert_script_run("sed -i 's/allow_unsupported_modules 0/allow_unsupported_modules 1/g' /lib/modprobe.d/10-unsupported-modules.conf");
+    assert_script_run('make modules_install', 3600);
+    assert_script_run('make install');
+
+    assert_script_run('mkinitrd /boot/initrd-$(make kernelrelease) $(make kernelrelease)');
+    assert_script_run('cp /boot/vmlinuz /boot/vmlinuz-$(make kernelrelease)');
+    assert_script_run('ls -la /boot | grep vmlinuz-$(make kernelrelease)');
+    assert_script_run('update-bootloader');
+
+    record_info 'curr kernel', script_output 'uname -r';
 
     power_action('reboot', textmode => 1, keepconsole => 1);
-
-    # make sure we wait until the reboot is done
-    select_console('sol', await_console => 0);
-    assert_screen('linux-login', 1800);
+    reconnect_mgmt_console();
+    $self->wait_boot_past_bootloader;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
This PR corrects steps required to build a kernel on sle15sp4.

The keys for the signing are not available, so there are two solutions.
One is to recreate them and set the proper value on /CONFIG_MODULE_SIG_KEY/ or disable the feature.
I think for this test case it is enough to go with the later.

I dont know how this used to work before but we need to copy the kernel to the boot and update the bootloader before the reboot.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

