### PR TITLE
WIP: Add ssh key to known hosts for img_proof

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -117,6 +117,9 @@ sub run {
 
     $instance->wait_for_guestregister() if is_ondemand();
 
+    # fetch the instance ssh public key, do not use default $instance->ssh_opts
+    assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
+
     my $img_proof = $provider->img_proof(
         instance => $instance,
         tests => $tests,


### PR DESCRIPTION
Add the ssh public key to the known hosts file to ensure, subsequent ssh
calls are not running into authentication trouble for img_proof.

- Related ticket: https://progress.opensuse.org/issues/107182
- Verification run: http://duck-norris.qam.suse.de/tests/8202
