### PR TITLE
Fix opensuse_welcome in upgrade_Leap

### DIFF
--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -15,7 +15,17 @@ use utils;
 use x11utils 'handle_welcome_screen';
 
 sub run {
-    handle_welcome_screen;
+    # In case of upgrade scenario, check if opensuse_welcome window has been already deactivated from startup
+    if (get_var('UPGRADE')) {
+        my @tags = qw(generic-desktop opensuse-welcome);
+        push(@tags, qw(gnome-activities opensuse-welcome-gnome40-activities)) if check_var('DESKTOP', 'gnome');
+        assert_screen \@tags;
+        if (match_has_tag('opensuse-welcome') || match_has_tag('opensuse-welcome-gnome40-activities')) {
+            handle_welcome_screen;
+        }
+    } else {
+        handle_welcome_screen;
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Corrected version of #14575
This change concerns only the upgrade scenarios. When UPGRADE=1, firstly
it is checked if the welcome opensuse has already been launched during
the creation of HDD_1.
If it has been launched, then generic-desktop is being checked. If it
hasn't been launched, then handle_welcome_screen runs.

- Related ticket: https://progress.opensuse.org/issues/107620
- Needles: N/A
- Verification run: [Leap15.3->15.4 gnome](https://openqa.opensuse.org/tests/2286500#step/opensuse_welcome/1) | [Leap15.3->15.4 kde](https://openqa.opensuse.org/tests/2286503#step/opensuse_welcome/1) | [Leap15.2->15.4 gnome](https://openqa.opensuse.org/tests/2286501#step/opensuse_welcome/5) | [Leap15.2->15.4 kde](https://openqa.opensuse.org/tests/2286502#step/opensuse_welcome/5) | [create_hdd_gnome](https://openqa.opensuse.org/tests/2286504#step/opensuse_welcome/4)
