### PR TITLE
Making transactional_update module fatal

### DIFF
--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -118,7 +118,10 @@ sub run {
 }
 
 sub test_flags {
-    return {no_rollback => 1};
+    return {
+        fatal => 1,
+        no_rollback => 1
+    };
 }
 
 1;


### PR DESCRIPTION
Missing curl package in sle15.4 transactional server role turned out to be a product bug which is being fixed 
(https://bugzilla.suse.com/show_bug.cgi?id=1197913)

As part of this commit, I am making the transactional_update module fatal, so no further related test are run unnecessarily.  

- Related ticket: https://progress.opensuse.org/issues/107356
- Verification run: https://openqa.opensuse.org/tests/2276517#

