### PR TITLE
Integrate 389ds in fips mode

### DIFF
--- a/schedule/security/389ds_sssd.yaml
+++ b/schedule/security/389ds_sssd.yaml
@@ -5,8 +5,13 @@ schedule:
     - boot/boot_to_desktop
     - console/consoletest_setup
     - network/setup_multimachine
+    - '{{fips_setup}}'
     - '{{tls_389ds}}'
 conditional_schedule:
+    fips_setup:
+        FIPS_ENABLED:
+            1:
+                - fips/fips_setup
     tls_389ds:
         HOSTNAME:
             server:


### PR DESCRIPTION
Progress issue: https://progress.opensuse.org/issues/88473
Implement "389ds + sssd" test in FIPS mode

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
