### PR TITLE
Change the ipsec test script's position

### DIFF
--- a/tests/security/cc/weak_ipsec_ciphers.pm
+++ b/tests/security/cc/weak_ipsec_ciphers.pm
@@ -17,7 +17,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
 
-    assert_script_run('cd /usr/local/atsec');
+    assert_script_run('cd /usr/local/atsec/ipsec/IPSEC_basic_eval');
     my $output = script_output('bash test_basic_ipsec_eval_weak.bash');
 
     my @lines = split(/\n/, $output);


### PR DESCRIPTION
We have moved the ipsec test scripts to another place, so we need to
adjust our test code.

Verify run: https://openqa.suse.de/tests/8749823#