### PR TITLE
Bump version of hashicorp/azurerm

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "= 2.56.0"
+      version = "= 3.5.0"
       source = "hashicorp/azurerm"
     }
     random = {
@@ -138,7 +138,7 @@ resource "azurerm_network_interface" "openqa-nic" {
     ip_configuration {
         name                          = "${element(random_id.service.*.hex, count.index)}-nic-config"
         subnet_id                     = azurerm_subnet.openqa-subnet.id
-        private_ip_address_allocation = "dynamic"
+        private_ip_address_allocation = "Dynamic"
         public_ip_address_id          = element(azurerm_public_ip.openqa-publicip.*.id, count.index)
     }
 }


### PR DESCRIPTION
Increase the Azure provider version to the latest version 3.5.0.

- Related ticket: https://progress.opensuse.org/issues/110527
- Verification run: [15-SP3-AZURE-BYOS-gen2](https://duck-norris.qam.suse.de/tests/8889) | [15-SP3-AZURE-Basic](https://duck-norris.qam.suse.de/tests/8890) | [15-SP3-AZURE-Standard](https://duck-norris.qam.suse.de/tests/8891) | [15-SP2-AZURE-BYOS](https://duck-norris.qam.suse.de/tests/8887) | [15-SP1-AZURE-CHOST-BYOS](https://duck-norris.qam.suse.de/tests/8888)