### PR TITLE
wicked: Fix duplicate mac-addr errors in wicked-testsuite

### DIFF
--- a/data/wicked/check_macvtap.c
+++ b/data/wicked/check_macvtap.c
@@ -1,5 +1,4 @@
 // Small program to test macvtap interfaces
-// It assumes that  MAC=0E:0E:0E:0E:0E:0E
 // the following command has been issued: arping -c 1 -I macvtap1 <destination
 // IP> It then listens on /dev/tapX to check whether the correct answer was
 // received.
@@ -17,24 +16,26 @@
 #define PACKET_SIZE 70
 #define SOURCE_IP_POS_IN_ARRAY 38
 #define DEST_IP_POS_IN_ARRAY 48
+#define DEST_MAC1_POS_IN_ARRAY 10
+#define DEST_MAC2_POS_IN_ARRAY 42
 #define FILENAME_LENGTH 16
 // Expected ARP packet
 // -1 stands for unknown data
 unsigned char
     arp_packet[PACKET_SIZE] =
-        {0x00, 0x00, 0x00, 0x00, 0x00, // 10 bytes preamble
-         0x00, 0x00, 0x00, 0x00, 0x00, 0x0e,
-         0x0e, 0x0e, 0x0e, 0x0e, 0x0e,       // destination MAC address
-         -1,   -1,   -1,   -1,   -1,   -1,   // source MAC address
+        {0x00, 0x00, 0x00, 0x00, 0x00,
+         0x00, 0x00, 0x00, 0x00, 0x00,       // 10 bytes preamble
+         -2,   -2,   -2,   -2,   -2,   -2,   // destination MAC address (3rd input parameter)
+         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // source MAC address
          0x08, 0x06,                         // ARP protocol
          0x00, 0x01, 0x08, 0x00, 0x06, 0x04, // Ethernet <=> IP
          0x00, 0x02,                         // "is at" answer
-         -1,   -1,   -1,   -1,   -1,   -1,   // source MAC address
-         -2,   -2,   -2,   -2, // source IP address (replaced with 1st input
-                               // param )
-         0x0e, 0x0e, 0x0e, 0x0e, 0x0e, 0x0e, // destination MAC address
-         -2,   -2,   -2,   -2, // destination IP address ( replaced with 2nd
-                               // input param)
+         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // source MAC address
+         -2,   -2,   -2,   -2,               // source IP address (replaced with 1st input
+                                             // param )
+         -2,   -2,   -2,   -2,   -2,   -2,   // destination MAC address
+         -2,   -2,   -2,   -2,               // destination IP address ( replaced with 2nd
+                                             // input param)
          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 18 bytes postamble
          0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
          0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
@@ -44,6 +45,24 @@ char fn[FILENAME_LENGTH];
 
 // Read buffer
 unsigned char buffer[PACKET_SIZE];
+
+void read_macaddr() {
+#define SYSFS_MAC "/sys/class/net/macvtap1/address"
+  unsigned char *mac = (unsigned char*) &arp_packet[DEST_MAC1_POS_IN_ARRAY];
+
+  FILE *fp = fopen(SYSFS_MAC, "r");
+  if (fp == NULL){
+    perror("Cannot open " SYSFS_MAC);
+    exit(-1);
+  }
+
+  if (fscanf(fp, " %02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
+              &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]) != 6){
+    printf("[ERROR] Cannot read <source-mac> from " SYSFS_MAC);
+    exit(-1);
+  }
+  memcpy(&arp_packet[DEST_MAC2_POS_IN_ARRAY], mac, 6);
+}
 
 // Search for /dev/tapX
 void search_tap() {
@@ -112,18 +131,28 @@ void analyze_packet() {
 
 // Main program
 int main(int argc, char **argv) {
-  if (argc < 2) {
+  if (argc < 3) {
     printf("No input parameters. Exit \n");
+    printf("Usage:\n  check_macvtap <source-ip> <dest-ip>\n");
     exit(-5);
   }
   // getting source and destination ips from command line and inserting them
   // into dedicated places in packet
   struct in_addr *source_ip =
       (struct in_addr *)&arp_packet[SOURCE_IP_POS_IN_ARRAY];
-  inet_pton(AF_INET, argv[1], source_ip);
+  if (inet_pton(AF_INET, argv[1], source_ip) != 1) {
+    printf("[ERROR] Invalid <source-ip> given!\n");
+    return -2;
+  }
+
   struct in_addr *dest_ip = (struct in_addr *)&arp_packet[DEST_IP_POS_IN_ARRAY];
-  inet_pton(AF_INET, argv[2], dest_ip);
+  if (inet_pton(AF_INET, argv[2], dest_ip) != 1){
+    printf("[ERROR] Invalid <dest-ip> given\n");
+    return -2;
+  }
+
   search_tap();
+  read_macaddr();
   read_packet();
   analyze_packet();
 

--- a/data/wicked/ifcfg/dummy0
+++ b/data/wicked/ifcfg/dummy0
@@ -2,4 +2,4 @@ NAME='Dummy link'
 STARTMODE='auto'
 BOOTPROTO='static'
  
-LLADDR='42:41:40:3F:3E:3D'
+LLADDR='__macaddr__'

--- a/data/wicked/ifcfg/macvtap1
+++ b/data/wicked/ifcfg/macvtap1
@@ -3,7 +3,7 @@ STARTMODE='auto'
 
 MACVTAP_DEVICE='iface'
 MACVTAP_MODE='vepa'
-LLADDR='0E:0E:0E:0E:0E:0E'
+LLADDR='__macaddr__'
 
 IPADDR='ip_address/16'
 IPADDR6='fd00:c0de:ba5e:17::18/48'

--- a/data/wicked/xml/bridge.xml
+++ b/data/wicked/xml/bridge.xml
@@ -35,6 +35,6 @@
   <name>dummy0</name>
 
   <dummy>
-    <address>42:41:40:3F:3E:3D</address>
+    <address>__macaddr__</address>
   </dummy>
 </interface>

--- a/data/wicked/xml/macvtap.xml
+++ b/data/wicked/xml/macvtap.xml
@@ -3,7 +3,7 @@
 
   <macvtap>
     <device>iface</device>
-    <address>0e:0e:0e:0e:0e:0e</address>
+    <address>__macaddr__</address>
     <mode>vepa</mode>
   </macvtap>
 

--- a/data/wicked/xml/ovs-bridge.xml
+++ b/data/wicked/xml/ovs-bridge.xml
@@ -54,6 +54,6 @@
   </link>
 
   <dummy>
-    <address>42:41:40:3F:3E:3D</address>
+    <address>__macaddr__</address>
   </dummy>
 </interface>

--- a/tests/wicked/advanced/sut/t15_macvtap_legacy.pm
+++ b/tests/wicked/advanced/sut/t15_macvtap_legacy.pm
@@ -21,7 +21,7 @@ sub run {
     my $config = '/etc/sysconfig/network/ifcfg-macvtap1';
     $self->get_from_data('wicked/ifcfg/macvtap1', $config);
     $self->get_from_data('wicked/ifcfg/macvtap_eth', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
-    $self->prepare_check_macvtap($config, $ctx->iface(), $self->get_ip(type => 'macvtap', netmask => 1));
+    $self->prepare_check_macvtap($config, $ctx->iface(), $self->get_ip(type => 'macvtap', netmask => 1), $self->unique_macaddr());
     $self->wicked_command('ifreload', $ctx->iface());
     $self->wicked_command('ifup', 'macvtap1');
     $self->validate_macvtap();

--- a/tests/wicked/advanced/sut/t16_macvtap_xml.pm
+++ b/tests/wicked/advanced/sut/t16_macvtap_xml.pm
@@ -19,7 +19,7 @@ sub run {
     record_info('Info', 'Create a macvtap interface from wicked XML files');
     my $config = '/etc/wicked/ifconfig/macvtap.xml';
     $self->get_from_data('wicked/xml/macvtap.xml', $config);
-    $self->prepare_check_macvtap($config, $ctx->iface(), $self->get_ip(type => 'macvtap', netmask => 1));
+    $self->prepare_check_macvtap($config, $ctx->iface(), $self->get_ip(type => 'macvtap', netmask => 1), $self->unique_macaddr());
     $self->wicked_command('ifreload', $ctx->iface());
     $self->wicked_command('ifup', 'macvtap1');
     $self->validate_macvtap();


### PR DESCRIPTION
For some tests, e.g. macvtap or bridge-with-dummy, we use predefined
fixed mac-addresses.
If the order of the interfaces is such, that the bridge gets the
mac-address of the dummy-interface, while we have the same job parallel
running on a other multi-machine setup, the backend ovs-switch has two
times the same mac-address. The result are unexpected network errors.

- Related ticket: 
  - https://gitlab.suse.de/wicked-maintainers/wicked/-/issues/111
  - https://gitlab.suse.de/wicked-maintainers/wicked/-/issues/176
## Verification run:
  - https://openqa.suse.de/tests/8425126

### In wicked-ci
```
[ 2703s] Target: SLE_12_SP5@x86_64
[ 2703s] OpenQA URL: http://openqa.wicked.suse.de/tests/overview?distri=sle&version=12-SP5&build=No-Branch
[ 2703s] Name                      State    URL
[ 2703s] -----------------------   ------   -----------------------------------
[ 2703s] Name                      State    URL
[ 2703s] ----                      -----    ---
[ 2703s] wicked_advanced_ref       passed   http://openqa.wicked.suse.de/t53761
[ 2703s] wicked_advanced_sut       passed   http://openqa.wicked.suse.de/t53762
[ 2703s] wicked_aggregate_ref      passed   http://openqa.wicked.suse.de/t53763
[ 2703s] wicked_aggregate_sut      passed   http://openqa.wicked.suse.de/t53764
[ 2703s] wicked_basic_ref          passed   http://openqa.wicked.suse.de/t53765
[ 2703s] wicked_basic_sut          passed   http://openqa.wicked.suse.de/t53766
[ 2703s] wicked_ipv6_ref           passed   http://openqa.wicked.suse.de/t53767
[ 2703s] wicked_ipv6_sut           passed   http://openqa.wicked.suse.de/t53768
[ 2703s] wicked_startandstop_ref   passed   http://openqa.wicked.suse.de/t53769
[ 2703s] wicked_startandstop_sut   passed   http://openqa.wicked.suse.de/t53770
[ 2703s] wicked_sysctl_ref         passed   http://openqa.wicked.suse.de/t53771
[ 2703s] wicked_sysctl_sut         failed   http://openqa.wicked.suse.de/t53772
[ 2703s] wicked_wlan_ref           passed   http://openqa.wicked.suse.de/t53773
[ 2703s] wicked_wlan_sut           passed   http://openqa.wicked.suse.de/t53774
[ 2703s]
[ 2703s] Target: SLE_15_SP3@x86_64
[ 2703s] OpenQA URL: http://openqa.wicked.suse.de/tests/overview?distri=sle&version=15-SP3&build=No-Branch
[ 2703s] Name                      State    URL
[ 2703s] -----------------------   ------   -----------------------------------
[ 2703s] Name                      State    URL
[ 2703s] ----                      -----    ---
[ 2703s] wicked_advanced_ref       passed   http://openqa.wicked.suse.de/t53775
[ 2703s] wicked_advanced_sut       passed   http://openqa.wicked.suse.de/t53776
[ 2703s] wicked_aggregate_ref      passed   http://openqa.wicked.suse.de/t53777
[ 2703s] wicked_aggregate_sut      passed   http://openqa.wicked.suse.de/t53778
[ 2703s] wicked_basic_ref          passed   http://openqa.wicked.suse.de/t53779
[ 2703s] wicked_basic_sut          passed   http://openqa.wicked.suse.de/t53780
[ 2703s] wicked_ipv6_ref           passed   http://openqa.wicked.suse.de/t53781
[ 2703s] wicked_ipv6_sut           passed   http://openqa.wicked.suse.de/t53782
[ 2703s] wicked_startandstop_ref   passed   http://openqa.wicked.suse.de/t53783
[ 2703s] wicked_startandstop_sut   passed   http://openqa.wicked.suse.de/t53784
[ 2703s] wicked_sysctl_ref         passed   http://openqa.wicked.suse.de/t53785
[ 2703s] wicked_sysctl_sut         passed   http://openqa.wicked.suse.de/t53786
[ 2703s] wicked_wlan_ref           passed   http://openqa.wicked.suse.de/t53787
[ 2703s] wicked_wlan_sut           passed   http://openqa.wicked.suse.de/t53788
[ 2703s]
[ 2703s] Target: SLE_15_SP4@x86_64
[ 2703s] OpenQA URL: http://openqa.wicked.suse.de/tests/overview?distri=sle&version=15-SP4&build=No-Branch
[ 2703s] Name                      State    URL
[ 2703s] -----------------------   ------   -----------------------------------
[ 2703s] Name                      State    URL
[ 2703s] ----                      -----    ---
[ 2703s] wicked_advanced_ref       passed   http://openqa.wicked.suse.de/t53789
[ 2703s] wicked_advanced_sut       passed   http://openqa.wicked.suse.de/t53790
[ 2703s] wicked_aggregate_ref      passed   http://openqa.wicked.suse.de/t53791
[ 2703s] wicked_aggregate_sut      passed   http://openqa.wicked.suse.de/t53792
[ 2703s] wicked_basic_ref          passed   http://openqa.wicked.suse.de/t53793
[ 2703s] wicked_basic_sut          passed   http://openqa.wicked.suse.de/t53794
[ 2703s] wicked_ipv6_ref           passed   http://openqa.wicked.suse.de/t53795
[ 2703s] wicked_ipv6_sut           passed   http://openqa.wicked.suse.de/t53796
[ 2703s] wicked_startandstop_ref   passed   http://openqa.wicked.suse.de/t53797
[ 2703s] wicked_startandstop_sut   passed   http://openqa.wicked.suse.de/t53798
[ 2703s] wicked_sysctl_ref         passed   http://openqa.wicked.suse.de/t53799
[ 2703s] wicked_sysctl_sut         passed   http://openqa.wicked.suse.de/t53800
[ 2703s] wicked_wlan_ref           passed   http://openqa.wicked.suse.de/t53801
[ 2703s] wicked_wlan_sut           passed   http://openqa.wicked.suse.de/t53802
[ 2703s]
[ 2703s] Target: openSUSE_Leap_15.3@x86_64
[ 2703s] OpenQA URL: http://openqa.wicked.suse.de/tests/overview?distri=opensuse&version=15.3&build=No-Branch
[ 2703s] Name                      State    URL
[ 2703s] -----------------------   ------   -----------------------------------
[ 2703s] Name                      State    URL
[ 2703s] ----                      -----    ---
[ 2703s] wicked_advanced_ref       passed   http://openqa.wicked.suse.de/t53803
[ 2703s] wicked_advanced_sut       passed   http://openqa.wicked.suse.de/t53804
[ 2703s] wicked_aggregate_ref      passed   http://openqa.wicked.suse.de/t53805
[ 2703s] wicked_aggregate_sut      passed   http://openqa.wicked.suse.de/t53806
[ 2703s] wicked_basic_ref          passed   http://openqa.wicked.suse.de/t53807
[ 2703s] wicked_basic_sut          passed   http://openqa.wicked.suse.de/t53808
[ 2703s] wicked_ipv6_ref           passed   http://openqa.wicked.suse.de/t53809
[ 2703s] wicked_ipv6_sut           passed   http://openqa.wicked.suse.de/t53810
[ 2703s] wicked_startandstop_ref   passed   http://openqa.wicked.suse.de/t53811
[ 2703s] wicked_startandstop_sut   passed   http://openqa.wicked.suse.de/t53812
[ 2703s] wicked_sysctl_ref         passed   http://openqa.wicked.suse.de/t53813
[ 2703s] wicked_sysctl_sut         passed   http://openqa.wicked.suse.de/t53814
[ 2703s] wicked_wlan_ref           passed   http://openqa.wicked.suse.de/t53815
[ 2703s] wicked_wlan_sut           passed   http://openqa.wicked.suse.de/t53816
[ 2703s]
[ 2703s] Target: openSUSE_Tumbleweed@i586
[ 2703s] OpenQA URL: http://openqa.wicked.suse.de/tests/overview?distri=opensuse&version=Tumbleweed&build=No-Branch
[ 2703s] Name                      State    URL
[ 2703s] -----------------------   ------   -----------------------------------
[ 2703s] Name                      State    URL
[ 2703s] ----                      -----    ---
[ 2703s] wicked_advanced_ref       passed   http://openqa.wicked.suse.de/t53817
[ 2703s] wicked_advanced_sut       passed   http://openqa.wicked.suse.de/t53818
[ 2703s] wicked_aggregate_ref      passed   http://openqa.wicked.suse.de/t53819
[ 2703s] wicked_aggregate_sut      passed   http://openqa.wicked.suse.de/t53820
[ 2703s] wicked_basic_ref          passed   http://openqa.wicked.suse.de/t53821
[ 2703s] wicked_basic_sut          passed   http://openqa.wicked.suse.de/t53822
[ 2703s] wicked_ipv6_ref           passed   http://openqa.wicked.suse.de/t53823
[ 2703s] wicked_ipv6_sut           passed   http://openqa.wicked.suse.de/t53824
[ 2703s] wicked_startandstop_ref   passed   http://openqa.wicked.suse.de/t53825
[ 2703s] wicked_startandstop_sut   passed   http://openqa.wicked.suse.de/t53826
[ 2703s] wicked_sysctl_ref         passed   http://openqa.wicked.suse.de/t53827
[ 2703s] wicked_sysctl_sut         passed   http://openqa.wicked.suse.de/t53828
[ 2703s] wicked_wlan_ref           passed   http://openqa.wicked.suse.de/t53829
[ 2703s] wicked_wlan_sut           passed   http://openqa.wicked.suse.de/t53830
[ 2703s]
[ 2703s] Target: openSUSE_Tumbleweed@x86_64
[ 2703s] OpenQA URL: http://openqa.wicked.suse.de/tests/overview?distri=opensuse&version=Tumbleweed&build=No-Branch
[ 2703s] Name                      State    URL
[ 2703s] -----------------------   ------   -----------------------------------
[ 2703s] Name                      State    URL
[ 2703s] ----                      -----    ---
[ 2703s] wicked_advanced_ref       passed   http://openqa.wicked.suse.de/t53831
[ 2703s] wicked_advanced_sut       passed   http://openqa.wicked.suse.de/t53832
[ 2703s] wicked_aggregate_ref      passed   http://openqa.wicked.suse.de/t53833
[ 2703s] wicked_aggregate_sut      passed   http://openqa.wicked.suse.de/t53834
[ 2703s] wicked_basic_ref          passed   http://openqa.wicked.suse.de/t53835
[ 2703s] wicked_basic_sut          passed   http://openqa.wicked.suse.de/t53836
[ 2703s] wicked_ipv6_ref           passed   http://openqa.wicked.suse.de/t53837
[ 2703s] wicked_ipv6_sut           passed   http://openqa.wicked.suse.de/t53838
[ 2703s] wicked_startandstop_ref   passed   http://openqa.wicked.suse.de/t53839
[ 2703s] wicked_startandstop_sut   passed   http://openqa.wicked.suse.de/t53840
[ 2703s] wicked_sysctl_ref         passed   http://openqa.wicked.suse.de/t53841
[ 2703s] wicked_sysctl_sut         passed   http://openqa.wicked.suse.de/t53842
[ 2703s] wicked_wlan_ref           passed   http://openqa.wicked.suse.de/t53843
[ 2703s] wicked_wlan_sut           passed   http://openqa.wicked.suse.de/t53844
```

The failing http://openqa.wicked.suse.de/t53772 from SLE-12-SP5 looks like something different. I run a rerun on master and the error was still there http://openqa.wicked.suse.de/tests/53850 .