### PR TITLE
merge get_container_image_full_name and get_container_registry_prefix

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -97,18 +97,6 @@ sub init {
     die("The UserID doesn't have the correct format: $self->{user_id}") unless $self->aws_account_id =~ /^\d{12}$/;
 }
 
-=head2 get_container_registry_prefix
-
-Get the full registry prefix URL (based on the account and region) to push container images on ECR.
-=cut
-
-sub get_container_registry_prefix {
-    my ($self) = @_;
-    my $region = $self->region;
-    my $full_name_prefix = sprintf('%s.dkr.ecr.%s.amazonaws.com', $self->aws_account_id, $region);
-    return $full_name_prefix;
-}
-
 =head2 get_container_image_full_name
 
 Returns the full name of the container image in ECR registry
@@ -117,7 +105,8 @@ C<tag> Tag of the container
 
 sub get_container_image_full_name {
     my ($self, $tag) = @_;
-    my $full_name_prefix = $self->get_container_registry_prefix();
+    my $full_name_prefix = sprintf('%s.dkr.ecr.%s.amazonaws.com', $self->aws_account_id, $self->region);
+
     return "$full_name_prefix/" . $self->container_registry . ":$tag";
 }
 
@@ -128,7 +117,7 @@ Configure the podman to access the cloud provider registry
 
 sub configure_podman {
     my ($self) = @_;
-    my $full_name_prefix = $self->get_container_registry_prefix();
+    my $full_name_prefix = sprintf('%s.dkr.ecr.%s.amazonaws.com', $self->aws_account_id, $self->region);
 
     assert_script_run("aws ecr get-login-password --region "
           . $self->region

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -85,16 +85,6 @@ sub configure_podman {
     assert_script_run($login_cmd);
 }
 
-=head2 get_container_registry_prefix
-
-Get the full registry prefix URL (based on the account and region) to push container images on ACR.
-=cut
-
-sub get_container_registry_prefix {
-    my ($self) = @_;
-    return sprintf('%s.azurecr.io', $self->container_registry);
-}
-
 =head2 get_container_image_full_name
 
 Returns the full name of the container image in ACR registry
@@ -103,7 +93,7 @@ C<tag> Tag of the container
 
 sub get_container_image_full_name {
     my ($self, $tag) = @_;
-    my $full_name_prefix = $self->get_container_registry_prefix();
+    my $full_name_prefix = sprintf('%s.azurecr.io', $self->container_registry);
     return "$full_name_prefix/$tag";
 }
 


### PR DESCRIPTION
These two function can be merged in one,in order to improve the
maintenance. 

get_container_registry_prefix function removed and the related call in get_container_image_full_name updated with the proper code in place.

Clients updated: 1) aws_client.pm , 2) amazon_client.pm

- Related ticket: https://progress.opensuse.org/issues/104229 
- Needles: None
- Verification run:  2 tests VR PASSED:
1. http://openqa.suse.de/t8400055 - aws 
2. http://openqa.suse.de/t8400058 - amazon

