### PR TITLE
Containers: remove ping from host configuration

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -42,9 +42,6 @@ sub run {
         }
     }
 
-    # Make sure we can access internet and DNS works
-    script_retry('ping -c 3 www.google.com');
-
     # Install engines in case they are not installed
     install_docker_when_needed($host_distri) if ($engine =~ 'docker');
     install_podman_when_needed($host_distri) if ($engine =~ 'podman');


### PR DESCRIPTION
For some reason, this ping doesn't work on some ppc jobs.
We already perform a system update, before, so if there is no external
connection, the update will fail. This check is redundant.

Related ticket: https://progress.opensuse.org/issues/109382
VR: [Leap 15.4](https://openqa.opensuse.org/tests/overview?version=15.4&distri=opensuse&build=jlausuch%2Fos-autoinst-distri-opensuse%23skip_ping) [Leap 15.3](https://openqa.opensuse.org/tests/overview?version=15.3&distri=opensuse&build=jlausuch%2Fos-autoinst-distri-opensuse%23skip_ping)
