### PR TITLE
Bump timeout on select_patterns waiting change

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -175,7 +175,9 @@ Being in the "select pattern" screen, performs steps needed to move the
 highlight cursor one item down.
 =cut
 sub move_down {
-    my $ret = wait_screen_change { send_key 'down' };
+    my $ret = wait_screen_change(sub {
+            send_key 'down';
+    }, 20);
     workaround_bsc1189550() if (!$workaround_bsc1189550_done && is_sle('>=15-sp3'));
     last if (!$ret);    # down didn't change the screen, so exit here
     check12qtbug if check_var('VERSION', '12');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/108977
- Verification run: [SLE](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23bump_timeout_select_patterns&version=15-SP4)
