### PR TITLE
Replace mpi packages with the corresponding mpi modules

### DIFF
--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -72,23 +72,24 @@ sub relogin_root {
 Installs the various scientific HPC libraries and prepares the environment for use
 L<https://documentation.suse.com/sle-hpc/15-SP3/single-html/hpc-guide/#sec-compute-lib>
 
+When subroutine returns immediately returns 1 to indicate that no relogin has occurred.
+
 =cut
 sub setup_scientific_module {
     my ($self) = @_;
-    return unless get_var('HPC_LIB', '');
+    return 1 unless get_var('HPC_LIB', '');
     my $mpi = get_required_var('MPI');
-    assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
 
     if (get_var('HPC_LIB') eq 'scipy') {
         zypper_call("in python3-scipy-gnu-hpc");
-        #
-        assert_script_run("env MPICC=/usr/lib64/mpi/gcc/$mpi/bin/mpicc python3 -m pip install mpi4py");
+        assert_script_run("env MPICC=mpicc python3 -m pip install mpi4py");
 
         # Make sure that env is updated. This will run scripts like 'source /usr/share/lmod/lmod/init/bash'
         $self->relogin_root;
         # TODO smoke checks? (ex /MODULEPATH/)
         assert_script_run('module load gnu python3-scipy');
     }
+    return 0;
 }
 
 1;

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -15,9 +15,10 @@ sub run ($self) {
     my $mpi = $self->get_mpi();
 
     # python3-devel is used to install and compile /mpi4py/ deps when HPC_LIB eq scipy
-    zypper_call("in $mpi $mpi-devel gcc gcc-c++ python3-devel");
-    $self->setup_scientific_module();
-    assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
+    zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel python3-devel");
+    my $need_restart = $self->setup_scientific_module();
+    $self->relogin_root if $need_restart;
+    assert_script_run "module load gnu $mpi";
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
     barrier_wait('MPI_BINARIES_READY');


### PR DESCRIPTION
Make use of the HPC modules which are the one used in the official
documentation and simplifies the setup of the system. So no more exports
to set environment and documented tools become available out of the box.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: 

https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2314731&version=15-SP4
https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2314731&version=15-SP3