### PR TITLE
JeOS: increase zypper up timeout

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -43,7 +43,7 @@ sub run {
     #   updates as for SLE DVD installation, so we need to update manually.
     if (is_jeos) {
         record_info('Updates', script_output('zypper lu'));
-        zypper_call('up', timeout => 300);
+        zypper_call('up', timeout => 600);
         if (is_aarch64) {
             # Disable grub timeout for aarch64 cases so that the test doesn't stall
             assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub");


### PR DESCRIPTION
It has been observed latelly that this command times out on
slow machines (aarch64 jobs) due to the amount of updates there are.
It's safer to increase the timeout to avoid keep restarting jobs
and praying for green result.

Example of timeouts:
https://openqa.suse.de/tests/8674239#step/patch_and_reboot/229
https://openqa.suse.de/tests/8674247#step/patch_and_reboot/229

VR: http://openqa.suse.de/t8678727
