### PR TITLE
Add console/check_os_release to regression yaml

### DIFF
--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -44,6 +44,7 @@ conditional_schedule:
     QCOW_GENERATION:
       0:
         - console/system_prepare
+        - console/check_os_release
         - console/check_system_info
         - console/check_network
         - console/system_state

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -25,6 +25,7 @@ conditional_schedule:
     QCOW_GENERATION:
       0:
         - console/system_prepare
+        - console/check_os_release
         - console/check_system_info
         - console/check_network
         - console/system_state

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -43,6 +43,7 @@ conditional_schedule:
     QCOW_GENERATION:
       0:
         - console/system_prepare
+        - console/check_os_release
         - console/check_system_info
         - console/check_network
         - console/system_state

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -26,6 +26,7 @@ conditional_schedule:
     QCOW_GENERATION:
       0:
         - console/system_prepare
+        - console/check_os_release
         - console/check_system_info
         - console/check_network
         - console/system_state

--- a/schedule/migration/s390x-zVM-Upgrade.yaml
+++ b/schedule/migration/s390x-zVM-Upgrade.yaml
@@ -27,6 +27,8 @@ conditional_schedule:
     REGRESSIONTEST:
       1:
         - console/system_prepare
+        - console/check_os_release
+        - console/check_system_info
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -42,6 +42,7 @@ conditional_schedule:
     QCOW_GENERATION:
       0:
         - console/system_prepare
+        - console/check_os_release
         - console/check_system_info
         - console/check_network
         - console/system_state

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -27,6 +27,7 @@ conditional_schedule:
       0:
         - console/check_upgraded_service
         - console/system_prepare
+        - console/check_os_release
         - console/check_system_info
         - console/check_network
         - console/system_state

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -42,6 +42,7 @@ conditional_schedule:
     QCOW_GENERATION:
       0:
         - console/system_prepare
+        - console/check_os_release
         - console/check_system_info
         - console/check_network
         - console/system_state

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -25,6 +25,7 @@ conditional_schedule:
     QCOW_GENERATION:
       0:
         - console/system_prepare
+        - console/check_os_release
         - console/check_system_info
         - console/check_network
         - console/system_state


### PR DESCRIPTION
The YAML files of regression test missing the check_os_release, so we need update the yaml files to add it.


- Related ticket: https://progress.opensuse.org/issues/109590
- Needles: N/A
- Verification run: 
http://openqa.nue.suse.com/tests/8480487#live offline x86
http://openqa.nue.suse.com/tests/8480488#live online x86

https://openqa.nue.suse.com/tests/8490296#details 390 offline
https://openqa.nue.suse.com/tests/8490047#live 390 online

https://openqa.nue.suse.com/tests/8490048#live ppc64le offline
https://openqa.nue.suse.com/tests/8490049#live ppc64le online

https://openqa.nue.suse.com/tests/8490051#live aarch64 offline
https://openqa.nue.suse.com/tests/8490052 aarch64 online
