### PR TITLE
Containers: Implement get_image_url()

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -14,16 +14,13 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use Mojo::Util 'trim';
 use Utils::Architectures;
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap is_microos is_sle_micro is_released);
 
 our @EXPORT = qw(
   get_opensuse_registry_prefix
-  get_container_image_to_test
-  get_container_url_from_var
-  get_suse_container_urls
   get_3rd_party_images
+  get_image_uri
 );
 
 # Returns a string which should be prepended to every pull from registry.opensuse.org.
@@ -51,7 +48,7 @@ sub get_opensuse_registry_prefix {
     }
 }
 
-our %images_uri = (
+our %images_list = (
     sle => {
         '12-SP3' => {
             released => sub { 'registry.suse.com/suse/sles12sp3' },
@@ -260,49 +257,8 @@ our %images_uri = (
 
 sub supports_image_arch {
     my ($distri, $version, $arch) = @_;
-    (grep { $_ eq $arch } @{$images_uri{$distri}{$version}{available_arch}}) ? 1 : 0;
+    (grep { $_ eq $arch } @{$images_list{$distri}{$version}{available_arch}}) ? 1 : 0;
 }
-
-# Returns an array with the contents of the given variable or undef, if the var is not set
-sub get_container_url_from_var {
-    my $var = shift;
-    my @urls = (trim(get_var($var)));
-    # Return undef if empty string
-    return ($urls[0]) ? (\@urls) : undef;
-}
-
-# Returns a tuple of image urls and their matching released "stable" counterpart.
-# If empty, no images available.
-sub get_suse_container_urls {
-    my %args = (
-        version => get_required_var('VERSION'),
-        arch => get_required_var('ARCH'),
-        distri => get_required_var('DISTRI'),
-        @_
-    );
-    my @untested_images = ();
-    my @released_images = ();
-
-    $args{version} =~ s/^Staging:(?<letter>.)$/Tumbleweed/ if is_tumbleweed || is_microos("Tumbleweed");
-    if (supports_image_arch($args{distri}, $args{version}, $args{arch})) {
-        push @untested_images, $images_uri{$args{distri}}{$args{version}}{totest}->($args{arch});
-        push @released_images, $images_uri{$args{distri}}{$args{version}}{released}->($args{arch});
-    } else {
-        die("Unknown combination of distro/arch.");
-    }
-
-    return (\@untested_images, \@released_images);
-}
-
-# Get single image from CONTAINER_IMAGE_TO_TEST or untested image from get_suse_container_urls()
-sub get_container_image_to_test {
-    my $images_to_test;
-    unless ($images_to_test = get_container_url_from_var('CONTAINER_IMAGE_TO_TEST')) {
-        ($images_to_test, undef) = get_suse_container_urls();
-    }
-    return $images_to_test->[0];
-}
-
 
 sub get_3rd_party_images {
     my $ex_reg = get_var('REGISTRY', 'docker.io');
@@ -340,6 +296,31 @@ sub get_3rd_party_images {
     ) unless (is_aarch64 || check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
 
     return (\@images);
+}
+
+# Return URI of the container image to be tested. It will:
+# - Be configured by the CONTAINER_IMAGE_TO_TEST variable.
+# - Be configured by the distri, version and arch parameter.
+# - Be determined by the running OS.
+# - Die otherwise.
+sub get_image_uri {
+    my (%args) = @_;
+    $args{version} //= get_required_var('VERSION');
+    $args{arch} //= get_required_var('ARCH');
+    $args{distri} //= get_required_var('DISTRI');
+    $args{released} //= !get_var('CONTAINERS_UNTESTED_IMAGES');
+
+    $args{version} =~ s/^Staging:(?<letter>.)$/Tumbleweed/ if is_tumbleweed || is_microos("Tumbleweed");
+
+    my $url = get_var('CONTAINER_IMAGE_TO_TEST');
+    return $url if ($url);
+
+    my $type = $args{released} ? 'released' : 'totest';
+    if (supports_image_arch($args{distri}, $args{version}, $args{arch})) {
+        return $images_list{$args{distri}}{$args{version}}{$type}->($args{arch});
+    }
+
+    die "Cannot find container image for ($args{distri},$args{version},$args{arch}) or missing CONTAINER_IMAGE_TO_TEST variable.";
 }
 
 1;

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -12,7 +12,7 @@ use testapi;
 use utils;
 use containers::common;
 use containers::container_images;
-use containers::urls 'get_suse_container_urls';
+use containers::urls 'get_image_uri';
 
 sub run {
     my ($self) = @_;
@@ -21,16 +21,15 @@ sub run {
 
     zypper_call("install container-diff") if (script_run("which container-diff") != 0);
 
-    my ($testing_images, $released_images) = get_suse_container_urls();
+    my $unreleased_image = get_image_uri(released => 0);
+    my $released_image = get_image_uri();
     # container-diff
-    for my $i (@{$testing_images}) {
-        my $image_file = $testing_images->[$i] =~ s/\/|:/-/gr;
-        my $container_diff_results = "/tmp/container-diff-$image_file.txt";
-        assert_script_run("docker pull $testing_images->[$i]", 360);
-        assert_script_run("docker pull $released_images->[$i]", 360);
-        assert_script_run("container-diff diff daemon://$testing_images->[$i] daemon://$released_images->[$i] --type=rpm --type=file --type=size > $container_diff_results", 300);
-        upload_logs("$container_diff_results");
-    }
+    my $image_file = $unreleased_image =~ s/\/|:/-/gr;
+    my $container_diff_results = "/tmp/container-diff-$image_file.txt";
+    assert_script_run("docker pull $unreleased_image", 360);
+    assert_script_run("docker pull $released_image", 360);
+    assert_script_run("container-diff diff daemon://$unreleased_image daemon://$released_image --type=rpm --type=file --type=size > $container_diff_results", 300);
+    upload_logs("$container_diff_results");
 
     # Clean container
     $docker->cleanup_system_host();

--- a/tests/containers/push_container_image_to_acr.pm
+++ b/tests/containers/push_container_image_to_acr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls 'get_container_image_to_test';
+use containers::urls 'get_image_uri';
 
 sub run {
     my ($self, $args) = @_;
@@ -18,7 +18,7 @@ sub run {
 
     my $provider = $self->provider_factory(service => 'ACR');
 
-    my $image = get_container_image_to_test();
+    my $image = get_image_uri();
     my $tag = $provider->get_default_tag();
 
     record_info('Pull', "Pulling $image");

--- a/tests/containers/push_container_image_to_ecr.pm
+++ b/tests/containers/push_container_image_to_ecr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls 'get_container_image_to_test';
+use containers::urls 'get_image_uri';
 
 sub run {
     my ($self, $args) = @_;
@@ -19,7 +19,7 @@ sub run {
     my $provider = $self->provider_factory(service => 'ECR');
     $self->{provider} = $provider;
 
-    my $image = get_container_image_to_test();
+    my $image = get_image_uri();
     my $tag = $provider->get_default_tag();
     $self->{tag} = $tag;
 

--- a/tests/containers/push_container_image_to_gcr.pm
+++ b/tests/containers/push_container_image_to_gcr.pm
@@ -9,7 +9,7 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use containers::urls 'get_container_image_to_test';
+use containers::urls 'get_image_uri';
 
 sub run {
     my ($self, $args) = @_;
@@ -18,7 +18,7 @@ sub run {
 
     my $provider = $self->provider_factory(service => 'GCR');
 
-    my $image = get_container_image_to_test();
+    my $image = get_image_uri();
     my $tag = $provider->get_default_tag();
 
     record_info('Pull', "Pulling $image");

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -20,7 +20,6 @@ use testapi;
 use utils;
 use containers::common;
 use containers::container_images;
-use containers::urls 'get_suse_container_urls';
 use containers::utils 'registry_url';
 use version_utils qw(is_sle is_leap is_jeos is_transactional);
 use power_action_utils 'power_action';
@@ -58,8 +57,6 @@ sub run {
     }
 
     my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
-
-    my ($untested_images, $released_images) = get_suse_container_urls();
     my $podman = $self->containers_factory('podman');
 
     my $user = $testapi::username;

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -16,7 +16,6 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use containers::common;
-use containers::urls 'get_suse_container_urls';
 
 # Get the total and used GiB of a given btrfs device
 sub _btrfs_fi {


### PR DESCRIPTION
Implement `get_image_url()` instead of `get_container_image_to_test()`, `get_container_url_from_var()` and `get_suse_container_urls()`. We have a list of SUSE and openSUSE released and unreleased container images but we always need only one image url to work with.

- Related ticket: [poo#108058](https://progress.opensuse.org/issues/108058)
- Verification run: In further comments