### PR TITLE
Cover 'unprivileged_bpf_disabled=1' for eBPF test case

### DIFF
--- a/data/ebpf/bpf_test.c
+++ b/data/ebpf/bpf_test.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <linux/bpf.h>
+#include <sys/syscall.h>
+#include <errno.h>
+#include <unistd.h>
+#include <string.h>
+
+/*
+ * on success, this function returns a file descriptor.
+ * on error, -1 is returned and errno is set to
+ * EINVAL, EPERM, or ENOMEM.
+ */
+int sys_bpf(enum bpf_cmd cmd, union bpf_attr *attr, unsigned int size)
+{
+        return syscall(__NR_bpf, cmd, attr, size);
+}
+
+int main(int argc, char **argv)
+{
+        // redirect stderr to stdout
+        dup2(1, 2);
+        // refer: https://github.com/torvalds/linux/tree/master/samples/bpf
+        union bpf_attr attr;
+        memset(&attr, 0, sizeof(attr));
+
+        attr.map_type    = BPF_MAP_TYPE_ARRAY;
+        attr.key_size    = sizeof(int);
+        attr.value_size  = sizeof(int);
+        attr.max_entries = 1;
+
+        int fd = sys_bpf(BPF_MAP_CREATE, &attr, sizeof(attr));
+        perror("BPF");
+
+        // release file descriptor
+        if (fd > 0) {
+                close(fd);
+        }
+
+        return 0;
+}

--- a/tests/security/ebpf/check_cap_bpf.pm
+++ b/tests/security/ebpf/check_cap_bpf.pm
@@ -1,4 +1,4 @@
-# Copyright 2021 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Test 'CAP_BPF' capability is available:


### PR DESCRIPTION
## Cover `unprivileged_bpf_disabled=1` for eBPF test case
- Added a C test code to check whether user can use bpf system call or not
- Updated `eBPF` test case to cover `unprivileged_bpf_disabled=1`

    Writing 1 to `unprivileged_bpf_disabled` will disable unprivileged calls to `bpf()`; 
    once disabled, calling `bpf()` without `CAP_SYS_ADMIN` or `CAP_BPF` 
    or root permission will return `-EPERM`. 
    Once set to 1, this can’t be cleared from the running kernel anymore.
    
Refer: [Linux kernel Documentation for /proc/sys/kernel/](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html#unprivileged-bpf-disabled)

- Related ticket: https://progress.opensuse.org/issues/108302
- Needles: NA
- Verification run:
  Leap 15.4: https://openqa.opensuse.org/tests/2250552
  sle15sp4: https://openqa.suse.de/tests/8360534
