### PR TITLE
Add missing --debug parameter

### DIFF
--- a/data/wpa_supplicant/wpa_supplicant_test.sh
+++ b/data/wpa_supplicant/wpa_supplicant_test.sh
@@ -120,7 +120,7 @@ if systemctl is-active wickedd >& /dev/null; then
     systemctl status wicked | cat
     echo "starting wicked ... "
     # wicked ifup might terminate with setup-in-progress (rc=162), so check the link manually
-    wicked --debug ifup wlan1 --timeout 60 > wicked.log 2>&1 || true
+    wicked --log-level debug --debug all ifup wlan1 --timeout 90 2>&1 | tee wicked.log || true
     sleep 30
     wicked ifstatus wlan1 | grep 'link' | grep 'state up\|state device-up'
 else


### PR DESCRIPTION
the `all` parameter was missing in the --debug parameter.

- Related ticket: https://progress.opensuse.org/issues/106676
- Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14604
- Verification run: http://duck-norris.qam.suse.de/tests/8479#step/wpa_supplicant/38
