### PR TITLE
sles4sap: Temporary fix for HANA on NVDIMM

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -228,6 +228,11 @@ sub run {
       "--logpath=$mountpts{hanalog}->{mountpt}/$sid",
       "--sapmnt=$mountpts{hanashared}->{mountpt}";
     push @hdblcm_args, "--pmempath=$pmempath", "--use_pmem" if get_var('NVDIMM');
+    # NOTE: Remove when SAP releases HANA with a fix for bsc#1195133
+    if (get_var('NVDIMM')) {
+        push @hdblcm_args, "--ignore=check_signature_file";
+        record_soft_failure("Workaround for bsc#1195133");
+    }
     my $cmd = join(' ', $hdblcm, @hdblcm_args);
     record_info 'hdblcm command', $cmd;
     assert_script_run $cmd, $tout;


### PR DESCRIPTION
Current HANA tests on NVDIMM are failing due to https://bugzilla.suse.com/show_bug.cgi?id=1195133

This PR adds a temporary fix to ignore the checksums file only on NVDIMM tests.  We should revert it when SAP ships a fixed HANA SPS05.

Verification run: https://openqa.suse.de/tests/8334839