### PR TITLE
data/regproxy: Add missing Wants=network-online.target

### DIFF
--- a/data/regproxy/regproxy.service
+++ b/data/regproxy/regproxy.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Registry proxy
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 WorkingDirectory=/usr/local/bin


### PR DESCRIPTION
Unlike network.target, network-online.target isn't active automatically.
The systemd.special man page recommends using Wants= even though network
is required here for some reason.

- Before: https://openqa.opensuse.org/tests/2267841#step/journal_check/43
- Verification run: https://openqa.opensuse.org/t2268644
