### PR TITLE
Public Cloud: Introduce registercloudguest test

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -24,6 +24,7 @@ sub load_maintenance_publiccloud_tests {
 
     loadtest "publiccloud/download_repos";
     loadtest "publiccloud/prepare_instance", run_args => $args;
+    loadtest "publiccloud/registercloudguest", run_args => $args;
     loadtest "publiccloud/register_system", run_args => $args;
     loadtest "publiccloud/transfer_repos", run_args => $args;
     loadtest "publiccloud/patch_and_reboot", run_args => $args;
@@ -86,6 +87,7 @@ sub load_latest_publiccloud_tests {
     elsif (get_var('PUBLIC_CLOUD_CONSOLE_TESTS') || get_var('PUBLIC_CLOUD_CONTAINERS')) {
         my $args = OpenQA::Test::RunArgs->new();
         loadtest "publiccloud/prepare_instance", run_args => $args;
+        loadtest "publiccloud/registercloudguest", run_args => $args;
         loadtest "publiccloud/register_system", run_args => $args;
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -25,7 +25,7 @@ sub load_maintenance_publiccloud_tests {
     loadtest "publiccloud/download_repos";
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/registercloudguest", run_args => $args;
-    loadtest "publiccloud/register_system", run_args => $args;
+    loadtest "publiccloud/register_addons", run_args => $args;
     loadtest "publiccloud/transfer_repos", run_args => $args;
     loadtest "publiccloud/patch_and_reboot", run_args => $args;
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
@@ -88,7 +88,7 @@ sub load_latest_publiccloud_tests {
         my $args = OpenQA::Test::RunArgs->new();
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/registercloudguest", run_args => $args;
-        loadtest "publiccloud/register_system", run_args => $args;
+        loadtest "publiccloud/register_addons", run_args => $args;
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
             load_publiccloud_consoletests();

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -203,8 +203,58 @@ sub wait_for_guestregister
         }
         sleep 1;
     }
+
     $self->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
     die('guestregister didn\'t end in expected timeout=' . $args{timeout});
+}
+
+=head2 check_guestregister
+
+    check_guestregister();
+
+Check that the registration state of newly created guest match our requirements.
+https://github.com/SUSE-Enceladus/cloud-regionsrv-client/blob/master/integration_test-process.txt
+=cut
+sub check_guestregister {
+    my ($self) = @_;
+
+    if (is_byos) {
+        if ($self->run_ssh_command(cmd => 'sudo zypper lr', proceed_on_failure => 1) !~ /No repositories defined/gm) {
+            die 'The BYOS instance should be unregistered and report "Warning: No repositories defined.".';
+        }
+
+        if ($self->run_ssh_command(cmd => 'sudo systemctl is-enabled guestregister.service', proceed_on_failure => 1) !~ /disabled/) {
+            die('guestregister.service is not disabled');
+        }
+
+        if ($self->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l', proceed_on_failure => 1) != 0) {
+            die('/etc/zypp/credentials.d/ is not empty');
+        }
+
+        if ($self->run_ssh_command(cmd => 'sudo stat --printf="%s" /var/log/cloudregister', proceed_on_failure => 1) != 0) {
+            die('/var/log/cloudregister is not empty');
+        }
+    } else {
+        if ($self->run_ssh_command(cmd => 'sudo zypper lr | wc -l', proceed_on_failure => 1, timeout => 360) < 5) {
+            die 'The list of zypper repositories is too short.';
+        }
+
+        if ($self->run_ssh_command(cmd => 'sudo systemctl is-enabled guestregister.service', proceed_on_failure => 1) !~ /enabled/) {
+            die('guestregister.service is not enabled');
+        }
+
+        if ($self->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l', proceed_on_failure => 1) == 0) {
+            die('/etc/zypp/credentials.d/ is empty');
+        }
+
+        if ($self->run_ssh_command(cmd => 'sudo stat --printf="%s" /var/log/cloudregister', proceed_on_failure => 1) == 0) {
+            die('/var/log/cloudregister is empty');
+        }
+    }
+
+    if (is_azure() && $self->run_ssh_command(cmd => 'sudo systemctl is-enabled regionsrv-enabler-azure.timer', proceed_on_failure => 1) !~ /enabled/) {
+        die('regionsrv-enabler-azure.timer is not enabled');
+    }
 }
 
 =head2 wait_for_ssh

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -18,6 +18,7 @@ our @EXPORT = qw(
   add_suseconnect_product
   ssh_add_suseconnect_product
   remove_suseconnect_product
+  ssh_remove_suseconnect_product
   cleanup_registration
   register_product
   assert_registration_screen_present
@@ -231,6 +232,22 @@ sub remove_suseconnect_product {
     $arch //= get_required_var('ARCH');
     $params //= '';
     script_retry("SUSEConnect -d -p $name/$version/$arch $params", retry => 5, delay => 60, timeout => 180);
+}
+
+=head2 ssh_remove_suseconnect_product
+
+    ssh_remove_suseconnect_product($name, [$version, [$arch, [$params]]]);
+
+Wrapper for SUSEConnect -d $name over ssh.
+=cut
+sub ssh_remove_suseconnect_product {
+    my ($remote, $name, $version, $arch, $params) = @_;
+    assert_script_run "sftp $remote:/etc/os-release /tmp/os-release";
+    assert_script_run 'source /tmp/os-release';
+    $version //= scc_version();
+    $arch //= get_required_var('arch');
+    $params //= '';
+    script_retry("ssh $remote sudo SUSEConnect -d -p $name/$version/$arch $params", retry => 5, delay => 60, timeout => 180);
 }
 
 =head2 cleanup_registration

--- a/schedule/publiccloud/smoketest.yml
+++ b/schedule/publiccloud/smoketest.yml
@@ -20,7 +20,8 @@ schedule:
   - boot/boot_to_desktop
   - publiccloud/download_repos
   - publiccloud/prepare_instance
-  - publiccloud/register_system
+  - publiccloud/registercloudguest
+  - publiccloud/register_addons
   - publiccloud/transfer_repos
   - publiccloud/patch_and_reboot
   - publiccloud/ssh_interactive_start

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -112,13 +112,14 @@ sub run {
     } else {
         $provider = $self->provider_factory();
         $instance = $provider->create_instance();
+
+        $instance->wait_for_guestregister() if is_ondemand();
+        $instance->check_guestregister();
     }
     if ($tests eq "default") {
         $tests = $img_proof_tests->{$flavor};
         die("Missing img_proof tests for $flavor - plz change img_proof.pm") unless $tests;
     }
-
-    $instance->wait_for_guestregister() if is_ondemand();
 
     my $img_proof = $provider->img_proof(
         instance => $instance,

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -71,6 +71,7 @@ sub run {
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     my $instance = $provider->create_instance(%instance_args);
     $instance->wait_for_guestregister();
+    $instance->check_guestregister();
     $args->{my_provider} = $provider;
     $args->{my_instance} = $instance;
     $instance->ssh_opts("");    # Clear $instance->ssh_opts which ombit the known hosts file and strict host checking by default

--- a/tests/publiccloud/register_addons.pm
+++ b/tests/publiccloud/register_addons.pm
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: FSFAP
 
 # Package: cloud-regionsrv-client
-# Summary: Register the remote system
+# Summary: Register addons in the remote system
+#   Registration is in registercloudguest test module
 #
 # Maintainer: <qa-c@suse.de>
 
@@ -25,16 +26,11 @@ sub run {
 
     select_host_console();    # select console on the host, not the PC instance
 
-    # The OnDemand (PAYG) images should be registered
-    # automatically by the guestregister.service
-    if (!is_ondemand()) {
-        my @addons = split(/,/, get_var('SCC_ADDONS', ''));
-        my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
-        registercloudguest($args->{my_instance});
-        for my $addon (@addons) {
-            next if ($addon =~ /^\s+$/);
-            register_addon($remote, $addon);
-        }
+    my @addons = split(/,/, get_var('SCC_ADDONS', ''));
+    my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
+    for my $addon (@addons) {
+        next if ($addon =~ /^\s+$/);
+        register_addon($remote, $addon);
     }
     record_info('repos (lr)', $args->{my_instance}->run_ssh_command(cmd => "sudo zypper lr"));
     record_info('repos (ls)', $args->{my_instance}->run_ssh_command(cmd => "sudo zypper ls"));

--- a/tests/publiccloud/registercloudguest.pm
+++ b/tests/publiccloud/registercloudguest.pm
@@ -27,8 +27,7 @@ sub run {
     # Create $instance to make the code easier to read
     my $instance = $args->{my_instance};
 
-    my $regcode = (is_byos()) ? get_required_var('SCC_REGCODE') : undef;
-    my $regcode_param = ($regcode) ? "-r $regcode" : '';
+    my $regcode_param = (is_byos()) ? "-r " . get_required_var('SCC_REGCODE') : '';
 
     select_host_console();    # select console on the host, not the PC instance
 

--- a/tests/publiccloud/registercloudguest.pm
+++ b/tests/publiccloud/registercloudguest.pm
@@ -1,0 +1,79 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: cloud-regionsrv-client
+# Summary: Test system (re)registration
+# https://github.com/SUSE-Enceladus/cloud-regionsrv-client/blob/master/integration_test-process.txt
+#
+# Maintainer: <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use version_utils;
+use registration;
+use warnings;
+use testapi;
+use strict;
+use utils;
+use publiccloud::utils;
+
+sub run {
+    my ($self, $args) = @_;
+
+    # Preserve args for post_fail_hook
+    $self->{instance} = $args->{my_instance};
+
+    # Create $instance to make the code easier to read
+    my $instance = $args->{my_instance};
+
+    my $regcode = (is_byos()) ? get_required_var('SCC_REGCODE') : undef;
+    my $regcode_param = ($regcode) ? "-r $regcode" : '';
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    # Test re-registration. Assuming the system has been registered before
+    # The `sudo SUSEConnect -d` is not supported on BYOS and should fail.
+    $instance->run_ssh_command(cmd => '! sudo SUSEConnect -d') if (is_byos());
+    $instance->run_ssh_command(cmd => 'sudo registercloudguest --clean');
+    if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600, proceed_on_failure => 1) > 2) {
+        die('The list of zypper repositories is not empty.');
+    }
+    if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l', proceed_on_failure => 1) != 0) {
+        die('Directory /etc/zypp/credentials.d/ is not empty.');
+    }
+
+    # The SUSEConnect registration should still work on BYOS
+    if (is_byos()) {
+        $instance->run_ssh_command(cmd => 'sudo SUSEConnect --version');
+        $instance->run_ssh_command(cmd => "sudo SUSEConnect $regcode_param");
+        $instance->run_ssh_command(cmd => 'sudo registercloudguest --clean');
+    }
+
+    $instance->run_ssh_command(cmd => "sudo registercloudguest $regcode_param");
+    if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
+        die('The list of zypper repositories is empty.');
+    }
+    if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l') == 0) {
+        die('Directory /etc/zypp/credentials.d/ is empty.');
+    }
+
+    $instance->run_ssh_command(cmd => "sudo registercloudguest $regcode_param --force-new");
+    if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
+        die('The list of zypper repositories is empty.');
+    }
+    if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l') == 0) {
+        die('Directory /etc/zypp/credentials.d/ is empty.');
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->{instance}->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
+    if (is_azure()) {
+        record_info('azuremetadata', $self->{instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
+    }
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -97,7 +97,10 @@ sub run {
     } else {
         $provider = $self->provider_factory();
         $instance = $self->{my_instance} = $provider->create_instance();
-        $instance->wait_for_guestregister() unless is_openstack;
+        unless (is_openstack) {
+            $instance->wait_for_guestregister();
+            $instance->check_guestregister();
+        }
     }
 
     assert_script_run("cd $root_dir");

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -176,6 +176,7 @@ sub run {
     my $provider = $self->provider_factory();
     my $instance = $provider->create_instance(use_extra_disk => {size => $disk_size, type => $disk_type});
     $instance->wait_for_guestregister();
+    $instance->check_guestregister();
 
     $tags->{os_kernel_release} = $instance->run_ssh_command(cmd => 'uname -r');
     $tags->{os_kernel_version} = $instance->run_ssh_command(cmd => 'uname -v');


### PR DESCRIPTION
There are two parts:
 * `publiccloud::instance::check_guestregister()` executed right after the instance boots up.
 * `publiccloud/registercloudguest` test module deregistering, reregistering and force registering the instance.
 * `publiccloud/register_system` ➡️ `publiccloud/register_addons` register only the addons **(new change)**.

This test follows [SUSE-Enceladus/cloud-regionsrv-client/integration_test-process.txt](https://github.com/SUSE-Enceladus/cloud-regionsrv-client/blob/master/integration_test-process.txt)

- Related ticket: [poo#109304](https://progress.opensuse.org/issues/109304)
- Verification run: [12-SP4 GCE BYOS containers](http://pdostal-server.suse.cz/tests/14361), [12-SP5 EC2 img_proof](http://pdostal-server.suse.cz/tests/14359), [15-SP1 Azure BYOS gen2 consoletests](http://pdostal-server.suse.cz/tests/14360), [15-SP3 EC2 consoletests](http://pdostal-server.suse.cz/tests/14362), [15-SP3 EC2 BYOS ARM containers](http://pdostal-server.suse.cz/tests/14354), [15-SP4 Azure BYOS gen2 fio](http://pdostal-server.suse.cz/tests/14348)
