### PR TITLE
wicked: Run t01_sysctl_load_files only with >= 0.6.69

### DIFF
--- a/tests/wicked/sysctl/sut/t01_sysctl_load_files.pm
+++ b/tests/wicked/sysctl/sut/t01_sysctl_load_files.pm
@@ -138,7 +138,7 @@ sub run {
     my ($self, $ctx) = @_;
     $self->select_serial_terminal();
 
-    return if $self->skip_by_wicked_version('>=0.6.68');
+    return if $self->skip_by_wicked_version('>=0.6.69');
 
     record_info('sysctl.d', script_output("ls -R @sysctl_d", proceed_on_failure => 1));
 


### PR DESCRIPTION
The https://github.com/openSUSE/wicked/pull/905 will be in wicked version `0.6.69`, thus this tests is only valid for this version.
