### PR TITLE
x11/enlightenment_first_start: Also work without the acpid error dialog

### DIFF
--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -53,7 +53,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1};
+    return {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -41,7 +41,6 @@ sub run {
     }
     assert_and_click "enlightenment_assistant_next";
     if (get_required_var('ARCH') =~ /86/ || is_aarch64 || is_arm) {
-        assert_and_click 'enlightenment_acpid_missing';
         my $retry = 0;
         while ($retry < 5) {
             assert_screen [qw(enlightenment_generic_desktop enlightenment_acpid_missing)];

--- a/tests/x11/terminology.pm
+++ b/tests/x11/terminology.pm
@@ -16,7 +16,8 @@ sub run {
     my ($self) = @_;
     x11_start_program('teminology', target_match => [qw(terminology terminology-config-scale)]);
     # Somehow the window loses focus after click_lastmatch hides the mouse, avoid that
-    mouse_set(25, 25);
+    click_lastmatch if match_has_tag('terminology-config-scale');
+    # Somehow the window loses focus after click_lastmatch hides the mouse, avoid that by clicking again
     click_lastmatch if match_has_tag('terminology-config-scale');
     $self->enter_test_text('terminology', cmd => 1);
     mouse_hide(1);


### PR DESCRIPTION
The acpid issue got fixed recently and the dialog doesn't appear anymore.
Proceed also if generic-desktop matches directly.

Also mark it as fatal while at it. The current failing tests waste 20min failing the following modules instead of quitting directly.

Terminology needed a minor change as well.

- Verification run: https://openqa.opensuse.org/tests/2345266

Needles already created as part of the VR run(s).

I'd also do a verification run for the case that the acpid error dialog appears, but I couldn't find any. Leap 15.4 has the fix as well resp. a different error dialog appears...