### PR TITLE
Improve softreboot to work on TUNNELED instances

### DIFF
--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -17,23 +17,24 @@ use publiccloud::utils "select_host_console";
 sub run {
     my ($self, $args) = @_;
 
-    # This ensure that we have used the setup console, even if no module was run before.
-    select_host_console();
-    my $setup_console = current_console();
+    # Only initialize tunnels, if not previously done
+    if (!get_var('_SSH_TUNNELS_INITIALIZED', 0)) {
+        # This ensures that we have used the setup console, even if no module was run before.
+        my $setup_console = current_console();
 
-    # Establish the tunnel (it will stay active in foreground and occupy this console!)
-    select_console('tunnel-console');
-    ssh_interactive_tunnel($args->{my_instance});
+        # Establish the tunnel (it will stay active in foreground and occupy this console!)
+        select_console('tunnel-console');
+        ssh_interactive_tunnel($args->{my_instance});
 
-    # Enable ssh connection on setup console, this is done normally with the
-    # first activation hook in susedistribution:activate_console()
-    if ($setup_console !~ /tunnel/) {
-        select_console($setup_console);
-        # The verbose output is visible only at the tunnel-console -
-        #   it doesn't interfere with tests as it isn't piped to /dev/sshserial
-        script_run('ssh -E /var/tmp/ssh_sut.log -vt sut', timeout => 0);
+        # Enable ssh connection on setup console, this is done normally with the
+        # first activation hook in susedistribution:activate_console()
+        if ($setup_console !~ /tunnel/) {
+            select_console($setup_console);
+            # The verbose output is visible only at the tunnel-console -
+            #   it doesn't interfere with tests as it isn't piped to /dev/sshserial
+            script_run('ssh -E /var/tmp/ssh_sut.log -vt sut', timeout => 0);
+        }
     }
-
     die("expect ssh serial") unless (get_var('SERIALDEV') =~ /ssh/);
 
     # Verify most important consoles


### PR DESCRIPTION
Improve the softreboot for publiccloud, so it works on TUNELLED test
runs without the need of the user to re-establish the tunnel afterwards.

- Verification run: [SLE 15-SP4 GCE](http://duck-norris.qam.suse.de/tests/8319) | [15-SP3 Azure containers](http://duck-norris.qam.suse.de/tests/8316) | [15-SP3 GCE imgproof](http://duck-norris.qam.suse.de/tests/8317) | [15-SP2 Staging images EC2 ltp](http://duck-norris.qam.suse.de/tests/8312) | [12-SP5 GCE-BYOS imgproof](http://duck-norris.qam.suse.de/tests/8318) | [12-SP5 EC2-BYOS ltp-syscalls](http://duck-norris.qam.suse.de/tests/8320)
