### PR TITLE
klp: Remove livepatch git revision check

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -351,23 +351,30 @@ sub verify_klp_pkg_patch_is_active {
     # livepatch git revision matches the one from the package
     # description.
     my $output = script_output("uname -v");
-    my $uname_v_gitrev;
+    my $uname_pattern = '\([a-z0-9]+/(?:lp|kGraft)\)$';
+    my $uses_gitrev = is_sle('<15-sp4');
+
     chomp($output);
-    if ($output =~ m,\([a-z0-9]+/(?:lp|kGraft)-([a-z0-9]+)\)$,i) {
-        $uname_v_gitrev = lc($1);
+
+    if ($uses_gitrev) {
+        $uname_pattern = '\([a-z0-9]+/(?:lp|kGraft)-([a-z0-9]+)\)$';
     }
-    else {
+
+    unless ($output =~ m,$uname_pattern,i) {
         die "Unable to recognize livepatch tag in 'uname -v' output: '$output'";
     }
 
-    my $pkgdesc_gitrev = klp_pkg_get_gitrev($klp_pkg);
-    my $pkgdesc_gitrev_len = length($pkgdesc_gitrev);
-    my $uname_v_gitrev_len = length($uname_v_gitrev);
-    if (($pkgdesc_gitrev_len > $uname_v_gitrev_len &&
-            substr($pkgdesc_gitrev, 0, $uname_v_gitrev_len) ne $uname_v_gitrev) ||
-        ($pkgdesc_gitrev_len <= $uname_v_gitrev_len &&
-            $pkgdesc_gitrev ne substr($uname_v_gitrev, 0, $pkgdesc_gitrev_len))) {
-        die "Livepatch package GIT rev '$pkgdesc_gitrev' doesn't match '$uname_v_gitrev' from 'uname -v'";
+    if ($uses_gitrev) {
+        my $uname_v_gitrev = lc($1);
+        my $pkgdesc_gitrev = klp_pkg_get_gitrev($klp_pkg);
+        my $pkgdesc_gitrev_len = length($pkgdesc_gitrev);
+        my $uname_v_gitrev_len = length($uname_v_gitrev);
+        if (($pkgdesc_gitrev_len > $uname_v_gitrev_len &&
+                substr($pkgdesc_gitrev, 0, $uname_v_gitrev_len) ne $uname_v_gitrev) ||
+            ($pkgdesc_gitrev_len <= $uname_v_gitrev_len &&
+                $pkgdesc_gitrev ne substr($uname_v_gitrev, 0, $pkgdesc_gitrev_len))) {
+            die "Livepatch package GIT rev '$pkgdesc_gitrev' doesn't match '$uname_v_gitrev' from 'uname -v'";
+        }
     }
 
     # Verify that the livepatch module has been properly signed by


### PR DESCRIPTION
livepatch git revision check was removed from uname output, thus remove the check from test. Check for git-hash/(lp|kGraft) was kept.

Link: bsc#1196281

Verification run:
- http://quasar.suse.cz/tests/8965 (SLES 15.4)
- http://quasar.suse.cz/tests/8961 (SLES 15)
- http://quasar.suse.cz/tests/8964 (SLES 12.5)
NOTE: openSUSE does not use this test
