### PR TITLE
Implement boost module test installed with spack

### DIFF
--- a/data/hpc/sample_boost.cpp
+++ b/data/hpc/sample_boost.cpp
@@ -1,27 +1,16 @@
-#include <mpi.h>
-#include <iostream>
-
 /**
-https://www.boost.org/doc/libs/1_69_0/doc/html/mpi/getting_started.html
+https://www.boost.org/doc/libs/1_78_0/doc/html/mpi/tutorial.html
 **/
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <iostream>
+namespace mpi = boost::mpi;
+
 int main(int argc, char* argv[])
 {
-  MPI_Init(&argc, &argv);
-
-  int rank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  if (rank == 0) {
-    int value = 17;
-    int result = MPI_Send(&value, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
-    if (result == MPI_SUCCESS)
-      std::cout << "Rank 0 OK!" << std::endl;
-  } else if (rank == 1) {
-    int value;
-    int result = MPI_Recv(&value, 1, MPI_INT, 0, 0, MPI_COMM_WORLD,
-			  MPI_STATUS_IGNORE);
-    if (result == MPI_SUCCESS && value == 17)
-      std::cout << "Rank 1 OK!" << std::endl;
-  }
-  MPI_Finalize();
+  mpi::environment env(argc, argv);
+  mpi::communicator world;
+  std::cout << "I am process " << world.rank() << " of " << world.size()
+	    << "." << std::endl;
   return 0;
 }

--- a/data/hpc/sample_cplusplus.cpp
+++ b/data/hpc/sample_cplusplus.cpp
@@ -1,0 +1,27 @@
+#include <mpi.h>
+#include <iostream>
+
+/**
+https://www.boost.org/doc/libs/1_69_0/doc/html/mpi/getting_started.html
+**/
+int main(int argc, char* argv[])
+{
+  MPI_Init(&argc, &argv);
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank == 0) {
+    int value = 17;
+    int result = MPI_Send(&value, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+    if (result == MPI_SUCCESS)
+      std::cout << "Rank 0 OK!" << std::endl;
+  } else if (rank == 1) {
+    int value;
+    int result = MPI_Recv(&value, 1, MPI_INT, 0, 0, MPI_COMM_WORLD,
+			  MPI_STATUS_IGNORE);
+    if (result == MPI_SUCCESS && value == 17)
+      std::cout << "Rank 1 OK!" << std::endl;
+  }
+  MPI_Finalize();
+  return 0;
+}

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -219,4 +219,40 @@ sub prepare_user_and_group {
     assert_script_run('useradd -u 7777 -g 7777 slurm');
 }
 
+=head2 prepare_spack_env
+
+  prepare_spack_env($mpi)
+
+After install spack and HPC C<mpi> required packages, prepares env
+variables. The HPC packages (*-gnu-hpc) use an installation path that is separate
+from the rest and can be exported via a network file system.
+
+After C<prepare_spack_env> run, C<spack> should be ready to build entire tool stack,
+downloading and installing all bits required for whatever package or compiler.
+=cut
+sub prepare_spack_env {
+    my ($self, $mpi) = @_;
+    $mpi //= 'mpich';
+    zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel";
+    $self->relogin_root;
+    assert_script_run 'source /etc/profile.d/lmod.sh';
+    assert_script_run 'module load gnu $mpi';
+    assert_script_run '/usr/lib/spack/run-find-external.sh';
+    assert_script_run 'source /usr/share/spack/setup-env.sh';
+}
+
+=head2 uninstall_spack_module
+
+  uninstall_spack_module($module)
+
+Unload and uninstall C<module> from spack stack
+=cut
+sub uninstall_spack_module {
+    my ($self, $module) = @_;
+    die 'uninstall_spack_module requires a module name' unless $module;
+    assert_script_run("spack unload $module");
+    script_run('module av');
+    assert_script_run("spack uninstall -y $module");
+    assert_script_run("spack find $module | grep 'No package matches the query'");
+}
 1;

--- a/schedule/hpc/multi_machine_spack_test.yaml
+++ b/schedule/hpc/multi_machine_spack_test.yaml
@@ -1,0 +1,22 @@
+---
+name: HPC Spack node
+description:    >
+    Schedule multimachine cluster for spack tests
+vars:
+  DESKTOP: textmode
+  BOOT_HDD_IMAGE: 1
+conditional_schedule:
+  bootmenu:
+    ARCH:
+      aarch64:
+  hpctest:
+    HPC:
+      mpi_master:
+        - hpc/spack_master
+      mpi_slave:
+        - hpc/spack_slave
+schedule:
+  - '{{bootmenu}}'
+  - boot/boot_to_desktop
+  - hpc/before_test
+  - '{{hpctest}}'

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -1,0 +1,82 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: HPC_Module: Test Spack package installation and features
+#
+# Acts as the master node of the cluster to execute parallel executions
+#
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base qw(hpcbase hpc::utils), -signatures;
+use testapi;
+use utils;
+use lockapi;
+
+sub run ($self) {
+    my $mpi = $self->get_mpi();
+    my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
+    my $mpi_bin = 'mpi_bin';
+    my @cluster_nodes = $self->cluster_names();
+    my $cluster_nodes = join(',', @cluster_nodes);
+    $self->prepare_spack_env($mpi);
+    record_info 'spack', script_output 'zypper -q info spack';
+    record_info 'boost spec', script_output 'spack spec boost';
+    assert_script_run "spack install boost+mpi^$mpi", timeout => 3600;
+    assert_script_run 'spack load boost';
+    record_info 'boost info', script_output 'spack info boost';
+
+    barrier_wait('CLUSTER_PROVISIONED');
+    ## all nodes should be able to ssh to each other, as MPIs requires so
+    $self->generate_and_distribute_ssh();
+
+    barrier_wait('MPI_SETUP_READY');
+    $self->check_nodes_availability();
+
+    record_info('INFO', script_output('cat /proc/cpuinfo'));
+
+    my $hostname = get_var('HOSTNAME', 'susetest');
+    record_info "hostname", "$hostname";
+    assert_script_run "hostnamectl status|grep $hostname";
+
+    assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O /tmp/$mpi_c");
+    assert_script_run("$mpi_compiler /tmp/$mpi_c -o /tmp/$mpi_bin -l boost_mpi -I \${BOOST_ROOT}/include/ -L \${BOOST_ROOT}/lib 2>&1 > /tmp/make.out");
+
+    ## distribute the binary
+    foreach (@cluster_nodes) {
+        assert_script_run("scp -o StrictHostKeyChecking=no /tmp/$mpi_bin root\@$_\:/tmp/$mpi_bin");
+    }
+
+    barrier_wait('MPI_BINARIES_READY');
+
+    # Testing compiled code
+    record_info('INFO', 'Run MPI over single machine');
+    assert_script_run("mpirun /tmp/$mpi_bin");
+
+    record_info('INFO', 'Run MPI over several nodes');
+    my $nodes = join(',', @cluster_nodes);
+    assert_script_run("mpirun -n 2 --host $nodes /tmp/$mpi_bin");
+    barrier_wait('MPI_RUN_TEST');
+}
+
+sub test_flags ($self) {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_run_hook ($self) {
+    $self->uninstall_spack_module('boost');
+}
+
+sub post_fail_hook ($self) {
+    # Upload all the modules.
+    # Inside compiled modules comes as <module>-<version>-<hash>
+    # Each module includes build logs under <module>-<version>-<hash>/.spack
+    my $compiler_ver = script_output("gcc --version | grep -E '\\b[0-9]+\.[0-9]+\.[0-9]+\$' | awk '{print \$4}'");
+    my $arch = get_var('ARCH');
+    my $node = script_output('hostname');
+    $self->tar_and_upload_log("/opt/spack/linux-sle_hpc15-$arch/gcc-$compiler_ver", "/tmp/spack_$node.tar.bz2");
+    upload_logs('/tmp/make.out');
+    $self->export_logs();
+}
+
+1;

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: HPC_Module: Client nodes of a cluster with Spack
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base qw(hpcbase hpc::utils), -signatures;
+use testapi;
+use lockapi;
+use utils;
+
+sub run ($self) {
+    my $mpi = $self->get_mpi();
+    $self->prepare_spack_env($mpi);
+    assert_script_run "spack install boost+mpi^$mpi", timeout => 3600;
+    assert_script_run 'spack load boost';
+
+    record_info 'boost info', script_output 'spack info boost';
+    barrier_wait('CLUSTER_PROVISIONED');
+    barrier_wait('MPI_SETUP_READY');
+    barrier_wait('MPI_BINARIES_READY');
+    barrier_wait('MPI_RUN_TEST');
+}
+
+sub test_flags ($self) {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_run_hook ($self) {
+    $self->uninstall_spack_module('boost');
+}
+
+sub post_fail_hook ($self) {
+    # Upload all the modules.
+    # Inside compiled modules comes as <module>-<version>-<hash>
+    # Each module includes build logs under <module>-<version>-<hash>/.spack
+    my $compiler_ver = script_output("gcc --version | grep -E '\\b[0-9]+\.[0-9]+\.[0-9]+\$' | awk '{print \$4}'");
+    my $arch = get_var('ARCH');
+    my $node = script_output('hostname');
+    $self->tar_and_upload_log("/opt/spack/linux-sle_hpc15-$arch/gcc-$compiler_ver", "/tmp/spack_$node.tar.bz2");
+}
+
+1;


### PR DESCRIPTION
   
    The steps are very similar to `mpi_*` modules, with the difference of
    installing different packages which mainly differ the install path and the
    use of environment modules.
    
    The main aim in this PR is to initialize Spack testing which installs and
    loads boost module and run a hello_world. Testing includes other spack
    features like uninstall and unload modules.
    
    The steps in the module has been testing only on sle15sp4. The plan is to
    merge those modules with the mpi_*. So the modules will subject to some
    refactoring to provide a better design and integrate more modules to test.
    
    Also the jobs uses 1G memory. Note that in the manual testing this reproduced
    some issues, and as such if the jobs start showing defects during the
    compilation by spack, it is recommended to increase QEMURAM to 4.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: http://aquarius.suse.cz/tests/9289
