### PR TITLE
Add debugging information for zypper ref

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -338,7 +338,8 @@ sub network_speed_test() {
     my $write_out = 'time_namelookup:\t%{time_namelookup} s\ntime_connect:\t\t%{time_connect} s\ntime_appconnect:\t%{time_appconnect} s\ntime_pretransfer:\t%{time_pretransfer} s\ntime_redirect:\t\t%{time_redirect} s\ntime_starttransfer:\t%{time_starttransfer} s\ntime_total:\t\t%{time_total} s\n';
     # PC RMT server domain name
     my $rmt_host = "smt-" . lc(get_required_var('PUBLIC_CLOUD_PROVIDER')) . ".susecloud.net";
-    $self->run_ssh_command(cmd => "grep \"$rmt_host\" /etc/hosts", proceed_on_failure => 1);
+    my $rmt = $self->run_ssh_command(cmd => "grep \"$rmt_host\" /etc/hosts", proceed_on_failure => 1);
+    record_info("rmt_host", $rmt);
     record_info("ping 1.1.1.1", $self->run_ssh_command(cmd => "ping -c30 1.1.1.1", proceed_on_failure => 1, timeout => 600));
     record_info("curl $rmt_host", $self->run_ssh_command(cmd => "curl -w '$write_out' -o /dev/null -v https://$rmt_host/", proceed_on_failure => 1));
 }

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -50,11 +50,20 @@ sub select_host_console {
     set_var('TUNNELED', $tunneled) if $tunneled;
 }
 
+# Get the current UTC timestamp as YYYY/mm/dd HH:MM:SS
+sub utc_timestamp {
+    my @weekday = ("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat");
+    my ($sec, $min, $hour, $day, $mon, $year, $wday, $yday, $isdst) = gmtime(time);
+    $year = $year + 1900;
+    return sprintf("%04d/%02d/%02d %02d:%02d:%02d", $year, $mon, $day, $hour, $min, $sec);
+}
+
 sub register_addon {
     my ($remote, $addon) = @_;
     my $arch = get_var('PUBLIC_CLOUD_ARCH') // "x86_64";
     $arch = "aarch64" if ($arch eq "arm64");
-    record_info($addon, "Going to register '$addon' addon");
+    my $timestamp = utc_timestamp();
+    record_info($addon, "Going to register '$addon' addon\nUTC: $timestamp");
     my $cmd_time = time();
     if ($addon =~ /ltss/) {
         ssh_add_suseconnect_product($remote, get_addon_fullname($addon), '${VERSION_ID}', $arch, "-r " . get_required_var('SCC_REGCODE_LTSS'));


### PR DESCRIPTION
Adds debugging information as requested in bsc#1196462:

* Timestamp when adding a new product
* Print /etc/hosts so that the smt server IP is logged

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1196462
- Verification run: http://duck-norris.qam.suse.de/t8247 http://duck-norris.qam.suse.de/t8248 (passing relevant steps)
