### PR TITLE
Move regionsrv-enabler-azure.timer to byos

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -231,6 +231,10 @@ sub check_guestregister {
             die('/etc/zypp/credentials.d/ is not empty');
         }
 
+        if (is_azure() && $self->run_ssh_command(cmd => 'sudo systemctl is-enabled regionsrv-enabler-azure.timer', proceed_on_failure => 1) !~ /enabled/) {
+            die('regionsrv-enabler-azure.timer is not enabled');
+        }
+
         if ($self->run_ssh_command(cmd => 'sudo stat --printf="%s" /var/log/cloudregister', proceed_on_failure => 1) != 0) {
             die('/var/log/cloudregister is not empty');
         }
@@ -250,10 +254,6 @@ sub check_guestregister {
         if ($self->run_ssh_command(cmd => 'sudo stat --printf="%s" /var/log/cloudregister', proceed_on_failure => 1) == 0) {
             die('/var/log/cloudregister is empty');
         }
-    }
-
-    if (is_azure() && $self->run_ssh_command(cmd => 'sudo systemctl is-enabled regionsrv-enabler-azure.timer', proceed_on_failure => 1) !~ /enabled/) {
-        die('regionsrv-enabler-azure.timer is not enabled');
     }
 }
 


### PR DESCRIPTION
The check for regionsrv-enabler-azure.timer should only happen for BYOS
and not for On-Demand images. This commit moves it there.

- Related ticket: https://progress.opensuse.org/issues/110076
- Verification run: [15-SP3 Azure OnDemand](https://duck-norris.qam.suse.de/tests/8591) | [15-SP3 Azure BYOS](https://duck-norris.qam.suse.de/tests/8592) | [15-SP3 Azure Incidents](https://duck-norris.qam.suse.de/tests/8593) (test runs cancelled after passing `prepare_instance`)
