### PR TITLE
Exclude nginx from consoletest for SLED

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1252,7 +1252,7 @@ sub load_consoletests {
     if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && is_sle('<15') && !get_var("MEDIA_UPGRADE")) {
         loadtest "feature/feature_console/deregister";
     }
-    loadtest "console/nginx" if ((is_opensuse && !is_staging) || is_sle('15+'));
+    loadtest "console/nginx" if ((is_opensuse && !is_staging) || (is_sle('15+') && !is_desktop));
     loadtest 'console/orphaned_packages_check' if is_jeos || get_var('UPGRADE') || get_var('ZDUP') || !is_sle('<12-SP4');
     loadtest "console/consoletest_finish";
 }


### PR DESCRIPTION
need to unschedule nginx from SLED. It should not be tested on SLED at all.
see https://progress.opensuse.org/issues/106673
verification run:
http://10.162.30.85/tests/4621 (SLES consoletests with nginx)
http://10.162.30.85/tests/4620 (SLED consoletests without nginx)
