### PR TITLE
Remove test module access_beta_distribution in YaST group

### DIFF
--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@pvm.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@pvm.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/btrfs/btrfs+warnings@pvm.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@pvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/clone_system/clone_system_pvm.yaml
+++ b/schedule/yast/clone_system/clone_system_pvm.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -14,7 +14,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -12,7 +12,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
@@ -14,7 +14,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -15,7 +15,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -17,7 +17,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/iscsi_configuration

--- a/schedule/yast/encryption/cryptlvm_sle_15.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
@@ -14,7 +14,6 @@ vars:
   YUI_REST_API: 1
 schedule:
   - installation/bootloader_start
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -14,7 +14,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -13,7 +13,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/validation/validate_install_repo
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -19,7 +19,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/validate_beta_message
-  - installation/access_beta_distribution
   - installation/language_keyboard/switch_keyboard_layout
   - installation/product_selection/install_SLES
   - installation/licensing/verify_license_translations

--- a/schedule/yast/installer_extended/installer_extended@pvm.yaml
+++ b/schedule/yast/installer_extended/installer_extended@pvm.yaml
@@ -17,7 +17,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/validate_beta_message
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/verify_license_translations
   - installation/licensing/verify_license_has_to_be_accepted

--- a/schedule/yast/installer_extended/installer_extended@s390x.yaml
+++ b/schedule/yast/installer_extended/installer_extended@s390x.yaml
@@ -17,7 +17,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/validate_beta_message
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/verify_license_translations
   - installation/licensing/verify_license_has_to_be_accepted

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/iscsi_configuration

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm_multipath.yaml
+++ b/schedule/yast/lvm_multipath.yaml
@@ -12,7 +12,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm_multipath_encrypted.yaml
+++ b/schedule/yast/lvm_multipath_encrypted.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+base/minimal+base@pvm.yaml
+++ b/schedule/yast/minimal+base/minimal+base@pvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+base/minimal+base@svirt-xen-hvm.yaml
+++ b/schedule/yast/minimal+base/minimal+base@svirt-xen-hvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x-disk-activation.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/disk_activation/select_configure_dasd_disks

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -12,7 +12,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
@@ -12,7 +12,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-xen-pv.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal@pvm.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal@pvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/modify_existing_partition/modify_existing_partition.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition.yaml
@@ -8,7 +8,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
@@ -8,7 +8,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/msdos/msdos.yaml
+++ b/schedule/yast/msdos/msdos.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/msdos/msdos@pvm.yaml
+++ b/schedule/yast/msdos/msdos@pvm.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/msdos/msdos@s390x.yaml
+++ b/schedule/yast/msdos/msdos@s390x.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/msdos/msdos@svirt-hyperv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-hyperv.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/msdos/msdos@svirt-xen-hvm.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-hvm.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/nvme.yaml
+++ b/schedule/yast/nvme.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_prep_boot_pvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_prep_boot_pvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_prep_boot_pvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_prep_boot_pvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_prep_boot_pvm.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -14,7 +14,6 @@ schedule:
   - installation/setup_libyui
   - installation/validation/repo_inst
   - installation/validation/validate_install_repo
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/select_disk/select_disk.yaml
+++ b/schedule/yast/select_disk/select_disk.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/select_disk/select_disk@pvm.yaml
+++ b/schedule/yast/select_disk/select_disk@pvm.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -17,7 +17,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@pvm.yaml
@@ -20,7 +20,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -17,7 +17,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/licensing/accept_license
   - installation/disk_activation/select_configure_dasd_disks
   - installation/disk_activation/configure_dasd

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -17,7 +17,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/licensing/accept_license
   - installation/registration/skip_registration
   - installation/module_selection/select_nonconflicting_modules

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
@@ -17,7 +17,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@uefi.yaml
@@ -17,7 +17,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -8,7 +8,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
@@ -8,7 +8,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_pvm.yaml
@@ -14,7 +14,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/skip_registration/skip_registration_pvm.yaml
+++ b/schedule/yast/skip_registration/skip_registration_pvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/sle/flows/default.yaml
+++ b/schedule/yast/sle/flows/default.yaml
@@ -4,8 +4,7 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta:
-  - installation/access_beta_distribution
+access_beta: []
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:

--- a/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
+++ b/schedule/yast/sles+sdk+proxy_SCC_via_YaST_pvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration

--- a/schedule/yast/ssh-x.yaml
+++ b/schedule/yast/ssh-x.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/ensure_installer_fullscreen
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license

--- a/schedule/yast/ssh_keys/do_not_import_ssh_keys.yaml
+++ b/schedule/yast/ssh_keys/do_not_import_ssh_keys.yaml
@@ -11,7 +11,6 @@ schedule:
   - x11/ssh_key_check
   - x11/reboot_and_install
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/ssh_keys/import_ssh_keys.yaml
+++ b/schedule/yast/ssh_keys/import_ssh_keys.yaml
@@ -11,7 +11,6 @@ schedule:
   - x11/ssh_key_check
   - x11/reboot_and_install
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/textmode/textmode.yaml
+++ b/schedule/yast/textmode/textmode.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/textmode/textmode@pvm.yaml
+++ b/schedule/yast/textmode/textmode@pvm.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/textmode/textmode@s390x_svirt.yaml
+++ b/schedule/yast/textmode/textmode@s390x_svirt.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/textmode/textmode@s390x_zVM.yaml
+++ b/schedule/yast/textmode/textmode@s390x_zVM.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/disk_activation/select_configure_dasd_disks

--- a/schedule/yast/textmode/textmode@svirt-xen.yaml
+++ b/schedule/yast/textmode/textmode@svirt-xen.yaml
@@ -7,7 +7,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role.yaml
@@ -14,7 +14,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -14,7 +14,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
     - installation/bootloader_start
     - installation/setup_libyui
-    - installation/access_beta_distribution
     - installation/product_selection/install_SLES
     - installation/licensing/accept_license
     - installation/registration/register_via_scc

--- a/schedule/yast/transactional_server/create_hdd_transactional_server@pvm.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server@pvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
     - installation/bootloader_start
     - installation/setup_libyui
-    - installation/access_beta_distribution
     - installation/product_selection/install_SLES
     - installation/licensing/accept_license
     - installation/registration/register_via_scc

--- a/schedule/yast/transactional_server/create_hdd_transactional_server@s390x.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server@s390x.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
     - installation/bootloader_start
     - installation/setup_libyui
-    - installation/access_beta_distribution
     - installation/product_selection/install_SLES
     - installation/licensing/accept_license
     - installation/registration/register_via_scc

--- a/schedule/yast/usb_install.yaml
+++ b/schedule/yast/usb_install.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - "{{registration_addons}}"

--- a/schedule/yast/xfs/xfs.yaml
+++ b/schedule/yast/xfs/xfs.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/xfs/xfs@s390x_svirt.yaml
+++ b/schedule/yast/xfs/xfs@s390x_svirt.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/xfs/xfs@s390x_zVM.yaml
+++ b/schedule/yast/xfs/xfs@s390x_zVM.yaml
@@ -10,7 +10,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/disk_activation/select_configure_dasd_disks

--- a/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-hvm.yaml
@@ -11,7 +11,6 @@ schedule:
   - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
+++ b/schedule/yast/xfs/xfs@svirt-xen-pv.yaml
@@ -11,7 +11,6 @@ schedule:
   - installation/isosize
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/xfs/xfs_spvm.yaml
+++ b/schedule/yast/xfs/xfs_spvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname.yaml
@@ -13,7 +13,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname.yaml
@@ -12,7 +12,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/yast_hostname/yast_hostname.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/validate_no_self_update
   - installation/licensing/accept_license

--- a/schedule/yast/yast_no_self_update/yast_no_self_update@s390x.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update@s390x.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/validate_no_self_update
   - installation/licensing/accept_license

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_pvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/yast_self_update/yast_self_update.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/validate_self_update
   - installation/licensing/accept_license

--- a/schedule/yast/yast_self_update/yast_self_update@s390x.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update@s390x.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/validate_self_update
   - installation/licensing/accept_license

--- a/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_pvm.yaml
@@ -11,7 +11,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -9,7 +9,6 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/disk_activation/select_configure_zfcp_disks


### PR DESCRIPTION
In YaST groups as almost all the test suite are using libyui REST
and YAML schedule, we need to unschedule this module now that the
Beta Flag is going to be removed in next snapshot.
