### PR TITLE
Get only first record of cmdline in boot.txt

### DIFF
--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -33,7 +33,7 @@ sub run {
     }
 
     # Check few file whether expected content is there.
-    assert_script_run "diff <(awk '/\\/proc\\/cmdline/{getline; print}' boot.txt) /proc/cmdline";
+    assert_script_run "diff <(awk '/\\/proc\\/cmdline/{getline; print}' boot.txt|head -n1) /proc/cmdline";
     assert_script_run "grep -q -f /etc/os-release basic-environment.txt";
 
     assert_script_run "cd ..";


### PR DESCRIPTION
With latest update /proc/cmdline is mentioned multiple times in boot.txt

- Fail: https://openqa.suse.de/tests/8351716#step/supportutils/26
- Verification run:
https://dzedro.suse.cz/tests/21346
https://openqa.suse.de/tests/8352012