### PR TITLE
Resize vpn-gateway YaST window to refresh content

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -204,7 +204,8 @@ sub start_partitioner {
 sub start_vpn_gateway {
     search('vpn');
     assert_and_click 'yast2_control-center_vpn-gateway-client';
-    assert_screen 'yast2-vpn-gateway-client', timeout => 180;
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2-vpn-gateway-client', 'alt-f10', 19, 9);
     send_key 'alt-c';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }


### PR DESCRIPTION
Follow up for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14342

- Related ticket: https://progress.opensuse.org/issues/105046
- Needles: None
- Verification run: [yast_control_center before](https://openqa.suse.de/tests/8254681#step/yast2_control_center/72) | [yast_control_center after](https://openqa.suse.de/tests/8254884#step/yast2_control_center/71)
