### PR TITLE
adding wait time for correct screen to appear before needle matching

### DIFF
--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -35,6 +35,7 @@ sub run {
     x11_start_program('designer-qt5');
     wait_still_screen 3;
     assert_and_click("designer-qt5-start");
+    wait_still_screen 3;
     assert_screen("designer-qt5-main");
     wait_screen_change { send_key "ctrl-r" };    # run the design preview
     assert_screen("designer-qt5-preview");


### PR DESCRIPTION
In some latest runs of `libqt5_qtbase`, there is [a failure related to needle not being matched](https://openqa.suse.de/tests/8450323#step/libqt5_qtbase/27), I am adding a waiting time for correct screen to render before the needle matching.

- Related ticket: https://progress.opensuse.org/issues/108076
- Verification runs: Tried 5 runs - 
[VR1 ppc64le](https://openqa.suse.de/tests/8470409#step/libqt5_qtbase/25), [VR2](https://openqa.suse.de/tests/8470410#step/libqt5_qtbase/25), [VR3](https://openqa.suse.de/tests/8470411#step/libqt5_qtbase/25), [VR4](https://openqa.suse.de/tests/8470412#step/libqt5_qtbase/25), [VR5 s390x](https://openqa.suse.de/tests/8474799#step/libqt5_qtbase/25)
 
