### PR TITLE
Download MU only on maintenance test runs

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -43,6 +43,11 @@ sub load_maintenance_publiccloud_tests {
             loadtest "publiccloud/xfsprepare";
             loadtest "xfstests/run";
             loadtest "xfstests/generate_report";
+        } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
+            loadtest "publiccloud/smoketest";
+            loadtest "publiccloud/sev" if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
+            loadtest "publiccloud/xen" if (get_var('PUBLIC_CLOUD_XEN'));
+            loadtest "publiccloud/az_l8s_nvme" if (get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'Standard_L(8|16|32|64)s_v2');
         }
         loadtest("publiccloud/ssh_interactive_end", run_args => $args);
     }
@@ -84,7 +89,7 @@ sub load_latest_publiccloud_tests {
     elsif (get_var('PUBLIC_CLOUD_FIO')) {
         loadtest 'publiccloud/storage_perf';
     }
-    elsif (get_var('PUBLIC_CLOUD_CONSOLE_TESTS') || get_var('PUBLIC_CLOUD_CONTAINERS')) {
+    elsif (get_var('PUBLIC_CLOUD_CONSOLE_TESTS') || get_var('PUBLIC_CLOUD_CONTAINERS') || get_var('PUBLIC_CLOUD_SMOKETEST')) {
         my $args = OpenQA::Test::RunArgs->new();
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/registercloudguest", run_args => $args;
@@ -95,6 +100,11 @@ sub load_latest_publiccloud_tests {
         }
         elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
             load_container_tests();
+        } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
+            loadtest "publiccloud/smoketest";
+            loadtest "publiccloud/sev" if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
+            loadtest "publiccloud/xen" if (get_var('PUBLIC_CLOUD_XEN'));
+            loadtest "publiccloud/az_l8s_nvme" if (get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'Standard_L(8|16|32|64)s_v2');
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
             loadtest "publiccloud/xfsprepare";
             loadtest "xfstests/run";
@@ -104,8 +114,7 @@ sub load_latest_publiccloud_tests {
     }
     elsif (get_var('PUBLIC_CLOUD_UPLOAD_IMG')) {
         loadtest "publiccloud/upload_image";
-    }
-    else {
+    } else {
         die "*publiccloud - Latest* expects PUBLIC_CLOUD_* job variable. None is matched from the expected ones.";
     }
 }

--- a/schedule/publiccloud/smoketest.yml
+++ b/schedule/publiccloud/smoketest.yml
@@ -1,4 +1,6 @@
 ---
+# Note: This YAML schedule is deprecated and will be removed soon.
+
 name: publiccloud-smoketest
 description: |
   Basic smoketests on public cloud instances
@@ -15,14 +17,22 @@ conditional_schedule:
     PUBLIC_CLOUD_INSTANCE_TYPE:
       'Standard_L8s_v2':
         - publiccloud/az_l8s_nvme
+  download_repos:
+    PUBLIC_CLOUD_QAM:
+      '1':
+        - publiccloud/download_repos
+  transfer_repos:
+    PUBLIC_CLOUD_QAM:
+      '1':
+        - publiccloud/transfer_repos
 
 schedule:
   - boot/boot_to_desktop
-  - publiccloud/download_repos
+  - '{{download_repos}}'
   - publiccloud/prepare_instance
   - publiccloud/registercloudguest
   - publiccloud/register_addons
-  - publiccloud/transfer_repos
+  - '{{transfer_repos}}'
   - publiccloud/patch_and_reboot
   - publiccloud/ssh_interactive_start
   - publiccloud/instance_overview


### PR DESCRIPTION
Allow the smoketest schedule to be executed also on product-QA test runs
by disabling the steps of downloading and transferring maintenance test
updates on non-MU test runs

Also adds the schedule possibility to remove the YAML schedule and
switch to `main_publiccloud.pm` instead.

- Related ticket: https://progress.opensuse.org/issues/110088
- Verification run: [GCE](https://duck-norris.qam.suse.de/tests/8744) and [EC2](https://duck-norris.qam.suse.de/tests/8770)
- Related yaml change: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/759