### PR TITLE
Increase timeout to trigger kernel panic

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -354,7 +354,7 @@ sub check_function {
         assert_script_run('ls -lah /var/crash/*/vmcore');
         my $vmlinux = (is_sle("<16") || is_leap("<16.0")) ? '/boot/vmlinux-$(uname -r)*' : '/usr/lib/modules/$(uname -r)/vmlinux*';
         my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` $vmlinux";
-        validate_script_output "$crash_cmd", sub { m/PANIC:\s([^\s]+)/ }, 600;
+        validate_script_output "$crash_cmd", sub { m/PANIC:\s([^\s]+)/ }, 800;
     }
     else {
         # migration tests need remove core files before migration start


### PR DESCRIPTION
In the last several runs we can see that previous timeout was not enough to
for [aarch64](https://openqa.suse.de/tests/8445331#step/kdump_and_crash/75) runs.

- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
