### PR TITLE
Expect journalctl's output in stderr

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -156,7 +156,7 @@ sub run {
             assert_script_run "rpm -q --conflicts systemd-logger | tee -a /dev/$serialdev | grep syslog";
         }
     } else {
-        validate_script_output('journalctl --no-pager --boot=-1', qr/no persistent journal was found/i) unless is_sle('<15');
+        validate_script_output('journalctl --no-pager --boot=-1 2>&1', qr/no persistent journal was found/i) unless is_sle('<15');
         assert_script_run "mkdir -p ${\ PERSISTENT_LOG_DIR }";
         assert_script_run "systemd-tmpfiles --create --prefix ${\ PERSISTENT_LOG_DIR }";
         # test for installed rsyslog and for imuxsock existance


### PR DESCRIPTION
Follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14386 as jobs with `VIRTIO_CONSOLE=0`
are failing e.g. [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220304-1-jeos-extratest@svirt-xen-hvm](https://openqa.suse.de/tests/8268615#step/journalctl/10)

- Verification runs: 
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220304-1-jeos-extratest@uefi-virtio-vga](http://kepler.suse.cz/tests/14327#step/journalctl/35)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220304-1-jeos-extratest@uefi-virtio-vga - tty](http://kepler.suse.cz/tests/14326#step/journalctl/16)
  * [hvm](http://kepler.suse.cz/tests/14325#step/journalctl/16)
  * [vmware](http://kepler.suse.cz/tests/14329#step/journalctl/10)
  * [sle-15-SP4-JeOS-for-MS-HyperV-x86_64-Build1.20-jeos-extratest@svirt-hyperv-uefi](http://kepler.suse.cz/tests/14332#step/journalctl/11)
