### PR TITLE
Ignore false softfail bsc#1191112 on normal system installation

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -596,7 +596,7 @@ sub handle_scc_popups {
         push @tags, 'expired-gpg-key' if is_sle('=15');
         while ($counter--) {
             die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
-            if (is_sle('15-SP4+') && get_var('VIDEOMODE', '') !~ /text|ssh-x/) {
+            if (is_sle('15-SP4+') && (get_var('VIDEOMODE', '') !~ /text|ssh-x/) && !get_var('PUBLISH_HDD_1')) {
                 record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
                 for (1 .. 2) { send_key 'alt-f10' }
             }


### PR DESCRIPTION
The softfail pointed to https://bugzilla.suse.com/show_bug.cgi?id=1191112 is
not reproducable on a normal installation. With this commit the
`PUBLISH_HDD_1` is used to distiguish those jobs and keep the softfail only
for the absolute problematic jobs.

This approach seems the most convenience compare to others. Which most of them
will required much more changes and maintance. The main problem is that i
didnt found an easy way to detect when the issue occurs. With needling would
have to do too many checks and maintain a batch of new unnecessary needles
just for a workaround. Also the condition block doesnt look like it can be
moved anywhere else, such as being specific in cases which the problem
appears.

Another solution would be to remove or replace the `record_soft_failure` with
`record_info` but as there is not detection will keep shown up in the jobs
even if they will not be reported as softfailed jobs in the results.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/108581
- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP4&build=b10n1k%2Fos-autoinst-distri-opensuse%2314525&distri=sle