### PR TITLE
Ignore to install gun9/10/11 packages refer bsc#1194917

### DIFF
--- a/lib/services/hpcpackage_remain.pm
+++ b/lib/services/hpcpackage_remain.pm
@@ -37,7 +37,8 @@ sub list_pkg {
 sub install_pkg {
     my $version = get_var('HDDVERSION');
     # Install all 'library wrappers' (packages matching -hpc, not having a version number with '_' after their name)
-    my @pkginstall = split('\n', script_output q[zypper search -r SLE-Module-HPC] . $version . q[-Pool -r SLE-Module-HPC] . $version . q[-Updates | cut -d '|' -f 2 | sed -e 's/ *//g' | grep -E '.*-hpc.*' | grep -vE 'system|module|suse' |  grep -vE '.*_[[:digit:]]+_[[:digit:]]+.*gnu|.*_[[:digit:]]+_[[:digit:]]+.*-hpc' | grep -vE '.*-static$' | grep -vE '.*hpc-macros.*'], proceed_on_failure => 1, timeout => 180);
+    record_soft_failure('bsc#1194917', "openQA test fails : nothing provides 'gcc9' needed by the to be installed gnu9-compilers-hpc-devel-1.4-3.14.3.noarch");
+    my @pkginstall = split('\n', script_output q[zypper search -r SLE-Module-HPC] . $version . q[-Pool -r SLE-Module-HPC] . $version . q[-Updates | cut -d '|' -f 2 | sed -e 's/ *//g' | grep -E '.*-hpc.*' | grep -vE 'system|module|suse' | grep -vE 'gnu9|gnu10|gnu11' |  grep -vE '.*_[[:digit:]]+_[[:digit:]]+.*gnu|.*_[[:digit:]]+_[[:digit:]]+.*-hpc' | grep -vE '.*-static$' | grep -vE '.*hpc-macros.*'], proceed_on_failure => 1, timeout => 180);
     # on x86 zypper will print out the Shell debug information, we need exclude it.
     @pkginstall = grep { !/LMOD_SH_DBG_ON/ } @pkginstall;
     zypper_call("in " . join(' ', @pkginstall), timeout => 1800);


### PR DESCRIPTION
Ignore to install gun9/10/11 packages refer bsc#1194917. Because there is an error which was introduced thru a maintenance update when versions of gnu-compilers-hpc for older gcc versions were erroneously released for SLE-15-SP3.

- Related ticket: https://progress.opensuse.org/issues/110154
- Verification run: https://openqa.suse.de/tests/8702813#step/install_service/19
