### PR TITLE
JeOS: help troubleshoot btrfs_autocompletion issues

### DIFF
--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -38,6 +38,7 @@ sub run {
     # On JeOS 'bash-completion' is not expected to be present. On general
     # SLES installation it is. Thus on JeOS we have to enable it manually.
     if (is_jeos) {
+        record_info('ps', script_output('ps -ef'));
         zypper_call('in bash-completion');
         assert_script_run('source $(rpmquery -l bash-completion | grep bash_completion.sh)');
     }
@@ -58,6 +59,7 @@ sub post_fail_hook {
     my ($self) = @_;
     assert_script_run('rpm -qa > /tmp/rpm_qa.txt');
     upload_logs('/tmp/rpm_qa.txt');
+    upload_logs('/var/log/zypper.log');
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
There are some not-so-sporadic issues in this module for JeOS tests
that fail when doing zypper install bash-completion with the error:
System management is locked by the application with pid XYZ...

It's difficult to reproduce the issue as it appears randomly.

Printing the list of processes before running zypper might help
to spot the issue when it happens again.

- Related ticket: https://progress.opensuse.org/issues/108064
- Verification run: https://openqa.suse.de/tests/8297079#step/btrfs_autocompletion/4
