### PR TITLE
k3s uses scripts for installation

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -21,11 +21,9 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 our @EXPORT = qw(install_k3s uninstall_k3s install_kubectl install_helm);
 
 sub install_k3s {
-    my $k3s_dowload_url = get_required_var("K3S_DOWNLOAD_URL");
-    assert_script_run("curl -LO $k3s_dowload_url");
-    assert_script_run("install -c -m 744 ./k3s /usr/local/bin/k3s");
-    enter_cmd("k3s server 2>&1 | tee k3s.log &");
-    script_retry("grep 'Wrote kubeconfig /etc/rancher/k3s/k3s.yaml' k3s.log", delay => 20, retry => 10);
+    assert_script_run("curl -sfL https://get.k3s.io | sh -");
+    enter_cmd("k3s server &");
+    script_retry("test -e /etc/rancher/k3s/k3s.yaml", delay => 20, retry => 10);
     assert_script_run("k3s kubectl get node");
     script_run("mkdir \$HOME/.kube");
     script_run("rm \$HOME/.kube/config");
@@ -33,10 +31,8 @@ sub install_k3s {
 }
 
 sub uninstall_k3s {
-    my $pid = script_output("ps | grep k3s-server | head -n 1 | cut -d ' ' -f1");
-    script_run("kill $pid");
-    script_run("rm \$HOME/.kube/config");
-    script_run("rm /usr/local/bin/k3s");
+    assert_script_run("rm \$HOME/.kube/config");
+    assert_script_run("/usr/local/bin/k3s-uninstall.sh");
 }
 
 sub install_kubectl {

--- a/tests/containers/helm_k3s.pm
+++ b/tests/containers/helm_k3s.pm
@@ -24,7 +24,6 @@ sub run {
     my ($self) = @_;
 
     $self->select_serial_terminal;
-    $self->{rancher_name} = "rancher-" . get_current_job_id();
     $self->{deployment_name} = "apache-" . get_current_job_id();
     my $chart = "bitnami/apache";
 
@@ -43,7 +42,7 @@ sub run {
     assert_script_run("helm list");
 
     # Wait for deployment
-    assert_script_run("kubectl rollout status deployment/$self->{deployment_name}");
+    script_retry("kubectl rollout status deployment/$self->{deployment_name}", delay => 30, retry => 5);
     assert_script_run("kubectl describe deployment/$self->{deployment_name}");
     assert_script_run("kubectl get pods | grep $self->{deployment_name}");
     assert_script_run("kubectl describe services/$self->{deployment_name}");


### PR DESCRIPTION
Now we are downloading k3s binary and installing that manually
but there are some scripts provided to be used
https://rancher.com/docs/k3s/latest/en/installation/install-options/

- Related ticket: https://progress.opensuse.org/issues/109295
- Verification run: http://copland.arch.suse.de/tests/1408
