### PR TITLE
Increase timeout value for ensure_serialdev_permissions

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1263,7 +1263,7 @@ sub ensure_serialdev_permissions {
     else {
         # when serial getty is started, it changes the group of serialdev from dialout to tty (but doesn't change it back when stopped)
         # let's make sure that both will work
-        assert_script_run "chown $testapi::username /dev/$testapi::serialdev && usermod -a -G tty,dialout,\$(stat -c %G /dev/$testapi::serialdev) $testapi::username";
+        assert_script_run("chown $testapi::username /dev/$testapi::serialdev && usermod -a -G tty,dialout,\$(stat -c %G /dev/$testapi::serialdev) $testapi::username", timeout => 120);
     }
 }
 


### PR DESCRIPTION
Increase timeout value for ensure_serialdev_permissions to resolve the timeout issue.

- Related ticket: https://progress.opensuse.org/issues/110704
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/8728575#step/gnome_music/5
https://openqa.suse.de/tests/8728576#step/gnome_music/5