### PR TITLE
Remove vino_screensharing_available from 15sp4

### DIFF
--- a/schedule/functional/extra_tests_gnome.yaml
+++ b/schedule/functional/extra_tests_gnome.yaml
@@ -56,7 +56,6 @@ schedule:
     - x11/vnc_two_passwords
     - '{{opensuse_tests}}'
     - '{{user_defined_snapshot}}'
-    - x11/remote_desktop/vino_screensharing_available
     - x11/rrdtool_x11
     - x11/yast2_lan_restart
     - '{{keyboard_layout_gdm}}'


### PR DESCRIPTION
Vino support has been removed :
https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/767

- Related ticket: https://progress.opensuse.org/issues/107338
- Needles: N/A
- Verification run: sle15sp4 [x86_64](https://openqa.suse.de/tests/8218433) | [aarch64](https://openqa.suse.de/tests/8209717)
[Tumbleweed](https://openqa.opensuse.org/tests/2205709)
