### PR TITLE
Add y2start.log output for bootloader_s390 (poo#107659)

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -297,6 +297,8 @@ sub run {
 
     my $exception = $@;
 
+    # add y2start/log output if exception is happening
+    die join("\n", '#', `cat /var/log/YaST2/y2start.log`) if $exception;
     die join("\n", '#' x 67, $exception, '#' x 67) if $exception;
 
     # activate console so we can call wait_serial later


### PR DESCRIPTION
The test suite textmode-server for s390x is failing in the test
bootloader_s390. There is no log output. Further information is
written to /var/log/y2start.log. This extension will be used for
the output of the log information to fix the bug.


- Related ticket: https://progress.opensuse.org/issues/107659
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
