### PR TITLE
Fix apache_ssl issue

### DIFF
--- a/tests/console/apache_ssl.pm
+++ b/tests/console/apache_ssl.pm
@@ -18,8 +18,7 @@ use utils 'clear_console';
 
 sub run {
     my $self = shift;
-    $self->select_serial_terminal;
-    clear_console;
+    select_console 'root-console';
     setup_apache2(mode => 'SSL');
 }
 


### PR DESCRIPTION
Serial terminal causes sporadic failures in apache_ssl.pm, especially in aarch64 architecture.
After running several tests, it seems that with root-console this issue doesn't appear.

- Related ticket: https://progress.opensuse.org/issues/109205
- Needles: N/A
- Verification run: textmode+role_textmode [aarch64](https://openqa.suse.de/tests/8601598#step/apache_ssl/40) | [ppc64le](https://openqa.suse.de/tests/8597824#step/apache_ssl/40) | [s390x](https://openqa.suse.de/tests/8597825#step/apache_ssl/40) | [x86_64](https://openqa.suse.de/tests/8597826#step/apache_ssl/40)

