### PR TITLE
Fix incorrect invocation of openmpi from module command

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -27,7 +27,7 @@ sub run ($self) {
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
     # for <15-SP2 the openmpi2 module is named simply openmpi
-    $mpi = 'openmpi' if ($mpi =~ /openmpi2/);
+    $mpi = 'openmpi' if ($mpi =~ /openmpi2|openmpi3|openmpi4/);
     assert_script_run "module load gnu $mpi";
     script_run "module av";
     barrier_wait('CLUSTER_PROVISIONED');

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -19,7 +19,7 @@ sub run ($self) {
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
     # for <15-SP2 the openmpi2 module is named simply openmpi
-    $mpi = 'openmpi' if ($mpi =~ /openmpi2/);
+    $mpi = 'openmpi' if ($mpi =~ /openmpi2|openmpi3|openmpi4/);
     assert_script_run "module load gnu $mpi";
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');


### PR DESCRIPTION
The specific versions are all comes as _openmpi_ and the version is not
required from `module load` which breaks the test recently. This is a quick
fix and maybe there is a better solution in the future.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run:
[openmpi4](http://aquarius.suse.cz/tests/9478)
[openmpi3](http://aquarius.suse.cz/tests/9472)