### PR TITLE
Fix failing wpa_supplicant test

### DIFF
--- a/data/wpa_supplicant/hostapd.sh
+++ b/data/wpa_supplicant/hostapd.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -e
 
 # Give the other shell some time to transfer up to the wifi_master namespace
 sleep 5
@@ -24,7 +22,7 @@ echo "dnsmasq is up."
 
 # Wait for termination signal
 timeout 30s grep -q 'terminate' <(tail -f hostapd.com)
-kill $hostapd_pid
+kill $hostapd_pid 2>/dev/null || true
 echo 'ok' >> hostapd.com
 sleep 1
 exit 0

--- a/tests/console/wpa_supplicant.pm
+++ b/tests/console/wpa_supplicant.pm
@@ -30,11 +30,12 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    zypper_call 'in wpa_supplicant hostapd iw dnsmasq unzip';
+    zypper_call 'in wpa_supplicant hostapd iw dnsmasq unzip dhcp-client';
     assert_script_run 'cd $(mktemp -d)';
     assert_script_run('curl -L -s ' . data_url('wpa_supplicant') . ' | cpio --make-directories --extract && cd data');
     $self->adopt_apparmor;
-    assert_script_run('bash -x ./wpa_supplicant_test.sh 2>&1 | tee wpa-supplicant_test.txt', timeout => 600);
+    script_run('./wpa_supplicant_test.sh 2>&1 | tee wpa-supplicant_test.txt', timeout => 600);
+    validate_script_output("cat wpa-supplicant_test.txt", qr/WPA_SUPPLICANT_TEST: PASSED/);
 }
 
 sub adopt_apparmor {


### PR DESCRIPTION
Attempt to fix the failing wpa_supplicant test on Tumbleweed by introducing two changes:

* Don't fail wpa_supplicant if an error happens during the cleanup routine (e.g. killing an already terminated process)
* The test now passes a cookie to openQA if and only if the test passes. We ignore the return code of the script and await the cookie to mark the test as successful.

- Related ticket: https://progress.opensuse.org/issues/106676
- Verification run: https://duck-norris.qam.suse.de/tests/8478#step/wpa_supplicant/38 (wpa_supplicant passes, failing in other steps)
