### PR TITLE
Fix number of parameters passed to diag

### DIFF
--- a/lib/data_integrity_utils.pm
+++ b/lib/data_integrity_utils.pm
@@ -74,7 +74,7 @@ sub verify_checksum {
             next;
         }
         if ($checksum eq $digest) {
-            diag("$image OK", "$image_path: OK");
+            diag("$image OK\n$image_path: OK");
         } else {
             $error .= "SHA256 checksum does not match for $image:\n\tCalculated: $digest\n\tExpected:   $checksum\n";
         }


### PR DESCRIPTION
Fast fix for a problem revealed by https://github.com/os-autoinst/os-autoinst/pull/2052

- Related ticket: https://openqa.suse.de/tests/8743614#step/bootloader_svirt/19
- Verification run: https://openqa.suse.de/tests/8746295#
