### PR TITLE
Check related hmac packages when FIPS installation

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -15,9 +15,10 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
-use utils qw(quit_packagekit zypper_call reconnect_mgmt_console);
+use utils qw(quit_packagekit zypper_call reconnect_mgmt_console package_upgrade_check);
 use bootloader_setup "add_grub_cmdline_settings";
 use power_action_utils "power_action";
+use version_utils 'is_sle';
 use Utils::Backends 'is_pvm';
 
 sub run {
@@ -62,6 +63,28 @@ sub run {
         zypper_call('in -t pattern fips');
         add_grub_cmdline_settings('fips=1', update_grub => 1);
         record_info 'Kernel Mode', 'FIPS kernel mode configured!';
+    }
+
+    # Check if hmac related packages are installed
+    # Refer to poo#110707
+    my $pkg_list = {
+        'libcryptsetup12-hmac' => '2.4.0',
+        'libsoftokn3-hmac' => '3.68.0',
+        'libgnutls30-hmac' => '3.7.0',
+        'libfreebl3-hmac' => '3.68.0',
+        'libopenssl1_1-hmac' => '1.1.1',
+        'libgcrypt20-hmac' => '1.9.0'
+    };
+    zypper_call("in " . join(' ', keys %$pkg_list));
+
+    if (is_sle('>=15-sp4')) {
+        package_upgrade_check($pkg_list);
+    }
+    else {
+        foreach my $pkg_name (keys %$pkg_list) {
+            my $pkg_ver = script_output("rpm -q --qf '%{version}\n' $pkg_name");
+            record_info("$pkg_name version", "Version of Current package: $pkg_ver");
+        }
     }
 
     power_action('reboot', textmode => 1);


### PR DESCRIPTION
Progress issue: https://progress.opensuse.org/issues/110707
Check if related hmac packages are installed when installing FIPS.


- Related ticket: https://progress.opensuse.org/issues/110707
- Needles:  None
- Verification run
   -Env mode test:  https://openqa.suse.de/tests/8702841#step/fips_setup/76
   -Kernel mode test: http://openqa.suse.de/tests/8702834#step/fips_setup/73
