### PR TITLE
Support NTLM authentication in Unified Installer

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -23,6 +23,7 @@ use utils qw(get_netboot_mirror type_string_slow enter_cmd_slow);
 use version_utils 'is_upgrade';
 use Utils::Backends;
 use YuiRestClient;
+use ntlm_auth;
 
 our @EXPORT = qw(
   boot_pvm
@@ -98,11 +99,13 @@ sub prepare_pvm_installation {
     my $mirror = get_netboot_mirror;
     my $mntpoint = "mnt/openqa/repo/$repo/boot/ppc64le";
     assert_screen "pvm-grub-command-line-fresh-prompt", no_wait => 1;
-    type_string_slow "linux $mntpoint/linux vga=normal install=$mirror ";
+
+    my $ntlm_p = get_var('NTLM_AUTH_INSTALL') ? $ntlm_auth::ntlm_proxy : '';
+    type_string_slow "linux $mntpoint/linux vga=normal $ntlm_p install=$mirror ";
     bootmenu_default_params;
     bootmenu_network_source;
     specific_bootmenu_params;
-    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
+    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED) unless get_var('NTLM_AUTH_INSTALL');
     type_string_slow remote_install_bootmenu_params;
     type_string_slow " fips=1" if (get_var('FIPS_INSTALLATION'));
     type_string_slow " UPGRADE=1" if (get_var('UPGRADE'));

--- a/lib/ntlm_auth.pm
+++ b/lib/ntlm_auth.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Basic variable setting for ntlm auth installer
+# Maintainer: rfan1 <richard.fan@suse.com>
+
+package ntlm_auth;
+
+use base Exporter;
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+our @EXPORT = qw(
+  $ntlm_user
+  $ntlm_paswd
+  $proxy_server
+  $listen_port
+  $ntlm_proxy
+);
+
+if (get_var("NTLM_AUTH_INSTALL")) {
+    our $ntlm_user = get_required_var("NTLM_USER");
+    our $ntlm_paswd = get_required_var("NTLM_PASSWD");
+    our $proxy_server = get_required_var("PROXY_SERVER");
+    our $listen_port = get_required_var("LISTEN_PORT");
+    our $ntlm_proxy = "proxy=http://$ntlm_user:$ntlm_paswd\@$proxy_server:$listen_port";
+}
+
+1;

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -252,6 +252,7 @@ sub run {
     }
     send_key $cmd{next};
     wait_still_screen 5;
+    send_key $cmd{next} if check_screen 'addon_product_installation';
 }
 
 1;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,6 +69,7 @@ sub get_product_shortcuts {
     }
     # We got new products in SLE 15 SP1
     elsif (is_sle '15-SP1+') {
+        return (sles => 's') if (get_var('ISO') =~ /Full/ && is_ppc64le() && get_var('NTLM_AUTH_INSTALL'));
         return (
             sles => (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'


### PR DESCRIPTION
Base on https://jira.suse.com/browse/SLE-22181
We need support NTLM authentication during the
installation phase. in this case, we have available
the Windows AD server and proxy server.

- Related ticket: https://progress.opensuse.org/issues/108134
- Needles: already uploaded to osd
- Verification run:
https://openqa.suse.de/tests/8538268 - PowerVM
http://openqa.suse.de/tests/8538306  - s390x
- Regression VR:
https://openqa.suse.de/tests/8538266
https://openqa.suse.de/tests/8538679