### PR TITLE
Skip bootloader for only aarch64 image boots

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -19,7 +19,7 @@ sub run {
     # default timeout in grub2 is set to 10s
     # osd's arm machines tend to stall when trying to match grub2
     # this leads to test failures because openQA does not assert grub2 properly
-    if (is_sle_micro && is_aarch64) {
+    if (is_sle_micro && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
         shift->wait_boot_past_bootloader(textmode => 1, ready_time => 300);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
Small patch to fix installation jobs in
[slem@aarch64](https://openqa.suse.de/tests/8225860)
- Verification runs:
  * [sle-micro-5.0-MicroOS-Image-Updates](https://openqa.suse.de/tests/8228029#step/disk_boot/1)
  * [sle-micro-5.0-DVD-Updates](https://openqa.suse.de/tests/8228028#step/disk_boot/1)
