### PR TITLE
Fix timeout on prepare_spack_env script

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -237,7 +237,7 @@ sub prepare_spack_env {
     $self->relogin_root;
     assert_script_run 'source /etc/profile.d/lmod.sh';
     assert_script_run 'module load gnu $mpi';
-    assert_script_run '/usr/lib/spack/run-find-external.sh';
+    assert_script_run '/usr/lib/spack/run-find-external.sh', timeout => 300;
     assert_script_run 'source /usr/share/spack/setup-env.sh';
 }
 

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -21,8 +21,8 @@ sub run ($self) {
     my $cluster_nodes = join(',', @cluster_nodes);
     $self->prepare_spack_env($mpi);
     record_info 'spack', script_output 'zypper -q info spack';
-    record_info 'boost spec', script_output 'spack spec boost';
-    assert_script_run "spack install boost+mpi^$mpi", timeout => 3600;
+    record_info 'boost spec', script_output('spack spec boost', timeout => 360);
+    assert_script_run "spack install boost+mpi^$mpi", timeout => 12000;
     assert_script_run 'spack load boost';
     record_info 'boost info', script_output 'spack info boost';
 

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -13,7 +13,7 @@ use utils;
 sub run ($self) {
     my $mpi = $self->get_mpi();
     $self->prepare_spack_env($mpi);
-    assert_script_run "spack install boost+mpi^$mpi", timeout => 3600;
+    assert_script_run "spack install boost+mpi^$mpi", timeout => 12000;
     assert_script_run 'spack load boost';
 
     record_info 'boost info', script_output 'spack info boost';


### PR DESCRIPTION
Mainly this seems to affect aarch64 (x86_64) looks that works just find within
the default timeout. In additional this seems to be an issue for
`run-find-external.sh`.

TODO: However the script it self needs investigation as it looks very simple
in a quick glance

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>
