### PR TITLE
Public Cloud: Fix lsblk command in publiccloud/storage_perf test

### DIFF
--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -183,7 +183,7 @@ sub run {
     registercloudguest($instance) if is_byos();
     $instance->run_ssh_command(cmd => 'sudo zypper --gpg-auto-import-keys -q in -y fio', timeout => 600);
 
-    my $block_device = '/dev/' . $instance->run_ssh_command(cmd => 'lsblk -n -l --output NAME,MOUNTPOINT | sort | tail -n1');
+    my $block_device = '/dev/' . $instance->run_ssh_command(cmd => 'lsblk -n -l --output NAME,MOUNTPOINT | grep -v sr0 | sort | tail -n1');
     record_info('dev', "Block device under test: $block_device");
 
     for my $href (@scenario) {


### PR DESCRIPTION
- Related ticket: [poo#109394](https://progress.opensuse.org/issues/109394)
- Failing run: [OSD](https://openqa.suse.de/tests/8493915#step/storage_perf/156)
- Verification run: [pdostal-server](http://pdostal-server.suse.cz/tests/14335#step/storage_perf/177)
