### PR TITLE
Remove some obsolete verification in nis_client

### DIFF
--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -22,8 +22,6 @@ use y2_module_consoletest;
 
 sub setup_nis_client {
     my $server_ip = shift;
-    assert_screen 'nis-client-install-missing-package';
-    send_key 'alt-i';    # install missing ypbind rpm
     assert_screen 'nis-client-configuration', 120;
     send_key 'alt-u';    # use NIS radio button
     wait_still_screen 4;


### PR DESCRIPTION
The parent job now installs ypbind, so we no longer see the pop-up for
installing it.

See failing job: https://openqa.suse.de/tests/8687144
VR: http://waaa-amazing.suse.cz/tests/16678

Before merging, we need to determine if we want to keep coverage for that [popup](https://openqa.suse.de/tests/8668096#step/nis_client/34) and make sure no other group is using this (eg in o3)
