### PR TITLE
Introduce FIRST_BOOT_CONFIG variable for MicroOS

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -313,5 +313,12 @@
             "sle": ["15-SP2", "15-SP3"]
         },
         "type": "ignore"
+    },
+    "no-config-drive": {
+        "description": "Timed out waiting for device (/dev/disk/by-label/ignition|/dev/combustion/config)",
+        "products": {
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "ignore"
     }
 }

--- a/lib/jeos.pm
+++ b/lib/jeos.pm
@@ -7,13 +7,13 @@ use testapi;
 use utils qw(ensure_serialdev_permissions);
 use power_action_utils qw(power_action);
 use Utils::Backends qw(is_hyperv);
-use version_utils qw(is_sle is_tumbleweed is_leap);
+use version_utils qw(is_sle);
 use bootloader_setup qw(change_grub_config grep_grub_settings grub_mkconfig set_framebuffer_resolution set_extrabootparams_grub_conf);
 
 our @EXPORT = qw(expect_mount_by_uuid set_grub_gfxmode reboot_image);
 
 sub expect_mount_by_uuid {
-    return (is_hyperv || is_sle('>=15-sp2') || is_tumbleweed || is_leap('>=15.2'));
+    return !(!is_hyperv && is_sle('<15-sp2'));
 }
 
 sub reboot_image {

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -35,7 +35,11 @@ sub load_boot_from_dvd_tests {
 
 sub load_boot_from_disk_tests {
     # Preparation for start testing
-    loadtest 'microos/disk_boot';
+    if (check_var("FIRST_BOOT_CONFIG", "wizard")) {
+        loadtest 'jeos/firstrun';
+    } else {
+        loadtest 'microos/disk_boot';
+    }
     loadtest 'installation/system_workarounds' if is_aarch64;
     replace_opensuse_repos_tests if is_repo_replacement_required;
     # ^ runs only outside of stagings, clear repos otherwise

--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -29,8 +29,10 @@ sub run {
     my $varsize = script_output "findmnt -rnboSIZE -T/var";
     die "/var did not grow, got $varsize B" unless $varsize > (5 * 1024 * 1024 * 1024);
 
-    # Verify that combustion ran
-    validate_script_output('cat /usr/share/combustion-welcome', qr/Combustion was here/);
+    if (get_var("FIRST_BOOT_CONFIG", "combustion+ignition") =~ /combustion/) {
+        # Verify that combustion ran
+        validate_script_output('cat /usr/share/combustion-welcome', qr/Combustion was here/);
+    }
 }
 
 1;

--- a/variables.md
+++ b/variables.md
@@ -68,7 +68,6 @@ EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET | string | | If specified, go back with the
 EXTRATEST | boolean | false | Enables execution of extra tests, see `load_extra_tests`
 FIRST_BOOT_CONFIG | string | combustion+ignition | The method used for initial configuration of MicroOS images. Possible values are: `combustion`, `ignition`, `combustion+ignition` and `wizard`. For ignition/combustion, the job needs to have a matching HDD attached.
 FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DVD`, `Krypton`, `Argon`, `Gnome-Live`, `DVD`, `Rescue-CD`, etc.
-SALT_FORMULAS_PATH | string | | Used to point to a tarball with relative path to [/data/yast2](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data/yast2) which contains all the needed files (top.sls, form.yml, ...) to support provisioning with Salt masterless mode.
 FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only.
 FULL_LVM_ENCRYPT | boolean | false | Enables/indicates encryption using lvm. boot partition may or not be encrypted, depending on the product default behavior.
 FUNCTION | string | | Specifies SUT's role for MM test suites. E.g. Used to determine which SUT acts as target/server and initiator/client for iscsi test suite
@@ -127,6 +126,7 @@ PERF_KERNEL | boolean | false | Enables kernel performance testing.
 PERF_INSTALL | boolean | false | Enables kernel performance testing installation part.
 PERF_SETUP | boolean | false | Enables kernel performance testing deployment part.
 PERF_RUNCASE | boolean | false | Enables kernel performance testing run case part.
+SALT_FORMULAS_PATH | string | | Used to point to a tarball with relative path to [/data/yast2](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data/yast2) which contains all the needed files (top.sls, form.yml, ...) to support provisioning with Salt masterless mode.
 _SECRET_PUBLIC_CLOUD_REST_URL | string | "https://publiccloud.qa.suse.de/vault" | Vault server URL
 _SECRET_PUBLIC_CLOUD_REST_USER | string | "" | Vault server user name
 _SECRET_PUBLIC_CLOUD_REST_PW | string | "" | Vault server user password

--- a/variables.md
+++ b/variables.md
@@ -66,6 +66,7 @@ EXTRABOOTPARAMS_BOOT_LOCAL | string | | Boot options applied during the boot pro
 EXTRABOOTPARAMS_DELETE_CHARACTERS | string | | Characters to delete from boot prompt.
 EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET | string | | If specified, go back with the cursor until this needle is matched to delete characters from there. Needs EXTRABOOTPARAMS_BOOT_LOCAL and should be combined with EXTRABOOTPARAMS_DELETE_CHARACTERS.
 EXTRATEST | boolean | false | Enables execution of extra tests, see `load_extra_tests`
+FIRST_BOOT_CONFIG | string | combustion+ignition | The method used for initial configuration of MicroOS images. Possible values are: `combustion`, `ignition`, `combustion+ignition` and `wizard`. For ignition/combustion, the job needs to have a matching HDD attached.
 FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DVD`, `Krypton`, `Argon`, `Gnome-Live`, `DVD`, `Rescue-CD`, etc.
 SALT_FORMULAS_PATH | string | | Used to point to a tarball with relative path to [/data/yast2](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data/yast2) which contains all the needed files (top.sls, form.yml, ...) to support provisioning with Salt masterless mode.
 FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only.


### PR DESCRIPTION
Allows new scenarios which don't use the combustion+ignition combination.

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/764
- Verification runs:
  * Variable unset, as before: http://10.160.67.86/tests/1226 (still running)
  * Using jeos-firstboot: http://10.160.67.86/tests/1225 (still running)

~~I'm not sure whether the `WIZARD` variable is the best approach here. Ideally we'd also test `ignition` and `combustion` separately, so we might want something like `MICROOS_CONFIG` with values like `combustion`, `combustion+ignition`, `jeos-firstboot` instead.~~  Using `FIRST_BOOT_CONFIG` now.