### PR TITLE
lib/containers/container_images: Increase timeout for zypper in systemd

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -255,7 +255,7 @@ sub test_systemd_install {
     if ($image_id eq 'opensuse-tumbleweed' ||
         ($image_id eq 'opensuse-leap' && check_version('>=15.4', "$image_version.$image_sp", qr/\d{2}\.\d/)) ||
         ($image_id eq 'sles' && check_version('>=15-SP4', "$image_version-SP$image_sp", qr/\d{2}-sp\d/))) {
-        assert_script_run "$runtime run $image /bin/bash -c 'zypper al udev && zypper -n in systemd'";
+        assert_script_run("$runtime run $image /bin/bash -c 'zypper al udev && zypper -n in systemd'", timeout => 300);
     }
 }
 


### PR DESCRIPTION
It has to refresh the repos first and then download and install the packages,
which can take longer than the default timeout of 90s. Use 300s like above.

- Verification run: https://openqa.opensuse.org/tests/2256620
