### PR TITLE
Split host and guest install, Adding host autoyast install option

### DIFF
--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -1,0 +1,324 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <boot_mbr>true</boot_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <serial>serial --unit=1 --speed=115200 --parity=no</serial>
+      <terminal>serial</terminal>
+      <timeout config:type="integer">10</timeout>
+      <trusted_grub>false</trusted_grub>
+      <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200</xen_append>
+      <xen_kernel_append>dom0_max_vcpus=4 dom0_mem=8192M,max:8192M loglvl=all guest_loglvl=all</xen_kernel_append>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">true</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>72M,low</listentry>
+      <listentry>256M,high</listentry>
+    </crash_kernel>
+    <crash_xen_kernel>201M\&lt;4G</crash_xen_kernel>
+  </kdump>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email><%= $get_var->('SCC_EMAIL') %></email>
+    <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    % if (keys %$addons) {
+    <addons config:type="list">
+      % while (my ($key, $addon) = each (%$addons)) {
+      <addon>
+        <name><%= $addon->{name} %></name>
+        <version><%= $addon->{version} %></version>
+        <arch><%= $addon->{arch} %></arch>
+        <release_type/>
+        % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sles')) {
+        <reg_code><%= $get_var->('SCC_REGCODE_WE') %></reg_code>
+        % }
+        % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sled')) {
+        <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+        % }
+        % if ($key eq 'rt') {
+        <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
+        % }
+        % if ($key eq 'ltss') {
+        <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+        % }
+      </addon>
+      % }
+    </addons>
+    %}
+  </suse_register>
+  <add-on>
+    <add_on_products config:type="list">
+      % for my $repo (@$repos) {
+      <listentry>
+        <media_url><%= $repo %></media_url>
+      </listentry>
+      % }
+    </add_on_products>
+  </add-on>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <login_settings/>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <interfaces config:type="list">
+      <interface>
+        <device>br0</device>
+        <bootproto>dhcp</bootproto>
+        <bridge>yes</bridge>
+        <bridge_forwarddelay>0</bridge_forwarddelay>
+        <bridge_ports>eth0 eth1</bridge_ports>
+        <bridge_stp>off</bridge_stp>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <device>eth0</device>
+        <bootproto>none</bootproto>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <device>eth1</device>
+        <bootproto>none</bootproto>
+        <startmode>hotplug</startmode>
+      </interface>
+    </interfaces>
+  </networking>
+  <partitioning config:type="list">
+    <drive>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>400G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>16G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list"/>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <packages config:type="list">
+      <package>dhcp-client</package>
+    </packages>
+    <products config:type="list">
+      <product><%= uc $get_var->('SLE_PRODUCT') %></product>
+    </products>
+    <patterns config:type="list">
+      % for my $pattern (@$patterns) {
+      <pattern><%= $pattern %></pattern>
+      % }
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>UTC</timezone>
+  </timezone>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+   <restricts config:type="list">
+     <restrict>
+       <options>kod nomodify notrap nopeer noquery</options>
+       <target>default</target>
+     </restrict>
+     <restrict>
+       <target>127.0.0.1</target>
+     </restrict>
+     <restrict>
+       <target>::1</target>
+     </restrict>
+   </restricts>
+   <peers config:type="list">
+     <peer>
+       <address>0.europe.pool.ntp.org</address>
+       <options>iburst</options>
+       <type>server</type>
+     </peer>
+     <peer>
+       <address>1.europe.pool.ntp.org</address>
+       <options>iburst</options>
+       <type>server</type>
+     </peer>
+     <peer>
+       <address>2.europe.pool.ntp.org</address>
+       <options>iburst</options>
+       <type>server</type>
+     </peer>
+     <peer>
+       <address>3.europe.pool.ntp.org</address>
+       <options>iburst</options>
+       <type>server</type>
+     </peer>
+   </peers>
+  </ntp-client>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <scripts>
+    <post-scripts config:type="list">
+      <script>
+        <filename>debug_libvirtd.sh</filename>
+        <source><![CDATA[
+cat >> /etc/libvirt/libvirtd.conf<< EOF
+log_level = 1
+log_filters="1:qemu 3:remote 4:event 3:util.json 3:rpc"
+log_outputs="1:file:/var/log/libvirt/libvirtd.log"
+EOF
+if [ -e /etc/xen/xl.conf ]; then sed -i '/autoballoon=/ s/.*/autoballoon="off"/' /etc/xen/xl.conf; fi
+cp /usr/lib/systemd/network/99-default.link  /etc/systemd/network/99-default.link
+sed -i s/MACAddressPolicy=persistent/MACAddressPolicy=none/ /etc/systemd/network/99-default.link
+
+mkdir -p /root/.config/fontconfig
+cat >> /root/.config/fontconfig/fonts.conf <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Cantarell</family>
+    </prefer>
+  </alias>
+</fontconfig>
+EOF
+]]>
+        </source>
+      </script>
+    </post-scripts>
+  </scripts>
+</profile>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -1,0 +1,303 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email><%= $get_var->('SCC_EMAIL') %></email>
+    <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    % if (keys %$addons) {
+    <addons config:type="list">
+      % while (my ($key, $addon) = each (%$addons)) {
+      <addon>
+        <name><%= $addon->{name} %></name>
+        <version><%= $addon->{version} %></version>
+        <arch><%= $addon->{arch} %></arch>
+        % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sles')) {
+        <reg_code><%= $get_var->('SCC_REGCODE_WE') %></reg_code>
+        % }
+        % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sled')) {
+        <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+        % }
+        % if ($key eq 'rt') {
+        <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
+        % }
+        % if ($key eq 'ltss') {
+        <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+        % }
+      </addon>
+      % }
+    </addons>
+    %}
+  </suse_register>
+  <add-on>
+    <add_on_products config:type="list">
+      % for my $repo (@$repos) {
+      <listentry>
+        <media_url><%= $repo %></media_url>
+      </listentry>
+      % }
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <boot_mbr>true</boot_mbr>
+      <cpu_mitigations>auto</cpu_mitigations>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <serial>serial --unit=1 --speed=115200 --parity=no</serial>
+      <timeout config:type="integer">10</timeout>
+      <trusted_grub>false</trusted_grub>
+      <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200</xen_append>
+      % if ($check_var->('VERSION', '15')) {
+      <terminal>serial</terminal>
+      <xen_kernel_append>dom0_max_vcpus=4 dom0_mem=8192M,max:8192M vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
+      % } else {
+      <terminal>console serial</terminal>
+      <xen_kernel_append>dom0_max_vcpus=4 vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
+      % }
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">true</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>201M,high</crash_kernel>
+    <crash_xen_kernel>201M\&lt;4G</crash_xen_kernel>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <login_settings/>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+<interfaces config:type="list">
+  <interface>
+    <device>br0</device>
+    <bootproto>dhcp</bootproto>
+    <bridge>yes</bridge>
+    <bridge_forwarddelay>0</bridge_forwarddelay>
+    <bridge_ports>eth0 eth1</bridge_ports>
+    <bridge_stp>off</bridge_stp>
+    <startmode>auto</startmode>
+  </interface>
+  <interface>
+    <device>eth0</device>
+    <bootproto>none</bootproto>
+    <startmode>hotplug</startmode>
+  </interface>
+  <interface>
+    <device>eth1</device>
+    <bootproto>none</bootproto>
+    <startmode>hotplug</startmode>
+  </interface>
+</interfaces>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+      <ntp_server>
+        <address>europe.pool.ntp.org</address>
+        <iburst config:type="boolean">true</iburst>
+        <offline config:type="boolean">false</offline>
+      </ntp_server>
+    </ntp_servers>
+    <ntp_sync>systemd</ntp_sync>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <!--device>/dev/sda</device-->
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>400G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>16G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list">
+        <service>firewalld</service>
+      </disable>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+      <on_demand config:type="list"/>
+    </services>
+  </services-manager>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>dhcp-client</package>
+    </packages>
+    <products config:type="list">
+      <product><%= uc $get_var->('SLE_PRODUCT') %></product>
+    </products>
+    <patterns config:type="list">
+      % for my $pattern (@$patterns) {
+      <pattern><%= $pattern %></pattern>
+      % }
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>UTC</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <authorized_keys config:type="list"/>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bernhard</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <home_btrfs_subvolume config:type="boolean">false</home_btrfs_subvolume>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$QSJG7nUenDgf$UcRX/Q6YWM2/S55RJ8Mgvu93oKEDlOs.7/rOTMYjjxXQPiZ/rq4ogx5EpkksVRZXoEF0kX8FeEa.gOTxl1l/t0</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <authorized_keys config:type="list"/>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <home_btrfs_subvolume config:type="boolean">false</home_btrfs_subvolume>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <scripts>
+    <post-scripts config:type="list">
+      <script>
+        <filename>debug_libvirtd.sh</filename>
+        <source><![CDATA[
+cat >> /etc/libvirt/libvirtd.conf<< EOF
+log_level = 1
+log_filters="1:qemu 3:remote 4:event 3:util.json 3:rpc"
+log_outputs="1:file:/var/log/libvirt/libvirtd.log"
+EOF
+cp /usr/lib/systemd/network/99-default.link  /etc/systemd/network/99-default.link
+sed -i s/MACAddressPolicy=persistent/MACAddressPolicy=none/ /etc/systemd/network/99-default.link
+
+mkdir -p /root/.config/fontconfig
+cat >> /root/.config/fontconfig/fonts.conf <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig> 
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Cantarell</family>
+    </prefer>
+  </alias>
+</fontconfig>
+EOF
+]]>
+        </source>
+      </script>
+    % if ($check_var->('VERSION', '15')) {
+      <script>
+        <filename>disable_dom0_balloon.sh</filename>
+        <source><![CDATA[
+if [ -e /etc/xen/xl.conf ]; then sed -i '/autoballoon=/ s/.*/autoballoon="off"/' /etc/xen/xl.conf; fi
+]]>
+        </source>
+      </script>
+   % } 
+    </post-scripts>
+  </scripts>
+</profile>

--- a/schedule/qam/common/virt/qam_virt_install_host_ay.yaml
+++ b/schedule/qam/common/virt/qam_virt_install_host_ay.yaml
@@ -1,0 +1,32 @@
+---
+name: qam_virt_install_host
+description:    >
+    Install host OS for virtualization tests.
+schedule:
+  - '{{host_install}}'
+conditional_schedule:
+  host_install:
+    HOST_INSTALL_AUTOYAST:
+      '0':
+        - boot/boot_from_pxe
+        - installation/welcome
+        - installation/accept_license
+        - installation/scc_registration
+        - installation/addon_products_sle
+        - installation/system_role
+        - installation/partitioning
+        - installation/partitioning_firstdisk
+        - installation/partitioning_finish
+        - installation/installer_timezone
+        - installation/user_settings
+        - installation/user_settings_root
+        - installation/resolve_dependency_issues
+        - installation/installation_overview
+        - installation/disable_grub_timeout
+        - installation/start_install
+        - installation/await_install
+        - installation/reboot_after_installation
+      '1':
+        - autoyast/prepare_profile
+        - boot/boot_from_pxe
+        - autoyast/installation

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -20,6 +20,10 @@ sub run {
     my $self = shift;
     # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
     $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
+    # Clean up VMs if any. This makes it possable to reinstall VMs.
+    systemctl("restart libvirtd");
+    assert_script_run('for i in $(virsh list --name|grep sles);do virsh destroy $i;done');
+    assert_script_run('for i in $(virsh list --name --inactive); do virsh undefine $i --remove-all-storage;done');
 
     # Ensure additional package is installed
     zypper_call '-t in libvirt-client iputils nmap supportutils xmlstarlet';


### PR DESCRIPTION
This PR will do:

1.  Splitting the host and guest  installation with yaml schedule files.
2.  Adding autoyast host installation option, see two templates host_12.xml.ep, host_15.xml.ep for detail.   GUI installation option and autoyast can be switched with variable: HOST_INSTALL_AUTOYAST
3.  autoyast configures host to comply with SUSE  "virtualization best practices" during installation
4. guest  installation test module supports  "rerun".

Autoyast  is SUSE linux native automated installation.  It does not only automate OS installation but also automate OS system configuration.  Unlike GUI installation modules in OpenQA , Autoyast install just need 3 test modules.  The two test modules (prepare_profile.pm, installation.pm)are developed and maintained by autoyast QA.  They are stable and rarely changed in upstream. The whole autoyast install uses much  fewer test modules and needles than GUI installation automation.

- Related ticket: https://progress.opensuse.org/issues/81094
- Needles: no
- Verification run: 
- sles15sp2-xen autoyast: 
http://openqa.qam.suse.cz/tests/overview?groupid=157&build=%3Asplit%3Axen%3Ariver&version=15-SP2&distri=sle
http://openqa.qam.suse.cz/tests/39404#dependencies
http://openqa.qam.suse.cz/tests/39404#

- sles15sp2-xen gui install: 
http://openqa.qam.suse.cz/tests/overview?build=%3A23269%3A&distri=sle&version=15-SP2&groupid=157

sles12sp5-xen autoyast:
http://openqa.qam.suse.cz/tests/overview?distri=sle&version=12-SP5&build=%3Asplit%3Axen%3Ainara&groupid=160

sles12sp4-kvm autoyast:
http://openqa.qam.suse.cz/tests/overview?distri=sle&version=12-SP4&build=%3Asplit%3Akvm%3Amisanthrope&groupid=142

sles15sp3 gui install:
http://openqa.qam.suse.cz/tests/overview?distri=sle&version=15-SP3&build=%3Atbaev%3Akaylee&groupid=156

Autoyast and gui installation have also been run with other sles15sp3, sp2, sp1 and sles15, sles12sp5, sp4. It might not be necessary post them all here. 