### PR TITLE
Enable PAM test module for leap>=15.3

### DIFF
--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -29,7 +29,7 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    die "This test module is not enabled for openSUSE Leap yet" if is_leap();
+    die "This test module is not enabled for openSUSE Leap yet" if is_leap('<15.3');
     my $version = get_required_var('VERSION');
     if (is_sle()) {
         my $qa_head_repo = "http://download.suse.de/ibs/QA:/Head/" . 'SLE-' . $version;


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/107434
Verification: http://kazhua.qa.suse.de/tests/96#