### PR TITLE
JeOS: rework condition for pushing data to InfluxDB

### DIFF
--- a/tests/jeos/image_info.pm
+++ b/tests/jeos/image_info.pm
@@ -76,7 +76,9 @@ sub run {
     my $influxdb_server = get_var('INFLUXDB_SERVER');
     my $influxdb_user = get_var('_SECRET_INFLUXDB_USER');
     my $influxdb_pwd = get_var('_SECRET_INFLUXDB_PWD');
-    return if (get_var('CASEDIR') || !($influxdb_server || $influxdb_user || $influxdb_pwd));
+
+    return if (get_var('CASEDIR') !~ m/^sle$|^opensuse$/);
+    return unless ($influxdb_server || $influxdb_user || $influxdb_pwd);
 
     my $job_url;
     my $openqa_host = get_required_var('OPENQA_HOSTNAME');


### PR DESCRIPTION
CASEDIR variable is always set, so this condition was always
returning and never executing the code afterwards.

OSD -> `CASEDIR=sle`
O3 -> `CASEDIR=opensuse`

- Related tickets: 
    - https://jira.suse.com/browse/TEAM-5808
    - https://progress.opensuse.org/issues/110224
