### PR TITLE
Rootless podman: configure Leap 15.3 for cgroups v2

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -35,7 +35,7 @@ sub run {
     my $podman = $self->containers_factory('podman');
 
     # Prepare for Podman 3.4.4 and CGroups v2
-    if (is_sle('15-SP3+') || is_leap('15.4+')) {
+    if (is_sle('15-SP3+') || is_leap('15.3+')) {
         record_info 'cgroup v2', 'Switching to cgroup v2';
         assert_script_run "usermod -a -G systemd-journal $testapi::username";
         if (is_transactional) {


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1195093
Follow up from:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14406
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14425

Leap 15.3 also runs podman 3.4.4 with cgroups1 by default.

Failure: https://openqa.opensuse.org/tests/2315809#step/rootless_podman/79
VR: https://openqa.opensuse.org/tests/2315881#
