### PR TITLE
xfstests: Add mkfs.btrfs option for 4k pagesize

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -773,6 +773,11 @@ elsif (get_var("QA_TESTSUITE")) {
     loadtest "qa_automation/execute_test_run";
 }
 elsif (get_var('XFSTESTS')) {
+    if (get_var('CHANGE_KERNEL_REPO') ||
+        get_var('CHANGE_KERNEL_PKG') ||
+        get_var('ASSET_CHANGE_KERNEL_RPM')) {
+        loadtest 'kernel/change_kernel';
+    }
     prepare_target;
     if (is_pvm || check_var('ARCH', 's390x')) {
         loadtest 'xfstests/install';

--- a/tests/kernel/change_kernel.pm
+++ b/tests/kernel/change_kernel.pm
@@ -17,8 +17,13 @@ use kernel 'remove_kernel_packages';
 sub from_repo {
     my ($repo, $pkg) = @_;
 
-    zypper_ar($repo, name => 'change-kernel') if ($repo);
-    zypper_call("in --force-resolution --force --replacefiles --repo change-kernel $pkg");
+    if ($repo) {
+        zypper_ar($repo, name => 'change-kernel');
+        zypper_call("in --force-resolution --force --replacefiles --repo change-kernel $pkg");
+    }
+    else {
+        zypper_call("in --force-resolution --force --replacefiles $pkg");
+    }
 }
 
 sub from_rpm {

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -261,6 +261,13 @@ sub format_with_options {
         format_partition($part, 'xfs', options => '-f -m crc=1,reflink=0,rmapbt=0, -i sparse=0 -lsize=100m');
         script_run("echo 'export XFS_MKFS_OPTIONS=\"-m crc=1,reflink=0,rmapbt=0, -i sparse=0 -lsize=100m\"' >> $CONFIG_FILE");
     }
+    # In case to test different mkfs.btrfs options
+    # $XFSTEST_MKFS_OPTION: options for mkfs.btrfs
+    # Example of 4k block size: -f -s 4k -n 16k
+    elsif ($filesystem eq 'btrfs' && (my $mkfs_option = get_var('XFSTEST_MKFS_OPTION'))) {
+        format_partition($part, 'btrfs', options => "$mkfs_option");
+        script_run("echo 'export BTRFS_MKFS_OPTIONS=\"$mkfs_option\"' >> $CONFIG_FILE");
+    }
     else {
         format_partition($part, $filesystem);
     }


### PR DESCRIPTION
1. xfstests: Add BTRFS_MKFS_OPTIONS for mkfs.btrfs
    
    Add BTRFS_MKFS_OPTIONS for testing btrfs.
    e.g BTRFS_MKFS_OPTIONS="-s 4k -n 16k" for 4k pagesize test.

2. xfstests: Add steps to change kernel
    The default pagesize of arm64 on sle15 is 4k. We need to change kernel
    to to kernel-64kb for subpage blocksize test.

3. Remove --repo option if no CHANGE_KERNEL_REPO
    When there is no CHANGE_KERNEL_REPO parameter(such as install from
    default repo), need to remove the --repo option of zypper

- Related ticket: https://progress.opensuse.org/issues/107614
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/8221616
https://openqa.suse.de/tests/8228626 (change_kernel)