### PR TITLE
Use serial console on support_server

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -6,7 +6,7 @@ use warnings;
 use base 'Exporter';
 use Exporter;
 
-use testapi;
+use testapi qw(is_serial_terminal :DEFAULT);
 use version_utils 'is_opensuse';
 
 our @EXPORT = qw(configure_hostname get_host_resolv_conf is_networkmanager
@@ -81,9 +81,9 @@ sub configure_static_ip {
         assert_script_run "rcnetwork restart";
     }
 
-    save_screenshot;
+    save_screenshot unless is_serial_terminal;
     assert_script_run "ip addr";
-    save_screenshot;
+    save_screenshot unless is_serial_terminal;
 }
 
 sub configure_dhcp {
@@ -96,10 +96,10 @@ sub configure_dhcp {
     type_string "NIC=`grep \$MAC /sys/class/net/*/address |cut -d / -f 5`;";
     type_string("echo \"STARTMODE='auto'\nBOOTPROTO='dhcp'\n\" > /etc/sysconfig/network/ifcfg-\$NIC;");
     enter_cmd 'done';
-    save_screenshot;
+    save_screenshot unless is_serial_terminal;
     assert_script_run "rcnetwork restart";
     assert_script_run "ip addr";
-    save_screenshot;
+    save_screenshot unless is_serial_terminal;
 }
 
 sub configure_default_gateway {

--- a/schedule/ha/bv/ha_supportserver.yaml
+++ b/schedule/ha/bv/ha_supportserver.yaml
@@ -24,7 +24,7 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   SUPPORT_SERVER: '1'
   VIDEOMODE: text
-  VIRTIO_CONSOLE: '0'
+  VIRTIO_CONSOLE: '1'
   # Below setting must be defined in the openQA UI because macros for %VERSION%,
   # %ARCH% and %BUILD% are usually not defined yet when this file is being loaded
   # HDD_1: openqa_support_server_sles12sp3.%ARCH%.qcow2

--- a/schedule/sles4sap/ha_supportserver.yaml
+++ b/schedule/sles4sap/ha_supportserver.yaml
@@ -24,7 +24,7 @@ vars:
   SUPPORT_SERVER: '1'
   SUPPORT_SERVER_ROLES: dhcp,dns,ntp,ssh,iscsi
   VIDEOMODE: text
-  VIRTIO_CONSOLE: '0'
+  VIRTIO_CONSOLE: '1'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: openqa_support_server_sles12sp3.%ARCH%.qcow2
 schedule:


### PR DESCRIPTION
setup of xvnc, xdmcp and iscsi does use ncurses/gui thus using root-console

- Verification run:

https://dzedro.suse.cz/tests/21576#step/setup/77 Desktop
https://dzedro.suse.cz/tests/21575#step/setup/110 HA
https://dzedro.suse.cz/tests/21592#step/setup/98 SAP
https://openqa.suse.de/tests/8630302 HA
https://openqa.suse.de/tests/8631925 HA
https://openqa.suse.de/tests/8634258 HA
TW is already using vertio console https://openqa.opensuse.org/tests/2314441
https://dzedro.suse.cz/tests/21619#step/setup/44 TW