### PR TITLE
Enable ZYPP_SINGLE_RPMTRANS  to increase zypper performance

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -27,6 +27,7 @@ our @EXPORT = qw(
   check_rollback_system
   reset_consoles_tty
   set_scc_proxy_url
+  set_zypp_single_rpmtrans
 );
 
 sub setup_sle {
@@ -53,6 +54,7 @@ sub setup_sle {
     # Enable Y2DEBUG for error debugging
     enter_cmd "echo 'export Y2DEBUG=1' >> /etc/bash.bashrc.local";
     script_run("source /etc/bash.bashrc.local", die_on_timeout => 0);
+    set_zypp_single_rpmtrans();
 }
 
 sub setup_migration {
@@ -205,6 +207,24 @@ sub set_scc_proxy_url {
         enter_cmd "echo 'url: $u' > /etc/SUSEConnect";
     }
     save_screenshot;
+}
+
+=head2 set_zypp_single_rpmtrans
+    set_zypp_single_rpmtrans();
+
+This function is used for adding ZYPP_SINGLE_RPMTRANS
+if the test case has ZYPP_SINGLE_RPMTRANS setting. this
+feature will enhance the zypper performance.
+
+jira feature https://jira.suse.com/browse/SLE-21973
+zypper single transaction performance enhancement (RFE)
+
+=cut
+
+sub set_zypp_single_rpmtrans {
+
+    assert_script_run 'export ZYPP_SINGLE_RPMTRANS=1 ' if get_var('ZYPP_SINGLE_RPMTRANS');
+
 }
 
 1;

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use migration;
 use version_utils qw(is_jeos is_desktop_installed is_leap);
 use Utils::Backends 'is_pvm';
 
@@ -60,6 +61,7 @@ sub run {
         }
 
     }
+    set_zypp_single_rpmtrans;
     # starting from 15.3, core binary RPMs was inherited from SLE build directly
     # allowing the vendor change during migration is needed
     # the change below also exists in openSUSE-release package

--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -48,6 +48,7 @@ sub remove_kgraft_patch {
 sub run {
     select_console 'root-console';
 
+    set_zypp_single_rpmtrans();
     check_or_install_packages;
 
     # set scc proxy url here to perform online migration via scc proxy

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -24,6 +24,7 @@ sub run {
 
     disable_installation_repos;
     add_test_repositories;
+    set_zypp_single_rpmtrans;
     fully_patch_system;
     install_patterns() if (get_var('PATTERNS'));
     deregister_dropped_modules;

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -50,6 +50,9 @@ sub patching_sle {
     # add test repositories and logs the required patches
     add_test_repositories();
 
+    # set zypper single rpmtrans
+    set_zypp_single_rpmtrans();
+
     # Default to fully update unless MINIMAL_UPDATE is set
     if (get_var('MINIMAL_UPDATE')) {
         minimal_patch_system();


### PR DESCRIPTION
Enable ZYPP_SINGLE_RPMTRANS  to increase zypper performance

We need to enable zypper single rpm trans by setting ZYPP_SINGLE_RPMTRANS=1. 
This will increase zypper performance by combining actions into a single transaction.

- Related ticket: https://progress.opensuse.org/issues/108341
- Needles: N/A
- Verification run: 
  zdup:
  https://openqa.nue.suse.com/t8350424
  https://openqa.nue.suse.com/t8360944
 yast2:
  https://openqa.nue.suse.com/t8361159
zypper:
 https://openqa.nue.suse.com/t8348700
 https://openqa.nue.suse.com/t8349515 
 https://openqa.nue.suse.com/t8350879
 https://openqa.nue.suse.com/t8350490 
