### PR TITLE
ipxe: Remove SATA disk workaround for aarch64 baremetal

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -159,11 +159,6 @@ sub run {
             prepare_disks if (!is_upgrade && !get_var('KEEP_DISKS'));
         }
         save_screenshot;
-        # Disable SATA disks on arm server as workaround for poo#88403
-        if (is_aarch64) {
-            script_run('for disk in $(lsscsi | awk \'/ST9500325AS/ {split ($6, dev, "/"); print dev[3] }\'); do echo 1> /sys/block/$disk/device/delete; done');
-            save_screenshot;
-        }
 
         set_bootscript_hdd if get_var('IPXE_UEFI');
 


### PR DESCRIPTION
Fix poo#107329: SATA disk workaround was hardware specific. Hardware
was replaced, workaround can be removed.

- Related ticket: https://progress.opensuse.org/issues/107329
- Needles: none
- Verification run: https://openqa.suse.de/tests/8218075#step/ipxe_install/3