### PR TITLE
Remove soft-failure bsc#1132116

### DIFF
--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -74,11 +74,6 @@ sub run {
     # install vsftps
     zypper_call("in vsftpd yast2-ftp-server", timeout => 180);
 
-    if (is_sle('>=15')) {
-        zypper_call("in yast2-users", timeout => 180);
-        record_soft_failure 'bsc#1132116';
-    }
-
     # clear any existing vsftpd leftover configs:
     script_run("rm /etc/vsftpd.conf");
     assert_script_run("rm -f /etc/vsftpd.pem");    #-f to not trigger error if file does not exist


### PR DESCRIPTION
yast2 users is always installed in SLE-15+, i.e.: https://openqa.suse.de/tests/8686871#step/yast2_ftp/4
Removing soffailure for https://bugzilla.suse.com/show_bug.cgi?id=1132116