### PR TITLE
Increase timeout to list vmcores

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -351,7 +351,7 @@ sub check_function {
 
     if ($args{test_type} eq 'function') {
         # Check, that vmcore exists, otherwise fail
-        assert_script_run('ls -lah /var/crash/*/vmcore');
+        assert_script_run('ls -lah /var/crash/*/vmcore', 180);
         my $vmlinux = (is_sle("<16") || is_leap("<16.0")) ? '/boot/vmlinux-$(uname -r)*' : '/usr/lib/modules/$(uname -r)/vmlinux*';
         my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` $vmlinux";
         validate_script_output "$crash_cmd", sub { m/PANIC:\s([^\s]+)/ }, 800;


### PR DESCRIPTION
[Failure](https://openqa.suse.de/tests/8476055#step/kdump_and_crash/66)
occures often on hyperv test runs.

- Verification run [sle-15-SP3-JeOS-for-MS-HyperV-QR-x86_64-Build4.10.3-jeos-extratest@svirt-hyperv](https://openqa.suse.de/t8482094)
