### PR TITLE
Fix gnome desktop notification close issue

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -22,6 +22,7 @@ use utils;
 use strict;
 use warnings;
 use x11utils 'ensure_unlocked_desktop';
+use version_utils 'is_upgrade';
 
 sub run {
     my $self = shift;
@@ -43,6 +44,9 @@ sub run {
     $console->reset;
 
     $console = select_console 'user-console';
+    # In migration tests sometimes the notification was stil on,
+    # we need to close it.
+    enter_cmd "gsettings set org.gnome.desktop.notifications show-banners false" if is_upgrade;
     enter_cmd "exit";    # logout
     $console->reset;
     wait_still_screen(2);


### PR DESCRIPTION
We need to close the notification for bernhard in consoletest_finish
before runs into the x11 after console tests.

- Related ticket: https://progress.opensuse.org/issues/110151
- Needles: N/A
- Verification run:
  https://openqa.nue.suse.com/tests/8638360
  https://openqa.nue.suse.com/tests/8644158 
  https://openqa.nue.suse.com/tests/8645554 
  https://openqa.nue.suse.com/tests/8651046#step/consoletest_finish/6