### PR TITLE
Fix volatile journal check

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -156,7 +156,7 @@ sub run {
             assert_script_run "rpm -q --conflicts systemd-logger | tee -a /dev/$serialdev | grep syslog";
         }
     } else {
-        script_run("journalctl --boot=-1 | grep 'no persistent journal was found'") or die "Persistent journal should not be enabled by default on SLE!\n";
+        validate_script_output('journalctl --no-pager --boot=-1', qr/no persistent journal was found/i) unless is_sle('<15');
         assert_script_run "mkdir -p ${\ PERSISTENT_LOG_DIR }";
         assert_script_run "systemd-tmpfiles --create --prefix ${\ PERSISTENT_LOG_DIR }";
         # test for installed rsyslog and for imuxsock existance


### PR DESCRIPTION
1. persistent journal, journalctl succeeds and grep fails-> exit code 1
2. no persistent journal, journalctl fails and grep succeeds -> exit code 1

Issue spot by @Vogtinator, thanks!

- Verification runs: 
* [tw - simulated error](http://kepler.suse.cz/tests/14263#step/journalctl/34)
* [leap15.4 - not matching expected string](http://kepler.suse.cz/tests/14269#step/journalctl/34)
* [opensuse-15.4-JeOS-for-kvm-and-xen-x86_64-Build6.3-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/14271#step/journalctl/30)
* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220301-1-jeos-extratest@uefi-virtio-vga](http://kepler.suse.cz/tests/14270#step/journalctl/18)
* [tw](http://kepler.suse.cz/tests/14273)
* [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.379-jeos-extra@64bit_virtio-2](http://kepler.suse.cz/tests/14272#step/journalctl/30)
