### PR TITLE
Fix update polkit cause GDM restart

### DIFF
--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -26,6 +26,9 @@ sub run {
     add_test_repositories;
     set_zypp_single_rpmtrans;
     fully_patch_system;
+    # Sometimes update package 'polkit' will cause GDM restart, so after
+    # update patches we'd better to select_console to make test robust.
+    select_console 'root-console';
     install_patterns() if (get_var('PATTERNS'));
     deregister_dropped_modules;
     # disable multiversion for kernel-default based on bsc#1097111, for migration continuous cases only


### PR DESCRIPTION
Update polkit cause GDM restart which cause system reboot fail, we need add select_console after zypper patch to make test robust.

- Related ticket: https://progress.opensuse.org/issues/97310
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/8770153#step/zypper_patch/11
