### PR TITLE
journal_check: Failed to start Load kdump kernel and initrd

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -334,5 +334,12 @@
             "sle": ["15-SP2", "15-SP3", "15-SP4"]
         },
         "type": "ignore"
+    },
+    "boo#1196335": {
+        "description": "Failed to start Load kdump kernel and initrd",
+        "products": {
+            "opensuse": ["Tumbleweed"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
The error appears sometimes, but not always
https://bugzilla.opensuse.org/show_bug.cgi?id=1196335

(as there is no reaction, the bug seems to not be worthy to be flagged
in stagings over and over)

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1196335
- Needles: N/A
- Verification run: Not Done
