### PR TITLE
Activate python2 as workaround on SLE15-SP1+

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -867,7 +867,7 @@ sub scc_deregistration {
         quit_packagekit;
         wait_for_purge_kernels;
         assert_script_run('SUSEConnect --version');
-        if (get_var('UPGRADE_TARGET_VERSION') == '15-SP3') {
+        if ((check_var('UPGRADE_TARGET_VERSION', '15-SP3')) && (is_sle('15-SP1+'))) {
             # Workaround for bsc#1189543, need register python2 before de-register system
             record_soft_failure 'bsc#1189543 - Stale python2 module blocks de-registration after system migration';
             add_suseconnect_product('sle-module-python2');


### PR DESCRIPTION
Update condition for workaround for bsc#1189543 to make sure on SLE15-SP1+.

- Related ticket: https://progress.opensuse.org/issues/110326
- Needles: N/A
- Verification run: 
 http://openqa.nue.suse.com/tests/8644254#  HA case
 http://openqa.nue.suse.com/tests/8644255#step/patch_sle/103  12SP4
 http://openqa.nue.suse.com/tests/8644259#details    15SP1
 http://openqa.nue.suse.com/tests/8644387#  Continuous migration SLE15GA ->15SP2, no activate python2, pass
 https://openqa.nue.suse.com/tests/8644416#step/scc_deregistration/11  Continuous migration SLE15SP1->15SP3, activate python2, pass
