### PR TITLE
Increase time to assert pop-up in samba_ncurses

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -89,7 +89,7 @@ sub setup_yast2_ldap_server {
     send_key $cmd{ok};
 
     record_info 'Setup LDAP', 'Workaround for cert name issue';
-    assert_screen 'yast2_samba-389ds-setup-error-workaround', 90;
+    assert_screen 'yast2_samba-389ds-setup-error-workaround', 180;
     send_key 'ret';
     wait_screen_change { send_key "alt-c" };
     die "'yast2 ldap-server' didn't finish with zero exit code" unless wait_serial("$module_name-0");


### PR DESCRIPTION
A lot of additional packages are being installed, it takes a lot of time in OOO. Test still fails but the fix will allow to report the bug.

- Related ticket: https://progress.opensuse.org/issues/61780