### PR TITLE
Fix failing zypper ref in cleanup_qam_testrepos

### DIFF
--- a/tests/console/cleanup_qam_testrepos.pm
+++ b/tests/console/cleanup_qam_testrepos.pm
@@ -30,7 +30,9 @@ sub get_repo_aliases() {
 
 sub run {
     my $self = shift;
-    return if (script_retry('zypper -n ref', timeout => (is_public_cloud ? 1200 : 300), retry => 3, delay => 30) == 0); # If all repos are OK we don't have to do anything
+    # If all repos are OK we don't have to do anything
+    return if (script_retry('zypper -n ref', timeout => (is_public_cloud ? 1200 : 300), retry => 3, delay => 30, die => 0) == 0);
+
     my $behav = get_var('QAM_TESTREPO_FAIL') // "fail";
     # Check all repositories if they are valid
     foreach my $repo (get_repo_aliases()) {


### PR DESCRIPTION
Fixes the issue, that the cleanup_qam_testrepos test dies if the first
'zypper ref' fails.

- Verification run: https://duck-norris.qam.suse.de/tests/8587
