### PR TITLE
Adapt `mm_network::setup_static_mm_network()` for Network Manager

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -9,7 +9,7 @@ use Exporter;
 use testapi;
 use version_utils 'is_opensuse';
 
-our @EXPORT = qw(configure_hostname get_host_resolv_conf
+our @EXPORT = qw(configure_hostname get_host_resolv_conf is_networkmanager
   configure_static_ip configure_dhcp configure_default_gateway configure_static_dns
   parse_network_configuration ip_in_subnet check_ip_in_subnet setup_static_mm_network);
 
@@ -41,19 +41,45 @@ sub get_host_resolv_conf {
     return \%conf;
 }
 
-sub configure_static_ip {
-    my ($ip, $mtu) = @_;
-    my $net_conf = parse_network_configuration();
-    my $mac = $net_conf->{fixed}->{mac};
-    $mtu //= 1458;
-    script_run "NIC=`grep $mac /sys/class/net/*/address |cut -d / -f 5`";
-    assert_script_run "echo \$NIC";
-    my ($ip_no_mask, $mask) = split('/', $ip);
-    script_run "arping -w 1 -I \$NIC $ip_no_mask";    # check for duplicate IP
+sub is_networkmanager {
+    return (script_run('readlink /etc/systemd/system/network.service | grep NetworkManager') == 0);
+}
 
-    assert_script_run "echo -e \"STARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'\\nMTU='$mtu'\" > /etc/sysconfig/network/ifcfg-\$NIC";
+sub configure_static_ip {
+    my ($ip, $is_nm, $mtu) = @_;
+    $is_nm //= is_networkmanager();
+    $mtu //= 1458;
+
+    if ($is_nm) {
+        my $device = script_output('nmcli -t -f DEVICE c');
+        my $nm_id = script_output('nmcli -t -f NAME c');
+
+        assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip4 $ip gw4 10.0.2.2 ipv4.method manual ";
+        assert_script_run "nmcli connection down '$nm_id'";
+        assert_script_run "nmcli connection up '$nm_id'";
+    } else {
+        # Get MAC address
+        my $net_conf = parse_network_configuration();
+        my $mac = $net_conf->{fixed}->{mac};
+
+        # Get default network adapter name
+        script_run "NIC=`grep $mac /sys/class/net/*/address |cut -d / -f 5`";
+        assert_script_run "echo \$NIC";
+
+        # check for duplicate IP
+        my ($ip_no_mask, $mask) = split('/', $ip);
+        script_run "arping -w 1 -I \$NIC $ip_no_mask";
+
+        # Configure the static networking
+        assert_script_run "echo -e \"STARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'\\nMTU='$mtu'\" > /etc/sysconfig/network/ifcfg-\$NIC";
+
+        configure_default_gateway();
+
+        # Restart the networking
+        assert_script_run "rcnetwork restart";
+    }
+
     save_screenshot;
-    assert_script_run "rcnetwork restart";
     assert_script_run "ip addr";
     save_screenshot;
 }
@@ -79,11 +105,24 @@ sub configure_default_gateway {
 }
 
 sub configure_static_dns {
-    my ($conf, $silent) = @_;
+    my ($conf, $is_nm, $silent) = @_;
+    $is_nm //= is_networkmanager();
     $silent //= 0;
+
     my $servers = join(" ", @{$conf->{nameserver}});
-    assert_script_run("sed -i -e 's|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$servers\"|' /etc/sysconfig/network/config");
-    assert_script_run("netconfig -f update");
+
+    if ($is_nm) {
+        my $device = script_output('nmcli -t -f DEVICE c');
+        my $nm_id = script_output('nmcli -t -f NAME c');
+
+        assert_script_run "nmcli connection modify '$nm_id' ipv4.dns '$servers'";
+        assert_script_run "nmcli connection down '$nm_id'";
+        assert_script_run "nmcli connection up '$nm_id'";
+    } else {
+        assert_script_run("sed -i -e 's|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$servers\"|' /etc/sysconfig/network/config");
+        assert_script_run("netconfig -f update");
+    }
+
     assert_script_run("cat /etc/resolv.conf") unless $silent;
 }
 
@@ -173,13 +212,9 @@ sub check_ip_in_subnet {
 
 sub setup_static_mm_network {
     my $ip = shift;
-    if (is_opensuse && !check_var('DESKTOP', 'textmode')) {
-        assert_script_run "systemctl disable NetworkManager --now";
-        assert_script_run "systemctl enable wicked --now";
-    }
-    configure_default_gateway;
-    configure_static_ip($ip);
-    configure_static_dns(get_host_resolv_conf());
+    my $is_nm = is_networkmanager();
+    configure_static_ip($ip, $is_nm);
+    configure_static_dns(get_host_resolv_conf(), $is_nm);
 }
 
 1;

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -12,23 +12,14 @@ use warnings;
 use testapi;
 use lockapi;
 use mm_network 'setup_static_mm_network';
-use utils qw(zypper_call permit_root_ssh);
+use utils qw(zypper_call permit_root_ssh set_hostname);
 use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
 use version_utils qw(is_sle is_opensuse);
-
-sub is_networkmanager {
-    return (script_run('readlink /etc/systemd/system/network.service | grep NetworkManager') == 0);
-}
 
 sub run {
     my ($self) = @_;
     my $hostname = get_var('HOSTNAME');
-    my ($nm_id, $device);
     select_console 'root-console';
-    if (is_networkmanager) {
-        $nm_id = script_output('nmcli -t -f NAME c');
-        $device = script_output('nmcli -t -f DEVICE c');
-    }
 
     # Do not use external DNS for our internal hostnames
     assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');
@@ -41,33 +32,12 @@ sub run {
     # Configure the internal network an  try it
     if ($hostname =~ /server|master/) {
         setup_static_mm_network('10.0.2.101/24');
-
-        if (is_networkmanager) {
-            assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip4 '10.0.2.101/24' gw4 10.0.2.2 ipv4.method manual ";
-            assert_script_run "nmcli connection down '$nm_id'";
-            assert_script_run "nmcli connection up '$nm_id'";
-        }
-        else {
-            assert_script_run 'systemctl restart  wicked';
-        }
-    }
-    else {
+    } else {
         setup_static_mm_network('10.0.2.102/24');
-
-        if (is_networkmanager) {
-            assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip4 '10.0.2.102/24' gw4 10.0.2.2 ipv4.method manual ";
-            assert_script_run "nmcli connection down '$nm_id'";
-            assert_script_run "nmcli connection up '$nm_id'";
-        }
-        else {
-            systemctl("restart wicked");
-        }
     }
 
     # Set the hostname to identify both minions
-    assert_script_run "hostnamectl set-hostname $hostname";
-    assert_script_run "hostnamectl status|grep $hostname";
-    assert_script_run "hostname|grep $hostname";
+    set_hostname $hostname;
 
     # Make sure that PermitRootLogin is set to yes
     # This is needed only when the new SSH config directory exists


### PR DESCRIPTION
Adapt `mm_network::setup_static_mm_network()` for Network Manager

- Tickets: [poo#105295](https://progress.opensuse.org/issues/105295), [bsc#1196606](https://bugzilla.opensuse.org/show_bug.cgi?id=1196606)
- Verification run: [openvpn-client@SLE15-SP3](http://pdostal-server.suse.cz/tests/13806), [wireguard-client@Tumbleweed](http://pdostal-server.suse.cz/tests/13804)
