### PR TITLE
Add Xen smoketest to publiccloud

### DIFF
--- a/schedule/publiccloud/smoketest.yml
+++ b/schedule/publiccloud/smoketest.yml
@@ -7,6 +7,10 @@ conditional_schedule:
     PUBLIC_CLOUD_CONFIDENTIAL_VM:
       '1':
         - publiccloud/sev
+  xen:
+    PUBLIC_CLOUD_XEN:
+      '1':
+        - publiccloud/xen
   az_l8s_nvme:
     PUBLIC_CLOUD_INSTANCE_TYPE:
       'Standard_L8s_v2':
@@ -23,5 +27,6 @@ schedule:
   - publiccloud/instance_overview
   - publiccloud/smoketest
   - '{{sev}}'
+  - '{{xen}}'
   - '{{az_l8s_nvme}}'
   - publiccloud/ssh_interactive_end

--- a/tests/publiccloud/xen.pm
+++ b/tests/publiccloud/xen.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run basic xen smoketest on a publiccloud test instance
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    # Check if we are using Xen hypervisor by searching for matching output in dmesg
+    assert_script_run("sudo dmesg > /var/tmp/dmesg");
+    assert_script_run("grep -e 'Hypervisor detected:.*Xen' /var/tmp/dmesg");
+    assert_script_run("grep -i 'Booting paravirtualized kernel on Xen' /var/tmp/dmesg");
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -271,3 +271,4 @@ PUBLIC_CLOUD_VAULT_NAMESPACE | string | "qac" | The Vault server namespace.
 PUBLIC_CLOUD_VAULT_TIMEOUT | integer | 60 | The number of seconds we wait for the Vault server to respond.
 PUBLIC_CLOUD_VAULT_TRIES | integer | 3 | The number of attempts to connect to Vault server.
 PUBLIC_CLOUD_USER | string | "" | The public cloud instance system user.
+PUBLIC_CLOUD_XEN | boolean | false | Indicates if this is a Xen test run.


### PR DESCRIPTION
Add new PUBLIC_CLOUD_XEN variable to indicate Xen test runs and add a
simple smoke test for them.

- Related ticket: https://progress.opensuse.org/issues/108344
- Verification runs: [15-SP3 EC2 Incidents (group)](http://duck-norris.qam.suse.de/tests/overview?groupid=166&distri=sle&build=verify-xen&version=15-SP3) | [15-SP3 m4.large xen](http://duck-norris.qam.suse.de/tests/8450#step/xen/9) | [15-SP3 c4.large xen](http://duck-norris.qam.suse.de/tests/8451#step/xen/9)
- Job groups update: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/702
