### PR TITLE
Containers: Improve and deduplicate containers::common::check_containers_connectivity()

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -10,12 +10,12 @@ use warnings;
 use testapi;
 use registration;
 use utils qw(zypper_call systemctl file_content_replace script_retry script_output_retry);
-use version_utils qw(is_sle is_leap is_microos is_sle_micro is_opensuse is_jeos is_public_cloud get_os_release check_version);
-use containers::utils qw(can_build_sle_base registry_url);
+use version_utils qw(is_sle is_leap is_microos is_sle_micro is_opensuse is_jeos is_public_cloud get_os_release check_version is_transactional);
+use containers::utils qw(can_build_sle_base registry_url container_ip container_route);
 
 our @EXPORT = qw(is_unreleased_sle install_podman_when_needed install_docker_when_needed install_containerd_when_needed
-  test_container_runtime test_container_image scc_apply_docker_image_credentials
-  scc_restore_docker_image_credentials install_buildah_when_needed test_rpm_db_backend activate_containers_module);
+  test_container_runtime test_container_image scc_apply_docker_image_credentials scc_restore_docker_image_credentials
+  install_buildah_when_needed test_rpm_db_backend activate_containers_module check_containers_connectivity);
 
 
 sub is_unreleased_sle {
@@ -261,6 +261,37 @@ sub test_rpm_db_backend {
     if ($host_distri eq 'opensuse-tumbleweed' || ($host_distri eq 'sles' && check_version('>=15-SP3', "$running_version-SP$sp", qr/\d{2}(?:-sp\d)?/))) {
         validate_script_output "$runtime run $image rpm --eval %_db_backend", sub { m/ndb/ };
     }
+}
+
+sub check_containers_connectivity {
+    my $runtime = shift;
+    record_info "connectivity", "Checking that containers can connect to the host, to each other and outside of the host";
+    my $container_name = 'sut_container';
+
+    # Run container in the background (sleep for 30d because infinite is not supported by sleep in busybox)
+    assert_script_run "$runtime pull " . registry_url('alpine');
+    assert_script_run "$runtime run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
+    my $container_ip = container_ip $container_name, $runtime;
+
+    # Connectivity to host check
+    my $container_route = container_route($container_name, $runtime);
+    assert_script_run "ping -c3 " . $container_route;
+    assert_script_run "$runtime run --rm " . registry_url('alpine') . " ping -c3 " . $container_route;
+
+    # Cross-container connectivity check
+    assert_script_run "ping -c3 " . $container_ip;
+    assert_script_run "$runtime run --rm " . registry_url('alpine') . " ping -c3 " . $container_ip;
+
+    # Outside IP connectivity check
+    script_retry "ping -c3 8.8.8.8", retry => 3, delay => 120;
+    script_retry "$runtime run --rm " . registry_url('alpine') . " ping -c3 8.8.8.8", retry => 3, delay => 120;
+
+    # Outside IP+DNS connectivity check
+    script_retry "ping -c3 google.com", retry => 3, delay => 120;
+    script_retry "$runtime run --rm " . registry_url('alpine') . " ping -c3 google.com", retry => 3, delay => 120;
+
+    # Kill the container running on background
+    assert_script_run "$runtime kill $container_name";
 }
 
 1;

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -9,7 +9,7 @@
 package containers::docker;
 use Mojo::Base 'containers::engine';
 use testapi;
-use containers::utils qw(registry_url get_docker_version check_runtime_version container_ip container_route);
+use containers::utils qw(registry_url get_docker_version check_runtime_version);
 use containers::common qw(install_docker_when_needed);
 use utils qw(systemctl file_content_replace);
 use version_utils qw(get_os_release);
@@ -32,28 +32,6 @@ sub configure_insecure_registries {
     assert_script_run('cat /etc/docker/daemon.json');
     systemctl('restart docker');
     record_info "setup $self->runtime", "deamon.json ready";
-}
-
-sub check_containers_connectivity {
-    record_info "connectivity", "Checking that containers can connect to the host, to each other and outside of the host";
-    my $container_name = 'sut_container';
-
-    # Run container in the background
-    assert_script_run "docker run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
-    my $container_ip = container_ip($container_name, 'docker');
-
-    # Connectivity to host check
-    my $default_route = container_route($container_name, 'docker');
-    assert_script_run "docker run --rm " . registry_url('alpine') . " ping -c3 " . $default_route;
-
-    # Cross-container connectivity check
-    assert_script_run "docker run --rm " . registry_url('alpine') . " ping -c3 " . $container_ip;
-
-    # Outisde connectivity check
-    assert_script_run "docker run --rm " . registry_url('alpine') . " wget google.com";
-
-    # Kill the container running on background
-    assert_script_run "docker kill $container_name ";
 }
 
 1;

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -9,10 +9,9 @@
 package containers::podman;
 use Mojo::Base 'containers::engine';
 use testapi;
-use containers::utils qw(registry_url container_ip);
+use containers::utils qw(registry_url);
 use containers::common qw(install_podman_when_needed);
 use utils qw(file_content_replace);
-use Utils::Systemd 'systemctl';
 use version_utils qw(get_os_release);
 has runtime => "podman";
 
@@ -29,29 +28,6 @@ sub configure_insecure_registries {
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
     file_content_replace("/etc/containers/registries.conf", REGISTRY => $registry);
-}
-
-sub check_containers_connectivity {
-    record_info "connectivity", "Checking that containers can connect to the host, to each other and outside of the host";
-    my $container_name = 'sut_container';
-
-    # Run container in the background
-    assert_script_run "podman pull " . registry_url('alpine');
-    assert_script_run "podman run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
-    my $container_ip = container_ip $container_name, 'podman';
-
-    # Connectivity to host check
-    my $default_route = script_output "podman run " . registry_url('alpine') . " ip route show default 2>/dev/null | awk \'/default/ {print \$3}\'";
-    assert_script_run "podman run --rm " . registry_url('alpine') . " ping -c3 " . $default_route;
-
-    # Cross-container connectivity check
-    assert_script_run "podman run --rm " . registry_url('alpine') . " ping -c3 " . $container_ip;
-
-    # Outside connectivity check
-    assert_script_run "podman run --rm " . registry_url('alpine') . " wget google.com";
-
-    # Kill the container running on background
-    assert_script_run "podman kill $container_name";
 }
 
 1;

--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -43,7 +43,7 @@ sub run {
     test_seccomp() if ($self->{runtime} eq 'docker');
 
     # Test the connectivity of Docker containers
-    $engine->check_containers_connectivity();
+    check_containers_connectivity($engine);
 
     # Run basic runtime tests
     basic_container_tests(runtime => $self->{runtime});

--- a/tests/containers/docker_firewall.pm
+++ b/tests/containers/docker_firewall.pm
@@ -12,6 +12,7 @@ use testapi;
 use utils 'script_retry';
 use version_utils qw(is_sle is_leap);
 use containers::utils qw(registry_url container_ip);
+use containers::common 'check_containers_connectivity';
 use Utils::Systemd 'systemctl';
 
 my $stop_firewall = 0;
@@ -61,7 +62,7 @@ sub run {
     script_retry "docker ps -q | wc -l | grep 0", delay => 5, retry => 12;
 
     # Test the connectivity of Docker containers
-    $engine->check_containers_connectivity();
+    check_containers_connectivity($engine);
 
     # Stop the firewall if it was started by this test module
     if ($stop_firewall == 1) {

--- a/tests/containers/podman_firewall.pm
+++ b/tests/containers/podman_firewall.pm
@@ -11,6 +11,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use utils 'script_retry';
 use containers::utils qw(registry_url container_ip);
+use containers::common 'check_containers_connectivity';
 use Utils::Systemd 'systemctl';
 
 my $stop_firewall = 0;
@@ -49,7 +50,7 @@ sub run {
     script_retry "podman ps -q | wc -l | grep 0", delay => 5, retry => 12;
 
     # Test the connectivity of Podman containers
-    $podman->check_containers_connectivity();
+    check_containers_connectivity($podman);
 
     # Stop the firewall if it was started by this test module
     systemctl('stop ' . $self->firewall()) if $stop_firewall;


### PR DESCRIPTION
 * The `check_containers_connectivity()` for `podman` and `docker` basically works the same - so I deduplicated it.
 * All three checks now executed firstly from the host and then from container. This should improve debugging.
 * When `dig` is available or installable we test the outside connectivity firstly without name resolution.

- Verification run: [podman@Tumbleweed](https://openqa.opensuse.org/tests/2262070), [docker@SLE12-SP5](http://pdostal-server.suse.cz/tests/13982), [podman@SLE Micro 5.2](https://openqa.suse.de/tests/8385286)
