### PR TITLE
Fix SUSEConnect timeout on system_prepare

### DIFF
--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -32,7 +32,7 @@ sub check_registered_system {
     $pro = 'SLE_' . $pro if ($pro eq 'HPC');
     suseconnect_ls($pro);
     my $ver = $system =~ s/\-SP/./r;
-    script_run("SUSEConnect -s | grep " . $ver);
+    script_run("SUSEConnect -s | grep " . $ver, die_on_timeout => 0);
 }
 
 sub check_registered_addons {


### PR DESCRIPTION
Add die_on_timeout=0 to make script_run won't report fail when timeout. 

- Related ticket: https://progress.opensuse.org/issues/106954
- Needles: N/A
- Verification run:  
  http://openqa.nue.suse.com/tests/8372921#step/system_prepare/21
  https://openqa.nue.suse.com/tests/8372921#step/system_prepare/21
  http://openqa.nue.suse.com/tests/8372671#step/system_prepare/21
  https://openqa.nue.suse.com/tests/8372921#step/system_prepare/21
  https://openqa.nue.suse.com/tests/8372921#step/system_prepare/21
