### PR TITLE
Enable BCI on 3rd party hosts

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -127,6 +127,9 @@ sub install_buildah_when_needed {
         } elsif ($host_os eq 'ubuntu') {
             assert_script_run "apt-get update", timeout => 900;
             assert_script_run "apt-get -y install buildah", timeout => 300;
+        } elsif ($host_os eq 'rhel') {
+            assert_script_run('yum update -y', timeout => 300);
+            assert_script_run('yum install -y buildah', timeout => 300);
         } else {
             activate_containers_module if $host_os =~ 'sles';
             zypper_call('in buildah', timeout => 300);


### PR DESCRIPTION
Execute BCI tests against sle15sp3 based container on different 3rd
party hosts. As of now, we have covered SLE, CentOS and Ubuntu.
This PR should add leap and RHEL.

- Ticket: [Enable BCI tests on all the hosts](https://progress.opensuse.org/issues/98183)
- Verification runs:
  * [sle-15-SP3-Container-Image-Updates-x86_64-Build13.53_nodejs-12-image-bci_on_leap15_3_host_podman@64bit](http://kepler.suse.cz/tests/16397)
  * [sle-15-SP3-Container-Image-Updates-x86_64-Build13.53_nodejs-12-image-bci_on_res85_host_podman@64bit](http://kepler.suse.cz/tests/16398)
  * [sle-15-SP3-Container-Image-Updates-x86_64-Build13.53_nodejs-12-image-bci_on_leap15_2_host_podman@64bit](http://kepler.suse.cz/tests/16400)
  * [sle-15-SP3-Container-Image-Updates-x86_64-Build13.53_nodejs-12-image-bci_on_res79_host_podman@64bit](http://kepler.suse.cz/tests/16399)