### PR TITLE
sssd_openldap_functional: update docker image before test

### DIFF
--- a/data/sssd/openldap/Dockerfile
+++ b/data/sssd/openldap/Dockerfile
@@ -7,6 +7,7 @@ COPY add_test_repositories.sh /tmp/add_test_repositories.sh
 RUN chmod +x /tmp/add_test_repositories.sh
 RUN /tmp/add_test_repositories.sh $maint_test_repo
 RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper update -y
 RUN zypper install -y $pkgs
 COPY --chown=ldap:ldap ldapserver.* slapd.conf /etc/openldap/
 COPY user.ldif /tmp/user.ldif


### PR DESCRIPTION
update docker image before test

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1197004
- Needles: no needles
- Verification run: https://openqa.suse.de/tests/8437320#
