### PR TITLE
Fix zgrep output for release_notes_from

### DIFF
--- a/tests/installation/release_notes_from_rpm.pm
+++ b/tests/installation/release_notes_from_rpm.pm
@@ -15,7 +15,7 @@ sub run {
     assert_screen('release-notes-button');
     send_key('ctrl-shift-alt-x');
     assert_screen('yast-xterm');
-    enter_cmd "zgrep -o \"Got release notes.*\" /var/log/YaST2/y2log*";
+    enter_cmd "zgrep -oh \"Got release notes.*\" /var/log/YaST2/y2log*";
     assert_screen [qw(got-releasenotes-RPM got-releasenotes-URL)];
     unless (match_has_tag 'got-releasenotes-RPM') {
         die('Release notes source does NOT match expectations or not found in YaST logs, expected source: RPM');

--- a/tests/installation/release_notes_from_url.pm
+++ b/tests/installation/release_notes_from_url.pm
@@ -15,7 +15,7 @@ sub run {
     assert_screen('release-notes-button');
     send_key('ctrl-shift-alt-x');
     assert_screen('yast-xterm');
-    enter_cmd "zgrep -o \"Got release notes.*\" /var/log/YaST2/y2log*";
+    enter_cmd "zgrep -oh \"Got release notes.*\" /var/log/YaST2/y2log*";
     assert_screen [qw(got-releasenotes-RPM got-releasenotes-URL)];
     unless (match_has_tag 'got-releasenotes-URL') {
         record_soft_failure('bsc#1190711 - Release notes source does NOT match expectations or not found in YaST logs, expected source: URL');


### PR DESCRIPTION
- PR 14536 introduced zgrep for checking the release notes. As a side
  effect when theree are more than one log file that matches the glob
  pattern the output will be prefixed by the filenmae. This moves the
  substring that the needle wants to match to the right and then we
  get matches around 70% only. Test then fails.
- [failed test release_notes_from_rpm](https://openqa.suse.de/tests/8444887#step/release_notes_from_rpm/4)
- As a bugfix we use parameter -h now too, this surpresses the output
  of filenames for matches.

- Related ticket: no ticket
- Needles: no needles
- Verification run: https://openqa.suse.de/tests/8453295#
