### PR TITLE
Containers Image tests: refactor host configuration

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -137,7 +137,7 @@ sub load_container_tests {
 
     if (is_container_image_test()) {
         # Container Image tests common
-        loadtest 'containers/host_configuration' unless (is_expanded_support_host || is_ubuntu_host || is_jeos);
+        loadtest 'containers/host_configuration' unless (is_jeos);
     }
 
     foreach (split(',\s*', $runtime)) {

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020-2021 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Setup system which will host containers
@@ -12,26 +12,54 @@
 use Mojo::Base qw(consoletest);
 use testapi;
 use utils;
-use Utils::Systemd qw(disable_and_stop_service);
-use version_utils qw(check_os_release is_sle);
+use version_utils qw(check_os_release get_os_release is_sle);
+use containers::common;
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     my $interface;
-    if (check_os_release('suse', 'PRETTY_NAME')) {
-        $interface = script_output q@ip r s default 0.0.0.0/0 | awk '{printf $5}'@;
-        validate_script_output "ip a s '$interface'", sub { m/((\d{1,3}\.){3}\d{1,3}\/\d{1,2})/ };
+    my $update_timeout = 600;
+    my ($version, $sp, $host_distri) = get_os_release;
+    my $engine = get_required_var('CONTAINER_RUNTIME');
+
+    # Update the system to get the latest released state of the hosts.
+    # Check routing table is well configured
+    if ($host_distri eq 'sles') {
+        zypper_call("--quiet up", timeout => $update_timeout);
         ensure_ca_certificates_suse_installed();
-        disable_and_stop_service(opensusebasetest::firewall, ignore_failure => 1);
     }
     else {
-        # Re-running dhclient on RHEL is confusing the routing tables
-        assert_script_run "dhclient -v" unless get_var("HDD_1") =~ /rhel/;
-        $interface = script_output q@ip r s default | head -1 | awk '{printf $5}'@;
-        validate_script_output "ip a s '$interface'", sub { m/((\d{1,3}\.){3}\d{1,3}\/\d{1,2})/ };
-        assert_script_run "curl http://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/ssl/certs/SUSE_Trust_Root.crt" if is_sle();
+        if ($host_distri eq 'ubuntu') {
+            # Sometimes, the host doesn't get an IP automatically via dhcp, we need force it just in case
+            assert_script_run("dhclient -v");
+            assert_script_run("apt-get update -qq -y", timeout => $update_timeout);
+        } elsif ($host_distri eq 'centos') {
+            assert_script_run("dhclient -v");
+            assert_script_run("yum update -y --allowerasing", timeout => $update_timeout);
+        } elsif ($host_distri eq 'rhel') {
+            assert_script_run("yum update -y", timeout => $update_timeout);
+        }
     }
+
+    # Make sure we can access internet and DNS works
+    script_retry('ping -c 3 www.google.com');
+
+    # Install engines in case they are not installed
+    install_docker_when_needed($host_distri) if ($engine =~ 'docker');
+    install_podman_when_needed($host_distri) if ($engine =~ 'podman');
+
+    # It has been observed that after system update, the ip forwarding doesn't work.
+    # Sometimes there is a need to restart the firewall and docker daemon.
+    if ($host_distri eq 'sles') {
+        # We can't use opensusebasetest::firewall here because VERSION variable referrs to the container image.
+        my $firewall = $version =~ /12/ ? 'SuSEfirewall2' : 'firewalld';
+        systemctl("restart $firewall");
+        systemctl("restart docker") if ($engine =~ 'docker');
+    }
+
+    # Record podman|docker version
+    record_info($engine, script_output("$engine info"));
 }
 
 sub test_flags {


### PR DESCRIPTION
I would like to enable Host config module in all hosts to perform the following actions:
- System update: so we test the latest state of the hosts as   users would do
- Install docker|podman if they are not pre-installed.
- in SLE, retart firewall and docker service. For some reason, there were some failures with containers not reaching internet. After some debugging, restarting the services was the solution.

Example of issues:
https://openqa.suse.de/tests/8400211
https://openqa.suse.de/tests/8400221
https://openqa.suse.de/tests/8400216
Even though the issue is not apparent in the test, after some analysis, the problem is that the containers can't reach internet.

- Verification run: 
[bci-python on all hosts](http://fromm.arch.suse.de/tests/overview?distri=sle&build=13.30_python-3.9-image&version=15-SP3)
[base image on all hosts](http://fromm.arch.suse.de/tests/overview?build=17.11.11&version=15-SP3&distri=sle)