### PR TITLE
usr_sbin_smbd: Soft fail on smb apparmor bug

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -34,6 +34,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils qw(is_sle);
 
 # Setup samba server
 sub samba_server_setup {
@@ -187,8 +188,9 @@ sub run {
     # Verify audit log contains no "DENIED" (etc. "samba/smbd") operations
     my $script_output = script_output("cat $audit_log");
     if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* profile=.*/sx) {
-        record_info("ERROR", "There are denied records found in $audit_log", result => 'fail');
-        $self->result('fail');
+        record_info("ERROR", "There are denied records found in $audit_log");
+        record_soft_failure('bsc#1196850') if is_sle('=15-SP3');
+        $self->result('fail') unless is_sle('=15-SP3');
     }
 
     # Upload logs for reference


### PR DESCRIPTION
No reason to block main updates due to existing bug
Argument result in record_info has no effect

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1196850
- Verification run: https://openqa.suse.de/tests/8381986#step/usr_sbin_smbd/98
