### PR TITLE
x11/multi_users_dm: Exit xterm before logout

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -77,6 +77,7 @@ sub run {
     wait_still_screen;
     enter_cmd "whoami|grep $user > /tmp/whoami.log";
     assert_script_sudo "grep $user /tmp/whoami.log";
+    send_key 'ctrl-d';
     # logout user
     handle_logout;
     # Wait some more seconds before selecting root-console, as it fails sporadically in aarch64


### PR DESCRIPTION
Otherwise it's visible behind the logout overlay and needles don't match.

e.g. https://openqa.opensuse.org/tests/2207205#step/multi_users_dm/32

Verification run: http://10.160.67.86/tests/1176