### PR TITLE
btrfs-progs: Add Soft fail for generate_report

### DIFF
--- a/tests/btrfs-progs/generate_report.pm
+++ b/tests/btrfs-progs/generate_report.pm
@@ -55,6 +55,8 @@ sub run {
     my $xml = generateXML($tc_result);
     assert_script_run("echo \'$xml\' > " . JUNIT_FILE);
     parse_junit_log JUNIT_FILE;
+
+    record_soft_failure "poo#110137 - Mark SKIPPED as soft failure" if check_var('SOFT_FAILURE', 1);
 }
 
 1;

--- a/tests/btrfs-progs/run.pm
+++ b/tests/btrfs-progs/run.pm
@@ -101,15 +101,17 @@ sub run {
         # Get test list
         my @tests = get_test_list($category);
 
+        my $status;
         for my $test (@tests) {
             # Run test and wait for it to finish
             my $begin = time();
-            my $status = test_run($category, $test);
+            $status = test_run($category, $test);
             my $delta = time() - $begin;
 
             # Add test status to STATUS_LOG file
             log_add(STATUS_LOG, "$category-$test", $status, $delta);
         }
+        set_var('SOFT_FAILURE', 1) if (@tests == 1) && ($status == 'SKIPPED');
     }
 }
 


### PR DESCRIPTION
Add soft_failure if only one test and it is skipped

- Related ticket: https://progress.opensuse.org/issues/110137
- Needles: N/A
- Verification run: 
http://10.67.133.102/tests/613 (PASSED)
http://10.67.133.102/tests/612 (Soft fail)
