### PR TITLE
Add helm test for Tumbleweed

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -126,6 +126,12 @@ sub load_host_tests_containerd_nerdctl {
     loadtest 'containers/containerd_nerdctl';
 }
 
+sub load_host_tests_helm() {
+    if (is_tumbleweed || is_leap) {
+        loadtest "containers/helm";
+    }
+}
+
 sub load_container_tests {
     my $args = OpenQA::Test::RunArgs->new();
     my $runtime = get_required_var('CONTAINER_RUNTIME');
@@ -159,6 +165,7 @@ sub load_container_tests {
             load_host_tests_docker() if (/docker/i);
             load_host_tests_containerd_crictl() if (/containerd_crictl/i);
             load_host_tests_containerd_nerdctl() if (/containerd_nerdctl/i);
+            load_host_tests_helm() if (/helm/i);
         }
     }
 

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Test deploy a helm chart
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use utils qw(zypper_call script_retry);
+use version_utils qw(is_sle);
+use registration qw(add_suseconnect_product get_addon_fullname);
+use mmapi 'get_current_job_id';
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+    $self->{deployment_name} = "apache-" . get_current_job_id();
+    my $chart = "bitnami/apache";
+
+    zypper_call("in -y jq aws-cli helm kubernetes-client");
+
+    # Check helm version
+    record_info('Helm version', script_output("helm version"));
+
+    # Connection to AWS
+    my $provider = $self->provider_factory(service => 'EKS');
+    $self->{provider} = $provider;
+
+    # Access to Cluster
+    record_info('Kubectl version', script_output("kubectl version"));
+    assert_script_run("cat \$HOME/.kube/config");
+    assert_script_run("kubectl get nodes");
+
+    # Add repo, search and show values
+    assert_script_run("helm repo add bitnami https://charts.bitnami.com/bitnami");
+    assert_script_run("helm repo update");
+    assert_script_run("helm search repo apache");
+    assert_script_run("helm show all $chart");
+
+    # Install apache
+    assert_script_run("helm install $self->{deployment_name} $chart");
+    assert_script_run("helm list");
+
+    # Wait for deployment
+    assert_script_run("kubectl rollout status deployment/$self->{deployment_name}");
+    assert_script_run("kubectl describe deployment/$self->{deployment_name}");
+    assert_script_run("kubectl get pods | grep $self->{deployment_name}");
+    assert_script_run("kubectl describe services/$self->{deployment_name}");
+
+    # Test
+    enter_cmd("kubectl port-forward  services/$self->{deployment_name} 10001:80 &");
+    script_retry("curl http://localhost:10001", delay => 30, retry => 5);
+
+    # Destroy the chart
+    assert_script_run("helm delete $self->{deployment_name}");
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    script_run("helm delete $self->{deployment_name}");
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
This new test checks the main operations of helm, and deploys
an apache on EKS

- Related ticket: https://progress.opensuse.org/issues/108572
- Verification run: http://copland.arch.suse.de/tests/1276 (Tumbleweed)
- http://copland.arch.suse.de/tests/1275 (Leap 15.3)
