### PR TITLE
Resize as workaround for YaST content not loading

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
@@ -35,6 +35,8 @@ sub select_tab {
 
 sub select_bond_slave_in_list {
     assert_screen(BOND_SLAVES_TAB);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED, 'alt-f10', 9, 2);
     assert_and_click(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
@@ -36,6 +36,8 @@ sub select_tab {
 
 sub select_bridged_device_in_list {
     assert_screen(BRIDGED_DEVICES_TAB);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch(BRIDGED_DEVICE_CHECKBOX_UNCHECKED, 'alt-f10', 9, 2);
     assert_and_click(BRIDGED_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -595,6 +595,8 @@ sub handle_scc_popups {
         push @tags, 'expired-gpg-key' if is_sle('=15');
         while ($counter--) {
             die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
+            record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+            for (1 .. 2) { send_key 'alt-f10' }
             assert_screen(\@tags, timeout => 360);
             if (match_has_tag('import-untrusted-gpg-key')) {
                 handle_untrusted_gpg_key;

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -62,7 +62,8 @@ sub initiator_discovered_targets_tab {
     send_key "alt-i";
     my $target_ip_only = (split('/', $test_data->{target_conf}->{ip}))[0];
     type_string_slow_extended $target_ip_only;
-    assert_screen 'iscsi-initiator-discovered-IP-adress';
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('iscsi-initiator-discovered-IP-adress', 'alt-f10', 9, 2);
     # next and press connect button
     send_key "alt-n";
     assert_and_click 'iscsi-initiator-connect-button';
@@ -86,7 +87,8 @@ sub initiator_discovered_targets_tab {
 sub initiator_connected_targets_tab {
     # go to discovered targets tab
     send_key "alt-d";
-    assert_screen 'iscsi-initiator-discovered-targets';
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('iscsi-initiator-discovered-targets', 'alt-f10', 9, 2);
     # go to connected targets tab
     send_key "alt-n";
     assert_screen 'iscsi-initiator-connected-targets';

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -92,7 +92,8 @@ sub target_service_tab {
 }
 
 sub config_2way_authentication {
-    assert_screen 'iscsi-target-modify-acls';
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('iscsi-target-modify-acls', 'alt-f10', 9, 2);
     send_key 'alt-a';
     assert_screen 'iscsi-target-modify-acls-initiator-popup';
     if (is_sle('>=15')) {

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -279,6 +279,8 @@ sub start_wake_on_lan {
     assert_screen 'yast2_control-center_wake-on-lan_install_wol';
     send_key $cmd{install};    # wol needs to be installed
     assert_screen 'yast2_control-center_wake-on-lan_overview', timeout => 60;
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2_control-center_wake-on-lan_overview', 'alt-f10', 9, 2);
     send_key 'alt-f';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -31,6 +31,8 @@ sub run {
     clear_console;
     select_console 'x11';
     y2_module_guitest::launch_yast2_module_x11($module, match_timeout => 90);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2_hostnames_added', 'alt-f10', 9, 2);
     assert_and_click "yast2_hostnames_added";
     send_key 'alt-i';
     assert_screen 'yast2_hostnames_edit_popup';

--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -39,7 +39,8 @@ sub run {
     # Check previously set values + Login Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-pwd-settings";
-    assert_screen "yast2_security-check-min-pwd-len-and-exp-days";
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2_security-check-min-pwd-len-and-exp-days', 'alt-f10', 9, 2);
     assert_and_click "yast2_security-login-settings";
     send_key "alt-d";
     wait_still_screen 1;
@@ -59,7 +60,8 @@ sub run {
     # Check previously set values
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-misc-settings";
-    assert_screen "yast2_security-file-perms-secure";
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2_security-file-perms-secure', 'alt-f10', 9, 2);
     wait_screen_change { send_key "alt-o" };
 }
 


### PR DESCRIPTION
Due to bsc#1191112, sometimes YaST module screens do not load their content.
A workaround to this is to maximize and unmaximize the YaST window via keybinds, in order to force refresh the content.

- Related ticket: https://progress.opensuse.org/issues/105046
- Needles: No needles
- Verification runs: 
[yast2_security before](https://openqa.suse.de/tests/7976962#step/yast2_security/16) | [yast2_security after](https://openqa.suse.de/tests/8218453#step/yast2_security/16)
[addon_products_via_SCC_yast2 before](https://openqa.suse.de/tests/8208270#step/addon_products_via_SCC_yast2/21) | [addon_products_via_SCC_yast2 after](https://openqa.suse.de/tests/8218090#step/addon_products_via_SCC_yast2/21)
[yast2_hostnames before](https://openqa.suse.de/tests/8250026#step/yast2_hostnames/12) | [yast2_hostnames after](https://openqa.suse.de/tests/8250339#)

also all three `iscsi` multimachine jobs:
[iscsi_client_normal_auth_backstore_fileio](https://openqa.suse.de/tests/8222152)
[iscsi_client_normal_auth_backstore_hdd](https://openqa.suse.de/tests/8222511)
[iscsi_client_normal_auth_backstore_lvm](https://openqa.suse.de/tests/8223121)