### PR TITLE
Workaround of qa_lib_virtauto package install failure due to removal of python2

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -12,6 +12,7 @@ use base "virt_autotest_base";
 use virt_autotest::utils;
 use testapi;
 use Utils::Architectures;
+use version_utils qw(is_sle);
 use virt_utils;
 use utils;
 use Utils::Backends 'is_remote_backend';
@@ -51,6 +52,11 @@ sub install_package {
     elsif ($repo_0_to_install =~ /SLE-15-Installer/m) {
         $dependency_repo = 'http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/';
         $dependency_rpms = 'bridge-utils';
+    }
+    # Temporary workaround to install python2 as it is removed from SLE15SP4
+    elsif (is_sle('=15-SP4')) {
+        $dependency_repo = 'http://dist.suse.de/install/SLP/SLE-15-SP4-Module-Desktop-Applications-Snapshot-202203-2/x86_64/DVD1';
+        $dependency_rpms = 'python-base';
     }
 
     if ($dependency_repo) {


### PR DESCRIPTION
qa_lib_virtauto package requires /usr/bin/python which was removed from SLE15SP4. there is a temporary workaround, to add a repo where python2 packages locates, to get RC1 tests continue. The final fix should be to remove python2 from qa_lib_virtauto package completely, which a progress ticket will be created.

install_package failure: https://openqa.nue.suse.com/tests/8419738#step/install_package/11

- Related ticket: https://progress.opensuse.org/issues/109124
- Verification run: is going to be run(verification run pass)
https://openqa.nue.suse.com/tests/8428041

@alice-suse @waynechen55 @guoxuguang @nanzhg 
