### PR TITLE
Wait boot in textmode on PowerVM only

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -65,8 +65,13 @@ sub run {
     }
 
     power_action('reboot', textmode => 1);
-    reconnect_mgmt_console if is_pvm;
-    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
+    if (is_pvm) {
+        reconnect_mgmt_console;
+        $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
+    }
+    else {
+        $self->wait_boot(bootloader_time => 200);
+    }
 
     # Workaround to resolve console switch issue
     $self->select_serial_terminal;


### PR DESCRIPTION
PR14633 breaks the current logic to connect the gnome console,
it tries to connect in textmode only.

- Related ticket: https://progress.opensuse.org/issues/109133
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/8489731
