### PR TITLE
Migrate ssh-X testsuite to libyui

### DIFF
--- a/schedule/yast/ssh-x.yaml
+++ b/schedule/yast/ssh-x.yaml
@@ -3,30 +3,38 @@ description:    >
   Conduct an installation using ssh with X-Forwarding.
   Might only be effective for zVM and powerVM
 vars:
+  YUI_REST_API: 1
   DESKTOP: textmode
-  PATTERNS: minimal,base
   VIDEOMODE: ssh-x
 schedule:
   - installation/bootloader_start
-  - installation/welcome
-  - installation/accept_license
-  # Required on zVM
+  - installation/setup_libyui
+  - installation/access_beta_distribution
+  - installation/ensure_installer_fullscreen
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+    # Required on zVM
   - '{{disk_activation}}'
-  - installation/scc_registration
-  - installation/addon_products_sle
-  - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_finish
-  - installation/installer_timezone
-  - installation/user_settings
-  - installation/user_settings_root
-  - installation/select_patterns
-  - installation/installation_overview
-  - installation/disable_grub_timeout
-  - installation/start_install
-  - installation/await_install
+  - installation/registration/register_via_scc
+  - installation/module_registration/skip_module_registration
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_text_mode
+  - installation/partitioning/select_guided_setup
+  - installation/partitioning/guided_setup/accept_default_part_scheme
+  - installation/partitioning/guided_setup/accept_default_fs_options
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
-  - installation/reboot_after_installation
+  - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
   - installation/validation/validate_sshd_reachable
@@ -35,4 +43,6 @@ conditional_schedule:
   disk_activation:
     BACKEND:
       s390x:
-        - installation/disk_activation
+        - installation/disk_activation/select_configure_dasd_disks
+        - installation/disk_activation/configure_dasd
+        - installation/disk_activation/finish_disk_activation

--- a/tests/installation/ensure_installer_fullscreen.pm
+++ b/tests/installation/ensure_installer_fullscreen.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enlarge the YaST window for fullscreen in ssh-X test.
+
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+use x11utils 'ensure_fullscreen';
+
+sub run {
+    ensure_fullscreen;
+}
+
+1;

--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -28,6 +28,9 @@ sub run {
                 $cmd = 'TERM=linux ';
             }
         }
+        if (check_var('VIDEOMODE', 'ssh-x')) {
+            $cmd .= 'QT_XCB_GL_INTEGRATION=none ';
+        }
         $cmd .= YuiRestClient::get_yui_params_string($port) . " yast.ssh";
         enter_cmd($cmd);
     }


### PR DESCRIPTION
- This commit migrates the ssh-X testsuite from a needle based approach
  to libyui. So we don't care if YaST windows are fullscreen or not.

Note that the VR for ppc64le still fails because when libyui sends the "press next" event in install_SLES there are still popups showing up sporadically on the screen, so this event won't arrive at YaST, even if the YUIRestServer sends an "200 OK" response back. Then in the next step accept license will complain that the required page will not appear. 

- Related ticket: https://progress.opensuse.org/issues/106514
- Needles: 
- Verification run: [Verification runs](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=rakoenig_fix_ensure_fullscreen&groupid=96) 