### PR TITLE
Restart systemd-vconsole-setup service to re-setup font

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -34,7 +34,7 @@ sub setup_sle {
 
     if (is_ppc64le && is_sle('<=12-sp5')) {
         record_soft_failure("bsc#1195046", 'ncurses display a wrong checker board character');
-        assert_script_run('echo /usr/lib/systemd/systemd-vconsole-setup >> /etc/bash.bashrc.local');
+        systemctl('restart systemd-vconsole-setup.service');
     }
 
     # Stop packagekitd

--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -263,8 +263,7 @@ sub install_services {
     }
     # On ppc64le, sometime the console font will be distorted into pseudo graphics characters.
     # we need to reset the console font. As it impacted all the console services, added this command to bashrc file
-    assert_script_run('echo /usr/lib/systemd/systemd-vconsole-setup >> /etc/bash.bashrc.local') if is_ppc64le;
-    assert_script_run '. /etc/bash.bashrc.local';
+    systemctl('restart systemd-vconsole-setup.service') if is_ppc64le;
     foreach my $s (sort keys %$service) {
         my $srv_pkg_name = $service->{$s}->{srv_pkg_name};
         my $srv_proc_name = $service->{$s}->{srv_proc_name};
@@ -303,11 +302,6 @@ sub install_services {
             record_info($srv_pkg_name, "failed reason: $@", result => 'fail');
             $srv_check_results{'before_migration'} = 'FAIL';
         }
-    }
-    # Keep the configuration file clean
-    if (is_ppc64le) {
-        assert_script_run("sed -i '\$d' /etc/bash.bashrc.local");
-        assert_script_run '. /etc/bash.bashrc.local';
     }
 }
 


### PR DESCRIPTION
Restart systemd-vconsole-setup service to re-setup font avoid
messy code problem

- Related ticket: https://progress.opensuse.org/issues/108200
- Verification run: http://openqa.suse.de/tests/8338206
 SLE12: https://openqa.suse.de/tests/8339333#step/patch_sle/22