### PR TITLE
Redesign check_system_info 

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -29,6 +29,7 @@ use nfs_common;
 use services::registered_addons;
 use services::hpcpackage_remain;
 use services::ntpd;
+use services::nodejs;
 use services::cups;
 use services::rpcbind;
 use services::users;
@@ -149,6 +150,12 @@ our $default_services = {
         srv_proc_name => 'nfs',
         support_ver => $support_ver_def,
         service_check_func => \&check_y2_nfs_func
+    },
+    nodejs => {
+        srv_pkg_name => 'nodejs',
+        srv_proc_name => 'nodejs',
+        support_ver => '>=15-SP3',
+        service_check_func => \&services::nodejs::full_nodejs_check
     },
     rpcbind => {
         srv_pkg_name => 'rpcbind',

--- a/lib/services/nodejs.pm
+++ b/lib/services/nodejs.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Package for nodejs update tests
+#
+# Maintainer: Lemon Li <leli@suse.com>
+
+package services::nodejs;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+my $service_type = 'Systemd';
+
+# check nodejs package installed as expected
+sub check_installed {
+    assert_script_run('grep -E "Installing: nodejs16" /tmp/install_nodejs.log');
+    script_run('zypper se -i nodejs | tee /tmp/search_nodejs', timeout => 60);
+    my $ret_s1 = script_output(q(grep package /tmp/search_nodejs | grep nodejs16 | awk -F\| '{print $1}'));
+    my $ret_s2 = script_output(q(grep package /tmp/search_nodejs | grep nodejs-common| awk -F\| '{print $1}'));
+    die "Expected package is not installed. ret_s1=$ret_s1' and ret_s2=$ret_s2'" if ('i' ne "$ret_s1" || 'i+' ne "$ret_s2");
+}
+
+# remove the nodejs and related log after test
+sub clean_nodejs {
+    zypper_call("rm nodejs-common");
+    assert_script_run('rm /tmp/install_nodejs.log');
+    assert_script_run('rm /tmp/search_nodejs');
+}
+
+# SLE-21783: Update nodejs-common for SLE15 SP4
+# check the nodejs16 is releaseed to SLE15 SP3 & SLE15 SP4
+# check the nodejs-common points to nodejs16
+# test steps:
+# 1) install nodejs-common on SLES15SP3 and migrated SLES15SP4 when wsm is available in SCC_ADDONS
+# 2) check nodejs16 is installed together with nodejs-common
+sub check_nodejs_common {
+    record_info('SLE-21783', 'check nodejs-common');
+    # first we check if it's been installed, if so remove it
+    zypper_call('rm nodejs-common') if (script_run('rpm -q nodejs-common') == 0);
+    zypper_call('in nodejs-common | tee /tmp/install_nodejs.log');
+    # check the new installed nodejs
+    check_installed;
+}
+
+# check nodejs before and after migration
+# stage is 'before' or 'after' system migration.
+sub full_nodejs_check {
+    my (%hash) = @_;
+    my ($stage, $type) = ($hash{stage}, $hash{service_type});
+    $service_type = $type;
+    if ($stage eq 'before') {
+        check_nodejs_common();
+    }
+    else {
+        # check the nodejs installed on base system after migration
+        check_installed();
+        check_nodejs_common();
+        clean_nodejs();
+    }
+}
+
+1;

--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -46,6 +46,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
+        - console/check_migration_features
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -27,6 +27,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
+        - console/check_migration_features
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -45,6 +45,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
+        - console/check_migration_features
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -28,6 +28,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
+        - console/check_migration_features
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -44,6 +44,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
+        - console/check_migration_features
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -29,6 +29,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
+        - console/check_migration_features
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -44,6 +44,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
+        - console/check_migration_features
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -27,6 +27,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
+        - console/check_migration_features
         - console/check_network
         - console/system_state
         - console/prepare_test_data

--- a/tests/console/check_migration_features.pm
+++ b/tests/console/check_migration_features.pm
@@ -1,0 +1,75 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Package: SUSEConnect
+# Summary: Verify migration features on target system.
+# Maintainer: Lemon Li <leli@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use Utils::Architectures;
+use utils;
+use version_utils;
+
+# SLE-21916: change bzr to breezy
+# check in the upgraded sysetem that bzr was repalced by breezy
+# test steps:
+# 1) install the bzr as usaual
+# 2) check the bzr version as usual to make sure it has breezy
+# 3) cleanup by removing the package
+sub check_bzr_to_breezy {
+    record_info('SLE-21916', 'Check bzr to breezy');
+    zypper_call('in bzr');
+
+    assert_script_run('bzr --version');
+    assert_script_run('bzr --version | grep breezy');
+    zypper_call('--no-refresh info breezy');
+
+    zypper_call("rm bzr", exitcode => [0]);
+}
+
+# SLE-20176 QA: Drop Python 2 (15 SP4)
+# check in the upgraded system to ensure Python2 dropped
+sub check_python2_dropped {
+    my $out = script_output('zypper se python2 | grep python2', proceed_on_failure => 1);
+    record_info('python2 dropped but still can be searched', 'Bug 1196533 - Python2 package still can be searched after migration to SLES15SP4', result => 'fail') if ($out =~ 'python2');
+}
+
+# SLE-23610: Python3 module
+# test steps:
+# 1) activate the python3 module
+# 2) install the python310 package
+# 3) check python3.10's version which should be 3.10.X
+# 4) check python3's version
+# 5) check python310's lifecycle
+sub check_python3_module {
+    record_info('SLE-23610', 'Check Python3 Module');
+    my $OS_VERSION = script_output("grep VERSION_ID /etc/os-release | cut -c13- | head -c -2");
+    my $ARCH = get_required_var('ARCH');
+    assert_script_run("SUSEConnect -p sle-module-python3/$OS_VERSION/$ARCH", timeout => 180);
+    zypper_call("se python310");
+    zypper_call("in python310");
+    assert_script_run("python3.10 --version | grep Python | grep 3.10.");
+    assert_script_run("python3 --version | grep Python | grep 3.6.");
+    assert_script_run("zypper lifecycle python310");
+}
+
+# function to check all the features after migration
+sub check_feature {
+    if (!get_var('MEDIA_UPGRADE')) {
+        check_bzr_to_breezy;
+        check_python3_module;
+    }
+    check_python2_dropped;
+}
+
+sub run {
+    select_console('root-console');
+    assert_script_run('setterm -blank 0') unless (is_s390x);
+
+    check_feature;
+}
+
+1;

--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -82,80 +82,6 @@ sub check_buildid {
     }
 }
 
-# SLE-21783: Update nodejs-common for SLE15 SP4
-# check the nodejs16 is releaseed to SLE15 SP3 & SLE15 SP4
-# check the nodejs-common points to nodejs16
-# test steps:
-# 1) install nodejs-common on SLES15SP3 and migrated SLES15SP4 when wsm is available in SCC_ADDONS
-# 2) check nodejs16 is installed together with nodejs-common
-sub check_nodejs_common {
-    record_info('SLE-21783', 'check nodejs-common');
-    # first we check if it's been installed, if so remove it
-    zypper_call('rm nodejs-common') if (script_run('rpm -q nodejs-common') == 0);
-    zypper_call('in nodejs-common | tee /tmp/install_nodejs.log');
-
-    assert_script_run('grep -E "Installing: nodejs16" /tmp/install_nodejs.log');
-    script_run('zypper se -i nodejs');
-    my $ret_s1 = script_output(q(zypper se -i nodejs | grep package | grep nodejs16 | awk -F\| '{print $1}'));
-    my $ret_s2 = script_output(q(zypper se -i nodejs | grep package | grep nodejs-common| awk -F\| '{print $1}'));
-    die "Expected package is not installed. ret_s1=$ret_s1' and ret_s2=$ret_s2'" if ('i' ne "$ret_s1" || 'i+' ne "$ret_s2");
-
-    zypper_call("rm nodejs-common");
-    assert_script_run('rm /tmp/install_nodejs.log');
-}
-
-# SLE-21916: change bzr to breezy
-# check in the upgraded sysetem that bzr was repalced by breezy
-# test steps:
-# 1) install the bzr as usaual
-# 2) check the bzr version as usual to make sure it has breezy
-# 3) cleanup by removing the package
-sub check_bzr_to_breezy {
-    record_info('SLE-21916', 'Check bzr to breezy');
-    zypper_call('in bzr');
-
-    assert_script_run('bzr --version');
-    assert_script_run('bzr --version | grep breezy');
-    zypper_call('--no-refresh info breezy');
-
-    zypper_call("rm bzr", exitcode => [0]);
-}
-
-# SLE-20176 QA: Drop Python 2 (15 SP4)
-# check in the upgraded system to ensure Python2 dropped
-sub check_python2_dropped {
-    my $out = script_output('zypper se python2 | grep python2', proceed_on_failure => 1);
-    record_info('python2 dropped but still can be searched', 'Bug 1196533 - Python2 package still can be searched after migration to SLES15SP4', result => 'fail') if $out;
-}
-
-# SLE-23610: Python3 module
-# test steps:
-# 1) activate the python3 module
-# 2) install the python310 package
-# 3) check python3.10's version which should be 3.10.X
-# 4) check python3's version
-# 5) check python310's lifecycle
-sub check_python3_module {
-    record_info('SLE-23610', 'Check Python3 Module');
-    my $OS_VERSION = script_output("grep VERSION_ID /etc/os-release | cut -c13- | head -c -2");
-    my $ARCH = get_required_var('ARCH');
-    assert_script_run("SUSEConnect -p sle-module-python3/$OS_VERSION/$ARCH", timeout => 180);
-    zypper_call("se python310");
-    zypper_call("in python310");
-    assert_script_run("python3.10 --version | grep Python | grep 3.10.");
-    assert_script_run("python3 --version | grep Python | grep 3.6.");
-    assert_script_run("zypper lifecycle python310");
-}
-
-# function to check all the features after migration
-sub check_feature {
-    if (!get_var('MEDIA_UPGRADE')) {
-        check_bzr_to_breezy;
-        check_python3_module;
-    }
-    check_python2_dropped;
-}
-
 sub run {
     select_console('root-console');
     assert_script_run('setterm -blank 0') unless (is_s390x);
@@ -186,15 +112,6 @@ sub run {
         check_addons($myaddons);
         check_product("after");
         check_buildid;
-        check_feature if (is_sle(">=15-SP4") && check_var('INSTALLONLY', '1'));
-    }
-
-    # feature SLE-21783
-    # Check nodejs-common on SLES15SP3+ before and after migration
-    # We just check nodejs_common for sle15-sp3+ and wsm module was registered
-    my $ret = script_run("SUSEConnect --status-text|grep -A3 -E 'Web and Scripting Module' | grep -qE '^\\s+Registered'");
-    if (is_sle('>=15-SP3') && ($ret == 0)) {
-        check_nodejs_common;
     }
 }
 


### PR DESCRIPTION
The original design for check_system_info is to check addons and modules register status before and after migration, but some other test added to the module later that's is not expected, I move migration feature related test which only check on target system to regression test, move nodejs to service check.

- Related ticket: https://progress.opensuse.org/issues/109998
- Needles: N/A
- Verification run: 
  x86:
http://openqa.nue.suse.com/tests/8585985#live  offline 15SP3
https://openqa.nue.suse.com/tests/8625216#step/install_service/350  online 15SP3

s390x:
http://openqa.nue.suse.com/tests/8585689#live offline 15SP1
http://openqa.nue.suse.com/tests/8585690#live online 15SP3

ppc64le:
http://openqa.nue.suse.com/tests/8585691#live offline 15SP3
http://openqa.nue.suse.com/tests/8585692#live online 15SP2

aarch64:
http://openqa.nue.suse.com/tests/8585693#live offline 15SP2
http://openqa.nue.suse.com/tests/8585694#live online 15SP3
