### PR TITLE
Transactional: increase timeout to install updates

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -29,7 +29,7 @@ sub run {
     }
     add_test_repositories;
     record_info 'Updates', script_output('zypper lu');
-    trup_call 'up', timeout => 600;
+    trup_call 'up', timeout => 1200;
     process_reboot(trigger => 1);
 }
 


### PR DESCRIPTION
Some maintenance jobs take more than 10 min to install all the updates
that are available from the GM image.

Example of failure: https://openqa.suse.de/tests/8684386#step/install_updates/59
