### PR TITLE
Increase TO value in order to display disk usage on slower machines

### DIFF
--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -30,7 +30,7 @@ my $btrfs_fs_usage = 'btrfs filesystem usage / --raw';
 
 sub get_space {
     my ($script) = @_;
-    my $script_output = script_output($script);
+    my $script_output = script_output($script, timeout => 120);
     return $script_output;
 }
 
@@ -38,7 +38,7 @@ sub snapper_cleanup {
     my ($scratch_size_gb, $scratchfile_mb) = @_;
     my $snaps_numb = "snapper list | grep number | wc -l";
 
-    script_run($btrfs_fs_usage);
+    script_run($btrfs_fs_usage, 120);
     # we want to fill up disk enough so that snapper cleanup triggers
     my $fill_space = "dd if=/dev/urandom of=data bs=1M count=$scratchfile_mb";
     my $snap_create = "snapper create --cleanup number --command '$fill_space'";
@@ -53,7 +53,7 @@ sub snapper_cleanup {
     assert_script_run("btrfs qgroup show -pcre /");
     assert_script_run("snapper list");
     clear_console;
-    script_run($btrfs_fs_usage);
+    script_run($btrfs_fs_usage, 120);
     # Get actual exclusive disk space to verify exclusive disk space is taken into account
     my $qgroup_excl_space = get_space("btrfs qgroup show  / --raw | grep 1/0 | awk -F ' ' '{print\$3}'");
     if ($qgroup_excl_space > $exp_excl_space) {
@@ -136,7 +136,7 @@ sub run {
     assert_script_run("snapper set-config NUMBER_LIMIT=0; snapper cleanup number; rm -fv data", 300);
     assert_script_run("snapper set-config NUMBER_LIMIT=$number_limit_pre NUMBER_MIN_AGE=$number_min_age_pre");
     assert_script_run("snapper get-config; snapper ls");    # final report
-    assert_script_run("$btrfs_fs_usage");    # final report
+    assert_script_run("$btrfs_fs_usage", 120);    # final report
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/103299#note-10
- Verification runs: 
Created job #8480470: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480470
Created job #8480471: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480471
Created job #8480472: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480472
Created job #8480473: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480473
Created job #8480474: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480474
Created job #8480475: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480475
Created job #8480476: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480476
Created job #8480477: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480477
Created job #8480478: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480478
Created job #8480479: sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20220407-1-jeos-filesystem@aarch64 -> https://openqa.suse.de/t8480479
```
