### PR TITLE
Fix missing separator in ls

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -63,8 +63,8 @@ sub run {
             } else {
                 assert_script_run("echo -en '\\n" . ('#' x 80) . "\\n# $maintrepo:\\n' >> /tmp/repos.list.txt");
                 assert_script_run("echo 'Downloaded $maintrepo:' \$(du -hs $parent | cut -f1) >> ~/repos/qem_download_status.txt");
-                if (script_run("ls $parent*.repo") == 0) {
-                    assert_script_run(sprintf(q(sed -i '1 s/]/_%s]/' %s*.repo), random_string(4), $parent));
+                if (script_run("ls $parent/*.repo") == 0) {
+                    assert_script_run(sprintf(q(sed -i '1 s/]/_%s]/' %s/*.repo), random_string(4), $parent));
                     assert_script_run("find $parent >> /tmp/repos.list.txt");
                 } else {
                     record_soft_failure("No .repo file found in $parent. This directory will be removed.");


### PR DESCRIPTION
A missing separator in the ls command of the repos causes openQA to
sometimes delete still needed repositories.

- Related ticket: https://progress.opensuse.org/issues/111150
- Verification run: https://duck-norris.qam.suse.de/tests/8894
