### PR TITLE
check for nvidia repo's gpg key for SLED install

### DIFF
--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -13,7 +13,7 @@ use warnings;
 use parent "y2_installbase";
 
 use testapi;
-use utils 'assert_screen_with_soft_timeout';
+use utils qw(assert_screen_with_soft_timeout handle_untrusted_gpg_key);
 use version_utils 'is_sle';
 use registration qw(skip_registration assert_registration_screen_present fill_in_registration_data verify_scc investigate_log_empty_license);
 
@@ -23,6 +23,10 @@ sub run {
         record_info('SCC reg.', 'SCC registration');
         assert_registration_screen_present();
         fill_in_registration_data();
+        wait_still_screen();
+        if (is_sle('>=15-SP4') && check_screen('import-untrusted-gpg-key', 5)) {
+            handle_untrusted_gpg_key();
+        }
     }
     else {
         return if check_var('SLE_PRODUCT', 'leanos');


### PR DESCRIPTION
The installation fails for SLED, after Nvidia repo is enabled in SCC recently. Now there is a window for Nvidia reop's gpg key.

This window appeared in different position before, there are code to handle that by import this key.

Now this window appears at the end of test `scc_registration`, so I will adjust the test case to check for this screen and trust this key.

- Related ticket: https://progress.opensuse.org/issues/109346
- Needles: None
- Verification run: https://openqa.suse.de/tests/8453667#step/scc_registration/12
