### PR TITLE
Make dependency repo adaptive to ARCH

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -55,7 +55,7 @@ sub install_package {
     }
     # Temporary workaround to install python2 as it is removed from SLE15SP4
     elsif (is_sle('=15-SP4')) {
-        $dependency_repo = 'http://dist.suse.de/install/SLP/SLE-15-SP4-Module-Desktop-Applications-Snapshot-202203-2/x86_64/DVD1';
+        $dependency_repo = 'http://dist.suse.de/install/SLP/SLE-15-SP4-Module-Desktop-Applications-Snapshot-202203-2/' . lc(get_required_var('ARCH')) . '/DVD1';
         $dependency_rpms = 'python-base';
     }
 


### PR DESCRIPTION
* **The** initial workaround was introduced by [pr#14596](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14596/). But it does not take other ARCHs into consideration, so test suites can still fail on platforms other than x86_64, for example, [this one](https://openqa.suse.de/tests/8428352#step/install_package/1).

* **This** commit aims to solve the problem by concatenating dependency repo URL with get_required_var('ARCH').

* **Verification runs:**
  * [x86_64 run](https://openqa.suse.de/tests/8434400)
  * [aarch64 run](https://openqa.suse.de/tests/8434402)
  * [s390x run](https://openqa.suse.de/tests/8434401)
