### PR TITLE
add graceful cluster shutdown test

### DIFF
--- a/schedule/ha/bv/basic_cluster_node.yaml
+++ b/schedule/ha/bv/basic_cluster_node.yaml
@@ -67,6 +67,7 @@ schedule:
   - '{{boot_to_desktop_node01}}'
   - ha/check_after_reboot
   - '{{remove_node}}'
+  - '{{graceful_shutdown}}'
   - ha/check_logs
 conditional_schedule:
   cluster_setup:
@@ -92,3 +93,7 @@ conditional_schedule:
     HA_REMOVE_NODE:
       1:
         - ha/remove_node
+  graceful_shutdown:
+    HA_GRACEFUL_SHUTDOWN:
+      1:
+        - ha/graceful_shutdown

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -173,6 +173,7 @@ sub run {
         barrier_create("HANA_CREATED_CONF_$cluster_name", $num_nodes);
         barrier_create("HANA_LOADED_CONF_$cluster_name", $num_nodes);
         barrier_create("MONITORING_CONF_DONE_$cluster_name", $num_nodes);
+        barrier_create("CLUSTER_GRACEFUL_SHUTDOWN_$cluster_name", $num_nodes);
         # We have to create barriers for each nodes if we want to be able to fence *all* nodes
         foreach (1 .. $num_nodes) {
             barrier_create("HANA_RA_RESTART_${cluster_name}_NODE$_", $num_nodes);

--- a/tests/ha/graceful_shutdown.pm
+++ b/tests/ha/graceful_shutdown.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: ha-cluster-bootstrap
+# Summary: shutdown a cluster gracefully and start it up again using "crm cluster" commands
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use hacluster;
+use version_utils 'is_sle';
+use utils;
+
+sub run {
+    die "Graceful cluster shutdown option --all was only introduced with SLE15 SP4" if (is_sle('<15-sp4'));
+
+    my $cluster_name = get_cluster_name;
+    my $crm_timeout = bmwqemu::scale_timeout(60);
+
+    # Waiting for the other nodes to be ready
+    barrier_wait("CLUSTER_GRACEFUL_SHUTDOWN_" . "$cluster_name");
+
+    # graceful shutdown
+    assert_script_run("crm cluster stop --all", $crm_timeout) if is_node(1);
+
+    wait_until_resources_stopped;
+
+    # confirm cluster is stopped (only needed for logging purposes)
+    record_info('corosync', 'check if corosync is stopped');
+    validate_script_output_retry("systemctl --no-pager -l status corosync", sub { m/Stopped Corosync/i });
+    record_info('pacemaker', 'check if pacemaker is stopped');
+    validate_script_output_retry("systemctl --no-pager -l status pacemaker", sub { m/Stopped Pacemaker/i });
+
+    # start the cluster, when all nodes are in sync
+    assert_script_run("crm cluster start --all", $crm_timeout) if is_node(1);
+
+    wait_until_resources_started;
+
+    # confirm cluster suite is started (only needed for logging purposes)
+    record_info('corosync', 'check if corosync is started');
+    validate_script_output_retry("systemctl --no-pager -l status corosync", sub { m/Started Corosync Cluster Engine/i });
+    record_info('pacemaker', 'check if pacemaker is started');
+    validate_script_output_retry("systemctl --no-pager -l status pacemaker", sub { m/Active: active \(running\)/i });
+    record_info('crm_mon', 'check crm_mon output');
+    validate_script_output_retry("$crm_mon_cmd", sub { m/No inactive resources/i });
+
+    save_state;
+}
+
+1;


### PR DESCRIPTION
This test adds a check for the `--all` feature of the `crm shutdown` function.

- Related ticket: https://jira.suse.com/browse/TEAM-5288 https://jira.suse.com/browse/SLE-22505
- Needles: no new needles
- Verification run (x86): 
https://openqa.suse.de/tests/8503971#step/graceful_shutdown/1
https://openqa.suse.de/tests/8503972#step/graceful_shutdown/1

- related setup yaml: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/356