### PR TITLE
Do not add python2 module to SLE12

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -867,7 +867,7 @@ sub scc_deregistration {
         quit_packagekit;
         wait_for_purge_kernels;
         assert_script_run('SUSEConnect --version');
-        if (get_var('UPGRADE_TARGET_VERSION') == '15-SP3') {
+        if (get_var('UPGRADE_TARGET_VERSION') == '15-SP3' && is_sle('15+')) {
             # Workaround for bsc#1189543, need register python2 before de-register system
             record_soft_failure 'bsc#1189543 - Stale python2 module blocks de-registration after system migration';
             add_suseconnect_product('sle-module-python2');


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/110326
- Needles: No new needles
- Verification run: 
HA SLE12: https://openqa.suse.de/tests/8639455#details
Cont migration (orignal failure): https://openqa.suse.de/tests/8639600
