### PR TITLE
Workaround for bsc#1189543, before de-register system need register python2

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -867,6 +867,11 @@ sub scc_deregistration {
         quit_packagekit;
         wait_for_purge_kernels;
         assert_script_run('SUSEConnect --version');
+        if (get_var('UPGRADE_TARGET_VERSION') == '15-SP3') {
+            # Workaround for bsc#1189543, need register python2 before de-register system
+            record_soft_failure 'bsc#1189543 - Stale python2 module blocks de-registration after system migration';
+            add_suseconnect_product('sle-module-python2');
+        }
         my $deregister_ret = script_run('SUSEConnect --de-register --debug > /tmp/SUSEConnect.debug 2>&1', 300);
         if (defined $deregister_ret and $deregister_ret == 104) {
             # https://bugzilla.suse.com/show_bug.cgi?id=1119512


### PR DESCRIPTION
Workaround for bsc#1189543, before de-register system need register
python2. Then de-register the system it can work.

- Related ticket: https://progress.opensuse.org/issues/110214
- Verification run: https://openqa.nue.suse.com/tests/8627882#