### PR TITLE
console/gpg: Use RSA keys explicitly and fix test for success

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -45,9 +45,9 @@ sub gpg_test {
         # Preparing a config file for gpg --batch option
         assert_script_run(
             "echo \"\$(cat <<EOF
-Key-Type: default
+Key-Type: RSA
 Key-Length: $key_size
-Subkey-Type: default
+Subkey-Type: RSA
 Subkey-Length: $key_size
 Name-Real: $username
 Name-Email: $email

--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -57,7 +57,7 @@ EOF
         );
         assert_script_run("cat $egg_file");
 
-        script_run("gpg2 -vv --batch --full-generate-key $egg_file &> /dev/$serialdev", 0);
+        script_run("gpg2 -vv --batch --full-generate-key $egg_file &> /dev/$serialdev; echo gpg-finished-\$? >/dev/$serialdev", 0);
     }
     else {
         # Batch mode does not work in gpg version < 2.1. Workaround like using
@@ -67,7 +67,7 @@ EOF
         # appeared at the bottom for needles matching
         assert_script_run "gpg -h";
 
-        script_run("gpg2 -vv --gen-key &> /dev/$serialdev", 0);
+        script_run("gpg2 -vv --gen-key &> /dev/$serialdev; echo gpg-finished-\$? >/dev/$serialdev", 0);
         assert_screen 'gpg-set-keytype';    # Your Selection?
         enter_cmd "1";
         assert_screen 'gpg-set-keysize';    # What keysize do you want?
@@ -110,7 +110,7 @@ EOF
         return;
     }
 
-    wait_serial("gpg: key.*accepted as trusted key", 90) || die "Key generating failed!";
+    wait_serial("gpg-finished-0", 90) || die "Key generation failed!";
 
     assert_script_run("gpg --list-keys | grep '\\[ultimate\\] $username <$email>'");
 


### PR DESCRIPTION
The test is meant to check with different key lengths, but those are only
used with non-ECC keys. So use RSA explicitly. Ideally there'll be a separate test for ECC keys in the future.

With ECC as default, key generation fails anyway because of
https://dev.gnupg.org/T5444.

Additionally, fix the `wait_serial` which failed with recent versions because the message isn't always printed.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1193133
- Verification run: http://10.160.67.86/tests/1188