### PR TITLE
Public Cloud: Disable libgcrypt

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -62,7 +62,7 @@ sub load_publiccloud_consoletests {
     loadtest 'console/journalctl';
     loadtest 'console/procps';
     loadtest 'console/suse_module_tools';
-    loadtest 'console/libgcrypt';
+    loadtest 'console/libgcrypt' unless is_sle '=12-SP4';
 }
 
 sub load_latest_publiccloud_tests {


### PR DESCRIPTION
The `console/libgcrypt` test module used to be in `EXCLUDE_MODULES` variable for SLE 12-SP4.
As I recently got rid of this variable I also exclude it from `lib/main_publiccloud` for SLE 12-SP4.

 * Verification run: [12-SP4](http://pdostal-server.suse.cz/tests/14458), [15-SP3](http://pdostal-server.suse.cz/tests/14459)
