### PR TITLE
console/consoletest_finish: Close PackageKit error notification

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -52,6 +52,12 @@ sub run {
     if (!check_var("DESKTOP", "textmode")) {
         select_console('x11', await_console => 0);
         ensure_unlocked_desktop;
+
+        # system_prepare stops packagekitd while the applet is fetching updates.
+        # This causes an (expected) error notification, which needs to be closed.
+        if (check_screen('packagekit-stopped-notification-close')) {
+            click_lastmatch;
+        }
     }
 }
 


### PR DESCRIPTION
`system_prepare` stops packagekitd, which causes an error notification. This
needs to be closed to not be in the way of needle matches.

- Needles: Created during the VR on o3
- Verification run: https://openqa.opensuse.org/tests/2246439
