### PR TITLE
Increase timeout for yast2 installation

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -33,14 +33,14 @@ sub sudo_with_pw {
         sleep 2;
     }
     else {
-        assert_script_run "expect -c '${env}spawn $command;expect \"password\";send \"$password\\r\";interact'$grep";
+        assert_script_run("expect -c '${env}spawn $command;expect \"password\";send \"$password\\r\";interact'$grep", timeout => $args{timeout});
     }
 }
 
 sub test_sudoers {
     my ($sudo_password) = @_;
     assert_script_run 'sudo journalctl -n10 --no-pager';
-    sudo_with_pw 'sudo zypper -n in -f yast2', password => $sudo_password;
+    sudo_with_pw 'sudo zypper -n in -f yast2', password => $sudo_password, timeout => 300;
 }
 
 sub run {


### PR DESCRIPTION
Fix occasional timeout issues in the installation of yast2.

- Related ticket: https://progress.opensuse.org/issues/109400
- Verification run: [Azure SLES15-SP4 CHOST](http://duck-norris.qam.suse.de/tests/8476) | [SLES15-SP3](http://duck-norris.qam.suse.de/tests/8477)
