### PR TITLE
data/regproxy: Start regproxy.server after network is up

### DIFF
--- a/data/regproxy/regproxy.service
+++ b/data/regproxy/regproxy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Registry proxy
-After=network.target
+After=network-online.target
 
 [Service]
 WorkingDirectory=/usr/local/bin


### PR DESCRIPTION
It queries the registry for available images on startup.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1197187
- Verification run: https://openqa.opensuse.org/tests/2264147
