### PR TITLE
Increase grub2_test default timeout to 200

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -28,7 +28,7 @@ Handle grub menu after reboot
       or product is sle, aarch64 and PLYMOUTH_DEBUG is set
 =cut
 sub grub_test {
-    my $timeout = get_var('GRUB_TIMEOUT', 90);
+    my $timeout = get_var('GRUB_TIMEOUT', 200);
 
     handle_installer_medium_bootup();
     workaround_type_encrypted_passphrase;


### PR DESCRIPTION
Having 90 seconds or any timeout for boot/reboot is ridiculous
openQA is generally slow and is not testing performance

- Fail:
https://openqa.suse.de/tests/8251201#step/handle_reboot/4
https://openqa.suse.de/tests/8164403#step/grub_test/3
https://openqa.suse.de/tests/8164408#step/grub_test/3
- Verification run:
https://openqa.suse.de/tests/8251319
https://openqa.suse.de/tests/8254482
https://openqa.suse.de/tests/8251323
https://openqa.suse.de/tests/8251335