### PR TITLE
Disable virtio-rng-pci device

### DIFF
--- a/schedule/sles4sap/migration/migration_offline_sles4sap.yaml
+++ b/schedule/sles4sap/migration/migration_offline_sles4sap.yaml
@@ -13,6 +13,8 @@ vars:
   PATCH: '1'
   UPGRADE: '1'
   ORIGINAL_TARGET_VERSION: '%VERSION%'
+  # disable virtio-rng-pci device to prevent device naming changes
+  QEMU_VIRTIO_RNG: '0'
   UPGRADE_TARGET_VERSION: '%VERSION%'
   HDDVERSION: '%ORIGIN_SYSTEM_VERSION%'
   BOOTFROM: d

--- a/schedule/sles4sap/migration/migration_online_sles4sap.yaml
+++ b/schedule/sles4sap/migration/migration_online_sles4sap.yaml
@@ -13,6 +13,8 @@ vars:
   MAX_JOB_TIME: '14400'
   MIGRATION_METHOD: zypper
   ONLINE_MIGRATION: '1'
+  # disable virtio-rng-pci device to prevent device naming changes
+  QEMU_VIRTIO_RNG: '0'
   SCC_ADDONS: ha
   SCC_PROXY_URL: '%SCC_URL%'
   SCC_REGISTER: installation


### PR DESCRIPTION
Recently there was an 'virtio-rng-pci' device added to openqa 
configuration. This causes shift in disk device naming and and various 
types of failures on migration tests. This PR removes the device from 
SLES4SAP migration tests using 'QEMU_VIRTIO_RNG: 0'. All migration 
tests restarted with this parameter finished without issue being 
present.

- Related ticket: https://progress.opensuse.org/issues/109692
- Needles: no new needles
- Verification run: 
- OFFLINE DVD
- https://openqa.suse.de/tests/8540487
- https://openqa.suse.de/tests/8540491
- OFFLINE SCC Full
- https://openqa.suse.de/tests/8540496
- https://openqa.suse.de/tests/8540498
- OFFLINE SCC 
- https://openqa.suse.de/tests/8540503
- https://openqa.suse.de/tests/8540508
- ONLINE
- https://openqa.suse.de/tests/8540506
- https://openqa.suse.de/tests/8496136