### PR TITLE
Improve stability of wpa_supplicant

### DIFF
--- a/data/wpa_supplicant/wpa_supplicant_test.sh
+++ b/data/wpa_supplicant/wpa_supplicant_test.sh
@@ -35,7 +35,6 @@ function GREP {
 ## ==== Prepare environment ================================================= ##
 set -o pipefail
 trap cleanup EXIT
-set -e
 prepare
 
 
@@ -76,6 +75,9 @@ GREP "FBI Surveillance Van 4" wifi_scan.txt
 echo "OK"
 
 echo "Connecting to open wifi networks ... "
+wpa_cli -i wlan1 reconfigure
+wpa_cli -i wlan1 reassociate
+sleep 20
 wpa_cli -i wlan1 status > status.txt
 GREP "ssid=FBI Surveillance Van 4" status.txt
 GREP "wpa_state=COMPLETED" status.txt


### PR DESCRIPTION
Fixes a very common race condition, where wpa_supplicant doesn't connect
to the open test Wifi network by forcing it to re-associate.

- Related ticket: https://progress.opensuse.org/issues/106676
- Verification runs **Tumbleweed**: [8565](https://duck-norris.qam.suse.de/tests/8565) | [8566](https://duck-norris.qam.suse.de/tests/8566) | [8567](https://duck-norris.qam.suse.de/tests/8567) | [8568](https://duck-norris.qam.suse.de/tests/8568) | [8569](https://duck-norris.qam.suse.de/tests/8569) | [8570](https://duck-norris.qam.suse.de/tests/8570) | [8571](https://duck-norris.qam.suse.de/tests/8571) | [8572](https://duck-norris.qam.suse.de/tests/8572) | [8573](https://duck-norris.qam.suse.de/tests/8573) | [8574](https://duck-norris.qam.suse.de/tests/8574) | [8575](https://duck-norris.qam.suse.de/tests/8575) - all passing
- Verification runs **SLE**: [15-SP2](https://duck-norris.qam.suse.de/tests/8578) | [15-SP1](https://duck-norris.qam.suse.de/tests/8579) | [15](https://duck-norris.qam.suse.de/tests/8580) - 15-SP3 missing due to broken repos today