### PR TITLE
Add setting to support qcow generation after migration for regression test

### DIFF
--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -6,6 +6,7 @@ description:    |
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   #means regression test part2 include x11 test.
   #REGRESSION_389DS: '1' means load 389ds test.
+  #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -37,19 +38,26 @@ schedule:
   - installation/first_boot
   - installation/system_workarounds
   - migration/post_upgrade
-  - console/system_prepare
-  - console/check_system_info
-  - console/check_network
-  - console/system_state
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - '{{check_upgraded_service}}'
-  - '{{openldap_to_389ds}}'
-  - '{{regression_tests}}'
-  - boot/grub_test_snapshot
-  - migration/version_switch_origin_system
-  - boot/snapper_rollback
+  - '{{qcow_generation}}'
 conditional_schedule:
+  qcow_generation:
+    QCOW_GENERATION:
+      0:
+        - console/system_prepare
+        - console/check_system_info
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - '{{check_upgraded_service}}'
+        - '{{openldap_to_389ds}}'
+        - '{{regression_tests}}'
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback
+      1:
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -5,6 +5,7 @@ description:    |
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   # means regression test part2 include x11 test.
   #REGRESSION_389DS: '1' means load 389ds test.
+  #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -18,19 +19,26 @@ schedule:
   - migration/online_migration/pre_migration
   - '{{migration_method}}'
   - migration/online_migration/post_migration
-  - console/system_prepare
-  - console/check_system_info
-  - console/check_network
-  - console/system_state
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - console/check_upgraded_service
-  - '{{openldap_to_389ds}}'
-  - '{{regression_tests}}'
-  - boot/grub_test_snapshot
-  - migration/version_switch_origin_system
-  - boot/snapper_rollback
+  - '{{qcow_generation}}'
 conditional_schedule:
+  qcow_generation:
+    QCOW_GENERATION:
+      0:
+        - console/system_prepare
+        - console/check_system_info
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - console/check_upgraded_service
+        - '{{openldap_to_389ds}}'
+        - '{{regression_tests}}'
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback
+      1:
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
   remove_ltss:
     REGRESSION_LTSS:
       1:

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -6,6 +6,7 @@ description:    |
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   #means regression test part2 include x11 test.
   #REGRESSION_389DS: '1' means load 389ds test.
+  #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -36,19 +37,26 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - migration/post_upgrade
-  - console/system_prepare
-  - console/check_system_info
-  - console/check_network
-  - console/system_state
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - '{{check_upgraded_service}}'
-  - '{{openldap_to_389ds}}'
-  - '{{regression_tests}}'
-  - boot/grub_test_snapshot
-  - migration/version_switch_origin_system
-  - boot/snapper_rollback
+  - '{{qcow_generation}}'
 conditional_schedule:
+  qcow_generation:
+    QCOW_GENERATION:
+      0:
+        - console/system_prepare
+        - console/check_system_info
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - '{{check_upgraded_service}}'
+        - '{{openldap_to_389ds}}'
+        - '{{regression_tests}}'
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback
+      1:
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -5,6 +5,7 @@ description:    |
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   # means regression test part2 include x11 test.
   #REGRESSION_389DS: '1' means load 389ds test.
+  #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -19,19 +20,26 @@ schedule:
   - migration/online_migration/pre_migration
   - '{{migration_method}}'
   - migration/online_migration/post_migration
-  - console/system_prepare
-  - console/check_system_info
-  - console/check_network
-  - console/system_state
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - '{{check_upgraded_service}}'
-  - '{{openldap_to_389ds}}'
-  - '{{regression_tests}}'
-  - boot/grub_test_snapshot
-  - migration/version_switch_origin_system
-  - boot/snapper_rollback
+  - '{{qcow_generation}}'
 conditional_schedule:
+  qcow_generation:
+    QCOW_GENERATION:
+      0:
+        - console/system_prepare
+        - console/check_system_info
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - '{{check_upgraded_service}}'
+        - '{{openldap_to_389ds}}'
+        - '{{regression_tests}}'
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback
+      1:
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -6,6 +6,7 @@ description:    |
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   #means regression test part2 include x11 test.
   #REGRESSION_389DS: '1' means load 389ds test.
+  #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -35,16 +36,23 @@ schedule:
   - installation/handle_reboot
   - installation/first_boot
   - migration/post_upgrade
-  - console/system_prepare
-  - console/check_system_info
-  - console/check_network
-  - console/system_state
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - '{{check_upgraded_service}}'
-  - '{{openldap_to_389ds}}'
-  - '{{regression_tests}}'
+  - '{{qcow_generation}}'
 conditional_schedule:
+  qcow_generation:
+    QCOW_GENERATION:
+      0:
+        - console/system_prepare
+        - console/check_system_info
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - '{{check_upgraded_service}}'
+        - '{{openldap_to_389ds}}'
+        - '{{regression_tests}}'
+      1:
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -5,6 +5,7 @@ description:    |
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   # means regression test part2 include x11 test.
   #REGRESSION_389DS: '1' means load 389ds test.
+  #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -19,16 +20,23 @@ schedule:
   - migration/online_migration/pre_migration
   - '{{migration_method}}'
   - migration/online_migration/post_migration
-  - console/check_upgraded_service
-  - console/system_prepare
-  - console/check_system_info
-  - console/check_network
-  - console/system_state
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - '{{openldap_to_389ds}}'
-  - '{{regression_tests}}'
+  - '{{qcow_generation}}'
 conditional_schedule:
+  qcow_generation:
+    QCOW_GENERATION:
+      0:
+        - console/check_upgraded_service
+        - console/system_prepare
+        - console/check_system_info
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - '{{openldap_to_389ds}}'
+        - '{{regression_tests}}'
+      1:
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
   remove_ltss:
     REGRESSION_LTSS:
       1:

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -5,6 +5,7 @@ description:    |
   #support service check test, normally set '0' for package media test.
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   #means regression test part2 include x11 test.
+  #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
   BOOT_HDD_IMAGE: 1
@@ -35,19 +36,26 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - migration/post_upgrade
-  - console/system_prepare
-  - console/check_system_info
-  - console/check_network
-  - console/system_state
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - '{{check_upgraded_service}}'
-  - migration/openldap_to_389ds
-  - '{{regression_tests}}'
-  - boot/grub_test_snapshot
-  - migration/version_switch_origin_system
-  - boot/snapper_rollback
+  - '{{qcow_generation}}'
 conditional_schedule:
+  qcow_generation:
+    QCOW_GENERATION:
+      0:
+        - console/system_prepare
+        - console/check_system_info
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - '{{check_upgraded_service}}'
+        - migration/openldap_to_389ds
+        - '{{regression_tests}}'
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback
+      1:
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -4,6 +4,7 @@ description:    |
   #REGRESSION_LTSS: '1' means base system supports ltss test.
   #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
   # means regression test part2 include x11 test.
+  # QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: gnome
   BOOT_HDD_IMAGE: 1
@@ -18,19 +19,26 @@ schedule:
   - migration/online_migration/pre_migration
   - '{{migration_method}}'
   - migration/online_migration/post_migration
-  - console/check_upgraded_service
-  - console/system_prepare
-  - console/check_system_info
-  - console/check_network
-  - console/system_state
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - migration/openldap_to_389ds
-  - '{{regression_tests}}'
-  - boot/grub_test_snapshot
-  - migration/version_switch_origin_system
-  - boot/snapper_rollback
+  - '{{qcow_generation}}'
 conditional_schedule:
+  qcow_generation:
+    QCOW_GENERATION:
+      0:
+        - console/check_upgraded_service
+        - console/system_prepare
+        - console/check_system_info
+        - console/check_network
+        - console/system_state
+        - console/prepare_test_data
+        - console/consoletest_setup
+        - migration/openldap_to_389ds
+        - '{{regression_tests}}'
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback
+      1:
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
   remove_ltss:
     REGRESSION_LTSS:
       1:


### PR DESCRIPTION
We need add setting in YAML file of regression job group to set the branch for qcow generation using condition-schedule. Set QCOW_GENERATION=1 then generate qcow after migration, QCOW_GENERATION=0 then continue run regression test after migration.

- Related ticket: https://progress.opensuse.org/issues/108263
- Needles: N/A
- Verification run: 
  x86_64:
  http://openqa.nue.suse.com/t8327814  offline, generate qcow
  http://openqa.nue.suse.com/t8327610  offline, no qcow generated
  http://openqa.nue.suse.com/tests/8334569#  online, generate qcow
  http://openqa.nue.suse.com/tests/8334234     online, no qcow generated
  s390x:
  http://openqa.nue.suse.com/tests/8334235  offline,generate qcow
  http://openqa.nue.suse.com/tests/8334237 offline no qcow
  http://openqa.nue.suse.com/tests/8334238#  online , generate qcow
  http://openqa.nue.suse.com/tests/8334160#  online, no qcow
  ppc64le:
  http://openqa.nue.suse.com/tests/8334240   offline, qcow
  http://openqa.nue.suse.com/tests/8334261  offline, no qcow
  http://openqa.nue.suse.com/tests/8334262  online, qcow
  http://openqa.nue.suse.com/tests/8334263  online, no qcow
  aarch64:
  http://openqa.nue.suse.com/tests/8334264 offline, qcow
  http://openqa.nue.suse.com/tests/8334265  offline, no qcow
  http://openqa.nue.suse.com/tests/8334266  online, qcow
  http://openqa.nue.suse.com/tests/8334327  online , no qcow