### PR TITLE
Correct rootless_podman userns capability check

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -139,7 +139,7 @@ sub verify_userid_on_container {
         record_soft_failure "bsc#1182428 - Issue with nsenter from podman-top";
     } else {
         validate_script_output "podman top $cid user huser", sub { /bernhard\s+bernhard/ };
-        validate_script_output "podman top $cid capeff", sub { /setuid/i };
+        validate_script_output "podman top $cid capeff", sub { /none/ };
     }
 
     ## Check if uid change within the container works as desired


### PR DESCRIPTION
No needles required

To resolve https://openqa.opensuse.org/tests/2285752#step/rootless_podman/229

Latest podman has corrected bsc#1182428 and so we didn't notice till now that this test was always incorrectly checking that setuid capability was present when we actually want the opposite