### PR TITLE
Replace zvm autoyast profile with patched profile

### DIFF
--- a/data/autoyast_sle15/autoyast_sles_zvm.xml
+++ b/data/autoyast_sle15/autoyast_sles_zvm.xml
@@ -20,41 +20,6 @@
   <dasd t="map">
     <devices t="list">
       <listentry t="map">
-        <channel>0.0.0120</channel>
-        <diag t="boolean">false</diag>
-        <format t="boolean">false</format>
-      </listentry>
-      <listentry t="map">
-        <channel>0.0.0190</channel>
-        <diag t="boolean">false</diag>
-        <format t="boolean">false</format>
-      </listentry>
-      <listentry t="map">
-        <channel>0.0.0191</channel>
-        <diag t="boolean">false</diag>
-        <format t="boolean">false</format>
-      </listentry>
-      <listentry t="map">
-        <channel>0.0.019d</channel>
-        <diag t="boolean">false</diag>
-        <format t="boolean">false</format>
-      </listentry>
-      <listentry t="map">
-        <channel>0.0.019e</channel>
-        <diag t="boolean">false</diag>
-        <format t="boolean">false</format>
-      </listentry>
-      <listentry t="map">
-        <channel>0.0.0200</channel>
-        <diag t="boolean">false</diag>
-        <format t="boolean">false</format>
-      </listentry>
-      <listentry t="map">
-        <channel>0.0.ffff</channel>
-        <diag t="boolean">false</diag>
-        <format t="boolean">false</format>
-      </listentry>
-      <listentry t="map">
         <channel>0.0.0150</channel>
         <diag t="boolean">false</diag>
         <format t="boolean">false</format>
@@ -472,12 +437,6 @@
   <host t="map">
     <hosts t="list">
       <hosts_entry t="map">
-        <host_address>10.162.42.101</host_address>
-        <names t="list">
-          <name>s390qa101.qa.suse.de s390qa101</name>
-        </names>
-      </hosts_entry>
-      <hosts_entry t="map">
         <host_address>127.0.0.1</host_address>
         <names t="list">
           <name>localhost</name>
@@ -562,7 +521,6 @@
     </dhcp_options>
     <dns t="map">
       <dhcp_hostname t="boolean">true</dhcp_hostname>
-      <hostname>s390qa101.qa.suse.de</hostname>
       <nameservers t="list">
         <nameserver>10.160.0.1</nameserver>
       </nameservers>

--- a/data/autoyast_sle15/autoyast_sles_zvm.xml
+++ b/data/autoyast_sle15/autoyast_sles_zvm.xml
@@ -1,348 +1,531 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <suse_register>
-    <do_registration config:type="boolean">true</do_registration>
-    <email/>
-    <reg_code>{{SCC_REGCODE}}</reg_code>
-    <install_updates config:type="boolean">true</install_updates>
-    <reg_server>{{SCC_URL}}</reg_server>
-    <addons config:type="list">
-      <addon>
-        <name>sle-module-server-applications</name>
-        <version>{{VERSION}}</version>
-        <arch>{{ARCH}}</arch>
-      </addon>
-      <addon>
-        <name>sle-module-desktop-applications</name>
-        <version>{{VERSION}}</version>
-        <arch>{{ARCH}}</arch>
-      </addon>
-    </addons>
-  </suse_register>
-  <bootloader>
-    <global>
-      <append>hvc_iucv=8 TERM=dumb mitigations=auto crashkernel=191M</append>
+  <bootloader t="map">
+    <global t="map">
+      <append>hvc_iucv=8 TERM=dumb mitigations=auto security=apparmor crashkernel=147M</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>false</secure_boot>
       <terminal>console</terminal>
-      <timeout config:type="integer">8</timeout>
+      <timeout t="integer">-1</timeout>
       <trusted_grub>false</trusted_grub>
-      <xen_kernel_append>crashkernel=191M\&lt;4G</xen_kernel_append>
+      <update_nvram>true</update_nvram>
+      <xen_kernel_append>crashkernel=147M\&lt;4G</xen_kernel_append>
     </global>
     <loader_type>grub2</loader_type>
   </bootloader>
-  <dasd>
-    <devices config:type="list">
-      <listentry>
+  <dasd t="map">
+    <devices t="list">
+      <listentry t="map">
+        <channel>0.0.0120</channel>
+        <diag t="boolean">false</diag>
+        <format t="boolean">false</format>
+      </listentry>
+      <listentry t="map">
+        <channel>0.0.0190</channel>
+        <diag t="boolean">false</diag>
+        <format t="boolean">false</format>
+      </listentry>
+      <listentry t="map">
+        <channel>0.0.0191</channel>
+        <diag t="boolean">false</diag>
+        <format t="boolean">false</format>
+      </listentry>
+      <listentry t="map">
+        <channel>0.0.019d</channel>
+        <diag t="boolean">false</diag>
+        <format t="boolean">false</format>
+      </listentry>
+      <listentry t="map">
+        <channel>0.0.019e</channel>
+        <diag t="boolean">false</diag>
+        <format t="boolean">false</format>
+      </listentry>
+      <listentry t="map">
+        <channel>0.0.0200</channel>
+        <diag t="boolean">false</diag>
+        <format t="boolean">false</format>
+      </listentry>
+      <listentry t="map">
+        <channel>0.0.ffff</channel>
+        <diag t="boolean">false</diag>
+        <format t="boolean">false</format>
+      </listentry>
+      <listentry t="map">
         <channel>0.0.0150</channel>
-        <diag config:type="boolean">false</diag>
-        <format config:type="boolean">false</format>
+        <diag t="boolean">false</diag>
+        <format t="boolean">false</format>
       </listentry>
     </devices>
-    <format_unformatted config:type="boolean">false</format_unformatted>
+    <format_unformatted t="boolean">false</format_unformatted>
   </dasd>
-  <deploy_image>
-    <image_installation config:type="boolean">false</image_installation>
-  </deploy_image>
-  <general>
-    <ask-list config:type="list"/>
-    <cio_ignore config:type="boolean">false</cio_ignore>
-    <mode>
-      <confirm config:type="boolean">false</confirm>
-      <final_reboot config:type="boolean">true</final_reboot>
+  <firewall t="map">
+    <default_zone>public</default_zone>
+    <enable_firewall t="boolean">true</enable_firewall>
+    <log_denied_packets>off</log_denied_packets>
+    <start_firewall t="boolean">true</start_firewall>
+    <zones t="list">
+      <zone t="map">
+        <description>Unsolicited incoming network packets are rejected. Incoming packets that are related to outgoing network connections are accepted. Outgoing network connections are allowed.</description>
+        <interfaces t="list"/>
+        <masquerade t="boolean">false</masquerade>
+        <name>block</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list"/>
+        <short>Block</short>
+        <target>%%REJECT%%</target>
+      </zone>
+      <zone t="map">
+        <description>For computers in your demilitarized zone that are publicly-accessible with limited access to your internal network. Only selected incoming connections are accepted.</description>
+        <interfaces t="list"/>
+        <masquerade t="boolean">false</masquerade>
+        <name>dmz</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>ssh</service>
+        </services>
+        <short>DMZ</short>
+        <target>default</target>
+      </zone>
+      <zone t="map">
+        <description>All network connections are accepted.</description>
+        <interfaces t="list">
+          <interface>docker0</interface>
+        </interfaces>
+        <masquerade t="boolean">false</masquerade>
+        <name>docker</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list"/>
+        <short>docker</short>
+        <target>ACCEPT</target>
+      </zone>
+      <zone t="map">
+        <description>Unsolicited incoming network packets are dropped. Incoming packets that are related to outgoing network connections are accepted. Outgoing network connections are allowed.</description>
+        <interfaces t="list"/>
+        <masquerade t="boolean">false</masquerade>
+        <name>drop</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list"/>
+        <short>Drop</short>
+        <target>DROP</target>
+      </zone>
+      <zone t="map">
+        <description>For use on external networks. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+        <interfaces t="list"/>
+        <masquerade t="boolean">true</masquerade>
+        <name>external</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>ssh</service>
+        </services>
+        <short>External</short>
+        <target>default</target>
+      </zone>
+      <zone t="map">
+        <description>For use in home areas. You mostly trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+        <interfaces t="list"/>
+        <masquerade t="boolean">false</masquerade>
+        <name>home</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>dhcpv6-client</service>
+          <service>mdns</service>
+          <service>samba-client</service>
+          <service>ssh</service>
+        </services>
+        <short>Home</short>
+        <target>default</target>
+      </zone>
+      <zone t="map">
+        <description>For use on internal networks. You mostly trust the other computers on the networks to not harm your computer. Only selected incoming connections are accepted.</description>
+        <interfaces t="list"/>
+        <masquerade t="boolean">false</masquerade>
+        <name>internal</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>dhcpv6-client</service>
+          <service>mdns</service>
+          <service>samba-client</service>
+          <service>ssh</service>
+        </services>
+        <short>Internal</short>
+        <target>default</target>
+      </zone>
+      <zone t="map">
+        <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+        <interfaces t="list">
+          <interface>eth0</interface>
+        </interfaces>
+        <masquerade t="boolean">false</masquerade>
+        <name>public</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>dhcpv6-client</service>
+          <service>ssh</service>
+          <service>tigervnc</service>
+          <service>tigervnc-https</service>
+        </services>
+        <short>Public</short>
+        <target>default</target>
+      </zone>
+      <zone t="map">
+        <description>All network connections are accepted.</description>
+        <interfaces t="list"/>
+        <masquerade t="boolean">false</masquerade>
+        <name>trusted</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list"/>
+        <short>Trusted</short>
+        <target>ACCEPT</target>
+      </zone>
+      <zone t="map">
+        <description>For use in work areas. You mostly trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+        <interfaces t="list"/>
+        <masquerade t="boolean">false</masquerade>
+        <name>work</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>dhcpv6-client</service>
+          <service>ssh</service>
+        </services>
+        <short>Work</short>
+        <target>default</target>
+      </zone>
+    </zones>
+  </firewall>
+  <general t="map">
+    <cio_ignore t="boolean">true</cio_ignore>
+    <mode t="map">
+      <confirm t="boolean">false</confirm>
     </mode>
-    <proposals config:type="list"/>
-    <signature-handling>
-      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
-      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
-      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
-      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
-      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
-      <import_gpg_key config:type="boolean">true</import_gpg_key>
-    </signature-handling>
-    <storage>
-      <start_multipath config:type="boolean">false</start_multipath>
-    </storage>
   </general>
-  <groups config:type="list">
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
+  <groups t="list">
+    <group t="map">
       <gid>100</gid>
       <groupname>users</groupname>
       <userlist/>
     </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>59</gid>
-      <groupname>maildrop</groupname>
-      <userlist>postfix</userlist>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>488</gid>
-      <groupname>kvm</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>42</gid>
-      <groupname>trusted</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>482</gid>
-      <groupname>systemd-coredump</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>51</gid>
-      <groupname>postfix</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>487</gid>
-      <groupname>lp</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>5</gid>
-      <groupname>tty</groupname>
-      <userlist>bernhard</userlist>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>65534</gid>
-      <groupname>nobody</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>478</gid>
-      <groupname>polkitd</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>483</gid>
-      <groupname>systemd-timesync</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>498</gid>
-      <groupname>mail</groupname>
-      <userlist>postfix</userlist>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>476</gid>
-      <groupname>vnc</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>491</gid>
-      <groupname>dialout</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>65533</gid>
-      <groupname>nogroup</groupname>
-      <userlist>nobody</userlist>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>15</gid>
-      <groupname>shadow</groupname>
-      <userlist>vnc</userlist>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>495</gid>
-      <groupname>lock</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>0</gid>
-      <groupname>root</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>496</gid>
-      <groupname>kmem</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>1</gid>
-      <groupname>bin</groupname>
-      <userlist>daemon</userlist>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>479</gid>
-      <groupname>sshd</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>481</gid>
-      <groupname>chrony</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>493</gid>
-      <groupname>audio</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>71</gid>
-      <groupname>ntadmin</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>497</gid>
-      <groupname>wheel</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>480</gid>
-      <groupname>nscd</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>477</gid>
-      <groupname>ts-shell</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>2</gid>
-      <groupname>daemon</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>492</gid>
-      <groupname>cdrom</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>499</gid>
-      <groupname>messagebus</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>489</gid>
-      <groupname>input</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>494</gid>
-      <groupname>utmp</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>485</gid>
-      <groupname>video</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>484</gid>
-      <groupname>systemd-journal</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
+    <group t="map">
       <gid>62</gid>
       <groupname>man</groupname>
       <userlist/>
     </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
+    <group t="map">
+      <gid>476</gid>
+      <groupname>systemd-timesync</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>496</gid>
+      <groupname>kmem</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>495</gid>
+      <groupname>lock</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>466</gid>
+      <groupname>gdm</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>483</gid>
+      <groupname>audit</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>475</gid>
+      <groupname>chrony</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>65534</gid>
+      <groupname>nobody</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>15</gid>
+      <groupname>shadow</groupname>
+      <userlist>vnc</userlist>
+    </group>
+    <group t="map">
+      <gid>65533</gid>
+      <groupname>nogroup</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>474</gid>
+      <groupname>ts-shell</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>471</gid>
+      <groupname>nscd</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>473</gid>
+      <groupname>zkeyadm</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>482</gid>
+      <groupname>srvGeoClue</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>488</gid>
+      <groupname>lp</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>493</gid>
+      <groupname>audio</groupname>
+      <userlist>pulse,brltty</userlist>
+    </group>
+    <group t="map">
+      <gid>0</gid>
+      <groupname>root</groupname>
+      <userlist>brltty</userlist>
+    </group>
+    <group t="map">
+      <gid>492</gid>
+      <groupname>cdrom</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>71</gid>
+      <groupname>ntadmin</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>468</gid>
+      <groupname>brlapi</groupname>
+      <userlist>brltty</userlist>
+    </group>
+    <group t="map">
+      <gid>463</gid>
+      <groupname>systemd-coredump</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>480</gid>
+      <groupname>pulse-access</groupname>
+      <userlist>brltty</userlist>
+    </group>
+    <group t="map">
+      <gid>2</gid>
+      <groupname>daemon</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>497</gid>
+      <groupname>wheel</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>477</gid>
+      <groupname>systemd-network</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
       <gid>490</gid>
       <groupname>disk</groupname>
       <userlist/>
     </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>486</gid>
+    <group t="map">
+      <gid>1</gid>
+      <groupname>bin</groupname>
+      <userlist>daemon</userlist>
+    </group>
+    <group t="map">
+      <gid>494</gid>
+      <groupname>utmp</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>470</gid>
+      <groupname>polkitd</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>489</gid>
+      <groupname>input</groupname>
+      <userlist>brltty</userlist>
+    </group>
+    <group t="map">
+      <gid>485</gid>
       <groupname>tape</groupname>
       <userlist/>
     </group>
+    <group t="map">
+      <gid>472</gid>
+      <groupname>cpacfstats</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>59</gid>
+      <groupname>maildrop</groupname>
+      <userlist>postfix</userlist>
+    </group>
+    <group t="map">
+      <gid>499</gid>
+      <groupname>messagebus</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>51</gid>
+      <groupname>postfix</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>464</gid>
+      <groupname>brltty</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>5</gid>
+      <groupname>tty</groupname>
+      <userlist>brltty</userlist>
+    </group>
+    <group t="map">
+      <gid>467</gid>
+      <groupname>rtkit</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>487</gid>
+      <groupname>render</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>36</gid>
+      <groupname>kvm</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>481</gid>
+      <groupname>flatpak</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>478</gid>
+      <groupname>systemd-journal</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>465</gid>
+      <groupname>vnc</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>484</gid>
+      <groupname>video</groupname>
+      <userlist>gdm</userlist>
+    </group>
+    <group t="map">
+      <gid>42</gid>
+      <groupname>trusted</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>469</gid>
+      <groupname>sshd</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>486</gid>
+      <groupname>sgx</groupname>
+      <userlist/>
+    </group>
+    <group t="map">
+      <gid>498</gid>
+      <groupname>mail</groupname>
+      <userlist>postfix</userlist>
+    </group>
+    <group t="map">
+      <gid>491</gid>
+      <groupname>dialout</groupname>
+      <userlist>brltty</userlist>
+    </group>
+    <group t="map">
+      <gid>479</gid>
+      <groupname>pulse</groupname>
+      <userlist/>
+    </group>
   </groups>
-  <host>
-    <hosts config:type="list">
-      <hosts_entry>
+  <host t="map">
+    <hosts t="list">
+      <hosts_entry t="map">
+        <host_address>10.162.42.101</host_address>
+        <names t="list">
+          <name>s390qa101.qa.suse.de s390qa101</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry t="map">
         <host_address>127.0.0.1</host_address>
-        <names config:type="list">
+        <names t="list">
           <name>localhost</name>
         </names>
       </hosts_entry>
-      <hosts_entry>
+      <hosts_entry t="map">
         <host_address>::1</host_address>
-        <names config:type="list">
+        <names t="list">
           <name>localhost ipv6-localhost ipv6-loopback</name>
         </names>
       </hosts_entry>
-      <hosts_entry>
+      <hosts_entry t="map">
         <host_address>fe00::0</host_address>
-        <names config:type="list">
+        <names t="list">
           <name>ipv6-localnet</name>
         </names>
       </hosts_entry>
-      <hosts_entry>
+      <hosts_entry t="map">
         <host_address>ff00::0</host_address>
-        <names config:type="list">
+        <names t="list">
           <name>ipv6-mcastprefix</name>
         </names>
       </hosts_entry>
-      <hosts_entry>
+      <hosts_entry t="map">
         <host_address>ff02::1</host_address>
-        <names config:type="list">
+        <names t="list">
           <name>ipv6-allnodes</name>
         </names>
       </hosts_entry>
-      <hosts_entry>
+      <hosts_entry t="map">
         <host_address>ff02::2</host_address>
-        <names config:type="list">
+        <names t="list">
           <name>ipv6-allrouters</name>
         </names>
       </hosts_entry>
-      <hosts_entry>
+      <hosts_entry t="map">
         <host_address>ff02::3</host_address>
-        <names config:type="list">
+        <names t="list">
           <name>ipv6-allhosts</name>
         </names>
       </hosts_entry>
     </hosts>
   </host>
-  <kdump>
-    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
-    <crash_kernel>163M</crash_kernel>
-    <crash_xen_kernel>163M\&lt;4G</crash_xen_kernel>
-    <general>
+  <kdump t="map">
+    <add_crash_kernel t="boolean">true</add_crash_kernel>
+    <crash_kernel>147M</crash_kernel>
+    <crash_xen_kernel>147M\&lt;4G</crash_xen_kernel>
+    <general t="map">
       <KDUMPTOOL_FLAGS/>
       <KDUMP_COMMANDLINE/>
       <KDUMP_COMMANDLINE_APPEND/>
@@ -372,69 +555,53 @@
       <KEXEC_OPTIONS/>
     </general>
   </kdump>
-  <language>
-    <language>en_US</language>
-    <languages/>
-  </language>
-  <login_settings/>
-  <networking>
-    <dhcp_options>
+  <networking t="map">
+    <dhcp_options t="map">
       <dhclient_client_id/>
       <dhclient_hostname_option>AUTO</dhclient_hostname_option>
     </dhcp_options>
-    <dns>
-      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
-      <nameservers config:type="list">
+    <dns t="map">
+      <dhcp_hostname t="boolean">true</dhcp_hostname>
+      <hostname>s390qa101.qa.suse.de</hostname>
+      <nameservers t="list">
         <nameserver>10.160.0.1</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
-      <searchlist config:type="list">
+      <searchlist t="list">
         <search>suse.de</search>
       </searchlist>
-      <write_hostname config:type="boolean">false</write_hostname>
     </dns>
-    <interfaces config:type="list">
-      <interface>
+    <interfaces t="list">
+      <interface t="map">
         <bootproto>static</bootproto>
-        <device>eth0</device>
         <ipaddr>{{HostIP}}</ipaddr>
-        <netmask>255.255.240.0</netmask>
+        <name>eth0</name>
         <prefixlen>20</prefixlen>
         <startmode>auto</startmode>
-      </interface>
-      <interface>
-        <bootproto>static</bootproto>
-        <device>lo</device>
-        <firewall>no</firewall>
-        <ipaddr>127.0.0.1</ipaddr>
-        <netmask>255.0.0.0</netmask>
-        <network>127.0.0.0</network>
-        <prefixlen>8</prefixlen>
-        <startmode>nfsroot</startmode>
-        <usercontrol>no</usercontrol>
+        <zone>public</zone>
       </interface>
     </interfaces>
-    <ipv6 config:type="boolean">true</ipv6>
-    <keep_install_network config:type="boolean">true</keep_install_network>
-    <managed config:type="boolean">false</managed>
-    <net-udev config:type="list">
-      <rule>
+    <ipv6 t="boolean">true</ipv6>
+    <keep_install_network t="boolean">true</keep_install_network>
+    <managed t="boolean">false</managed>
+    <net-udev t="list">
+      <rule t="map">
         <name>eth0</name>
         <rule>KERNELS</rule>
         <value>0.0.0800</value>
       </rule>
     </net-udev>
-    <routing>
-      <ipv4_forward config:type="boolean">false</ipv4_forward>
-      <ipv6_forward config:type="boolean">false</ipv6_forward>
-      <routes config:type="list">
-        <route>
+    <routing t="map">
+      <ipv4_forward t="boolean">false</ipv4_forward>
+      <ipv6_forward t="boolean">false</ipv6_forward>
+      <routes t="list">
+        <route t="map">
           <destination>10.162.63.254</destination>
           <device>eth0</device>
           <gateway>-</gateway>
           <netmask>255.255.255.255</netmask>
         </route>
-        <route>
+        <route t="map">
           <destination>default</destination>
           <device>eth0</device>
           <gateway>10.162.63.254</gateway>
@@ -442,147 +609,180 @@
         </route>
       </routes>
     </routing>
-    <s390-devices config:type="list">
-      <listentry>
+    <s390-devices t="list">
+      <listentry t="map">
         <chanids>0.0.0800:0.0.0801:0.0.0802</chanids>
-        <layer2 config:type="boolean">true</layer2>
+        <layer2 t="boolean">true</layer2>
         <type>qeth</type>
       </listentry>
     </s390-devices>
   </networking>
-  <nis>
+  <nis t="map">
     <netconfig_policy>auto</netconfig_policy>
-    <nis_broadcast config:type="boolean">false</nis_broadcast>
-    <nis_broken_server config:type="boolean">false</nis_broken_server>
+    <nis_broadcast t="boolean">false</nis_broadcast>
+    <nis_broken_server t="boolean">false</nis_broken_server>
     <nis_domain/>
-    <nis_local_only config:type="boolean">false</nis_local_only>
+    <nis_local_only t="boolean">false</nis_local_only>
+    <nis_options/>
+    <nis_other_domains t="list"/>
+    <nis_servers t="list"/>
+    <slp_domain t="map"/>
+    <start_autofs t="boolean">false</start_autofs>
+    <start_nis t="boolean">false</start_nis>
   </nis>
-  <ntp-client>
+  <ntp-client t="map">
     <ntp_policy>auto</ntp_policy>
-    <ntp_servers config:type="list"/>
+    <ntp_servers t="list"/>
     <ntp_sync>manual</ntp_sync>
   </ntp-client>
-  <partitioning config:type="list">
-    <drive>
+  <partitioning t="list">
+    <drive t="map">
       <device>/dev/disk/by-path/ccw-0.0.0150</device>
       <disklabel>dasd</disklabel>
-      <enable_snapshots config:type="boolean">true</enable_snapshots>
-      <initialize config:type="boolean">false</initialize>
-      <partitions config:type="list">
-        <partition>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">ext2</filesystem>
-          <format config:type="boolean">true</format>
+      <enable_snapshots t="boolean">true</enable_snapshots>
+      <partitions t="list">
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">ext2</filesystem>
+          <format t="boolean">true</format>
           <mount>/boot/zipl</mount>
-          <mountby config:type="symbol">path</mountby>
-          <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">1</partition_nr>
-          <resize config:type="boolean">false</resize>
+          <mountby t="symbol">path</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">1</partition_nr>
+          <resize t="boolean">false</resize>
           <size>314572800</size>
         </partition>
-        <partition>
-          <create config:type="boolean">true</create>
-          <create_subvolumes config:type="boolean">true</create_subvolumes>
-          <filesystem config:type="symbol">btrfs</filesystem>
-          <format config:type="boolean">true</format>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <create_subvolumes t="boolean">true</create_subvolumes>
+          <filesystem t="symbol">btrfs</filesystem>
+          <format t="boolean">true</format>
           <mount>/</mount>
-          <mountby config:type="symbol">path</mountby>
-          <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">2</partition_nr>
-          <resize config:type="boolean">false</resize>
+          <mountby t="symbol">path</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">2</partition_nr>
+          <quotas t="boolean">true</quotas>
+          <resize t="boolean">false</resize>
           <size>20047724544</size>
-          <subvolumes config:type="list">
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>boot/grub2/s390x-emu</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">false</copy_on_write>
+          <subvolumes t="list">
+            <subvolume t="map">
+              <copy_on_write t="boolean">false</copy_on_write>
               <path>var</path>
             </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>home</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>root</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
               <path>usr/local</path>
             </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
               <path>tmp</path>
             </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>opt</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
               <path>srv</path>
             </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>root</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>opt</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>home</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>boot/grub2/s390x-emu</path>
+            </subvolume>
           </subvolumes>
-          <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
+          <subvolumes_prefix>@</subvolumes_prefix>
         </partition>
-        <partition>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">swap</filesystem>
-          <format config:type="boolean">true</format>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">swap</filesystem>
+          <format t="boolean">true</format>
           <mount>swap</mount>
-          <mountby config:type="symbol">path</mountby>
-          <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">3</partition_nr>
-          <resize config:type="boolean">false</resize>
+          <mountby t="symbol">path</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">3</partition_nr>
+          <resize t="boolean">false</resize>
           <size>1789919232</size>
         </partition>
       </partitions>
-      <type config:type="symbol">CT_DISK</type>
+      <type t="symbol">CT_DISK</type>
       <use>all</use>
     </drive>
   </partitioning>
-  <report>
-    <errors>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
-    </errors>
-    <messages>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
-    </messages>
-    <warnings>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
-    </warnings>
-    <yesno_messages>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
-    </yesno_messages>
-  </report>
-  <services-manager>
-    <default_target>multi-user</default_target>
-    <services>
-      <disable config:type="list"/>
-      <enable config:type="list">
+  <proxy t="map">
+    <enabled t="boolean">false</enabled>
+  </proxy>
+  <security t="map">
+    <console_shutdown>halt</console_shutdown>
+    <cracklib_dict_path>/usr/lib/cracklib_dict</cracklib_dict_path>
+    <disable_restart_on_update>no</disable_restart_on_update>
+    <disable_stop_on_removal>no</disable_stop_on_removal>
+    <extra_services>insecure</extra_services>
+    <fail_delay>3</fail_delay>
+    <gid_max>60000</gid_max>
+    <gid_min>1000</gid_min>
+    <hibernate_system>active_console</hibernate_system>
+    <kernel.sysrq>184</kernel.sysrq>
+    <lsm_select>apparmor</lsm_select>
+    <mandatory_services>secure</mandatory_services>
+    <net.ipv4.ip_forward>0</net.ipv4.ip_forward>
+    <net.ipv4.tcp_syncookies>0</net.ipv4.tcp_syncookies>
+    <net.ipv6.conf.all.forwarding>0</net.ipv6.conf.all.forwarding>
+    <pass_max_days>99999</pass_max_days>
+    <pass_min_days>0</pass_min_days>
+    <pass_min_len>5</pass_min_len>
+    <pass_warn_age>7</pass_warn_age>
+    <passwd_encryption>sha512</passwd_encryption>
+    <passwd_remember_history>0</passwd_remember_history>
+    <passwd_use_cracklib>yes</passwd_use_cracklib>
+    <permission_security>easy</permission_security>
+    <run_updatedb_as/>
+    <smtpd_listen_remote>no</smtpd_listen_remote>
+    <sys_gid_max>499</sys_gid_max>
+    <sys_gid_min>100</sys_gid_min>
+    <sys_uid_max>499</sys_uid_max>
+    <sys_uid_min>100</sys_uid_min>
+    <syslog_on_no_error>no</syslog_on_no_error>
+    <uid_max>60000</uid_max>
+    <uid_min>1000</uid_min>
+    <useradd_cmd>/usr/sbin/useradd.local</useradd_cmd>
+    <userdel_postcmd>/usr/sbin/userdel-post.local</userdel_postcmd>
+    <userdel_precmd>/usr/sbin/userdel-pre.local</userdel_precmd>
+  </security>
+  <services-manager t="map">
+    <default_target>graphical</default_target>
+    <services t="map">
+      <enable t="list">
+        <service>YaST2-Firstboot</service>
+        <service>YaST2-Second-Stage</service>
         <service>apparmor</service>
         <service>auditd</service>
-        <service>btrfsmaintenance-refresh</service>
-        <service>ca-certificates</service>
+        <service>bluetooth</service>
+        <service>klog</service>
         <service>cio_ignore</service>
+        <service>cpi</service>
         <service>cron</service>
+        <service>firewalld</service>
+        <service>wickedd-auto4</service>
+        <service>wickedd-dhcp4</service>
+        <service>wickedd-dhcp6</service>
+        <service>wickedd-nanny</service>
         <service>display-manager</service>
+        <service>haveged</service>
+        <service>iscsi</service>
         <service>issue-generator</service>
         <service>kbdsettings</service>
-        <service>kdump-early</service>
         <service>kdump</service>
-        <service>klog</service>
+        <service>kdump-early</service>
         <service>lvm2-monitor</service>
+        <service>wicked</service>
         <service>nscd</service>
         <service>postfix</service>
         <service>purge-kernels</service>
@@ -590,28 +790,25 @@
         <service>rsyslog</service>
         <service>smartd</service>
         <service>sshd</service>
-        <service>wicked</service>
-        <service>wickedd-auto4</service>
-        <service>wickedd-dhcp4</service>
-        <service>wickedd-dhcp6</service>
-        <service>wickedd-nanny</service>
-        <service>YaST2-Firstboot</service>
-        <service>YaST2-Second-Stage</service>
-        <service>getty@tty1</service>
-        <service>serial-getty@ttysclp0</service>
+        <service>systemd-remount-fs</service>
       </enable>
+      <on_demand t="list">
+        <listentry>iscsid</listentry>
+      </on_demand>
     </services>
   </services-manager>
-  <software>
-    <install_recommended config:type="boolean">true</install_recommended>
+  <software t="map">
+    <install_recommended t="boolean">true</install_recommended>
     <instsource/>
-    <packages config:type="list">
+    <packages t="list">
+      <package>yast2-security</package>
+      <package>yast2</package>
       <package>xorg-x11-fonts</package>
       <package>xorg-x11-Xvnc</package>
-      <package>xorg-x11</package>
+      <package>wicked</package>
       <package>snapper</package>
-      <package>sles-release</package>
       <package>sle-module-server-applications-release</package>
+      <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
       <package>openssh</package>
       <package>kexec-tools</package>
@@ -619,50 +816,90 @@
       <package>icewm</package>
       <package>grub2</package>
       <package>glibc</package>
+      <package>firewalld</package>
       <package>e2fsprogs</package>
       <package>btrfsprogs</package>
       <package>autoyast2</package>
     </packages>
-    <patterns config:type="list">
+    <patterns t="list">
       <pattern>apparmor</pattern>
       <pattern>base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>basic_desktop</pattern>
       <pattern>enhanced_base</pattern>
+      <pattern>fonts</pattern>
+      <pattern>gnome_basic</pattern>
+      <pattern>gnome_basis</pattern>
       <pattern>minimal_base</pattern>
-      <pattern>sw_management</pattern>
       <pattern>x11</pattern>
+      <pattern>x11_enhanced</pattern>
       <pattern>x11_yast</pattern>
       <pattern>yast2_basis</pattern>
+      <pattern>yast2_desktop</pattern>
+      <pattern>yast2_server</pattern>
     </patterns>
-    <products config:type="list">
-      <listentry>SLES</listentry>
+    <products t="list">
+      <product>SLES</product>
     </products>
   </software>
-  <ssh_import>
-    <copy_config config:type="boolean">false</copy_config>
-    <import config:type="boolean">false</import>
+  <ssh_import t="map">
+    <copy_config t="boolean">false</copy_config>
+    <import t="boolean">false</import>
   </ssh_import>
-  <timezone>
-    <hwclock>UTC</hwclock>
+  <suse_register t="map">
+    <addons t="list">
+      <addon t="map">
+        <arch>s390x</arch>
+        <name>sle-module-desktop-applications</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>s390x</arch>
+        <name>sle-module-server-applications</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>s390x</arch>
+        <name>sle-module-basesystem</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+    </addons>
+    <do_registration t="boolean">true</do_registration>
+    <email/>
+    <install_updates t="boolean">false</install_updates>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <slp_discovery t="boolean">false</slp_discovery>
+  </suse_register>
+  <tftp-server t="map">
+    <start_tftpd t="boolean">false</start_tftpd>
+  </tftp-server>
+  <timezone t="map">
     <timezone>America/New_York</timezone>
   </timezone>
-  <user_defaults>
+  <user_defaults t="map">
     <expire/>
     <group>100</group>
-    <groups/>
     <home>/home</home>
     <inactive>-1</inactive>
-    <no_groups config:type="boolean">true</no_groups>
     <shell>/bin/bash</shell>
-    <skel>/etc/skel</skel>
     <umask>022</umask>
   </user_defaults>
-  <users config:type="list">
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
+  <users t="list">
+    <user t="map">
+      <authorized_keys t="list"/>
+      <encrypted t="boolean">true</encrypted>
       <fullname>Bernhard M. Wiedemann</fullname>
       <gid>100</gid>
       <home>/home/bernhard</home>
-      <password_settings>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
         <expire/>
         <flag/>
         <inact/>
@@ -672,51 +909,16 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>$6$yd/h2uuA1GPE$h92feWvgVeMop20ZVOGGJE9ZDdg9f4fLG0r.Of/kw.WZJ9uHhocAnzeu20DKiX0o6.G7Mno4YSwJLFtfAXIpS1</user_password>
+      <user_password>$6$J/Sx0idyfgMMuF7S$L2HnL.jreFz6.KVfcCSEtD2rizW54kAIjryMqJAwWl1MqLcBGq7IXMArynJWBbceJbgtRH84NiYtDKlYo/S/21</user_password>
       <username>bernhard</username>
     </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>root</fullname>
-      <gid>0</gid>
-      <home>/root</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/bin/bash</shell>
-      <uid>0</uid>
-      <user_password>$6$Hr5nAT2e6eoJ$636z6NQsd9BRa8Eszqg2xmOiyPKcB4VsWOUceLuJGhrXzzC2n0ycjsYjXGVEHxmskEOjyYXLy7GeLQfK9QU1d0</user_password>
-      <username>root</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>SSH daemon</fullname>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>PulseAudio daemon</fullname>
       <gid>479</gid>
-      <home>/var/lib/sshd</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/bin/false</shell>
-      <uid>476</uid>
-      <user_password>!</user_password>
-      <username>sshd</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>bin</fullname>
-      <gid>1</gid>
-      <home>/bin</home>
-      <password_settings>
+      <home>/var/lib/pulseaudio</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
         <expire/>
         <flag/>
         <inact/>
@@ -725,214 +927,17 @@
         <warn/>
       </password_settings>
       <shell>/sbin/nologin</shell>
-      <uid>1</uid>
+      <uid>494</uid>
       <user_password>!</user_password>
-      <username>bin</username>
+      <username>pulse</username>
     </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>user for rpcbind</fullname>
-      <gid>65534</gid>
-      <home>/var/lib/empty</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>480</uid>
-      <user_password>!</user_password>
-      <username>rpc</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>systemd Core Dumper</fullname>
-      <gid>482</gid>
-      <home>/</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>482</uid>
-      <user_password>!!</user_password>
-      <username>systemd-coredump</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>Chrony Daemon</fullname>
-      <gid>481</gid>
-      <home>/var/lib/chrony</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/bin/false</shell>
-      <uid>481</uid>
-      <user_password>!</user_password>
-      <username>chrony</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>Postfix Daemon</fullname>
-      <gid>51</gid>
-      <home>/var/spool/postfix</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/bin/false</shell>
-      <uid>51</uid>
-      <user_password>!</user_password>
-      <username>postfix</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>Printing daemon</fullname>
-      <gid>487</gid>
-      <home>/var/spool/lpd</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>478</uid>
-      <user_password>!</user_password>
-      <username>lp</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>User for nscd</fullname>
-      <gid>480</gid>
-      <home>/run/nscd</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>477</uid>
-      <user_password>!</user_password>
-      <username>nscd</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>nobody</fullname>
-      <gid>65534</gid>
-      <home>/var/lib/nobody</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/bin/bash</shell>
-      <uid>65534</uid>
-      <user_password>!</user_password>
-      <username>nobody</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>User for polkitd</fullname>
-      <gid>478</gid>
-      <home>/var/lib/polkit</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>475</uid>
-      <user_password>!</user_password>
-      <username>polkitd</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>Daemon</fullname>
-      <gid>2</gid>
-      <home>/sbin</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>2</uid>
-      <user_password>!</user_password>
-      <username>daemon</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>systemd Time Synchronization</fullname>
-      <gid>483</gid>
-      <home>/</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>483</uid>
-      <user_password>!!</user_password>
-      <username>systemd-timesync</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>User for D-Bus</fullname>
-      <gid>499</gid>
-      <home>/run/dbus</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/usr/bin/false</shell>
-      <uid>499</uid>
-      <user_password>!</user_password>
-      <username>messagebus</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
       <fullname>Mailer daemon</fullname>
       <gid>498</gid>
       <home>/var/spool/clientmqueue</home>
-      <password_settings>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
         <expire/>
         <flag/>
         <inact/>
@@ -945,12 +950,109 @@
       <user_password>!</user_password>
       <username>mail</username>
     </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>user for VNC</fullname>
-      <gid>476</gid>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>NFS statd daemon</fullname>
+      <gid>65533</gid>
+      <home>/var/lib/nfs</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>472</uid>
+      <user_password>!</user_password>
+      <username>statd</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>469</gid>
+      <home>/var/lib/sshd</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>470</uid>
+      <user_password>!</user_password>
+      <username>sshd</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>2</uid>
+      <user_password>!</user_password>
+      <username>daemon</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>systemd Core Dumper</fullname>
+      <gid>463</gid>
+      <home>/</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/usr/sbin/nologin</shell>
+      <uid>463</uid>
+      <user_password>!*</user_password>
+      <username>systemd-coredump</username>
+    </user>
+    <user t="map">
+      <authorized_keys t="list"/>
+      <encrypted t="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$Tpt.dmOZoOyxH6D1$3zxKLiB.4U6xYdq/P9NrzPxGu/B/Z6jyQt/sYZmzief3IRSSaoW.1MxZRrgAPcU.xldoRR0tUrMFFLdHhPH.80</user_password>
+      <username>root</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>user for rpcbind</fullname>
+      <gid>65534</gid>
       <home>/var/lib/empty</home>
-      <password_settings>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
         <expire/>
         <flag/>
         <inact/>
@@ -961,14 +1063,15 @@
       <shell>/sbin/nologin</shell>
       <uid>474</uid>
       <user_password>!</user_password>
-      <username>vnc</username>
+      <username>rpc</username>
     </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>NFS statd daemon</fullname>
-      <gid>65533</gid>
-      <home>/var/lib/nfs</home>
-      <password_settings>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>user for VNC</fullname>
+      <gid>465</gid>
+      <home>/var/lib/empty</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
         <expire/>
         <flag/>
         <inact/>
@@ -977,16 +1080,302 @@
         <warn/>
       </password_settings>
       <shell>/sbin/nologin</shell>
-      <uid>479</uid>
+      <uid>466</uid>
       <user_password>!</user_password>
-      <username>statd</username>
+      <username>vnc</username>
     </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>User for nscd</fullname>
+      <gid>471</gid>
+      <home>/run/nscd</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>473</uid>
+      <user_password>!</user_password>
+      <username>nscd</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>User for GeoClue D-Bus service</fullname>
+      <gid>482</gid>
+      <home>/var/lib/srvGeoClue</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>496</uid>
+      <user_password>!</user_password>
+      <username>srvGeoClue</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>Printing daemon</fullname>
+      <gid>488</gid>
+      <home>/var/spool/lpd</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>497</uid>
+      <user_password>!</user_password>
+      <username>lp</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>Flatpak system helper</fullname>
+      <gid>481</gid>
+      <home>/home/flatpak</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>495</uid>
+      <user_password>!</user_password>
+      <username>flatpak</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>RealtimeKit</fullname>
+      <gid>467</gid>
+      <home>/proc</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>469</uid>
+      <user_password>!</user_password>
+      <username>rtkit</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>user account for the brltty daemon</fullname>
+      <gid>100</gid>
+      <home>/var/lib/brltty</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>468</uid>
+      <user_password>!</user_password>
+      <username>brltty</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>51</uid>
+      <user_password>!</user_password>
+      <username>postfix</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>499</gid>
+      <home>/run/dbus</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/usr/bin/false</shell>
+      <uid>499</uid>
+      <user_password>!</user_password>
+      <username>messagebus</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/nobody</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>!</user_password>
+      <username>nobody</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>User for polkitd</fullname>
+      <gid>470</gid>
+      <home>/var/lib/polkit</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>471</uid>
+      <user_password>!</user_password>
+      <username>polkitd</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>Chrony Daemon</fullname>
+      <gid>475</gid>
+      <home>/var/lib/chrony</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>475</uid>
+      <user_password>!</user_password>
+      <username>chrony</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>1</uid>
+      <user_password>!</user_password>
+      <username>bin</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>Gnome Display Manager daemon</fullname>
+      <gid>466</gid>
+      <home>/var/lib/gdm</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>467</uid>
+      <user_password>!</user_password>
+      <username>gdm</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>systemd Network Management</fullname>
+      <gid>477</gid>
+      <home>/</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/usr/sbin/nologin</shell>
+      <uid>477</uid>
+      <user_password>!*</user_password>
+      <username>systemd-network</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>systemd Time Synchronization</fullname>
+      <gid>476</gid>
+      <home>/</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/usr/sbin/nologin</shell>
+      <uid>476</uid>
+      <user_password>!*</user_password>
+      <username>systemd-timesync</username>
+    </user>
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
       <fullname>Manual pages viewer</fullname>
       <gid>62</gid>
       <home>/var/lib/empty</home>
-      <password_settings>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
         <expire/>
         <flag/>
         <inact/>
@@ -1000,7 +1389,7 @@
       <username>man</username>
     </user>
   </users>
-  <zfcp>
-    <devices config:type="list"/>
+  <zfcp t="map">
+    <devices t="list"/>
   </zfcp>
 </profile>


### PR DESCRIPTION
Generating an autoyast profile with the fix for [bsc#1196963](https://bugzilla.suse.com/show_bug.cgi?id=1196963) resolves the [autoyast_zvm failures](https://openqa.suse.de/tests/8344918#).

- Related ticket: No ticket
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/8352578#
