### PR TITLE
Fix leap to sle zypper migration timeout on kde

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -54,7 +54,7 @@ sub run {
         script_run("(zypper migration $option; echo ZYPPER-DONE) |& tee /dev/$serialdev", 0);
     }
     # migration process take long time
-    my $timeout = 7200;
+    my $timeout = (is_leap_migration && (check_var('DESKTOP', 'kde'))) ? 10800 : 7200;
     my $migration_checks = [
         $zypper_migration_bsc1184347, $zypper_migration_bsc1196114,
         $zypper_migration_target, $zypper_disable_repos, $zypper_continue, $zypper_migration_done,


### PR DESCRIPTION
On KDE leap to sle with zypper migration, the migration will take 3 hours to finish, we need to 
extend the timeout for 'zypper migration'.

- Related ticket: https://progress.opensuse.org/issues/110281
- Needles: N/A
- Verification run: 
kde leap to sle
  https://openqa.nue.suse.com/tests/8628683
  https://openqa.nue.suse.com/tests/8634401
regression:
  https://openqa.nue.suse.com/tests/8634498