### PR TITLE
WIP: Introduce skip_progressbars

### DIFF
--- a/lib/Installation/ProgressBarHandler/AbstractProgressBar.pm
+++ b/lib/Installation/ProgressBarHandler/AbstractProgressBar.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The abstract class introduces methods to handle
+# an abstract progreess bar with unknown content.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::ProgressBarHandler::AbstractProgressBar;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{prb_any} = $self->{app}->progressbar({type => 'YProgressBar'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self, $args) = @_;
+    return $self->{prb_any}->exist($args);
+}
+
+1;

--- a/lib/Installation/ProgressBarHandler/ProgressBarController.pm
+++ b/lib/Installation/ProgressBarHandler/ProgressBarController.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces business actions for
+#          taking care of progress bars that are shown in intermediate steps
+#          during the installation.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::ProgressBarHandler::ProgressBarController;
+use strict;
+use warnings;
+use Installation::ProgressBarHandler::AbstractProgressBar;
+use YuiRestClient;
+use YuiRestClient::Wait;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{AbstractProgressBar} = Installation::ProgressBarHandler::AbstractProgressBar->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+my $iterations = 0;
+
+sub check_progressbar_visible {
+    my ($self, %args) = @_;
+    $args{interval} //= 1;
+    $args{clean_time} //= 20;
+
+    if ($self->{AbstractProgressBar}->is_shown({timeout => 0})) {
+        $iterations = 0;
+        return 0;
+    }
+
+    $iterations++;
+    if (($iterations * $args{interval}) < $args{clean_time}) {
+        return 0;
+    }
+    return 1;
+}
+
+sub wait_progressbars_disappear {
+    my ($self, $args) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->check_progressbar_visible(%$args);
+    }, %$args);
+}
+
+1;

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -13,6 +13,7 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_nonconflicting_modules
+  - installation/skip_progressbars
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_SLES_with_GNOME
   - installation/partitioning/select_guided_setup

--- a/tests/installation/skip_progressbars.pm
+++ b/tests/installation/skip_progressbars.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Wait for any progress bar to disappear.
+# Use TIMEOUT_SCALE so expected installation time can be adjusted
+# for slower architectures.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi 'get_var';
+use Installation::ProgressBarHandler::ProgressBarController;
+
+sub run {
+    my $progressbar_controller = Installation::ProgressBarHandler::ProgressBarController->new();
+
+    my $timeout = 600 * get_var('TIMEOUT_SCALE', 1);
+    $progressbar_controller->wait_progressbars_disappear({
+            timeout => $timeout,
+            clean_time => 40,
+            interval => 2,
+            message => 'System seems to be stuck in progress bars'});
+
+}
+
+1;


### PR DESCRIPTION
- in some situations the transition between two installation screens
  is longer because something has to be updated or loaded and you will
  see some screens or popups with progress bars to entertain you.
- this code is implementing a test module that waits until progress
  bars are not displayed for 40 seconds.
- the idea is to put this before tests that otherwise would time out
  on slower plattforms.


- Related ticket: https://progress.opensuse.org/issues/108758
- Needles: https: not needed, libyui code
- Verification run: https://openqa.suse.de/tests/8580538
