### PR TITLE
xfstests: fix boot fail when enable kdump in spvm

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -23,7 +23,8 @@ use strict;
 use 5.018;
 use warnings;
 use base 'opensusebasetest';
-use utils 'zypper_call';
+use utils;
+use Utils::Backends;
 use power_action_utils 'power_action';
 use kdump_utils;
 use testapi;
@@ -42,6 +43,7 @@ sub run {
 
     # Reboot
     power_action('reboot');
+    reconnect_mgmt_console if is_pvm;
     $self->wait_boot(bootloader_time => 200);
     select_console('root-console');
     die "Failed to enable kdump" unless kdump_is_active;


### PR DESCRIPTION
enable_kdump run in ppc64le machin fails in booting (e.g. https://openqa.suse.de/tests/8306291#step/enable_kdump/36). This PR is to fix this issue.

- Verification run: https://openqa.suse.de/t8314983
