### PR TITLE
Add Tumbleweed support for LUKS unlock via SSH (via dracut-ssh)

### DIFF
--- a/data/autoyast_opensuse/autoyast_btrfs_luks1_separate_boot.xml
+++ b/data/autoyast_opensuse/autoyast_btrfs_luks1_separate_boot.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">30</timeout>
+    </global>
+  </bootloader>
+  <login_settings>
+    <autologin_user>bernhard</autologin_user>
+  </login_settings>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <partitioning t="list">
+    <drive t="map">
+      <device>/dev/vda</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots t="boolean">true</enable_snapshots>
+      <partitions t="list">
+        <partition t="map">
+          <create t="boolean">true</create>
+          <format t="boolean">false</format>
+          <partition_id t="integer">263</partition_id>
+          <partition_nr t="integer">1</partition_nr>
+          <resize t="boolean">false</resize>
+          <size>209715200</size>
+        </partition>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <create_subvolumes t="boolean">false</create_subvolumes>
+          <crypt_key>nots3cr3t</crypt_key>
+          <crypt_method t="symbol">luks1</crypt_method>
+          <filesystem t="symbol">btrfs</filesystem>
+          <format t="boolean">true</format>
+          <loop_fs t="boolean">true</loop_fs>
+          <mount>/boot</mount>
+          <mountby t="symbol">device</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">2</partition_nr>
+          <quotas t="boolean">false</quotas>
+          <resize t="boolean">false</resize>
+          <size>1073741824</size>
+          <subvolumes t="list"/>
+          <subvolumes_prefix/>
+        </partition>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <create_subvolumes t="boolean">true</create_subvolumes>
+          <filesystem t="symbol">btrfs</filesystem>
+          <format t="boolean">true</format>
+          <mount>/</mount>
+          <mountby t="symbol">uuid</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">3</partition_nr>
+          <quotas t="boolean">true</quotas>
+          <resize t="boolean">false</resize>
+          <size>18038652928</size>
+          <subvolumes t="list">
+            <subvolume t="map">
+              <copy_on_write t="boolean">false</copy_on_write>
+              <path>var</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>usr/local</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>tmp</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>srv</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>root</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>opt</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>home</path>
+            </subvolume>
+          </subvolumes>
+          <subvolumes_prefix>@</subvolumes_prefix>
+        </partition>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">swap</filesystem>
+          <format t="boolean">true</format>
+          <mount>swap</mount>
+          <mountby t="symbol">uuid</mountby>
+          <partition_id t="integer">130</partition_id>
+          <partition_nr t="integer">4</partition_nr>
+          <resize t="boolean">false</resize>
+          <size>2147483648</size>
+        </partition>
+      </partitions>
+      <type t="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <products config:type="list">
+        <product>openSUSE</product>
+    </products>
+    <patterns config:type="list">
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>gnome</pattern>
+    </patterns>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/schedule/security/autoyast_btrfs_luks1_separate_boot_tw.yaml
+++ b/schedule/security/autoyast_btrfs_luks1_separate_boot_tw.yaml
@@ -1,0 +1,21 @@
+---
+name: autoyast_btrfs_luks1_separate_boot
+description: >
+  Tumbleweed with luks1 encrypt with separate boot
+vars:
+  AUTOYAST: autoyast_opensuse/autoyast_btrfs_luks1_separate_boot.xml
+  DESKTOP: gnome
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - installation/handle_reboot
+  - installation/boot_encrypt
+  - installation/first_boot
+  - autoyast/console
+  - console/system_prepare
+  - console/zypper_ar
+  - console/zypper_ref
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/shutdown

--- a/tests/security/luks1/unlock_via_ssh_client.pm
+++ b/tests/security/luks1/unlock_via_ssh_client.pm
@@ -3,8 +3,8 @@
 #
 # Summary: Luks1 decrypt with ssh
 #
-# Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81780, tc#1768639
+# Maintainer: rfan1 <richard.fan@suse.com> Starry Wang <starry.wang@suse.com>
+# Tags: poo#81780, tc#1768639, poo#110953
 
 use strict;
 use warnings;
@@ -33,20 +33,23 @@ sub run {
 
     # ssh to the server and unlock the boot partiton
     enter_cmd('ssh -i /root/.ssh/id_rsa root@10.0.2.101');
+    wait_still_screen(1);
     save_screenshot;
 
-    # We need add some sleep here to make sure each command can get return
-    sleep 5;
+    # We need wait a few seconds here to make sure each command can get return
+    wait_still_screen(5);
     send_key 'up';
     save_screenshot;
-    sleep 5;
+    wait_still_screen(5);
     send_key 'ret';
-    sleep 5;
+    wait_still_screen(5);
     save_screenshot;
     enter_cmd("$testapi::password");
-    sleep 5;
-    enter_cmd('exit');
-    sleep 5;
+    wait_still_screen(5);
+    save_screenshot;
+    # exit from ssh session if it is not closed by remote host
+    enter_cmd('exit') unless check_screen('ssh_connection_closed_by_remote_host');
+    wait_still_screen(5);
     save_screenshot;
     reset_consoles;
 }

--- a/tests/security/luks1/unlock_via_ssh_server.pm
+++ b/tests/security/luks1/unlock_via_ssh_server.pm
@@ -3,8 +3,8 @@
 #
 # Summary: Luks1 decrypt with ssh
 #
-# Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#107488, tc#1769799
+# Maintainer: rfan1 <richard.fan@suse.com> Starry Wang <starry.wang@suse.com>
+# Tags: poo#107488, tc#1769799, poo#110953
 
 use strict;
 use warnings;
@@ -45,7 +45,7 @@ sub run {
     wait_for_children;
 
     # Make sure the boot is unlocked and server should be up
-    assert_screen('displaymanager', 200);
+    assert_screen([qw(generic-desktop opensuse-welcome displaymanager)], 200);
 
     # Double confirm the boot partiton is encrypted
     select_console('root-console');


### PR DESCRIPTION
1. Added YAML schedule and autoyast XML files for TW.
2. Updated the test code for TW.

- Related ticket: https://progress.opensuse.org/issues/110953
- Needles: 
    There are two needles created:
    - https://openqa.opensuse.org/tests/2345181#step/shutdown/5
    - https://openqa.opensuse.org/tests/2345245#step/unlock_via_ssh_client/11
- Verification run: 
    Tumbleweed:
    - https://openqa.opensuse.org/tests/2349994
    - https://openqa.opensuse.org/tests/2350014
    - https://openqa.opensuse.org/tests/2350234
    sle15sp4:
    - http://openqa.suse.de/tests/8750680
    - http://openqa.suse.de/tests/8750681
