### PR TITLE
installation: partitioning: Add option to create ext4/xfs partition

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -33,6 +33,17 @@ sub run {
         assert_screen 'partitioning-ext4_root-btrfs_home';
         send_key 'alt-n';
     }
+    elsif (check_var('PARTITION_EDIT', 'ext4_xfs')) {
+        send_key 'alt-g';
+        send_key 'alt-n';
+        send_key 'down';
+        send_key 'alt-f';
+        type_string 'ext4';
+        send_key 'alt-i';
+        send_key 'x';
+        assert_screen 'partitioning-ext4_root-xfs_home';
+        send_key 'alt-n';
+    }
 
     # Storage NG introduces a new partitioning dialog. We detect this
     # by the existence of the "Guided Setup" button and set the


### PR DESCRIPTION
Add option to create root partition as ext4 and home partition as xfs

- Related ticket: https://progress.opensuse.org/issues/110137
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1601
- Verification run: http://10.67.133.102/tests/594
