### PR TITLE
LTP testing on OpenStack JeOS

### DIFF
--- a/data/publiccloud/log_instance.sh
+++ b/data/publiccloud/log_instance.sh
@@ -121,6 +121,22 @@ azure_stop_log()
     fi
 }
 
+openstack_start_log()
+{
+    read_unique_counter
+    set +e
+    openstack server start "$INSTANCE_ID" > "${OUTPUT_DIR}/$CNT""_boot_log_start.txt" 2>&1
+    set -e
+}
+
+openstack_stop_log()
+{
+    read_unique_counter
+    set +e
+    openstack server stop "$INSTANCE_ID" > "${OUTPUT_DIR}/$CNT""_boot_log_start.txt" 2>&1
+    set -e
+}
+
 read_unique_counter()
 {
     CNT=$(printf "%03d" "$(cat "$CNT_FILE" 2> /dev/null)")
@@ -163,6 +179,9 @@ case $PROVIDER in
         ;;
     GCE)
         gce_"${COMMAND}"_log
+        ;;
+    OPENSTACK)
+        openstack_"${COMMAND}"_log
         ;;
     *)
         echo "Unknown provider $PROVIDER given";

--- a/data/publiccloud/restart_instance.sh
+++ b/data/publiccloud/restart_instance.sh
@@ -59,6 +59,9 @@ case $PROVIDER in
     GCE)
         gcloud compute instances reset "$INSTANCE_ID" --zone "$ZONE"
         ;;
+    OPENSTACK)
+        openstack server reboot "$INSTANCE_ID"
+        ;;
     *)
         echo "Unknown provider $PROVIDER given";
         exit 2;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -581,6 +581,12 @@ sub load_jeos_openstack_tests {
         return;
     } else {
         loadtest "jeos/prepare_openstack", run_args => $args;
+    }
+
+    if (get_var('LTP_COMMAND_FILE')) {
+        loadtest 'publiccloud/run_ltp';
+        return;
+    } else {
         loadtest 'publiccloud/ssh_interactive_start', run_args => $args;
     }
 

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -19,7 +19,7 @@ use version_utils qw(is_sle is_public_cloud);
 use publiccloud::ssh_interactive;
 use registration;
 
-our @EXPORT = qw(select_host_console is_byos is_ondemand is_ec2 is_azure is_gce registercloudguest register_addon);
+our @EXPORT = qw(select_host_console is_byos is_ondemand is_ec2 is_azure is_gce registercloudguest register_addon register_openstack);
 
 # Select console on the test host, if force is set, the interactive session will
 # be destroyed. If called in TUNNELED environment, this function die.
@@ -111,6 +111,17 @@ sub registercloudguest {
     my $cmd_time = time();
     $instance->retry_ssh_command(cmd => "sudo registercloudguest -r $regcode", timeout => 420, retry => 3, delay => 120);
     record_info('registercloudguest time', 'The command registercloudguest took ' . (time() - $cmd_time) . ' seconds.');
+}
+
+sub register_openstack {
+    my $instance = shift;
+
+    my $regcode = get_required_var 'SCC_REGCODE';
+    my $fake_scc = get_var 'SCC_URL', '';
+
+    my $cmd = "sudo SUSEConnect -r $regcode";
+    $cmd .= " --url $fake_scc" if $fake_scc;
+    $instance->run_ssh_command(cmd => $cmd, timeout => 700, retry => 5);
 }
 
 # Check if we are a BYOS test run

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -19,6 +19,7 @@ use Mojo::File;
 use Mojo::JSON;
 use publiccloud::utils;
 use Data::Dumper;
+use version_utils;
 
 our $root_dir = '/root';
 
@@ -96,7 +97,7 @@ sub run {
     } else {
         $provider = $self->provider_factory();
         $instance = $self->{my_instance} = $provider->create_instance();
-        $instance->wait_for_guestregister();
+        $instance->wait_for_guestregister() unless is_openstack;
     }
 
     assert_script_run("cd $root_dir");
@@ -106,6 +107,7 @@ sub run {
     assert_script_run('chmod +x log_instance.sh');
 
     registercloudguest($instance) if (is_byos() && !$qam);
+    register_openstack($instance) if is_openstack;
     # in repo with LTP rpm is internal we need to manually upload package to VM
     if (get_var('LTP_RPM_MANUAL_UPLOAD')) {
         my $ltp_rpm = get_ltp_rpm($ltp_repo);


### PR DESCRIPTION
- motivation: []eOS OpenStack] Enable LTP tests](https://progress.opensuse.org/issues/107455)

As part of the OpenStack JeOS epic, we need to execute LTP tests against
JeOS openstack image. As of now it would be enough to stress *containers, syscalls and cve*

- Verification runs: 
  * [openstack-commands@64bit](http://kepler.suse.cz/tests/16353)
  * [openstack-cve@64bit](http://kepler.suse.cz/tests/16349)
  * [openstack-syscalls@64bit](http://kepler.suse.cz/tests/16357#)
  * [openstack-containers@64bit](http://kepler.suse.cz/tests/16362#)

DISCLAIMER: I haven't used any LTP_EXCLUDES in VRs