### PR TITLE
Fix failing virt_install

### DIFF
--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -16,7 +16,7 @@ sub run {
     ensure_installed('virt-install');
     x11_start_program('xterm');
     become_root;
-    script_run('virt-install --name TESTING --memory 512 --disk none --boot cdrom --graphics vnc &', 0);
+    script_run('virt-install --name TESTING --osinfo detect=on,require=off --memory 512 --disk none --boot cdrom --graphics vnc &', 0);
     wait_still_screen(15);
     x11_start_program('vncviewer :0', target_match => 'virtman-gnome_virt-install', match_timeout => 100);
     # closing all windows


### PR DESCRIPTION
Add requires `--osinfo` parameter to the virt-install step of the test.

- Related ticket: https://progress.opensuse.org/issues/107893
- Verification run: https://duck-norris.qam.suse.de/tests/8627