### PR TITLE
Increase wait in firefox_html5 due to yt ads

### DIFF
--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -39,7 +39,7 @@ sub run {
         }
         last;
     }
-    send_key_until_needlematch('firefox-testvideo', 'spc', 15, 5);
+    send_key_until_needlematch('firefox-testvideo', 'spc', 30, 5);
     $self->exit_firefox;
 }
 1;


### PR DESCRIPTION

Increase wait in firefox_html5 due to yt ads

example of issue: https://openqa.suse.de/tests/8696557#step/firefox_html5/30

- Related ticket: https://progress.opensuse.org/issues/110665
- Needles: no needles
- Verification run: no verification
