### PR TITLE
Add python-pycairo test

### DIFF
--- a/data/python/pycairo_sample.py
+++ b/data/python/pycairo_sample.py
@@ -1,0 +1,18 @@
+import cairo
+
+with cairo.SVGSurface("pycairo_generated.svg", 200, 200) as surface:
+    context = cairo.Context(surface)
+    x, y, x1, y1 = 0.1, 0.5, 0.4, 0.9
+    x2, y2, x3, y3 = 0.6, 0.1, 0.9, 0.5
+    context.scale(200, 200)
+    context.set_line_width(0.04)
+    context.move_to(x, y)
+    context.curve_to(x1, y1, x2, y2, x3, y3)
+    context.stroke()
+    context.set_source_rgba(1, 0.2, 0.2, 0.6)
+    context.set_line_width(0.02)
+    context.move_to(x, y)
+    context.line_to(x1, y1)
+    context.move_to(x2, y2)
+    context.line_to(x3, y3)
+    context.stroke()

--- a/data/python/pycairo_sample.svg
+++ b/data/python/pycairo_sample.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="200pt" height="200pt" viewBox="0 0 200 200" version="1.1">
+<g id="surface1">
+<path style="fill:none;stroke-width:0.04;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-miterlimit:10;" d="M 0.1 0.5 C 0.4 0.9 0.6 0.1 0.9 0.5 " transform="matrix(200,0,0,200,0,0)"/>
+<path style="fill:none;stroke-width:0.02;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%,20%,20%);stroke-opacity:0.6;stroke-miterlimit:10;" d="M 0.1 0.5 L 0.4 0.9 M 0.6 0.1 L 0.9 0.5 " transform="matrix(200,0,0,200,0,0)"/>
+</g>
+</svg>

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -108,6 +108,7 @@ schedule:
     - console/rpm
     - console/slp
     - console/pkcon
+    - console/python_pycairo
     - console/command_not_found
     - console/openssl_alpn
     - console/autoyast_removed

--- a/tests/console/python_pycairo.pm
+++ b/tests/console/python_pycairo.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: python-cairo tests
+# - install python-cairo package
+# - import pycairo script and sample svg file
+# - execute pycairo script and generate svg file
+# - Compare the generated svg file with expected one
+#
+# Maintainer: QE-Core <qe-core@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Make sure pycairo python module is installed
+    zypper_call "in python3 python3-pycairo";
+
+    # Import pycairo script and sample svg file
+    assert_script_run("curl -O " . data_url("python/pycairo_sample.py"));
+    assert_script_run("curl -O " . data_url("python/pycairo_sample.svg"));
+
+    # Execute pycairo script and generate the svg file
+    assert_script_run("python3 pycairo_sample.py");
+
+    # Compare generated svg file with the expected one
+    assert_script_run("diff pycairo_sample.svg pycairo_generated.svg");
+
+    $self->cleanup();
+}
+
+sub post_fail_hook {
+    my $self = shift;
+    upload_logs("pycairo_generated.svg");
+    $self->cleanup();
+    $self->SUPER::post_fail_hook;
+}
+
+sub cleanup {
+    script_run("rm -f pycairo_sample.py pycairo_sample.svg pycairo_generated.svg");
+}
+
+1;


### PR DESCRIPTION
- Generate a svg file by executing a pycairo script
- Compare the generated svg with the expected one

https://progress.opensuse.org/issues/106191

- Related ticket: https://progress.opensuse.org/issues/106191
- Needles: NA
- Verification runs: [TW](https://openqa.opensuse.org/tests/2235285#step/python_pycairo/1), [Leap](https://openqa.opensuse.org/tests/2235286#step/python_pycairo/1), [SLE15-SP4-x86_64](https://openqa.suse.de/tests/8296895#step/python_pycairo/1), [SLE15-SP4-ppc64le](https://openqa.suse.de/tests/8296892#step/python_pycairo/1), [SLE15-SP4-aarch64](https://openqa.suse.de/tests/8296891#step/python_pycairo/1)
