### PR TITLE
[qam] Extract 'clamav' from 'extra_tests_textmode' to meet the RAM req

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -25,7 +25,6 @@ schedule:
   - console/mta
   - console/check_default_network_manager
   - console/git
-  - console/clamav
   - console/cups
   - console/java
   - console/sqlite3

--- a/schedule/qam/common/qam-clamav.yaml
+++ b/schedule/qam/common/qam-clamav.yaml
@@ -1,7 +1,7 @@
-name: extra_tests_clamav
+name: qam-clamav
 description:    >
-    Maintainer: QE Core.
-    Extract 'clamav' module from 'extra_tests_textmode' to meet the RAM
+    Maintainer: qe-core <qe-core@suse.de>
+    Extract 'clamav' module from 'mau-extratests1' to meet the RAM
     requirements.
 schedule:
     - installation/bootloader_start

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -12,6 +12,11 @@
 # - check that clamscan is able to recognize an EICAR virus pdf, txt and zip format
 # - check that clamdscan is able to recognize an EICAR virus pdf, txt and zip format
 #
+# NOTE: As the vendor states, clamav needs at least 2GB of RAM to work smooth.
+# To avoid interference and overload the openQA, the test is extracted from its
+# original location and executed on its own dedicated test suites, qam-clamav
+# for maintenance and extra_tests_clamav in functional.
+#
 # Maintainer: Ben Chou <bchou@suse.com>
 # Tags: TC1595169, poo#46880, poo#65375, poo#80182
 


### PR DESCRIPTION
As the vendor states, `clamav` needs at least 2GB of RAM to work smooth. To avoid interference and overload the **openQA**, the test is extracted from its original location and executed on its own dedicated test suite. This was already done for functional in PR #14581.

- Related ticket: https://progress.opensuse.org/issues/109169
- Needles:
- Verification runs:

| |x86_64|aarch64|s390x|
|:---------------|:----------:|:-----------:|:---------:|
|SLE 15 SP3|[:heavy_check_mark:](https://openqa.suse.de/t8541502)|[:heavy_check_mark:](https://openqa.suse.de/tests/8541503)|[:heavy_check_mark:](https://openqa.suse.de/t8541504)|
|SLE 15 SP2|[:heavy_check_mark:](https://openqa.suse.de/t8541981)|[:heavy_check_mark:](https://openqa.suse.de/t8541979)|[:heavy_check_mark:](https://openqa.suse.de/t8541980)|
|SLE 15 SP1|[:heavy_check_mark:](https://openqa.suse.de/t8542019)|[:heavy_check_mark:](https://openqa.suse.de/t8542014)|[:heavy_check_mark:](https://openqa.suse.de/t8542015)|
|SLE 15|[:heavy_check_mark:](https://openqa.suse.de/t8542027)|[:heavy_check_mark:](https://openqa.suse.de/t8542024)|[:heavy_check_mark:](https://openqa.suse.de/t8542025)|
|SLE 12 SP5|[:heavy_check_mark:](https://openqa.suse.de/t8542044)|[:heavy_check_mark:](https://openqa.suse.de/t8542034)|[:heavy_check_mark:](https://openqa.suse.de/t8542043)|
|SLE 12 SP4|[:heavy_check_mark:](https://openqa.suse.de/t8542069)| |[:heavy_check_mark:](https://openqa.suse.de/t8542066)|
|SLE 12 SP3|[:heavy_check_mark:](https://openqa.suse.de/t8542083)| | |
|SLE 12 SP2|[:heavy_check_mark:](https://openqa.suse.de/t8542086)| | |