### PR TITLE
xfstests: enable kdump in ppc/s390 and change kdump switch usage

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -776,6 +776,9 @@ elsif (get_var('XFSTESTS')) {
     prepare_target;
     if (is_pvm || check_var('ARCH', 's390x')) {
         loadtest 'xfstests/install';
+        unless (check_var('NO_KDUMP', '1')) {
+            loadtest 'xfstests/enable_kdump';
+        }
         loadtest 'xfstests/partition';
         loadtest 'xfstests/run';
         loadtest 'xfstests/generate_report';
@@ -783,7 +786,7 @@ elsif (get_var('XFSTESTS')) {
     else {
         if (check_var('XFSTESTS', 'installation')) {
             loadtest 'xfstests/install';
-            unless (get_var('NO_KDUMP')) {
+            unless (check_var('NO_KDUMP', '1')) {
                 loadtest 'xfstests/enable_kdump';
             }
             if (get_var('XFSTEST_KLP')) {

--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -6,7 +6,7 @@
 # Summary: Upload logs and generate junit report
 # - Get xfs status.log from datadir
 # - End log and upload logs (and all subdirs)
-# - Upload kdump logs unless NO_KDUMP is set
+# - Upload kdump logs unless NO_KDUMP is set to 1
 # - Upload system logs
 # - Parse /opt/status.log for PASSED/FAILED/SKIPPED
 # - Generate XML file using parsed results from previous step
@@ -119,8 +119,8 @@ sub run {
     # Upload test logs
     upload_subdirs($LOG_DIR, 1200);
 
-    # Upload kdump logs if not set "NO_KDUMP"
-    unless (get_var('NO_KDUMP')) {
+    # Upload kdump logs if not set "NO_KDUMP=1"
+    unless (check_var('NO_KDUMP', '1')) {
         upload_subdirs($KDUMP_DIR, 1200);
     }
 

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -11,7 +11,7 @@
 # - Start test from list, write log to file
 # - Collect test log and system logs
 # - Check if SUT crashed, reset if necessary
-# - Save kdump data, unless NO_KDUMP is set
+# - Save kdump data, unless NO_KDUMP is set to 1
 # - Stop heartbeat after last test on list
 # - Collect all logs
 # Maintainer: Yong Sun <yosun@suse.com>
@@ -470,8 +470,8 @@ sub run {
 
         sleep(1);
         select_console('root-console');
-        # Save kdump data to KDUMP_DIR if not set "NO_KDUMP"
-        unless (get_var('NO_KDUMP')) {
+        # Save kdump data to KDUMP_DIR if not set "NO_KDUMP=1"
+        unless (check_var('NO_KDUMP', '1')) {
             unless (save_kdump($test, $KDUMP_DIR, vmcore => 1, kernel => 1, debug => 1)) {
                 # If no kdump data found, write warning to log
                 my $msg = "Warning: $test crashed SUT but has no kdump data";


### PR DESCRIPTION
- Enable kdump in ppc64le and s390x when test xfstests
- Change enable kdump switch usage for more convenience in debug
before: checking NO_KDUMP exists or not
after: to see if NO_KDUMP is equal to 1 or not

- Verification run: https://openqa.suse.de/tests/8208288