### PR TITLE
Check package libgcrypt20-hmac installed

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -166,16 +166,22 @@ sub run {
     my ($gpg_version) = $gpg_version_output =~ /gpg \(GnuPG\) (\S+)/;
     record_info('gpg version', "Version of Current gpg package: $gpg_version");
 
-    # libgcrypt version check
-    my $pkg_list = {libgcrypt20 => '1.9.0'};
+    # Libgcrypt and libgcrypt20-hmac version check
+    # Refer to poo#107509
+    my $pkg_list = {
+        libgcrypt20 => '1.9.0',
+        'libgcrypt20-hmac' => '1.9.0'
+    };
     zypper_call("in " . join(' ', keys %$pkg_list));
 
     if (is_sle('>=15-sp4')) {
         package_upgrade_check($pkg_list);
     }
     else {
-        my $libgcrypt_ver = script_output("rpm -q --qf '%{version}\n' libgcrypt20");
-        record_info('libgcrypt20 version', "Version of Current package: $libgcrypt_ver");
+        foreach my $pkg_name (keys %$pkg_list) {
+            my $pkg_ver = script_output("rpm -q --qf '%{version}\n' $pkg_name");
+            record_info("$pkg_name version", "Version of Current package: $pkg_ver");
+        }
     }
 
     # GPG key generation and basic function testing with differnet key lengths


### PR DESCRIPTION
Progress issue: https://progress.opensuse.org/issues/107509

Check if the package libgcrypt20-hmac is installed

- Related ticket:  https://progress.opensuse.org/issues/107509
- Needles: None
- Verification run:
  - ENV mode: http://openqa.suse.de/tests/8695346#step/gpg/1
  - Kernel mode: https://openqa.suse.de/tests/8695319#step/gpg/1
