### PR TITLE
Integrate boost library into mpi_master

### DIFF
--- a/data/hpc/sample_boost.cpp
+++ b/data/hpc/sample_boost.cpp
@@ -1,0 +1,27 @@
+#include <mpi.h>
+#include <iostream>
+
+/**
+https://www.boost.org/doc/libs/1_69_0/doc/html/mpi/getting_started.html
+**/
+int main(int argc, char* argv[])
+{
+  MPI_Init(&argc, &argv);
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank == 0) {
+    int value = 17;
+    int result = MPI_Send(&value, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+    if (result == MPI_SUCCESS)
+      std::cout << "Rank 0 OK!" << std::endl;
+  } else if (rank == 1) {
+    int value;
+    int result = MPI_Recv(&value, 1, MPI_INT, 0, 0, MPI_COMM_WORLD,
+			  MPI_STATUS_IGNORE);
+    if (result == MPI_SUCCESS && value == 17)
+      std::cout << "Rank 1 OK!" << std::endl;
+  }
+  MPI_Finalize();
+  return 0;
+}

--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -1,10 +1,10 @@
 # SUSE's openQA tests
 #
-# Copyright 2020 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Provide functionality for hpc tests.
-# Maintainer: George Gkioulis <ggkioulis@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
 package hpc::utils;
 use strict;
@@ -25,6 +25,22 @@ sub get_mpi() {
     }
 
     return $mpi;
+}
+
+=head2 get_mpi_src
+
+ get_mpi_src();
+
+Returns the source code which is used based on B<HPC_LIB> job variable. The variable indicates the HPC library
+which the mpi use to compile the source code. if the variable is not set, one of the other MPI implementations
+will be used(mpich, openmpi, mvapich2).
+
+Returns an array with the mpi compiler and the source code located in /data/hpc
+
+=cut
+sub get_mpi_src {
+    return ('mpicc', 'simple_mpi.c') unless get_var('HPC_LIB', '');
+    return ('mpic++', 'sample_boost.cpp') if (get_var('HPC_LIB') == 'boost');
 }
 
 1;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -1,17 +1,14 @@
 # SUSE's openQA tests
 #
-# Copyright 2017-2019 SUSE LLC
+# Copyright 2017-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Basic MPI integration test. Checking for installability and
-#     usability of mpirun and mpicc. Using mpirun locally and across
+#     usability of MPI implementations, or HPC libraries. Using mpirun locally and across
 #     available nodes. Test meant to be run in VMs, so thus using ethernet
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use base 'hpc::utils';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::utils);
 use testapi;
 use lockapi;
 use utils;
@@ -21,7 +18,8 @@ use version_utils 'is_sle';
 sub run {
     my $self = shift;
     my $mpi = $self->get_mpi();
-    my $mpi_c = 'simple_mpi.c';
+    my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
+
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);
 
@@ -30,7 +28,7 @@ sub run {
         add_suseconnect_product('sle-module-development-tools');
     }
 
-    zypper_call("in $mpi $mpi-devel gcc");
+    zypper_call("in $mpi $mpi-devel gcc gcc-c++");
     assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
 
     barrier_wait('CLUSTER_PROVISIONED');
@@ -43,33 +41,34 @@ sub run {
     record_info('INFO', script_output('cat /proc/cpuinfo'));
 
     assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O /tmp/$mpi_c");
-    assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpicc /tmp/simple_mpi.c -o /tmp/simple_mpi | tee /tmp/make.out");
+    assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/$mpi_compiler /tmp/$mpi_c -o /tmp/mpi_bin | tee /tmp/make.out");
 
     ## distribute the binary
     foreach (@cluster_nodes) {
-        assert_script_run("scp -o StrictHostKeyChecking=no /tmp/simple_mpi root\@$_\:/tmp/simple_mpi");
+        assert_script_run("scp -o StrictHostKeyChecking=no /tmp/mpi_bin root\@$_\:/tmp/mpi_bin");
     }
     barrier_wait('MPI_BINARIES_READY');
 
-    record_info('INFO', 'Run MPI over single machine');
-    ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
-    if ($mpi =~ m/openmpi/) {
-        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --allow-run-as-root /tmp/simple_mpi");
-    } else {
-        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun /tmp/simple_mpi | tee /tmp/mpirun.out");
+    unless (get_var('HPC_LIB', '') == 'boost') {
+        record_info('INFO', 'Run MPI over single machine');
+        ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
+        if ($mpi =~ m/openmpi/) {
+            assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --allow-run-as-root /tmp/mpi_bin");
+        } else {
+            assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun /tmp/mpi_bin | tee /tmp/mpirun.out");
+        }
     }
-
     record_info('INFO', 'Run MPI over several nodes');
     if ($mpi =~ m/openmpi/) {
-        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --allow-run-as-root --host $cluster_nodes  /tmp/simple_mpi");
+        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --allow-run-as-root --host $cluster_nodes  /tmp/mpi_bin");
     } elsif ($mpi eq 'mvapich2') {
         # we do not support ethernet with mvapich2
-        my $return = script_run("set -o pipefail;/usr/lib64/mpi/gcc/$mpi/bin/mpirun --host $cluster_nodes /tmp/simple_mpi |& tee /tmp/simple_mpi.log");
+        my $return = script_run("set -o pipefail;/usr/lib64/mpi/gcc/$mpi/bin/mpirun --host $cluster_nodes /tmp/mpi_bin |& tee /tmp/mpi_bin.log");
         if ($return == 143) {
             record_info("mvapich2 info", "echo $return - No IB device found");
         } elsif ($return == 139 || $return == 255) {
             # process running (on master return 139, on slave return 255)
-            if (script_run('grep \'Caught error: Segmentation fault (signal 11)\' /tmp/simple_mpi.log') == 0) {
+            if (script_run('grep \'Caught error: Segmentation fault (signal 11)\' /tmp/mpi_bin.log') == 0) {
                 record_soft_failure('bsc#1144000 MVAPICH2: segfault while executing without ib_uverbs loaded');
             }
         } else {
@@ -77,7 +76,7 @@ sub run {
             die("echo $return - not expected errorcode");
         }
     } else {
-        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --host $cluster_nodes /tmp/simple_mpi");
+        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun -print-all-exitcodes --host $cluster_nodes /tmp/mpi_bin");
     }
 
     barrier_wait('MPI_RUN_TEST');
@@ -91,6 +90,7 @@ sub post_fail_hook {
     my $self = shift;
     upload_logs('/tmp/make.out');
     upload_logs('/tmp/mpirun.out');
+    upload_logs('/tmp/mpi_bin.log');
     $self->export_logs();
 }
 


### PR DESCRIPTION
Modify the `mpi_master` in order to run HPC scientific libraries. The beginning is with [boost](https://theboostcpplibraries.com/boost.mpi-simple-data-exchange)
The sample of the source code exercises the exchange data between two processes. the process with rank 0 receives data with recv().
The process with rank 1 sends data with send(). If you start the program with more than two processes, the other processes exit without doing anything.
According to this, only two nodes are required. That means that the code can be run in a single node and even if the module uses `--host` with three nodes including the master,
only two of them will be chosen to run the binary. We can identify and check those, using the mpirun paramenter `-print-all-exitcodes`. This will report the node and the exit code of its execution.

`get_mpi_src` is used to fetch the source code and the appropiate compiler for that particular source code. This is accomplished with `HPC_LIB`. if the variable is not set
the other MPI implementations will be used(mpich, openmpi, mvapich2)

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/63115
- Verification run: 
http://aquarius.suse.cz/tests/8165
