### PR TITLE
Need not load check_system_info in migration regression test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1192,7 +1192,6 @@ sub load_consoletests {
         loadtest "console/x_vt";
     }
     loadtest "console/zypper_lr";
-    loadtest "console/check_system_info" if (is_sle && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
     # Enable installation repo from the usb, unless we boot from USB, but don't use it
     # for the installation, like in case of LiveCDs and when using http/smb/ftp mirror
     if (check_var('USBBOOT', 1) && !(is_jeos || is_livecd) && !get_var('NETBOOT')) {


### PR DESCRIPTION
We already have the check_system_info after post_migration, so we don't need load the check_system_info in regression test any more.

- Related ticket: https://progress.opensuse.org/issues/109996
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/8559441#
  daily jobs to avoid regression:
  https://openqa.nue.suse.com/tests/8559477
  https://openqa.nue.suse.com/tests/8559478