### PR TITLE
Refactor LTP whitelist module into a class

### DIFF
--- a/t/07_ltp_whitelist.t
+++ b/t/07_ltp_whitelist.t
@@ -6,7 +6,7 @@ use Test::More;
 use Test::MockModule;
 use Test::Warnings;
 use Test::MockObject;
-use LTP::WhiteList qw(override_known_failures);
+use LTP::WhiteList;
 use testapi;
 
 
@@ -20,24 +20,24 @@ subtest 'whitelist_entry_match' => sub {
         product => 'sle:15-SP3'
     };
 
-    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), $entry, "Product match regex");
+    is_deeply(LTP::WhiteList::_whitelist_entry_match($entry, $env), $entry, "Product match regex");
 
     $entry->{arch} = '^x86_64$';
-    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), undef, "Missing field in ltp-environment, doesn't match the entry");
+    is_deeply(LTP::WhiteList::_whitelist_entry_match($entry, $env), undef, "Missing field in ltp-environment, doesn't match the entry");
 
     $env->{arch} = 'foo';
-    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), undef, "Different value in ltp-environment, doesn't match the entry");
+    is_deeply(LTP::WhiteList::_whitelist_entry_match($entry, $env), undef, "Different value in ltp-environment, doesn't match the entry");
 
     $env->{arch} = 'x86_64';
-    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), $entry, "Multiple values need match");
+    is_deeply(LTP::WhiteList::_whitelist_entry_match($entry, $env), $entry, "Multiple values need match");
 
     $env->{flavor} = 'EC2-HVM';
-    is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), $entry, "Entry match with less attributes");
+    is_deeply(LTP::WhiteList::_whitelist_entry_match($entry, $env), $entry, "Entry match with less attributes");
 
     for my $attr (qw(product ltp_version revision arch kernel backend retval flavor)) {
         $entry = {$attr => '^incredible_value$'};
         $env = {$attr => "incredible_value"};
-        is_deeply(LTP::WhiteList::whitelist_entry_match($entry, $env), $entry, "Check match attribute $attr");
+        is_deeply(LTP::WhiteList::_whitelist_entry_match($entry, $env), $entry, "Check match attribute $attr");
     }
 
 };
@@ -80,53 +80,54 @@ subtest override_known_failures => sub {
     Mojo::File::path('test_known_issues.json')->spurt(Mojo::JSON::encode_json($known_issues_json));
 
     my $env = {product => 'sle:15', retval => 0};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Check override_known_failures doesn't override");
+    my $whitelist = LTP::WhiteList->new();
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Check override_known_failures doesn't override");
 
     $env = {product => 'sle:15', retval => 2};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures single retval");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures single retval");
 
     $env = {product => 'sle:15', retval => [0, 2]};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures retval array");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures retval array");
 
     $env = {product => 'sle:15', retval => [0, 2, 3]};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Check override_known_failures don't override on new error");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Check override_known_failures don't override on new error");
 
 
     $env = {product => 'sle:12', retval => 0};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override with retval=0");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override with retval=0");
 
     $env = {product => 'sle:12', retval => [0]};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override with retval=0");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override with retval=0");
 
     $env = {product => 'sle:12', retval => 1};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override");
 
     $env = {product => 'sle:12', retval => [1]};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check override_known_failures override");
 
 
     $msg = undef;
     $env = {product => 'sle:11', retval => 0};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check for zero result");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check for zero result");
     like($msg, qr/ZERO/, 'Check softrecord_message contains correct entry message ZERO');
 
     $msg = undef;
     $env = {product => 'sle:11', retval => [0, 0, 0]};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check for zero result, if all are zero");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Check for zero result, if all are zero");
     like($msg, qr/ZERO/, 'Check softrecord_message contains correct entry message ZERO');
 
     delete $self->{result};
     $msg = undef;
     $env = {product => 'sle:11', retval => [0, 0, 2, 0]};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Ignore zero and softfail");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 1, "Ignore zero and softfail");
     like($msg, qr/TWO/, 'Check softrecord_message contains correct entry message TWO');
     is($self->{result}, 'softfail', 'Result was patched to `softfail`');
 
     $env = {product => 'sle:11', retval => [0, 0, 1, 0]};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Ignore zero and fail");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Ignore zero and fail");
 
     $env = {product => 'sle:11', retval => [0, 2, 1, 0]};
-    is(override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Ignore zero and fail [2]");
+    is($whitelist->override_known_failures($self, $env, 'testsuite_01', 'test_01'), 0, "Ignore zero and fail [2]");
 
 };
 

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -16,7 +16,7 @@ use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 use serial_terminal;
 use Mojo::File 'path';
 use Mojo::JSON;
-use LTP::WhiteList 'override_known_failures';
+use LTP::WhiteList;
 require bmwqemu;
 
 sub start_result {
@@ -350,8 +350,10 @@ sub run_post_fail {
 
     $self->fail_if_running();
 
-    if ($self->{ltp_tinfo} and get_var('LTP_KNOWN_ISSUES') and $self->{result} eq 'fail') {
-        override_known_failures($self, $self->{ltp_env}, $self->{ltp_tinfo}->runfile, $self->{ltp_tinfo}->test->{name});
+    if ($self->{ltp_tinfo} and $self->{result} eq 'fail') {
+        my $whitelist = LTP::WhiteList->new();
+
+        $whitelist->override_known_failures($self, $self->{ltp_env}, $self->{ltp_tinfo}->runfile, $self->{ltp_tinfo}->test->{name});
     }
 
     if ($msg =~ qr/died/) {


### PR DESCRIPTION
Reloading the LTP known issues file multiple times is somewhat expensive and causes performance issues during LTP job initialization because every test is checked against skip entries in the file. Refactor the whitelist module into a class so that the whitelist data can be queried multiple times after being loaded once.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - ltp_kernel_misc https://openqa.suse.de/tests/8576977 (`block_dev` and `tpci` tests will not be scheduled)
  - ltp_net_rpc_tests https://openqa.suse.de/tests/8576978
  - ltp_net_rpc_tests without `LTP_KNOWN_ISSUES` https://openqa.suse.de/tests/8576979
  - ltp_syscalls https://openqa.suse.de/tests/8576980 (compare boot_ltp run time with original job: https://openqa.suse.de/tests/8554772)