### PR TITLE
Fix connection reset by peer

### DIFF
--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -48,6 +48,8 @@ sub run {
 
     # Disable bash monitoring, so the output of completed background jobs doesn't confuse openQA
     script_run("set +m");
+    # Fix poo#101256, connection reset by peer
+    assert_script_run 'iptables -I INPUT 1 -m conntrack --ctstate INVALID -j DROP';
 
     # Install or import defined guests
     foreach my $guest (values %virt_autotest::common::guests) {


### PR DESCRIPTION
When installing some Guest VMs via PXE at the same time some installer got error "connection reset by peer". This will fix the issue. See more detail in ticket.

- Related ticket: https://progress.opensuse.org/issues/101256
- Needles: no
- Verification run: 
- sles12sp5: http://openqa.qam.suse.cz/tests/38105
- sles15sp2: http://openqa.qam.suse.cz/tests/38106
- sles15sp3: http://openqa.qam.suse.cz/tests/38085
