### PR TITLE
Fix supportutils need a lot of time to finish on migration

### DIFF
--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -6,7 +6,7 @@
 # Package: supportutils
 # Summary: Test is files created by supportconfig are readable and contain some basic data.
 # - Delete any previously existing supportconfig data
-# - Run supportconfig -t . -B test
+# - Run supportconfig -B test
 # - Check for supportconfig contents
 # - Cleanup supportconfig data
 # Maintainer: Juraj Hura <jhura@suse.com>
@@ -20,20 +20,24 @@ use upload_system_log 'upload_supportconfig_log';
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
-
+    select_console 'root-console';
     my $options = get_var('SUPPORTCOFIG_OPTIONS', '');
-    assert_script_run "rm -rf nts_* scc_* ||:";
+    assert_script_run "rm -rf /var/log/nts_* /var/log/scc_* ||:";
     upload_supportconfig_log(file_name => 'test', options => $options, timeout => 2000);
 
+    my $scc_file = '/var/log/scc_test.txz';
     # bcc#1166774
-    if (script_run("test -d scc_test") == 0) {
-        assert_script_run "cd scc_test";
+    if (script_run("test -e $scc_file") == 0) {
+        assert_script_run "xz -dc $scc_file | tar -xf -";
+        assert_script_run 'cd scc_test';
     } else {
         assert_script_run "cd nts_test";
     }
 
     # Check few file whether expected content is there.
-    assert_script_run "diff <(awk '/\\/proc\\/cmdline/{getline; print}' boot.txt|head -n1) /proc/cmdline";
+    # we just compare the first line after /proc/cmdline in boot.txt
+    # with the content in /proc/cmdline.
+    assert_script_run(q(diff <(awk '/^# \/proc\/cmdline/{getline; print; exit}' boot.txt) /proc/cmdline));
     assert_script_run "grep -q -f /etc/os-release basic-environment.txt";
 
     assert_script_run "cd ..";


### PR DESCRIPTION
We need to tune the supportconfig to make it consume less time for migration tests. 
and on S390x it failed to upload the supportconfig tarball file.


- Related ticket:  
       https://progress.opensuse.org/issues/104938
       https://progress.opensuse.org/issues/107983

- Needles: N/A
- Verification run: 
Function:
https://openqa.nue.suse.com/t8710404
https://openqa.nue.suse.com/t8710405
https://openqa.nue.suse.com/t8710406
Migration:
https://openqa.nue.suse.com/t8702097
https://openqa.nue.suse.com/t8702098
https://openqa.nue.suse.com/t8702099