### PR TITLE
Add fips installation support for PowerPC

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -104,6 +104,7 @@ sub prepare_pvm_installation {
     specific_bootmenu_params;
     registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
     type_string_slow remote_install_bootmenu_params;
+    type_string_slow " fips=1" if (get_var('FIPS_INSTALLATION'));
     type_string_slow " UPGRADE=1" if (get_var('UPGRADE'));
     send_key 'ret';
 


### PR DESCRIPTION
Fips support is required on PowerPC platform
from SLES15SP4, so add the installation test
into openQA.

- Related ticket: https://progress.opensuse.org/issues/108782
- Needles: n/a
- Verification run: 
http://openqa.suse.de/tests/8390986# -Textmode
https://openqa.suse.de/tests/8416491# - Gnome