### PR TITLE
JeOS: move image_info module after bootloader

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -609,13 +609,13 @@ sub load_jeos_openstack_tests {
 }
 
 sub load_jeos_tests {
-    loadtest "jeos/image_info";
     if ((is_arm || is_aarch64) && is_opensuse()) {
         # Enable jeos-firstboot, due to boo#1020019
         load_boot_tests();
         loadtest "jeos/prepare_firstboot";
     }
     load_boot_tests();
+    loadtest "jeos/image_info";
     loadtest "jeos/firstrun";
     loadtest "jeos/record_machine_id";
     loadtest "console/system_prepare" if is_sle;

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -30,8 +30,8 @@ conditional_schedule:
             'JeOS-for-kvm-and-xen-Updates':
                 - qa_automation/patch_and_reboot
 schedule:
-    - jeos/image_info
     - '{{bootloader}}'
+    - jeos/image_info
     - jeos/firstrun
     - jeos/record_machine_id
     - console/system_prepare


### PR DESCRIPTION
Some images have 10s grub timeout, and while running this module
the timeout is gone and can't get to the editing mode.

- Related ticket: https://progress.opensuse.org/issues/110512
- Example of failure: https://openqa.opensuse.org/tests/2324220#step/bootloader_uefi/4
- Example of how it should look like: https://openqa.opensuse.org/tests/2317568#step/bootloader_uefi/3
- VR: https://openqa.opensuse.org/tests/2324673#

