### PR TITLE
Public Cloud: Install rsync when not present by default

### DIFF
--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -31,6 +31,8 @@ sub run {
         assert_script_run('du -sh ~/repos');
         my $timeout = 2400;
 
+        $args->{my_instance}->run_ssh_command(cmd => "wchich rsync || sudo zypper -n in rsync");
+
         # Mitigate occasional CSP network problems (especially one CSP is prone to those issues!)
         # Delay of 2 minutes between the tries to give their network some time to recover after a failure
         script_retry("rsync --timeout=$timeout -uvahP -e ssh ~/repos '$remote:/tmp/repos'", timeout => $timeout + 10, retry => 3, delay => 120);


### PR DESCRIPTION
The CHOST images are shipped without `rsync` so in that case we need to install it to be able to receive the maintenance updates. See the log:

```bash
$ timeout 2410 rsync --timeout=2400 -uvahP -e ssh ~/repos 'susetest@35.189.239.108:/tmp/repos'; echo 7mWfM-$?-
bash: rsync: command not found
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: error in rsync protocol data stream (code 12) at io.c(235) [sender=3.1.3]
7mWfM-12-
```

- Related issue: https://openqa.suse.de/tests/8695199#step/transfer_repos/12
- Verification run: http://pdostal-server.suse.cz/tests/14694#live

The verification run is failing because of another issue.