### PR TITLE
Remove resize YaST window from registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -595,8 +595,10 @@ sub handle_scc_popups {
         push @tags, 'expired-gpg-key' if is_sle('=15');
         while ($counter--) {
             die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
-            record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
-            for (1 .. 2) { send_key 'alt-f10' }
+            if (is_sle('15-SP4+') && get_var('VIDEOMODE', '') !~ /text|ssh-x/) {
+                record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+                for (1 .. 2) { send_key 'alt-f10' }
+            }
             assert_screen(\@tags, timeout => 360);
             if (match_has_tag('import-untrusted-gpg-key')) {
                 handle_untrusted_gpg_key;


### PR DESCRIPTION
It does not make sense have the workaround for YaST windows in text mode registration, related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14342. 
- Related ticket: No ticket, but affects https://openqa.suse.de/tests/8254680#step/register_system/11
- Needles: None
- Verification run:  https://openqa.suse.de/tests/8255217#step/register_system/12