### PR TITLE
containers: restart firewalld after installing docker

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -86,6 +86,9 @@ sub install_docker_when_needed {
                 # docker package can be installed
                 zypper_call('in docker', timeout => 300);
 
+                # Restart firewalld if enabled before. Ensure docker can properly interact
+                systemctl 'try-restart firewalld';
+
                 remove_suseconnect_product('SLES-LTSS') if ($ltss_needed);
             }
         }


### PR DESCRIPTION

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1196801
- Needles: N/A
- Verification runs:
* [jeos-container_host@64bit_virtio-2G](https://openqa.opensuse.org/t2239248)
* [jeos-container_image@64bit_virtio-2G](https://openqa.opensuse.org/t2239250)
