### PR TITLE
Detect ssh port state on remote machine directly instead of waiting for needle

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -15,7 +15,7 @@ use testapi;
 use Utils::Architectures;
 use Utils::Backends qw(use_ssh_serial_console is_remote_backend set_ssh_console_timeout);
 use ipmi_backend_utils;
-use virt_autotest::utils qw(is_xen_host);
+use virt_autotest::utils qw(is_xen_host check_port_state);
 use IPC::Run;
 
 sub set_ssh_console_timeout_before_use {
@@ -128,7 +128,7 @@ sub login_to_console {
             send_key 'down';
             send_key 'ret';
             #wait sshd up
-            assert_screen('sshd-server-started', 180);
+            die "Can not connect to machine to perform offline upgrade via ssh" unless (check_port_state(get_required_var('SUT_IP'), 22, 10));
             save_screenshot;
             #switch to ssh console
             use_ssh_serial_console;


### PR DESCRIPTION
* **Needle** sshd-server-started matching fails at offline upgrade step very often which definitely delays completion of virtualization test run, especially those in acceptance group. The situation becomes even worse with Build113.1.
* **This** commit aims to solve the problem completely by detecting open ssh port on remote machine straightaway instead of waiting for needle, and at the same time, saving screenshot. This can help increase the chance of survival tremendously instead of terminate the whole test directly without even probing the possibility.
* **New** subroutine check_port_state in lib/virt_autotest/utils.pm
* **Offline** upgrade will call check_port_state directly instead of waiting for sshd-server-started needle matching in tests/virt_autotest/login_console.pm

* **Verification runs:**
  * ssh port is open [link1](http://10.67.19.99/tests/152) or [link2](http://10.163.41.174/tests/152)
  * ssh port is not open [link1](http://10.67.19.99/tests/154) or [link2](http://10.163.41.174/tests/154)
  * die inside check_port_state [link1](http://10.67.19.99/tests/163) or [link2](http://10.163.41.174/tests/163)
  * [A full test run kvm](https://openqa.suse.de/tests/8368466)
  * [A full test run xen](https://openqa.suse.de/tests/8372575)
