### PR TITLE
Change in Disk Encription screen in Leap 15.4

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -24,7 +24,7 @@ sub run {
             assert_screen "upgrade-enter-password";
         }
         type_password();
-        send_key is_sle('<=15-SP4') || is_leap('<=15.4') ?
+        send_key is_sle('<=15-SP4') || is_leap('<15.4') ?
           $cmd{ok} :
           'alt-d';
     }


### PR DESCRIPTION
The dialog window that asks for disk encription has changed in Leap 15.4. The acceptance button is now 'Decrypt' instead of 'Ok'. In the `upgrade_select` script, it was specified to press `Alt+D` for versions lesser than *or equal* to 15.4

- Related ticket: https://progress.opensuse.org/issues/107380
- Needles: *not needed*
- Verification runs:

|**Flavor**|**Upgrade 42.3**|**Upgrade 15.0**| **Upgrade 15.2**|
|---|---|---|---|
|DVD |https://openqa.opensuse.org/tests/2223350#step/upgrade_select/2|https://openqa.opensuse.org/tests/2223349#step/upgrade_select/2|https://openqa.opensuse.org/tests/2222778#step/upgrade_select/2
|NET |https://openqa.opensuse.org/tests/2223388#step/upgrade_select/2|https://openqa.opensuse.org/tests/2223373#step/upgrade_select/2|https://openqa.opensuse.org/tests/2223374#step/upgrade_select/2
