### PR TITLE
Revert "BCI: use retry for cd command"

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -18,7 +18,6 @@ use Mojo::Base qw(consoletest);
 use XML::LibXML;
 use testapi;
 use File::Basename;
-use utils qw(script_retry);
 
 our $test_envs = get_var('BCI_TEST_ENVS', 'base,init,dotnet,python,node,go,multistage');
 our $error_count = 0;
@@ -93,7 +92,7 @@ sub run {
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     my $bci_dir = fileparse($bci_tests_repo, qr/\.[^.]*/);
-    script_retry("cd $bci_dir", timeout => 300, delay => 60, retry => 3);
+    assert_script_run("cd $bci_dir");
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
     assert_script_run("export CONTAINER_RUNTIME=$engine");
     $version =~ s/-SP/./g;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#14847

Can't run `timeout xyz` before `cd` command.. 