### PR TITLE
Add scipy HPC library test

### DIFF
--- a/data/hpc/sample_scipy.py
+++ b/data/hpc/sample_scipy.py
@@ -1,0 +1,13 @@
+"""
+TODO: Extend it in order to run one script for scipy and numpy
+"""
+from mpi4py import MPI
+import scipy  # unsued import. it just verify that the setup works
+import numpy as np  # unsued import.
+
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+print('Hello from process {} out of {}'.format(rank, size))

--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: mpirun helper class to prepare the string for invocation
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package hpc::formatter;
+use Mojo::Base 'hpcbase', -signatures;
+use hpc::utils;
+use testapi qw(get_var get_required_var);
+
+has mpirun => sub {
+    my ($self) = shift;
+    my $mpi = get_required_var('MPI');
+    $self->mpirun("/usr/lib64/mpi/gcc/$mpi/bin/mpirun");
+    my @mpirun_args = ('-print-all-exitcodes');
+    ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
+    push @mpirun_args, '--allow-run-as-root ' if $mpi =~ m/openmpi/;
+    (@mpirun_args == 0) ? $self->mpirun :
+      sprintf "%s %s", $self->mpirun, join(' ', @mpirun_args);
+};
+
+has need_interpreter => sub { return (get_var('HPC_LIB') =~ /scipy|numpy/); };
+
+=head2 single_node
+
+ single_node($bin);
+
+Prepares and returns the command to run as string for a single host (localhost).
+C<bin> is required. C<need_interpreter> boolean will tell if the C<bin>
+is actually a source code where needs invoke _python_ interpreter.
+
+=cut
+sub single_node ($self, $bin) {
+    #my ($self, $bin) = @_;
+    die unless $bin;
+    $bin = 'python3 ' . $bin if $self->need_interpreter;
+    sprintf "%s %s", $self->mpirun, $bin;
+}
+
+=head2 all_nodes
+
+ all_nodes($bin);
+
+Prepares and returns the command to run as string for
+ all the nodes in the cluster.
+C<bin> is required.
+C<need_interpreter> boolean will tell if the C<bin> is actually
+a source code where needs invoke _python_ interpreter.
+TODO: improve the identification of the C<bin>
+
+=cut
+sub all_nodes ($self, $bin) {
+    #my ($self, $bin) = @_;
+    die unless $bin;
+    my @cluster_nodes = $self->cluster_names();
+    my $nodes = join(',', @cluster_nodes);
+    $bin = 'python3 ' . $bin if $self->need_interpreter;
+    sprintf "%s --host %s %s", $self->mpirun, $nodes, $bin;
+}
+
+1;

--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -40,6 +40,7 @@ Returns an array with the mpi compiler and the source code located in /data/hpc
 =cut
 sub get_mpi_src {
     return ('mpicc', 'simple_mpi.c') unless get_var('HPC_LIB', '');
+    # not a boost lib. but using it we can distiguish between `.c` and `.cpp` source code
     return ('mpic++', 'sample_boost.cpp') if (get_var('HPC_LIB') eq 'boost');
     return ('', 'sample_scipy.py') if (get_var('HPC_LIB') eq 'scipy');
 }
@@ -78,14 +79,7 @@ sub setup_scientific_module {
     my $mpi = get_required_var('MPI');
     assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
 
-    if (get_var('HPC_LIB') eq 'boost') {
-        # ignore it for now as package is not available on sle15sp4
-        # zypper_call("in boost-gnu-hpc") ;
-        # $self->relogin_root;
-        # # TODO: Add MPI_FLAVOR `module load TOOLCHAIN MPI_FLAVOR boost`
-        # assert_script_run('module load gnu boost');
-    }
-    elsif (get_var('HPC_LIB') eq 'scipy') {
+    if (get_var('HPC_LIB') eq 'scipy') {
         zypper_call("in python3-scipy-gnu-hpc");
         #
         assert_script_run("env MPICC=/usr/lib64/mpi/gcc/$mpi/bin/mpicc python3 -m pip install mpi4py");

--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -40,7 +40,61 @@ Returns an array with the mpi compiler and the source code located in /data/hpc
 =cut
 sub get_mpi_src {
     return ('mpicc', 'simple_mpi.c') unless get_var('HPC_LIB', '');
-    return ('mpic++', 'sample_boost.cpp') if (get_var('HPC_LIB') == 'boost');
+    return ('mpic++', 'sample_boost.cpp') if (get_var('HPC_LIB') eq 'boost');
+    return ('', 'sample_scipy.py') if (get_var('HPC_LIB') eq 'scipy');
+}
+
+=head2 relogin_root
+
+ relogin_root();
+
+This sub logouts the root user and relogins him from terminal.
+Useful to rerun configuration scripts after some changes
+
+=cut
+sub relogin_root {
+    my $self = shift;
+    record_info 'relogin', 'user needs to logout and login back to trigger scripts which set env variales and others';
+
+    type_string('pkill -u root');
+    record_info "pkill done";
+    $self->wait_boot_textmode(ready_time => 30);
+    select_console('root-virtio-terminal');
+    # Make sure that sshd is up. (TODO: investigate)
+    systemctl('restart sshd');
+}
+
+=head2 setup_scientific_module
+
+ setup_scientific_module();
+
+Installs the various scientific HPC libraries and prepares the environment for use
+L<https://documentation.suse.com/sle-hpc/15-SP3/single-html/hpc-guide/#sec-compute-lib>
+
+=cut
+sub setup_scientific_module {
+    my ($self) = @_;
+    return unless get_var('HPC_LIB', '');
+    my $mpi = get_required_var('MPI');
+    assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
+
+    if (get_var('HPC_LIB') eq 'boost') {
+        # ignore it for now as package is not available on sle15sp4
+        # zypper_call("in boost-gnu-hpc") ;
+        # $self->relogin_root;
+        # # TODO: Add MPI_FLAVOR `module load TOOLCHAIN MPI_FLAVOR boost`
+        # assert_script_run('module load gnu boost');
+    }
+    elsif (get_var('HPC_LIB') eq 'scipy') {
+        zypper_call("in python3-scipy-gnu-hpc");
+        #
+        assert_script_run("env MPICC=/usr/lib64/mpi/gcc/$mpi/bin/mpicc python3 -m pip install mpi4py");
+
+        # Make sure that env is updated. This will run scripts like 'source /usr/share/lmod/lmod/init/bash'
+        $self->relogin_root;
+        # TODO smoke checks? (ex /MODULEPATH/)
+        assert_script_run('module load gnu python3-scipy');
+    }
 }
 
 1;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -14,11 +14,12 @@ use lockapi;
 use utils;
 use registration;
 use version_utils 'is_sle';
+use hpc::formatter;
 
 sub run ($self) {
     my $mpi = $self->get_mpi();
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
-
+    my $mpi_bin = 'mpi_bin';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);
 
@@ -27,8 +28,7 @@ sub run ($self) {
         add_suseconnect_product('sle-module-development-tools');
     }
 
-    zypper_call("in $mpi $mpi-devel gcc gcc-c++");
-    assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
+    zypper_call("in $mpi $mpi-devel gcc gcc-c++ python3-devel");
 
     barrier_wait('CLUSTER_PROVISIONED');
     ## all nodes should be able to ssh to each other, as MPIs requires so
@@ -38,31 +38,38 @@ sub run ($self) {
     $self->check_nodes_availability();
 
     record_info('INFO', script_output('cat /proc/cpuinfo'));
+    # re-export as the user is re-logged in
+    assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
+    $self->setup_scientific_module();
+    my $hostname = get_var('HOSTNAME', 'susetest');
+    record_info "hostname", "$hostname";
+    assert_script_run "hostnamectl status|grep $hostname";
+    assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
 
     assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O /tmp/$mpi_c");
-    assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/$mpi_compiler /tmp/$mpi_c -o /tmp/mpi_bin | tee /tmp/make.out");
+    assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/$mpi_compiler /tmp/$mpi_c -o /tmp/$mpi_bin | tee /tmp/make.out") if $mpi_compiler;
 
+
+    # python code is not compiled. *mpi_bin* is expected as a compiled binary. if compilation was not
+    # invoked return source code (ex: sample_scipy.py).
+    $mpi_bin = ($mpi_compiler) ? $mpi_bin : $mpi_c;
     ## distribute the binary
     foreach (@cluster_nodes) {
-        assert_script_run("scp -o StrictHostKeyChecking=no /tmp/mpi_bin root\@$_\:/tmp/mpi_bin");
+        assert_script_run("scp -o StrictHostKeyChecking=no /tmp/$mpi_bin root\@$_\:/tmp/$mpi_bin");
     }
-    barrier_wait('MPI_BINARIES_READY');
 
-    unless (get_var('HPC_LIB', '') == 'boost') {
+    barrier_wait('MPI_BINARIES_READY');
+    my $mpirun_s = hpc::formatter->new();
+
+    unless (get_var('HPC_LIB', '') eq 'boost') {
         record_info('INFO', 'Run MPI over single machine');
-        ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
-        if ($mpi =~ m/openmpi/) {
-            assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --allow-run-as-root /tmp/mpi_bin");
-        } else {
-            assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun /tmp/mpi_bin | tee /tmp/mpirun.out");
-        }
+        assert_script_run($mpirun_s->single_node("/tmp/$mpi_bin | tee /tmp/mpirun.out"));
     }
+
     record_info('INFO', 'Run MPI over several nodes');
-    if ($mpi =~ m/openmpi/) {
-        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --allow-run-as-root --host $cluster_nodes  /tmp/mpi_bin");
-    } elsif ($mpi eq 'mvapich2') {
+    if ($mpi eq 'mvapich2') {
         # we do not support ethernet with mvapich2
-        my $return = script_run("set -o pipefail;/usr/lib64/mpi/gcc/$mpi/bin/mpirun --host $cluster_nodes /tmp/mpi_bin |& tee /tmp/mpi_bin.log");
+        my $return = script_run("set -o pipefail;" . $mpirun_s->all_nodes("/tmp/$mpi_bin |& tee /tmp/mpi_bin.log"));
         if ($return == 143) {
             record_info("mvapich2 info", "echo $return - No IB device found");
         } elsif ($return == 139 || $return == 255) {
@@ -75,7 +82,7 @@ sub run ($self) {
             die("echo $return - not expected errorcode");
         }
     } else {
-        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun -print-all-exitcodes --host $cluster_nodes /tmp/mpi_bin");
+        assert_script_run($mpirun_s->all_nodes('/tmp/$mpi_bin | tee /tmp/mpirun.out'));
     }
 
     barrier_wait('MPI_RUN_TEST');

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -61,7 +61,7 @@ sub run ($self) {
     barrier_wait('MPI_BINARIES_READY');
     my $mpirun_s = hpc::formatter->new();
 
-    unless (get_var('HPC_LIB', '') eq 'boost') {
+    unless ($mpi_bin eq '.cpp') {    # because calls expects minimum 2 nodes
         record_info('INFO', 'Run MPI over single machine');
         assert_script_run($mpirun_s->single_node("/tmp/$mpi_bin | tee /tmp/mpirun.out"));
     }

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -4,31 +4,30 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: openmpi mpirun check
-# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+# Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base qw(hpcbase hpc::utils);
+use Mojo::Base qw(hpcbase hpc::utils), -signatures;
 use testapi;
 use lockapi;
 use utils;
 
-sub run {
-    my $self = shift;
+sub run ($self) {
     my $mpi = $self->get_mpi();
 
-    zypper_call("in $mpi");
-
+    # python3-devel is used to install and compile /mpi4py/ deps when HPC_LIB eq scipy
+    zypper_call("in $mpi $mpi-devel gcc gcc-c++ python3-devel");
+    $self->setup_scientific_module();
+    assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
     barrier_wait('MPI_BINARIES_READY');
     barrier_wait('MPI_RUN_TEST');
 }
 
-sub test_flags {
+sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
-}
+sub post_fail_hook ($self) { }
 
 1;


### PR DESCRIPTION
Install `python3-scipy-gnu-hpc` and run a /hello/ python script.
To do so i use a python module /mpi4py/ which helps in translating MPI syntax
for C++ to Python. The script is really simple and it just validates that the
availability of the scipy(in fact numpy comes along too).
TODO: Update script with a more realistic scenario

After the installation some env variables are not populated so a
logout/restart is required, such as some init scripts will
rerun in order to set those variables. (/usr/share/lmod/lmod/init/bash,
/etc/profile.d, etc). After relogin variables as `MODULEPATH` should be
available in the env and `module av` should be able to find the modules
installed from `*-gnu-hpc` like _scipy_.

I introduce a new module, `formatter.pm`. The aim is to prepare the MPI
command for execution. This is needed for simplicity of the various expressions
of the commands against the several MPI implementations in combination the
numerous scientific modules. The idea is to be able to express as following
for maximux flexibility:

- $mpi_str_obj->all_nodes('path/to/bin');
- $mpi_str_obj->single_host('python path/to/bin');

I consider that the `formatter` is not fully ready but it seems to work for
now.

I have some additional concerns for `setup_scientific_module`. I imagined it
as one place to have all the config steps for each HPC library. However i
found that there would be some which will be available from /spack/ in the
future and are not available in sle15sp4. One of them is *boost*. that
particular block is commented out as the steps will not work for the time
being.

Finally it is just confusing to have this line inside `relogin_root` but sshd
is inactive after login back and needs restart.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Related ticket: https://progress.opensuse.org/issues/63262
- Verification run: http://aquarius.suse.cz/tests/8869
https://openqa.suse.de/tests/overview?version=15-SP4&build=b10n1k%2Fos-autoinst-distri-opensuse%2314495&distri=sle