### PR TITLE
To make sure the firefox menu can show up

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -23,8 +23,8 @@ sub run() {
 
     $self->start_firefox;
     wait_still_screen;
-    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt', 4, 10);
-    send_key('h');
+    send_key('alt');
+    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt-h', 5, 10);
     wait_still_screen;
     assert_screen('firefox-help-menu');
     send_key_until_needlematch('test-firefox-3', 'a', 9, 6);


### PR DESCRIPTION
To make sure the firefox menu can show up

- Related ticket: https://progress.opensuse.org/issues/103533
- Verification run: 
http://openqa.suse.de/t8262402
http://openqa.suse.de/tests/8270332#step/firefox/10
opensuse: https://openqa.opensuse.org/tests/2230818#
