### PR TITLE
Integrate weak IPsec ciphers into openQA

### DIFF
--- a/schedule/security/cc_ipsec.yaml
+++ b/schedule/security/cc_ipsec.yaml
@@ -30,4 +30,7 @@ conditional_schedule:
             server:
                 - security/cc/ipsec_server
             client:
+                - security/atsec/setup_atsec_env
                 - security/cc/ipsec_client
+                - security/cc/weak_ipsec_ciphers
+                - security/cc/ipsec_cleanup

--- a/tests/security/cc/ipsec_cleanup.pm
+++ b/tests/security/cc/ipsec_cleanup.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Cleanup the ipsec test env
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#108557
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use audit_test;
+use Utils::Architectures;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    my $client_ip = get_var('CLIENT_IP', '10.0.2.102');
+    my $netdev = get_var('NETDEV', 'eth0');
+
+    # Stop the ipip tunnel
+    assert_script_run("cd $audit_test::test_dir/ipsec_configuration/toe");
+    assert_script_run('./ipsec_setup_tunnel_toe.sh stop');
+
+    # Delete the ip that we added if arch is s390x
+    assert_script_run("ip addr del $client_ip/24 dev $netdev") if (is_s390x);
+}
+
+1;

--- a/tests/security/cc/ipsec_client.pm
+++ b/tests/security/cc/ipsec_client.pm
@@ -60,12 +60,6 @@ sub run {
 
     # Stop the IPSec service
     assert_script_run('ipsec stop');
-
-    # Stop the ipip tunnel
-    assert_script_run('./ipsec_setup_tunnel_toe.sh stop');
-
-    # Delete the ip that we added if arch is s390x
-    assert_script_run("ip addr del $client_ip/24 dev $netdev") if (is_s390x);
 }
 
 1;

--- a/tests/security/cc/weak_ipsec_ciphers.pm
+++ b/tests/security/cc/weak_ipsec_ciphers.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run CC 'ipsec' client case
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#101226
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    assert_script_run('cd /usr/local/atsec');
+    my $output = script_output('bash test_basic_ipsec_eval_weak.bash');
+
+    my @lines = split(/\n/, $output);
+    foreach my $line (@lines) {
+        if ($line =~ (/(.*):\s+(.*)/)) {
+            # This is used to test weak ciphers are not allowed.
+            # If the connection are establish, it means test failed
+            # because the ciphers written in ipsec.conf are not allowed.
+            my $result = $2 eq 'Okay' ? 'fail' : 'ok';
+            record_info($1, "Case $1 result is $2", result => $result);
+            $self->result($result) if $result eq 'fail';
+        }
+    }
+
+    # Parse the log file to check if the fail reason is expected
+    my $log_file = 'ccc-ipsec-eval-weak.log';
+    my $contents = script_output("cat $log_file");
+
+    my $test_results = {};
+    my @test_cases;
+    my ($test_name, $fail_reason);
+    foreach my $c (split(/\n/, $contents)) {
+        if ($c =~ /(IKE version:.*|esp:.*)/) {
+            $test_name = $1;
+            $fail_reason = undef;
+            push(@test_cases, $test_name);
+        }
+        elsif ($c =~ /NO_PROPOSAL_CHOSEN/) {
+            $test_results->{$test_name} = $c;
+            $test_name = undef;
+        }
+    }
+    foreach my $case (@test_cases) {
+        if (my $reason = $test_results->{$case}) {
+            record_info($case, "Test case $case failed as expected: $reason");
+        }
+        else {
+            record_info($case, "Test case $case failed in unexpected reason. See ccc-ipsec-eval-weak.log for details", result => 'fail');
+            $self->result('fail');
+        }
+    }
+
+    # Upload log file
+    upload_logs($log_file);
+}
+
+1;


### PR DESCRIPTION
This case is used to test that weak ciphers are not allowed.

Relate: https://progress.opensuse.org/issues/108557
Verify run:
    https://openqa.suse.de/tests/8373879#  (x86_64)
    https://openqa.suse.de/tests/8373881# (aarch64)
    https://openqa.suse.de/tests/8373974# (s390x)
