### PR TITLE
Bug1195759 zypper fails error code 107

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -576,11 +576,16 @@ sub zypper_call {
         my $msg = "'zypper -n $command' failed with code $ret";
         if ($ret == 104) {
             $msg .= " (ZYPPER_EXIT_INF_CAP_NOT_FOUND)\n\nRelated zypper logs:\n";
-            script_run('tac /var/log/zypper.log | grep -F -m1 -B10000 "Hi, me zypper" | tac | grep \'\(SolverRequester.cc\|THROW\|CAUGHT\)\' > /tmp/z104.txt');
+            script_run('tac /var/log/zypper.log | grep -F -m1 -B100000 "Hi, me zypper" | tac | grep \'\(SolverRequester.cc\|THROW\|CAUGHT\)\' > /tmp/z104.txt');
             $msg .= script_output('cat /tmp/z104.txt');
         }
+        elsif ($ret == 107) {
+            $msg .= " (ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED)\n\nRelated zypper logs:\n";
+            script_run('tac /var/log/zypper.log | grep -F -m1 -B100000 "Hi, me zypper" | tac | grep \'RpmPostTransCollector.cc(executeScripts):.* scriptlet failed, exit status\' > /tmp/z107.txt');
+            $msg .= script_output('cat /tmp/z107.txt') . "\n\n";
+        }
         else {
-            script_run('tac /var/log/zypper.log | grep -F -m1 -B10000 "Hi, me zypper" | tac | grep \'Exception.cc\' > /tmp/zlog.txt');
+            script_run('tac /var/log/zypper.log | grep -F -m1 -B100000 "Hi, me zypper" | tac | grep \'Exception.cc\' > /tmp/zlog.txt');
             $msg .= "\n\nRelated zypper logs:\n";
             $msg .= script_output('cat /tmp/zlog.txt');
         }


### PR DESCRIPTION
Implementation of a Regex search for every occurence of: `RpmPostTransCollector.cc(executeScripts):.* scriptlet failed, exit status` and report them in a single record_info box that is triggered when zypper's return code is 107 which resolves to `ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED`

- Related ticket: https://progress.opensuse.org/issues/106916
- Needles: *not applicable*
- Verification run:
    SLE15_SP3, x86_64: https://openqa.suse.de/tests/8244087#step/rmt_feature/18
