### PR TITLE
Containers: Fix image URL logic

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -20,7 +20,8 @@ use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_microos is_sle_
 
 our @EXPORT = qw(
   get_opensuse_registry_prefix
-  get_urls_from_var
+  get_container_image_to_test
+  get_container_url_from_var
   get_suse_container_urls
   get_3rd_party_images
 );
@@ -262,12 +263,12 @@ sub supports_image_arch {
     (grep { $_ eq $arch } @{$images_uri{$distri}{$version}{available_arch}}) ? 1 : 0;
 }
 
-# Returns a tuple of image urls.
-# If empty, no images available.
-sub get_urls_from_var {
+# Returns an array with the contents of the given variable or undef, if the var is not set
+sub get_container_url_from_var {
     my $var = shift;
-    my @urls = split(/,/, trim(get_var($var)));
-    return (\@urls);
+    my @urls = (trim(get_var($var)));
+    # Return undef if empty string
+    return ($urls[0]) ? (\@urls) : undef;
 }
 
 # Returns a tuple of image urls and their matching released "stable" counterpart.
@@ -292,6 +293,16 @@ sub get_suse_container_urls {
 
     return (\@untested_images, \@released_images);
 }
+
+# Get single image from CONTAINER_IMAGE_TO_TEST or untested image from get_suse_container_urls()
+sub get_container_image_to_test {
+    my $images_to_test;
+    unless ($images_to_test = get_container_url_from_var('CONTAINER_IMAGE_TO_TEST')) {
+        ($images_to_test, undef) = get_suse_container_urls();
+    }
+    return $images_to_test->[0];
+}
+
 
 sub get_3rd_party_images {
     my $ex_reg = get_var('REGISTRY', 'docker.io');

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -13,7 +13,7 @@ use testapi;
 use utils;
 use containers::common;
 use containers::container_images;
-use containers::urls qw(get_suse_container_urls get_urls_from_var);
+use containers::urls qw(get_suse_container_urls get_container_url_from_var);
 
 sub run {
     my ($self, $args) = @_;
@@ -28,8 +28,8 @@ sub run {
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
     for my $version (split(/,/, $versions)) {
         my $images_to_test;
-        # Get list of images from CONTAINER_IMAGES_TO_TEST or use the default
-        unless ($images_to_test = get_urls_from_var('CONTAINER_IMAGES_TO_TEST')) {
+        # Get array of single image from CONTAINER_IMAGES_TO_TEST or from get_suse_container_urls()
+        unless ($images_to_test = get_container_url_from_var('CONTAINER_IMAGE_TO_TEST')) {
             my ($untested_images, $released_images) = get_suse_container_urls(version => $version);
             $images_to_test = check_var('CONTAINERS_UNTESTED_IMAGES', '1') ? $untested_images : $released_images;
         }

--- a/tests/containers/push_container_image_to_acr.pm
+++ b/tests/containers/push_container_image_to_acr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls qw(get_suse_container_urls get_urls_from_var);
+use containers::urls 'get_container_image_to_test';
 
 sub run {
     my ($self, $args) = @_;
@@ -18,12 +18,7 @@ sub run {
 
     my $provider = $self->provider_factory(service => 'ACR');
 
-    my $image;
-    unless ($image = get_urls_from_var('CONTAINER_IMAGES_TO_TEST')->[0]) {
-        # Get list of images from CONTAINER_IMAGES_TO_TEST or use the default
-        my ($untested_images, $released_images) = get_suse_container_urls();
-        $image = $untested_images->[0];
-    }
+    my $image = get_container_image_to_test();
     my $tag = $provider->get_default_tag();
 
     record_info('Pull', "Pulling $image");

--- a/tests/containers/push_container_image_to_ecr.pm
+++ b/tests/containers/push_container_image_to_ecr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls qw(get_suse_container_urls get_urls_from_var);
+use containers::urls 'get_container_image_to_test';
 
 sub run {
     my ($self, $args) = @_;
@@ -19,12 +19,7 @@ sub run {
     my $provider = $self->provider_factory(service => 'ECR');
     $self->{provider} = $provider;
 
-    my $image;
-    unless ($image = get_urls_from_var('CONTAINER_IMAGES_TO_TEST')->[0]) {
-        # Get list of images from CONTAINER_IMAGES_TO_TEST or use the default
-        my ($untested_images, $released_images) = get_suse_container_urls();
-        $image = $untested_images->[0];
-    }
+    my $image = get_container_image_to_test();
     my $tag = $provider->get_default_tag();
     $self->{tag} = $tag;
 

--- a/tests/containers/push_container_image_to_gcr.pm
+++ b/tests/containers/push_container_image_to_gcr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls qw(get_suse_container_urls get_urls_from_var);
+use containers::urls 'get_container_image_to_test';
 
 sub run {
     my ($self, $args) = @_;
@@ -18,12 +18,7 @@ sub run {
 
     my $provider = $self->provider_factory(service => 'GCR');
 
-    my $image;
-    unless ($image = get_urls_from_var('CONTAINER_IMAGES_TO_TEST')->[0]) {
-        # Get list of images from CONTAINER_IMAGES_TO_TEST or use the default
-        my ($untested_images, $released_images) = get_suse_container_urls();
-        $image = $untested_images->[0];
-    }
+    my $image = get_container_image_to_test();
     my $tag = $provider->get_default_tag();
 
     record_info('Pull', "Pulling $image");

--- a/variables.md
+++ b/variables.md
@@ -199,7 +199,7 @@ RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1
 REBOOT_TIMEOUT | integer | 0 | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
 REGISTRY | string | docker.io | Registry to pull third-party container images from
 CONTAINER_IMAGE_VERSIONS | string | | List of comma-separated versions from `get_suse_container_urls()`
-CONTAINER_IMAGES_TO_TEST | string | | List of comma-separated URLs of a specific container images to test.
+CONTAINER_IMAGE_TO_TEST | string | | Single URL string of a specific container image to test.
 REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.
 REMOTE_REPOINST | boolean | | Use linuxrc features to install OS from specified repository (install) while booting installer from DVD (instsys)
 REPO_* | string | | Url pointing to the mirrored repo. REPO_0 contains installation iso.


### PR DESCRIPTION
 * Rename and fix `containers::urls::get_container_url_from_var()` (previously `get_urls_from_var()`)
 * Rename `CONTAINER_IMAGES_TO_TEST` to `CONTAINER_IMAGE_TO_TEST`
 * Introduce `containers::urls::get_container_url_to_test()`
   * Usable in test modules where only single image is expected.
   * Not usable in `tests/containers/image.pm` where multiple images of various versions are expected.

- Related ticket: [poo#107776](https://progress.opensuse.org/issues/107776)
- Follow-up of: #14400
- Parallel attempt: #14434 
- Verification run: [EKS](http://pdostal-server.suse.cz/tests/13764), [EKS with specified image](http://pdostal-server.suse.cz/tests/13765), [Docker with specified image](http://pdostal-server.suse.cz/tests/13766), [Docker](http://pdostal-server.suse.cz/tests/13767), [Docker with multiple SLE image versions](http://pdostal-server.suse.cz/tests/13753)
