### PR TITLE
opensusebasetest: Fix call of upload_coredump

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1308,7 +1308,7 @@ errors during logs collection will be ignored, which is usefull for the
 post_fail_hook calls.
 =cut
 sub upload_coredumps {
-    my (%args) = @_;
+    my ($self, %args) = @_;
     my $res = script_run("coredumpctl --no-pager", timeout => 10);
     if (!$res) {
         record_info("COREDUMPS found", "we found coredumps on SUT, attemp to upload");

--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -58,7 +58,7 @@ sub post_fail_hook {
         }
         else {
             #host online upgrade
-            opensusebasetest::upload_coredumps;
+            $self->upload_coredumps;
             save_screenshot;
 
             virt_utils::collect_host_and_guest_logs;


### PR DESCRIPTION
`opensusebasetest::upload_coredump()` is mostly called as method.
But if it is called so, e.g.:
```
$self->upload_coredump(proceed_on_failure => 1);
```
the `$self` is passed as first argument and we get the warning:
```
Odd number of elements in hash assignment at /var/lib/openqa/pool/4/os-autoinst-distri-opensuse/lib/opensusebasetest.pm line 1311.
```
This run show the error: http://openqa-3.wicked.suse.de/tests/76296/logfile?filename=autoinst-log.txt

- Verification run:   http://openqa-3.wicked.suse.de/tests/76304/logfile?filename=autoinst-log.txt (still failing, but the warning is gone)
