### PR TITLE
Activate development-tools module

### DIFF
--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -21,6 +21,13 @@ use version_utils 'is_sle';
 use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
 
 sub run {
+    if (is_sle('>=15-sp4')) {
+        my $self = shift;
+        $self->select_serial_terminal;
+        # Activating development-tools module to install libqt5-qttools package
+        add_suseconnect_product("sle-module-development-tools");
+    }
+
     select_console('x11');
     ensure_installed("libqt5-qttools yast2-installation", timeout => 180);
 


### PR DESCRIPTION
Activating development-tools module for the installation of libqt5-qttools package.

https://progress.opensuse.org/issues/108076

Signed-off-by: Avinesh Kumar <akumar@suse.de>

- Related ticket: https://progress.opensuse.org/issues/108076
- Verification runs: 
  sle15-sp4:  [x86_64](https://openqa.suse.de/tests/8341320#step/libqt5_qtbase/25), [aarch64](https://openqa.suse.de/tests/8341318#step/libqt5_qtbase/20), [ppc64le](https://openqa.suse.de/tests/8341317#step/libqt5_qtbase/20), [s390x](https://openqa.suse.de/tests/8341316#step/libqt5_qtbase/20)
