### PR TITLE
 Implement Firefox test in FIPS mode on IBM Power

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2174,6 +2174,7 @@ sub load_security_console_prepare {
     loadtest "security/test_repo_setup" if (get_var("SECURITY_TEST") =~ /^crypt_/ && !is_opensuse);
     loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
     loadtest "console/openssl_alpn" if (get_var("FIPS_ENABLED") && get_var("JEOS"));
+    loadtest "console/yast2_vnc" if (get_var("FIPS_ENABLED") && is_pvm);
 }
 
 # The function name load_security_tests_crypt_* is to avoid confusing

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -8,15 +8,17 @@
 #          Global mode - setup fips=1 in kernel command line
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#39071, poo#105591, poo#105999
+# Tags: poo#39071, poo#105591, poo#105999, poo#109133
 
+use base 'opensusebasetest';
 use strict;
 use warnings;
 use base "consoletest";
 use testapi;
-use utils qw(quit_packagekit zypper_call);
+use utils qw(quit_packagekit zypper_call reconnect_mgmt_console);
 use bootloader_setup "add_grub_cmdline_settings";
 use power_action_utils "power_action";
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -67,7 +69,8 @@ sub run {
     record_info('CPU_core', script_output("cat /proc/cpuinfo | grep processor | wc -l"));
 
     power_action('reboot', textmode => 1);
-    $self->wait_boot(bootloader_time => 200);
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
 
     # Workaround to resolve console switch issue
     $self->select_serial_terminal;

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use utils qw(zypper_call package_upgrade_check);
+use utils qw(zypper_call package_upgrade_check clear_console);
 use Utils::Architectures;
 use version_utils 'is_sle';
 
@@ -85,7 +85,7 @@ sub run {
         my $mozilla_nss_ver = script_output("rpm -q --qf '%{version}\n' mozilla-nss");
         record_info('mozilla-nss version', "Version of Current package: $mozilla_nss_ver");
     }
-
+    clear_console;
     select_console 'x11';
     x11_start_program('firefox https://html5test.opensuse.org', target_match => 'firefox-html-test', match_timeout => 360);
 
@@ -95,7 +95,8 @@ sub run {
     # Search "Passwords" section
     if ($firefox_version >= 91) {
         type_string "Use a primary", timeout => 2;
-    } else {
+    }
+    else {
         type_string "Use a master", timeout => 2;
     }
     assert_and_click("firefox-master-password-checkbox");

--- a/tests/security/test_repo_setup.pm
+++ b/tests/security/test_repo_setup.pm
@@ -13,6 +13,7 @@ use Utils::Architectures;
 use utils;
 use version_utils "is_sle";
 use registration qw(cleanup_registration register_product add_suseconnect_product);
+use Utils::Backends 'is_pvm';
 
 sub repo_cleanup {
     cleanup_registration;
@@ -43,6 +44,9 @@ sub run {
             repo_cleanup;
             # Base system registration
             register_product;
+
+            # For FIPS tests on powerVM, we may need add desktop repo to enable x11 access
+            add_suseconnect_product('sle-module-desktop-applications') if (get_var("FIPS_ENABLED") && is_pvm);
 
             # WE addon registration (according to the conditions)
             if (get_var("SECTEST_REQUIRE_WE") && is_x86_64) {


### PR DESCRIPTION
For Firefox tests on power platform, we may need to
access the x11 console, we start the vnc server via
display-manager

- Related ticket: https://progress.opensuse.org/issues/109133
- Needles: have already uploaded
- Verification run: 
https://openqa.suse.de/tests/8472593[The failed case is tracked via bsc#1197670]
https://openqa.suse.de/tests/8474019 [fips env mode]