### PR TITLE
Remove softfailure bsc#1165915

### DIFF
--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -46,11 +46,7 @@ sub run {
     assert_script_run("lsblk");
 
     # Install bzip2 to check for bsc#1165915
-    if (script_run("zypper -n in bzip2") == 8) {
-        record_soft_failure('bsc#1165915');
-        assert_script_run('update-ca-certificates');
-        zypper_call("in bzip2");
-    }
+    zypper_call("in bzip2");
 
     assert_script_run("SUSEConnect --status-text", 300);
     zypper_call("lr -d");


### PR DESCRIPTION
In PC, there are few fails when trying to install `bzip2` while the
system does not have refreshed repositories. Thus package installation
call timeouts while zypper is still refreshing repos.

- [fail](https://openqa.suse.de/tests/8263335#step/instance_overview/36)
- VR: [sle-15-SP3-AZURE-Basic-Updates-x86_64-Build20220303-1-publiccloud_consoletests@64bit](https://openqa.suse.de/t8264137)
