### PR TITLE
Fix gnote failure on GNOME42

### DIFF
--- a/tests/x11/gnote/gnote_edit_format.pm
+++ b/tests/x11/gnote/gnote_edit_format.pm
@@ -23,6 +23,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use version_utils qw(is_sle is_tumbleweed);
 
 
 sub run {
@@ -42,6 +43,7 @@ sub run {
     send_key "ctrl-s";    #strikeline off
     send_key "ctrl-i";    #italic off
     assert_screen 'gnote-edit-format', 5;
+    assert_and_click 'close-new-note1' if (is_tumbleweed || is_sle('>=15-SP4'));
 
     $self->cleanup_gnote('gnote-new-note-matched');
 }

--- a/tests/x11/gnote/gnote_first_run.pm
+++ b/tests/x11/gnote/gnote_first_run.pm
@@ -16,10 +16,10 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_tumbleweed';
+use version_utils qw(is_tumbleweed is_sle);
 
 sub run {
-    if (is_tumbleweed) {
+    if (is_tumbleweed || is_sle('>=15-sp4')) {
         select_console('root-console');
         quit_packagekit;
         zypper_call('in gnote');

--- a/tests/x11/gnote/gnote_link_note.pm
+++ b/tests/x11/gnote/gnote_link_note.pm
@@ -38,6 +38,8 @@ sub run {
     wait_screen_change { send_key 'esc' };
     #close the note "Start Here"
     wait_screen_change { send_key 'ctrl-w' } if is_sle('<15');
+    assert_and_click 'close-start-here' if (is_tumbleweed || is_sle('>=15-SP4'));
+    assert_and_click 'close-new-note1' if (is_tumbleweed || is_sle('>=15-SP4'));
     $self->cleanup_gnote('gnote-new-note-matched');
 }
 

--- a/tests/x11/gnote/gnote_rename_title.pm
+++ b/tests/x11/gnote/gnote_rename_title.pm
@@ -16,7 +16,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_tumbleweed);
 
 
 sub run {
@@ -27,6 +27,7 @@ sub run {
     send_key "up";
     send_key "up";
     enter_cmd "new title-opensuse";
+    assert_and_click 'close-new-note-title' if (is_tumbleweed || is_sle('>=15-SP4'));
     $self->cleanup_gnote('gnote-new-note-title-matched');
 }
 

--- a/tests/x11/gnote/gnote_undo_redo.pm
+++ b/tests/x11/gnote/gnote_undo_redo.pm
@@ -24,7 +24,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_tumbleweed);
 
 
 sub undo_redo_once {
@@ -49,6 +49,7 @@ sub run {
     assert_and_click 'gnote-back2allnotes';
     assert_and_dclick 'gnote-new-note-matched';
     $self->undo_redo_once;
+    assert_and_click 'close-new-note1' if (is_tumbleweed || is_sle('>=15-SP4'));
 
     #clean: remove the created new note
     $self->cleanup_gnote('gnote-new-note-matched');


### PR DESCRIPTION
gnote won't be installed by default on SLE start from 15SP4, so we need to install it before testing.
GNOTE42 has a new UI, so we need update test cases to make them work well on GNOTE42.

- Related ticket: https://progress.opensuse.org/issues/108887
- Needles: already added when debugging on osd and o3
- Verification run: 
- SLE https://openqa.suse.de/tests/8580413
- TW https://openqa.opensuse.org/tests/2306329
