### PR TITLE
Fix the failure when installing rmt-server success

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -251,15 +251,10 @@ sub rmt_wizard {
     my $setup_console = current_console();
 
     # install RMT and mariadb
-    eval {
-        zypper_call 'in rmt-server', log => 'zypper.log';
-    };
-    if ($@ && script_run('grep -E "rmt-server-config.*scriptlet failed" /tmp/zypper.log') == 0) {
+    my $ret = zypper_call('in rmt-server', exitcode => [0, 107], log => 'zypper.log');
+    if (($ret == 107) && (script_run('grep -E "rmt-server-config.*scriptlet failed" /tmp/zypper.log') == 0)) {
         record_soft_failure 'bsc#1195759';
         zypper_call 'in rmt-server';
-    }
-    else {
-        die 'zypper in rmt-server failed';
     }
     zypper_call 'in mariadb';
 


### PR DESCRIPTION
The added workaround for bsc#1195759 has a problem that when a 
case installing rmt-server package successfully, the test would go 'else'
and die with 'zypper in rmt-server failed'. Our case is using the dev
version of rmt-server, which is higher than released version. The soft
failure bsc#1195759 is not existing on our case, but it is die. This
ticket is going to fix this problem.

- Related ticket: https://progress.opensuse.org/issues/107914
- Needles: N/A
- Verification run: 
migration team case:
https://openqa.nue.suse.com/tests/8381157#step/rmt_feature/15 (this case has no problem with installing rmt-server)
https://openqa.nue.suse.com/tests/8381159#step/rmt_import/9 (this case has soft failure bsc#1195759)
qam team case:
https://openqa.nue.suse.com/tests/8381160#step/rmt_feature/16 (this case has soft failure bsc#1195759)
