### PR TITLE
Fix brasero_launch and gnome_documents failure on SLE15SP4

### DIFF
--- a/tests/x11/brasero/brasero_launch.pm
+++ b/tests/x11/brasero/brasero_launch.pm
@@ -18,7 +18,7 @@ use utils;
 use version_utils 'is_sle';
 
 sub run {
-    assert_gui_app('brasero', install => !is_sle, remain => 1);
+    assert_gui_app('brasero', install => !is_sle('<15-SP4'), remain => 1);
 
     # check about window
     send_key 'alt-h';

--- a/tests/x11/gnomeapps/gnome_documents.pm
+++ b/tests/x11/gnomeapps/gnome_documents.pm
@@ -12,9 +12,10 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
-    assert_gui_app('gnome-documents');
+    assert_gui_app('gnome-documents', install => is_sle('>=15-SP4'));
 }
 
 1;


### PR DESCRIPTION
brasero and gnome-documents won't be installed by default start from SLE15SP4
See https://bugzilla.suse.com/show_bug.cgi?id=1195178
and https://bugzilla.suse.com/show_bug.cgi?id=1197374 for more details

- Related ticket: https://progress.opensuse.org/issues/109139
- Needles: N/A
- Verification run:
- SLE:  
> wayland-desktopapps-other https://openqa.suse.de/tests/8429887
> x11-desktopapps-other https://openqa.suse.de/tests/8429872
- TW:
> https://openqa.opensuse.org/tests/2270693
