### PR TITLE
Fix false positive in test tflite2

### DIFF
--- a/tests/ai_ml/tflite2.pm
+++ b/tests/ai_ml/tflite2.pm
@@ -13,13 +13,15 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 use utils;
+use version_utils qw(is_opensuse is_leap);
 
 sub run {
     my ($self) = @_;
 
     $self->select_serial_terminal;
     # Install required software
-    zypper_call('in tensorflow2-lite python3-Pillow');
+    zypper_call('in tensorflow2-lite python3-Pillow python3-numpy');
+    my $ret = zypper_call('in  python3-tensorflow ', exitcode => [0, 4, 104]);
 
     select_console('user-console');
     # Perform tests in a separate folder
@@ -28,8 +30,19 @@ sub run {
     # Extract model and labels
     assert_script_run('unzip ~/data/ai_ml/models/mobilenet_v1_1.0_224_quant_and_labels.zip');
 
-    # Run the test
-    assert_script_run("python3 ~/data/ai_ml/label_image.py --image ~/data/ai_ml/images/White_shark.jpg --model_file mobilenet_v1_1.0_224_quant.tflite --label_file labels_mobilenet_quant_v1_224.txt | tee /dev/$serialdev | head -n1", sub { m/great white shark$/ });
+    my $result = script_output("python3 ~/data/ai_ml/label_image.py --image ~/data/ai_ml/images/White_shark.jpg --model_file mobilenet_v1_1.0_224_quant.tflite --label_file labels_mobilenet_quant_v1_224.txt | tee /dev/$serialdev | head -n1", proceed_on_failure => 1);
+    record_info("TEST LOG", "$result");
+
+    if ($result !~ /great white shark/) {
+        if ($ret == 4 && is_opensuse) {
+            record_soft_failure("boo#1199429 nothing provides 'libprotobuf.so.30()(64bit)' needed by the to be installed tensorflow2");
+        } elsif ($ret == 104 && is_leap) {
+            record_soft_failure("boo#1199330 package python3-tensorflow is not found");
+        } else {
+            die("Failed to match the result 'great white shark' after the python test run");
+        }
+
+    }
 
     # Clean-up
     assert_script_run('popd && rm -rf tflite2_tests');


### PR DESCRIPTION
Test tflite2 was showing false positive even with the error "no module named numpy".  Now Test is modified to installs required modules and verifies the output after the test run. 
While fixing the test, I found a bug in tensorflow package installation and bug is reported. Now I added softfail  in the test.
https://bugzilla.opensuse.org/show_bug.cgi?id=1199330
https://bugzilla.opensuse.org/show_bug.cgi?id=1199429

- Related ticket: https://progress.opensuse.org/issues/110548
- Needles: No
- Verification run: 
   Tumbleweed: [x86_64](https://openqa.opensuse.org/tests/2353183#step/tflite2/46)  | [aarch64](https://openqa.opensuse.org/tests/2352999#step/tflite2/34)
    Leap:  [x86_64](https://openqa.opensuse.org/tests/2330104#step/tflite2/31) | [aarch64](https://openqa.opensuse.org/tests/2353188#step/tflite2/19)