### PR TITLE
Wait longer for rollback registration checks

### DIFF
--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -53,7 +53,7 @@ sub rollback_and_reboot {
         }
         record_info('ps', script_output('ps -ef'));
         bmwqemu::diag("SUSEConnect --rollback is still running [$runs/10]");
-        sleep 20;
+        sleep 60;
     }
     die "SUSEConnect --rollback is running longer than expected";
 }


### PR DESCRIPTION
Follow up for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14558
