### PR TITLE
Fix FIPS gnutls_server and sshd error

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -68,6 +68,7 @@ sub ssh_basic_check {
     # Check that the daemons listens on right addresses/ports
     check_sshd_port();
     # create a new user to test sshd
+    script_run("userdel -rf $ssh_testman");
     assert_script_run("useradd -m $ssh_testman");
     assert_script_run("echo $changepwd | chpasswd");
     assert_script_run("usermod -aG \$(stat -c %G /dev/$serialdev) $ssh_testman");

--- a/tests/fips/gnutls/gnutls_server.pm
+++ b/tests/fips/gnutls/gnutls_server.pm
@@ -19,6 +19,7 @@ sub run {
 
     # Create test folder
     my $test_dir = "gnutls";
+    assert_script_run "rm -rf $test_dir";
     assert_script_run "mkdir $test_dir && cd $test_dir";
 
     # Add support for X.509.  First we generate a CA


### PR DESCRIPTION
Fix FIPS test case 'gnutls_server' 'File exists' error; fix FIPS test case 'sshd' useradd user 'sshboy' already exists error
poo#109903 - [sle][security][sle15sp4][fips][64bit-ipmi] test fails in gnutls_server: command 'mkdir gnutls && cd gnutls' failed on "gnutls exists"
poo#110428 - [sle][security][sle15sp4][fips][64bit-ipmi] test fails in sshd: useradd: user 'sshboy' already exists

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
