### PR TITLE
Set expected value on mpi variable when openmpi2 is used

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -26,6 +26,8 @@ sub run ($self) {
     zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel python3-devel");
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
+    # for <15-SP2 the openmpi2 module is named simply openmpi
+    $mpi = 'openmpi' if ($mpi =~ /openmpi2/);
     assert_script_run "module load gnu $mpi";
     script_run "module av";
     barrier_wait('CLUSTER_PROVISIONED');

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -18,6 +18,8 @@ sub run ($self) {
     zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel python3-devel");
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
+    # for <15-SP2 the openmpi2 module is named simply openmpi
+    $mpi = 'openmpi' if ($mpi =~ /openmpi2/);
     assert_script_run "module load gnu $mpi";
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');


### PR DESCRIPTION
The mpi variable takes the openmpi2 which is used to install the gnu-hpc
modules. But the `module load` command fails to find the module as such
because is named simply as _openmpi_.

This will fix the maintanance jobs which fail for <15-SP2 versions

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: 

http://aquarius.suse.cz/tests/9442