### PR TITLE
Enlarge counter value to match expected snapshot

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -273,11 +273,11 @@ sub boot_into_snapshot {
     }
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
-        send_key_until_needlematch('snap-before-update', 'down', 40, 5);
+        send_key_until_needlematch('snap-before-update', 'down', 60, 5);
         save_screenshot;
     }
     # in an online migration
-    send_key_until_needlematch('snap-before-migration', 'down', 40, 5) if (get_var('ONLINE_MIGRATION'));
+    send_key_until_needlematch('snap-before-migration', 'down', 60, 5) if (get_var('ONLINE_MIGRATION'));
     save_screenshot;
     send_key 'ret';
     # avoid timeout for booting to HDD


### PR DESCRIPTION
For some regression test modules, it need to install some packages
by "zypper" before performing regression test, where snapshots are
created. Now need to press more times 'down' key to find the snapshot
of before migration. This PR is going to enlarge counter value to match
expected snapshot.

- Related ticket: https://progress.opensuse.org/issues/109283
- Needles: N/A
- Verification run:
http://openqa.nue.suse.com/tests/8459275#step/grub_test_snapshot/62
http://openqa.nue.suse.com/tests/8459278#step/grub_test_snapshot/59
