### PR TITLE
Fix ec2

### DIFF
--- a/data/publiccloud/terraform/sap/ec2.tfvars
+++ b/data/publiccloud/terraform/sap/ec2.tfvars
@@ -153,9 +153,6 @@ hana_instancetype = "%MACHINE_TYPE%"
 # Custom owner for private AMI
 #hana_os_owner = "amazon"
 
-# Hostname, without the domain part
-name = "hana"
-
 # Enable system replication and HA cluster
 #hana_ha_enabled = true
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -310,6 +310,8 @@ sub terraform_prepare_env {
         assert_script_run('git config --global http.sslVerify false') if get_var('HA_SAP_GIT_NO_VERIFY');
         assert_script_run('cd ' . TERRAFORM_DIR);
         assert_script_run('git clone --depth 1 --branch ' . get_var('HA_SAP_GIT_TAG', 'master') . ' ' . get_required_var('HA_SAP_GIT_REPO') . ' .');
+        # Workaround for https://github.com/SUSE/ha-sap-terraform-deployments/issues/810
+        assert_script_run('sed -i "/key_name/s/terraform/&$RANDOM/" aws/infrastructure.tf');
         # By default use the default provided Salt formula packages
         assert_script_run('rm -f requirements.yml') unless get_var('HA_SAP_USE_REQUIREMENTS');
         assert_script_run('cd');    # We need to ensure to be in the home directory


### PR DESCRIPTION
This PR randomizes the name of the key pair as a workaround for https://github.com/SUSE/ha-sap-terraform-deployments/issues/810

```
Error: error importing EC2 Key Pair (qashapopenqa - terraform): InvalidKeyPair.Duplicate: The keypair 'qashapopenqa - terraform' already exists.
	status code: 400, request id: 76ccd48b-8a37-4b14-838a-1d11dc2a6723

  with aws_key_pair.key-pair,
  on infrastructure.tf line 49, in resource "aws_key_pair" "key-pair":
  49: resource "aws_key_pair" "key-pair" {
```


- Failing test: https://openqa.suse.de/tests/8352213
- Verification run: https://openqa.suse.de/tests/8369428 (failing because of https://bugzilla.suse.com/show_bug.cgi?id=1197398)