### PR TITLE
Do not check screen before refreshing YaST content

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -244,7 +244,8 @@ sub start_hypervisor {
 sub start_add_system_extensions_or_modules {
     search 'system ext';
     assert_and_click 'yast2_control-center_add-system-extensions-or-modules';
-    assert_screen 'yast2_control-center_registration', timeout => 180;
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2_control-center_registration', 'alt-f10', 9, 2);
     send_key 'alt-r';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
@@ -278,7 +279,6 @@ sub start_wake_on_lan {
     assert_and_click 'yast2_control-center_wake-on-lan';
     assert_screen 'yast2_control-center_wake-on-lan_install_wol';
     send_key $cmd{install};    # wol needs to be installed
-    assert_screen 'yast2_control-center_wake-on-lan_overview', timeout => 60;
     record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
     send_key_until_needlematch('yast2_control-center_wake-on-lan_overview', 'alt-f10', 9, 2);
     send_key 'alt-f';


### PR DESCRIPTION
Follow up for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14342

- Related ticket: https://progress.opensuse.org/issues/105046
- Needles: None
- Verification run: [yast_control_center](https://openqa.suse.de/tests/8254293#step/yast2_control_center/97)