### PR TITLE
Hpc best practices

### DIFF
--- a/lib/hpc/cluster.pm
+++ b/lib/hpc/cluster.pm
@@ -7,7 +7,7 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 package hpc::cluster;
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use utils;
 
@@ -15,8 +15,7 @@ our @EXPORT = qw(
   provision_cluster
 );
 
-sub provision_cluster {
-    my ($self) = @_;
+sub provision_cluster ($self) {
     my $config = << "EOF";
 sed -i '/^DHCLIENT_SET_HOSTNAME.*/c\\DHCLIENT_SET_HOSTNAME="no"' /etc/sysconfig/network/dhcp
 EOF

--- a/lib/hpc/cluster.pm
+++ b/lib/hpc/cluster.pm
@@ -4,12 +4,10 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Base module for HPC cluster provisioning
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
 package hpc::cluster;
-use base hpcbase;
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use utils;
 

--- a/lib/hpc/configs.pm
+++ b/lib/hpc/configs.pm
@@ -7,7 +7,7 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 package hpc::configs;
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use utils;
 use Storable;
@@ -139,8 +139,7 @@ Default slurmdb.conf always set to the latest supported version
 Prepare slurm.conf based on test requirements and settings
 
 =cut
-sub prepare_slurm_conf {
-    my ($self) = @_;
+sub prepare_slurm_conf ($self) {
     my $slurm_conf = get_required_var('SLURM_CONF');
 
     my @cluster_ctl_nodes = $self->master_node_names();
@@ -219,8 +218,7 @@ sub prepare_slurm_conf {
 Prepare slurmdbd.conf based on test requirements and settings
 
 =cut
-sub prepare_slurmdb_conf {
-    my ($self) = @_;
+sub prepare_slurmdb_conf ($self) {
     my @cluster_compute_nodes = $self->slave_node_names();
 
     my $config = << "EOF";

--- a/lib/hpc/configs.pm
+++ b/lib/hpc/configs.pm
@@ -4,15 +4,12 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Base module for HPC config handling
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
 package hpc::configs;
-use base hpcbase;
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use utils;
-use Data::Dumper;
 use Storable;
 use Tie::IxHash;
 use version_utils 'is_sle';

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -4,12 +4,10 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Base module for HPC tests
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
 package hpcbase;
-use base 'opensusebasetest';
-use strict;
-use warnings;
+use Mojo::Base 'opensusebasetest';
 use testapi;
 use utils;
 

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -6,12 +6,12 @@
 # Summary: Initialization of barriers for HPC multimachine tests
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'opensusebasetest';
+use Mojo::Base 'opensusebasetest', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
+sub run ($self) {
     # Get number of nodes
     my $nodes = get_required_var('CLUSTER_NODES');
 
@@ -78,7 +78,7 @@ sub run {
     record_info('barriers initialized');
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1};
 }
 

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -4,11 +4,9 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Initialization of barriers for HPC multimachine tests
-# Maintainer: Petr Cervinka <pcervinka@suse.com>, Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'opensusebasetest';
-use strict;
-use warnings;
+use Mojo::Base 'opensusebasetest';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/before_test.pm
+++ b/tests/hpc/before_test.pm
@@ -6,13 +6,12 @@
 # Summary:  Basic preparation before any HPC test
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base qw(hpcbase hpc::cluster);
+use Mojo::Base qw(hpcbase hpc::cluster), -signatures;
 use testapi;
 use utils;
 use lockapi;
 
-sub run {
-    my ($self) = @_;
+sub run ($self) {
     $self->select_serial_terminal;
 
     # disable packagekitd
@@ -36,7 +35,7 @@ sub run {
     }
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 

--- a/tests/hpc/before_test.pm
+++ b/tests/hpc/before_test.pm
@@ -4,12 +4,9 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary:  Basic preparation before any HPC test
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use base 'hpc::cluster';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::cluster);
 use testapi;
 use utils;
 use lockapi;

--- a/tests/hpc/conman.pm
+++ b/tests/hpc/conman.pm
@@ -11,14 +11,12 @@
 #
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use utils;
 use susedistribution;
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     zypper_call('in conman');
 
     # test with unix domain socket
@@ -65,8 +63,7 @@ sub run {
     send_key 'ctrl-d';
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('conmand');
     $self->SUPER::post_fail_hook;

--- a/tests/hpc/conman.pm
+++ b/tests/hpc/conman.pm
@@ -9,12 +9,9 @@
 #
 #    This tests the conman package from the HPC module
 #
-# Maintainer: Matthias Griessmeier <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use utils;
 use susedistribution;

--- a/tests/hpc/ganglia_client.pm
+++ b/tests/hpc/ganglia_client.pm
@@ -5,12 +5,10 @@
 
 # Summary: Ganglia Test - client
 #   Acts as client node, which publishes data to the server via gmetric command
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/323979
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/ganglia_client.pm
+++ b/tests/hpc/ganglia_client.pm
@@ -8,14 +8,12 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/323979
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     # Get number of nodes
     my $nodes = get_required_var("CLUSTER_NODES");
     # Get ganglia-server hostname
@@ -65,8 +63,7 @@ sub run {
     barrier_wait('GANGLIA_SERVER_DONE');
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('gmond');
 }

--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -6,13 +6,10 @@
 # Summary: Ganglia Test - server
 #   Acts as server which gets data from the client and is running the webinterface
 #   to show the metrics for all connected hosts
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>, Anton Pappas <apappas@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/323979
 
-use base 'hpcbase';
-use base 'x11test';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase x11test);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -9,14 +9,13 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/323979
 
-use Mojo::Base qw(hpcbase x11test);
+use Mojo::Base qw(hpcbase x11test), -signatures;
 use testapi;
 use lockapi;
 use utils;
 use version_utils 'is_sle';
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     # Get number of nodes
     my $nodes = get_required_var("CLUSTER_NODES");
     # Get hostname
@@ -67,8 +66,7 @@ sub run {
     barrier_wait('GANGLIA_SERVER_DONE');
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('apache2');
     $self->upload_service_log('gmond');

--- a/tests/hpc/genders.pm
+++ b/tests/hpc/genders.pm
@@ -9,14 +9,12 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/324149
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     # Install genders package
     zypper_call('in genders');
 

--- a/tests/hpc/genders.pm
+++ b/tests/hpc/genders.pm
@@ -6,12 +6,10 @@
 # Summary: HPC_Module: genders
 #    This test is setting up a genders scenario according to the testcase
 #    described in FATE 324149
-# Maintainer: Petr Cervinka <pcervinka@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/324149
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/hpc_master.pm
+++ b/tests/hpc/hpc_master.pm
@@ -10,13 +10,9 @@
 #    set-up is fairly complex, so that NFS shares are mounted, required
 #    database(s) are ready to be used, some data is being populated to
 #    the databases, artificial users are added etc.
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use base 'hpc::configs';
-use base 'hpc::migration';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::configs hpc::migration);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/hpc_master.pm
+++ b/tests/hpc/hpc_master.pm
@@ -12,13 +12,12 @@
 #    the databases, artificial users are added etc.
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base qw(hpcbase hpc::configs hpc::migration);
+use Mojo::Base qw(hpcbase hpc::configs hpc::migration), -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $nodes = get_required_var("CLUSTER_NODES");
     $self->prepare_user_and_group();
 
@@ -78,12 +77,11 @@ sub run {
     barrier_wait('HPC_MASTER_RUN_TESTS');
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/hpc_master_backup.pm
+++ b/tests/hpc/hpc_master_backup.pm
@@ -9,12 +9,9 @@
 #    configured. At the same time it is expected that the HPC cluster
 #    set-up is fairly complex, so that NFS shares are mounted, required
 #    database(s) are ready to be used, artificial users are added etc.
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use base 'hpc::migration';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::migration);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/hpc_master_backup.pm
+++ b/tests/hpc/hpc_master_backup.pm
@@ -11,13 +11,12 @@
 #    database(s) are ready to be used, artificial users are added etc.
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base qw(hpcbase hpc::migration);
+use Mojo::Base qw(hpcbase hpc::migration), -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $nodes = get_required_var("CLUSTER_NODES");
     $self->prepare_user_and_group();
 
@@ -53,12 +52,11 @@ sub run {
     barrier_wait('HPC_MASTER_RUN_TESTS');
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/hpc_migration.pm
+++ b/tests/hpc/hpc_migration.pm
@@ -14,12 +14,9 @@
 #    could be checked before and after online zypper migration.
 #    See: README.migration
 #
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use base 'hpc::migration';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::migration);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/hpc_slave.pm
+++ b/tests/hpc/hpc_slave.pm
@@ -6,12 +6,9 @@
 # Summary: HPC Slave
 #    This test is setting up an HPC slave node, so that various services
 #    are ready to be used
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use base 'hpc::migration';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::migration);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/hpc_support.pm
+++ b/tests/hpc/hpc_support.pm
@@ -6,13 +6,9 @@
 # Summary: HPC support node
 #    This tests only ensure the availability of a node which could hold some
 #    supportive services, like for instance required database
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use base 'hpc::configs';
-use base 'hpc::migration';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::configs hpc::migration);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/hwloc.pm
+++ b/tests/hpc/hwloc.pm
@@ -4,11 +4,9 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Run testsuite included in hwloc sources
-# Maintainer: Thomas Blume <tblume@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base "consoletest";
-use warnings;
-use strict;
+use Mojo::Base 'consoletest';
 use testapi;
 use utils;
 

--- a/tests/hpc/libsolve_installcheck.pm
+++ b/tests/hpc/libsolve_installcheck.pm
@@ -4,13 +4,11 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Checking if it is possible to install packages in repo with libsolv
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base "opensusebasetest";
+use Mojo::Base 'opensusebasetest';
 use testapi;
 use utils;
-use strict;
-use warnings;
 
 sub run {
     my ($self) = @_;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -8,15 +8,14 @@
 #     available nodes. Test meant to be run in VMs, so thus using ethernet
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base qw(hpcbase hpc::utils);
+use Mojo::Base qw(hpcbase hpc::utils), -signatures;
 use testapi;
 use lockapi;
 use utils;
 use registration;
 use version_utils 'is_sle';
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $mpi = $self->get_mpi();
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
 
@@ -82,12 +81,11 @@ sub run {
     barrier_wait('MPI_RUN_TEST');
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my $self = shift;
+sub post_fail_hook ($self) {
     upload_logs('/tmp/make.out');
     upload_logs('/tmp/mpirun.out');
     upload_logs('/tmp/mpi_bin.log');

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -6,10 +6,7 @@
 # Summary: openmpi mpirun check
 # Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
 
-use base 'hpcbase';
-use base 'hpc::utils';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::utils);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -6,12 +6,10 @@
 # Summary: HPC_Module: mrsh master
 #    This test is setting up a mrsh scenario according to the testcase
 #    described in FATE
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321722
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -9,7 +9,7 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321722
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase' -signatures;
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/mrsh_slave.pm
+++ b/tests/hpc/mrsh_slave.pm
@@ -6,12 +6,10 @@
 # Summary: HPC_Module: mrsh slave
 #    This test is setting up a mrsh scenario according to the testcase
 #    described in FATE
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321722
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/mrsh_slave.pm
+++ b/tests/hpc/mrsh_slave.pm
@@ -9,14 +9,12 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321722
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     # make sure that nobody has permissions for $serialdev to get openQA work properly
     assert_script_run("chmod 666 /dev/$serialdev");
 
@@ -35,12 +33,11 @@ sub run {
     barrier_wait("MRSH_MASTER_DONE");
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('munge');
     $self->upload_service_log('mrshd');

--- a/tests/hpc/munge_master.pm
+++ b/tests/hpc/munge_master.pm
@@ -7,14 +7,12 @@
 # of this package
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     # Get number of nodes
     my $nodes = get_required_var("CLUSTER_NODES");
 
@@ -44,8 +42,7 @@ sub run {
     barrier_wait('MUNGE_DONE');
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('munge');
 }

--- a/tests/hpc/munge_master.pm
+++ b/tests/hpc/munge_master.pm
@@ -5,11 +5,9 @@
 
 # Summary: Installation of munge package from HPC module and sanity check
 # of this package
-# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>, soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/munge_slave.pm
+++ b/tests/hpc/munge_slave.pm
@@ -7,14 +7,12 @@
 # of this package
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     # install munge, wait for master and munge key
     zypper_call('in munge');
     barrier_wait('MUNGE_INSTALLATION_FINISHED');
@@ -28,8 +26,7 @@ sub run {
     barrier_wait('MUNGE_DONE');
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('munge');
 }

--- a/tests/hpc/munge_slave.pm
+++ b/tests/hpc/munge_slave.pm
@@ -5,11 +5,9 @@
 
 # Summary: Installation of munge package from HPC module and sanity check
 # of this package
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/pdsh_master.pm
+++ b/tests/hpc/pdsh_master.pm
@@ -9,14 +9,12 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321714
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     # Get number of nodes
     my $nodes = get_required_var("CLUSTER_NODES");
 
@@ -40,12 +38,11 @@ sub run {
     barrier_wait("PDSH_SLAVE_DONE");
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('mrshd');
     $self->upload_service_log('munge');

--- a/tests/hpc/pdsh_master.pm
+++ b/tests/hpc/pdsh_master.pm
@@ -6,12 +6,10 @@
 # Summary: HPC_Module: pdsh master
 #    This test is setting up a pdsh scenario according to the testcase
 #    described in FATE
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321714
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/pdsh_slave.pm
+++ b/tests/hpc/pdsh_slave.pm
@@ -9,13 +9,12 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321714
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $server_hostname = get_required_var("PDSH_MASTER_HOSTNAME");
 
     my $packages_to_install = 'munge pdsh';
@@ -41,12 +40,11 @@ sub run {
     barrier_wait("PDSH_SLAVE_DONE");
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     upload_logs '/tmp/pdsh.log';
     $self->upload_service_log('munge');

--- a/tests/hpc/pdsh_slave.pm
+++ b/tests/hpc/pdsh_slave.pm
@@ -6,12 +6,10 @@
 # Summary: HPC_Module: pdsh slave
 #    This test is setting up a pdsh scenario according to the testcase
 #    described in FATE
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321714
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/post_migration.pm
+++ b/tests/hpc/post_migration.pm
@@ -10,13 +10,12 @@
 #    already installed on the HPC cluster.
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $nodes = get_required_var("CLUSTER_NODES");
 
     record_info('Post migration tests');
@@ -31,8 +30,7 @@ sub test_flags {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/post_migration.pm
+++ b/tests/hpc/post_migration.pm
@@ -8,11 +8,9 @@
 #    HPC system. As such this module is not taking care of installing
 #    any components, as it is assumed that those components have been
 #    already installed on the HPC cluster.
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/powerman.pm
+++ b/tests/hpc/powerman.pm
@@ -9,11 +9,9 @@
 #
 #    This tests the powerman package from the HPC module
 #
-# Maintainer: Matthias Griessmeier <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use utils;
 use susedistribution;

--- a/tests/hpc/powerman.pm
+++ b/tests/hpc/powerman.pm
@@ -11,14 +11,12 @@
 #
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use utils;
 use susedistribution;
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     # install powerman
     zypper_call('in powerman');
 
@@ -58,8 +56,7 @@ EOF
     wait_serial(/.*cannot be handled by power control device.*/);
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('powerman');
 }

--- a/tests/hpc/product_migration.pm
+++ b/tests/hpc/product_migration.pm
@@ -4,12 +4,10 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Checking ability to migrate from SLE 12 with HPC module to SLE 12 HPC Product
-# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/326567
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use utils;
 use registration 'add_suseconnect_product';

--- a/tests/hpc/product_migration.pm
+++ b/tests/hpc/product_migration.pm
@@ -7,13 +7,12 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/326567
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use utils;
 use registration 'add_suseconnect_product';
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $suseconnect_str = ' -e testing@suse.com -r ';
     my $version = get_required_var('VERSION');
     ## replace SP-X with 12.X as this form is expected by SUSEConnect

--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -16,12 +16,10 @@
 #   associated database
 # - injected error is correctly recorded
 #
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/318824
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use Utils::Architectures;
 use utils;

--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -19,12 +19,12 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/318824
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use Utils::Architectures;
 use utils;
 
-sub inject_error {
+sub inject_error() {
     # Inject some software errors
     script_run('echo 0x9c00410000080f2b > /sys/kernel/debug/mce-inject/status');
     script_run('echo d5a099a9 > /sys/kernel/debug/mce-inject/addr');
@@ -33,9 +33,7 @@ sub inject_error {
     script_run("echo \"sw\" > /sys/kernel/debug/mce-inject/flags");
 }
 
-sub run {
-    my $self = shift;
-
+sub run ($self) {
     # load kernel module
     assert_script_run('modprobe mce-inject') if (is_x86_64 && check_var('VERSION', '15-SP2'));
 
@@ -86,8 +84,7 @@ sub run {
     ##TODO: try to add error injection for ARM
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->export_logs_basic;
 }

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -8,14 +8,13 @@
 #    that the slurm db accounting can be configured
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base qw(hpcbase hpc::configs);
+use Mojo::Base qw(hpcbase hpc::configs), -signatures;
 use testapi;
 use lockapi;
 use utils;
 use version_utils 'is_sle';
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $hostname = get_required_var("HOSTNAME");
 
     barrier_wait('CLUSTER_PROVISIONED');
@@ -84,12 +83,11 @@ EOF
     barrier_wait("SLURM_MASTER_RUN_TESTS");
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -6,12 +6,9 @@
 # Summary: slurm db node
 #    This tests only ensure the proper db is being set for the HPC cluster, so
 #    that the slurm db accounting can be configured
-# Maintainer: Sebastian Chlad <schlad@suse.de>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use base 'hpc::configs';
-use strict;
-use warnings;
+use Mojo::Base qw(hpcbase hpc::configs);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -6,10 +6,9 @@
 # Summary: Slurm master node
 #    This test is setting up slurm master node and runs tests depending
 #    on the slurm cluster configuration
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>, Yiannis Bonatakis <ybonatakis@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase';
-use base 'hpc::configs';
+use Mojo::Base qw(hpcbase hpc::configs);
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -8,16 +8,14 @@
 #    on the slurm cluster configuration
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base qw(hpcbase hpc::configs);
+use Mojo::Base qw(hpcbase hpc::configs), -signatures;
 use testapi;
 use lockapi;
 use utils;
 use version_utils 'is_sle';
 
 ## TODO: provide better parser for HPC specific tests
-sub validate_result {
-    my ($result) = @_;
-
+sub validate_result ($result) {
     if ($result == 0) {
         return 'PASS';
     } elsif ($result == 1) {
@@ -27,9 +25,7 @@ sub validate_result {
     }
 }
 
-sub generate_results {
-    my ($name, $description, $result) = @_;
-
+sub generate_results ($name, $description, $result) {
     my %results = (
         test => $name,
         description => $description,
@@ -38,8 +34,7 @@ sub generate_results {
     return %results;
 }
 
-sub pars_results {
-    my (@test) = @_;
+sub pars_results (@test) {
     my $file = 'tmpresults.xml';
 
     # check if there are some single test failing
@@ -71,9 +66,7 @@ sub pars_results {
     }
 }
 
-sub run_tests {
-    my ($slurm_conf) = @_;
-
+sub run_tests ($slurm_conf) {
     my $file = 'tmpresults.xml';
     assert_script_run("touch $file");
 
@@ -102,7 +95,7 @@ sub run_tests {
 ## Basic tests: for HPC/slurm cluster ##
 ## 1 master node, 2+ slave nodes      ##
 ########################################
-sub run_basic_tests {
+sub run_basic_tests() {
     my @all_results;
 
     my %test00 = t00_version_check();
@@ -137,7 +130,7 @@ sub run_basic_tests {
     return @all_results;
 }
 
-sub t00_version_check {
+sub t00_version_check() {
     my $description = 'Simple SINFO version print for ease of checking';
 
     my $result = script_output('sinfo --version');
@@ -147,7 +140,7 @@ sub t00_version_check {
     return %results;
 }
 
-sub t01_basic {
+sub t01_basic() {
     my $name = 'Srun check: -w';
     my $description = 'Basic SRUN test with -w option';
 
@@ -157,7 +150,7 @@ sub t01_basic {
     return %results;
 }
 
-sub t02_basic {
+sub t02_basic() {
     my $name = 'Sinfo check';
     my $description = 'Simple SINFO test';
 
@@ -169,7 +162,7 @@ sub t02_basic {
     return %results;
 }
 
-sub t03_basic {
+sub t03_basic() {
     my $name = 'Sbatch test';
     my $description = 'Basic SBATCH test';
     my $sbatch = 'slurm_sbatch.sh';
@@ -188,7 +181,7 @@ sub t03_basic {
     return %results;
 }
 
-sub t04_basic {
+sub t04_basic() {
     my $name = 'Slurm-torque test';
     my $description = 'Basic slurm-torque test. https://fate.suse.com/323998';
     my $pbs = 'slurm_pbs.sh';
@@ -208,7 +201,7 @@ sub t04_basic {
     return %results;
 }
 
-sub t05_basic {
+sub t05_basic() {
     my $name = 'PMIx Support in SLURM';
     my $description = 'Basic check if pmix is present. https://jira.suse.com/browse/SLE-10802';
     my $result = 0;
@@ -221,7 +214,7 @@ sub t05_basic {
     return %results;
 }
 
-sub t06_basic {
+sub t06_basic() {
     my $name = 'Srun check: -N -n';
     my $description = 'Basic SRUN test with -N and -n option';
     my $cluster_nodes = get_required_var('CLUSTER_NODES');
@@ -232,7 +225,7 @@ sub t06_basic {
     return %results;
 }
 
-sub t07_basic {
+sub t07_basic() {
     my $name = 'Srun check: -w';
     my $description = 'Basic SRUN test with -w option on multiple nodes';
     my $cluster_nodes = get_required_var('CLUSTER_NODES');
@@ -244,7 +237,7 @@ sub t07_basic {
     return %results;
 }
 
-sub t08_basic {
+sub t08_basic() {
     my $name = 'pdsh-slurm';
     my $description = 'Basic check of pdsh-slurm over ssh';
     my $result = 0;
@@ -270,7 +263,7 @@ sub t08_basic {
 ## Accounting tests: for HPC/slurm cluster ##
 #############################################
 
-sub run_accounting_tests {
+sub run_accounting_tests() {
     my @all_results;
 
     my %test01 = t01_accounting();
@@ -279,7 +272,7 @@ sub run_accounting_tests {
     return @all_results;
 }
 
-sub t01_accounting {
+sub t01_accounting() {
     my $name = 'Slurm accounting';
     my $description = 'Basic check for slurm accounting cmd';
     my $result = 0;
@@ -359,7 +352,7 @@ sub t01_accounting {
 ## HA tests: for HPC/slurm cluster ##
 #####################################
 
-sub run_ha_tests {
+sub run_ha_tests() {
     my @all_results;
 
     my %test01 = t01_ha();
@@ -371,7 +364,7 @@ sub run_ha_tests {
     return @all_results;
 }
 
-sub t01_ha {
+sub t01_ha() {
     my $name = 'scontrol: slurm ctl fail-over';
     my $description = 'HPC cluster with 2 slurm ctls where one is taking over gracefully';
     my $cluster_nodes = get_required_var('CLUSTER_NODES');
@@ -397,7 +390,7 @@ sub t01_ha {
     return %results;
 }
 
-sub t02_ha {
+sub t02_ha() {
     my $name = 'kill: Slurm ctl fail-over';
     my $description = 'HPC cluster with 2 slurm ctls where one is killed';
     my $cluster_nodes = get_required_var('CLUSTER_NODES');
@@ -431,7 +424,7 @@ sub t02_ha {
 ## Accounting and HA: for HPC/slurm cluster ####
 ################################################
 
-sub run_accounting_ha_tests {
+sub run_accounting_ha_tests() {
     my @all_results;
 
     ##TODO
@@ -444,9 +437,7 @@ sub run_accounting_ha_tests {
 ##          Meant as fast moving tests                ##
 ########################################################
 
-sub extended_hpc_tests {
-    my ($master_ip, $slave_ip) = @_;
-
+sub extended_hpc_tests ($master_ip, $slave_ip) {
     # do all test preparations and setup
     zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);
     # https://progress.opensuse.org/issues/107395 include twopence post scripts error code
@@ -460,8 +451,7 @@ sub extended_hpc_tests {
     parse_extra_log('XUnit', './results/TEST-hpc-test.xml');
 }
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $nodes = get_required_var('CLUSTER_NODES');
     my $slurm_conf = get_required_var('SLURM_CONF');
     my $version = get_required_var('VERSION');
@@ -529,12 +519,11 @@ sub run {
     barrier_wait('SLURM_MASTER_RUN_TESTS');
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -6,13 +6,12 @@
 # Summary: slurm cluster initialization
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $nodes = get_required_var("CLUSTER_NODES");
 
     barrier_wait('CLUSTER_PROVISIONED');
@@ -44,12 +43,11 @@ sub run {
     barrier_wait("SLURM_MASTER_RUN_TESTS");
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -4,11 +4,9 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: slurm cluster initialization
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -6,11 +6,9 @@
 # Summary: Slurm accounting - database
 #    This test is setting up slurm control backup node with accounting
 #    configured (database)
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo:Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -8,13 +8,12 @@
 #    configured (database)
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo:Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $nodes = get_required_var("CLUSTER_NODES");
 
     barrier_wait('CLUSTER_PROVISIONED');
@@ -42,12 +41,11 @@ sub run {
     barrier_wait('SLURM_MASTER_RUN_TESTS');
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -8,14 +8,13 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/316379, https://progress.opensuse.org/issues/20308
 
-use Mojo::Base 'hpcbase';
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;
 use version_utils 'is_sle';
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     $self->prepare_user_and_group();
 
     # Install slurm
@@ -44,12 +43,11 @@ sub run {
     barrier_wait("SLURM_MASTER_RUN_TESTS");
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
+sub post_fail_hook ($self) {
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -5,12 +5,10 @@
 
 # Summary: HPC_Module: slurm slave
 #    This test is setting up a slurm slave and tests if the daemon can start
-# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/316379, https://progress.opensuse.org/issues/20308
 
-use base 'hpcbase';
-use strict;
-use warnings;
+use Mojo::Base 'hpcbase';
 use testapi;
 use lockapi;
 use utils;


### PR DESCRIPTION
- Use of Mojo::Base https://docs.mojolicious.org/Mojo/Base
      strict and warnings are inherited by this Class
- Use kernel maillist for maintainer                                                                                                                                                                                                 
                                                                                                                                                                                                                                             
With this PR all the HPC modules introduce the `signatures` flag which is                                                                                                                                                                    
supported by `Mojo::Base`. The signature declares lexical variables that are                                                                                                                                                                 
in scope for the block                                                                                                                                                                                                                       
and every subroutine invocation, first is checked for its signature.


- Related ticket: https://progress.opensuse.org/issues/xyz
- Verification run: 
https://openqa.suse.de/tests/8266698
https://openqa.suse.de/tests/8266713#dependencies