### PR TITLE
K8s test uses CONTAINER_IMAGES_TO_TEST variable

### DIFF
--- a/tests/containers/run_container_in_k8s.pm
+++ b/tests/containers/run_container_in_k8s.pm
@@ -20,7 +20,7 @@ sub run {
 
     my $cmd = '"cat", "/etc/os-release"';
 
-    my $image_tag = $self->{provider}->get_default_tag();
+    my $image_tag = get_var("CONTAINER_IMAGES_TO_TEST") // $self->{provider}->get_default_tag();
     $self->{image_tag} = $image_tag;
 
     my $image = $self->{provider}->get_container_image_full_name($image_tag);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/107776
- Verification run: 
- http://copland.arch.suse.de/tests/1013 (without variable)
- http://copland.arch.suse.de/tests/1015 (with variable)