### PR TITLE
Vagrant: give boxes up to two minutes to shut down

### DIFF
--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -22,7 +22,7 @@ sub run_test_per_provider {
     run_vagrant_cmd("up $boxname --provider $provider", timeout => 1200);
 
     # test if the box survives a reboot
-    run_vagrant_cmd('halt');
+    run_vagrant_cmd('halt', timeout => 120);
     run_vagrant_cmd("up $boxname", timeout => 1200);
 
     run_vagrant_cmd("destroy -f $boxname");


### PR DESCRIPTION
Boxes fired up using virtualbox are not the fastest of kinds when run inside qemu
To start up a box, we allow up to 1200s already. To shut down, the timeout of 30s
is too optimistic.

According the logs of e.g. https://openqa.opensuse.org/tests/2273451#step/tumbleweed/58
we can see that in …/tumbleweed/77 the serial finally received the result from the
halt command; this was approx with 1 minute delay

- Related ticket: https://progress.opensuse.org/issues/105271 (unspecific)
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2274039 [running]
