### PR TITLE
Revert "Fix opensuse_welcome in upgrade_Leap"

### DIFF
--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -15,15 +15,7 @@ use utils;
 use x11utils 'handle_welcome_screen';
 
 sub run {
-    # In case of upgrade scenario, check if opensuse_welcome window has been already deactivated from startup
-    if (get_var('UPGRADE')) {
-        my @tags = qw(generic-desktop opensuse-welcome);
-        push(@tags, qw(gnome-activities opensuse-welcome-gnome40-activities)) if check_var('DESKTOP', 'gnome');
-        assert_screen \@tags;
-        if (match_has_tag('opensuse-welcome') || match_has_tag('opensuse-welcome-gnome40-activities')) {
-            handle_welcome_screen;
-        }
-    }
+    handle_welcome_screen;
 }
 
 sub test_flags {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#14575

opensuse-welcome definitively needs to be handled on NON-Upgrade cases.

In Upgrade scenarios it's true, in some cases it might not show up if the old distro already showed it and 'it was disabled to auto launch' then. But the much more common scenario is that we install a fresh install, and up on first boot where we have welcome and need to handle it.