### PR TITLE
kernel: Add fwupd test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2817,6 +2817,7 @@ sub load_extra_tests_syscontainer {
 sub load_extra_tests_kernel {
     loadtest "kernel/module_build";
     loadtest "kernel/tuned";
+    loadtest "kernel/fwupd";
 }
 
 # Scheduling set for validation of specific installation

--- a/tests/kernel/fwupd.pm
+++ b/tests/kernel/fwupd.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: fwupd
+# Summary: fwupd smoke test
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Install and start fwupd
+    zypper_call "in fwupd";
+    systemctl "start fwupd";
+
+    # Get all devices that support firmware updates
+    assert_script_run "fwupdmgr get-devices";
+    # Gets the configured remotes
+    assert_script_run "fwupdmgr get-remotes";
+}
+
+1;


### PR DESCRIPTION
Enhancement poo#107782: Create new test for fwupd daemon to check we
can install/start it and get list of devices.

- Related ticket: https://progress.opensuse.org/issues/107782
- Needles: none
- Verification run: 
TW: https://openqa.opensuse.org/tests/2220735
SLE: http://10.100.12.105/tests/1562
uefi: http://10.100.12.105/tests/1568#step/fwupd/12