### PR TITLE
x11/dolphin: Wait for the file creation dialog before typing

### DIFF
--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -47,6 +47,7 @@ sub run {
 
     assert_and_click 'dolphin_create_new_text_file';
     mouse_hide();
+    assert_screen 'dolphin_new_text_file_dialog';
     type_string 'empty';
     assert_screen 'dolphin_new_text_file';
     send_key 'ret';


### PR DESCRIPTION
Currently it might start typing before the dialog appeared.

- Related ticket: https://progress.opensuse.org/issues/95530#change-496453
- Verification runs:
  * TW X11: http://10.160.67.86/tests/1193
  * TW Wayland: http://10.160.67.86/tests/1192
  * 15.3 X11: http://10.160.67.86/tests/1198
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/763