### PR TITLE
Remove conflicting suggestion in coding style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,6 @@ and additionally the following rules:
 * The test code should use simple perl statements, not overly hacky
   approaches, to encourage contributions by newcomers and test writers which
   are not programmers or perl experts
-* Update the copyright information with the current year and *SUSE LLC* as the
-  legal entity. For new files make sure to only state the year during which
-  the code was written.
 * Use `my ($self) = @_;` for parameter parsing in methods when accessing the
   `$self` object. Do not parse any parameter if you do not need any.
 * [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself)


### PR DESCRIPTION
Remove the bullet which conflicting with the proposal in L49.
L49 suggests that copyright update is not required with year
L58(removed) suggests update of the year

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

