### PR TITLE
Improve containers::common::activate_containers_module subroutine

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -13,6 +13,7 @@ use version_utils;
 use utils qw(zypper_call systemctl file_content_replace script_retry script_output_retry);
 use containers::utils qw(can_build_sle_base registry_url container_ip container_route);
 use transactional qw(trup_call check_reboot_changes);
+use Mojo::JSON;
 
 our @EXPORT = qw(is_unreleased_sle install_podman_when_needed install_docker_when_needed install_containerd_when_needed
   test_container_runtime test_container_image scc_apply_docker_image_credentials scc_restore_docker_image_credentials
@@ -25,13 +26,18 @@ sub is_unreleased_sle {
 }
 
 sub activate_containers_module {
-    my ($running_version, $sp, $host_distri) = get_os_release;
-    my $suseconnect = script_output_retry('SUSEConnect --status-text', timeout => 240, retry => 3, delay => 60);
-    if ($suseconnect !~ m/Containers/) {
-        $running_version eq '12' ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
-        $suseconnect = script_output_retry('SUSEConnect --status-text', timeout => 240, retry => 3, delay => 60);
+    my $json = Mojo::JSON::decode_json(script_output_retry('SUSEConnect -s', timeout => 240, retry => 3, delay => 60));
+    my ($not_registered, $version, $arch);
+    foreach (@$json) {
+        if ($_->{identifier} =~ 'sle-module-containers' && $_->{status} =~ 'Not Registered') {
+            $not_registered = 1;
+            $version = $_->{version};
+            $arch = $_->{arch};
+            last;
+        }
     }
-    record_info('SUSEConnect', $suseconnect);
+    add_suseconnect_product("sle-module-containers", $version, $arch) if ($not_registered);
+    record_info('SUSEConnect', script_output_retry('SUSEConnect --status-text', timeout => 240, retry => 3, delay => 60));
 }
 
 


### PR DESCRIPTION
Parse the `SUSEConnect -s` output and check for the containers module status.

- Related ticket: https://progress.opensuse.org/issues/110331
- Related issue: https://openqa.suse.de/tests/8634857
- Verification run: [SLE12-SP3](http://pdostal-server.suse.cz/tests/14534), [SLE15-SP3-GCE-BYOS](http://pdostal-server.suse.cz/tests/14532)
