### PR TITLE
Snapper can be running before mock function executes

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -88,6 +88,14 @@ By updating the lastrun files timestamps, we make sure those routines won't be e
 while tests are running. 
 =cut
 sub cron_mock_lastrun {
+    my $tries = 5;
+    while (script_run(q/ps aux | grep '[s]napper'/) == 0 && $tries > 0) {
+        sleep 30;
+        bmwqemu::diag('Snapper is running in the background...');
+        $tries--;
+    }
+    $tries or bmwqemu::diag('Snapper might be still running in the background');
+
     assert_script_run 'touch /var/spool/cron/lastrun/cron.{hourly,daily,weekly,monthly}';
     assert_script_run 'ls -al /var/spool/cron/lastrun/cron.{hourly,daily,weekly,monthly}';
 }


### PR DESCRIPTION
- Related ticket: [[sporadic] test fails in snapper_cleanup - snapper cleanup number - Config is in use.](https://progress.opensuse.org/issues/103299)
- Verification run: [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220428-1-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/16749#step/snapper_create/8)
