### PR TITLE
 Zypper migration: option for new variable TARGET_VERSION

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -177,7 +177,7 @@
     "bsc#1188215": {
         "description": "Failed to start Create missing directories from rpmdb",
         "products": {
-            "sle-micro": [ "5.1" ]
+            "sle-micro": [ "5.0", "5.1" ]
         },
         "type": "bug"
     },

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -19,7 +19,7 @@ use transactional;
 
 sub check_migrated_version {
     # check if the migration success or not by checking the /etc/os-release file with the VERSION
-    my $target_version = get_var("VERSION");
+    my $target_version = get_var("TARGET_VERSION", get_required_var("VERSION"));
     assert_script_run("grep VERSION= /etc/os-release | grep $target_version");
 }
 
@@ -66,9 +66,9 @@ sub run {
     while ($out) {
         diag "out=$out";
         if ($out =~ $zypper_migration_target) {
-            my $version = get_var("VERSION");
-            $version =~ s/-/ /;
-            if ($out =~ /(\d+)\s+\|\s?SUSE Linux Enterprise.*?$version/m) {
+            my $target_version = get_var("TARGET_VERSION", get_required_var("VERSION"));
+            $target_version =~ s/-/ /;
+            if ($out =~ /(\d+)\s+\|\s?SUSE Linux Enterprise.*?$target_version/m) {
                 send_key "$1";
             }
             else {


### PR DESCRIPTION
The reason for this variable is that maintenance aggregate jobs need to keep the "previous" version (e.g. 5.0) in `VERSION` in order to trigger the incidents for that version. With this new variable, we have more flexibility to choose which is the target version.

Related ticket: https://progress.opensuse.org/issues/108824
VR: https://openqa.suse.de/tests/8461223