### PR TITLE
[virt_autotest] Remove reset_unprivileged_userfaultfd for 15-SP4 KVM guest_migration

### DIFF
--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -26,11 +26,6 @@ sub run {
     set_var('DST_PASS', $password);
     bmwqemu::save_vars();
 
-    #workaround from 15-SP4 kernel(v5.14) new behavior
-    #Refer to bsc#1191511 for more details
-    $self->reset_unprivileged_userfaultfd if (is_sle('>=15-SP4') && is_kvm_host);
-
-
     # clean up logs from prevous tests
     script_run('[ -d /var/log/qa/ctcs2/ ] && rm -rf /var/log/qa/ctcs2/');
     script_run('[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/');
@@ -63,15 +58,6 @@ sub run {
 
     #wait for child finish
     wait_for_children;
-}
-
-#Since 15-SP4 kernel(v5.14), default value of unprivileged_userfaultfd sysctl is 0.
-#if unprivileged user want to use userfaultfd syscalls, we just only need to manually
-#reset unprivileged_userfaultfd value is 1 as the workaround on postcopy migration dst
-sub reset_unprivileged_userfaultfd {
-    script_run("sysctl -w vm.unprivileged_userfaultfd=1", 15);
-    script_run("sysctl -a | grep vm.unprivileged_userfaultfd", 15);
-    save_screenshot;
 }
 
 1;


### PR DESCRIPTION
Refer to [Bug 1191511](https://bugzilla.suse.com/show_bug.cgi?id=1191511), vm.unprivileged_userfaultfd is enabled from libvirt8.0 on 15-SP4. I had double confirmed that vm.unprivileged_userfaultfd is enable as the default on 15-SP4 Public Beta. So, remove the exited workaround - reset_unprivileged_userfaultfd for 15-SP4 KVM guest_migration as this PR purpose. 

- Verification run: 
[virt-guest-migration-developing-from-developing-to-developing-kvm-src](https://openqa.suse.de/tests/8248401#)
[virt-guest-migration-developing-from-developing-to-developing-kvm-dst](https://openqa.suse.de/tests/8248400#)
[virt-guest-migration-sles12sp5-from-sles12sp5-to-developing-kvm-src](https://openqa.suse.de/tests/8249505#)
[virt-guest-migration-sles12sp5-from-sles12sp5-to-developing-kvm-dst](https://openqa.suse.de/tests/8249504#)
[virt-guest-migration-sles15sp3-from-sles15sp3-to-developing-kvm-src](https://openqa.suse.de/tests/8249507)
[virt-guest-migration-sles15sp3-from-sles15sp3-to-developing-kvm-dst](https://openqa.suse.de/tests/8249506)
