### PR TITLE
Add live patching repo on 12-SP3 due to kgraft

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -24,6 +24,7 @@ use List::Util qw(first pairmap uniq notall);
 use qam;
 use maintenance_smelt qw(get_packagebins_in_modules get_incident_packages);
 use testapi;
+use version_utils qw(is_sle);
 
 sub has_conflict {
     my $binary = shift;
@@ -88,6 +89,7 @@ sub run {
     $self->select_serial_terminal;
 
     zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);
+    zypper_call("ar -f http://dist.suse.de/ibs/SUSE/Updates/SLE-Live-Patching/12-SP3/" . get_var('ARCH') . "/update/ sle-module-live-patching:12-SP3::update") if is_sle('=12-SP3');
 
     # Get packages affected by the incident.
     my @packages = get_incident_packages($incident_id);


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/8281292#step/update_install/61 https://suse.slack.com/archives/C02CBB35W5B/p1643895398501289
- Verification run: https://openqa.suse.de/tests/overview?build=%3A23157%3Akernel-ec2&flavor=Server-DVD-Incidents-Install