### PR TITLE
Refactor ssh-scan in instance creation

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -258,6 +258,8 @@ sub create_instances {
     foreach my $instance (@vms) {
         record_info("INSTANCE $instance->{instance_id}", Dumper($instance));
         $instance->wait_for_ssh() if ($args{check_connectivity});
+        # Install server's ssh publicckeys to prevent authenticity interactions
+        assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
     }
     return @vms;
 }

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -123,7 +123,7 @@ sub run {
         results_dir => 'img_proof_results'
     );
 
-    # IP address of instance can change during img_proof (because of hard-reboot)
+    # Because the IP address of instance might change during img_proof due to the hard-reboot, we need to re-add the ssh public keys
     assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
 
     upload_logs($img_proof->{logfile});

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -73,10 +73,7 @@ sub run {
     $instance->wait_for_guestregister();
     $args->{my_provider} = $provider;
     $args->{my_instance} = $instance;
-
-    # fetch the instance ssh public key, do not use default $instance->ssh_opts
-    assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
-    $instance->ssh_opts("");
+    $instance->ssh_opts("");    # Clear $instance->ssh_opts which ombit the known hosts file and strict host checking by default
 
     $instance->network_speed_test();
 

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -99,9 +99,6 @@ sub run {
         $instance->wait_for_guestregister();
     }
 
-    # Ensure the ssh public key is in the known hosts file for any upcoming connections
-    assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
-
     assert_script_run("cd $root_dir");
     assert_script_run('curl ' . data_url('publiccloud/restart_instance.sh') . ' -o restart_instance.sh');
     assert_script_run('curl ' . data_url('publiccloud/log_instance.sh') . ' -o log_instance.sh');

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -177,9 +177,6 @@ sub run {
     my $instance = $provider->create_instance(use_extra_disk => {size => $disk_size, type => $disk_type});
     $instance->wait_for_guestregister();
 
-    # Add host key to prevent authenticity issues when using ssh
-    assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
-
     $tags->{os_kernel_release} = $instance->run_ssh_command(cmd => 'uname -r');
     $tags->{os_kernel_version} = $instance->run_ssh_command(cmd => 'uname -v');
 


### PR DESCRIPTION
Remove duplicates of the ssh-scan routine to add the ssh pubkey of the
publiccloud instance on the openQA VM.


- Verification run: [imgproof](http://duck-norris.qam.suse.de/t8249) | [consoletests](http://duck-norris.qam.suse.de/t8250) | [ltp cve](http://duck-norris.qam.suse.de/t8251) | [fio/storage_perf](http://duck-norris.qam.suse.de/t8252)
