### PR TITLE
mm_network: Fix wicked networking restart

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -232,8 +232,7 @@ sub restart_networking {
         assert_script_run 'nmcli networking off';
         assert_script_run 'nmcli networking on';
     } else {
-        assert_script_run 'wicked ifdown all';
-        assert_script_run 'wicked ifup all';
+        assert_script_run 'rcnetwork restart';
     }
 
     record_info('network cfg', script_output('ip address show; echo; ip route show; echo; grep -v "^#" /etc/resolv.conf', proceed_on_failure => 1));


### PR DESCRIPTION
- Related ticket: [poo#110563](https://progress.opensuse.org/issues/110563)
- Verification run: [remote_ssh_controller@64bit](http://pdostal-server.suse.cz/tests/14650), [wireguard_server@64bit](http://pdostal-server.suse.cz/tests/14655), [SLE12-SP4-qam-wicked_basic_sut@64bit](http://pdostal-server.suse.cz/tests/14660), [SLE15-SP3-qam-wicked_basic_ref@64bit](http://pdostal-server.suse.cz/tests/14661), [firewalld-policy-firewall@64bit](http://pdostal-server.suse.cz/tests/14665)
