### PR TITLE
Wait for resources to start before test

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -12,6 +12,7 @@ use Exporter;
 use strict;
 use warnings;
 use version_utils 'is_sle';
+use Scalar::Util 'looks_like_number';
 use utils;
 use testapi;
 use lockapi;
@@ -61,6 +62,7 @@ our @EXPORT = qw(
   test_flags
   is_not_maintenance_update
   activate_ntp
+  calculate_sbd_start_delay
 );
 
 =head1 SYNOPSIS
@@ -935,6 +937,58 @@ Enables NTP service in SUT.
 sub activate_ntp {
     my $ntp_service = is_sle('15+') ? 'chronyd' : 'ntpd';
     systemctl "enable --now $ntp_service.service";
+}
+
+=head2 calculate_sbd_start_delay
+
+  calculate_sbd_start_delay();
+
+Calculates start time delay after node is fenced.
+Prevents cluster failure if fenced node restarts too quickly.
+Delay time is used either if specified in sbd config variable "SBD_DELAY_START"
+or calculated:
+"corosync_token + corosync_consensus + SBD_WATCHDOG_TIMEOUT * 2"
+Variables 'corosync_token' and 'corosync_consensus' are converted to seconds.
+=cut
+sub calculate_sbd_start_delay {
+    my %params;
+    my $default_wait = 35 * get_var('TIMEOUT_SCALE', 1);
+
+    %params = (
+        'corosync_token' => script_output("corosync-cmapctl | awk -F \" = \" '/config.totem.token\\s/ {print \$2}'"),
+        'corosync_consensus' => script_output("corosync-cmapctl | awk -F \" = \" '/totem.consensus\\s/ {print \$2}'"),
+        'sbd_watchdog_timeout' => script_output("awk -F \"=\" '/SBD_WATCHDOG_TIMEOUT/ {print \$2}' /etc/sysconfig/sbd"),
+        'sbd_delay_start' => script_output("awk -F \"=\" '/SBD_DELAY_START/ {print \$2}' /etc/sysconfig/sbd")
+    );
+
+    # if delay is false return 0sec wait
+    if ($params{'sbd_delay_start'} == 'no' || $params{'sbd_delay_start'} == 0) {
+        record_info("SBD start delay", "SBD delay disabled in config file");
+        return 0;
+    }
+
+    # if delay is only true, calculate according to default equation
+    if ($params{'sbd_delay_start'} == 'yes' || $params{'sbd_delay_start'} == 1) {
+        for my $param_key (keys %params) {
+            if (!looks_like_number($params{$param_key})) {
+                record_soft_failure("SBD start delay",
+                    "Parameter '$param_key' returned non numeric value:\n$params{$param_key}");
+                return $default_wait;
+            }
+            my $sbd_delay_start_time =
+              $params{'corosync_token'} / 1000 +
+              $params{'corosync_consensus'} / 1000 +
+              $params{'sbd_watchdog_timeout'} * 2;
+            record_info("SBD start delay", "SBD delay calculated: $sbd_delay_start_time");
+            return ($sbd_delay_start_time);
+        }
+    }
+
+    # if sbd_delay_stat is specified by number explicitly
+    if (looks_like_number($params{'sbd_delay_start'})) {
+        record_info("SBD start delay", "Specified explicitly in config: $params{'sbd_delay_start'}");
+        return $params{'sbd_delay_start'};
+    }
 }
 
 1;

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -11,63 +11,12 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use Scalar::Util qw(looks_like_number);
 use Time::HiRes 'sleep';
 use Utils::Architectures;
 use lockapi;
 use hacluster;
 use version_utils qw(is_sles4sap);
 use utils qw(systemctl);
-
-=head2 calculate_sbd_start_delay
-
-Calculates start time delay after node is fenced.
-Prevents cluster failure if fenced node restarts too quickly.
-Delay time is used either if specified in sbd config variable "SBD_DELAY_START"
-or calculated:
-"corosync_token + corosync_consensus + SBD_WATCHDOG_TIMEOUT * 2"
-Variables 'corosync_token' and 'corosync_consensus' are converted to seconds.
-=cut
-sub calculate_sbd_start_delay {
-    my %params;
-    my $default_wait = 35 * get_var('TIMEOUT_SCALE', 1);
-
-    %params = (
-        'corosync_token' => script_output("corosync-cmapctl | awk -F \" = \" '/config.totem.token\\s/ {print \$2}'"),
-        'corosync_consensus' => script_output("corosync-cmapctl | awk -F \" = \" '/totem.consensus\\s/ {print \$2}'"),
-        'sbd_watchdog_timeout' => script_output("awk -F \"=\" '/SBD_WATCHDOG_TIMEOUT/ {print \$2}' /etc/sysconfig/sbd"),
-        'sbd_delay_start' => script_output("awk -F \"=\" '/SBD_DELAY_START/ {print \$2}' /etc/sysconfig/sbd")
-    );
-
-    # if delay is false return 0sec wait
-    if ($params{'sbd_delay_start'} == 'no' || $params{'sbd_delay_start'} == 0) {
-        record_info("SBD start delay", "SBD delay disabled in config file");
-        return 0;
-    }
-
-    # if delay is only true, calculate according to default equation
-    if ($params{'sbd_delay_start'} == 'yes' || $params{'sbd_delay_start'} == 1) {
-        for my $param_key (keys %params) {
-            if (!looks_like_number($params{$param_key})) {
-                record_soft_failure("SBD start delay",
-                    "Parameter '$param_key' returned non numeric value:\n$params{$param_key}");
-                return $default_wait;
-            }
-            my $sbd_delay_start_time =
-              $params{'corosync_token'} / 1000 +
-              $params{'corosync_consensus'} / 1000 +
-              $params{'sbd_watchdog_timeout'} * 2;
-            record_info("SBD start delay", "SBD delay calculated: $sbd_delay_start_time");
-            return ($sbd_delay_start_time);
-        }
-    }
-
-    # if sbd_delay_stat is specified by number explicitly
-    if (looks_like_number($params{'sbd_delay_start'})) {
-        record_info("SBD start delay", "Specified explicitly in config: $params{'sbd_delay_start'}");
-        return $params{'sbd_delay_start'};
-    }
-}
 
 sub run {
     my $cluster_name = get_cluster_name;


### PR DESCRIPTION
HA cluster crash tests are failing after node fencing. This is caused 
by new SBD timout which is introduced to prevent fenced node trying to 
join cluster too quickly. This PR implements wait time according to 
SBD delay and waits for RAs being started first.

- Related ticket: https://jira.suse.com/browse/TEAM-5875
- Verification run:
Crash test:
  Failed: https://openqa.suse.de/tests/8322897#step/ha_cluster_crash_test/101
  PASS: https://mordor.suse.cz/tests/3299#
  Alpha cluster (using affected module):
  https://mordor.suse.cz/tests/3295#
