### PR TITLE
Check RT kernel booted in SelfInstall-RT

### DIFF
--- a/schedule/sle-micro/selfinstall.yaml
+++ b/schedule/sle-micro/selfinstall.yaml
@@ -1,4 +1,4 @@
-name:           sle_micro_raw_image
+name:           sle_micro_selfinstall_image
 description:    >
     Maintainer: jalausuch@suse.com, qa-c@suse.de.
     SUSE Linux Enterprise Micro tests
@@ -15,10 +15,15 @@ conditional_schedule:
     ENABLE_SELINUX:
       '1':
         - transactional/enable_selinux
+  rt:
+    FLAVOR:
+      'Default-RT-SelfInstall':
+        - rt/rt_is_realtime
 schedule:
   - installation/bootloader_uefi
   - microos/selfinstall
   - transactional/host_config
+  - '{{rt}}'
   - '{{registration}}'
   - '{{maintenance}}'
   - '{{selinux}}'


### PR DESCRIPTION
Verify that RT has been booted as it is
[MicroOS-Image-RT](https://openqa.opensuse.org/tests/2335154#step/rt_is_realtime/21)

- Verification runs:
  * [leap-micro-5.2-MicroOS-Image-RT-SelfInstall](https://openqa.opensuse.org/t2337898) 
  * [sle-micro-5.2-Default-RT-SelfInstall](http://kepler.suse.cz/tests/16874#) 