### PR TITLE
Use wait_still_screen with longer wait time

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -80,7 +80,7 @@ sub run {
         assert_screen("inst-packageinstallationstarted", $started_timeout);
     }
     else {
-        sleep 2;    # textmode is sometimes pressing alt-i too early
+        wait_still_screen(3);    # wait so alt-i is pressed when installation overview is not being generated
         send_key $cmd{install};
         if (check_var('FAIL_EXPECTED', 'SMALL-DISK')) {
             assert_screen 'installation-proposal-error';


### PR DESCRIPTION
Often is install button not pressed because alt-i is pressed too soon or
while the button is not ready (Evaluating ...)
e.g.
https://openqa.suse.de/tests/8295190/video?filename=video.ogv
![start_install](https://user-images.githubusercontent.com/9447312/157419828-f9defe48-9019-4b4a-ab5b-32f692e27214.gif)

- https://progress.opensuse.org/issues/99237
- Last few failues:
https://openqa.suse.de/tests/8295190#step/start_install/3
https://openqa.suse.de/tests/8285679#step/start_install/3
- Verification run:
https://openqa.suse.de/tests/8299223
