### PR TITLE
Remove LTSS before migration

### DIFF
--- a/schedule/ha/bv/migration/migration_rolling_upgrade.yaml
+++ b/schedule/ha/bv/migration/migration_rolling_upgrade.yaml
@@ -58,6 +58,7 @@ schedule:
   - boot/boot_to_desktop
   - console/suseconnect_scc
   - update/zypper_up
+  - migration/online_migration/register_without_ltss
   - console/console_reboot
   - ha/wait_barriers
   - console/system_prepare


### PR DESCRIPTION
Remove LTSS before rolling upgrade

QR rolling upgrade migrations are failing because LTSS modules is not 
removed before starting migration. This PR adds 'register_without_ltss' 
test into rolling upgrade schedule, which removes LTSS module after 
initial package update.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1198245
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: 
failed: https://openqa.suse.de/tests/8688430#step/zypper_migration/4
passed: https://openqa.suse.de/tests/8724236#dependencies  
