### PR TITLE
BCI: skip coredump_collect in BCI tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -169,5 +169,5 @@ sub load_container_tests {
         }
     }
 
-    loadtest 'console/coredump_collect' unless is_jeos;
+    loadtest 'console/coredump_collect' unless (is_jeos || get_var('BCI_TESTS'));
 }


### PR DESCRIPTION
These tests are only targetting the image, they don't use to fail
and they are executed in multiple hosts, including Ubuntu, CentOS,
etc. It doesn't make sense to run this module in these kind of
scenarios as it doesn't bring any benefit at it timesout sometimes
on Ubuntu.
