### PR TITLE
Unschedule lan modules for svirt-xen

### DIFF
--- a/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle-svirt-hvm.yaml
@@ -29,9 +29,6 @@ schedule:
     - x11/yast2_snapper
     - yast2_gui/yast2_hostnames
     - yast2_gui/yast2_network_settings
-    - yast2_gui/yast2_lan_restart_bridge
-    - yast2_gui/yast2_lan_restart_vlan
-    - yast2_gui/yast2_lan_restart_bond
 test_data:
     software:
         patterns:


### PR DESCRIPTION
Un-scheduling this modules for the same reason that we don't do it for s390x, we lost connection with libyui REST and we would need dedicated test with needles to tackle it. For now it is enough test coverage in x86_64. In the future we can consider to re-add them. At the moment the test suite was resurrected after one SP failing for miss-configuration.
