### PR TITLE
Containers: nerdctl: Install apparmor pattern on SLE15-SP3

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -140,6 +140,7 @@ sub install_buildah_when_needed {
 sub install_containerd_when_needed {
     my $registry = registry_url();
     zypper_call('in containerd cni-plugins', timeout => 300);
+    zypper_call('in -t pattern apparmor') if is_sle('=15-SP3');
     assert_script_run "curl " . data_url('containers/containerd.toml') . " -o /etc/containerd/config.toml";
     file_content_replace("/etc/containerd/config.toml", REGISTRY => $registry);
     assert_script_run('cat /etc/containerd/config.toml');


### PR DESCRIPTION
- Related ticket: [Jira SLE-23180](https://jira.suse.com/browse/SLE-23180)
- Before: http://pdostal-server.suse.cz/tests/13935#step/containerd_nerdctl/46
- After: http://pdostal-server.suse.cz/tests/13938

```bash
# nerdctl run -it --rm 18.156.2.117:5000/library/alpine:3.6 echo 'Hello'; echo pkeQK-$?-
FATA[0000] get apparmor_parser version: exec: "apparmor_parser": executable file not found in $PATH 
pkeQK-1-
```

This error does not appear on SLE15-SP4 neither on Tumbleweed.
After this is fixed we can merge [qac-openqa-yaml!691](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/691/diffs).