### PR TITLE
Fix race condition in open_ssh_port

### DIFF
--- a/lib/Installation/InstallationSettings/InstallationSettingsController.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsController.pm
@@ -28,27 +28,14 @@ sub init {
 
 sub get_installation_settings_page {
     my ($self) = @_;
-    die "Installation Settings Page is not displayed" unless $self->{InstallationSettingsPage}->is_shown();
     die "Overview content on Installation Settings Page is not loaded completely" unless $self->{InstallationSettingsPage}->is_loaded_completely();
     return $self->{InstallationSettingsPage};
-}
-
-sub wait_for_overview_content_to_be_loaded {
-    my ($self) = @_;
-    YuiRestClient::Wait::wait_until(object => sub {
-            my $overview_content = $self->get_installation_settings_page()->get_overview_content();
-            return ($overview_content =~ m/SSH port will be/);
-    }, timeout => 60, message => "Overview content is not loaded.");
-}
-
-sub enable_ssh_service {
-    my ($self) = @_;
-    $self->get_installation_settings_page()->enable_ssh_service();
 }
 
 sub open_ssh_port {
     my ($self) = @_;
     $self->get_installation_settings_page()->open_ssh_port();
+    $self->get_installation_settings_page()->is_ssh_port_open();
 }
 
 sub access_booting_options {

--- a/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
@@ -32,18 +32,15 @@ sub get_overview_content {
     return $self->{rct_overview}->text();
 }
 
-sub enable_ssh_service {
-    my ($self) = @_;
-    YuiRestClient::Wait::wait_until(object => sub {
-            $self->{rct_overview}->activate_link('security--enable_sshd');
-            return $self->is_ssh_service_enabled;
-    }, message => "'SSH service will be enabled' message is not shown, though SSH service is expected to be enabled.");
-}
-
 sub is_ssh_service_enabled {
     my ($self) = @_;
     my $overview_content = $self->get_overview_content();
     return ($overview_content =~ m/SSH service will be enabled/);
+}
+
+sub open_ssh_port {
+    my ($self) = @_;
+    $self->{rct_overview}->activate_link('security--open_ssh');
 }
 
 sub is_ssh_port_open {
@@ -67,14 +64,6 @@ sub is_loaded_completely {
         }, timeout => 60, message => "Overview content is not loaded.");
     };
     $result ? 1 : 0;
-}
-
-sub open_ssh_port {
-    my ($self) = @_;
-    YuiRestClient::Wait::wait_until(object => sub {
-            $self->{rct_overview}->activate_link('security--open_ssh');
-            return $self->is_ssh_port_open;
-    }, message => "'SSH port will be open' message is not shown, though SSH port is expected to be opened.");
 }
 
 sub access_booting_options {


### PR DESCRIPTION
We verified that the port is open before it's actually opened in some
cases (hyperv). This fixes it. 
Also now takes screenshots in overview page.

Ticket: https://progress.opensuse.org/issues/104226
VR: https://openqa.suse.de/tests/overview?build=JRivrain/os-autoinst-distri-opensuse%2314419