### PR TITLE
HA: Increase timeout on cluster stop

### DIFF
--- a/tests/ha/check_cluster_integrity.pm
+++ b/tests/ha/check_cluster_integrity.pm
@@ -11,12 +11,11 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use lockapi;
 use hacluster;
-use utils 'systemctl';
 
 sub run {
     select_console 'root-console';
+    sleep 120;
     # Check for the state of the whole cluster
     check_cluster_state;
 }

--- a/tests/ha/cluster_state_mgmt.pm
+++ b/tests/ha/cluster_state_mgmt.pm
@@ -23,7 +23,7 @@ sub run {
     }
     else {
         record_info("Stop cluster", "Cluster is stopping");
-        script_run "crm cluster stop";
+        script_run "crm cluster stop", timeout => 300;
     }
 }
 


### PR DESCRIPTION
This fix will allow  us to re-enable QAM HA rolling upgrade migration tests from 12-SP3 to 12-SP4.

- Failing test: https://openqa.suse.de/tests/5793977#step/check_cluster_integrity/6
- Verification run: https://openqa.suse.de/tests/8303249