### PR TITLE
lib/main_common: Drop ristretto from the Rescue-CD

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1299,7 +1299,8 @@ sub load_x11tests {
     if (xfcestep_is_applicable()) {
         # Midori got dropped from TW
         loadtest "x11/midori" unless (is_staging || is_livesystem || !is_leap("<16.0"));
-        loadtest "x11/ristretto";
+        # Tumbleweed and Leap 15.4+ no longer have ristretto on the Rescue CD
+        loadtest "x11/ristretto" unless (check_var("FLAVOR", "Rescue-CD") && !is_leap("<=15.3"));
     }
     if (gnomestep_is_applicable()) {
         # TODO test on openSUSE https://progress.opensuse.org/issues/31972


### PR DESCRIPTION
On TW it's no longer on there for some time now and this also reached 15.4
meanwhile.

- Verification runs:
  * 15.4: http://10.160.67.86/t1196
  * 15.3: http://10.160.67.86/t1197
