### PR TITLE
Wait for reset-rollback-registration to finish

### DIFF
--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -38,7 +38,6 @@ sub run {
     # On JeOS 'bash-completion' is not expected to be present. On general
     # SLES installation it is. Thus on JeOS we have to enable it manually.
     if (is_jeos) {
-        record_info('ps', script_output('ps -ef'));
         zypper_call('in bash-completion');
         assert_script_run('source $(rpmquery -l bash-completion | grep bash_completion.sh)');
     }

--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -15,8 +15,6 @@ use strict;
 use warnings;
 use power_action_utils qw(power_action);
 
-
-
 sub check_package
 {
     my ($not_installed, $pkgname, $check_path) = @_;
@@ -47,6 +45,15 @@ sub rollback_and_reboot {
     }
     select_console('root-console');
     assert_script_run("snapper list");
+    # check whether SUSEConnect --rollback is running executed by rollback-reset-registration
+    # this might cause a system management lock by zypper
+    for (my $runs = 0; $runs < 5; $runs++) {
+        if (script_run('test -f /var/lib/rollback/check-registration') == 1) {
+            return 1;
+        }
+        record_info('ps', script_output('ps -ef'));
+        sleep 20;
+    }
 }
 
 sub run {


### PR DESCRIPTION
The script is called on first boot after a snapper rollback in order to
verify that after a rollback the correct products are registered at SCC.

Tests were proceeding further after rollback and that can lead to
problems with lock described in [Test fails in btrfs_autocompletion -
System management is locked by the application with pid 1658
(zypper).](https://progress.opensuse.org/issues/108064).

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Verification runs: 
  * [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220314-1-jeos-filesystem@uefi-virtio-vga](http://kepler.suse.cz/tests/14501#live)
  * [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220314-1-jeos-filesystem@uefi-virtio-vga](http://kepler.suse.cz/tests/14494#step/snapper_jeos_cli/105)
