### PR TITLE
Leap Micro: adapt SelfInstall schedule for aarch64 images

### DIFF
--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -11,6 +11,9 @@ use testapi;
 use microos "microos_login";
 
 sub run {
+    my ($self) = @_;
+    assert_screen 'selfinstall-screen', 180;
+    send_key 'down' unless check_screen 'selfinstall-select-drive';
     assert_screen 'selfinstall-select-drive';
     send_key 'ret';
     assert_screen 'slem-selfinstall-overwrite-drive';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/110845
- Verification run: https://openqa.opensuse.org/tests/2338944#step/selfinstall/3
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/2d7c467239e53d24183b99f3ca71ecd355133d64

The PR fixes the self-install way of selecting the right disk, however, it doesn't fix the issue with booting from the right disk after reboot. This can be tackled in a different PR.