### PR TITLE
LTP: Move open-posix / realtime flags to LTP_EXTRA_CONF_FLAGS

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -183,8 +183,8 @@ sub prepare_ltp_git {
     my $url = get_var('LTP_GIT_URL', 'https://github.com/linux-test-project/ltp');
     my $rel = get_var('LTP_RELEASE');
     my $prefix = get_ltproot();
-    my $configure = "./configure --with-open-posix-testsuite --with-realtime-testsuite --prefix=$prefix";
-    my $extra_flags = get_var('LTP_EXTRA_CONF_FLAGS', '');
+    my $configure = "./configure --prefix=$prefix";
+    my $extra_flags = get_var('LTP_EXTRA_CONF_FLAGS', '--with-open-posix-testsuite --with-realtime-testsuite');
 
     $rel = "-b $rel" if ($rel);
 


### PR DESCRIPTION
We use LTP_EXTRA_CONF_FLAGS for 32bit builds
(PKG_CONFIG_LIBDIR=/usr/lib/pkgconfig CFLAGS=-m32 LDFLAGS=-m32),
which run only syscalls and cve. Therefore disable building open-posix /
realtime testsuites for 32bit builds saves compilation time.

It also helps to speedup custom 64bit builds on osd/o3, if they don't
require open-posix / realtime (most of them). To skip building it,
define variable as empty string: LTP_EXTRA_CONF_FLAGS="".

Verification run:
- http://quasar.suse.cz/tests/9020 (SLE 15.4 ltp_install git without posix, realtime)
- http://quasar.suse.cz/tests/9023 (Tumbleweed ltp_install git without posix, realtime)
- http://quasar.suse.cz/tests/9011 (Tumbleweed ltp_cve_m32@64bit)