### PR TITLE
Remove unnecessary scripts in the spack setup

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -235,9 +235,7 @@ sub prepare_spack_env {
     $mpi //= 'mpich';
     zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel";
     $self->relogin_root;
-    assert_script_run 'source /etc/profile.d/lmod.sh';
     assert_script_run 'module load gnu $mpi';
-    assert_script_run '/usr/lib/spack/run-find-external.sh', timeout => 300;
     assert_script_run 'source /usr/share/spack/setup-env.sh';
 }
 


### PR DESCRIPTION
Remove `source /etc/profile.d/lmod.sh` which based on the feedbacks
it should not be sourced after a relogin. If do, something would be wrong.
Also `/usr/lib/spack/run-find-external.sh` should be run from the spack
installation. So it doesnt need to repeat it.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


