### PR TITLE
Fix xrdp_server failure on GNOME41

### DIFF
--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -96,10 +96,15 @@ sub run {
         # Force restart on gdm to check if the active session number is correct
         assert_and_click "status-bar";
         assert_and_click "power-button";
-        assert_screen([qw(other-users-logged-in-1user other-users-logged-in-2users)]);
+        if (is_sle('>=15-SP4')) {
+            assert_and_click('reboot-click-restart');
+        }
 
-        if (match_has_tag('other-users-logged-in-2users')) {
-            record_soft_failure 'bsc#1116281 GDM didnt behave correctly when the error message Multiple logins are not supported. is triggered';
+        else {
+            assert_screen([qw(other-users-logged-in-1user other-users-logged-in-2users)]);
+            if (match_has_tag('other-users-logged-in-2users')) {
+                record_soft_failure 'bsc#1116281 GDM didnt behave correctly when the error message Multiple logins are not supported. is triggered';
+            }
         }
 
         assert_and_click "force-restart";


### PR DESCRIPTION
The behavior of "restart" on GNOME40+ is different from previous
We need to handle them separately. 

- Related ticket: https://progress.opensuse.org/issues/107305
- Needles: N/A
- Verification run: 
- https://openqa.suse.de/tests/8286827#details
