### PR TITLE
Add a schedule to install openSUSE Tumbleweed

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1492,9 +1492,11 @@ sub reconnect_mgmt_console {
     elsif (is_x86_64) {
         if (is_ipmi) {
             select_console 'sol', await_console => 0;
-            assert_screen([qw(qa-net-selection prague-pxe-menu grub2)], 300);
-            # boot to hard disk is default
-            send_key 'ret';
+            if (!get_var('IPXE')) {
+                assert_screen([qw(qa-net-selection prague-pxe-menu grub2)], 300);
+                # boot to hard disk is default
+                send_key 'ret';
+            }
         }
     }
     elsif (is_aarch64) {

--- a/schedule/kernel/prepare_baremetal_tumbleweed.yaml
+++ b/schedule/kernel/prepare_baremetal_tumbleweed.yaml
@@ -1,0 +1,33 @@
+name:          prepare_baremetal_tumbleweed
+description:    >
+  Universal installation schedule to prepare bare metal using IPXE or
+  prepare PowerVM for tumbleweed
+vars:
+  DESKTOP: textmode
+schedule:
+  - '{{boot}}'
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/handle_reboot
+  - installation/first_boot
+conditional_schedule:
+  boot:
+    IPXE:
+      1:
+        - installation/ipxe_install
+    BACKEND:
+      spvm:
+        - installation/bootloader


### PR DESCRIPTION
Some tests require hardware that was purchased for QA of SLES, and thus
we cannot simply connect that hardware to openSUSE's openQA instance    
Maybe sharing hardware will be possible in the future, but for now we
just want to be able to install and test Tumbleweed on our internal
hardware, too.
    
This adds a simple schedule to install Tumbleweed to our baremetal machines using ipxe_install.


Verification run: [http://baremetal-support.qa.suse.de/tests/2047](http://baremetal-support.qa.suse.de/tests/2047)
Related ticket: is a prerequisite for [https://progress.opensuse.org/issues/104871](https://progress.opensuse.org/issues/104871)