### PR TITLE
Update executable mpirun in formatter class

### DIFF
--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -14,7 +14,7 @@ use testapi qw(get_var get_required_var);
 has mpirun => sub {
     my ($self) = shift;
     my $mpi = get_required_var('MPI');
-    $self->mpirun("/usr/lib64/mpi/gcc/$mpi/bin/mpirun");
+    $self->mpirun("mpirun");
     my @mpirun_args = ('-print-all-exitcodes');
     ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
     push @mpirun_args, '--allow-run-as-root ' if $mpi =~ m/openmpi/;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -27,6 +27,7 @@ sub run ($self) {
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
     assert_script_run "module load gnu $mpi";
+    script_run "module av";
     barrier_wait('CLUSTER_PROVISIONED');
     ## all nodes should be able to ssh to each other, as MPIs requires so
     $self->generate_and_distribute_ssh();


### PR DESCRIPTION
the formatter class construct the mpi commands. After the last update
the path is not valid as it should be already set in the env and should
be able to called directly using the path which defined from the gnu-hpc

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run:
http://aquarius.suse.cz/tests/9418
http://aquarius.suse.cz/tests/9415