### PR TITLE
[WIP]Repair ssh public key file to avoid invalid format problem

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -23,6 +23,8 @@ sub run {
     my ($self) = @_;
     mouse_hide(1);
     x11_start_program('xterm');
+    # Repair public key to make sure ssh without password works fine
+    enter_cmd("ssh-keygen -f ~/.ssh/id_rsa -y > ~/.ssh/id_rsa.pub");
     enter_cmd("ssh -o StrictHostKeyChecking=no -XC root\@localhost xterm");
     assert_screen "ssh-second-xterm";
     $self->set_standard_prompt();


### PR DESCRIPTION
To make sure the ssh public key file can be used. Sometimes, load
key got invalid format error. We can repair the public key before
load it. In case, the public key cannot be used. Add public RSA 
key to make sure ssh without password works fine

- Related ticket: https://progress.opensuse.org/issues/92332
- Verification run:http://openqa.suse.de/tests/8296533#step/sshxterm/5
  http://openqa.suse.de/tests/8296532#step/sshxterm/4