### PR TITLE
Tweak is_leap: GNOME-Next can falsy trigger to be 'is_leap' with GNOME 42.0

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -272,6 +272,9 @@ sub is_leap {
     # Leap and its stagings
     return 0 unless check_var('DISTRI', 'opensuse');
     return 0 unless $version =~ /^\d{2,}\.\d/ || $version =~ /^Jump/;
+    # GNOME-Next is 'mean' as it can be VERSION=42.0, easily to be confused with Leap 42.x
+    # But GNOME-Next is always based on Tumbleweed
+    return 0 if is_gnome_next;
     return 1 unless $query;
 
     # Hacks for staging and HG2G :)


### PR DESCRIPTION
GNOME 42.0 is out. While testing it as part of GNOME-Next, we have seen very
obscure failures, which were not the case up to the release candidate

Turns out we managed to confuse openQA with VERSION=42.0 and various
places checking is_leap('<15.1') and the like. With 42.rc is_leap did not
yet interpret this as Leap based, but 42.0 matches close enough that we are
considered Leap now.

- Related ticket: Non filed - debugged directly by scratching my head
- Needles: N/A
- Verification run: https://openqa.opensuse.org/t2258899 (important step is passing over consoletest_finsih)
