### PR TITLE
SLEM5.1: Change default boot option for Image-RT

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -43,8 +43,7 @@ sub microos_reboot {
     # No grub bootloader on xen-pv
     # grub2 needle is unreliable (stalls during timeout) - poo#28648
     assert_screen 'grub2', 300;
-    send_key('ret') if match_has_tag('grub2');
-
+    send_key('ret') unless get_var('KEEP_GRUB_TIMEOUT');
     microos_login;
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -347,7 +347,7 @@ sub is_sles4sap_standard {
 Returns true if called on a real time system
 =cut
 sub is_rt {
-    return check_var('SLE_PRODUCT', 'rt');
+    return (check_var('SLE_PRODUCT', 'rt') || get_var('FLAVOR') =~ /rt/i);
 }
 
 =head2 is_hpc

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -28,10 +28,15 @@ conditional_schedule:
     SLE_MICRO_K3S:
       '1':
         - containers/k3s_cli_check
+  rt:
+    FLAVOR:
+      'MicroOS-Image-RT':
+        - rt/rt_is_realtime
 
 schedule:
   - '{{boot}}'
   - transactional/host_config
+  - '{{rt}}'
   - '{{registration}}'
   - '{{maintenance}}'
   - '{{selinux}}'

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -15,17 +15,23 @@ use warnings;
 use testapi;
 use transactional qw(process_reboot);
 use bootloader_setup qw(change_grub_config);
+use version_utils qw(is_rt is_sle_micro);
+
+sub need_kernel_change {
+    return is_rt && is_sle_micro('<5.2');
+}
 
 sub run {
     select_console 'root-console';
 
     # GRUB Configuration
-    my $disable_grub_timeout = get_var('DISABLE_GRUB_TIMEOUT');
+    my $keep_grub_timeout = get_var('KEEP_GRUB_TIMEOUT');
     my $extrabootparams = get_var('EXTRABOOTPARAMS');
     change_grub_config('=\"[^\"]*', "& $extrabootparams", 'GRUB_CMDLINE_LINUX_DEFAULT') if $extrabootparams;
-    change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT') if $disable_grub_timeout;
+    $keep_grub_timeout or change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT');
+    change_grub_config('=0', '="1>2"', 'GRUB_DEFAULT') if need_kernel_change;
 
-    if ($disable_grub_timeout or $extrabootparams) {
+    if (!$keep_grub_timeout or $extrabootparams or need_kernel_change) {
         record_info('GRUB', script_output('cat /etc/default/grub'));
         assert_script_run('transactional-update grub.cfg');
         process_reboot(trigger => 1);
@@ -35,7 +41,7 @@ sub run {
 }
 
 sub test_flags {
-    return {no_rollback => 1};
+    return {no_rollback => 1, fatal => 1, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
SLEM5.1 comes with 2 kernels pre-installed in case of *RT-Image*
flavor. Unfortunately, grub2 is set to boot from the first record in
grub menu which boots kernel-default. Removal of kernel-default cannot be done
without removing kernel-rt at the same time.

- Related ticket: [SLE Micro RT - Boot RT kernel instead of default
  one](https://progress.opensuse.org/issues/102723)
- Verification runs: 
  * [sle-micro-5.2-DVD.x86_64](http://kepler.suse.cz/tests/13904)
  * [sle-micro-5.2-DVD-B-Staging.x86_64](http://kepler.suse.cz/tests/13903)
  * [microos-Tumbleweed-MicroOS-Image.x86_64](http://kepler.suse.cz/tests/13901)
  * [microos-Tumbleweed-MicroOS-Image-Kubic-kubeadm.x86_64](http://kepler.suse.cz/tests/13900)
  * [microos-Tumbleweed-MicroOS-Image-ContainerHost.x86_64](http://kepler.suse.cz/tests/13898)
  * [sle-micro-5.2-MicroOS-Image-RT.x86_64](http://kepler.suse.cz/tests/13897)
  * [microos-Staging:B-Staging-DVD.x86_64](http://kepler.suse.cz/tests/13902)
  * [microos-Tumbleweed-Kubic-DVD.x86_64](http://kepler.suse.cz/tests/13896)
  * [microos-Staging:O-Staging-Kubic-DVD.x86_64](http://kepler.suse.cz/tests/13895)
  * [sle-micro-5.1-MicroOS-Image-RT-Updates.x86_64](http://kepler.suse.cz/tests/13899)
  * [openSUSE-MicroOS-DVD-x86_64-Snapshot20220221](http://kepler.suse.cz/tests/13905)