### PR TITLE
Add query for SIE on s390x

### DIFF
--- a/tests/qemu/kvm.pm
+++ b/tests/qemu/kvm.pm
@@ -36,6 +36,8 @@ sub run {
         }
     }
     elsif (is_s390x) {
+        # Native kvm requires SIE support (start-interpretive execution)
+        die "SIE support on s390x cpu required for native kvm" if (script_run('grep sie /proc/cpuinfo') != 0);
         enter_cmd "qemu-system-s390x -nographic -enable-kvm -kernel /boot/image -initrd /boot/initrd";
         assert_screen 'qemu-reached-target-basic-system', 60;
     }


### PR DESCRIPTION
Check for SIE (start-interpretive execution) support on the CPU, which
is a required feature for native kvm on s390x. Fail the test if SIE is
not a listed feature of the CPU.

- Related ticket: https://progress.opensuse.org/issues/110155
- Verification run: https://openqa.suse.de/t8585957 (passing) | https://openqa.suse.de/t8585957 (failing, CPU does not support SIE)
