### PR TITLE
Containers: use retries for Ubuntu apt-get commands

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -47,7 +47,7 @@ sub install_podman_when_needed {
         if ($host_os eq 'centos') {
             assert_script_run "yum -y install @pkgs --nobest --allowerasing", timeout => 300;
         } elsif ($host_os eq 'ubuntu') {
-            assert_script_run "apt-get -y install @pkgs", timeout => 300;
+            script_retry("apt-get -y install @pkgs", timeout => 300);
         } else {
             # We may run openSUSE with DISTRI=sle and opensuse doesn't have SUSEConnect
             activate_containers_module if $host_os =~ 'sle';
@@ -78,7 +78,7 @@ sub install_docker_when_needed {
         } elsif ($host_os eq 'ubuntu') {
             # Make sure you are about to install from the Docker repo instead of the default Ubuntu repo
             assert_script_run "apt-cache policy docker-ce";
-            assert_script_run "apt-get -y install docker-ce", timeout => 300;
+            script_retry("apt-get -y install docker-ce", timeout => 300);
         } else {
             if ($host_os =~ 'sle') {
                 # We may run openSUSE with DISTRI=sle and openSUSE does not have SUSEConnect
@@ -130,8 +130,8 @@ sub install_buildah_when_needed {
             assert_script_run "dnf -y update", timeout => 900;
             assert_script_run "dnf -y install buildah", timeout => 300;
         } elsif ($host_os eq 'ubuntu') {
-            assert_script_run "apt-get update", timeout => 900;
-            assert_script_run "apt-get -y install buildah", timeout => 300;
+            script_retry("apt-get update", timeout => 900);
+            script_retry("apt-get -y install buildah", timeout => 300);
         } elsif ($host_os eq 'rhel') {
             assert_script_run('yum update -y', timeout => 300);
             assert_script_run('yum install -y buildah', timeout => 300);

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -74,7 +74,7 @@ sub run {
     my @packages = packages_to_install($version, $sp, $host_distri);
     if ($host_distri eq 'ubuntu') {
         foreach my $pkg (@packages) {
-            script_retry("apt-get -y install $pkg", timeout => 300, delay => 60, retry => 5);
+            script_retry("apt-get -y install $pkg", timeout => 300);
         }
         assert_script_run('pip3 --quiet install --upgrade pip', timeout => 600);
         assert_script_run("pip3 --quiet install tox", timeout => 600);

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -33,7 +33,7 @@ sub run {
         if ($host_distri eq 'ubuntu') {
             # Sometimes, the host doesn't get an IP automatically via dhcp, we need force it just in case
             assert_script_run("dhclient -v");
-            assert_script_run("apt-get update -qq -y", timeout => $update_timeout);
+            script_retry("apt-get update -qq -y", timeout => $update_timeout);
         } elsif ($host_distri eq 'centos') {
             assert_script_run("dhclient -v");
             assert_script_run("yum update -q -y --nobest", timeout => $update_timeout);


### PR DESCRIPTION
When running tests on Ubuntu, there are some timeouts or some failed
commands due to Ubuntu mirrors not available or for some other
random reasons.
This will make our tests a bit more reliable in the preparation phase.
Example:
https://openqa.suse.de/tests/8764062#step/host_configuration/32

VR: http://openqa.suse.de/t8765048
