### PR TITLE
The EFI secret key for hibernation is only supported on x86_64

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -156,14 +156,6 @@
         },
         "type": "bug"
     },
-    "bsc#1187591": {
-        "description": "EFI secret key getting failed: EFI_NOT_FOUND|EFI secret key size 0 is less than 64. Please regenerate secret key",
-        "products": {
-            "opensuse": ["Tumbleweed", "15.2", "15.3"],
-            "sle": ["15-SP2", "15-SP3"]
-        },
-        "type": "bug"
-    },
     "bsc#1187613": {
         "description": "kernel: Grant table initialized",
         "products": {
@@ -318,6 +310,14 @@
         "description": "Timed out waiting for device (/dev/disk/by-label/ignition|/dev/combustion/config)",
         "products": {
             "microos":  ["Tumbleweed"]
+        },
+        "type": "ignore"
+    },
+    "bsc#1187591": {
+        "description": "hibernation: the secret key is invalid",
+        "products": {
+            "opensuse": ["Tumbleweed", "15.3"],
+            "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "ignore"
     }


### PR DESCRIPTION
On other architectures with enabled SecureBoot the hibernation should be
locked down. More information can be found in
https://bugzilla.suse.com/show_bug.cgi?id=1187591

- Verification run: [sle-15-SP4-JeOS-for-kvm-and-xen-aarch64-Build1.53-jeos-filesystem@aarch64](https://openqa.suse.de/t8362696)
