### PR TITLE
Fix STIG case "oscap_xccdf_remediate" timed out

### DIFF
--- a/tests/security/stig/oscap_xccdf_remediate.pm
+++ b/tests/security/stig/oscap_xccdf_remediate.pm
@@ -23,7 +23,7 @@ sub run {
     my $f_report = $stigtest::f_report;
 
     # Verify mitigation mode
-    my $ret = script_run("oscap xccdf eval --profile $profile_ID --remediate --oval-results --report $f_report $f_ssg_sle_ds > $f_stdout 2> $f_stderr", timeout => 300);
+    my $ret = script_run("oscap xccdf eval --profile $profile_ID --remediate --oval-results --report $f_report $f_ssg_sle_ds > $f_stdout 2> $f_stderr", timeout => 600);
     record_info("Return=$ret", "# oscap xccdf eval --profile $profile_ID --remediate\" returns: $ret");
     if ($ret) {
         $self->result('fail');


### PR DESCRIPTION
Fix STIG case "oscap_xccdf_remediate" timed out
poo#108034 - [sle][security][sle15sp4]test fails in oscap_xccdf_remediate: timed out

- Related ticket: https://progress.opensuse.org/issues/108034
- Needles: NA
- Verification run:
  aarch64: http://openqa.nue.suse.com/tests/8327979
  x86_64:  http://openqa.nue.suse.com/tests/8327981
  s390x: https://openqa.nue.suse.com/tests/8327982
  The failed test modules can be tracked by bsc#1194724, bsc#1194676