### PR TITLE
WIP: Add firefox html5 selenium test

### DIFF
--- a/data/selenium/selenium_html5.py
+++ b/data/selenium/selenium_html5.py
@@ -1,0 +1,99 @@
+import sys
+
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.firefox.options import Options
+
+res = {}
+audio_codecs = [
+        "row-audio.codecs.pcm",
+        "row-audio.codecs.mp3",
+        "row-audio.codecs.mp4.aac",
+        "row-audio.codecs.mp4.ac3",
+        "row-audio.codecs.mp4.ec3",
+        "row-audio.codecs.ogg.vorbis",
+        "row-audio.codecs.ogg.opus"
+        ]
+img_formats = [
+        "row-canvas.jpeg",
+        "row-canvas.png",
+        "row-canvas.jpegxr",
+        "row-canvas.webp"
+        ]
+video_codecs = [
+        "row-video.codecs.mp4.mpeg4",
+        "row-video.codecs.mp4.h264",
+        "row-video.codecs.mp4.h265",
+        "row-video.codecs.ogg.theora",
+        "row-video.codecs.webm.vp8",
+        "row-video.codecs.webm.vp9",
+        ]
+
+options = Options()
+options.headless = True
+driver = webdriver.Firefox(".", options=options)
+driver.get("https://html5test.opensuse.org/")
+WebDriverWait(driver, 1000000).until(EC.presence_of_element_located((By.XPATH, '//*[@id="score"]/div/h2/strong')))
+element = driver.find_element_by_xpath('//*[@id="score"]/div/h2/strong')
+print("\n==================\n")
+# TOTAL SCORE CHECK
+try:
+    score = int(element.text)
+    if score < 500:
+        print("OVERALL SCORE: FAIL [[" + str(score) + " (<500), too low!]]")
+    else:
+        print("OVERALL SCORE: OK " + str(score) + " (>500), all good!")
+except:
+    print("OVERALL SCORE: ERROR [[Could not parse score from html]]")
+print("\n==================\n")
+
+# VIDEO SCORE + CODEC CHECK
+res["video"] = []
+element = driver.find_element_by_xpath('//*[@id="head-video"]/th/div/div/span')
+try:
+    video_score = element.text
+    if int(video_score.split("/")[0]) < 28:
+        print("VIDEO SCORE: FAIL [[Supported video codecs are <28, too low!]]")
+    else:
+        print("VIDEO SCORE: OK (Supported video codecs are " + str(video_score) + " (>28), all good!)")
+    for codec in video_codecs:
+        element = driver.find_element_by_xpath('//*[@id="' + codec + '"]/td/div')
+        if "No" in element.text:
+            res["video"].append(codec)
+    if res["video"]:
+        print("Unsupported video codecs:\n----------\n")
+        for codec in res["video"]:
+            print(codec)
+    else:
+        print("All video codecs are supported!")
+except:
+    print("VIDEO SCORE: ERROR [[Could not parse video score from html]]")
+print("\n==================")
+
+# AUDIO SCORE + CODEC CHECK
+res["audio"] = []
+element = driver.find_element_by_xpath('//*[@id="head-audio"]/th/div/div/span')
+try:
+    audio_score = element.text
+    if int(audio_score.split("/")[0]) < 27:
+        print("AUDIO SCORE: FAIL [[Supported audio codecs are " + audio_score.split("/")[0] + " (<27), too low!]]")
+    else:
+        print("AUDIO SCORE: OK (Supported audio codecs are " + str(audio_score) + " (>=27), all good!)")
+    for codec in audio_codecs:
+        element = driver.find_element_by_xpath('//*[@id="' + codec + '"]/td/div')
+        if "No" in element.text:
+            res["audio"].append(codec)
+    if res["audio"]:
+        print("Unsupported audio codecs:\n----------\n")
+        for codec in res["video"]:
+            print(codec)
+    else:
+        print("All audio codecs are supported!")
+except Exception as e:
+    print("AUDIO SCORE: ERROR [[Could not parse score from html]]")
+    print(e)
+print("\n==================")

--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -5,41 +5,50 @@
 # SPDX-License-Identifier: FSFAP
 
 # Package: MozillaFirefox
-# Summary: Case#1479221: Firefox: HTML5 Video
-# - Launch xterm, kill firefox, cleanup previous firefox configuration, launch
-# firefox
-# - Open "youtube.com/html5" and check result
-# - Open "youtube.com/watch?v=Z4j5rJQMdOU" and check result
-# - Exit firefox
-# Maintainer: wnereiz <wnereiz@gmail.com>
+# Summary: Case#1479221: Firefox: HTML5
+# - Launch xterm, install python and selenium
+# - Open opensuse html5 test page
+# - Access various page elements and check results
+# - Close
+# Maintainer: vanastasiadis <vasilios.anastasiadis@suse.com>
 
 use strict;
 use warnings;
 use base "x11test";
 use testapi;
+use utils;
 
 sub run {
     my ($self) = @_;
-    $self->start_firefox_with_profile;
+    select_console "x11";
+    x11_start_program('xterm');
+    
+    # prepare python + selenium
+    become_root;
+    quit_packagekit;
+    zypper_call("in python3");
+    enter_cmd "exit";
+    assert_script_run("pip3 install selenium");
+    assert_script_run "mkdir temp_selenium && cd temp_selenium";
+    assert_script_run "wget https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz && tar -xf geckodriver-v0.30.0-linux64.tar.gz";
+    assert_script_run "export PATH=\"\$(pwd):\$PATH\"";
+    assert_script_run "wget --quiet " . data_url('selenium/selenium_html5.py')     . " -O selenium_html5.py";
 
-    $self->firefox_open_url('youtube.com/watch?v=Z4j5rJQMdOU');
-    while (check_screen([qw(firefox-youtube-signin firefox-accept-youtube-cookies)], 15)) {
-        if (match_has_tag('firefox-accept-youtube-cookies')) {
-            # get to the accept button with tab and space
-            wait_still_screen(2);
-            send_key_until_needlematch('firefox-accept-youtube-cookies-agree', 'tab', 7, 1);
-            assert_and_click('firefox-accept-youtube-cookies-agree');
-            wait_still_screen(2);
-            next;
+    # run selenium script, parse results and upload logs
+    assert_script_run "python3 selenium_html5.py >&1 | tee selenium_output.txt ";
+    my $res = script_output("cat selenium_output.txt");
+    my @errs = ();
+    foreach my $line (split(/\n/, $res)) {
+        if (index($line, 'FAIL') != -1) {
+            my ($match) = $line =~ /\[\[ ( (?:(?!\]\]).)* ) \]\]/x;
+            push (@errs, $match);
         }
-        elsif (match_has_tag('firefox-youtube-signin')) {
-            assert_and_click('firefox-youtube-signin');
-            wait_still_screen(2);
-            next;
-        }
-        last;
     }
-    send_key_until_needlematch('firefox-testvideo', 'spc', 30, 5);
-    $self->exit_firefox;
+    upload_logs('geckodriver.log', log_name => 'html5-geckodriver-log.txt');
+    upload_logs('selenium_output.txt', log_name => 'html5-selenium-results.txt');
+    if (@errs){
+        my $errors = join(" | ", @errs);
+        die "$errors";
+    }
 }
 1;


### PR DESCRIPTION
This is a POC exploring ways to use python-selenium in openqa for specific tests. The test runs a python script which uses selenium to access https://html5test.opensuse.org/ and check a number of values and scores, which are then parsed in perl to determine success/failure of the test.

The test also uploads the geckodriver log and the full test result log.

(limits and checks are arbitrarily selected for the sake of demonstration)

- Related ticket: https://progress.opensuse.org/issues/109896
- Verification runs:
example of successful run: http://10.161.229.209/tests/610#
example of failed run (enforced higher score expectations): http://10.161.229.209/tests/608#step/firefox_html5/31
