### PR TITLE
Update the eula translation test data

### DIFF
--- a/schedule/yast/installer_extended/installer_extended.yaml
+++ b/schedule/yast/installer_extended/installer_extended.yaml
@@ -49,9 +49,9 @@ test_data:
     language: English (US)
     translations:
       - language: Czech
-        text: Licenční smlouva společnosti
+        text: Licenční smlouva s koncovým uživatelem
       - language: English (US)
-        text: End User License Agreement
+        text: End User License Agreement for SUSE Products
       - language: French
         text: Contrat de licence utilisateur final
       - language: German
@@ -59,19 +59,19 @@ test_data:
       - language: Italian
         text: Contratto di licenza
       - language: Japanese
-        text: 版ソフトウェア
+        text: エンドユーザ使用許諾契約
       - language: Korean
-        text: 소프트웨어
+        text: SUSE 제품에 관한
       - language: Portuguese (Brazilian)
         text: Contrato de Licença para Usuário Final
       - language: Russian
         text: Лицензионное соглашение
       - language: Simplified Chinese
-        text: 软件的
+        text: SUSE 产品
       - language: Spanish
         text: Acuerdo de licencia de usuario final
       - language: Traditional Chinese
-        text: 版軟體的
+        text: 最終使用者授權合約
   beta_text: 'You are accessing our Beta Distribution'
   modules:
     - sle-ha

--- a/schedule/yast/installer_extended/installer_extended@pvm.yaml
+++ b/schedule/yast/installer_extended/installer_extended@pvm.yaml
@@ -47,9 +47,9 @@ test_data:
     language: English (US)
     translations:
       - language: Czech
-        text: Licenční smlouva společnosti
+        text: Licenční smlouva s koncovým uživatelem
       - language: English (US)
-        text: End User License Agreement
+        text: End User License Agreement for SUSE Products
       - language: French
         text: Contrat de licence utilisateur final
       - language: German
@@ -57,19 +57,19 @@ test_data:
       - language: Italian
         text: Contratto di licenza
       - language: Japanese
-        text: 版ソフトウェア
+        text: エンドユーザ使用許諾契約
       - language: Korean
-        text: 소프트웨어
+        text: SUSE 제품에 관한
       - language: Portuguese (Brazilian)
         text: Contrato de Licença para Usuário Final
       - language: Russian
         text: Лицензионное соглашение
       - language: Simplified Chinese
-        text: 软件的
+        text: SUSE 产品
       - language: Spanish
         text: Acuerdo de licencia de usuario final
       - language: Traditional Chinese
-        text: 版軟體的
+        text: 最終使用者授權合約
   beta_text: 'You are accessing our Beta Distribution'
   modules:
     - sle-ha

--- a/schedule/yast/installer_extended/installer_extended@s390x.yaml
+++ b/schedule/yast/installer_extended/installer_extended@s390x.yaml
@@ -48,9 +48,9 @@ test_data:
     language: English (US)
     translations:
       - language: Czech
-        text: Licenční smlouva společnosti
+        text: Licenční smlouva s koncovým uživatelem
       - language: English (US)
-        text: End User License Agreement
+        text: End User License Agreement for SUSE Products
       - language: French
         text: Contrat de licence utilisateur final
       - language: German
@@ -58,19 +58,19 @@ test_data:
       - language: Italian
         text: Contratto di licenza
       - language: Japanese
-        text: 版ソフトウェア
+        text: エンドユーザ使用許諾契約
       - language: Korean
-        text: 소프트웨어
+        text: SUSE 제품에 관한
       - language: Portuguese (Brazilian)
         text: Contrato de Licença para Usuário Final
       - language: Russian
         text: Лицензионное соглашение
       - language: Simplified Chinese
-        text: 软件的
+        text: SUSE 产品
       - language: Spanish
         text: Acuerdo de licencia de usuario final
       - language: Traditional Chinese
-        text: 版軟體的
+        text: 最終使用者授權合約
   beta_text: 'You are accessing our Beta Distribution'
   modules:
     - sle-ha

--- a/test_data/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/test_data/yast/installer_extended/installer_extended_aarch64.yaml
@@ -3,9 +3,9 @@ license:
   language: English (US)
   translations:
     - language: Czech
-      text: Licenční smlouva společnosti
+      text: Licenční smlouva s koncovým uživatelem
     - language: English (US)
-      text: End User License Agreement
+      text: End User License Agreement for SUSE Products
     - language: French
       text: Contrat de licence utilisateur final
     - language: German
@@ -13,19 +13,19 @@ license:
     - language: Italian
       text: Contratto di licenza
     - language: Japanese
-      text: 版ソフトウェア
+      text: エンドユーザ使用許諾契約
     - language: Korean
-      text: 소프트웨어
+      text: SUSE 제품에 관한
     - language: Portuguese (Brazilian)
       text: Contrato de Licença para Usuário Final
     - language: Russian
       text: Лицензионное соглашение
     - language: Simplified Chinese
-      text: 软件的
+      text: SUSE 产品
     - language: Spanish
       text: Acuerdo de licencia de usuario final
     - language: Traditional Chinese
-      text: 版軟體的
+      text: 最終使用者授權合約
 beta_text: 'You are accessing our Beta Distribution'
 modules:
   - sle-ha

--- a/test_data/yast/installer_extended/installer_extended_ppc64le_s390x.yaml
+++ b/test_data/yast/installer_extended/installer_extended_ppc64le_s390x.yaml
@@ -3,9 +3,9 @@ license:
   language: English (US)
   translations:
     - language: Czech
-      text: Licenční smlouva společnosti
+      text: Licenční smlouva s koncovým uživatelem
     - language: English (US)
-      text: End User License Agreement
+      text: End User License Agreement for SUSE Products
     - language: French
       text: Contrat de licence utilisateur final
     - language: German
@@ -13,19 +13,19 @@ license:
     - language: Italian
       text: Contratto di licenza
     - language: Japanese
-      text: 版ソフトウェア
+      text: エンドユーザ使用許諾契約
     - language: Korean
-      text: 소프트웨어
+      text: SUSE 제품에 관한
     - language: Portuguese (Brazilian)
       text: Contrato de Licença para Usuário Final
     - language: Russian
       text: Лицензионное соглашение
     - language: Simplified Chinese
-      text: 软件的
+      text: SUSE 产品
     - language: Spanish
       text: Acuerdo de licencia de usuario final
     - language: Traditional Chinese
-      text: 版軟體的
+      text: 最終使用者授權合約
 beta_text: 'You are accessing our Beta Distribution'
 modules:
   - sle-ha


### PR DESCRIPTION
- Related ticket: Related to [failures in verify_license_translations](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=&modules=verify_license_translations&module_re=&distri=sle&version=15-SP4&build=148.1&groupid=129#)
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/overview?build=ge0r%2Fos-autoinst-distri-opensuse%23update-eula-data&version=15-SP4&distri=sle
