### PR TITLE
Containers: Get rid of several RunArgs initiations

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -19,15 +19,17 @@ our @EXPORT = qw(
   load_publiccloud_tests
 );
 
-sub load_podman_tests() {
-    load_container_engine_test('podman');
-    load_3rd_party_image_test('podman');
+sub load_podman_tests {
+    my ($run_args) = @_;
+    load_container_engine_test('podman', $run_args);
+    load_3rd_party_image_test('podman', $run_args);
 }
 
-sub load_docker_tests() {
-    load_container_engine_test('docker');
+sub load_docker_tests {
+    my ($run_args) = @_;
+    load_container_engine_test('docker', $run_args);
     loadtest 'containers/docker_runc' unless (is_aarch64 && is_sle('<=15'));
-    load_3rd_party_image_test('docker');
+    load_3rd_party_image_test('docker', $run_args);
     loadtest 'containers/registry' unless (is_aarch64 && is_sle('<=15-SP1'));
     loadtest 'containers/zypper_docker' unless (is_aarch64 && is_sle('<=15'));
 }
@@ -50,8 +52,8 @@ sub load_maintenance_publiccloud_tests {
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
             load_publiccloud_consoletests();
         } elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
-            load_podman_tests() if is_sle('>=15-sp1');
-            load_docker_tests();
+            load_podman_tests($args) if (is_sle('>=15-sp1'));
+            load_docker_tests($args);
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
             loadtest "publiccloud/xfsprepare";
             loadtest "xfstests/run";
@@ -106,8 +108,8 @@ sub load_latest_publiccloud_tests {
             load_publiccloud_consoletests();
         }
         elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
-            load_podman_tests();
-            load_docker_tests();
+            load_podman_tests($args);
+            load_docker_tests($args);
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
             loadtest "publiccloud/xfsprepare";
             loadtest "xfstests/run";

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -13,26 +13,11 @@ use version_utils;
 use main_common qw(loadtest);
 use testapi qw(check_var get_var);
 use Utils::Architectures qw(is_aarch64);
-use main_containers qw(load_3rd_party_image_test load_container_engine_test);
+use main_containers qw(load_container_tests);
 
 our @EXPORT = qw(
   load_publiccloud_tests
 );
-
-sub load_podman_tests {
-    my ($run_args) = @_;
-    load_container_engine_test($run_args);
-    load_3rd_party_image_test($run_args);
-}
-
-sub load_docker_tests {
-    my ($run_args) = @_;
-    load_container_engine_test($run_args);
-    loadtest 'containers/docker_runc' unless (is_aarch64 && is_sle('<=15'));
-    load_3rd_party_image_test($run_args);
-    loadtest 'containers/registry' unless (is_aarch64 && is_sle('<=15-SP1'));
-    loadtest 'containers/zypper_docker' unless (is_aarch64 && is_sle('<=15'));
-}
 
 sub load_maintenance_publiccloud_tests {
     my $args = OpenQA::Test::RunArgs->new();
@@ -52,8 +37,7 @@ sub load_maintenance_publiccloud_tests {
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
             load_publiccloud_consoletests();
         } elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
-            load_podman_tests($args) if (is_sle('>=15-sp1'));
-            load_docker_tests($args);
+            load_container_tests();
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
             loadtest "publiccloud/xfsprepare";
             loadtest "xfstests/run";
@@ -108,10 +92,7 @@ sub load_latest_publiccloud_tests {
             load_publiccloud_consoletests();
         }
         elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
-            $args->{runtime} = 'podman';
-            load_podman_tests($args);
-            $args->{runtime} = 'docker';
-            load_docker_tests($args);
+            load_container_tests();
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
             loadtest "publiccloud/xfsprepare";
             loadtest "xfstests/run";

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -21,15 +21,15 @@ our @EXPORT = qw(
 
 sub load_podman_tests {
     my ($run_args) = @_;
-    load_container_engine_test('podman', $run_args);
-    load_3rd_party_image_test('podman', $run_args);
+    load_container_engine_test($run_args);
+    load_3rd_party_image_test($run_args);
 }
 
 sub load_docker_tests {
     my ($run_args) = @_;
-    load_container_engine_test('docker', $run_args);
+    load_container_engine_test($run_args);
     loadtest 'containers/docker_runc' unless (is_aarch64 && is_sle('<=15'));
-    load_3rd_party_image_test('docker', $run_args);
+    load_3rd_party_image_test($run_args);
     loadtest 'containers/registry' unless (is_aarch64 && is_sle('<=15-SP1'));
     loadtest 'containers/zypper_docker' unless (is_aarch64 && is_sle('<=15'));
 }
@@ -108,7 +108,9 @@ sub load_latest_publiccloud_tests {
             load_publiccloud_consoletests();
         }
         elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
+            $args->{runtime} = 'podman';
             load_podman_tests($args);
+            $args->{runtime} = 'docker';
             load_docker_tests($args);
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
             loadtest "publiccloud/xfsprepare";

--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -74,6 +74,7 @@ return 1 if load_yaml_schedule;
 
 if (is_container_test) {
     my $run_args = OpenQA::Test::RunArgs->new();
+    $run_args->{runtime} = 'podman';
     load_boot_from_disk_tests();
     load_container_tests();
 }

--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -73,8 +73,6 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
 return 1 if load_yaml_schedule;
 
 if (is_container_test) {
-    my $run_args = OpenQA::Test::RunArgs->new();
-    $run_args->{runtime} = 'podman';
     load_boot_from_disk_tests();
     load_container_tests();
 }

--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -73,6 +73,7 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
 return 1 if load_yaml_schedule;
 
 if (is_container_test) {
+    my $run_args = OpenQA::Test::RunArgs->new();
     load_boot_from_disk_tests();
     load_container_tests();
 }


### PR DESCRIPTION
This is attempt to deduplicate the `OpenQA::Test::RunArgs->new()` objects in `lib/main_containers.pm`.

- Verification runs (all passing): [SLE15-SP4-containerd](http://pdostal-server.suse.cz/tests/14043), [SLE15-SP4-docker](http://pdostal-server.suse.cz/tests/14044), [Tumbleweed-podman](http://pdostal-server.suse.cz/tests/14045), [SLE15-SP3-bci-python](http://pdostal-server.suse.cz/tests/14053), [SLE15-SP3-image-on-SLE15-SP3-host-podman](http://pdostal-server.suse.cz/tests/14052), [MicroOS-containerhost](http://pdostal-server.suse.cz/tests/14046), [SLE15-SP3-EC2](http://pdostal-server.suse.cz/tests/14145), [SLE15-SP4-JeOS-containers](http://pdostal-server.suse.cz/tests/14051), [SLE-Micro-5.2-containers](http://pdostal-server.suse.cz/tests/14054), [Tumbleweed-image-on-Centos](http://pdostal-server.suse.cz/tests/14055), [Tumbleweed-image-on-Ubuntu](http://pdostal-server.suse.cz/tests/14056), [Tumbleweed-containers_image](http://pdostal-server.suse.cz/tests/14057), [Tumbleweed-containers_host_podman](http://pdostal-server.suse.cz/tests/14147), [Tumbleweed-containers_host_docker](http://pdostal-server.suse.cz/tests/14059)
