### PR TITLE
Adapt yast2_kdump after UI change

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -169,7 +169,7 @@ sub activate_kdump {
     if (is_ppc64le || is_aarch64) {
         send_key('alt-y');
         type_string $memory_kdump;
-        send_key('ret');
+        wait_screen_change(sub { send_key 'ret' }, 10) for (1 .. 2);
         record_soft_failure 'default kdump memory size is too small for ppc64le and aarch64, see bsc#1161421';
         $expect_restart_info = 1;
     }


### PR DESCRIPTION
We are missing ret key in https://openqa.suse.de/tests/8216714#step/yast2_kdump/20
It seems like there was some UI change that makes it necessary to hit enter twice: https://openqa.suse.de/tests/8257437#step/yast2_kdump/19 we enter 320, which is more than the maximum allowed value. So Yast changes it to the max allowed value, 287, after we type enter, but then we need to type enter again. Another option would be to set $memory_kdump to 287 only for aarch64, but that might cause problems again if the value changes for some reason. Typing enter twice does not hurt in this case, as we see on ppc.

- Related ticket: https://progress.opensuse.org/issues/107314

VR 
aarch64 https://openqa.suse.de/tests/8263831
ppc https://openqa.suse.de/tests/8264596