### PR TITLE
Fix mrsh_master from typo in the signature of Mojo::Base

### DIFF
--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -9,7 +9,7 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 # Tags: https://fate.suse.com/321722
 
-use Mojo::Base 'hpcbase' -signatures;
+use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use lockapi;
 use utils;


### PR DESCRIPTION
The signature of the `Mojo::Base` needs a comma before the `-signatures` flag.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


