### PR TITLE
BCI: adaptations to run 15-SP4 images

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -66,12 +66,16 @@ sub run {
     my $bci_devel_repo = get_var('BCI_DEVEL_REPO');
     my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
     my $bci_timeout = get_var('BCI_TIMEOUT', 1200);
+    my $version = get_required_var('VERSION');
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     my $bci_dir = fileparse($bci_tests_repo, qr/\.[^.]*/);
     assert_script_run("cd $bci_dir");
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
     assert_script_run("export CONTAINER_RUNTIME=$engine");
+    $version =~ s/-SP/./g;
+    assert_script_run("export OS_VERSION=$version");
+    assert_script_run("export TARGET=ibs-cr");
     assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;
 
     # Run the tests for each environment


### PR DESCRIPTION
According to https://github.com/SUSE/BCI-tests/blob/main/bci_tester/data.py#L54
we need to provide these variables to make sure we are testing the right images. 
Currently, `15.3` (15-SP3) by default, but this is needed to enable 15-SP4 images.

- Related ticket: https://progress.opensuse.org/issues/110304
- VR: https://openqa.suse.de/tests/8672500#