### PR TITLE
Fix typo created by #fcbc94c69fd0facd91b34e1b921fe4d4e1173ddb

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -196,7 +196,7 @@ sub add_suseconnect_product {
     if ($name =~ /PackageHub/ && check_var('BETA', '1')) {
         record_info('INFO', 'PackageHub installation might fail in early development');
     }
-    die "SUSEConnect failed activating module $name after $$retry retries.";
+    die "SUSEConnect failed activating module $name after $retry retries.";
 }
 
 =head2 ssh_add_suseconnect_product


### PR DESCRIPTION
It was introduced in this PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14283

- Failure: https://openqa.suse.de/tests/8252341#step/suseconnect_scc/42
- VR: https://openqa.suse.de/tests/8254700

