### PR TITLE
Increase timeout for dig command

### DIFF
--- a/tests/yast2_cmd/yast_dns_server.pm
+++ b/tests/yast2_cmd/yast_dns_server.pm
@@ -71,13 +71,13 @@ sub run {
     assert_script_run(qq(sed -i 's/NETCONFIG_FORCE_REPLACE="no"/NETCONFIG_FORCE_REPLACE="yes"/' /etc/sysconfig/network/config));
 
     #Forward server and test lookup
-    my $opensuseip = script_output("dig www.opensuse.org +short");
+    my $opensuseip = script_output("dig www.opensuse.org +short", 300);
     $opensuseip =~ s/.*^(\d+\.\d+\.\d+\.\d+).*/$1/ms;
     $self->cmd_handle("forwarders", "add", ip => "10.0.2.3");
     #disable dnssec validation
     assert_script_run("sed -i 's/#dnssec-validation auto/dnssec-validation no/' /etc/named.conf");
     systemctl("start named.service");
-    validate_script_output('dig @localhost www.opensuse.org +short', sub { /\Q$opensuseip\E/ });
+    validate_script_output('dig @localhost www.opensuse.org +short', sub { /\Q$opensuseip\E/ }, timeout => 300);
 
     assert_script_run("sed -i 's/dnssec-validation no/#dnssec-validation auto/' /etc/named.conf");
     $self->cmd_handle("forwarders", "remove", ip => "10.0.2.3");

--- a/tests/yast2_cmd/yast_lan.pm
+++ b/tests/yast2_cmd/yast_lan.pm
@@ -26,10 +26,10 @@ sub run {
     $self->select_serial_terminal;
     zypper_call "in yast2-network";
     my $type = is_sle('>15') ? 'type=vlan' : '';
-    validate_script_output "yast lan add name=vlan50 ethdevice=eth0 $type 2>&1", sub { m/Virtual/ || m/vlan50/ }, timeout => 60;
-    validate_script_output 'yast lan show id=1 2>&1', sub { m/vlan50/ };
-    validate_script_output 'yast lan edit id=1 bootproto=dhcp 2>&1', sub { m/IP address assigned using DHCP/ || m/Configured with dhcp/ }, 60;
-    assert_script_run 'yast lan delete id=1 2>&1';
-    validate_script_output 'yast lan list 2>&1', sub { !m/Virtual/ && !m/vlan50/ };
+    validate_script_output_retry "yast lan add name=vlan50 ethdevice=eth0 $type 2>&1", sub { m/Virtual/ || m/vlan50/ }, timeout => 120;
+    validate_script_output_retry 'yast lan show id=1 2>&1', sub { m/vlan50/ }, timeout => 120;
+    validate_script_output_retry 'yast lan edit id=1 bootproto=dhcp 2>&1', sub { m/IP address assigned using DHCP/ || m/Configured with dhcp/ }, timeout => 120;
+    assert_script_run 'yast lan delete id=1 2>&1', timeout => 120;
+    validate_script_output_retry 'yast lan list 2>&1', sub { !m/Virtual/ && !m/vlan50/ }, timeout => 120;
 }
 1;


### PR DESCRIPTION

- on aarch64 the timeout was too short for this platfrom which  resulted in failed tests.
- Problems with scripts terminated with SIGTERM could be resolved by setting QEMURAM to 4096

- Related ticket: https://progress.opensuse.org/issues/107326
- Needles: 
- Verification run: https://openqa.suse.de/tests/8437442
