### PR TITLE
Disable kernel multiversion before migration

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -23,6 +23,7 @@ our @EXPORT = qw(
   register_system_in_textmode
   deregister_dropped_modules
   disable_installation_repos
+  disable_kernel_multiversion
   record_disk_info
   check_rollback_system
   reset_consoles_tty
@@ -141,6 +142,13 @@ sub disable_installation_repos {
     else {
         zypper_call "mr -d -l";
     }
+}
+
+# Based on bsc#1097111, need to disable kernel multiversion before migration, and enable it after migration
+# https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-update-preparation.html#sec-update-preparation-multiversion
+sub disable_kernel_multiversion {
+    my $sed_para = check_var('VERSION', get_var('ORIGIN_SYSTEM_VERSION')) ? 's/^multiversion/#multiversion/g' : 's/^#multiversion/multiversion/g';
+    script_run("sed -i $sed_para /etc/zypp/zypp.conf");
 }
 
 # Record disk info to help debug diskspace exhausted

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -22,6 +22,7 @@ use bootloader_setup qw(change_grub_config grub_mkconfig);
 use registration;
 use services::registered_addons 'full_registered_check';
 use List::MoreUtils 'uniq';
+use migration 'disable_kernel_multiversion';
 use strict;
 use warnings;
 
@@ -89,6 +90,12 @@ sub run {
         if (!get_var('MEDIA_UPGRADE')) {
             services::registered_addons::full_registered_check;
         }
+    }
+
+    # enable multiversion for kernel-default based on bsc#1097111, for migration continuous cases only
+    if (get_var('FLAVOR', '') =~ /Continuous-Migration/) {
+        record_soft_failure 'bsc#1097111 - File conflict of SLE12 SP3 and SLE15 kernel';
+        disable_kernel_multiversion;
     }
 
     assert_script_run 'rpm -q systemd-coredump || zypper -n in systemd-coredump || true', timeout => 200 if get_var('COLLECT_COREDUMPS');

--- a/tests/migration/online_migration/post_migration.pm
+++ b/tests/migration/online_migration/post_migration.pm
@@ -15,6 +15,7 @@ use utils;
 use version_utils qw(is_desktop_installed is_sles4sap is_sle);
 use qam qw(add_test_repositories remove_test_repositories);
 use x11utils 'ensure_unlocked_desktop';
+use migration 'disable_kernel_multiversion';
 
 sub run {
     select_console 'root-console';
@@ -35,6 +36,12 @@ sub run {
     }
     diag "SUSEConnect --status-text: $out";
     assert_script_run "SUSEConnect --status-text | grep -v 'Not Registered'" unless get_var('MEDIA_UPGRADE');
+
+    # enable multiversion for kernel-default based on bsc#1097111, for migration continuous cases only
+    if (get_var('FLAVOR', '') =~ /Continuous-Migration/) {
+        record_soft_failure 'bsc#1097111 - File conflict of SLE12 SP3 and SLE15 kernel';
+        disable_kernel_multiversion;
+    }
 
     add_maintenance_repos() if (get_var('MAINT_TEST_REPO'));
 

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -28,6 +28,12 @@ sub run {
     fully_patch_system;
     install_patterns() if (get_var('PATTERNS'));
     deregister_dropped_modules;
+    # disable multiversion for kernel-default based on bsc#1097111, for migration continuous cases only
+    if (get_var('FLAVOR', '') =~ /Continuous-Migration/) {
+        record_soft_failure 'bsc#1097111 - File conflict of SLE12 SP3 and SLE15 kernel';
+        disable_kernel_multiversion;
+    }
+
     cleanup_disk_space if get_var('REMOVE_SNAPSHOTS');
     power_action('reboot', keepconsole => 1, textmode => 1);
     reconnect_mgmt_console if is_pvm;

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -117,6 +117,12 @@ sub patching_sle {
     set_var("VIDEOMODE", $orig_videomode);
     set_var("SCC_REGISTER", $orig_scc_register);
 
+    # disable multiversion for kernel-default based on bsc#1097111, for migration continuous cases only
+    if (get_var('FLAVOR', '') =~ /Continuous-Migration/) {
+        record_soft_failure 'bsc#1097111 - File conflict of SLE12 SP3 and SLE15 kernel';
+        disable_kernel_multiversion;
+    }
+
     # Record the installed rpm list
     assert_script_run 'rpm -qa > /tmp/rpm-qa.txt';
     upload_logs '/tmp/rpm-qa.txt';


### PR DESCRIPTION
Based on bsc#1097111, we need to temporarily disabling kernel
multiversion before migration, and enable it after migration.

- Related ticket: https://progress.opensuse.org/issues/110104
- Needles: N/A
- Verification run: 
x86_64:
ph0: https://openqa.suse.de/tests/8734807
ph1: https://openqa.suse.de/tests/8734807
ph0: https://openqa.suse.de/tests/8734808
ph1: https://openqa.suse.de/tests/8735943
s390x:
ph0: https://openqa.suse.de/tests/8735961
ph1: https://openqa.suse.de/tests/8735962
ph0: https://openqa.suse.de/tests/8735963
ph1: https://openqa.suse.de/tests/8735964
