### PR TITLE
Add azure-nfs test

### DIFF
--- a/data/publiccloud/terraform/azure_nfstest.tf
+++ b/data/publiccloud/terraform/azure_nfstest.tf
@@ -1,0 +1,258 @@
+terraform {
+  required_providers {
+    azurerm = {
+      version = ">= 3.2.0"
+      source = "hashicorp/azurerm"
+    }
+    random = {
+      version = "= 3.1.0"
+      source = "hashicorp/random"
+    }
+  }
+}
+
+provider "azurerm" {
+    features {}
+}
+
+## ---- variables ----------------------------------------------------------- ##
+
+## general variables
+
+variable "name" {
+    default = "openqa-vm"
+}
+
+variable "tags" {
+    type = map(string)
+    default = {}
+}
+
+variable "region" {
+    default = "westeurope"
+}
+
+## vm-instance variables
+
+variable "instance_count" {
+    default = "1"
+}
+variable "type" {
+    default = "Standard_A2_v2"
+}
+
+variable "image_id" {
+    default = ""
+}
+
+variable "offer" {
+    default=""
+}
+
+variable "sku" {
+    default="gen1"
+}
+
+## ---- data ---------------------------------------------------------------- ##
+
+// IP address of the client
+data "http" "myip" {
+  url = "http://ipv4.icanhazip.com"
+}
+
+## -------------------------------------------------------------------------- ##
+
+resource "random_id" "service" {
+    keepers = {
+        name = var.name
+    }
+    byte_length = 8
+}
+
+## resource group
+
+resource "azurerm_resource_group" "openqa-group" {
+    name     = "${var.name}-${element(random_id.service.*.hex, 0)}"
+    location = var.region
+
+    tags = merge({
+            openqa_created_by = var.name
+            openqa_created_date = timestamp()
+            openqa_created_id = element(random_id.service.*.hex, 0)
+        }, var.tags)
+}
+
+## virtual network
+
+resource "azurerm_virtual_network" "openqa-network" {
+    name                = "${azurerm_resource_group.openqa-group.name}-vnet"
+    address_space       = ["192.168.0.0/16"]
+    location            = var.region
+    resource_group_name = azurerm_resource_group.openqa-group.name
+}
+
+resource "azurerm_subnet" "openqa-subnet" {
+    name                 = "${azurerm_resource_group.openqa-group.name}-subnet"
+    resource_group_name  = azurerm_resource_group.openqa-group.name
+    virtual_network_name = azurerm_virtual_network.openqa-network.name
+    address_prefixes     = ["192.168.1.0/24"]
+    service_endpoints    = ["Microsoft.Storage"]
+}
+
+resource "azurerm_public_ip" "openqa-publicip" {
+    name                         = "${azurerm_resource_group.openqa-group.name}-public-ip"
+    location                     = var.region
+    resource_group_name          = azurerm_resource_group.openqa-group.name
+    allocation_method            = "Dynamic"
+    count                        = var.instance_count
+}
+
+resource "azurerm_network_security_group" "openqa-nsg" {
+    name                = "${azurerm_resource_group.openqa-group.name}-nsg"
+    location            = var.region
+    resource_group_name = azurerm_resource_group.openqa-group.name
+
+    security_rule {
+        name                       = "SSH"
+        priority                   = 1001
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+}
+
+resource "azurerm_subnet_network_security_group_association" "openqa-net-sec-association" {
+    subnet_id                   = azurerm_subnet.openqa-subnet.id
+    network_security_group_id   = azurerm_network_security_group.openqa-nsg.id
+}
+
+resource "azurerm_network_interface" "openqa-nic" {
+    name                      = "${azurerm_resource_group.openqa-group.name}-nic"
+    location                  = var.region
+    resource_group_name       = azurerm_resource_group.openqa-group.name
+    count                     = var.instance_count
+
+    ip_configuration {
+        name                          = "${element(random_id.service.*.hex, count.index)}-nic-config"
+        subnet_id                     = azurerm_subnet.openqa-subnet.id
+        private_ip_address_allocation = "Dynamic"
+        public_ip_address_id          = element(azurerm_public_ip.openqa-publicip.*.id, count.index)
+    }
+}
+
+## storage and NFS share
+
+resource "azurerm_storage_account" "openqa-group" {
+  name                      = "storage${element(random_id.service.*.hex, 0)}"
+  resource_group_name       = azurerm_resource_group.openqa-group.name
+  location                  = azurerm_resource_group.openqa-group.location
+  account_tier              = "Premium"    # Required for NFS share
+  account_replication_type  = "LRS"
+  account_kind              = "FileStorage"
+  enable_https_traffic_only = false
+}
+
+resource "azurerm_storage_account_network_rules" "openqa-group" {
+  depends_on = [azurerm_storage_share.openqa-group]
+
+  storage_account_id         = azurerm_storage_account.openqa-group.id
+  default_action             = "Deny"
+  virtual_network_subnet_ids = [azurerm_subnet.openqa-subnet.id]
+  // AZURE LIMITATION: After setting Deny, we need to allow this host otherwise we cannot do changes or delete the resources
+  ip_rules = [chomp(data.http.myip.body)]
+  
+  private_link_access {
+    endpoint_resource_id     = azurerm_subnet.openqa-subnet.id
+  }
+}
+
+
+resource "azurerm_storage_share" "openqa-group" {
+  name                 = "nfsdata"
+  storage_account_name = azurerm_storage_account.openqa-group.name
+  quota                = 100
+  enabled_protocol     = "NFS"
+}
+
+## virtual machine
+
+resource "azurerm_image" "image" {
+    name                      = "${azurerm_resource_group.openqa-group.name}-disk1"
+    location                  = var.region
+    resource_group_name       = azurerm_resource_group.openqa-group.name
+    count = var.image_id != "" ? 1 : 0
+
+    os_disk {
+        os_type = "Linux"
+        os_state = "Generalized"
+        blob_uri = "https://openqa.blob.core.windows.net/sle-images/${var.image_id}"
+        size_gb = 30
+    }
+}
+
+resource "azurerm_linux_virtual_machine" "openqa-vm" {
+  name                = "${var.name}-${element(random_id.service.*.hex, count.index)}"
+  resource_group_name = azurerm_resource_group.openqa-group.name
+  location            = var.region
+  size                = var.type
+  computer_name       = "${var.name}-${element(random_id.service.*.hex, count.index)}"
+  admin_username      = "azureuser"
+  disable_password_authentication = true
+
+  count                 = var.instance_count
+
+  network_interface_ids = [azurerm_network_interface.openqa-nic[count.index].id]
+
+  tags = merge({
+          openqa_created_by = var.name
+          openqa_created_date = timestamp()
+          openqa_created_id = element(random_id.service.*.hex, count.index)
+      }, var.tags)
+
+  admin_ssh_key {
+    username   = "azureuser"
+    public_key = file("~/.ssh/id_rsa.pub")
+  }
+
+  os_disk {
+    name                 = "${var.name}-${element(random_id.service.*.hex, count.index)}-osdisk"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+    # SLE images are 30G by default. Uncomment this line in case we need to increase the disk size
+    # note: value can not be decreased because 30 GB is minimum allowed by Azure
+    # disk_size_gb         = 30
+  }
+
+  source_image_id =  var.image_id != "" ? azurerm_image.image.0.id : null
+  dynamic "source_image_reference" {
+    for_each = range(var.image_id != "" ? 0 : 1)
+    content {
+      publisher = var.image_id != "" ? "" : "SUSE"
+      offer     = var.image_id != "" ? "" : var.offer
+      sku       = var.image_id != "" ? "" : var.sku
+      version   = var.image_id != "" ? "" : "latest"
+    }
+  }
+}
+
+output "vm_name" {
+    value = azurerm_linux_virtual_machine.openqa-vm.*.id
+}
+
+data "azurerm_public_ip" "openqa-publicip" {
+    name                = azurerm_public_ip.openqa-publicip[count.index].name
+    resource_group_name = azurerm_linux_virtual_machine.openqa-vm.0.resource_group_name
+    count               = var.instance_count
+}
+
+output "public_ip" {
+    value = data.azurerm_public_ip.openqa-publicip.*.ip_address
+}
+
+output "resource_id" {
+    value = "${element(random_id.service.*.hex, 0)}"
+}

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -48,6 +48,8 @@ sub load_maintenance_publiccloud_tests {
             loadtest "publiccloud/sev" if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
             loadtest "publiccloud/xen" if (get_var('PUBLIC_CLOUD_XEN'));
             loadtest "publiccloud/az_l8s_nvme" if (get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'Standard_L(8|16|32|64)s_v2');
+        } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
+            loadtest("publiccloud/azure_nfs", run_args => $args);
         }
         loadtest("publiccloud/ssh_interactive_end", run_args => $args);
     }
@@ -89,7 +91,7 @@ sub load_latest_publiccloud_tests {
     elsif (get_var('PUBLIC_CLOUD_FIO')) {
         loadtest 'publiccloud/storage_perf';
     }
-    elsif (get_var('PUBLIC_CLOUD_CONSOLE_TESTS') || get_var('PUBLIC_CLOUD_CONTAINERS') || get_var('PUBLIC_CLOUD_SMOKETEST')) {
+    elsif (get_var('PUBLIC_CLOUD_CONSOLE_TESTS') || get_var('PUBLIC_CLOUD_CONTAINERS') || get_var('PUBLIC_CLOUD_SMOKETEST') || get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
         my $args = OpenQA::Test::RunArgs->new();
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/registercloudguest", run_args => $args;
@@ -109,6 +111,8 @@ sub load_latest_publiccloud_tests {
             loadtest "publiccloud/xfsprepare";
             loadtest "xfstests/run";
             loadtest "xfstests/generate_report";
+        } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
+            loadtest("publiccloud/azure_nfs", run_args => $args);
         }
         loadtest("publiccloud/ssh_interactive_end", run_args => $args);
     }

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -20,6 +20,7 @@ use version_utils;
 use constant SSH_TIMEOUT => 90;
 
 has instance_id => undef;    # unique CSP instance id
+has resource_id => undef;    # randomized resource id for all resources (e.g. resource group and storage account)
 has public_ip => undef;    # public IP of instance
 has username => undef;    # username for ssh connection
 has ssh_key => undef;    # path to ssh-key for connection

--- a/tests/publiccloud/azure_nfs.pm
+++ b/tests/publiccloud/azure_nfs.pm
@@ -1,0 +1,99 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test Azure NFS file shares
+# - Create Azure VM and Azure storage account with NFS
+# - mount the NFS share
+# - perform basic file checks there (see check_nfs_share)
+# This test uses the data/publiccloud/terraform/azure_nfstest.tf terraform profile
+# to create a VM and a storage account in its own resource group. All resources are disposed after execution
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use publiccloud::utils "select_host_console";
+
+# Mount directory for the NFS test
+my $az_nfs_dir = "/mount/nfsdata";
+
+sub check_nfs_share {
+    my $share = shift;
+
+    ##  NFS share test: Download some data and check permissions
+    # * Download a file, and set the permission to read-only by owner
+    # * Check if the permissiosn are correctly set
+    # * Check if the default user (azureuser) can not read the file
+    # * Check if hard links are working
+    # * Check if soft links are working
+    assert_script_run("cd $share");
+    assert_script_run("curl -v -o Big_Buck_Bunny_8_seconds_bird_clip.ogv " . data_url('Big_Buck_Bunny_8_seconds_bird_clip.ogv'));
+    assert_script_run("sync");
+    assert_script_run("chmod 0400 Big_Buck_Bunny_8_seconds_bird_clip.ogv");
+    assert_script_run("chown root:root Big_Buck_Bunny_8_seconds_bird_clip.ogv");
+    validate_script_output('stat -c "%a" Big_Buck_Bunny_8_seconds_bird_clip.ogv', sub { m/400/ });
+    assert_script_run("! sudo -u azureuser cat Big_Buck_Bunny_8_seconds_bird_clip.ogv >/dev/null");
+    # Check file integrity via md5sums
+    assert_script_run("md5sum Big_Buck_Bunny_8_seconds_bird_clip.ogv > Big_Buck_Bunny_8_seconds_bird_clip.ogv.md5");
+    assert_script_run("mv Big_Buck_Bunny_8_seconds_bird_clip.ogv Big_Buck_Bunny_8_seconds_bird_clip.ogv.orig");
+    # Check hard link
+    my $inode = script_output('stat -c "%i" Big_Buck_Bunny_8_seconds_bird_clip.ogv.orig');    # save inode for later comparison
+    validate_script_output('stat -c "%h" Big_Buck_Bunny_8_seconds_bird_clip.ogv.orig', sub { m/1/ });    # number of hard links must be 1
+    assert_script_run("ln Big_Buck_Bunny_8_seconds_bird_clip.ogv.orig Big_Buck_Bunny_8_seconds_bird_clip.ogv");
+    validate_script_output('stat -c "%h" Big_Buck_Bunny_8_seconds_bird_clip.ogv.orig', sub { m/2/ });    # number of hard links must now be 2
+    validate_script_output('stat -c "%h" Big_Buck_Bunny_8_seconds_bird_clip.ogv', sub { m/2/ });
+    validate_script_output('stat -c "%i" Big_Buck_Bunny_8_seconds_bird_clip.ogv', sub { m/$inode/ });    # compare inode of link
+    assert_script_run("md5sum -c Big_Buck_Bunny_8_seconds_bird_clip.ogv.md5");
+    assert_script_run("rm Big_Buck_Bunny_8_seconds_bird_clip.ogv");
+    assert_script_run("! stat Big_Buck_Bunny_8_seconds_bird_clip.ogv");
+    # Check soft link
+    assert_script_run("ln -s Big_Buck_Bunny_8_seconds_bird_clip.ogv.orig Big_Buck_Bunny_8_seconds_bird_clip.ogv");
+    assert_script_run("md5sum -c Big_Buck_Bunny_8_seconds_bird_clip.ogv.md5");
+    assert_script_run("rm Big_Buck_Bunny_8_seconds_bird_clip.ogv.orig");
+    assert_script_run("stat Big_Buck_Bunny_8_seconds_bird_clip.ogv");
+    assert_script_run("! md5sum -c Big_Buck_Bunny_8_seconds_bird_clip.ogv.md5");    # must fail, because the soft-link is broken now
+    assert_script_run("rm Big_Buck_Bunny_8_seconds_bird_clip.ogv");
+}
+
+sub run {
+    my ($self, $args) = @_;
+
+    my $instance = $args->{my_instance};
+    my $resource_id = $instance->resource_id;
+    record_info("resource_id", $resource_id);
+
+    # Create mount point and canary to check if remote nfs is mounted
+    assert_script_run("mkdir -p $az_nfs_dir");
+    assert_script_run("echo 'This is the local directory' > $az_nfs_dir/local");
+    # This is the location for the NFS file share created in the azure_nfstest.tf terraform profile
+    # See https://docs.microsoft.com/en-us/azure/storage/files/storage-files-how-to-mount-nfs-shares
+    my $share = "storage${resource_id}.file.core.windows.net:/storage${resource_id}/nfsdata";
+    script_retry("mount -t nfs \"$share\" $az_nfs_dir -o vers=4,minorversion=1,sec=sys", retry => 3, delay => 120);
+    assert_script_run("! stat $az_nfs_dir/local");    # Check for local canary
+    assert_script_run("echo 'This is the remote NFS directory' > $az_nfs_dir/remote");
+
+    check_nfs_share($az_nfs_dir);
+}
+
+sub cleanup() {
+    script_run("cd");
+    script_run("umount $az_nfs_dir");
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    cleanup();
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    cleanup();
+    $self->SUPER::post_run_hook;
+}
+
+1;

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -16,6 +16,7 @@ use publiccloud::utils "select_host_console";
 
 sub run {
     my ($self, $args) = @_;
+    die "tunnel-console requires the TUNELLED=1 setting" unless (get_var("TUNNELED"));
 
     # Only initialize tunnels, if not previously done
     if (!get_var('_SSH_TUNNELS_INITIALIZED', 0)) {


### PR DESCRIPTION
Adds the new azure_nfs test for testing the internal Azure NFS file share.
This test requires also adding a new terraform profile that includes the
creation of an Azure storage account.

- Related ticket: https://progress.opensuse.org/issues/101189
- Verification run: [Azure-NFS](https://duck-norris.qam.suse.de/tests/8807) | [GCE](http://duck-norris.qam.suse.de/tests/8808) (ensure no side effects are there)