### PR TITLE
Handle cannot find python2 information from zypper search command

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -101,7 +101,7 @@ sub check_bzr_to_breezy {
 # SLE-20176 QA: Drop Python 2 (15 SP4)
 # check in the upgraded system to ensure Python2 dropped
 sub check_python2_dropped {
-    my $out = script_output('zypper se python2 | grep python2');
+    my $out = script_output('zypper se python2 | grep python2', proceed_on_failure => 1);
     record_info('python2 dropped but still can be searched', 'Bug 1196533 - Python2 package still can be searched after migration to SLES15SP4', result => 'fail') if $out;
 }
 


### PR DESCRIPTION
Handle cannot find python2 information from zypper search command,
if python2 cannot be searched, set proceed_on_failure => 1, allows
to proceed with validation when $script is failing

- Related ticket: https://progress.opensuse.org/issues/108095
- Verification run:https://openqa.suse.de/tests/8306040#step/check_system_info#1/27
https://openqa.suse.de/tests/8306282