### PR TITLE
Add auxiliary functions for pc instance

### DIFF
--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -32,7 +32,7 @@ sub ssh_interactive_tunnel {
     my $upload_port = get_required_var('QEMUPORT') + 1;
     my $upload_host = testapi::host_ip();
 
-    $instance->run_ssh_command(
+    $instance->ssh_script_run(
         # Create /dev/sshserial fifo on remote and tail|tee it to /dev/$serialdev on local
         #   timeout => switches to script_run instead of script_output to be used so the test will not wait for the command to end
         #   tunnel the worker port (for downloading from data/ and uploading assets / logs

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -25,7 +25,7 @@ sub run {
 
     my $cmd_time = time();
     my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;
-    $args->{my_instance}->retry_ssh_command(cmd => "sudo zypper -n ref", timeout => $ref_timeout, retry => 6, delay => 60);
+    $args->{my_instance}->ssh_script_retry("sudo zypper -n ref", timeout => $ref_timeout, retry => 6, delay => 60);
     record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');
     record_soft_failure('bsc#1195382 - Considerable decrease of zypper performance and increase of registration times') if ((time() - $cmd_time) > 240);
 

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -29,23 +29,23 @@ sub prepare_ssh_tunnel {
     assert_script_run("install -o $testapi::username -g users -m 0600 ~/.ssh/* /home/$testapi::username/.ssh/");
 
     # Skip setting root password for img_proof, because it expects the root password to NOT be set
-    $instance->run_ssh_command(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd root));
+    $instance->ssh_assert_script_run(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd root));
 
     # Permit root passwordless login over SSH
-    $instance->run_ssh_command('sudo sed -i "s/PermitRootLogin no/PermitRootLogin prohibit-password/g" /etc/ssh/sshd_config');
-    $instance->run_ssh_command('sudo systemctl reload sshd');
+    $instance->ssh_assert_script_run('sudo sed -i "s/PermitRootLogin no/PermitRootLogin prohibit-password/g" /etc/ssh/sshd_config');
+    $instance->ssh_assert_script_run('sudo systemctl reload sshd');
 
     # Copy SSH settings for remote root
-    $instance->run_ssh_command('sudo install -o root -g root -m 0700 -dD /root/.ssh');
-    $instance->run_ssh_command(sprintf("sudo install -o root -g root -m 0644 /home/%s/.ssh/authorized_keys /root/.ssh/", $instance->{username}));
+    $instance->ssh_assert_script_run('sudo install -o root -g root -m 0700 -dD /root/.ssh');
+    $instance->ssh_assert_script_run(sprintf("sudo install -o root -g root -m 0644 /home/%s/.ssh/authorized_keys /root/.ssh/", $instance->{username}));
 
     # Create remote user and set him a password
-    $instance->run_ssh_command("test -d /home/$testapi::username || sudo useradd -m $testapi::username");
-    $instance->run_ssh_command(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd $testapi::username));
+    $instance->ssh_assert_script_run("test -d /home/$testapi::username || sudo useradd -m $testapi::username");
+    $instance->ssh_assert_script_run(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd $testapi::username));
 
     # Copy SSH settings for remote user
-    $instance->run_ssh_command("sudo install -o $testapi::username -g users -m 0700 -dD /home/$testapi::username/.ssh");
-    $instance->run_ssh_command("sudo install -o $testapi::username -g users -m 0644 ~/.ssh/authorized_keys /home/$testapi::username/.ssh/");
+    $instance->ssh_assert_script_run("sudo install -o $testapi::username -g users -m 0700 -dD /home/$testapi::username/.ssh");
+    $instance->ssh_assert_script_run("sudo install -o $testapi::username -g users -m 0644 ~/.ssh/authorized_keys /home/$testapi::username/.ssh/");
 
     # Create log file for ssh tunnel
     my $ssh_sut = '/var/tmp/ssh_sut.log';

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -37,11 +37,11 @@ sub run {
         # Mitigate occasional CSP network problems (especially one CSP is prone to those issues!)
         # Delay of 2 minutes between the tries to give their network some time to recover after a failure
         script_retry("rsync --timeout=$timeout -uvahP -e ssh ~/repos '$remote:/tmp/repos'", timeout => $timeout + 10, retry => 3, delay => 120);
-        $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
-        $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar -p10 '{}' \\;");
-        $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
+        $args->{my_instance}->ssh_assert_script_run("sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
+        $args->{my_instance}->ssh_assert_script_run("sudo find /tmp/repos/ -name *.repo -exec zypper ar -p10 '{}' \\;");
+        $args->{my_instance}->ssh_assert_script_run("sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
 
-        $args->{my_instance}->run_ssh_command(cmd => "zypper lr -P");
+        $args->{my_instance}->ssh_assert_script_run("zypper lr -P");
     }
 }
 


### PR DESCRIPTION
Introduce some auxiliary functions for executing commands on a
publiccloud instance. The names follow the default testapi conventions
to remove some confusion with the almighty 'run_ssh_command' subroutine.

- Related ticket: https://progress.opensuse.org/issues/110119
- Verification run: [GCE](https://duck-norris.qam.suse.de/tests/10523)
