### PR TITLE
Increase max-correction value for chrony testing

### DIFF
--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -50,7 +50,7 @@ sub run {
     assert_script_run 'chronyc makestep';
     assert_script_run 'chronyc tracking';
     assert_script_run 'chronyc activity';
-    assert_script_run 'chronyc waitsync 60 0.01', 610;
+    assert_script_run 'chronyc waitsync 120 0.5', 1210;
 }
 
 sub post_checks {


### PR DESCRIPTION
It has taken about 20 attempts to even start a time correction in case of
worst case scenario. Thus the 10 ms correction limit could
not have been reached in many test runs within 600s.

- Related ticket: https://progress.opensuse.org/issues/106374
- Verification run: https://openqa.suse.de/tests/8400416#step/ntp_client/1
