### PR TITLE
Add AutoYaST in YaST Maintenance Updates

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_maintenance.xml.ep
+++ b/data/autoyast_sle15/create_hdd/create_hdd_maintenance.xml.ep
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email><%= $get_var->('SCC_EMAIL') %></email>
+        <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        % if (keys %$addons) {
+        <addons config:type="list">
+            % while (my ($key, $addon) = each (%$addons)) {
+            <addon>
+                <name><%= $addon->{name} %></name>
+                <version><%= $addon->{version} %></version>
+                <arch><%= $addon->{arch} %></arch>
+                % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sles')) {
+                <reg_code><%= $get_var->('SCC_REGCODE_WE') %></reg_code>
+                % }
+                % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sled')) {
+                <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+                % }
+                % if ($key eq 'rt') {
+                <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
+                % }
+                % if ($key eq 'ltss') {
+                <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+                % }
+            </addon>
+            % }
+        </addons>
+        %}
+    </suse_register>
+    <add-on>
+        <add_on_products config:type="list">
+            % for my $repo (@$repos) {
+            % my ($repo_id, $addon) = $repo =~ (/(\d+)\/(.*)\//);
+            <listentry>
+                <media_url><%= $repo %></media_url>
+		        <name><%= $addon . "_" . $repo_id %></name>
+		        <alias><%= $addon . "_" . $repo_id %></alias>
+            </listentry>
+            % }
+        </add_on_products>
+    </add-on>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">45</timeout>
+        </global>
+    </bootloader>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+        <signature-handling>
+            <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+            <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+            <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+            <import_gpg_key config:type="boolean">true</import_gpg_key>
+        </signature-handling>
+    </general>
+    <partitioning config:type="list">
+        <drive>
+            <initialize config:type="boolean">true</initialize>
+            <use>all</use>
+        </drive>
+    </partitioning>
+    <networking>
+        <interfaces config:type="list">
+            <interface>
+                <bootproto>dhcp</bootproto>
+                <device>eth0</device>
+                <dhclient_set_default_route>yes</dhclient_set_default_route>
+                <startmode>auto</startmode>
+            </interface>
+        </interfaces>
+    </networking>
+    <firewall>
+        <enable_firewall config:type="boolean">true</enable_firewall>
+        <start_firewall config:type="boolean">true</start_firewall>
+        <zones config:type="list">
+            <zone>
+                <name>public</name>
+                <interfaces config:type="list">
+                    <interface>eth0</interface>
+                </interfaces>
+                <services config:type="list">
+                    <service>ssh</service>
+                </services>
+                <ports config:type="list">
+                    <port>22/tcp</port>
+                </ports>
+            </zone>
+        </zones>
+    </firewall>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+    <keyboard>
+        <keyboard_values>
+            <delay/>
+            <discaps config:type="boolean">false</discaps>
+            <numlock>bios</numlock>
+            <rate/>
+        </keyboard_values>
+        <keymap>english-us</keymap>
+    </keyboard>
+    <language>
+        <language>en_US</language>
+        <languages/>
+    </language>
+    <ntp-client>
+        <ntp_policy>auto</ntp_policy>
+    </ntp-client>
+    <software>
+        <products config:type="list">
+            <product><%= uc $get_var->('SLE_PRODUCT') %></product>
+        </products>
+        % if ($get_var->('SCC_ADDONS') =~ m/\brt\b/) {
+        <kernel>kernel-rt</kernel>
+        % }
+        <patterns config:type="list">
+            % for my $pattern (@$patterns) {
+            <pattern><%= $pattern %></pattern>
+            % }
+        </patterns>
+    </software>
+    <services-manager>
+        % if ($check_var->('DESKTOP', 'gnome')) {
+        <default_target>graphical</default_target>
+        % }
+        % if ($check_var->('DESKTOP', 'textmode')) {
+        <default_target>multi-user</default_target>
+        % }
+        <services>
+            <disable config:type="list"/>
+            <enable config:type="list">
+                <service>sshd</service>
+            </enable>
+        </services>
+    </services-manager>
+    <timezone>
+        <hwclock>UTC</hwclock>
+        <timezone>Europe/Berlin</timezone>
+    </timezone>
+    <users config:type="list">
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <gid>100</gid>
+            <home>/home/bernhard</home>
+            <password_settings>
+                <expire/>
+                <flag/>
+                <inact>-1</inact>
+                <max>99999</max>
+                <min>0</min>
+                <warn>7</warn>
+            </password_settings>
+            <shell>/bin/bash</shell>
+            <uid>1000</uid>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <fullname>root</fullname>
+            <gid>0</gid>
+            <home>/root</home>
+            <password_settings>
+                <expire/>
+                <flag/>
+                <inact/>
+                <max/>
+                <min/>
+                <warn/>
+            </password_settings>
+            <shell>/bin/bash</shell>
+            <uid>0</uid>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <scripts>
+        <post-scripts config:type="list">
+            <script>
+                <filename>post.sh</filename>
+                <interpreter>shell</interpreter>
+                <source><![CDATA[
+#!/bin/sh
+# zypper process is locked by some ruby process, modify the repo file
+cd /etc/zypp/repos.d
+sed -i 's/enabled=1/enabled=0/' $(ls|grep -i nvidia)
+zypper lr
+exit 0
+
+]]></source>
+            </script>
+        </post-scripts>
+    </scripts>
+</profile>

--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -84,9 +84,15 @@ sub add_test_repositories {
     # please be sure that the PATCH_TEST_REPO is empty.
     @repos = split(',', $oldrepo) if ($oldrepo);
 
-    for my $var (@repos) {
-        zypper_call("--no-gpg-checks ar -f $gpg -n 'TEST_$counter' $var 'TEST_$counter'");
-        $counter++;
+    if (get_var("NO_ADD_MAINT_TEST_REPOS")) {
+        # If we don't want to add again (and duplicate) repositories that were already added during install,
+        # we still need to disable gpg check for all repositories.
+        zypper_call('--gpg-auto-import-keys ref', timeout => 1400, exitcode => [0, 106]);
+    } else {
+        for my $var (@repos) {
+            zypper_call("--no-gpg-checks ar -f $gpg -n 'TEST_$counter' $var 'TEST_$counter'");
+            $counter++;
+        }
     }
 
     if (is_sle('=12-SP2')) {

--- a/schedule/yast/sle_15_sp3/autoyast_create_hdd_maintenance.yaml
+++ b/schedule/yast/sle_15_sp3/autoyast_create_hdd_maintenance.yaml
@@ -1,0 +1,22 @@
+---
+name: autoyast_create_hdd_maintenance
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - qa_automation/patch_and_reboot
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -56,7 +56,9 @@ sub run {
 
     my $suffix = is_jeos ? '-base' : '';
     assert_script_run("rpm -ql --changelog kernel-default$suffix > /tmp/kernel_changelog.log");
+    zypper_call("lr -u", log => 'repos_list.txt');
     upload_logs('/tmp/kernel_changelog.log');
+    upload_logs('/tmp/repos_list.txt');
 
     # DESKTOP can be gnome, but patch is happening in shell, thus always force reboot in shell
     power_action('reboot', textmode => 1);

--- a/variables.md
+++ b/variables.md
@@ -122,6 +122,7 @@ NFSCLIENT | boolean | false | Indicates/enables nfs client in `console/yast2_nfs
 NFSSERVER | boolean | false | Indicates/enables nfs server in `console/yast2_nfs_server`.
 NICEVIDEO |||
 NICTYPE_USER_OPTIONS | string | | `hostname=myguest` causes a fake DHCP hostname 'myguest' provided to SUT. It is used as expected hostname if `EXPECTED_INSTALL_HOSTNAME` is not set.
+NO_ADD_MAINT_TEST_REPOS | boolean | true |  Do not add again (and duplicate) repositories that were already added during install
 NOAUTOLOGIN | boolean | false | Indicates disabled auto login.
 NOIMAGES |||
 NOLOGS | boolean | false | Do not collect logs if set to true. Handy during development.


### PR DESCRIPTION
Replace mru_install with an autoyast install for yast maintenance.

Currently mau-extratests-yast2ui and mau-extratests-yast2ui-textmode
are depending on mru-install-with-addons. We want to use a ligthter, and 
easier-to-maintain (for us) job as a parent job. 

for now this is limited to sle 15 sp3.

- Related ticket: https://progress.opensuse.org/issues/109214
- Verification run: 
mru_install
http://waaa-amazing.suse.cz/tests/16803
http://waaa-amazing.suse.cz/tests/16802
dependencies
http://waaa-amazing.suse.cz/tests/16805
http://waaa-amazing.suse.cz/tests/16804

Without autoyast/yaml and new parameter http://waaa-amazing.suse.cz/tests/16800

Gitlab MR https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/253/diffs
