### PR TITLE
Add new test cases: mariadb_ssl

### DIFF
--- a/schedule/security/mariadb_ssl.yaml
+++ b/schedule/security/mariadb_ssl.yaml
@@ -1,0 +1,32 @@
+name: mariadb_ssl
+description:    >
+    mariadb test in fips mode with `--ssl` parameter.
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - '{{setup_multimachine}}'
+    - '{{fips_setup}}'
+    - '{{mariadb}}'
+conditional_schedule:
+    bootloader:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+            ppc64le:
+                - installation/bootloader
+    setup_multimachine:
+        ARCH:
+            aarch64:
+                - network/setup_multimachine
+            x86_64:
+                - network/setup_multimachine
+    fips_setup:
+        FIPS_ENABLED:
+            1:
+                - fips/fips_setup
+    mariadb:
+        HOSTNAME:
+            server:
+                - security/mariadb/mariadb_ssl_server
+            client:
+                - security/mariadb/mariadb_ssl_client

--- a/tests/security/mariadb/mariadb_ssl_client.pm
+++ b/tests/security/mariadb/mariadb_ssl_client.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run mariadb connect to server with '--ssl' parameter test case
+# Maintainer: Starry Wang <starry.wang@suse.com> Ben Chou <bchou@suse.com>
+# Tags: poo#109154, tc#1767518
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Utils::Architectures;
+use lockapi;
+
+sub run {
+    my ($self) = @_;
+    my $password = 'my_password';
+    my $server_ip = get_var('SERVER_IP', '10.0.2.101');
+    my $client_ip = get_var('CLIENT_IP', '10.0.2.102');
+
+    select_console 'root-console';
+
+    # We don't run setup_multimachine in s390x, but we need to know the server and client's
+    # ip address, so we add a known ip to NETDEV.
+    my $netdev = get_var('NETDEV', 'eth0');
+    assert_script_run("ip addr add $client_ip/24 dev $netdev") if (is_s390x);
+
+    zypper_call('in mariadb');
+    mutex_wait('MARIADB_SERVER_READY');
+
+    # Try to connect mysql server
+    assert_script_run("ping -c 3 $server_ip");
+    validate_script_output("mysql --ssl -h $server_ip -u root -p$password -e \"show databases;\";", sub { m/Database/ });
+
+    # Delete the ip that we added if arch is s390x
+    assert_script_run("ip addr del $client_ip/24 dev $netdev") if (is_s390x);
+}
+
+1;

--- a/tests/security/mariadb/mariadb_ssl_server.pm
+++ b/tests/security/mariadb/mariadb_ssl_server.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Setup mariadb server enviroment and wait client to connect
+# Maintainer: Starry Wang <starry.wang@suse.com> Ben Chou <bchou@suse.com>
+# Tags: poo#109154, tc#1767518
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Utils::Architectures;
+use lockapi;
+use mmapi 'wait_for_children';
+
+sub run {
+    my ($self) = @_;
+    my $db_service = 'mysql';
+    my $password = 'my_password';
+    my $server_ip = get_var('SERVER_IP', '10.0.2.101');
+    my $client_ip = get_var('CLIENT_IP', '10.0.2.102');
+
+    select_console 'root-console';
+
+    # We don't run setup_multimachine in s390x, but we need to know the server and client's
+    # ip address, so we add a known ip to NETDEV.
+    my $netdev = get_var('NETDEV', 'eth0');
+    assert_script_run("ip addr add $server_ip/24 dev $netdev") if (is_s390x);
+    systemctl("stop firewalld") if (is_s390x);
+
+    # Install mariadb, edit the config file and start mysql service
+    zypper_call('in mariadb');
+    assert_script_run('sed -i "/^bind-address.*/c\\bind-address = 0.0.0.0" /etc/my.cnf');
+    record_info('mariadb_bind_address', script_output('cat /etc/my.cnf | grep bind-address'));
+    systemctl("start $db_service");
+
+    # Update privilege to allow remote access
+    my $sql = "GRANT ALL PRIVILEGES ON *.* TO \'root\'@\'%\' IDENTIFIED BY '$password' WITH GRANT OPTION;";
+    assert_script_run("mysql -uroot -e \"$sql\"");
+    assert_script_run("mysql -uroot -e \"flush privileges;\"");
+    record_info('listen_port', script_output('ss -tnlp | grep 3306'));
+
+    mutex_create('MARIADB_SERVER_READY');
+    wait_for_children;
+
+    # Stop mariadb service
+    systemctl("stop $db_service");
+
+    # Delete the ip that we added if arch is s390x
+    assert_script_run("ip addr del $server_ip/24 dev $netdev") if (is_s390x);
+}
+
+1;


### PR DESCRIPTION
## New test cases: mariadb_ssl

- Setup mariadb multi-machine testing environment.
- Try to connect the mariadb server with the '--ssl' parameter.

----

- Related ticket: https://progress.opensuse.org/issues/109154
- Needles: NA
- Verification run: 
  - leap 15.4 x64 server: https://openqa.opensuse.org/tests/2272582
  - leap 15.4 x64 client : https://openqa.opensuse.org/tests/2272583
  - TW x64 client : https://openqa.opensuse.org/tests/2272624
  - TW x64 server: https://openqa.opensuse.org/tests/2272623
  - Leap 15.4 aarch64 client: https://openqa.opensuse.org/tests/2275513
  - Leap 15.4 aarch64 server:https://openqa.opensuse.org/tests/2275512
  
    ---------

  - sle15sp4 x64 server: https://openqa.suse.de/tests/8480225
  - sle15sp4 x64 client  : https://openqa.suse.de/tests/8480226
  - sle15sp4 aarch64 server: https://openqa.suse.de/tests/8480227
  - sle15sp4 aarch64 client  : https://openqa.suse.de/tests/8480228
  - sle15sp4 s390x server: https://openqa.suse.de/tests/8480229
  - sle15sp4 s390x client  : https://openqa.suse.de/tests/8480230
 