### PR TITLE
xfstests: Add xfs_repair switch

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -210,7 +210,10 @@ sub create_loop_device_by_rootsize {
 
 sub set_config {
     my $self = shift;
-    script_run("echo 'export KEEP_DMESG=yes' >> $CONFIG_FILE");
+    script_run("echo export KEEP_DMESG=yes >> $CONFIG_FILE");
+    if (get_var('XFSTESTS_XFS_REPAIR')) {
+        script_run("echo export TEST_XFS_REPAIR_REBUILD=1 >> $CONFIG_FILE");
+    }
     record_info('Config file', script_output("cat $CONFIG_FILE"));
 }
 


### PR DESCRIPTION
Set TEST_XFS_REPAIR_REBUILD=1 to have: 
1. _check_xfs_filesystem run command 'xfs_repair -n' to check the filesystem; 
2. xfs_repair to rebuild metadata indexes; 
3. run 'xfs_repair -n' the third time to check the results of the rebuilding.

Recently will only enable 1 test with TEST_XFS_REPAIR_REBUILD to avoid unknown influence.

- Verification run: http://10.67.133.102/tests/580