### PR TITLE
Refresh login settings window by resizing

### DIFF
--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -49,6 +49,8 @@ sub run {
 
     # Check previously set values + Miscellaneous Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
+    record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2_security-login-settings', 'alt-f10', 9, 2);
     assert_and_click "yast2_security-login-settings";
     assert_screen "yast2_security-login-attempts";
     # set file permissions to 'secure'


### PR DESCRIPTION
Due to the [yast2 UI bug](https://bugzilla.suse.com/show_bug.cgi?id=1191112), Login Settings are not appearing correctly, as seen here: https://openqa.suse.de/tests/8364966#step/yast2_security/25

- Related ticket: No ticket
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/8368510
