### PR TITLE
Exclude twopence error code in zypper in call

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -454,7 +454,8 @@ sub extended_hpc_tests {
 
     # do all test preparations and setup
     zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);
-    zypper_call('in git-core twopence-shell-client bc iputils python');
+    # https://progress.opensuse.org/issues/107395 include twopence post scripts error code
+    zypper_call('in git-core twopence-shell-client bc iputils python3', exitcode => [0, 107]);
     assert_script_run('git -c http.sslVerify=false clone https://github.com/schlad/hpc-testing.git --branch HPC');
 
     #execute tests


### PR DESCRIPTION
twopence package fails to in some post scriptlet command but this can be
ignored and let the test module go on. In additional, provide correct package
name for python, even if that is already installed and it could be removed.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/107395
- Verification run: http://aquarius.suse.cz/tests/7966
