### PR TITLE
Fix Major Linux Security Module conflicts

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -101,7 +101,9 @@ sub run {
                 assert_screen 'inst-xen-pattern';
             }
         }
-        set_linux_security_to_none if (check_var('LINUX_SECURITY_MODULE', 'none') && is_sle('>=15-SP4'));
+        # the Installer of 15SP4 requires Apparmor pattern activation by default. If Apparmor not presented in PATTERNS and needle matches
+        # select None for Major Linux Security Module.
+        set_linux_security_to_none if (is_sle('>=15-SP4') && check_screen("apparmor-not-selected") && !(get_var('PATTERNS') =~ 'default|all|apparmor'));
         ensure_ssh_unblocked;
         $self->check_default_target();
     }


### PR DESCRIPTION
With the previous commit[0] some tests started failing because even if the PATTERNS do not include apparmor the module is already selected and the flow doesnt effect the installation overview window.
Add a needle check should avoid to go into `set_linux_security_to_none` in such cases.

[0] https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14314

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Needles:  installation_overview-apparmor-unselected-20220223.json
- Verification run: 

- [textmode_ha](https://openqa.suse.de/tests/8218192)
- [offline_slehpc15sp3_pscc_basesys-desk-dev-hpc-python2-srv-wsm_def_full_ms](https://openqa.suse.de/tests/8218193)
- [with apparmor selected](http://aquarius.suse.cz/tests/7944)
- [with apparmor not selected](http://aquarius.suse.cz/tests/7943)