### PR TITLE
solve the spectre_v2 and spec-ctl of mitigations problem.

### DIFF
--- a/tests/cpu_bugs/mitigations.pm
+++ b/tests/cpu_bugs/mitigations.pm
@@ -129,7 +129,7 @@ sub run {
                 print "$item is vulnerabilities, but unable to get sysfs define on nosmt, try auto";
                 $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = $mitigations_list{sysfs}->{auto}->{$item};
                 if ($item eq 'spectre_v2') {
-                    $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Full generic retpoline,.*IBPB: conditional, IBRS_FW*";
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Retpolines,.*IBPB: conditional, IBRS_FW*";
                 }
             }
             if (is_qemu) {
@@ -150,7 +150,7 @@ sub run {
                     $mitigations_list{sysfs}->{default}->{spec_store_bypass} = $mitigations_list{sysfs}->{auto}->{spec_store_bypass};
                 }
                 if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/ && $item eq 'spectre_v2') {
-                    $mitigations_list{sysfs}->{auto}->{spectre_v2} = 'Mitigation: Full generic retpoline, STIBP: disabled, RSB filling';
+                    $mitigations_list{sysfs}->{auto}->{spectre_v2} = 'Mitigation: Retpolines, STIBP: disabled, RSB filling';
                     $mitigations_list{sysfs}->{'auto,nosmt'}->{spectre_v2} = $mitigations_list{sysfs}->{auto}->{spectre_v2};
                     $mitigations_list{sysfs}->{off}->{spectre_v2} = 'Vulnerable, STIBP: disabled';
                 }

--- a/tests/cpu_bugs/spectre_v2.pm
+++ b/tests/cpu_bugs/spectre_v2.pm
@@ -21,7 +21,7 @@ use Mitigation;
 
 my $eibrs_string_on = "Mitigation: Enhanced IBRS, IBPB: always-on, RSB filling";
 my $eibrs_string_default = "Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling";
-my $retpoline_string = "Mitigation: Full generic retpoline,";
+my $retpoline_string = "Mitigation: Retpolines,";
 
 our %mitigations_list =
   (
@@ -35,7 +35,7 @@ our %mitigations_list =
         on => "${retpoline_string}.*IBPB: always-on, IBRS_FW, STIBP: forced.*",
         off => "Vulnerable,.*IBPB: disabled,.*STIBP: disabled",
         auto => "${retpoline_string}.*IBPB: conditional, IBRS_FW, STIBP: conditional,.*",
-        retpoline => "Mitigation: Full generic retpoline.*",
+        retpoline => "Mitigation: Retpolines.*",
         default => "",
     },
     cmdline => [

--- a/tests/cpu_bugs/xen_domu_mitigation_test.pm
+++ b/tests/cpu_bugs/xen_domu_mitigation_test.pm
@@ -309,7 +309,7 @@ my $mitigations_auto_on_pv_haswell = {"mitigations=auto" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto'],
-'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Full generic retpoline, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Unknown.*XEN PV detected, hypervisor mitigation required'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Speculative Store Bypass disabled via prctl and seccomp'],
@@ -323,7 +323,7 @@ my $mitigations_auto_on_pv = {"mitigations=auto" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto'],
-'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Full generic retpoline, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Unknown.*XEN PV detected, hypervisor mitigation required'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Speculative Store Bypass disabled via prctl and seccomp'],
@@ -336,7 +336,7 @@ my $mitigations_auto_on_hvm = {"mitigations=auto" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Full generic retpoline, IBPB: conditional, IBRS_FW, RSB filling'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines, IBPB: conditional, IBRS_FW, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Mitigation: PTI'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Speculative Store Bypass disabled via prctl and seccomp'],
@@ -350,7 +350,7 @@ my $mitigations_auto_on_hvm_haswell = {"mitigations=auto" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Full generic retpoline, IBPB: conditional, IBRS_FW, RSB filling'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines, IBPB: conditional, IBRS_FW, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Mitigation: PTI'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Speculative Store Bypass disabled via prctl and seccomp'],
@@ -363,7 +363,7 @@ my $mitigations_on_on_pv = {"mitigations=on" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=on'],
-'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Full generic retpoline, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Unknown.*XEN PV detected, hypervisor mitigation required'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Speculative Store Bypass disabled via prctl and seccomp'],
@@ -377,7 +377,7 @@ my $mitigations_on_on_pv_haswell = {"mitigations=on" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=on'],
-'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Full generic retpoline, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines, IBPB: conditional, IBRS_FW, STIBP: conditional, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Unknown.*XEN PV detected, hypervisor mitigation required'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Speculative Store Bypass disabled via prctl and seccomp'],
@@ -391,7 +391,7 @@ my $mitigations_on_on_hvm = {"mitigations=on" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=on'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Full generic retpoline, IBPB: conditional, IBRS_FW, RSB filling'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines, IBPB: conditional, IBRS_FW, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Mitigation: PTI'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Speculative Store Bypass disabled via prctl and seccomp'],
@@ -405,7 +405,7 @@ my $mitigations_on_on_hvm_haswell = {"mitigations=on" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=on'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Full generic retpoline, IBPB: conditional, IBRS_FW, RSB filling'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines, IBPB: conditional, IBRS_FW, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Mitigation: PTI'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Speculative Store Bypass disabled via prctl and seccomp'],
@@ -566,7 +566,7 @@ sub install_domu {
               . " --vcpu=2"
               . " --vnc"
               . " --events on_reboot=destroy"
-              . " --serial pty", timeout => 3600);
+              . " --serial pty", timeout => 5400);
     }
     # Check if the DomU is up
     script_run("virsh start \"${domu_name}\"");

--- a/tests/cpu_bugs/xen_mitigations.pm
+++ b/tests/cpu_bugs/xen_mitigations.pm
@@ -97,7 +97,7 @@ my $xpti_domu_false = {"domu=false" => {
 my $spec_ctrl_no = {no => {
         default => {
             #expection string. If it doesn't appear go die
-            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk JMP, SPEC_CTRL: IBRS- SSBD-.*, Other:$',
+            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk JMP, SPEC_CTRL: IBRS- STIBP- SSBD-.*, Other:$',
 'Support for HVM VMs: MD_CLEAR', 'Support for PV VMs: MD_CLEAR', '^(XEN)   XPTI (64-bit PV only): Dom0 disabled, DomU disabled (with PCID)$', '^(XEN)   PV L1TF shadowing: Dom0 disabled, DomU disabled$']},
             #unexpection string. If it appears go die.
             unexpected => {'xl dmesg' => ['']}
@@ -106,7 +106,7 @@ my $spec_ctrl_no = {no => {
 };
 my $spec_ctrl_no_xen = {"no-xen" => {
         default => {
-            expected => {'xl dmesg' => ['Xen settings: BTI-Thunk JMP, SPEC_CTRL: IBRS- SSBD-.*, Other:$']},
+            expected => {'xl dmesg' => ['Xen settings: BTI-Thunk JMP, SPEC_CTRL: IBRS- STIBP- SSBD-.*, Other:$']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
@@ -141,14 +141,14 @@ my $spec_ctrl_hvm_0 = {"hvm=0" => {
 };
 my $spec_ctrl_msr_sc_on = {"msr-sc=on" => {
         default => {
-            expected => {'xl dmesg' => ['Support for HVM VMs: MSR_SPEC_CTRL RSB EAGER_FPU MD_CLEAR', 'Support for PV VMs: MSR_SPEC_CTRL RSB EAGER_FPU MD_CLEAR']},
+            expected => {'xl dmesg' => ['Support for HVM VMs: MSR_SPEC_CTRL RSB EAGER_FPU MD_CLEAR', 'Support for PV VMs: MSR_SPEC_CTRL EAGER_FPU MD_CLEAR']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
 };
 my $spec_ctrl_msr_sc_off = {"msr-sc=off" => {
         default => {
-            expected => {'xl dmesg' => ['Support for HVM VMs: RSB EAGER_FPU MD_CLEAR', 'Support for PV VMs: RSB EAGER_FPU MD_CLEAR']},
+            expected => {'xl dmesg' => ['Support for HVM VMs: RSB EAGER_FPU MD_CLEAR', 'Support for PV VMs: EAGER_FPU MD_CLEAR']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
@@ -184,7 +184,7 @@ my $spec_ctrl_md_clear_on = {"md-clear=on" => {
 };
 my $spec_ctrl_bti_thunk_retp_for_intel = {"bti-thunk=retpoline" => {
         default => {
-            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk RETPOLINE, SPEC_CTRL: IBRS+ SSBD-.*, Other:']},
+            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk RETPOLINE, SPEC_CTRL: IBRS+ STIBP- SSBD-.*, Other:']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
@@ -198,49 +198,49 @@ my $spec_ctrl_bti_thunk_retp_for_amd = {"bti-thunk=lfence" => {
 };
 my $spec_ctrl_bti_thunk_jmp = {"bti-thunk=jmp" => {
         default => {
-            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk JMP, SPEC_CTRL: IBRS+ SSBD-.*, Other:']},
+            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk JMP, SPEC_CTRL: IBRS+ STIBP- SSBD-.*, Other:']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
 };
 my $spec_ctrl_ibrs_off = {"ibrs=off" => {
         default => {
-            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS- SSBD-.*, Other:']},
+            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS- STIBP- SSBD-.*, Other:']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
 };
 my $spec_ctrl_ibrs_on = {"ibrs=on" => {
         default => {
-            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS+ SSBD-.*, Other:']},
+            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS+ STIBP- SSBD-.*, Other:']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
 };
 my $spec_ctrl_ibpb_off = {"ibpb=off" => {
         default => {
-            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD-.*, Other:']},
+            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. STIBP- SSBD-.*, Other:']},
             unexpected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD-.*, Other:.*IBPB']}
         }
     }
 };
 my $spec_ctrl_ibpb_on = {"ibpb=on" => {
         default => {
-            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD-.*, Other: IBPB']},
+            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. STIBP- SSBD-.*, Other: IBPB']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
 };
 my $spec_ctrl_ssbd_off = {"ssbd=off" => {
         default => {
-            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD-.*, Other:']},
+            expected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. STIBP- SSBD-.*, Other:']},
             unexpected => {'xl dmesg' => ['^(XEN) *Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD\+.*(TSX|).*, Other:']}
         }
     }
 };
 my $spec_ctrl_ssbd_on = {"ssbd=on" => {
         default => {
-            expected => {'xl dmesg' => ['Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD+.*, Other:']},
+            expected => {'xl dmesg' => ['Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. STIBP- SSBD+.*, Other:']},
             unexpected => {'xl dmesg' => ['Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD-.*, Other:']}
         }
     }
@@ -268,14 +268,14 @@ my $spec_ctrl_l1d_flsh_off = {"l1d-flush=off" => {
 };
 my $spec_ctrl_l1d_flsh_on = {"l1d-flush=on" => {
         default => {
-            expected => {'xl dmesg' => ['Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD-.*, Other: .*L1D_FLUSH']},
+            expected => {'xl dmesg' => ['Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. STIBP- SSBD-.*, Other: .*L1D_FLUSH']},
             unexpected => {},
         }
     }
 };
 my $spec_ctrl_branch_harden_on = {"branch-harden=on" => {
         default => {
-            expected => {'xl dmesg' => ['Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. SSBD-.*, Other: .*BRANCH_HARDEN']},
+            expected => {'xl dmesg' => ['Xen settings: BTI-Thunk .*, SPEC_CTRL: IBRS. STIBP- SSBD-.*, Other: .*BRANCH_HARDEN']},
             unexpected => {},
         }
     }


### PR DESCRIPTION
Modify the code of mitigations.pm,spectre_v2.pm,xen_domu_mitigation_test.pm,xen_mitigations.pm to solve the problem of spectre_v2 problem on RC1 version.

- Verification run: http://openqa.qa2.suse.asia/group_overview/39
