### PR TITLE
Helm: Avoid stop all the test when a module fails

### DIFF
--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -115,7 +115,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {fatal => 1, milestone => 1};
+    return {milestone => 1};
 }
 
 1;


### PR DESCRIPTION
Helm test has independent modules and the test could continue
with other modules if one of them has failed

See: https://openqa.suse.de/tests/8759653