### PR TITLE
Revert "Disable rootless podman workaround for cgrous v2 in 15-SP3"

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -33,7 +33,7 @@ sub run {
     $self->select_serial_terminal;
 
     # Prepare for Podman 3.4.4 and CGroups v2
-    if (is_sle('15-SP4+') || is_leap('15.4+')) {
+    if (is_sle('15-SP3+') || is_leap('15.4+')) {
         record_info 'cgroup v2', 'Switching to cgroup v2';
         assert_script_run "usermod -a -G systemd-journal $testapi::username";
         if (is_transactional) {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#14423

podman update is already public and this configuration is needed.