### PR TITLE
Extract 'clamav' from 'extra_tests_textmode' to meet the RAM req

### DIFF
--- a/schedule/functional/extra_tests_clamav.yaml
+++ b/schedule/functional/extra_tests_clamav.yaml
@@ -1,0 +1,10 @@
+name: extra_tests_clamav
+description:    >
+    Maintainer: QE Core.
+    Extract 'clamav' module from 'extra_tests_textmode' to meet the RAM
+    requirements.
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - console/clamav
+    - console/coredump_collect

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -135,7 +135,6 @@ schedule:
     - console/redis
     - console/rsync
     - console/rust
-    - console/clamav
     - console/shells
     - console/sudo
     - console/dstat


### PR DESCRIPTION
As the vendor states, `clamav` needs at least 2GB of RAM to work smooth. To avoid interference and overload the **openQA**, the test is extracted from its original location and executed on its own dedicated test suite.

- Related ticket: https://progress.opensuse.org/issues/108082
- Needles:
- Verification runs:

|Distro |x86_64 |aarch64 |ppc64le |s390x |
|:---------------|:----------:|:-----------:|:-----------:|:---------:|
|Tumbleweed  |[:heavy_check_mark:](https://openqa.opensuse.org/t2264780) |[:heavy_check_mark:](https://openqa.opensuse.org/t2264782) |- |- |
|Leap 15.4   |[:heavy_check_mark:](https://openqa.opensuse.org/t2264779) |- |- |- |
|SLE 15 SP4  |[:heavy_check_mark:](https://openqa.suse.de/t8393542) |[:heavy_check_mark:](https://openqa.suse.de/t8393543) |[:heavy_check_mark:](https://openqa.suse.de/t8393545) |- |
