### PR TITLE
Enhance gpg testcase in FIPS env mode

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -57,6 +57,14 @@ EOF
         );
         assert_script_run("cat $egg_file");
 
+        # Kill gpg-agent service when executing gpg2 command in case gpg-agent
+        # does NOT see current environment variable: LIBGCRYPT_FORCE_FIPS_MODE=1
+        # when gpg version > 2.1
+        # Refer to bug #1198135
+        if (get_var('FIPS_ENV_MODE')) {
+            assert_script_run('gpgconf --kill gpg-agent');
+        }
+
         script_run("gpg2 -vv --batch --full-generate-key $egg_file &> /dev/$serialdev; echo gpg-finished-\$? >/dev/$serialdev", 0);
     }
     else {


### PR DESCRIPTION
Progress issue: https://progress.opensuse.org/issues/109596

kill gpg-agent service when executing gpg2 comand in case gpg-agent
does NOT see your environment variable: LIBGCRYPT_FORCE_FIPS_MODE=1
when gpg > 2.1


- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1198135
- Needles: N/A
- Kernel mode verification run:  http://openqa.suse.de/tests/8574276#step/gpg/19
- Env mode verificaiton run: https://openqa.suse.de/tests/8574277#step/gpg/21
- Root cause of test case failed: Known bug https://bugzilla.suse.com/show_bug.cgi?id=1196125