### PR TITLE
sles4sap: Run terraform workspace after terraform init

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -364,12 +364,13 @@ sub terraform_apply {
             q(%SLE_VERSION%) => $sle_version
         );
         upload_logs(TERRAFORM_DIR . "/$cloud_name/terraform.tfvars", failok => 1);
+        script_retry('terraform init -no-color', timeout => $terraform_timeout, delay => 3, retry => 6);
         assert_script_run("terraform workspace new $resource_group -no-color", $terraform_timeout);
     }
     else {
         assert_script_run('cd ' . TERRAFORM_DIR);
+        script_retry('terraform init -no-color', timeout => $terraform_timeout, delay => 3, retry => 6);
     }
-    script_retry('terraform init -no-color', timeout => $terraform_timeout, delay => 3, retry => 6);
 
     my $cmd = 'terraform plan -no-color ';
     if (!get_var('PUBLIC_CLOUD_SLES4SAP')) {


### PR DESCRIPTION
With Terraform 1.1.x the `terraform workspace` command fails if there are no providers set, thus the `terraform init` command must be run first to download the providers.

Failed test:
https://openqa.suse.de/tests/8335472/logfile?filename=serial_terminal.txt

Verification runs (failing for other reasons):
- EC2: https://openqa.suse.de/tests/8335542
- Azure: https://openqa.suse.de/tests/8335543
- GCP: https://openqa.suse.de/tests/8335544