### PR TITLE
Postpone snapper cron job execution

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -80,6 +80,18 @@ sub snapper_nodbus_restore {
     }
 }
 
+=head2 cron_mock_lastrun
+snapper-0.5 and older is using cron jobs in order to schedule and execute cleanup routines.
+Script /usr/lib/cron/run-crons looks into /etc/cron.{hourly,daily,weekly,monthly} for jobs
+to be executed. The info about last run is stored in /var/spool/cron/lastrun
+By updating the lastrun files timestamps, we make sure those routines won't be executed 
+while tests are running. 
+=cut
+sub cron_mock_lastrun {
+    assert_script_run 'touch /var/spool/cron/lastrun/cron.{hourly,daily,weekly,monthly}';
+    assert_script_run 'ls -al /var/spool/cron/lastrun/cron.{hourly,daily,weekly,monthly}';
+}
+
 sub post_fail_hook {
     my ($self) = shift;
     select_console('log-console');

--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -23,6 +23,7 @@ use warnings;
 use testapi;
 use utils 'clear_console';
 use List::Util qw(max min);
+use version_utils qw(is_sle);
 
 my $exp_excl_space;
 my $btrfs_fs_usage = 'btrfs filesystem usage / --raw';
@@ -70,6 +71,7 @@ sub snapper_cleanup {
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
+    $self->cron_mock_lastrun() if is_sle('<15');
 
     if (get_var("UPGRADE") || get_var("AUTOUPGRADE") && !get_var("BOOT_TO_SNAPSHOT")) {
         assert_script_run "snapper setup-quota";

--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -19,6 +19,7 @@ use warnings;
 use base 'btrfs_test';
 use testapi;
 use utils;
+use version_utils qw(is_sle);
 
 # In many cases script output returns not only script execution results
 # but other data which was written to serial device. We have to ensure
@@ -56,6 +57,7 @@ sub get_last_snap_number {
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
+    $self->cron_mock_lastrun() if is_sle('<15');
 
     my @snapper_cmd = "snapper create";
     my @snap_numbers;


### PR DESCRIPTION
`snapper-0.5` that is present in sle12sp5 comes with cron jobs
`/etc/cron.{daily,hourly}/suse.de-snapper` to do the regular snapshot cleanup.
Jobs might be triggered by a single schedule of run-crons `-*/15 * * * *   root  test -x /usr/lib/cron/run-crons &&
/usr/lib/cron/run-crons >/dev/null 2>&1` and according to timestamps of
`/var/spool/cron/lastrun/cron.{daily,hourly,monthly,weekly}` files.

- Related ticket: [[sporadic] test fails in snapper_cleanup - snapper cleanup number - Config is in use.](https://progress.opensuse.org/issues/103299)
- Verification run: [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220401-1-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/16053)
