### PR TITLE
Containers: use retries for yum commands

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -45,7 +45,7 @@ sub install_podman_when_needed {
     my @pkgs = qw(podman);
     if (script_run("which podman") != 0) {
         if ($host_os eq 'centos') {
-            assert_script_run "yum -y install @pkgs --nobest --allowerasing", timeout => 300;
+            script_retry "yum -y install @pkgs --nobest --allowerasing", timeout => 300;
         } elsif ($host_os eq 'ubuntu') {
             script_retry("apt-get -y install @pkgs", timeout => 300);
         } else {
@@ -133,8 +133,8 @@ sub install_buildah_when_needed {
             script_retry("apt-get update", timeout => 900);
             script_retry("apt-get -y install buildah", timeout => 300);
         } elsif ($host_os eq 'rhel') {
-            assert_script_run('yum update -y', timeout => 300);
-            assert_script_run('yum install -y buildah', timeout => 300);
+            script_retry('yum update -y', timeout => 300);
+            script_retry('yum install -y buildah', timeout => 300);
         } else {
             activate_containers_module if $host_os =~ 'sle';
             zypper_call('in buildah', timeout => 300);

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -80,7 +80,7 @@ sub run {
         assert_script_run("pip3 --quiet install tox", timeout => 600);
     } elsif ($host_distri =~ /centos|rhel/) {
         foreach my $pkg (@packages) {
-            assert_script_run("yum install -y $pkg", timeout => 300);
+            script_retry("yum install -y $pkg", timeout => 300);
         }
         assert_script_run('pip3 --quiet install --upgrade pip', timeout => 600);
         assert_script_run("pip3 --quiet install tox", timeout => 600);

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -36,9 +36,9 @@ sub run {
             script_retry("apt-get update -qq -y", timeout => $update_timeout);
         } elsif ($host_distri eq 'centos') {
             assert_script_run("dhclient -v");
-            assert_script_run("yum update -q -y --nobest", timeout => $update_timeout);
+            script_retry("yum update -q -y --nobest", timeout => $update_timeout);
         } elsif ($host_distri eq 'rhel') {
-            assert_script_run("yum update -q -y", timeout => $update_timeout);
+            script_retry("yum update -q -y", timeout => $update_timeout);
         }
     }
 


### PR DESCRIPTION
Similar to Ubuntu, CentOS fails to install packages from time to time.
https://openqa.suse.de/tests/8755832#step/bci_prepare/28

VR: http://openqa.suse.de/t8765388
