### PR TITLE
publiccloud : add registration in post_fail_hook to increase chances that system is actually registered

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -117,6 +117,7 @@ sub post_fail_hook {
         record_info('azuremetadata', $self->{instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
     }
     $self->SUPER::post_fail_hook;
+    registercloudguest($self->{instance});
 }
 
 sub test_flags {


### PR DESCRIPTION
At the end of check_registercloudguest test module we expect the SUT to be registered.
If this test module fails the system may stay unregistered which breaks the following modules.

I suggest to force-register the system in post_fail_hook subroutine of this test module so the test run can continue.