### PR TITLE
Remove snmp test from xen and hyperv

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -17,6 +17,16 @@ conditional_schedule:
                 - console/yast2_lan_device_settings
             x86_64:
                 - console/yast2_lan_device_settings
+    snmp:
+        MACHINE:
+            64bit:
+                - network/snmp
+            aarch64:
+                - network/snmp
+            ppc64le:
+                - network/snmp
+            s390x-kvm-sle12:
+                - network/snmp
     update_repos:
         VERSION:
             'Tumbleweed':
@@ -125,7 +135,7 @@ schedule:
     - console/sqlite3
     - console/sysctl
     - console/sysstat
-    - network/snmp
+    - '{{snmp}}'
     - console/curl_ipv6
     - console/wget_ipv6
     - console/ca_certificates_mozilla


### PR DESCRIPTION
Validate_script_output produces an unkwnown `?^` string
The test will be unscheduled from xen and hyperv tests.

- Related ticket: https://progress.opensuse.org/issues/108079
- Needles: N/A
- Verification run: pending