### PR TITLE
Containers: validate output zypper lr with retries

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -205,10 +205,11 @@ sub test_zypper_on_container {
     # Check for bsc#1192941, which affects the docker runtime only - this is just check not softfailure as this won't be fixed.
     # bsc#1192941 states that the entrypoint of a derived image is set in a way, that program arguments are not passed anymore
     # we run 'zypper ls' on a container, and if we detect the zypper usage message, we know that the 'ls' parameter was ignored
-    if ($runtime->runtime eq 'docker' && script_run("docker run --rm -ti $image zypper ls | grep 'Usage:'", timeout => 270) == 0) {
-        record_info('bsc#1192941', 'bsc#1192941 - zypper-docker entrypoint confuses program arguments');
+    if ($runtime->runtime eq 'docker') {
+        my $zypper_output = script_output_retry("docker run --rm -ti $image zypper ls", timeout => 270, delay => 60, retry => 3);
+        record_info('bsc#1192941', 'bsc#1192941 - zypper-docker entrypoint confuses program arguments') if ($zypper_output =~ /Usage:/);
     }
-    validate_script_output("$runtime run -i --entrypoint '' $image zypper lr -s", sub { m/.*Alias.*Name.*Enabled.*GPG.*Refresh.*Service/ }, timeout => 180);
+    validate_script_output_retry("$runtime run -i --entrypoint '' $image zypper lr -s", sub { m/.*Alias.*Name.*Enabled.*GPG.*Refresh.*Service/ }, timeout => 180);
     assert_script_run("$runtime run -t -d --name 'refreshed' --entrypoint '' $image bash", timeout => 300);
     script_retry("$runtime exec refreshed zypper -nv ref", timeout => 600, retry => 3, delay => 60);
     assert_script_run("$runtime commit refreshed refreshed-image", timeout => 120);

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1655,11 +1655,12 @@ sub script_output_retry {
     my $timeout = $args{timeout} // 30;
     my $die = $args{die} // 1;
 
-    my $exec = "timeout " . ($timeout - 3) . " $cmd";
+    my $exec = "timeout --foreground " . ($timeout - 3) . " $cmd";
     for (1 .. $retry) {
         my $ret = eval { script_output($exec, timeout => $timeout, proceed_on_failure => 0); };
         return $ret if ($ret);
         sleep $delay;
+        record_info('Retry', 'script_output failed, retrying.');
     }
     die("Waiting for Godot: $cmd") if $die;
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/107062#note-26
- Failing test: https://openqa.suse.de/tests/8262854#step/image_docker/921
- Verification run: http://openqa.suse.de/t8268078  http://openqa.suse.de/t8268079
