### PR TITLE
Add support for php8

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1089,6 +1089,7 @@ sub load_console_server_tests {
         loadtest "console/php_pcre" if is_sle;
         # TODO test on SLE https://progress.opensuse.org/issues/31972
         loadtest "console/mariadb_odbc" if is_opensuse;
+        loadtest "console/php8" unless is_leap("<15.4") || is_sle("<15-SP4");
         loadtest "console/php7";
         loadtest "console/php7_mysql";
         loadtest "console/php7_postgresql";

--- a/tests/console/php7.pm
+++ b/tests/console/php7.pm
@@ -3,7 +3,7 @@
 # Copyright 2017 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: php7 php-json
+# Package: php7 php7-json
 # Summary: Simple PHP7 code hosted locally
 #   This test requires the Web and Scripting module on SLE.
 # - Setup apache2 to use php7 modules
@@ -26,7 +26,7 @@ sub run {
     assert_script_run('grep "PHP Version 7" /tmp/tests-console-php7.txt');
 
     # test function provided by external module (php7-json RPM)
-    zypper_call 'in php-json';
+    zypper_call 'in php7-json';
     assert_script_run('php -r \'echo json_encode(array("foo" => true))."\\n";\' | grep :true');
 
     # test reading file

--- a/tests/console/php8.pm
+++ b/tests/console/php8.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: php8 php8-zlib
+# Summary: Simple PHP8 code hosted locally
+#   This test requires the Web and Scripting module on SLE.
+# - Setup apache2 to use php8 modules
+# - Run "curl http://localhost/index.php", check output for "PHP Version 8"
+# Maintainer: Ondřej Súkup <osukup@suse.cz> Fabian Vogt <fvogt@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use utils;
+use testapi;
+use apachetest;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    setup_apache2(mode => 'PHP8');
+    assert_script_run('curl http://localhost/index.php | tee /tmp/tests-console-php8.txt');
+    assert_script_run('grep "PHP Version 8" /tmp/tests-console-php8.txt');
+
+    # test function provided by external module (php8-zlib RPM)
+    zypper_call 'in php8-zlib';
+    my $code = '
+    $dc = deflate_init(ZLIB_ENCODING_GZIP);
+    $data = deflate_add($dc, "TEST\n", ZLIB_FINISH);
+    $ic = inflate_init(ZLIB_ENCODING_GZIP);
+    print(inflate_add($ic, $data, ZLIB_FINISH));';
+    # Newlines cause continuation lines and confuse serial matching
+    $code =~ s/\n//g;
+    assert_script_run("php -r '$code' | grep TEST");
+
+    # test reading file
+    assert_script_run('php -r \'echo readfile("/etc/hosts")."\\n";\' | grep localhost');
+}
+1;


### PR DESCRIPTION
Remove php8 when installing php7 and vice versa.
Add a new php8 test based on the php7 test, which uses php8-zlib instead as
json is now built-in.

- Related ticket: https://progress.opensuse.org/issues/107113
- Verification run: http://10.160.67.86/tests/1183
