### PR TITLE
containers: restart firewall if enabled before

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -86,8 +86,10 @@ sub install_docker_when_needed {
                 # docker package can be installed
                 zypper_call('in docker', timeout => 300);
 
-                # Restart firewalld if enabled before. Ensure docker can properly interact
-                systemctl 'try-restart firewalld';
+                # Restart firewalld if enabled before. Ensure docker can properly interact (boo#1196801)
+                if (script_run('systemctl is-active firewalld') == 0) {
+                    systemctl 'try-restart firewalld';
+                }
 
                 remove_suseconnect_product('SLES-LTSS') if ($ltss_needed);
             }


### PR DESCRIPTION
This fixes a regression caused by #14474

VRs: 
[opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64](https://openqa.opensuse.org/tests/2243604)
[opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64](https://openqa.opensuse.org/tests/2243605)
[sle-15-SP3-AZURE-BYOS-Updates](https://openqa.suse.de/tests/8325426)