### PR TITLE
Fix screen share test in SLE 15-SP4

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1335,6 +1335,7 @@ sub load_x11tests {
                 loadtest(is_sle('<15') ? "x11/rhythmbox" : "x11/gnome_music");
                 loadtest "x11/wireshark";
                 loadtest "x11/ImageMagick";
+                loadtest "x11/remote_desktop/screensharing_available" if is_sle("15-sp4+");
                 loadtest "x11/ghostscript";
             }
         }
@@ -1581,7 +1582,7 @@ sub load_extra_tests_desktop {
 
     }
     if (gnomestep_is_applicable()) {
-        loadtest "x11/remote_desktop/vino_screensharing_available";
+        loadtest "x11/remote_desktop/screensharing_available";
     }
     if (get_var("DESKTOP") =~ /kde|gnome/) {
         loadtest "x11/libqt5_qtbase" if (is_sle("12-SP3+") || is_opensuse);

--- a/tests/x11/remote_desktop/screensharing_available.pm
+++ b/tests/x11/remote_desktop/screensharing_available.pm
@@ -1,7 +1,7 @@
 # Copyright 2018-2019 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# Package: gnome-control-center vino systemd
+# Package: gnome-control-center vino systemd gnome-remote-desktop
 # Summary: Test if the Screen Sharing GNOME Desktop functionality works
 #   We currently need to install vino package for that
 # - Launch "gnome-control-center sharing"
@@ -19,14 +19,13 @@ use strict;
 use warnings;
 use testapi;
 use x11utils 'handle_relogin';
-use version_utils 'is_leap';
+use version_utils qw(is_leap is_sle);
 
 sub run {
     select_console 'x11';
 
     # Run the gnome-control-center - the sharing section
     x11_start_program "gnome-control-center sharing", target_match => 'vino_screensharing_available-gnome-control-center-sharing';
-
     # Always check the common sharing functionality is enabled
     if (check_screen 'disabled_sharing') {
         assert_and_click 'disabled_sharing';
@@ -37,16 +36,13 @@ sub run {
     if (match_has_tag 'without_screensharing') {
         record_info 'vino missing', 'After the installation the screen sharing is not available - vino is missing and we need to install it now.';
         send_key 'ctrl-q';
-
         # Install the vino package which is probably the case of missing screen sharing option
         ensure_installed 'vino';
-
         # Log of and back in to ensure the vino feature gets enabled
         handle_relogin;
 
         # Run the gnome-control-center to ensure the same state as we were while entering this if block
         x11_start_program "gnome-control-center sharing", target_match => 'vino_screensharing_available-gnome-control-center-sharing';
-
         # Always check the common sharing functionality is enabled
         if (check_screen 'disabled_sharing') {
             assert_and_click 'disabled_sharing';
@@ -64,7 +60,7 @@ sub run {
         record_soft_failure 'boo#1137569 - screen sharing not yet supported on wayland';
     } else {
         assert_screen 'with_screensharing';
-        record_info 'vino present', 'Vino and the screen sharing are present';
+        is_sle("15-sp4+") ? record_info('gnome-remote-desktop present and the screen sharing are present') : record_info('vino present', 'Vino and the screen sharing are present');
     }
     send_key 'ctrl-q';
 }


### PR DESCRIPTION
vino is considered out-of-date, and now gnome-remote-desktop progressively provides the screen sharing. 
So I have renamed the  test module `vino_screensharing_available` to `screensharing_available` to verify the availability of screen share across all SLE Versions. If the screen sharing is not available then test does the installation of package `gnome-remote-desktop`  in SLE 15 SP4 and in lower version `vino` package. 

https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/767

- Related ticket:https://progress.opensuse.org/issues/104601
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1597
- Verification run: 
   SLE 15-SP4 : http://10.161.229.147/tests/2055#step/vino_screensharing_available/1
   SLE 15-SP3: https://openqa.suse.de/tests/8323509#step/vino_screensharing_available/1
   SLE 15-SP1: https://openqa.suse.de/tests/8324219#step/vino_screensharing_available/1
   SLE 15-SP2: https://openqa.suse.de/tests/8328802#step/vino_screensharing_available/1
   
   Latest Verification run:
  [SLE 15-SP4](http://10.161.229.147/tests/2075#step/screensharing_available/1) | [SLE 15-SP3](https://openqa.suse.de/tests/8361120#step/screensharing_available/1) | [SLE 15-SP2](https://openqa.suse.de/tests/8361800#step/screensharing_available/1) | [SLE 15-SP1](https://openqa.suse.de/tests/8362903#step/screensharing_available/1) | [LEAP 15 aarch64](https://openqa.opensuse.org/tests/2256530#step/screensharing_available/1) | [LEAP 15 PPC64](https://openqa.opensuse.org/tests/2256529#step/screensharing_available/1)