### PR TITLE
Add leap-micro AY profile

### DIFF
--- a/data/autoyast_opensuse/autoyast_leap-micro.xml.ep
+++ b/data/autoyast_opensuse/autoyast_leap-micro.xml.ep
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+      <hiddenmenu>false</hiddenmenu>
+    </global>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <software>
+    <products config:type="list">
+      <product>Leap-Micro</product>
+    </products>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <packages config:type="list">
+      <package>grub2</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>microos-base</pattern>
+      <pattern>microos-container_runtime</pattern>
+      <pattern>microos-selinux</pattern>
+    </patterns>
+  </software>
+  <kdump>
+  <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+  <crash_kernel>191M</crash_kernel>
+  <general>
+    <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+    <KDUMP_DUMPLEVEL>1</KDUMP_DUMPLEVEL>
+  </general>
+</kdump>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -286,6 +286,7 @@
         "description": "health-checker/fail.sh check\" failed|Machine didn't come up correct, do a rollback",
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2" ],
+            "leap-micro": ["5.2"],
             "microos":  ["Tumbleweed"]
         },
         "type": "ignore"


### PR DESCRIPTION
Add autoyast profile for leap-micro 5.2

- Verification run: [leap-micro-5.2-DVD-x86_64-Build_-microos_installation_autoyast@64bit](http://kepler.suse.cz/tests/15782#)
