### PR TITLE
Record whilelist normally whether has it set or not

### DIFF
--- a/tests/console/orphaned_packages_check.pm
+++ b/tests/console/orphaned_packages_check.pm
@@ -44,8 +44,7 @@ sub compare_orphans_lists {
     # Summary
     record_info('Detected Orphans', to_string @{$args{zypper_orphans}});
     record_info('Orphans whitelisted',
-        $args{whitelist} // 'No orphans whitelisted within the test suite',
-        result => $args{whitelist} ? 'ok' : 'fail'
+        $args{whitelist} // 'No orphans whitelisted within the test suite'
     );
     record_info('Missing',
         @missed_orphans ? to_string @missed_orphans : 'None',


### PR DESCRIPTION
We don't need mark red when white list hasn't been set.

- Related ticket: https://progress.opensuse.org/issues/105199
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/8434843#step/orphaned_packages_check/10
