### PR TITLE
wicked: Adopt sysctl.d load order

### DIFF
--- a/tests/wicked/sysctl/sut/t01_sysctl_load_files.pm
+++ b/tests/wicked/sysctl/sut/t01_sysctl_load_files.pm
@@ -17,8 +17,8 @@ use Mojo::Util qw(trim);
 
 our $wicked_show_config = 'wicked --log-level debug --debug all  show-config all';
 our @sysctl_d = qw(
-  /run/sysctl.d
   /etc/sysctl.d
+  /run/sysctl.d
   /usr/local/lib/sysctl.d
   /usr/lib/sysctl.d
   /lib/sysctl.d


### PR DESCRIPTION
With https://github.com/openSUSE/wicked/pull/905 wicked adopted the
load order to systemd.

