### PR TITLE
Increase Vagrant shutdown timeout & ensure vagrant logs get uploaded on timeouts

### DIFF
--- a/lib/vagrant.pm
+++ b/lib/vagrant.pm
@@ -32,8 +32,17 @@ sub run_vagrant_cmd {
     my ($cmd, %args) = @_;
 
     my $logfile = 'vagrant_cmd.log';
-    my $ret = script_run("VAGRANT_LOG=DEBUG vagrant $cmd 2> $logfile", %args);
+    local $@;
+    my $ret = eval {
+        return script_run("VAGRANT_LOG=DEBUG vagrant $cmd 2> $logfile", %args);
+    };
     return undef if $ret == 0;
-    upload_logs($logfile);
-    die "'vagrant $cmd' failed with $ret";
+    if (!$ret) {
+        upload_logs($logfile);
+
+        if ($@) {
+            die $@;
+        }
+        die "'vagrant $cmd' failed with $ret";
+    }
 }

--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -22,10 +22,10 @@ sub run_test_per_provider {
     run_vagrant_cmd("up $boxname --provider $provider", timeout => 1200);
 
     # test if the box survives a reboot
-    run_vagrant_cmd('halt');
+    run_vagrant_cmd('halt', timeout => 120);
     run_vagrant_cmd("up $boxname", timeout => 1200);
 
-    run_vagrant_cmd("destroy -f $boxname");
+    run_vagrant_cmd("destroy -f $boxname", timeout => 120);
 }
 
 sub run() {


### PR DESCRIPTION
- Related ticket: n/a
- Needles: n/a
- Verification run: https://openqa.opensuse.org/tests/2274110 [Success]