### PR TITLE
Add summary to pc helper scripts

### DIFF
--- a/data/publiccloud/log_instance.sh
+++ b/data/publiccloud/log_instance.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Continously read the serial console from a given publiccloud instance
+# Usage: ./log_instance.sh (start|stop) (EC2|AZURE|GCE) <instance_id> <host> [zone]
 
 COMMAND=$1
 PROVIDER=$2

--- a/data/publiccloud/restart_instance.sh
+++ b/data/publiccloud/restart_instance.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -e
+# Bash script to forcefully reset a publiccloud VM
+# Usage: ./restart_instance.sh (EC2|AZURE) <instance_id> <host>
 
 check_ssh()
 {


### PR DESCRIPTION
Add a summary at the beginning of our publiccloud helper scripts to make
it more obvious, what they are doing and how they can be used.
