### PR TITLE
Add the CPU model information in fips_setup

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -62,6 +62,10 @@ sub run {
         record_info 'Kernel Mode', 'FIPS kernel mode configured!';
     }
 
+    # Record the CPU model information
+    record_info('CPU_info', script_output("cat /proc/cpuinfo | grep '^model' | tail -1"));
+    record_info('CPU_core', script_output("cat /proc/cpuinfo | grep processor | wc -l"));
+
     power_action('reboot', textmode => 1);
     $self->wait_boot(bootloader_time => 200);
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/108647
- Needles: NA
- Verification run:
intel : https://openqa.suse.de/t8417738 
amd : https://openqa.suse.de/tests/8417739#
note: Both intel/amd show **QEMU Virtual CPU version 2.5+**, I think this PR is only suitable for Baremetal testing.