### PR TITLE
Remove obsolete soft-fail

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -511,7 +511,7 @@ Also handle workarounds when needed.
 =cut
 sub handle_welcome_screen {
     my (%args) = @_;
-    assert_screen([qw(opensuse-welcome opensuse-welcome-boo1169203 opensuse-welcome-gnome40-activities)], $args{timeout});
+    assert_screen([qw(opensuse-welcome opensuse-welcome-gnome40-activities)], $args{timeout});
     send_key 'esc' if match_has_tag('opensuse-welcome-gnome40-activities');
     workaround_broken_opensuse_welcome_window() if match_has_tag("opensuse-welcome-boo1169203");
     untick_welcome_on_next_startup;


### PR DESCRIPTION
Remove soft-fail for [boo#1169203](https://bugzilla.opensuse.org/show_bug.cgi?id=1169203), as it hasn't been updated since 2020 and it creates false positives in opensuse_welcome module.

- Related ticket: https://progress.opensuse.org/issues/109563
- Needles: N/A
- Verification run: N/A