### PR TITLE
Make sure the firefox menu can show up

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -23,8 +23,9 @@ sub run() {
 
     $self->start_firefox;
     wait_still_screen;
-    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt', 4, 10);
-    send_key('h');
+    send_key('alt');
+    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt-h', 4, 10);
+    send_key('alt-h');
     wait_still_screen;
     assert_screen('firefox-help-menu');
     send_key_until_needlematch('test-firefox-3', 'a', 9, 6);


### PR DESCRIPTION
Make sure the firefox menu can show up. Before update the code,
Checked https://openqa.opensuse.org/tests/2245717#next_previous.
From firefox first failed case, there are 2/19 test cases failed.
Run the case with this PR, for sle cases, this problem cannot
reproduce again. For TW cases, run 100 cases, all of them can
pass. According those data, I think this PR can fix the menu
cannot show up problem.

- Related ticket: https://progress.opensuse.org/issues/103533
- Verification run: 
opensuse:https://openqa.opensuse.org/t2232952
https://openqa.opensuse.org/t2232953
https://openqa.opensuse.org/t2232954
https://openqa.opensuse.org/t2232955
https://openqa.opensuse.org/t2232956
https://openqa.opensuse.org/t2232957
https://openqa.opensuse.org/t2232958
https://openqa.opensuse.org/t2232959
https://openqa.opensuse.org/t2232960
https://openqa.opensuse.org/t2232961
sles:
http://openqa.suse.de/tests/8286759
http://openqa.suse.de/tests/8286755
