### PR TITLE
Append condition which produce bsc#1191112 on HPC

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -596,7 +596,7 @@ sub handle_scc_popups {
         push @tags, 'expired-gpg-key' if is_sle('=15');
         while ($counter--) {
             die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
-            if (is_sle('15-SP4+') && (get_var('VIDEOMODE', '') !~ /text|ssh-x/) && (!get_var('PUBLISH_HDD_1') || !check_var('SLE_PRODUCT', 'hpc'))) {
+            if (is_sle('15-SP4+') && (get_var('VIDEOMODE', '') !~ /text|ssh-x/) && !(get_var('PUBLISH_HDD_1') || check_var('SLE_PRODUCT', 'hpc'))) {
                 record_soft_failure('bsc#1191112', 'Resizing window as workaround for YaST content not loading');
                 for (1 .. 2) { send_key 'alt-f10' }
             }


### PR DESCRIPTION
There are some jobs which do not contain `PUBLISH_HDD_1` on HPC group
which still perform full installation, however. I appended the
condition to check if the sle_product is HPC.

This will not prevent the false softfail to showed up in all the other
groups. This is only to maintain the status report on HPC.

Revert if you find other HPC products failing because of this.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

