### PR TITLE
Move check target version from zypper_migration to check_os_release

### DIFF
--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -21,7 +21,7 @@ sub run {
     $self->select_serial_terminal;
 
     my %checker = ();
-    $checker{VERSION} = get_required_var('VERSION');
+    $checker{VERSION} = get_var("TARGET_VERSION", get_required_var("VERSION"));
     $checker{VERSION_ID} = $checker{VERSION};
 
     if (is_sle) {

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -149,8 +149,6 @@ sub run {
         $out = wait_serial($migration_checks, $timeout);
     }
 
-    check_migrated_version unless is_sle_micro;
-
     select_console('root-console', await_console => 0);
     # wait long time for snapper to settle down
     assert_screen 'root-console', 600;


### PR DESCRIPTION
We need to remove the check_migrated_version from zypper_migration since
check_os_release will be loaded after post_migration. This needs to realize
the check for TARGET_VERSION in check_os_release.pm

- Related ticket: https://progress.opensuse.org/issues/109410
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/tests/8492255