### PR TITLE
Add ssh key after running img_proof

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -123,6 +123,9 @@ sub run {
         results_dir => 'img_proof_results'
     );
 
+    # IP address of instance can change during img_proof (because of hard-reboot)
+    assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
+
     upload_logs($img_proof->{logfile});
     parse_extra_log(IPA => $img_proof->{results});
     assert_script_run('rm -rf img_proof_results');


### PR DESCRIPTION
img_proof might change the IP address because of the preformed
hard-reboot. This means we need to add the ssh key after running
img_proof to be able to access the machine via ssh.

- Related ticket: https://progress.opensuse.org/issues/107182
- Verification run: http://duck-norris.qam.suse.de/t8204 (Failure due to [poo#107182](https://progress.opensuse.org/issues/107182))
