### PR TITLE
Add three test cases to Audit test module

### DIFF
--- a/schedule/security/audit.yaml
+++ b/schedule/security/audit.yaml
@@ -4,7 +4,10 @@ description:    >
 schedule:
     - boot/boot_to_desktop
     - console/consoletest_setup
+    - security/audit/auditd
+    - security/audit/auditctl
     - security/audit/autrace
     - security/audit/ausearch
     - security/audit/aureport
     - security/audit/aulastlog
+    - security/audit/aulast

--- a/tests/security/audit/auditctl.pm
+++ b/tests/security/audit/auditctl.pm
@@ -1,0 +1,62 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-Later
+#
+# Summary: Controlling the Audit system using auditctl
+# Maintainer: llzhao <llzhao@suse.com>, shawnhao <weixuan.hao@suse.com>
+# Tags: poo#81772, tc#1768551
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $audit_rules = '/etc/audit/rules.d/audit.rules';
+    my $audit_log = '/var/log/audit/audit.log';
+    select_console 'root-console';
+
+    # Disable audit
+    validate_script_output('auditctl -e 0', sub { m/enabled 0/ });
+
+    # Make sure auditctl indeed disabled auditd
+    assert_script_run("echo '' > $audit_log");
+    systemctl('restart apparmor');
+    my $ret = script_run("tail -1 $audit_log | grep SERVICE_START");
+    if ($ret == 0) {
+        # $ret == 0, report error since there should be no audit logs related to apparmor restart
+        record_info('Error: ', 'unexpected audit log recorded', result => 'fail');
+    } else {
+        # $ret == 1 is the expected return value
+        record_info('Checked: ', 'auditd temporarily disabled as expected');
+    }
+
+    # Check audit status
+    validate_script_output('auditctl -s', sub { m/enabled 0/ });
+
+    # Enable audit
+    validate_script_output('auditctl -e 1', sub { m/enabled 1/ });
+
+    # Make sure auditctl indeed enabled auditd
+    assert_script_run("echo '' > $audit_log");
+    systemctl('restart apparmor');
+    $ret = script_run("tail -1 $audit_log | grep SERVICE_START");
+    if ($ret == 0) {
+        # $ret == 0 is the expected return value showing that auditd is enabled now
+        record_info('Checked: ', 'auditd temporarily enabled as expected');
+    } else {
+        # $ret == 1, report error that apparmor log has not been recorded
+        record_info('Error: ', 'auditd failed to record apparmor logs', result => 'fail');
+    }
+
+    # Check audit status again
+    validate_script_output('auditctl -s', sub { m/enabled 1/ });
+
+    # List all rules by default
+    validate_script_output('auditctl -l', sub { m/-a never,task/ });
+
+    # Double check the audit rule file
+    validate_script_output("cat $audit_rules", sub { m/-a task,never/ });
+}
+
+1;

--- a/tests/security/audit/auditd.pm
+++ b/tests/security/audit/auditd.pm
@@ -1,0 +1,38 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-Later
+#
+# Summary: Controlling the Auditd daemon as root by "systemctl" to verify it can work
+# Maintainer: llzhao <llzhao@suse.com>, shawnhao <weixuan.hao@suse.com>
+# Tags: poo#81772, tc#1768549
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+
+    # Install packages if they are not installed by default
+    if (script_run('rpm -q audit')) {
+        zypper_call('in audit libaudit1');
+    }
+
+    # Check auditd status by default on a clean new VM
+    systemctl('is-active auditd');
+
+    # Stop auditd
+    systemctl('stop auditd');
+
+    # Check auditd status
+    validate_script_output('systemctl status --no-pager auditd', sub { m/Active: inactive./ }, proceed_on_failure => 1);
+
+    # Start auditd again
+    systemctl('start auditd');
+
+    # Check auditd status again
+    systemctl('is-active auditd');
+}
+
+1;

--- a/tests/security/audit/aulast.pm
+++ b/tests/security/audit/aulast.pm
@@ -1,0 +1,67 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-Later
+#
+# Summary: Verify the "aulast" can print a list of the last logged-in users
+# Maintainer: llzhao <llzhao@suse.com>, shawnhao <weixuan.hao@suse.com>
+# Tags: poo#81772, tc#1768581
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $audit_log = '/var/log/audit/audit.log';
+    my $testfile = '/tmp/testfile';
+    my $user = 'testuser';
+    my $pwd = 'testpassw0rd';
+    my $wrong_pwd = 'wrongpassw0rd';
+
+    select_console 'root-console';
+    zypper_call('in expect');
+
+    # Check if audit service is active
+    assert_script_run('systemctl restart auditd');
+
+    # Create a test user for testing and clear the audit log
+    assert_script_run("useradd -m $user");
+    assert_script_run("echo $user:$pwd | chpasswd");
+    assert_script_run("echo '' > $audit_log");
+
+    # Let user login localhost and then log out
+    assert_script_run(
+        "expect -c 'spawn ssh -v -o StrictHostKeyChecking=no $user\@localhost; expect \"Password: \"; send \"$pwd\\n\"; expect \"~*\"; send \"exit\\n\"'"
+    );
+
+    # Run aulast to print last logged-in users
+    validate_script_output('aulast', sub { m/$user/ });
+
+    # Create a null test file
+    assert_script_run("touch $testfile");
+
+    # Print last logged-in users into test file
+    assert_script_run("aulast -f $testfile");
+
+    # Copy audit log to test file
+    assert_script_run("cp $audit_log $testfile");
+
+    # Run aulast -f testfile again to print last logged-in user
+    validate_script_output("aulast -f $testfile", sub { m/$user/ });
+
+    # Report bad logins
+    assert_script_run('aulast --bad');
+
+    # Let test user login localhost but fail it
+    assert_script_run(
+        "expect -c 'spawn ssh -v -o StrictHostKeyChecking=no $user\@localhost; expect \"Password: \"; send \"$wrong_pwd\"; exit'"
+    );
+
+    # Report bad login again, the bad login from test user should be recorded
+    validate_script_output('aulast --bad', sub { m/$user/ });
+
+    # Print out the audit event serial numbers
+    validate_script_output("aulast --user $user --proof", sub { m/serial numbers/ });
+}
+
+1;

--- a/tests/security/audit/aulastlog.pm
+++ b/tests/security/audit/aulastlog.pm
@@ -4,7 +4,7 @@
 # Summary: Verify the "aulastlog" can print the last login for all users of a machine similar to the way lastlog does
 #          The login name, port and last login time will be printed
 # Maintainer: llzhao <llzhao@suse.com>, shawnhao <weixuan.hao@suse.com>
-# Tags: poo#81772 tc#1768580
+# Tags: poo#81772, tc#1768580
 
 use base 'opensusebasetest';
 use strict;

--- a/tests/security/audit/aureport.pm
+++ b/tests/security/audit/aureport.pm
@@ -3,7 +3,7 @@
 #
 # Summary: Verify the "aureport" utility can generate default audit report and reports with specifc parameters
 # Maintainer: llzhao <llzhao@suse.com>, shawnhao <weixuan.hao@suse.com>
-# Tags: poo#81772 tc#1768552
+# Tags: poo#81772, tc#1768552
 
 use base 'opensusebasetest';
 use strict;

--- a/tests/security/audit/ausearch.pm
+++ b/tests/security/audit/ausearch.pm
@@ -4,7 +4,7 @@
 # Summary: Verify the "ausearch" utility can search the audit log file for certain events using various keys or
 #          other characteristics of the logged format
 # Maintainer: llzhao <llzhao@suse.com>, shawnhao <weixuan.hao@suse.com>
-# Tags: poo#81772 tc#1768578
+# Tags: poo#81772, tc#1768578
 
 use base 'opensusebasetest';
 use strict;

--- a/tests/security/audit/autrace.pm
+++ b/tests/security/audit/autrace.pm
@@ -4,7 +4,7 @@
 # Summary: Verify the "autrace" utility traces individual processes in a fashion similar to strace.
 #          The output of autrace is logged to the audit log.
 # Maintainer: llzhao <llzhao@suse.com>, shawnhao <weixuan.hao@suse.com>
-# Tags: poo#81772 tc#1768579
+# Tags: poo#81772, tc#1768579
 
 use base 'opensusebasetest';
 use strict;
@@ -28,13 +28,13 @@ sub run {
 
     select_console 'root-console';
 
-    # Install related packages and start audit service
-    zypper_call('in audit libaudit1');
-    assert_script_run('systemctl start auditd');
-
     # Use autrace to trace an individual process, output will be logged to audit log
-    script_run('autrace /bin/ls /tmp');
-    record_info('autrace_output: ', 'autrace will report error here as expected');
+    my $ret = script_run('autrace /bin/ls /tmp');
+    if ($ret) {
+        record_info('autrace_output: ', 'autrace will report error here as expected');
+    } else {
+        record_info('Error: ', 'autrace should report error here', result => 'fail');
+    }
 
     # Delete all existing rules
     assert_script_run('auditctl -D');


### PR DESCRIPTION
Add auditd, auditctl, aulast to Audit module.
Auditd: Controlling audit daemon as root by systemctl to verify it can
work
Auditctl: Controlling the audit system using auditctl
Aulast: Verify the aualst can print a list of the last logged-in users

- Related ticket: https://progress.opensuse.org/issues/81772
- Needles: N/A
- Verification run: 
  - o3: https://openqa.opensuse.org/tests/2243169#
  - osd: https://openqa.suse.de/tests/8323123#
