### PR TITLE
Fix scheduling test 'python_liblouis' twice

### DIFF
--- a/schedule/functional/extra_tests_gnome.yaml
+++ b/schedule/functional/extra_tests_gnome.yaml
@@ -27,6 +27,12 @@ conditional_schedule:
                 - x11/wine
                 - x11/chrome
     python_liblouis:
+        DISTRI:
+            sle:
+                - '{{python_liblouis_sle}}'
+            opensuse:
+                - console/python_liblouis
+    python_liblouis_sle:
         ARCH:
             'x86_64':
                 - console/python_liblouis
@@ -46,7 +52,6 @@ conditional_schedule:
                 - x11/network/hwsim_wpa2_enterprise_setup
                 - x11/network/yast2_network_use_nm
                 - x11/network/NM_wpa2_enterprise
-                - console/python_liblouis
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop


### PR DESCRIPTION
The test *python_liblouis* had been scheduled twice by mistake.

- Related ticket: https://progress.opensuse.org/issues/108683
- Needles: *not applicable*
- Verification runs:

|||||
|-|-|-|-|
|**Tumbleweed**|[x86_64](https://openqa.opensuse.org/t2258844)|[aarch64](https://openqa.opensuse.org/t2258845)|[ppc64le](https://openqa.opensuse.org/t2258846)|
|**Leap 15.4**|[x86_64](https://openqa.opensuse.org/t2258843)|||
|**SLE15 SP2**|[x86_64](https://openqa.suse.de/t8368898)|[aarch64](https://openqa.suse.de/t8368899)||
|**SLE15 SP3**|[x86_64](https://openqa.suse.de/t8368896)|[aarch64](https://openqa.suse.de/t8368897)||
|**SLE15 SP4**|[x86_64](https://openqa.suse.de/t8368900)|[aarch64](https://openqa.suse.de/t8368901)||