### PR TITLE
Use php8 instead of php7 from SLE15SP4 onwards

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1110,20 +1110,26 @@ sub load_console_server_tests {
     loadtest "console/apache";
     loadtest "console/dns_srv";
     loadtest "console/postgresql_server" unless (is_leap('<15.0'));
-    # TODO test on openSUSE https://progress.opensuse.org/issues/31972
     if (is_sle('12-SP1+')) {    # shibboleth-sp not available on SLES 12 GA
         loadtest "console/shibboleth";
     }
     if (!is_staging && (is_opensuse || get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/)) {
-        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-        loadtest "console/php_pcre" if is_sle;
-        # TODO test on SLE https://progress.opensuse.org/issues/31972
+        loadtest "console/php_pcre";
+        # TODO test on SLE https://progress.opensuse.org/issues/31972 
         loadtest "console/mariadb_odbc" if is_opensuse;
-        loadtest "console/php8" unless is_leap("<15.4") || is_sle("<15-SP4");
-        loadtest "console/php7";
-        loadtest "console/php7_mysql";
-        loadtest "console/php7_postgresql";
-        loadtest "console/php7_timezone";
+        if (is_leap("<15.4") || is_sle("<15-SP4")) {
+            loadtest "console/php7";
+            loadtest "console/php7_mysql";
+            loadtest "console/php7_postgresql";
+            loadtest "console/php7_timezone";
+        }
+        else {
+            loadtest "console/php7" unless is_sle;
+            loadtest "console/php8";
+            loadtest "console/php8_mysql";
+            loadtest "console/php8_postgresql";
+            loadtest "console/php8_timezone";
+        }
     }
     # TODO test on openSUSE https://progress.opensuse.org/issues/31972
     loadtest "console/apache_ssl" if is_sle;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1115,7 +1115,7 @@ sub load_console_server_tests {
     }
     if (!is_staging && (is_opensuse || get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/)) {
         loadtest "console/php_pcre";
-        # TODO test on SLE https://progress.opensuse.org/issues/31972 
+        # TODO test on SLE https://progress.opensuse.org/issues/31972
         loadtest "console/mariadb_odbc" if is_opensuse;
         if (is_leap("<15.4") || is_sle("<15-SP4")) {
             loadtest "console/php7";

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -56,7 +56,6 @@ conditional_schedule:
                 - appgeo/gdal
                 - console/rabbitmq
                 - console/rails
-                - console/php_pcre
                 - console/openqa_review
                 - console/zbar
                 - console/a2ps

--- a/tests/console/php8_mysql.pm
+++ b/tests/console/php8_mysql.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: php8-mysql mysql sudo
+# Summary: PHP8 code that interacts locally with MySQL
+#   This tests creates a MySQL database and inserts an element. Then,
+#   PHP reads the elements and writes a new one in the database. If
+#   all succeed, the test passes.
+#
+#   The test requires the Web and Scripting module on SLE
+# - Setup apache to use php8 modules
+# - Install php8-mysql mysql sud
+# - Restart mysql service
+# - Create a test database
+# - Insert a element "can you read this?"
+# - Grab a php test file from datadir, test it with curl in apache
+# - Run select manually to check for the element
+# - Drop created database
+# Maintainer: QE Core <qe-core@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+use registration qw(add_suseconnect_product get_addon_fullname);
+use apachetest;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    setup_apache2(mode => 'PHP8');
+    # install requirements
+    zypper_call "in php8-mysql mysql sudo";
+
+    systemctl 'restart mysql', timeout => 300;
+
+    test_mysql;
+}
+1;

--- a/tests/console/php8_postgresql.pm
+++ b/tests/console/php8_postgresql.pm
@@ -1,0 +1,65 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: php8 php8-pgsql postgresql*-contrib sudo unzip
+# Summary: PHP8 code that interacts locally with PostgreSQL
+#   This tests creates a PostgreSQL database and inserts an element.
+#   Then, PHP reads the elements and writes a new one in the database.
+#   If all succeed, the test passes.
+#
+#   The test requires the Web and Scripting module on SLE
+# - Setup apache2 to use php8 modules
+# - Install php8-pgsql postgresql*-contrib sudo
+# - Start postgresql service
+# - Populate postgresql with test db from data dir
+# - Run a select command
+# - Setup postgresql (password, access control)
+# - Grab php test file from datadir
+# - Run "curl --no-buffer http://localhost/test_postgresql_connector.php | grep 'can you read this?'"
+# - Run select on database to check inclusion
+# - Set PG_OLDEST, PG_LATEST and run a set of tests
+#   - Create a new database
+#   - Start/Stop/Status a database
+#   - Upgrade a postgresql instance
+#   - Cleanup database
+# - Import and run dvdrental test
+# - Cleanup postgresql database
+# Maintainer: QE Core <qe-core@suse.com>
+
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use apachetest qw(setup_apache2 setup_pgsqldb test_pgsql destroy_pgsqldb postgresql_cleanup);
+use Utils::Systemd 'systemctl';
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    # ensure apache2 + php7 installed and running
+    setup_apache2(mode => 'PHP8');
+
+    # install requirements, all postgresql versions to test db upgrade if there are multiple versions
+    zypper_call 'in php8-pgsql postgresql*-contrib sudo unzip';
+
+    # start postgresql service
+    systemctl 'start postgresql';
+
+    # setup database
+    setup_pgsqldb;
+
+    # test itself
+    test_pgsql;
+
+    # destroy database
+    destroy_pgsqldb;
+
+    # poo#62000
+    postgresql_cleanup;
+}
+
+1;

--- a/tests/console/php8_timezone.pm
+++ b/tests/console/php8_timezone.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: php8 timezone
+# Summary: Basic timezone and php extra test, to make sure php timezone is consistent with the system one.
+# Maintainer: QE Core <qe-core@suse.com>
+
+
+use base "consoletest";
+use strict;
+use warnings;
+use utils;
+use testapi;
+use apachetest;
+
+my $date_time = "a";
+my $php_time = "b";
+
+sub compare_time {
+    $date_time = script_output 'date +"%H:%M"';
+    $php_time = script_output "php8 -r 'date_default_timezone_set(\"Europe/Berlin\");echo date(\"H:i\"), \"\n\";'";
+    return ($date_time eq $php_time);
+}
+
+sub run {
+    #Preparation
+    my $self = shift;
+    $self->select_serial_terminal;
+    setup_apache2(mode => 'PHP8');
+
+    #Save current timezone
+    my $current_timezone = script_output 'timedatectl | grep "Time zone" | awk \'{print $3}\' ';
+
+    #Set timezone
+    assert_script_run 'timedatectl set-timezone Europe/Berlin';
+
+    #Compare times (if first fails, try again to cover a possible minute change)
+    if (compare_time() == 0) {
+        if (compare_time() == 0) {
+            #Cleanup and fail
+            script_run "timedatectl set-timezone $current_timezone";
+            die sprintf("Time from `date`: %s and `php date`: %s do not match", $date_time, $php_time);
+        }
+    }
+
+    #Cleanup
+    assert_script_run "timedatectl set-timezone $current_timezone";
+}
+1;

--- a/tests/console/php_pcre.pm
+++ b/tests/console/php_pcre.pm
@@ -31,7 +31,16 @@ sub run {
     assert_script_run "./test_pcrecpp";
     save_screenshot;
 
-    my $php = (is_leap('<15.0') || is_sle('<15')) ? 'php5' : 'php7';
+    my $php = '';
+    if (is_leap('<15.0') || is_sle('<15')) {
+        $php = 'php5';
+    }
+    elsif (is_leap("<15.4") || is_sle("<15-SP4")) {
+        $php = 'php7';
+    }
+    else {
+        $php = 'php8';
+    }
     zypper_call("in $php");
     assert_script_run "php simple.php | grep 'matches'";
     save_screenshot;


### PR DESCRIPTION
From SLE15 SP4 and newer versions, PHP8 will be used instead of PHP7. Same applies to Tumbleweed and Leap 15.4.

- Related ticket: https://progress.opensuse.org/issues/100940
- Needles: *not_needed*
- Verification runs:

|Distro |x86_64 |aarch64 |ppc64le |s390x |
|:---------------|:----------:|:-----------:|:-----------:|:---------:|
|Tumbleweed |[:heavy_check_mark:](https://openqa.opensuse.org/t2286235#step/php_pcre/17) |[:heavy_check_mark:](https://openqa.opensuse.org/t2286200#step/php_pcre/17) |- |- |
|Leap 15.4 |[:heavy_check_mark:](https://openqa.opensuse.org/t2286236#step/php_pcre/17) |[:heavy_check_mark:](https://openqa.opensuse.org/t2286237#step/php_pcre/17) |- |- |
|SLE 15 SP4 |[:heavy_check_mark:](https://openqa.suse.de/t8491685#step/php_pcre/17) |[:heavy_check_mark:](https://openqa.suse.de/t8491686#step/php_pcre/17) |[:heavy_check_mark:](https://openqa.suse.de/t8491687#step/php_pcre/17) |[:heavy_check_mark:](https://openqa.suse.de/t8491688#step/php_pcre/17) |
|SLE 15 SP3 |[:heavy_check_mark:](https://openqa.suse.de/t8491943#step/php_pcre/17) |- |- |- |
|SLE 12 SP5 |[:heavy_check_mark:](https://openqa.suse.de/t8491924#step/php_pcre/17) |- |- |- |

:memo: NOTE: this is a workaround to fix [#100940](https://progress.opensuse.org/issues/100940). There's an [epic](https://progress.opensuse.org/issues/109569) for unifying all the php tests in a near future.