### PR TITLE
Fix failing ssh-keyscan in boottime

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -257,9 +257,11 @@ sub create_instances {
     my @vms = $self->terraform_apply(%args);
     foreach my $instance (@vms) {
         record_info("INSTANCE $instance->{instance_id}", Dumper($instance));
-        $instance->wait_for_ssh() if ($args{check_connectivity});
-        # Install server's ssh publicckeys to prevent authenticity interactions
-        assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
+        if ($args{check_connectivity}) {
+            $instance->wait_for_ssh();
+            # Install server's ssh publicckeys to prevent authenticity interactions
+            assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
+        }
     }
     return @vms;
 }

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -297,6 +297,7 @@ sub measure_timings {
     }
 
     $ret->{analyze}->{ssh_access} = $instance->wait_for_ssh(timeout => 300);
+    assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
 
     my ($systemd_analyze, $systemd_blame) = do_systemd_analyze($instance);
     $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));


### PR DESCRIPTION
Fix the failing ssh-keyscan command in the boottime test runs.

- Related ticket: https://progress.opensuse.org/issues/108320
- Verification run: http://duck-norris.qam.suse.de/t8360
