### PR TITLE
Use pkit restart button instead of manual restart.

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -13,13 +13,7 @@ use warnings;
 use utils;
 use testapi;
 use x11utils qw(ensure_unlocked_desktop turn_off_kde_screensaver);
-
-# Check if running kernel is the last installed
-sub kernel_updated {
-    select_console "root-console";
-    my $current = script_output "uname -r | cut -d'-' -f1,2";
-    return script_run "rpm -q --last kernel-default | head -1 | grep $current";
-}
+use power_action_utils qw(power_action);
 
 # Update with Plasma applet for software updates using PackageKit
 sub run {
@@ -88,12 +82,12 @@ sub run {
         send_key("alt-f4");
     }
 
-    if (kernel_updated) {
-        enter_cmd "reboot";
+    if (check_screen "updates_installed-restart") {
+        assert_screen_change {
+            assert_and_click_until_screen_change "plasma-updates_installed-restart"
+        }
+        power_action 'reboot', {observe => 1};
         $self->wait_boot;
-    }
-    else {
-        select_console "x11";
     }
 }
 


### PR DESCRIPTION
When it detects that a restart is needed, the Plasma PackageKit applet
provides a restart button. This commit adds this workflow to the test
and removes the old manual one.

- Related ticket: [poo#68578](https://progress.opensuse.org/issues/68578)
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/766
- Verification run: [Leap 15.3](http://apappas.udp.ovpn1.nue.suse.de/tests/812#step/updates_packagekit_kde/42)  (TW not provided as there is no scenario that triggers this)
