### PR TITLE
Update needle tag name in x3270_ssl

### DIFF
--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -8,7 +8,7 @@
 # Summary: x3270 for SSL support testing, with openssl s_server running on local system
 #
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#65570, poo#65615, poo#89005, poo#106504
+# Tags: poo#65570, poo#65615, poo#89005, poo#106504, poo#109566
 
 use base "x11test";
 use strict;
@@ -85,7 +85,7 @@ sub run {
     send_key "ctrl-c";
     send_key "alt-tab";
     send_key "ctrl-c";
-    assert_screen 'generic-desktop';
+    assert_screen 'x3270_ssl_desktop';
 
     # Terminate openssl s_server
     select_console 'root-console';


### PR DESCRIPTION
Change the needle tag name in `x3270_ssl` from `generic-desktop` to `x3270_ssl_desktop`.

- Related ticket: https://progress.opensuse.org/issues/109566
- Needles: 
  There are two needles added with the `x3270_ssl_desktop` tag name:
  - https://openqa.suse.de/tests/8490264#step/x3270_ssl/22
  - https://openqa.suse.de/tests/8491021#step/x3270_ssl/29
- Verification run: 
  - x64: https://openqa.suse.de/tests/8490264
  - aarch64: https://openqa.suse.de/tests/8490276
  - s390x: https://openqa.suse.de/tests/8490280
  - powervm: https://openqa.suse.de/tests/8491021