### PR TITLE
Integrate 'DRNG test preparation' into OpenQA

### DIFF
--- a/schedule/security/atsec_tests.yaml
+++ b/schedule/security/atsec_tests.yaml
@@ -4,7 +4,9 @@ description:    >
 schedule:
     - '{{bootloader_zkvm}}'
     - boot/boot_to_desktop
+    - security/atsec/setup_atsec_env
     - security/atsec/kvm_check
+    - security/atsec/drng_test_preparation
 conditional_schedule:
     bootloader_zkvm:
         ARCH:

--- a/tests/security/atsec/drng_test_preparation.pm
+++ b/tests/security/atsec/drng_test_preparation.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run 'DRNG test preparation' test case of ATSec test suite
+# Maintainer: xiaojing.liu <xiaojing.liu@suse.com>
+# Tags: poo#108485
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # Install the required packages
+    zypper_call('in gcc libopenssl-devel libgcrypt-devel');
+
+    my $test_dir = '/root/eval/drng';
+    # Complile gather_random_data
+    my $exe_file = 'gather_random_data';
+    assert_script_run('cd /usr/local/atsec');
+    assert_script_run("gcc -o $exe_file -lcrypto -lssl -lgcrypt gather_random_data.c");
+
+    # Prepare the test directory
+    assert_script_run("mkdir -p $test_dir");
+
+    # Copy the executable file to test directory
+    assert_script_run("cp $exe_file $test_dir/");
+
+    # Run the test
+    assert_script_run("cd $test_dir");
+    assert_script_run("./$exe_file 2");
+
+    # Check result
+    # We need to filter 'total ' and gather_random_data from the results of 'ls -l',
+    # then check if there are only 3 files are generated (As expected).
+    my $result = script_output("ls -l | grep -v \"total\" | grep -v \"$exe_file\"");
+    my @lines = split(/\n/, $result);
+    record_info('ERROR', "Others files are generated\n$result", result => 'fail') if (scalar(@lines) != 3);
+
+    foreach my $line (@lines) {
+        my @items = split(/\s/, $line);
+        my $file_size = $items[4];
+        my $file_name = $items[-1];
+
+        # Skip gather_random_data
+        next if ($file_name eq $exe_file);
+
+        # The size of file should be 5M
+        if (int($file_size) != 5242880) {
+            record_info('ERROR', "The size of $file_name isn't 5M:\n $file_size $file_name", result => 'fail');
+            $self->result('fail');
+        }
+    }
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/security/atsec/setup_atsec_env.pm
+++ b/tests/security/atsec/setup_atsec_env.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Download the test scripts which Atsec tests need
+# Maintainer: xiaojing.liu <xiaojing.liu@suse.com>
+# Tags: poo#108485
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # Install tool packages
+    zypper_call('in wget');
+
+    # Download the test scripts
+    my $code_path = get_required_var('CODE_PATH');
+    my @lines = split(/[\/\.]+/, $code_path);
+    my $file_name = $lines[-2];
+    my $file_tar = $file_name . 'tar';
+    assert_script_run("wget --no-check-certificate $code_path -O /tmp/$file_tar");
+    assert_script_run("tar -xvf /tmp/$file_tar -C /tmp/");
+    assert_script_run("mv /tmp/$file_name /usr/local/atsec");
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Related: https://progress.opensuse.org/issues/108485
Verify run: https://openqa.suse.de/tests/8339847 (s390x)
                  https://openqa.suse.de/tests/8339699 (x86)
                  https://openqa.suse.de/tests/8340047 (aarch64)