### PR TITLE
Fix invalid conversion error in influxdb_push_data

### DIFF
--- a/lib/db_utils.pm
+++ b/lib/db_utils.pm
@@ -56,7 +56,7 @@ sub influxdb_push_data {
     my ($url, $db, $data, %args) = @_;
     $args{quiet} //= 1;
     $data = build_influx_query($data);
-    my $cmd = sprintf("curl -i -X POST '%s/write?db=%s' --write-out 'RETURN_CODE:%{response_code}' --data-binary '%s'", $url, $db, $data);
+    my $cmd = sprintf("curl -i -X POST '%s/write?db=%s' --write-out 'RETURN_CODE:%%{response_code}' --data-binary '%s'", $url, $db, $data);
     record_info('curl', $cmd);
     my $output = script_output($cmd, quiet => $args{quiet});
     my ($return_code) = $output =~ /RETURN_CODE:(\d+)/;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -472,7 +472,7 @@ sub terraform_destroy {
     else {
         assert_script_run('cd ' . TERRAFORM_DIR);
         # Add region variable also to `terraform destroy` (poo#63604) -- needed by AWS.
-        my $azure_args = (is_azure()) ? sprintf("-var 'offer=%s' -var 'sku=%s'", get_var('PUBLIC_CLOUD_AZURE_OFFER'), get_var('PUBLIC_CLOUD_AZURE_SKU')) : undef;
+        my $azure_args = (is_azure()) ? sprintf("-var 'offer=%s' -var 'sku=%s'", get_var('PUBLIC_CLOUD_AZURE_OFFER'), get_var('PUBLIC_CLOUD_AZURE_SKU')) : '';
         $cmd = sprintf(q(terraform destroy -no-color -auto-approve -var 'region=%s' %s), $self->provider_client->region, $azure_args);
     }
     # Retry 3 times with considerable delay. This has been introduced due to poo#95932 (RetryableError)

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -239,7 +239,10 @@ sub run {
                 # we will do anaysis for same load types which we just pushed to db
                 my @load_types = keys %$values;
                 # Change the test module result to 'fail' if deviation in analyze_previous_series() occures
-                $self->{result} = 'fail' if analyze_previous_series(\%influx_read_args, \@load_types) == 1;
+                if (analyze_previous_series(\%influx_read_args, \@load_types) == 1) {
+                    record_info("Possible performance deviation", "The test module detected a possible performance deviation", result => 'fail');
+                    $self->{result} = 'fail';
+                }
             }
             else {
                 record_info('NO DATA', "We need at least 10 test results to analyze " . $href->{name} . "\n");


### PR DESCRIPTION
Fix an invalid conversion error in the sprintf routine in
influxdb_push_data, where a `%` was missing.

- Related ticket: https://progress.opensuse.org/issues/108320
- Verification run: http://duck-norris.qam.suse.de/t8372 (test run completed, fails due to deviations)
