### PR TITLE
Add helm test using k3s test

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Basic functionality for testing kubernetes. Includes k3s tools
+# Maintainer: qa-c team <qa-c@suse.de>
+
+
+package containers::k8s;
+
+use base Exporter;
+use Exporter;
+use strict;
+use warnings;
+use testapi;
+use utils qw(zypper_call script_retry);
+use version_utils qw(is_sle);
+use registration qw(add_suseconnect_product get_addon_fullname);
+
+our @EXPORT = qw(install_k3s uninstall_k3s install_kubectl install_helm);
+
+sub install_k3s {
+    my $k3s_dowload_url = get_required_var("K3S_DOWNLOAD_URL");
+    assert_script_run("curl -LO $k3s_dowload_url");
+    assert_script_run("install -c -m 744 ./k3s /usr/local/bin/k3s");
+    enter_cmd("k3s server 2>&1 | tee k3s.log &");
+    script_retry("grep 'Wrote kubeconfig /etc/rancher/k3s/k3s.yaml' k3s.log", delay => 20, retry => 10);
+    assert_script_run("k3s kubectl get node");
+    script_run("mkdir \$HOME/.kube");
+    script_run("rm \$HOME/.kube/config");
+    assert_script_run("ln -s /etc/rancher/k3s/k3s.yaml \$HOME/.kube/config");
+}
+
+sub uninstall_k3s {
+    my $pid = script_output("ps | grep k3s-server | head -n 1 | cut -d ' ' -f1");
+    script_run("kill $pid");
+    script_run("rm \$HOME/.kube/config");
+    script_run("rm /usr/local/bin/k3s");
+}
+
+sub install_kubectl {
+    if (is_sle) {
+        zypper_call("in kubernetes1.18-client");
+    }
+    else {
+        zypper_call("in kubernetes-client");
+    }
+}
+
+sub install_helm {
+    add_suseconnect_product(get_addon_fullname('phub')) if is_sle('15-sp3+');
+    zypper_call("in helm");
+}
+
+1;

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -127,8 +127,14 @@ sub load_host_tests_containerd_nerdctl {
 }
 
 sub load_host_tests_helm() {
-    if (is_tumbleweed || is_leap || is_sle) {
-        loadtest "containers/helm";
+    if (is_sle('15-sp3+')) {
+        loadtest "containers/helm_eks";
+        loadtest "containers/helm_k3s";
+    } elsif (is_opensuse) {
+        loadtest "containers/helm_k3s";
+    }
+    else {
+        die("Helm test not supported on this host");
     }
 }
 

--- a/tests/containers/helm_k3s.pm
+++ b/tests/containers/helm_k3s.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Test deploy a helm chart in a k3s
+# - install k3s, kubectl and helm
+# - test helm repo add, update, search and show all
+# - add bitnami repo
+# - test helm install with apache helm chart
+# - test helm list
+# - check the correct deployment of the helm chart
+# - cleanup system (helm and k3s)
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use utils qw(script_retry);
+use mmapi 'get_current_job_id';
+use containers::k8s;
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+    $self->{rancher_name} = "rancher-" . get_current_job_id();
+    $self->{deployment_name} = "apache-" . get_current_job_id();
+    my $chart = "bitnami/apache";
+
+    install_k3s();
+    install_kubectl();
+    install_helm();
+
+    # Add repo, search and show values
+    assert_script_run("helm repo add bitnami https://charts.bitnami.com/bitnami");
+    assert_script_run("helm repo update");
+    assert_script_run("helm search repo apache");
+    assert_script_run("helm show all $chart");
+
+    # Install apache
+    assert_script_run("helm install $self->{deployment_name} $chart");
+    assert_script_run("helm list");
+
+    # Wait for deployment
+    assert_script_run("kubectl rollout status deployment/$self->{deployment_name}");
+    assert_script_run("kubectl describe deployment/$self->{deployment_name}");
+    assert_script_run("kubectl get pods | grep $self->{deployment_name}");
+    assert_script_run("kubectl describe services/$self->{deployment_name}");
+
+    # Test
+    enter_cmd("kubectl port-forward  services/$self->{deployment_name} 10002:80 &");
+    script_retry("curl http://localhost:10002", delay => 30, retry => 5);
+
+    # Destroy the chart and k3s
+    assert_script_run("helm delete $self->{deployment_name}");
+    uninstall_k3s();
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    script_run("helm delete $self->{deployment_name}");
+    uninstall_k3s();
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
With this commit we introduce a new test for helm command but
in this case using k3s that can be deployed locally, this allows
not depending on the external kubernetes deployments.

- Related ticket: https://progress.opensuse.org/issues/109295
- Verification run:
- http://copland.arch.suse.de/tests/1365 (TW)
- http://copland.arch.suse.de/tests/1369 (SLE)
