### PR TITLE
Improve softreboot to work on TUNNELED instances

### DIFF
--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -17,23 +17,6 @@ use publiccloud::utils "select_host_console";
 sub run {
     my ($self, $args) = @_;
 
-    # This ensure that we have used the setup console, even if no module was run before.
-    select_host_console();
-    my $setup_console = current_console();
-
-    # Establish the tunnel (it will stay active in foreground and occupy this console!)
-    select_console('tunnel-console');
-    ssh_interactive_tunnel($args->{my_instance});
-
-    # Enable ssh connection on setup console, this is done normally with the
-    # first activation hook in susedistribution:activate_console()
-    if ($setup_console !~ /tunnel/) {
-        select_console($setup_console);
-        # The verbose output is visible only at the tunnel-console -
-        #   it doesn't interfere with tests as it isn't piped to /dev/sshserial
-        script_run('ssh -E /var/tmp/ssh_sut.log -vt sut', timeout => 0);
-    }
-
     die("expect ssh serial") unless (get_var('SERIALDEV') =~ /ssh/);
 
     # Verify most important consoles


### PR DESCRIPTION
Improve the softreboot for publiccloud, so it works on TUNELLED test
runs without the need of the user to re-establish the tunnel afterwards.

- Verification run: [consoletests](http://duck-norris.qam.suse.de/t8269) | [img_proof](http://duck-norris.qam.suse.de/t8270) | [ltp-cve](http://duck-norris.qam.suse.de/t8271) | [boottime](http://duck-norris.qam.suse.de/t8272)