### PR TITLE
Fixed test fails in x3270_ssl: permission denied when access serialdev on s390x

### DIFF
--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -32,6 +32,10 @@ sub run {
 
     select_console 'root-console';
 
+    # On s390x platform, make sure that non-root user has
+    # permissions for $serialdev to get openQA work properly.
+    ensure_serialdev_permissions if (is_s390x);
+
     my $cert_file = '/tmp/server.cert';
     my $key_file = '/tmp/server.key';
     my $tracelog_file = '/tmp/x3270-trace.log';
@@ -83,7 +87,7 @@ sub run {
     send_key "ctrl-c";
     assert_screen 'generic-desktop';
 
-    #Terminate openssl s_server
+    # Terminate openssl s_server
     select_console 'root-console';
     send_key "ctrl-c";
     clear_console;


### PR DESCRIPTION
Fixed test fails in x3270_ssl: permission denied when access serialdev on s390x

[poo#106504](https://progress.opensuse.org/issues/106504) - [sle][security][sle15sp4] test fails in x3270_ssl about script_run timeout without setting

Adjust non-root user can access serialdev in s390x, 
refer: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14193/commits/61845ec9d1c4de92202fbac6e5c8a2f8b8a7a178

- Related ticket: https://progress.opensuse.org/issues/106504
- Needles: NA
- Verification run: 
  - x86_64: https://openqa.suse.de/tests/8263071
  - aarch64: https://openqa.suse.de/tests/8263072
  - s390x: https://openqa.suse.de/tests/8263073
