### PR TITLE
grub_test: increase number of time to hit 'down' key to make sure to reach the 'linux' line

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -76,7 +76,7 @@ sub bug_workaround_bsc1005313 {
     record_soft_failure "Running with plymouth:debug to catch bsc#1005313" if get_var('PLYMOUTH_DEBUG');
     send_key 'e';
     # Move to end of kernel boot parameters line
-    send_key_until_needlematch "linux-line-selected", "down";
+    send_key_until_needlematch "linux-line-selected", "down", 25;
     send_key "end";
 
     assert_screen "linux-line-matched";


### PR DESCRIPTION
- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1197186
- Verification run: https://openqa.opensuse.org/tests/2248658#step/grub_test/26
