### PR TITLE
Add softfail for external testkit known failure

### DIFF
--- a/tests/console/create_hdd_systemd_testkit.pm
+++ b/tests/console/create_hdd_systemd_testkit.pm
@@ -15,7 +15,7 @@ use base "consoletest";
 use testapi;
 use utils;
 
-my $testdir = '/usr/lib/systemd/test/SAP/';
+my $testdir = '/usr/lib/test/external/';
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
Implement the soft fail for the known failure in the external testkit execution. 

- Related ticket: https://progress.opensuse.org/issues/108893
- Needles: No
- Verification run: 
   SLE 15-SP2: [create_hdd_systemd_testkit](http://10.161.229.147/tests/3483) | [start_systemd_testkit_offline](http://10.161.229.147/tests/3484#step/start_systemd_testkit_offline/1)
   SLE 15-SP3: [create_hdd_systemd_testkit](http://10.161.229.147/tests/3485) | [start_systemd_testkit_offline](http://10.161.229.147/tests/3486#step/start_systemd_testkit_offline/1)
SLE 15-SP4: [create_hdd_systemd_testkit](http://10.161.229.147/tests/3489) | [start_systemd_testkit_offline](http://10.161.229.147/tests/3490#step/start_systemd_testkit_offline/1)
