### PR TITLE
Bump RAM for AutoYaST multibtrfs scenario

### DIFF
--- a/schedule/yast/autoyast_multi_btrfs.yaml
+++ b/schedule/yast/autoyast_multi_btrfs.yaml
@@ -6,7 +6,7 @@ vars:
   DESKTOP: gnome
   ENCRYPT: 1
   NUMDISKS: '4'
-  QEMURAM: 2048
+  QEMURAM: 3052
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start


### PR DESCRIPTION
When there is encryption a bit of more RAM is needed sometimes:
Fixes https://openqa.suse.de/tests/8292864#step/boot_encrypt/6
Verification: https://openqa.suse.de/tests/8340474#step/first_boot/10
