### PR TITLE
Resize yast2 window in order to refresh content

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
@@ -26,7 +26,8 @@ sub select_device_type {
         bond => 'alt-o',
         vlan => 'alt-v'
     };
-    assert_screen(DEVICE_TYPE_DIALOG);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch(DEVICE_TYPE_DIALOG, 'alt-f10', 9, 2);
     send_key $shortcut->{$device};
 }
 

--- a/lib/YaST/NetworkSettings/OverviewTab.pm
+++ b/lib/YaST/NetworkSettings/OverviewTab.pm
@@ -27,17 +27,20 @@ sub new {
 }
 
 sub press_add {
-    assert_screen(OVERVIEW_TAB);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 9, 2);
     send_key('alt-a');
 }
 
 sub press_edit {
-    assert_screen(OVERVIEW_TAB);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 9, 2);
     send_key('alt-i');
 }
 
 sub press_delete {
-    assert_screen(OVERVIEW_TAB);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 9, 2);
     send_key('alt-t');
 }
 
@@ -65,7 +68,8 @@ sub select_device {
 }
 
 sub press_ok {
-    assert_screen(OVERVIEW_TAB);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 9, 2);
     send_key('alt-o');
 }
 


### PR DESCRIPTION
Due to bsc#1191112 we need to perform the workaround of maximizing/unmaximizing yast2 window in order to refresh the content.

- Related ticket: No ticket, related to [this failure](https://openqa.suse.de/tests/8300489#step/yast2_lan_restart_vlan/24)
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/8301833#step/yast2_lan_restart_bridge/46
