### PR TITLE
Don't run ZYPP_SINGLE_RPMTRANS tests on OFFLINE_SUT

### DIFF
--- a/tests/console/zypper_in.pm
+++ b/tests/console/zypper_in.pm
@@ -47,7 +47,7 @@ sub run {
     assert_script_run("rpm -e $pkgname");
     assert_script_run("! rpm -q $pkgname");
 
-    if (!is_sle('<15-SP4') && !is_leap('<15.4')) {
+    if (!is_sle('<15-SP4') && !is_leap('<15.4') && !check_var('OFFLINE_SUT', '1')) {
         # older releases than 15 don't have the --allow-unsigned-rpm switch
         # also they have issues with this rpms being hashed by something newer than MD5
         # and also this ZYPP_SINGLE_RPMTRANS feature flag is only available as of 15.4


### PR DESCRIPTION
Without network access we can't download the RPMs

https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14405#discussion_r832043713
https://openqa.suse.de/t8369805