### PR TITLE
fwupd: Don't run get_devices on PowerVM

### DIFF
--- a/tests/kernel/fwupd.pm
+++ b/tests/kernel/fwupd.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends 'is_pvm';
 
 sub run {
     my $self = shift;
@@ -22,7 +23,7 @@ sub run {
     systemctl "start fwupd";
 
     # Get all devices that support firmware updates
-    assert_script_run "fwupdmgr get-devices";
+    assert_script_run "fwupdmgr get-devices" unless is_pvm;
     # Gets the configured remotes
     assert_script_run "fwupdmgr get-remotes";
 }


### PR DESCRIPTION
Fix poo#108088: PowerVM doesn't have supported devices.

- Related ticket: https://progress.opensuse.org/issues/108088
- Needles: none
- Verification run: 
x86_64: https://openqa.suse.de/tests/8306518
aarch64: https://openqa.suse.de/tests/8306526
ppc64le: https://openqa.suse.de/tests/8306519
ppc64le-pvm: https://openqa.suse.de/tests/8306541

