### PR TITLE
A new test to execute systemd testkit in offline mode

### DIFF
--- a/schedule/functional/create_systemd_testkit.yaml
+++ b/schedule/functional/create_systemd_testkit.yaml
@@ -1,0 +1,9 @@
+---
+name: Create_systemd_testkit
+description: >
+    Maintainer: QE-core
+    Download systemd tar file and create a hdd
+schedule:
+    - boot/boot_to_desktop
+    - console/create_hdd_systemd_testkit
+    - shutdown/shutdown

--- a/schedule/functional/start_offline_systemd_testkit.yaml
+++ b/schedule/functional/start_offline_systemd_testkit.yaml
@@ -1,0 +1,8 @@
+---
+name: Start_systemd_testkit
+description: >
+    Maintainer: QE-core
+    Execute the systemd in offline mode
+schedule:
+    - boot/boot_to_desktop
+    - console/start_systemd_testkit_offline

--- a/tests/console/create_hdd_systemd_testkit.pm
+++ b/tests/console/create_hdd_systemd_testkit.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This module fetches the binary from defined URL in the OPENQA Variable
+# EXTERNAL_TESTSUITE_URL and publishes the result in HDD
+# Maintainer: QE Core <qe-core@suse.de>
+
+use strict;
+use warnings;
+use File::Basename;
+use Mojo::JSON qw(encode_json);
+use base "consoletest";
+use testapi;
+use utils;
+
+my $testdir = '/usr/lib/systemd/test/SAP/';
+
+sub run {
+    my ($self) = @_;
+    my $systemd_suse_url = get_var("EXTERNAL_TESTSUITE_URL");    # Tarball location to do download
+    $self->select_serial_terminal;
+    assert_script_run("mkdir -p  $testdir");
+    assert_script_run("wget --no-check-certificate $systemd_suse_url -O $testdir" . basename($systemd_suse_url));
+    assert_script_run("ls -l $testdir");
+}
+
+1;

--- a/tests/console/start_systemd_testkit_offline.pm
+++ b/tests/console/start_systemd_testkit_offline.pm
@@ -1,0 +1,117 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Use the created hdd and run the external testkits in offline mode.
+# * Go to the directory testdir and untar the external testkits
+# * Ensure that the network is not available
+# * Start the test by running the systemd_pepare.sh
+# * Run the systemd_run.sh and save the result
+# * Make sure that network is still down
+# * Parse the saved result and return the status
+# Verify the output of the external testkits run.
+# Maintainer: QE Core <qe-core@suse.de>
+# Tags: poo#106284
+
+use base 'consoletest';
+use testapi;
+use utils;
+use Mojo::JSON qw(encode_json);
+use strict;
+use warnings;
+
+my $log = '/tmp/systemd_run.log';
+my $testdir = '/usr/lib/systemd/test/SAP';
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+    assert_script_run("cd $testdir");
+    assert_script_run("tar -zxvf systemd_suse.tgz");
+    # Make the Network offline if OFFLIE_SUT is set to 1
+    # To be common criteria compliant, binaries not controlled by SUSE must be excecuted isolated
+    # hence the reason to disable the network here, beyond this step, treat the machine as tainted.
+    assert_script_run(qq{(ping -c4 build.suse.de && exit 1 || exit 0 )});
+    assert_script_run(qq{(ping -c4 8.8.8.8 && exit 1 || exit 0)});
+    record_info("START", "Testsuite execution is starting");
+    assert_script_run "cp systemd/*.sh .";
+    assert_script_run 'sh -e ./systemd_prepare.sh';
+    # Wait at least 180s for test to finish
+    my $wait = 180;
+    # Run the test and save the logs and results
+    # systemd_run.sh will fail with a non-zero retval if any of the sub-tests
+    # fail. We ignore it to parse the individual results from the log
+    my $out = script_output "su - abcadm -c '$testdir/systemd_run.sh' 2>&1 | tee $log", $wait, proceed_on_failure => 0;
+    record_info("END", "Testsuite excecution finished");
+    record_info("TEST LOG", "$out");
+    assert_script_run(qq{(ping -c4 build.suse.de && exit 1 || exit 0 )});
+    assert_script_run(qq{(ping -c4 8.8.8.8 && exit 1 || exit 0)});
+    # Parse the result of each sub test after running systemd_run.sh
+    # Test verifies the saved results and returns result information.
+    $self->parse_results_from_output($out);
+    $self->upload_systemdlib_tests_logs;
+}
+
+sub parse_results_from_output {
+    my ($self, $out) = @_;
+    my $results_file = 'systemd_run.results';
+    my $distro = uc(get_required_var('DISTRI'));
+    my $testunit = '';
+    my $outcome = '';
+    my $error_line = '';
+    my %results = (
+        tests => [],
+        info => {timestamp => 0, distro => $distro, results_file => $results_file},
+        summary => {duration => 0, passed => 0, num_tests => 0}
+    );
+
+    $out =~ s/\r//gs;
+    foreach my $line (split(/\n/, $out)) {
+        if ($line =~ /^\/home.+\/([a-z0-9]+)\/run_test.sh$/) {
+            # Test block started. Identify test unit name and assume test will pass
+            $testunit = $1;
+            $outcome = 'passed';
+            next;
+        }
+
+        if ($line =~ /(ERROR:|FAILED:|failed$)/) {
+            $outcome = 'failed';
+            $error_line = $line;
+        }
+
+        if ($testunit && ($line =~ /(^=+$|^#+$)/)) {
+            # Test block end has been reached. Record results
+
+            if ($outcome eq 'failed') {
+                my $openQA_result = $self->record_testresult('fail');
+                my $openQA_filename = $self->next_resultname('txt');
+                $openQA_result->{title} = $testunit;
+                $openQA_result->{text} = $openQA_filename;
+                $self->write_resultfile($openQA_filename, "# Failure:\n$error_line\n");
+                $self->{dents}++;
+            }
+
+            $results{summary}{num_tests}++;
+            $results{summary}{passed}++ if ($outcome eq 'passed');
+            push @{$results{tests}}, {nodeid => $testunit, test_index => 0, outcome => $outcome};
+            $testunit = '';
+            $outcome = '';
+            $error_line = '';
+        }
+
+        last if ($line =~ /^### JOURNALCTL/);
+    }
+
+    my $json = encode_json \%results;
+    record_info("IPA Results", $json);
+    assert_script_run "echo '$json' > /tmp/$results_file";
+}
+
+sub upload_systemdlib_tests_logs {
+    my ($self) = @_;
+    my $out = script_output('journalctl --no-pager -axb -o short-precise');
+    record_info("JOURNAL", "$out");
+}
+
+1;


### PR DESCRIPTION
A new test `create_hdd_systemd_testkit` fetches the systemd binary passed in the variable EXTERNAL_TESTSUITE_URL to the SUT and publish the hdd. This test  depends on the mru-install-minimal-with-addons/create_hdd_textmode
`start_systemd_testkit_offline` test depends on create_hdd_systemd_testkit and which starts in network offline mode. Runs the binary in offline mode and verify the test result.

There is a know issue in running external testkit in SLE-15 SP3 and SP4 and I will add the soft fail after this PR merge. It will be handled in separate ticket https://progress.opensuse.org/issues/108893

- Related ticket: https://progress.opensuse.org/issues/106517
- Needles: No
- Verification run:
   SLE 15-SP3: [create_hdd_systemd_testkit](http://10.161.229.147/tests/2642) | [run_systemd_testkit](http://10.161.229.147/tests/2643#)
   SLE 15-SP2:  [create_hdd_systemd_testkit](http://10.161.229.147/tests/2659) | [run_systemd_testkit](http://10.161.229.147/tests/2660#)
   SLE 15-SP4:  [create_hdd_systemd_testkit](http://10.161.229.147/tests/2661) | [run_systemd_testkit](http://10.161.229.147/tests/2662#)
