### PR TITLE
Keep 15sp2 and 15sp3 needles for slem testing

### DIFF
--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -36,10 +36,6 @@ $needle::cleanuphandler = sub {
     unregister_needle_tags("ENV-VERSION-12-SP3");
     unregister_needle_tags("ENV-VERSION-11-SP4");
     unregister_needle_tags("ENV-12ORLATER-1");
-    unregister_needle_tags("ENV-SP2ORLATER-1");
-    unregister_needle_tags("ENV-SP3ORLATER-1");
-    unregister_needle_tags("ENV-15ORLATER-1");
-    unregister_needle_tags("ENV-15SP1ORLATER-1");
     unregister_needle_tags("ENV-FLAVOR-Server-DVD");
 };
 


### PR DESCRIPTION
Keep needle tags that are causing YaST2 installation failures in
current slem testing.

- Verification runs:
  * [sle-micro-5.0-DVD-Updates-x86_64-Build20220228-1-sle-micro_installation+update@64bit](http://kepler.suse.cz/tests/14243) 
  * [sle-micro-5.1-DVD-Updates-x86_64-Build20220228-1-sle-micro_installation+update@uefi](http://kepler.suse.cz/tests/14244)
