### PR TITLE
Fix script_run timeout issue in rmt_chinese

### DIFF
--- a/tests/x11/rmt/rmt_chinese.pm
+++ b/tests/x11/rmt/rmt_chinese.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2021-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: yast2-rmt rmt-server
@@ -34,7 +34,8 @@ sub set_language_to_Chinese {
     x11_start_program('xterm');
     wait_still_screen 2, 2;
     become_root;
-    script_run('yast2 language');
+    script_run('yast2 language', die_on_timeout => 0);
+    assert_screen 'yast2-language', 60;
     send_key_until_needlematch 'yast2-lang-simplified-chinese', 'down', 180;
     send_key 'alt-o';
 


### PR DESCRIPTION
Add die_on_timeout=0 to prevent script_run return failure when timeout, 
and add assert_screen to make it more stable.
- Related ticket: https://progress.opensuse.org/issues/107920
- Verification run: 
https://openqa.nue.suse.com/tests/8322879#step/rmt_chinese/20
