### PR TITLE
Do not wrap yast2 arguments with double quotes

### DIFF
--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -17,7 +17,7 @@ sub yast2_console_exec {
     $y2_start .= (defined($args{yast2_opts})) ?
       $args{yast2_opts} . ' ' . $args{yast2_module} :
       $args{yast2_module};
-    $y2_start .= " \"$args{args}\"" if (defined($args{args}));
+    $y2_start .= " $args{args}" if (defined($args{args}));
     $y2_start .= ';';
     # poo#40715: Hyper-V 2012 R2 serial console is unstable (a Hyper-V product bug)
     # and is in many cases loosing the 15th character, so e.g. instead of the expected


### PR DESCRIPTION
When passing a string that contains words separated by spaces as argument to the `yast2_console_exec` function, wrapping it with double quotes leads to yast2 error, unknown command. 
Not wrapping the argument with double quotes mitigates the issue.

- Related ticket: No ticket
- Needles: No needles
- Verification run: 
example when passing argument `modules target=compact` : [previous run](https://openqa.suse.de/tests/8391905#step/clone/5) (failing) | [verification run](https://openqa.suse.de/tests/8392443#step/clone/5) | [verification run TW](https://openqa.opensuse.org/tests/2285520#details)
