### PR TITLE
Workaround for bsc#1195046

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -32,6 +32,11 @@ our @EXPORT = qw(
 sub setup_sle {
     select_console 'root-console';
 
+    if (is_ppc64le && is_sle('<=12-sp5')) {
+        record_soft_failure("bsc#1195046", 'ncurses display a wrong checker board character');
+        assert_script_run('echo /usr/lib/systemd/systemd-vconsole-setup >> /etc/bash.bashrc.local');
+    }
+
     # Stop packagekitd
     if (is_sle('12+')) {
         quit_packagekit;


### PR DESCRIPTION
Workaround for bsc#1195046 - [Build 84.1][NCurses-UI] openQA test
fails in patch_sle - ncurses display a wrong "checker board" character

- Related ticket: https://progress.opensuse.org/issues/107482
- Verification run: https://openqa.suse.de/tests/8221635#
