### PR TITLE
Clear screen after ncurses to prevent cluttering

### DIFF
--- a/tests/jeos/rpi_wifi.pm
+++ b/tests/jeos/rpi_wifi.pm
@@ -40,6 +40,8 @@ sub run {
     enter_cmd(get_required_var('RPI_WIFI_PSK'));
 
     assert_screen 'text-logged-in-root';
+    script_run 'clear';
+
     assert_script_run 'ip a';
     assert_script_run('ping -c1 ' . get_required_var('RPI_WIFI_WORKER_IP'));
 }


### PR DESCRIPTION
Prevent something like https://openqa.suse.de/tests/8383000#step/rpi_wifi/27