### PR TITLE
Add missing guest yaml schedule file

### DIFF
--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -8,7 +8,7 @@
       <gfxmode>auto</gfxmode>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
-      <serial>serial --unit=1 --speed=115200 --parity=no</serial>
+      <serial>serial --speed=115200 --unit=<%= $get_var->('SERIALDEV') =~ s/ttyS//r %> --word=8 --parity=no --stop=1</serial>
       <terminal>serial</terminal>
       <timeout config:type="integer">10</timeout>
       <trusted_grub>false</trusted_grub>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -46,15 +46,14 @@
       <gfxmode>auto</gfxmode>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
-      <serial>serial --unit=1 --speed=115200 --parity=no</serial>
+      <serial>serial --speed=115200 --unit=<%= $get_var->('SERIALDEV') =~ s/ttyS//r %> --word=8 --parity=no --stop=1</serial>
       <timeout config:type="integer">10</timeout>
       <trusted_grub>false</trusted_grub>
       <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200</xen_append>
+      <terminal>console</terminal>
       % if ($check_var->('VERSION', '15')) {
-      <terminal>serial</terminal>
       <xen_kernel_append>dom0_max_vcpus=4 dom0_mem=8192M,max:8192M vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
       % } else {
-      <terminal>console serial</terminal>
       <xen_kernel_append>dom0_max_vcpus=4 vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
       % }
     </global>

--- a/schedule/qam/common/virt/qam_virt_install_guest.yaml
+++ b/schedule/qam/common/virt/qam_virt_install_guest.yaml
@@ -1,0 +1,18 @@
+---
+name: qam_virt_install_guest
+description:    >
+  Install guest VMs for virtualization tests.
+schedule:
+  - virt_autotest/login_console
+  - virtualization/universal/prepare_guests
+  - virtualization/universal/ssh_hypervisor_init
+  - virtualization/universal/waitfor_guests
+  - virtualization/universal/ssh_guests_init
+  - virtualization/universal/register_guests
+  - virtualization/universal/upgrade_guests
+  - virtualization/universal/patch_guests
+  - virtualization/universal/patch_and_reboot
+  - virt_autotest/login_console
+  - virtualization/universal/list_guests
+  - virtualization/universal/kernel
+  - virtualization/universal/finish


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

1. Adding schedule yaml file for guest installation which I forgot add in PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14635. 
2. Improved sle15 host autoyast templates a bit to work better with new AMD machines: using native console instead of serial

- Related ticket: https://progress.opensuse.org/issues/81094
- Needles: no
- Verification run: 
- sles15sp2 xen: http://openqa.qam.suse.cz/tests/41344#
- sles12sp4 xen: http://openqa.qam.suse.cz/tests/41342
- sles15sp3 kvm: http://openqa.qam.suse.cz/tests/41358

Some tests have also been run with other sles15sp3, sp1 and sles15, sles12sp5, sp3. It might not be necessary post them all here. 
