### PR TITLE
Containers nits

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -34,7 +34,7 @@ sub run {
     record_info('Version', script_output('buildah --version'));
 
     record_info('Test', "Pull image $image");
-    assert_script_run("buildah pull $image");
+    assert_script_run("buildah pull $image", timeout => 300);
     validate_script_output('buildah images', sub { /registry.opensuse.org\/opensuse\/tumbleweed/ });
 
     record_info('Test', "Create container from $image");

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -31,6 +31,8 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
+    my $podman = $self->containers_factory('podman');
+
     # Prepare for Podman 3.4.4 and CGroups v2
     if (is_sle('15-SP3+') || is_leap('15.4+')) {
         record_info 'cgroup v2', 'Switching to cgroup v2';
@@ -57,7 +59,6 @@ sub run {
     }
 
     my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
-    my $podman = $self->containers_factory('podman');
 
     my $user = $testapi::username;
 

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -76,7 +76,7 @@ sub _test_btrfs_device_mgmt {
     # check if the partition is full
     my ($total, $used) = _btrfs_fi("/var");
     die "partition should be full" unless (int($used) >= int($total * 0.99));
-    die("pull should fail on full partition") if ($rt->pull($container, die => 0) == 0);
+    die("pull should fail on full partition") if ($rt->pull($container, timeout => 600, die => 0) == 0);
     # Increase the amount of available storage by adding the second HDD ('/dev/vdb') to the pool
     assert_script_run "btrfs device add /dev/vdb $dev_path";
     assert_script_run "btrfs fi show $dev_path/btrfs";
@@ -84,7 +84,7 @@ sub _test_btrfs_device_mgmt {
     my $var_blocks_after = script_output('df 2>/dev/null | grep /var | awk \'{print $2;}\'');
     record_info("btrfs blocks", "before adding vdb: $var_blocks\nafter: $var_blocks_after");
     die "available number of block didn't increase" if ($var_blocks >= $var_blocks_after);
-    $rt->pull($container);
+    $rt->pull($container, timeout => 600);
     assert_script_run qq{test \$(ls -t $dev_path/btrfs/subvolumes/ | head -n 1) != \$(cat $btrfs_head)};
 }
 


### PR DESCRIPTION
 * Increase some timeouts (in `buildah` we pull ~150MB image, in `validate_btrfs` we pull ~400MB image.
 * Run the `containers_factory` at the beginning of `rootless_podman` as there are cases when this is needed.

- Verification run: [podman](http://pdostal-server.suse.cz/tests/13906), [docker](http://pdostal-server.suse.cz/tests/13905)
