### PR TITLE
wait_boot: Check for PXE menu on machines with PXE boot

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1147,6 +1147,7 @@ sub wait_boot {
         $self->handle_pxeboot(bootloader_time => $bootloader_time, pxemenu => 'pxe-custom-kernel', pxeselect => 'pxe-custom-kernel-selected');
     }
     else {
+        assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600) if (uses_qa_net_hardware() || get_var("PXEBOOT"));
         $self->handle_grub(bootloader_time => $bootloader_time, in_grub => $in_grub);
         # part of soft failure bsc#1118456
         if (get_var('UEFI') && is_hyperv) {


### PR DESCRIPTION
On IPMI machines, GRUB menu does not show up at all and `handle_grub()` returns immediately. This may result in login prompt needle matching too early during reboot, even before the machine actually starts rebooting. The test will then try to activate a console and fail because the system is still booting. Insert an alternative needle check for PXE boot menu where applicable to prevent matching stale login prompt.

Example of failure: http://openqa.qam.suse.cz/tests/40307#step/install_ltp/2

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - With PXE: http://openqa.qam.suse.cz/tests/40615#step/update_kernel/41
  - Without PXE: https://openqa.suse.de/tests/8503763
