### PR TITLE
Configure nfs sharing between hpc master and slave nodes

### DIFF
--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -15,7 +15,7 @@ has mpirun => sub {
     my ($self) = shift;
     my $mpi = get_required_var('MPI');
     $self->mpirun("mpirun");
-    my @mpirun_args = ('-print-all-exitcodes');
+    my @mpirun_args;
     ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
     push @mpirun_args, '--allow-run-as-root ' if $mpi =~ m/openmpi/;
     (@mpirun_args == 0) ? $self->mpirun :

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -22,6 +22,7 @@ sub run ($self) {
     my $mpi_bin = 'mpi_bin';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);
+    my $exports_path = '/home/bernhard/bin';
 
     zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel python3-devel");
     my $need_restart = $self->setup_scientific_module();
@@ -33,37 +34,34 @@ sub run ($self) {
     barrier_wait('CLUSTER_PROVISIONED');
     ## all nodes should be able to ssh to each other, as MPIs requires so
     $self->generate_and_distribute_ssh();
-
-    barrier_wait('MPI_SETUP_READY');
     $self->check_nodes_availability();
 
     record_info('INFO', script_output('cat /proc/cpuinfo'));
     my $hostname = get_var('HOSTNAME', 'susetest');
     record_info "hostname", "$hostname";
     assert_script_run "hostnamectl status | grep $hostname";
-    assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O /tmp/$mpi_c");
-    assert_script_run("$mpi_compiler /tmp/$mpi_c -o /tmp/$mpi_bin | tee /tmp/make.out") if $mpi_compiler;
+    assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O $exports_path/$mpi_c");
+
+    $self->setup_nfs_server($exports_path);
+    barrier_wait('MPI_SETUP_READY');
+    assert_script_run("$mpi_compiler $exports_path/$mpi_c -o $exports_path/$mpi_bin | tee /tmp/make.out") if $mpi_compiler;
 
     # python code is not compiled. *mpi_bin* is expected as a compiled binary. if compilation was not
     # invoked return source code (ex: sample_scipy.py).
     $mpi_bin = ($mpi_compiler) ? $mpi_bin : $mpi_c;
-    ## distribute the binary
-    foreach (@cluster_nodes) {
-        assert_script_run("scp -o StrictHostKeyChecking=no /tmp/$mpi_bin root\@$_\:/tmp/$mpi_bin");
-    }
 
     barrier_wait('MPI_BINARIES_READY');
     my $mpirun_s = hpc::formatter->new();
 
     unless ($mpi_bin eq '.cpp') {    # because calls expects minimum 2 nodes
         record_info('INFO', 'Run MPI over single machine');
-        assert_script_run($mpirun_s->single_node("/tmp/$mpi_bin | tee /tmp/mpirun.out"));
+        assert_script_run($mpirun_s->single_node("$exports_path/$mpi_bin | tee /tmp/mpirun.out"));
     }
 
     record_info('INFO', 'Run MPI over several nodes');
     if ($mpi eq 'mvapich2') {
         # we do not support ethernet with mvapich2
-        my $return = script_run("set -o pipefail;" . $mpirun_s->all_nodes("/tmp/$mpi_bin |& tee /tmp/mpi_bin.log"));
+        my $return = script_run("set -o pipefail;" . $mpirun_s->all_nodes("$exports_path/$mpi_bin |& tee /tmp/mpi_bin.log"));
         if ($return == 143) {
             record_info("mvapich2 info", "echo $return - No IB device found");
         } elsif ($return == 139 || $return == 255) {
@@ -76,7 +74,7 @@ sub run ($self) {
             die("echo $return - not expected errorcode");
         }
     } else {
-        assert_script_run($mpirun_s->all_nodes('/tmp/$mpi_bin | tee /tmp/mpirun.out'));
+        assert_script_run($mpirun_s->all_nodes("$exports_path/$mpi_bin | tee /tmp/mpirun.out"));
     }
 
     barrier_wait('MPI_RUN_TEST');


### PR DESCRIPTION
Trying to simulate a real-world hpc setup, where the compute nodes are bare
machines which merely used to perform computation. This also makes the jobs a
bit faster as we do not need to provision those nodes with hpc packages. The
only compromise here is some required dependencies which hpc modules install
and are required to run mpi binaries.
    
To do so we need to export the location of the binary of which will run to test
mpi and the location of the installed HPC modules.

> The same needs to apply to spack. But expected to be slightly different situation there


- Related ticket: https://progress.opensuse.org/issues/109584
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
