### PR TITLE
Python 3.10 available in SLE15 SP4 and Tumbleweed

### DIFF
--- a/data/console/man_or_boy.py
+++ b/data/console/man_or_boy.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import sys
+sys.setrecursionlimit(1025)
+ 
+def A(k, x1, x2, x3, x4, x5):
+    def B():
+        nonlocal k
+        k -= 1
+        return A(k, B, x1, x2, x3, x4)
+    return x4() + x5() if k <= 0 else B()
+ 
+print(A(10, lambda: 1, lambda: -1, lambda: -1, lambda: 1, lambda: 0))

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -78,6 +78,7 @@ conditional_schedule:
                 - console/supportutils
                 - console/zziplib
                 - console/vsftpd
+                - console/python310_version_check
                 - network/samba/samba_adcli
     tumbleweed_tests:
         VERSION:
@@ -86,6 +87,7 @@ conditional_schedule:
                 - console/systemd_rpm_macros
                 - console/vsftpd
                 - console/python_flake8
+                - console/python310_version_check
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop

--- a/tests/console/python310_version_check.pm
+++ b/tests/console/python310_version_check.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: python310
+# Summary: Run python310 testsuite
+# - Test suitable only for SLE15SP4+
+# - Check that Python 3.6 is the main version installed
+# - Check that Python 3.10 is available to install
+# - Run some basic test (man_or_boy.py)
+# Maintainer: QE Core <qe-core@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use version_utils;
+use utils "zypper_call";
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    if (is_sle('>=15-SP4')) {
+        my $python_version = script_output("rpm -q python3 | awk -F \'-\' \'{print \$2}\'");
+        if ((package_version_cmp($python_version, "3.6") < 0) ||
+            (package_version_cmp($python_version, "3.7") >= 0)) {
+            # Factory default Python3 version for SLE15-SP4 should be 3.6
+            die("Python default version differs from 3.6");
+        }
+        my $arch = get_var('ARCH');
+        assert_script_run("SUSEConnect -p sle-module-python3/15.4/$arch");
+    }
+
+    my @python310_results = split "\n", script_output("zypper se python310 | awk -F \'|\' \'/python310/ {gsub(\" \", \"\"); print \$2}\'");
+    if ((scalar(@python310_results) == 0) || ($python310_results[0] ne "python310")) {
+        die("Python 3.10 not found in the repositories\n\n");
+    }
+    else {
+        zypper_call("install python310");
+        # Running classic testing algorithm 'man_or_boy'. More info at:
+        # https://rosettacode.org/wiki/Man_or_boy_test
+        assert_script_run("curl -O " . data_url("console/man_or_boy.py"));
+        my $man_or_boy = script_output("python3.10 man_or_boy.py");
+        if ($man_or_boy != -67) {
+            die("Execution of 'man_or_boy.py' not correct\n");
+        }
+    }
+}
+
+1;


### PR DESCRIPTION
Check Python 3.10 is available in 15-SP4 and Tumbleweed - needs to be installed and executed separately as default Python remains 3.6 in SP4 and 3.8 in TW. Check functionality by executing some Python programs with python3.10 specifically.

- Related ticket: https://progress.opensuse.org/issues/105945
- Needles: *not applicable*
- Verification runs:

| | | | | |
| - | - | - | - | - |
| **SLE 15 SP4** | [x86_64](https://openqa.suse.de/tests/8335425#step/python310_version_check/33) | [aarch64](https://openqa.suse.de/tests/8335426#step/python310_version_check/33) | [ppc64le](https://openqa.suse.de/tests/8335427#step/python310_version_check/33) | [s390x](https://openqa.suse.de/tests/8335428#step/python310_version_check/33) |
| **Tumbleweed** | [x86_64](https://openqa.opensuse.org/tests/2247502#step/python310_version_check/22) | [aarch64](https://openqa.opensuse.org/tests/2247504#step/python310_version_check/22) | | |