### PR TITLE
journal_check: Failed to start Load kdump kernel and initrd (also microos)

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -338,7 +338,8 @@
     "boo#1196335": {
         "description": "Failed to start Load kdump kernel and initrd",
         "products": {
-            "opensuse": ["Tumbleweed"]
+            "opensuse": ["Tumbleweed"],
+            "microos":  ["Tumbleweed"]
         },
         "type": "ignore"
     }


### PR DESCRIPTION
Also exclude this on MicroOS, where it's even more commonly seen than openSUSE Tumbleweed

- Related ticket: https://bugzilla.opensuse.org/1196335
- Needles: N/A
