### PR TITLE
Fix console prompt init on SSH serial terminal

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -737,7 +737,7 @@ sub activate_console {
         }
     }
 
-    $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell)/;
+    $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell|serial-ssh)/;
     my ($name, $user, $type) = ($1, $1, $2);
     $name = $user //= '';
     $type //= '';
@@ -837,6 +837,9 @@ sub activate_console {
         handle_password_prompt;
         ensure_user($user);
         assert_screen "text-logged-in-$user", 60;
+    }
+    elsif ($type eq 'serial-ssh') {
+        serial_terminal::set_serial_prompt($user eq 'root' ? '# ' : '$ ');
     }
     else {
         diag 'activate_console called with generic type, no action';


### PR DESCRIPTION
Console prompt is currently not initialized properly for serial SSH terminal which results in multiple warnings about uninitialized value in `wait_serial()`:

    Use of uninitialized value $regexp in concatenation (.) or string at /usr/lib/os-autoinst/testapi.pm line 927.

Move prompt initialization code form `serial_terminal::login()` into a separate function and call it from `activate_console()` when activating serial SSH terminal.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - serial SSH: https://openqa.suse.de/tests/8334621 (cloned from https://openqa.suse.de/tests/8310607 - compare autoinst-log.txt)
  - virtio: https://openqa.suse.de/tests/8334622
