### PR TITLE
chromium: Prevent sporadic lost characters due to unresponsive address bar

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -8,15 +8,18 @@
 # Summary: Basic test of chromium visiting an html-test
 # Maintainer: Stephan Kulow <coolo@suse.de>
 
-use base "x11test";
-use strict;
-use warnings;
+use Mojo::Base 'x11test', -signatures;
 use testapi;
 use utils;
 
 # Prevent lost characters due to temporary unresponsiveness of chromium address bar.
+# It looks like chromium becomes unresponsive after typing about 3
+# characters, likely due to some auto-completion feature.
 # See https://progress.opensuse.org/issues/109737 for details
-sub enter_address { enter_cmd @_, max_interval => utils::SLOW_TYPING_SPEED }
+sub type_address ($string) {
+    type_string substr($string, 0, 3), @_, max_interval => utils::SLOW_TYPING_SPEED;
+    enter_cmd substr($string, 3), @_;
+}
 
 sub run {
     select_console 'x11';
@@ -32,18 +35,18 @@ sub run {
     # Additional waiting to prevent unready address bar
     # https://progress.opensuse.org/issues/36304
     assert_screen 'chromium-highlighted-urlbar';
-    enter_address('chrome://version ');
+    type_address('chrome://version ');
     assert_screen 'chromium-about';
 
     send_key 'ctrl-l';
     assert_screen 'chromium-highlighted-urlbar';
-    enter_address('https://html5test.opensuse.org');
+    type_address('https://html5test.opensuse.org');
     assert_screen 'chromium-html-test', 90;
 
     # check a site with different ssl configuration (boo#1144625)
     send_key 'ctrl-l';
     assert_screen 'chromium-highlighted-urlbar';
-    enter_address('https://upload.wikimedia.org/wikipedia/commons/d/d0/OpenSUSE_Logo.svg');
+    type_address('https://upload.wikimedia.org/wikipedia/commons/d/d0/OpenSUSE_Logo.svg');
     assert_screen 'chromium-opensuse-logo', 90;
     send_key 'alt-f4';
 }

--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -14,6 +14,10 @@ use warnings;
 use testapi;
 use utils;
 
+# Prevent lost characters due to temporary unresponsiveness of chromium address bar.
+# See https://progress.opensuse.org/issues/109737 for details
+sub enter_address { enter_cmd @_, max_interval => utils::SLOW_TYPING_SPEED }
+
 sub run {
     select_console 'x11';
     mouse_hide;
@@ -28,18 +32,18 @@ sub run {
     # Additional waiting to prevent unready address bar
     # https://progress.opensuse.org/issues/36304
     assert_screen 'chromium-highlighted-urlbar';
-    enter_cmd "chrome://version ";
+    enter_address('chrome://version ');
     assert_screen 'chromium-about';
 
     send_key 'ctrl-l';
     assert_screen 'chromium-highlighted-urlbar';
-    enter_cmd "https://html5test.opensuse.org";
+    enter_address('https://html5test.opensuse.org');
     assert_screen 'chromium-html-test', 90;
 
     # check a site with different ssl configuration (boo#1144625)
     send_key 'ctrl-l';
     assert_screen 'chromium-highlighted-urlbar';
-    enter_cmd("https://upload.wikimedia.org/wikipedia/commons/d/d0/OpenSUSE_Logo.svg");
+    enter_address('https://upload.wikimedia.org/wikipedia/commons/d/d0/OpenSUSE_Logo.svg');
     assert_screen 'chromium-opensuse-logo', 90;
     send_key 'alt-f4';
 }


### PR DESCRIPTION
The address bar of browsers has multiple functionalities so typing too
fast can cause problems like missing characters due to the system trying
to auto-complete addresses or lookup pages, services, etc.
This caused problems with a fail-ratio of 1% in case of very slim test
scenarios that only include the chromium test modules and higher fail
ratios in case of realistic, multi-module test scenarios.

The first commit uses slow typing within the address bar of chromium to
prevent that we loose characters. I checked one old and one new job and
saw that the runtime for the test module chromium increased from 2m30s
to 3m30s.

Verified with 500 runs of a reduced test scenario using the test
command:

```
name=okurz_poo109737_chromium_pr14698; start=001 end=500 openqa-clone-set \
https://openqa.opensuse.org/tests/2287796 $name \
SCHEDULE=tests/boot/boot_to_desktop,tests/x11/chromium \
CASEDIR=https://github.com/okurz/os-autoinst-distri-opensuse.git#fix/chromium_poo109737
```

with 0/500 jobs failed vs. 4/500 failed (<1%) without the change.

The second commit only types the first characters slower to save time

Verified with 500 jobs in
https://openqa.opensuse.org/tests/overview?build=okurz_poo109737_chromium_pr14698_only_first_three_characters_slow
reducing the average runtime of the test module chromium from 3m30s back to
2m30s.

Related progress issue: https://progress.opensuse.org/issues/109737