### PR TITLE
Improve MM test mru-install-multipath-remote

### DIFF
--- a/data/supportserver/pxe/setup_pxe.sh
+++ b/data/supportserver/pxe/setup_pxe.sh
@@ -3,7 +3,7 @@
 myname="$(basename "$0")"
 kernel_dflt="client/vmlinuz"
 kernelargs_dflt=\
-"initrd=client/initrd splash=off video=1024x768-16 plymouth.ignore-serial-consoles console=ttyS0 console=tty quiet mitigations=auto"
+"initrd=client/initrd splash=off video=1024x768-16 plymouth.ignore-serial-consoles console=ttyS0 console=tty verbose mitigations=auto"
 
 if ! [ -f /usr/share/syslinux/pxelinux.0 ] ; then
 	# On a properly generated supportserver this should never happen, of course.

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -24,6 +24,7 @@ sub run {
     # We have tests that boot from HDD and wait for DVD boot menu's timeout, so
     # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
     my $timeout = get_var('UEFI') ? 140 : 80;
+    my $ready_time = get_var('USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL') ? 900 : 500;
     # Increase timeout on ipmi bare metal backend, firmware initialization takes
     # a lot of time
     $timeout += 300 if is_ipmi;
@@ -48,7 +49,7 @@ sub run {
         wait_serial('Welcome to SUSE Linux', $timeout) || die "System did not boot in $timeout seconds.";
     }
     else {
-        $self->wait_boot(bootloader_time => $timeout, nologin => $nologin);
+        $self->wait_boot(bootloader_time => $timeout, nologin => $nologin, ready_time => $ready_time);
     }
 }
 

--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -66,6 +66,7 @@ sub _set_timeout {
     ${$timeout} *= 2 if check_var_array('PATTERNS', 'all');
     # multipath installations seem to take longer (failed some time)
     ${$timeout} *= 2 if check_var('MULTIPATH', 1);
+    ${$timeout} *= 2 if get_var('USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL');
 
     # Reset timeout for migration group test cases
     if (get_var('FLAVOR') =~ /Migration/) {
@@ -182,13 +183,6 @@ sub run {
             next;
         }
         last;
-    }
-
-    if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_REPORT_PKGINSTALL')) {
-        my $jobid_server = (get_parents())->[0] or die "USE_SUPPORT_SERVER_REPORT_PKGINSTALL set, but no parent supportserver job found";
-        # notify the supportserver about current status (e.g.: meddle_multipaths.pm)
-        mutex_create("client_pkginstall_done", $jobid_server);
-        record_info("Disk I/O", "Mutex \"client_pkginstall_done\" created");
     }
 
     # Stop reboot countdown where necessary for e.g. uploading logs

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -64,7 +64,7 @@ sub run {
     if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL')) {
         # "Press ESC for boot menu"
         # Expected: match in about 5 seconds
-        assert_screen("initboot_ESC_prompt", 10);
+        assert_screen("initboot_ESC_prompt");
         send_key "esc";
 
         # Expected: the BIOS boot menu featuring a netboot entry

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -127,12 +127,6 @@ sub run {
             }
         }
     }
-    if (get_var('USE_SUPPORT_SERVER') && get_var('USE_SUPPORT_SERVER_REPORT_PKGINSTALL')) {
-        my $jobid_server = (get_parents())->[0] or die "USE_SUPPORT_SERVER_REPORT_PKGINSTALL set, but no parent supportserver job found";
-        # notify the supportserver about current status (e.g.: meddle_multipaths.pm)
-        mutex_create("client_pkginstall_start", $jobid_server);
-        record_info("Disk I/O", "Mutex \"client_pkginstall_start\" created");
-    }
 }
 
 1;

--- a/tests/support_server/meddle_multipaths.pm
+++ b/tests/support_server/meddle_multipaths.pm
@@ -39,14 +39,9 @@ sub run {
 
         # Wait until client reports that, after it properly got its system
         # disk, heavy I/O is now about to begin (see start_install.pm).
-        mutex_wait("client_pkginstall_start", $jobid_client);
         assert_script_run("/usr/local/bin/multipath_flaky_luns.sh", 30);
         $meddler_pid = script_output("/bin/cat \"$meddler_pidfile\"", 30);
         record_info("Meddling", "Client system disk: LUN meddling started. PID: $meddler_pid");
-
-        # Keep going until client reports that it is through package
-        # installation and is about to reboot (see await_install.pm)
-        mutex_wait("client_pkginstall_done", $jobid_client);
 
         # Restore the multipaths and report (cf. support_server/flaky_mp_iscsi.pm)
         script_run("kill -INT $meddler_pid");


### PR DESCRIPTION
-use verbose (not quiet) in pxe setup, it's better to see what is happening
-increase boot ready_time for PXE custom kernel, it can take some time
-increase installtion timeout when USE_SUPPORT_SERVER_PXE_CUSTOMKERNEL
-drop unnecessary mutexes, not needed because support server can do all the
 configuration without waiting for client
-use default timeout (30) for assert_screen initboot_ESC_prompt

- Related ticket: https://progress.opensuse.org/issues/94264
- Verification run: https://openqa.suse.de/tests/overview?build=pxe&distri=sle, multiple runs see `Next & previous results`
