### PR TITLE
Add initial podman pods test

### DIFF
--- a/data/containers/hello-kubic.yaml
+++ b/data/containers/hello-kubic.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-kubic
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: hello-kubic
+  template:
+    metadata:
+      labels:
+        app: hello-kubic
+    spec:
+      containers:
+      - name: hello-kubic
+        image: registry.opensuse.org/kubic/hello-kubic:latest
+        ports:
+        - containerPort: 8080
+        imagePullPolicy: Always
+        env:
+        # - name: MESSAGE
+        #   value: I haven't specified a message yet
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -83,6 +83,7 @@ sub load_host_tests_podman {
         # In Public Cloud we don't have internal resources
         load_image_test($run_args) unless is_public_cloud;
         load_3rd_party_image_test($run_args);
+        loadtest 'containers/podman_pods';
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
         loadtest 'containers/podman_firewall' unless (is_public_cloud || is_openstack || is_microos);
         # Buildah is not available in SLE Micro and MicroOS

--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: podman
+# Summary: Test podman pods functionality
+# - Use data/containers/hello-kubic.yaml to run pods
+# - Confirm 3 pods are spawned
+# - Clean up pods using hello-kubic.yaml
+# Maintainer: Richard Brown <rbrown@suse.com>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use utils;
+
+sub run {
+    my ($self, $args) = @_;
+    $self->select_serial_terminal;
+    my $podman = $self->containers_factory('podman');
+
+    record_info('Prep', 'Get kube yaml');
+    assert_script_run("wget " . data_url("containers/hello-kubic.yaml") . " -O hello-kubic.yaml");
+
+    record_info('Test', 'Create hello-kubic pod');
+    assert_script_run('podman play kube hello-kubic.yaml');
+
+    record_info('Test', 'Confirm pods are running');
+    record_info('pod ps', script_output('podman pod ps'));
+    assert_script_run('podman pod ps | grep "Running" | wc -l | grep -q 3');
+
+    record_info('Cleanup', 'Stop pods');
+    assert_script_run('podman play kube --down hello-kubic.yaml');
+}
+
+1;


### PR DESCRIPTION
No needles required

A nice, simple, basic commandline test to check the core functionality of podmans pod and play kube functionality

Uses a static kube.yaml stored in the openQA codebase to pull a maintained image and spin up a simple 3 pod deployment

Doesn't do any fancy networking or other nonsense, to keep it simple and suitable for use on public cloud/everywhere else we use podman

Should catch bugs like https://bugzilla.opensuse.org/show_bug.cgi?id=1198293 in the future
