### PR TITLE
mm_network: NetworkManager: Get single device and connection name

### DIFF
--- a/lib/mailtest.pm
+++ b/lib/mailtest.pm
@@ -56,7 +56,7 @@ sub prepare_mail_server {
         ($ip_addr, $ip_mask) = split(/\//, $mail_server_ip);
         configure_default_gateway;
         configure_static_dns(get_host_resolv_conf());
-        configure_static_ip("$mail_server_ip");
+        configure_static_ip(ip => "$mail_server_ip");
         set_var("MAIL_SERVER_IP", "$mail_server_ip") if not get_var("MAIL_SERVER_IP");
     }
 
@@ -79,7 +79,7 @@ sub prepare_mail_client {
         $mail_client_ip = get_var("MAIL_CLIENT_IP", "10.0.2.20/15");
         configure_default_gateway;
         configure_static_dns(get_host_resolv_conf());
-        configure_static_ip("$mail_client_ip");
+        configure_static_ip(ip => "$mail_client_ip");
 
         # Wait for the mail server ready
         mutex_lock "mail_server";

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -9,7 +9,7 @@ use Exporter;
 use testapi;
 use version_utils 'is_opensuse';
 
-our @EXPORT = qw(configure_hostname get_host_resolv_conf
+our @EXPORT = qw(configure_hostname get_host_resolv_conf is_networkmanager
   configure_static_ip configure_dhcp configure_default_gateway configure_static_dns
   parse_network_configuration ip_in_subnet check_ip_in_subnet setup_static_mm_network);
 
@@ -41,19 +41,45 @@ sub get_host_resolv_conf {
     return \%conf;
 }
 
-sub configure_static_ip {
-    my ($ip, $mtu) = @_;
-    my $net_conf = parse_network_configuration();
-    my $mac = $net_conf->{fixed}->{mac};
-    $mtu //= 1458;
-    script_run "NIC=`grep $mac /sys/class/net/*/address |cut -d / -f 5`";
-    assert_script_run "echo \$NIC";
-    my ($ip_no_mask, $mask) = split('/', $ip);
-    script_run "arping -w 1 -I \$NIC $ip_no_mask";    # check for duplicate IP
+sub is_networkmanager {
+    return (script_run('readlink /etc/systemd/system/network.service | grep NetworkManager') == 0);
+}
 
-    assert_script_run "echo -e \"STARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'\\nMTU='$mtu'\" > /etc/sysconfig/network/ifcfg-\$NIC";
+sub configure_static_ip {
+    my ($ip, $is_nm, $mtu) = @_;
+    $is_nm //= is_networkmanager();
+    $mtu //= 1458;
+
+    if ($is_nm) {
+        my $device = script_output('nmcli -t -f DEVICE c');
+        my $nm_id = script_output('nmcli -t -f NAME c');
+
+        assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip4 $ip gw4 10.0.2.2 ipv4.method manual ";
+        assert_script_run "nmcli connection down '$nm_id'";
+        assert_script_run "nmcli connection up '$nm_id'";
+    } else {
+        # Get MAC address
+        my $net_conf = parse_network_configuration();
+        my $mac = $net_conf->{fixed}->{mac};
+
+        # Get default network adapter name
+        script_run "NIC=`grep $mac /sys/class/net/*/address |cut -d / -f 5`";
+        assert_script_run "echo \$NIC";
+
+        # check for duplicate IP
+        my ($ip_no_mask, $mask) = split('/', $ip);
+        script_run "arping -w 1 -I \$NIC $ip_no_mask";
+
+        # Configure the static networking
+        assert_script_run "echo -e \"STARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'\\nMTU='$mtu'\" > /etc/sysconfig/network/ifcfg-\$NIC";
+
+        configure_default_gateway();
+
+        # Restart the networking
+        assert_script_run "rcnetwork restart";
+    }
+
     save_screenshot;
-    assert_script_run "rcnetwork restart";
     assert_script_run "ip addr";
     save_screenshot;
 }
@@ -79,11 +105,24 @@ sub configure_default_gateway {
 }
 
 sub configure_static_dns {
-    my ($conf, $silent) = @_;
+    my ($conf, $is_nm, $silent) = @_;
+    $is_nm //= is_networkmanager();
     $silent //= 0;
+
     my $servers = join(" ", @{$conf->{nameserver}});
-    assert_script_run("sed -i -e 's|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$servers\"|' /etc/sysconfig/network/config");
-    assert_script_run("netconfig -f update");
+
+    if ($is_nm) {
+        my $device = script_output('nmcli -t -f DEVICE c');
+        my $nm_id = script_output('nmcli -t -f NAME c');
+
+        assert_script_run "nmcli connection modify '$nm_id' ipv4.dns '$servers'";
+        assert_script_run "nmcli connection down '$nm_id'";
+        assert_script_run "nmcli connection up '$nm_id'";
+    } else {
+        assert_script_run("sed -i -e 's|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$servers\"|' /etc/sysconfig/network/config");
+        assert_script_run("netconfig -f update");
+    }
+
     assert_script_run("cat /etc/resolv.conf") unless $silent;
 }
 
@@ -173,13 +212,9 @@ sub check_ip_in_subnet {
 
 sub setup_static_mm_network {
     my $ip = shift;
-    if (is_opensuse && !check_var('DESKTOP', 'textmode')) {
-        assert_script_run "systemctl disable NetworkManager --now";
-        assert_script_run "systemctl enable wicked --now";
-    }
-    configure_default_gateway;
-    configure_static_ip($ip);
-    configure_static_dns(get_host_resolv_conf());
+    my $is_nm = is_networkmanager();
+    configure_static_ip($ip, $is_nm);
+    configure_static_dns(get_host_resolv_conf(), $is_nm);
 }
 
 1;

--- a/lib/mm_tests.pm
+++ b/lib/mm_tests.pm
@@ -28,7 +28,7 @@ sub configure_static_network {
     my $ip = shift;
 
     configure_default_gateway;
-    configure_static_ip($ip);
+    configure_static_ip(ip => $ip);
     configure_static_dns(get_host_resolv_conf());
     assert_script_run "ping -c 1 10.0.2.2 || journalctl -b --no-pager -o short-precise >/dev/$serialdev";
 }

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -37,7 +37,7 @@ sub setup_static_network {
     $args{ip} //= '10.0.2.15';
     $args{gw} //= testapi::host_ip();
     $args{silent} //= 0;
-    configure_static_dns(get_host_resolv_conf(), undef, $args{silent});
+    configure_static_dns(get_host_resolv_conf(), silent => $args{silent});
     assert_script_run('echo default ' . $args{gw} . ' - - > /etc/sysconfig/network/routes');
     my $iface = iface();
     assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$args{ip}'">/etc/sysconfig/network/ifcfg-$iface);

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -37,7 +37,7 @@ sub setup_static_network {
     $args{ip} //= '10.0.2.15';
     $args{gw} //= testapi::host_ip();
     $args{silent} //= 0;
-    configure_static_dns(get_host_resolv_conf(), $args{silent});
+    configure_static_dns(get_host_resolv_conf(), undef, $args{silent});
     assert_script_run('echo default ' . $args{gw} . ' - - > /etc/sysconfig/network/routes');
     my $iface = iface();
     assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$args{ip}'">/etc/sysconfig/network/ifcfg-$iface);

--- a/tests/console/ipsec_tools_h2h.pm
+++ b/tests/console/ipsec_tools_h2h.pm
@@ -29,7 +29,7 @@ sub run {
 
     # install ipsec-tools and config gateway and static ip on worker
     configure_default_gateway;
-    configure_static_ip($my_static_ip);
+    configure_static_ip(ip => $my_static_ip);
     configure_static_dns(get_host_resolv_conf());
     zypper_call 'in ipsec-tools';
 

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -12,23 +12,14 @@ use warnings;
 use testapi;
 use lockapi;
 use mm_network 'setup_static_mm_network';
-use utils qw(zypper_call permit_root_ssh);
+use utils qw(zypper_call permit_root_ssh set_hostname);
 use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
 use version_utils qw(is_sle is_opensuse);
-
-sub is_networkmanager {
-    return (script_run('readlink /etc/systemd/system/network.service | grep NetworkManager') == 0);
-}
 
 sub run {
     my ($self) = @_;
     my $hostname = get_var('HOSTNAME');
-    my ($nm_id, $device);
     select_console 'root-console';
-    if (is_networkmanager) {
-        $nm_id = script_output('nmcli -t -f NAME c');
-        $device = script_output('nmcli -t -f DEVICE c');
-    }
 
     # Do not use external DNS for our internal hostnames
     assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');
@@ -41,33 +32,12 @@ sub run {
     # Configure the internal network an  try it
     if ($hostname =~ /server|master/) {
         setup_static_mm_network('10.0.2.101/24');
-
-        if (is_networkmanager) {
-            assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip4 '10.0.2.101/24' gw4 10.0.2.2 ipv4.method manual ";
-            assert_script_run "nmcli connection down '$nm_id'";
-            assert_script_run "nmcli connection up '$nm_id'";
-        }
-        else {
-            assert_script_run 'systemctl restart  wicked';
-        }
-    }
-    else {
+    } else {
         setup_static_mm_network('10.0.2.102/24');
-
-        if (is_networkmanager) {
-            assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip4 '10.0.2.102/24' gw4 10.0.2.2 ipv4.method manual ";
-            assert_script_run "nmcli connection down '$nm_id'";
-            assert_script_run "nmcli connection up '$nm_id'";
-        }
-        else {
-            systemctl("restart wicked");
-        }
     }
 
     # Set the hostname to identify both minions
-    assert_script_run "hostnamectl set-hostname $hostname";
-    assert_script_run "hostnamectl status|grep $hostname";
-    assert_script_run "hostname|grep $hostname";
+    set_hostname $hostname;
 
     # Make sure that PermitRootLogin is set to yes
     # This is needed only when the new SSH config directory exists

--- a/tests/ses/nodes_preparation.pm
+++ b/tests/ses/nodes_preparation.pm
@@ -50,7 +50,7 @@ sub run {
         # configure network
         configure_default_gateway;
         my $node_ip = get_var('NODE_IP');
-        configure_static_ip("$node_ip/24");
+        configure_static_ip(ip => "$node_ip/24");
         configure_static_dns(get_host_resolv_conf());
         # add node entries to /etc/hosts
         my $hosts = <<'EOF';

--- a/tests/slenkins/slenkins_control_network.pm
+++ b/tests/slenkins/slenkins_control_network.pm
@@ -15,7 +15,7 @@ use mm_network;
 
 sub run {
     configure_default_gateway;
-    configure_static_ip('10.0.2.1/24');
+    configure_static_ip(ip => '10.0.2.1/24');
     configure_static_dns(get_host_resolv_conf());
 
     script_output("

--- a/tests/slepos/prepare.pm
+++ b/tests/slepos/prepare.pm
@@ -66,7 +66,7 @@ sub run {
     configure_hostname(get_var('SLEPOS'));
     if (get_var('IP_BASED')) {
         configure_default_gateway;
-        configure_static_ip(get_var('MY_ADDR') . "/24");
+        configure_static_ip(ip => get_var('MY_ADDR') . "/24");
         configure_static_dns(get_host_resolv_conf());
     }
     else {

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -165,10 +165,11 @@ sub switch_to_wicked {
     assert_script_run('rm -f /etc/NetworkManager/system-connections/*');
     systemctl("restart NetworkManager");
     assert_script_run("nmcli connection add type ethernet con-name $iface ifname $iface ip4 $ip gw4 10.0.2.2");
-    configure_static_dns(get_host_resolv_conf());
+    configure_static_dns(get_host_resolv_conf(), is_nm => 1, nm_id => $iface);
     assert_script_run("nmcli con up $iface ifname $iface");
     record_info('devices', script_output('nmcli device status'));
     record_info('ip a', script_output('ip a'));
+    record_info('ip r', script_output('ip r'));
     record_info('nameserver', script_output('cat /etc/resolv.conf'));
     assert_script_run('ping -c 5 10.0.2.2');
     zypper_call("in wicked", timeout => 400);


### PR DESCRIPTION
- Tickets: [poo#105295](https://progress.opensuse.org/issues/105295), [bsc#1196606](https://bugzilla.opensuse.org/show_bug.cgi?id=1196606)
- Reverts: #14476
- Fixes: [1](https://openqa.opensuse.org/tests/2240838#step/before_test/20) and [2](https://openqa.opensuse.org/tests/2240848#step/xrdp_server/27)
- Verification run: [wicked](http://pdostal-server.suse.cz/tests/14171), [wireguard](http://pdostal-server.suse.cz/tests/14179), [multipath](http://pdostal-server.suse.cz/tests/14177), [remote-desktop](https://openqa.opensuse.org/tests/2276756)
