### PR TITLE
Publish asset in svirt-xen for libyui image

### DIFF
--- a/schedule/yast/create_hdd_gnome_libyui.yaml
+++ b/schedule/yast/create_hdd_gnome_libyui.yaml
@@ -23,6 +23,9 @@ conditional_schedule:
     ARCH:
       s390x:
         - shutdown/svirt_upload_assets
+    VIRSH_VMM_FAMILY:
+      xen:
+        - shutdown/svirt_upload_assets
 test_data:
   install_packages:
     - libyui-rest-api


### PR DESCRIPTION
We are missing to upload the asset in the image creation:
https://openqa.suse.de/tests/8763867#step/shutdown/17
https://openqa.suse.de/tests/8763868#
