### PR TITLE
Add leap to sle tech preview with yast2 migration

### DIFF
--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -24,6 +24,12 @@ sub check_or_install_packages {
             record_soft_failure('bsc#1197268', 'suseconnect-ng obsoletes zypper-migration-plugin in leap to sle migration');
             zypper_call('rm zypper-migration-plugin');
             zypper_call "in yast2-registration rollback-helper";
+            if (get_var('LEAP_TECH_PREVIEW_REPO')) {
+                record_info('SLE-23610', 'TechPreview: yast-migration-sle a simplified Leap -> SLE migration');
+                my $tech_preview_repo = get_var('LEAP_TECH_PREVIEW_REPO');
+                zypper_call("ar $tech_preview_repo");
+                zypper_call('in yast2-migration-sle');
+            }
             systemctl 'enable rollback.service';
             systemctl 'start rollback.service';
         } else {

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -150,7 +150,8 @@ sub run {
         zypper_call "rs $service{$addon}\t";    # remove service
     }
 
-    script_run("yast2 migration; echo yast2-migration-done-\$? > /dev/$serialdev", 0);
+    my $migration_cmd = get_var('LEAP_TECH_PREVIEW_REPO') ? 'migration_sle' : 'migration';
+    script_run("yast2 $migration_cmd; echo yast2-migration-done-\$? > /dev/$serialdev", 0);
 
     # yast2 migration would check and install minimal update before migration
     # if the system doesn't perform full update or minimal update


### PR DESCRIPTION
yast-migration-sle a simplified Leap to SLE migration. 
https://jira.suse.com/browse/SLE-24226
To use this migration tool, we need to set LEAP_TECH_PREVIEW_REPO

- Related ticket: https://openqa.nue.suse.com/tests/8625408
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t8638142
  https://openqa.nue.suse.com/t8638143
  https://openqa.nue.suse.com/t8638144