### PR TITLE
Flush journal when shifting to persistent logs

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -159,6 +159,9 @@ sub run {
         validate_script_output('journalctl --no-pager --boot=-1 2>&1', qr/no persistent journal was found/i) unless is_sle('<15');
         assert_script_run "mkdir -p ${\ PERSISTENT_LOG_DIR }";
         assert_script_run "systemd-tmpfiles --create --prefix ${\ PERSISTENT_LOG_DIR }";
+        # https://bugzilla.suse.com/show_bug.cgi?id=1196637
+        # should be backported to sle15sp3/leap15.3 later
+        assert_script_run 'journalctl --flush' if (is_sle('15-sp4+') || is_leap('15.4+'));
         # test for installed rsyslog and for imuxsock existance
         # rsyslog must be there by design
         assert_script_run 'rpm -q rsyslog';


### PR DESCRIPTION
Flushing the journal to `/var` is an operation that needs to be explicitly
requested by the user. More details can be found in [Bug 1196637 -
[Build 1.20] Initial boot logs are lost after setting persistent journal](https://bugzilla.suse.com/show_bug.cgi?id=1196637)

- Verification runs:
* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220308-1-jeos-extratest@64bit-virtio-vga](http://kepler.suse.cz/tests/14385#step/journalctl/1) 
* [sle-15-SP4-JeOS-for-kvm-and-xen-x86_64-Build1.20-jeos-extratest@uefi-virtio-vga](http://kepler.suse.cz/tests/14386#step/journalctl/31)
* [opensuse-15.4-JeOS-for-kvm-and-xen-x86_64-Build6.6-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/14387#step/journalctl/43)
* [opensuse-15.3-JeOS-for-kvm-and-xen-x86_64-Build9.398-jeos-extra@64bit_virtio-2G](http://kepler.suse.cz/tests/14383#step/journalctl/1)
