### PR TITLE
[WIP] kernel: Schedule no_enlarge_swap in textmode only

### DIFF
--- a/schedule/kernel/prepare_baremetal.yaml
+++ b/schedule/kernel/prepare_baremetal.yaml
@@ -14,7 +14,7 @@ schedule:
     - installation/addon_products_sle
     - installation/system_role
     - installation/partitioning
-    - installation/partitioning/no_enlarge_swap
+    - '{{no_enlarge_swap}}'
     - installation/partitioning_firstdisk
     - installation/partitioning_finish
     - installation/installer_timezone
@@ -44,3 +44,7 @@ conditional_schedule:
         BACKEND:
             spvm:
                 - installation/bootloader
+    no_enlarge_swap:
+        SYSTEM_ROLE:
+            textmode:
+                - installation/partitioning/no_enlarge_swap


### PR DESCRIPTION
Fix poo#108123: Module no_enlarge_swap should be scheduled only on
installations with SYSTEM_ROLE=textmode in prepare_baremetal for
kernel jobs.

- Related ticket: https://progress.opensuse.org/issues/108123
- Needles: none
- Verification run:
x86_64:
x86_64-xen:
pvm:
