### PR TITLE
Implement secure boot kernel lockdown check

### DIFF
--- a/schedule/security/secureboot_kernel_lockdown.yaml
+++ b/schedule/security/secureboot_kernel_lockdown.yaml
@@ -1,0 +1,7 @@
+name: Secureboot kernel lockdown check
+description:    >
+    Verify that if we are "secure booted" that kernel lockdown is enabled
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/secureboot/kernel_lockdown

--- a/tests/security/secureboot/kernel_lockdown.pm
+++ b/tests/security/secureboot/kernel_lockdown.pm
@@ -19,8 +19,7 @@ sub run {
     validate_script_output('mokutil --sb-state', sub { m/SecureBoot enabled/ });
 
     validate_script_output('cat /sys/kernel/security/lockdown', sub { /\[integrity\]/ });
-    my $result = script_run('dd if=/dev/mem count=1');
-    if (!$result) {
+    if (script_run('dd if=/dev/mem count=1') == 0) {
         die('lockdown is NOT enabled');
     }
 }

--- a/tests/security/secureboot/kernel_lockdown.pm
+++ b/tests/security/secureboot/kernel_lockdown.pm
@@ -1,0 +1,33 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Verify that if we are "secure booted" that kernel lockdown is enabled
+#
+# Maintainer: rfan1 <richard.fan@suse.com>
+# Tags: poo#109611
+
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    # Make sure system is secureboot enabled
+    validate_script_output('mokutil --sb-state', sub { m/SecureBoot enabled/ });
+
+    # Print the context of "/sys/kernel/security/lockdown" file
+    my $file_cont = script_output('cat /sys/kernel/security/lockdown');
+    record_info('lockdown info', "$file_cont");
+
+    # Make sure lockdown is enabled
+    validate_script_output('if grep "\[none\]" /sys/kernel/security/lockdown; then echo "FAIL"; else echo "PASS"; fi', sub { /PASS/ });
+    my $result = script_run('dd if=/dev/mem count=1');
+    if (!$result) {
+        die('lockdown is NOT enabled');
+    }
+}
+
+1;

--- a/tests/security/secureboot/kernel_lockdown.pm
+++ b/tests/security/secureboot/kernel_lockdown.pm
@@ -18,12 +18,7 @@ sub run {
     # Make sure system is secureboot enabled
     validate_script_output('mokutil --sb-state', sub { m/SecureBoot enabled/ });
 
-    # Print the context of "/sys/kernel/security/lockdown" file
-    my $file_cont = script_output('cat /sys/kernel/security/lockdown');
-    record_info('lockdown info', "$file_cont");
-
-    # Make sure lockdown is enabled
-    validate_script_output('if grep "\[none\]" /sys/kernel/security/lockdown; then echo "FAIL"; else echo "PASS"; fi', sub { /PASS/ });
+    validate_script_output('cat /sys/kernel/security/lockdown', sub { /\[integrity\]/ });
     my $result = script_run('dd if=/dev/mem count=1');
     if (!$result) {
         die('lockdown is NOT enabled');


### PR DESCRIPTION
Verify that if we are "secure booted" that kernel lockdown is enabled

- Related ticket: https://progress.opensuse.org/issues/109611
- Needles: n/a
- Verification run: 
https://openqa.suse.de/tests/8490287 -x86_64 + sle
https://openqa.suse.de/tests/8491097 -aach64 + sle
https://openqa.opensuse.org/tests/2286256 -x86_64 + tw [failed case is tracked via bsc#1198101]