### PR TITLE
Comment upload_log function due to file is too big

### DIFF
--- a/tests/cpu_bugs/mitigation_perf.pm
+++ b/tests/cpu_bugs/mitigation_perf.pm
@@ -174,7 +174,7 @@ sub run {
         }
         sleep(30);
     }
-    upload_logs("/root/$logfile");
+    #upload_logs("/root/$logfile");
     if (check_var('NETTEST', '1')) {
         record_info("Info", "Finished net performanace test on " . get_var('HOST'), result => 'ok');
     } else {


### PR DESCRIPTION
Not use upload_log to upload file to openqa

- Related ticket: N/A
- Needles: N/A
- Verification run: http://openqa.qa2.suse.asia/tests/45706
