### PR TITLE
Drop useless greps of extensions

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -37,12 +37,8 @@ sub run {
     script_retry("$cmd", retry => 5, delay => 60, timeout => 180);
     # Check available extenstions (only present in sle)
     assert_script_run q[SUSEConnect --list-extensions];
-    if (is_sle) {
-        # What has been activated by default
-        assert_script_run q[SUSEConnect --list-extensions | grep -e '\(Activated\)'];
-        assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'    \e\[1mServer Applications Module\')"' unless is_sle('=12-sp5');
-        assert_script_run 'SUSEConnect --list-extensions | grep "$(echo -en \'    \e\[1mWeb and Scripting Module\')"';
-    }
+    # What has been activated by default
+    assert_script_run q[SUSEConnect --list-extensions | grep -e '\(Activated\)'] if is_sle;
 
     # add modules
     register_addons_cmd if $scc_addons;


### PR DESCRIPTION
I first saved the extensions output in file and did grep just the module without colors and each hardcoded character.
But then I realized this grep have no purpose. It will just grep the module does not matter in what state it is.

- Fail: https://openqa.suse.de/tests/8248277#step/suseconnect_scc/20
- Verification run: https://openqa.suse.de/tests/8248413#step/suseconnect_scc/18
