### PR TITLE
Don't run salt on live media

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1195,8 +1195,8 @@ sub load_consoletests {
         loadtest "console/puppet";
     }
     # salt in SLE is only available for SLE12 ASMM or SLES15 and variants of
-    # SLES but not SLED
-    if (is_opensuse || (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && !is_desktop)) {
+    # SLES but not SLED. Don't run it on live media, not really useful there.
+    if (!get_var("LIVETEST") && is_opensuse || (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && !is_desktop)) {
         loadtest "console/salt";
     }
     if (!is_staging && (is_x86_64

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1196,7 +1196,7 @@ sub load_consoletests {
     }
     # salt in SLE is only available for SLE12 ASMM or SLES15 and variants of
     # SLES but not SLED
-    if (is_opensuse || !is_staging && (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && !is_desktop)) {
+    if (is_opensuse || (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && !is_desktop)) {
         loadtest "console/salt";
     }
     if (!is_staging && (is_x86_64


### PR DESCRIPTION
The `is_staging` condition was added in 2017, probably no longer necessary.

Not running it on live media saves RAM, which makes the rest of the test faster and more reliable.

Verification runs:
- Leap 15.4 Xfce Live: http://10.160.67.86/tests/1200

No VR for SLE stagings, they all use the YAML schedule.