### PR TITLE
Remove yast2_nis in yast2_ncurses_gnome

### DIFF
--- a/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml
@@ -26,7 +26,6 @@ conditional_schedule:
         - console/yast2_tftp
         - console/yast2_proxy
         - console/yast2_vnc
-        - console/yast2_nis
         - console/yast2_http
         - console/yast2_ftp
         - console/yast2_apparmor


### PR DESCRIPTION
Related tickets:
- https://openqa.suse.de/tests/8686871#step/yast2_nis/25
- https://bugzilla.suse.com/show_bug.cgi?id=1073281

In Tumbleweed we already drop NIS, and we have this test module
in SLE marked as softfailure, very likely misconfigured according
to bug report. At the same time we cover NIS in SLE in Multi-machine
without issues.

