### PR TITLE
Fix failing samba test runs for Tumbleweed

### DIFF
--- a/tests/network/samba/server.pm
+++ b/tests/network/samba/server.pm
@@ -41,7 +41,7 @@ sub run {
 
     record_info 'access';
     assert_script_run "rpcclient -U '$username%$password' -c srvinfo localhost";
-    validate_script_output "net share -S localhost -U '$username%$password'", qr/$username/;
+    validate_script_output "net share -S localhost -U '$username%$password'", sub { $_ =~ m/profiles/ && $_ =~ m/users/ && $_ =~ m/groups/ };
 
     record_info 'delete user';
     assert_script_run "smbpasswd -x $username";


### PR DESCRIPTION
net share does not list the username when listing the shares available
on the server. This commit checks for the presence of the default share names
instead of the username.

- Related ticket: https://progress.opensuse.org/issues/110049
- Verification run: https://duck-norris.qam.suse.de/tests/8804
