### PR TITLE
Remove the redundant check_upgraded_service in yaml file

### DIFF
--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -24,7 +24,6 @@ conditional_schedule:
   qcow_generation:
     QCOW_GENERATION:
       0:
-        - console/check_upgraded_service
         - console/system_prepare
         - console/check_system_info
         - console/check_network


### PR DESCRIPTION
Remove the redundant check_upgraded_service in yaml file.

- Related ticket: https://progress.opensuse.org/issues/109127
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/8429184#