### PR TITLE
Fix EC2 cluster issue

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -358,6 +358,7 @@ sub terraform_apply {
         my $sle_version = get_var('FORCED_DEPLOY_REPO_VERSION') ? get_var('FORCED_DEPLOY_REPO_VERSION') : get_var('VERSION');
         $sle_version =~ s/-/_/g;
         my $ha_sap_repo = get_var('HA_SAP_REPO') ? get_var('HA_SAP_REPO') . '/SLE_' . $sle_version : '';
+        my $suffix = sprintf("%08x", rand(0xffffffff));
         file_content_replace('terraform.tfvars',
             q(%MACHINE_TYPE%) => $instance_type,
             q(%REGION%) => $self->provider_client->region,
@@ -371,7 +372,7 @@ sub terraform_apply {
         );
         upload_logs(TERRAFORM_DIR . "/$cloud_name/terraform.tfvars", failok => 1);
         script_retry('terraform init -no-color', timeout => $terraform_timeout, delay => 3, retry => 6);
-        assert_script_run("terraform workspace new $resource_group -no-color", $terraform_timeout);
+        assert_script_run("terraform workspace new ${resource_group}-${suffix} -no-color", $terraform_timeout);
     }
     else {
         assert_script_run('cd ' . TERRAFORM_DIR);

--- a/tests/publiccloud/sles4sap.pm
+++ b/tests/publiccloud/sles4sap.pm
@@ -6,7 +6,7 @@
 # Package: pacemaker-cli crmsh csync2
 # Summary: Test public cloud SLES4SAP images
 #
-# Maintainer: Loic Devulder <ldevulder@suse.de>
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
@@ -163,7 +163,7 @@ sub fence_node {
 
 sub run {
     my ($self) = @_;
-    my $timeout = 120;
+    my $timeout = bmwqemu::scale_timeout(480);
     my @cluster_types = split(',', get_required_var('CLUSTER_TYPES'));
 
     $self->select_serial_terminal;


### PR DESCRIPTION
With some cloud providers there are resources with a TTL that make it difficult to restart a test if failed. The fix is to have a random string in the resources' names.

This PR:
- Appends a random string of 8 hex characters to the Terraform workspace name (used as a prefix for cloud resources by [ha-sap-terraform-deployments](https://github.com/SUSE/ha-sap-terraform-deployments/)).
- Increases the timeout for the main function.

---

- Failing test: https://openqa.suse.de/tests/8684864
- Verification run: https://openqa.suse.de/tests/8689839 (failing for other reason)
https://openqa.suse.de/tests/8689908