### PR TITLE
Don't install unsupported or unavailable packages

### DIFF
--- a/tests/console/zypper_in.pm
+++ b/tests/console/zypper_in.pm
@@ -56,7 +56,7 @@ sub run {
     script_run 'zypper -n in --allow-unsigned-rpm ' . data_url('zypper/pa.rpm');
     script_run 'rm -f /preinstall_fail';
 
-    assert_script_run 'zypper -n in adaptec-firmware adobe-sourcecodepro-fonts alsa-devel apache2 atmel-firmware';
+    assert_script_run 'zypper -n in adaptec-firmware apache2 atmel-firmware';
 
     assert_script_run 'unset ZYPP_SINGLE_RPMTRANS';
 }


### PR DESCRIPTION
https://openqa.suse.de/tests/8254161
https://openqa.suse.de/tests/8254131

This looks like bug https://openqa.suse.de/tests/8254141#step/zypper_in/26
but that is not reason to break everything else!

- Related ticket: https://progress.opensuse.org/issues/105948
- Verification run: https://openqa.suse.de/tests/8251592