### PR TITLE
Revert "To make sure the firefox menu can show up"

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -23,8 +23,8 @@ sub run() {
 
     $self->start_firefox;
     wait_still_screen;
-    send_key('alt');
-    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt-h', 5, 10);
+    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt', 4, 10);
+    send_key('h');
     wait_still_screen;
     assert_screen('firefox-help-menu');
     send_key_until_needlematch('test-firefox-3', 'a', 9, 6);


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#14421

Seems to have made the situation rather worse than better (failing in scenarios that used to be stable before)