### PR TITLE
Refactor get_container_test_image

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -21,6 +21,7 @@ use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_microos is_sle_
 our @EXPORT = qw(
   get_opensuse_registry_prefix
   get_urls_from_var
+  get_container_test_image
   get_suse_container_urls
   get_3rd_party_images
 );
@@ -329,6 +330,16 @@ sub get_3rd_party_images {
     ) unless (is_aarch64 || check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
 
     return (\@images);
+}
+
+# Get the container image under test defined either in CONTAINER_IMAGE_TO_TEST or the default container for the currently running SLES version
+sub get_container_test_image {
+    my $image = get_var('CONTAINER_IMAGE_TO_TEST', '');
+    return $image if (defined $image && $image ne '');
+
+    # If not defined return the first entry of the default list
+    my ($untested_images, $released_images) = get_suse_container_urls();
+    return $untested_images->[0];
 }
 
 1;

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -29,7 +29,7 @@ sub run {
     for my $version (split(/,/, $versions)) {
         my $images_to_test;
         # Get list of images from CONTAINER_IMAGES_TO_TEST or use the default
-        unless ($images_to_test = get_urls_from_var('CONTAINER_IMAGES_TO_TEST')) {
+        unless ($images_to_test = get_urls_from_var('CONTAINER_IMAGE_TO_TEST')) {
             my ($untested_images, $released_images) = get_suse_container_urls(version => $version);
             $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
         }

--- a/tests/containers/push_container_image_to_acr.pm
+++ b/tests/containers/push_container_image_to_acr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls qw(get_suse_container_urls get_urls_from_var);
+use containers::urls qw(get_suse_container_urls get_container_test_image);
 
 sub run {
     my ($self, $args) = @_;
@@ -18,14 +18,8 @@ sub run {
 
     my $provider = $self->provider_factory(service => 'ACR');
 
-    my $image;
-    unless ($image = get_urls_from_var('CONTAINER_IMAGES_TO_TEST')->[0]) {
-        # Get list of images from CONTAINER_IMAGES_TO_TEST or use the default
-        my ($untested_images, $released_images) = get_suse_container_urls();
-        $image = $untested_images->[0];
-    }
+    my $image = get_container_test_image();
     my $tag = $provider->get_default_tag();
-
     record_info('Pull', "Pulling $image");
     assert_script_run("podman pull $image", 360);
 
@@ -34,8 +28,7 @@ sub run {
     record_info('Img version', $image_build);
 
     my $image_name = $provider->push_container_image($image, $tag);
-    record_info('Registry',
-        "Image successfully uploaded to ACR:\n$image_name\n" . script_output("podman inspect $image_name"));
+    record_info('Registry', "Image successfully uploaded to ACR:\n$image_name\n" . script_output("podman inspect $image_name"));
 }
 
 sub post_fail_hook {

--- a/tests/containers/push_container_image_to_ecr.pm
+++ b/tests/containers/push_container_image_to_ecr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls qw(get_suse_container_urls get_urls_from_var);
+use containers::urls qw(get_suse_container_urls get_container_test_image);
 
 sub run {
     my ($self, $args) = @_;
@@ -19,15 +19,9 @@ sub run {
     my $provider = $self->provider_factory(service => 'ECR');
     $self->{provider} = $provider;
 
-    my $image;
-    unless ($image = get_urls_from_var('CONTAINER_IMAGES_TO_TEST')->[0]) {
-        # Get list of images from CONTAINER_IMAGES_TO_TEST or use the default
-        my ($untested_images, $released_images) = get_suse_container_urls();
-        $image = $untested_images->[0];
-    }
+    my $image = get_container_test_image();
     my $tag = $provider->get_default_tag();
     $self->{tag} = $tag;
-
     record_info('Pull', "Pulling $image");
     assert_script_run("podman pull $image", 360);
 

--- a/tests/containers/push_container_image_to_gcr.pm
+++ b/tests/containers/push_container_image_to_gcr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls qw(get_suse_container_urls get_urls_from_var);
+use containers::urls qw(get_suse_container_urls get_container_test_image);
 
 sub run {
     my ($self, $args) = @_;
@@ -18,14 +18,9 @@ sub run {
 
     my $provider = $self->provider_factory(service => 'GCR');
 
-    my $image;
-    unless ($image = get_urls_from_var('CONTAINER_IMAGES_TO_TEST')->[0]) {
-        # Get list of images from CONTAINER_IMAGES_TO_TEST or use the default
-        my ($untested_images, $released_images) = get_suse_container_urls();
-        $image = $untested_images->[0];
-    }
-    my $tag = $provider->get_default_tag();
 
+    my $image = get_container_test_image();
+    my $tag = $provider->get_default_tag();
     record_info('Pull', "Pulling $image");
     assert_script_run("podman pull $image", 360);
 
@@ -34,8 +29,7 @@ sub run {
     record_info('Img version', $image_build);
 
     my $image_name = $provider->push_container_image($image, $tag);
-    record_info('Registry',
-        "Image successfully uploaded to GCR:\n$image_name\n" . script_output("podman inspect $image_name"));
+    record_info('Registry', "Image successfully uploaded to GCR:\n$image_name\n" . script_output("podman inspect $image_name"));
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Remove duplicate handling of getting the container test images and
create a library function for this. In addition this renames the used variable to
`CONTAINER_IMAGE_TO_TEST` and changes the behaviour to assuming a single
image to be tested.

- Related ticket: https://progress.opensuse.org/issues/107776
- Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14400
- Verification run: [AKS](http://duck-norris.qam.suse.de/tests/8342) | [EKS](http://duck-norris.qam.suse.de/tests/8337) | [podman](https://openqa.suse.de/tests/8286612)
