### PR TITLE
Remove workaround for bsc#1161421

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -167,10 +167,12 @@ sub activate_kdump {
     }
     # ppcl64e and aarch64 needs increased kdump memory bsc#1161421
     if (is_ppc64le || is_aarch64) {
-        send_key('alt-y');
-        type_string $memory_kdump;
-        wait_screen_change(sub { send_key 'ret' }, 10) for (1 .. 2);
-        record_soft_failure 'default kdump memory size is too small for ppc64le and aarch64, see bsc#1161421';
+        if (is_sle('<15-sp4')) {
+            send_key('alt-y');
+            type_string $memory_kdump;
+            wait_screen_change(sub { send_key 'ret' }, 10) for (1 .. 2);
+            record_soft_failure 'default kdump memory size is too small for ppc64le and aarch64, see bsc#1161421';
+        }
         $expect_restart_info = 1;
     }
     # enable and verify fadump settings


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/107815
- Verification run: [yast2_ncurses_textmode](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=jknphy%2Fos-autoinst-distri-opensuse%23remove_kdump_workaround)
