### PR TITLE
Increase timeout checks for SUSEConnect --rollback

### DIFF
--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -47,13 +47,15 @@ sub rollback_and_reboot {
     assert_script_run("snapper list");
     # check whether SUSEConnect --rollback is running executed by rollback-reset-registration
     # this might cause a system management lock by zypper
-    for (my $runs = 0; $runs < 5; $runs++) {
+    for (my $runs = 1; $runs < 11; $runs++) {
         if (script_run('test -f /var/lib/rollback/check-registration') == 1) {
             return 1;
         }
         record_info('ps', script_output('ps -ef'));
+        bmwqemu::diag("SUSEConnect --rollback is still running [$runs/10]");
         sleep 20;
     }
+    die "SUSEConnect --rollback is running longer than expected";
 }
 
 sub run {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/108064
- Verification run: [sle-15-SP2-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220322-1-jeos-filesystem@svirt-xen-hvm](http://kepler.suse.cz/tests/14636#step/snapper_jeos_cli/58)
