### PR TITLE
registration::remove_suseconnect_product() Use script_retry to for SUSEConnect -d

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -230,7 +230,7 @@ sub remove_suseconnect_product {
     $version //= scc_version();
     $arch //= get_required_var('ARCH');
     $params //= '';
-    assert_script_run("SUSEConnect -d -p $name/$version/$arch $params", timeout => 150);
+    script_retry("SUSEConnect -d -p $name/$version/$arch $params", retry => 5, delay => 60, timeout => 180);
 }
 
 =head2 cleanup_registration


### PR DESCRIPTION
- Related request: #14327
- Example failure: [openqa.suse.de](https://openqa.suse.de/tests/8219630#step/zypper_patch/16)
- Related ticket: [poo#107062 note-10](https://progress.opensuse.org/issues/107062#note-10)
- Verification run: In progress
