### PR TITLE
console/journalctl: Update has_default_persistent_journal for Leap 15.4

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -33,9 +33,9 @@ use constant {
     SEALING_DELAY => 10
 };
 
-# by default persistent journal is set for opensuse, except of leap 15.3+
+# Tumbleweed uses a persistent journal, Leap 15.3+ (except 15.3 AArch64 JeOS) inherits SLE's default
 sub has_default_persistent_journal {
-    return is_opensuse && (!is_leap('15.3+') || check_var('FLAVOR', 'JeOS-for-AArch64'));
+    return is_tumbleweed || (is_leap('=15.3') && check_var('FLAVOR', 'JeOS-for-AArch64'));
 }
 
 # If the daemon is stopped uncleanly, or if the files are found to be corrupted, they are renamed using the ".journal~" suffix


### PR DESCRIPTION
With 15.4, systemd-logger became a noop, and such even the AArch64 JeOS
uses the SLE default of not having journal persistence by default.

So only Tumbleweed and 15.3 AArch64 JeOS remain.

- Verification run: https://openqa.opensuse.org/tests/2216222
