### PR TITLE
Fix a typo in btrfs-progs tests

### DIFF
--- a/tests/btrfs-progs/run.pm
+++ b/tests/btrfs-progs/run.pm
@@ -111,7 +111,7 @@ sub run {
             # Add test status to STATUS_LOG file
             log_add(STATUS_LOG, "$category-$test", $status, $delta);
         }
-        set_var('SOFT_FAILURE', 1) if (@tests == 1) && ($status == 'SKIPPED');
+        set_var('SOFT_FAILURE', 1) if (@tests == 1) && ($status eq 'SKIPPED');
     }
 }
 


### PR DESCRIPTION
Should use 'eq' for string compare in perl

- Related ticket: N/A
- Needles: N/A
- Verification run: 
http://10.67.133.102/tests/649 (multiple tests  included SKIPPED)
http://10.67.133.102/tests/647 (single PASSED test)
http://10.67.133.102/tests/648 (single SKIPPED test, report SOFT_FAILURE as expect)