### PR TITLE
Disable virtio-rng-pci device

### DIFF
--- a/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
@@ -14,6 +14,8 @@ vars:
   MAX_JOB_TIME: '14400'
   ORIGINAL_TARGET_VERSION: '%VERSION%'
   PATCH: '1'
+  # disable virtio-rng-pci device to prevent device naming changes
+  QEMU_VIRTIO_RNG: '0'
   TERMINATE_AFTER_JOBS_DONE: '1'
   TIMEOUT_SCALE: '2'
   UPGRADE: '1'

--- a/schedule/ha/bv/migration/migration_online_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_online_sles_ha.yaml
@@ -14,6 +14,8 @@ vars:
   MIGRATION_METHOD: 'zypper'
   ONLINE_MIGRATION: '1'
   ORIGINAL_TARGET_VERSION: '%VERSION%'
+  # disable virtio-rng-pci device to prevent device naming changes
+  QEMU_VIRTIO_RNG: '0'
   SCC_REGISTER: 'installation'
   TIMEOUT_SCALE: '2'
   UPGRADE_TARGET_VERSION: '%VERSION%'

--- a/schedule/ha/bv/migration/migration_verify_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_verify_sles_ha.yaml
@@ -10,6 +10,8 @@ vars:
   DESKTOP: 'textmode'
   HA_CLUSTER: '1'
   QEMU_DISABLE_SNAPSHOTS: '1'
+  # disable virtio-rng-pci device to prevent device naming changes
+  QEMU_VIRTIO_RNG: '0'
   TIMEOUT_SCALE: '2'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1, UEFI_PFLASH_VARS


### PR DESCRIPTION
Recently there was an 'virtio-rng-pci' device added to openqa 
configuration. This causes shift in disk device naming and and various 
types of failures on migration tests. This PR removes the device from 
HA migration tests using 'QEMU_VIRTIO_RNG: 0'. All migration tests 
restarted with this parameter finished without issue being present.

- Related ticket: https://progress.opensuse.org/issues/109692
- Needles: No new needles
- Verification run:
Offline DVD migration:
https://openqa.suse.de/tests/8503651#dependencies
https://openqa.suse.de/tests/8504401#dependencies
Offline SCC migration:
https://openqa.suse.de/tests/8504479#dependencies
https://openqa.suse.de/tests/8506208#dependencies
Online migration:
https://openqa.suse.de/tests/8495507#dependencies
https://openqa.suse.de/tests/8504492#dependencies

