### PR TITLE
Increase memory and cpu for nested vm

### DIFF
--- a/data/swtpm/swtpm_legacy.xml
+++ b/data/swtpm/swtpm_legacy.xml
@@ -3,9 +3,9 @@
   <uuid>7b256a70-1525-4b57-bdcf-e9dc779c3e1d</uuid>
   <metadata>
   </metadata>
-  <memory unit='KiB'>1048576</memory>
-  <currentMemory unit='KiB'>1048576</currentMemory>
-  <vcpu placement='static'>1</vcpu>
+  <memory unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
     <boot dev='hd'/>

--- a/data/swtpm/swtpm_uefi.xml
+++ b/data/swtpm/swtpm_uefi.xml
@@ -3,9 +3,9 @@
   <uuid>b5049116-80e1-4c6a-9a68-d48e6528c687</uuid>
   <metadata>
   </metadata>
-  <memory unit='KiB'>1048576</memory>
-  <currentMemory unit='KiB'>1048576</currentMemory>
-  <vcpu placement='static'>1</vcpu>
+  <memory unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
     <loader readonly='yes' type='pflash'>/usr/share/qemu/ovmf-x86_64-code.bin</loader>


### PR DESCRIPTION
In nested test environment, we use 1G memory
and 1 vcpu currently, increase them to get
better performance

- Related ticket: https://progress.opensuse.org/issues/106807
- Needles: n/a
- Verification run: 
http://openqa.suse.de/tests/8372850#step/swtpm_verify/47 -UEFI [the failed case is track via bsc#1197324]
http://openqa.suse.de/tests/8372923#                                         -Legacy
