### PR TITLE
Deactivate python2 module when failure happened

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -86,7 +86,8 @@ our $default_services = {
         srv_pkg_name => 'hpcpackage_remain',
         srv_proc_name => 'hpcpackage_remain',
         support_ver => $support_ver_ge15,
-        service_check_func => \&services::hpcpackage_remain::full_pkgcompare_check
+        service_check_func => \&services::hpcpackage_remain::full_pkgcompare_check,
+        service_cleanup_func => \&services::hpcpackage_remain::hpcpkg_cleanup
     },
     registered_addons => {
         srv_pkg_name => 'registered_addons',

--- a/lib/services/hpcpackage_remain.pm
+++ b/lib/services/hpcpackage_remain.pm
@@ -100,4 +100,9 @@ sub full_pkgcompare_check {
     }
 }
 
+sub hpcpkg_cleanup {
+    # De-register python2 module after unexpected failure happened
+    remove_suseconnect_product('sle-module-python2') if (get_var('DROPPED_MODULES', '') =~ /python2/);
+}
+
 1;


### PR DESCRIPTION
We need cleanup environment to deactivate pyhonn2 when issue happened in case it will block later test.

- Related ticket: https://progress.opensuse.org/issues/110302
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/8645523#step/yast2_migration/14