### PR TITLE
Use zgrep to check release notes

### DIFF
--- a/tests/installation/release_notes_from_rpm.pm
+++ b/tests/installation/release_notes_from_rpm.pm
@@ -15,7 +15,7 @@ sub run {
     assert_screen('release-notes-button');
     send_key('ctrl-shift-alt-x');
     assert_screen('yast-xterm');
-    enter_cmd "grep -o \"Got release notes.*\" /var/log/YaST2/y2log";
+    enter_cmd "zgrep -o \"Got release notes.*\" /var/log/YaST2/y2log*";
     assert_screen [qw(got-releasenotes-RPM got-releasenotes-URL)];
     unless (match_has_tag 'got-releasenotes-RPM') {
         die('Release notes source does NOT match expectations or not found in YaST logs, expected source: RPM');

--- a/tests/installation/release_notes_from_url.pm
+++ b/tests/installation/release_notes_from_url.pm
@@ -15,7 +15,7 @@ sub run {
     assert_screen('release-notes-button');
     send_key('ctrl-shift-alt-x');
     assert_screen('yast-xterm');
-    enter_cmd "grep -o \"Got release notes.*\" /var/log/YaST2/y2log";
+    enter_cmd "zgrep -o \"Got release notes.*\" /var/log/YaST2/y2log*";
     assert_screen [qw(got-releasenotes-RPM got-releasenotes-URL)];
     unless (match_has_tag 'got-releasenotes-URL') {
         record_soft_failure('bsc#1190711 - Release notes source does NOT match expectations or not found in YaST logs, expected source: URL');


### PR DESCRIPTION
Use zgrep to check release notes, so that archived yast2 logs are also parsed.

- Related ticket: No ticket
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/8364380#step/release_notes_from_rpm/3