### PR TITLE
Containers: Fix host configuration

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -47,12 +47,10 @@ sub run {
     install_podman_when_needed($host_distri) if ($engine =~ 'podman');
 
     # It has been observed that after system update, the ip forwarding doesn't work.
-    # Sometimes there is a need to restart the firewall and docker daemon.
-    if ($host_distri =~ /sles|opensuse/) {
-        # We can't use opensusebasetest::firewall here because VERSION variable referrs to the container image.
-        my $firewall = $version =~ /12/ ? 'SuSEfirewall2' : 'firewalld';
+    # In Leap 15.3 there is a need to restart the firewall and docker daemon.
+    if ($host_distri eq 'opensuse-leap' && $version eq '15' && $sp eq '3') {
         systemctl("restart docker") if ($engine =~ 'docker');
-        systemctl("restart $firewall");
+        systemctl("restart firewalld");
     }
 
     # Record podman|docker version


### PR DESCRIPTION
It turned out that the only problem is in Leap 15.3 tests, where
we are using docker and podman in the same job. However, this
condition is not needed for Leap 15.2.

https://progress.opensuse.org/issues/109455

[some BCI tests](https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=jlausuch%2Fos-autoinst-distri-opensuse%23bci_host_config)
[all BCI tests](http://fromm.arch.suse.de/tests/overview?distri=sle&version=15-SP3&build=13.40_python-3.9-image)
[TW image](https://openqa.opensuse.org/tests/2282933)
[Leap 15.4 image](https://openqa.opensuse.org/tests/overview?version=15.4&build=jlausuch%2Fos-autoinst-distri-opensuse%23bci_host_config&distri=opensuse) -> for Leap 15.3 image, the hosts are just the same, so there is no difference.