### PR TITLE
Revert "Prevent change of Apparmor selection when is presented in Patterns"

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -101,8 +101,7 @@ sub run {
                 assert_screen 'inst-xen-pattern';
             }
         }
-     # the Installer of 15SP4 requires Apparmor pattern activation by default. If Apparmor not presented in PATTERNS select None for Major Linux Security Module
-        set_linux_security_to_none if (is_sle('>=15-SP4') && !(get_var('PATTERNS') =~ 'default|all|apparmor'));
+        set_linux_security_to_none if (check_var('LINUX_SECURITY_MODULE', 'none') && is_sle('>=15-SP4'));
         ensure_ssh_unblocked;
         $self->check_default_target();
     }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#14314 as a lot of jobs failed when PATTERNS variable was not set up.