### PR TITLE
Increase snapper call timeouts

### DIFF
--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -52,7 +52,7 @@ sub snapper_cleanup {
     script_run "echo There are `$snaps_numb` snapshots AFTER cleanup";
     assert_script_run("btrfs qgroup show -pcre /");
     assert_script_run("snapper list");
-    clear_console;
+    clear_console unless testapi::is_serial_terminal();
     script_run($btrfs_fs_usage, 120);
     # Get actual exclusive disk space to verify exclusive disk space is taken into account
     my $qgroup_excl_space = get_space("btrfs qgroup show  / --raw | grep 1/0 | awk -F ' ' '{print\$3}'");

--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -86,7 +86,7 @@ sub run {
     }
     assert_script_run("snapper list");
     # Delete all those snapshots we just created so other tests are not confused
-    assert_script_run("snapper delete --sync $first_snap_to_delete-" . get_last_snap_number(), timeout => 180);
+    assert_script_run("snapper delete --sync $first_snap_to_delete-" . get_last_snap_number(), timeout => 240);
     assert_script_run("snapper list");
 }
 


### PR DESCRIPTION
Especially `aarch64` jobs are mostly failing in timeout issues related
with snapper. I assume that the problem rather points to performance
than product issue.
The other problem is a race condition when executing `clear_console` on
serial terminal console.

```
# clear
btrfs filesystem usage / --raw; echo gJ3MD-$?-
```

- failures [snapshot removal](https://openqa.suse.de/tests/9061161#step/snapper_create/169) and [btrfs usage](https://openqa.suse.de/tests/9064763#step/snapper_cleanup/171)
- Verification runs: 
  * [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-aarch64](https://openqa.suse.de/tests/9065071#step/snapper_create/169)
  * [sle-15-SP4-Server-DVD-Updates-aarch64](https://openqa.suse.de/tests/9065733)