### PR TITLE
Remove obsolete data autoyast_reinstall_ppc64le

### DIFF
--- a/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le.yaml
+++ b/test_data/yast/autoyast_reinstall/autoyast_reinstall_ppc64le.yaml
@@ -1,8 +1,0 @@
-paths:
-  - /var/lib/gdm/.bashrc
-  - /var/lib/empty/.bashrc
-  - /var/lib/polkit/.bashrc
-  - /var/lib/nobody/.bashrc
-  - /var/lib/pulseaudio/.bashrc
-<<: !include test_data/yast/autoyast_reinstall/partitioning_no_home.yaml
-<<: !include test_data/yast/autoyast/profiles/reinstall.yaml


### PR DESCRIPTION
We un-scehduled the test suite that uses this file, as we will run it
only on powervm/hmc from now on.
