### PR TITLE
Add measured boot test into TPM cases

### DIFF
--- a/data/swtpm/ssh_script
+++ b/data/swtpm/ssh_script
@@ -2,12 +2,13 @@
  
 # This script is used for access remote host via ssh and run some commands
 # without interactive operations
+# In this test, we add some basic test scenarios for swtpm
 # Usage: ssh_script [host] [user] [password]
 # Reference: https://www.journaldev.com/1405/expect-script-ssh-example-tutorial
 # Author: https://www.journaldev.com/author/pankaj
 
 set a_exp $::env(TPM_CHK_CMD)
-set timeout 60
+set timeout 100
 spawn ssh [lindex $argv 1]@[lindex $argv 0]
 expect "yes/no*" {
     send "yes\r"
@@ -15,5 +16,8 @@ expect "yes/no*" {
     } "*?assword" { send "[lindex $argv 2]\r" }
 
 expect " #" { send "ls /dev/tpm*\r" }
+expect " #" { send "ls /sys/kernel/security/tpm0/binary_bios_measurements\r" }
+expect " #" { send "cat /sys/kernel/security/tpm0/binary_bios_measurements\r" }
+expect " #" { send "tpm2_eventlog /sys/kernel/security/tpm0/binary_bios_measurements\r" }
 expect " #" { send "$a_exp\r" }
 expect " #" { send "exit\r" }

--- a/schedule/security/tpm2.yaml
+++ b/schedule/security/tpm2.yaml
@@ -5,6 +5,7 @@ schedule:
     - boot/boot_to_desktop
     - console/consoletest_setup
     - security/tpm2/tpm2_env_setup
+    - security/tpm2/tpm2_measured_boot
     - security/tpm2/tpm2_engine/tpm2_engine_info
     - security/tpm2/tpm2_engine/tpm2_engine_random_data
     - security/tpm2/tpm2_engine/tpm2_engine_rsa_operation

--- a/tests/security/tpm2/tpm2_measured_boot.pm
+++ b/tests/security/tpm2/tpm2_measured_boot.pm
@@ -1,0 +1,29 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: TPM2 measured boot test
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#108386
+
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+
+sub run {
+    return unless get_var('QEMUTPM');
+
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Measured boot basic check, in current test logic, it depends on backend qemu and ovmf
+    # packages version to check measured boot on VM side. But we have other test modules to
+    # cover it on both TW and SLES
+    if (get_var('QEMUTPM_VER') eq '2.0') {
+        assert_script_run('ls /sys/kernel/security/tpm0/binary_bios_measurements');
+        assert_script_run('tpm2_eventlog /sys/kernel/security/tpm0/binary_bios_measurements');
+    }
+}
+
+1;


### PR DESCRIPTION
Base on bsc#1197104 and bsc#1197267, added measured boot test
to current tpm related tests

- Related ticket: https://progress.opensuse.org/issues/108386
- Needles: n/a
- Verification run: 
TW:
https://openqa.opensuse.org/tests/2255368#
https://openqa.opensuse.org/tests/2255369#
https://openqa.opensuse.org/tests/2255370#
https://openqa.opensuse.org/tests/2255371#
SLE:
https://openqa.suse.de/tests/8360651#
https://openqa.suse.de/tests/8360652# [ failed case is tracked via bsc#1197324]
https://openqa.suse.de/tests/8360653#
https://openqa.suse.de/tests/8360654#