### PR TITLE
Improve guest autoyast profile and cover sle15sp4 test

### DIFF
--- a/data/virtualization/autoyast/guest_12.xml.ep
+++ b/data/virtualization/autoyast/guest_12.xml.ep
@@ -1,0 +1,334 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>true</activate>
+    % if ($vm_name !~ /PV/) {
+      <append>console=ttyS0,115200 console=tty0</append>
+    % }
+      <boot_root>true</boot_root>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>console</terminal>
+      <timeout config:type="integer">8</timeout>
+      <trusted_grub>false</trusted_grub>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_reboot config:type="boolean">true</final_reboot>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">true</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <suse_register>
+  <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <slp_discovery config:type="boolean">false</slp_discovery>
+    <!--  optionally register some add-ons   -->
+    <addons config:type="list">
+    <addon>
+    <name>sle-module-adv-systems-management</name>
+    <version>12</version>
+    <arch>{{ARCH}}</arch>
+    <release_type/>
+    </addon>
+    % if ($ltss_code) {
+    <addon>
+      <name>SLES-LTSS</name>
+      <version>{{VERSION}}</version>
+      <arch>{{ARCH}}</arch>
+      <reg_code><%= $ltss_code %></reg_code>
+      <release_type/>
+    </addon>
+    % }
+    </addons>
+  </suse_register>
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE:/CA/{{CA_STR}}/</media_url>
+      </listentry>
+      % for my $repo (@$repos) {
+      <listentry>
+        <media_url><%= $repo %></media_url>
+      </listentry>
+      % }
+    </add_on_products>
+  </add-on>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id><%= $vm_name %></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <hostname><%= $vm_name %></hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">true</write_hostname>
+      <nameservers config:type="list">
+      <nameserver>192.168.122.1</nameserver>
+      </nameservers>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth0</device>
+        <ipaddr>{{IP}}</ipaddr>
+        <netmask>255.255.255.0</netmask>
+        <network>192.168.122.0</network>
+        <prefixlen>24</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>{{MAC}}</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>-</device>
+          <gateway>192.168.122.1</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+  </networking>
+  <kdump>
+    % if ($vm_name !~ /PV/) {
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>168M</listentry>
+    </crash_kernel>
+    % } else {
+    <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    % }
+  </kdump>
+  <partitioning config:type="list">
+    <drive>
+    % if ($vm_name =~ /PV|HVM/) {
+      <device>/dev/xvda</device>
+    % } else {
+      <device>/dev/vda</device>
+    % }
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>16G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>2G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list">
+        <service>SuSEfirewall2</service>
+      </disable>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>apache2</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>UTC</timezone>
+  </timezone>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+   <restricts config:type="list">
+     <restrict>
+       <options>kod nomodify notrap nopeer noquery</options>
+       <target>default</target>
+     </restrict>
+     <restrict>
+       <target>127.0.0.1</target>
+     </restrict>
+     <restrict>
+       <target>::1</target>
+     </restrict>
+   </restricts>
+   <peers config:type="list">
+     <peer>
+       <address>0.europe.pool.ntp.org</address>
+       <options>iburst</options>
+       <type>server</type>
+     </peer>
+     <peer>
+       <address>1.europe.pool.ntp.org</address>
+       <options>iburst</options>
+       <type>server</type>
+     </peer>
+     <peer>
+       <address>2.europe.pool.ntp.org</address>
+       <options>iburst</options>
+       <type>server</type>
+     </peer>
+     <peer>
+       <address>3.europe.pool.ntp.org</address>
+       <options>iburst</options>
+       <type>server</type>
+     </peer>
+   </peers>
+  </ntp-client>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/</user_password>
+      <username>root</username>
+    </user>
+  </users>
+<scripts>
+<post-scripts config:type="list">
+<script>
+<filename>PU1-cv-users.sh</filename>
+<source>
+<![CDATA[
+#!/bin/bash
+mkdir -p -m 700 /root/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' >> /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_key
+]]></source>
+</script>
+</post-scripts>
+</scripts>
+</profile>

--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -1,0 +1,324 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-legacy</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        <release_type/>
+      </addon>
+      <addon>
+        <name>PackageHub</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        <release_type/>
+      </addon>
+      <addon>
+        <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        <release_type/>
+      </addon>
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        <release_type/>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        <release_type/>
+      </addon>
+      % if ($ltss_code) {
+      <addon>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        <release_type/>
+       <reg_code><%= $ltss_code %></reg_code>
+      </addon>
+      % }
+    </addons>
+  </suse_register>
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url>http://download.suse.de/ibs/SUSE:/CA/{{CA_STR}}/</media_url>
+      </listentry>
+    % for my $repo (@$repos) {
+      <listentry>
+        <media_url><%= $repo %></media_url>
+      </listentry>
+      % }
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+    % if ($vm_name !~ /PV/) {
+      <append>console=ttyS0,115200 console=tty0</append>
+    % }
+      <cpu_mitigations>auto</cpu_mitigations>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>console</terminal>
+      <timeout config:type="integer">8</timeout>
+      <trusted_grub>false</trusted_grub>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_reboot config:type="boolean">true</final_reboot>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">true</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id><%= $vm_name %></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <hostname><%= $vm_name %></hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">true</write_hostname>
+      <nameservers config:type="list">
+      <nameserver>192.168.122.1</nameserver>
+      </nameservers>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+      <bootproto>static</bootproto>
+      <device>eth0</device>
+      <ipaddr>{{IP}}</ipaddr>
+      <netmask>255.255.255.0</netmask>
+      <network>192.168.122.0</network>
+      <!-- gateway>192.168.122.1</gateway -->
+      <prefixlen>24</prefixlen>
+      <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+       <name>eth0</name>
+       <rule>ATTR{address}</rule>
+       <value>{{MAC}}</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>-</device>
+          <gateway>192.168.122.1</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+  </networking>
+  <kdump>
+    % if ($vm_name !~ /PV/) {
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>168M</listentry>
+    </crash_kernel>
+    % } else {
+    <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    % }
+  </kdump>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+      <ntp_server>
+        <address>europe.pool.ntp.org</address>
+        <iburst config:type="boolean">true</iburst>
+        <offline config:type="boolean">false</offline>
+      </ntp_server>
+    </ntp_servers>
+    <ntp_sync>systemd</ntp_sync>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+    % if ($vm_name =~ /PV|HVM/) {
+      <device>/dev/xvda</device>
+    % } else {
+      <device>/dev/vda</device>
+    % }
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <size>16G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <size>2G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list">
+        <service>firewalld</service>
+      </disable>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+      <on_demand config:type="list"/>
+    </services>
+  </services-manager>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>apache2</package>
+    </packages>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>enhanced_base</pattern>
+      <pattern>apparmor</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>UTC</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <authorized_keys config:type="list"/>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bernhard</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <home_btrfs_subvolume config:type="boolean">false</home_btrfs_subvolume>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <authorized_keys config:type="list"/>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <home_btrfs_subvolume config:type="boolean">false</home_btrfs_subvolume>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/</user_password>
+      <username>root</username>
+    </user>
+  </users>
+<scripts>
+<post-scripts config:type="list">
+<script>
+<filename>PU1-cv-users.sh</filename>
+<source>
+<![CDATA[
+#!/bin/bash
+mkdir -p -m 700 /root/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' >> /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_key
+]]></source>
+</script>
+</post-scripts>
+</scripts>
+</profile>

--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -316,6 +316,59 @@ cat >> /root/.config/fontconfig/fonts.conf <<EOF
   </alias>
 </fontconfig>
 EOF
+mkdir -p -m 700 /root/.ssh
+cat >> /root/.ssh/id_rsa<< EOF
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+NhAAAAAwEAAQAAAYEAtFzEfa/DTa+fPvAZmw/gsk0HfYkKoiGI2OOYFYhKpdPkea2oVh0A
+cbkgMZCWzzC7ncptX33Ut/jg7gVTvJxwAWe3hmj2SUEEztGNm6SVworP9BsT1A/eBCfjSP
++P6s6crsOQm3ztjGs13hd/JgUTv3HmeeGSJGTLqkx6uZKfq4atislAcbpvbVgu7h4dCRQq
+Ea6NvLkUoDZ97lUjHtaQIoXasJWegmg8Hzf9/mhKg08/3vxONQCiYw8ew2gjumpSm5J9lf
+A9mpbYY5we2bSjbGH5IkOlfarvZRLYHhUHhGSZJVj26vgmC3L6+xcrPDOegADagc2uSnPG
+uwC2WTRG6225rAsvmr0vz7X7ey1zYw3zU1F0PjUQzR7b3PVJhzsfXHaJIFOeIcQH8b/Ctr
+HL2lngUCRwLu+qDTK5xsSiDHTQR9GWzbnUoC5R1fWfzyGGFze18R3CbiIPYY6Nq8lHT3UQ
+OChmnmTfa1569PPKiVLQyY9DAWkUgmbauc1miclJAAAFiG6RBSlukQUpAAAAB3NzaC1yc2
+EAAAGBALRcxH2vw02vnz7wGZsP4LJNB32JCqIhiNjjmBWISqXT5HmtqFYdAHG5IDGQls8w
+u53KbV991Lf44O4FU7yccAFnt4Zo9klBBM7RjZuklcKKz/QbE9QP3gQn40j/j+rOnK7DkJ
+t87YxrNd4XfyYFE79x5nnhkiRky6pMermSn6uGrYrJQHG6b21YLu4eHQkUKhGujby5FKA2
+fe5VIx7WkCKF2rCVnoJoPB83/f5oSoNPP978TjUAomMPHsNoI7pqUpuSfZXwPZqW2GOcHt
+m0o2xh+SJDpX2q72US2B4VB4RkmSVY9ur4Jgty+vsXKzwznoAA2oHNrkpzxrsAtlk0Rutt
+uawLL5q9L8+1+3stc2MN81NRdD41EM0e29z1SYc7H1x2iSBTniHEB/G/wraxy9pZ4FAkcC
+7vqg0yucbEogx00EfRls251KAuUdX1n88hhhc3tfEdwm4iD2GOjavJR091EDgoZp5k32te
+evTzyolS0MmPQwFpFIJm2rnNZonJSQAAAAMBAAEAAAGBAKhduOcDPjO079kW1TBVABIxqf
+5cAVscJt0giIYBNn3acXvMykmoxRNkF1Ntf/plqZ5AqxzrH7mlUIOg4Ww+NKh7I20Lam0z
+jsNqBuD2IP78Cef7puTc8wm6Goe4WaZ9vPG/iaw8UJw2MJDkKkNZlfeu4dGA6qWimiSdRC
+sbXoYGMNZPzCLeQMo3+Yc7ASvKcQMUiSdVNpXgiGoFe8V70g0IGv+gi9l8aDNUV3w36ubt
+Adisem0r7GrAYJ1VB5UrTeOtMB0jfUfhTWpzskPBIj1no6k0iv+3/xX1Q/A33zgo62qNlY
+8ufw1E45dH/e/V2EXrNt/muP5l12Jm/oUggLepkPfXvDOmjO6HUn0MrSIRQc+h/jHbW8oM
+uB/9w84blDtAxPBFlWBwqwFMiwBrcb69wX+hSSk4lt1fgb0cmVdZ/g6/LUZ+rhDJBoF8tt
+hLQNwc/spI2jyVWQA6xI0QCyXnAZkhDl7SG4l1+bNSbdVOycTwJIwxtFY83c/TOOGFiQAA
+AMEAvcP/w/VVhC9dUeolArTs+G+NLIhRAmAtF1buYqfpyKw+XFKo3ZCDV8L/YeApQRiggW
+UN3fRdFmduW6y7gGQFhmjZsPDzjBGnSAYHX7LP5JaykaV/kMzXKPLPQf5JvAMPw6mokTd8
+yHuwPczjlzAkAXeXNk/dJ3kk5y0CL3lGC5KTLLlSSrhXlZai82SH1QNuudZLKsHUZ8du+f
+Qjh/pwD6+DDT2mg2kxKA12oPlmTOOUnI7cQxT7HQEYjybK9CHXAAAAwQDnvXWMmZKgWfnc
+4LZlxCYQvr5ZXQUksxgACW9WWoBR/7e9SjQs1th8NmEbX5JQsgxuXjXLhalr30UZzTbO82
+u0lwyCraVgAfr2YL8PuhCkSimi6NI9CrvetfbgHPsDAR45bMmLDbU3kGFKN47T2v6oYSYX
+KY6dS805LzaQH2+RnHR+xxZjd305lAZXkxZT54MOV80L3YSk7HyfCdY0WUS01UBD6uAQbw
+cvmWDxCp8gUkKrFL/ASyV9yK+IYy4ZJAcAAADBAMc+aBhA+T9Jwq7/x6lCzrG4zO3w+l0X
+AztXQAAHH64nkiECQ+pTn/qHH6TEfSkeqj97o/RDlGbf3s0NogUZEhSxGMxMhoqPatMa93
+UajDxU+4Xchxtt4S6MPHMIYRRcRi+pqa91Iz8wYYsN3PHVoRKsbRI2H0Nh5cqjjHeN1DhD
+lbzZvl0rkSQSotKBVWnX/1aU5Pk0RX8HKzYyLZiTjXJAX8RKnem5gsmeVv6yRbcQ2Fp5+I
+t3XODgiOxVK190LwAAAApyb290QHJpdmVyAQIDBAUGBw==
+-----END OPENSSH PRIVATE KEY-----
+EOF
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' > /root/.ssh/id_rsa.pub
+
+cat >> /root/.ssh/config << EOF
+StrictHostKeyChecking no
+HostKeyAlgorithms ssh-rsa
+PreferredAuthentications publickey
+#ControlMaster auto
+#ControlPersist 86400
+#ControlPath ~/.ssh/ssh_%r_%h_%p
+EOF
+cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys /root/.ssh/config
 ]]>
         </source>
       </script>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -41,6 +41,7 @@
   </add-on>
   <bootloader>
     <global>
+      <activate>true</activate>
       <boot_mbr>true</boot_mbr>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
@@ -285,6 +286,60 @@ cat >> /root/.config/fontconfig/fonts.conf <<EOF
   </alias>
 </fontconfig>
 EOF
+mkdir -p -m 700 /root/.ssh
+cat >> /root/.ssh/id_rsa<< EOF
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+NhAAAAAwEAAQAAAYEAtFzEfa/DTa+fPvAZmw/gsk0HfYkKoiGI2OOYFYhKpdPkea2oVh0A
+cbkgMZCWzzC7ncptX33Ut/jg7gVTvJxwAWe3hmj2SUEEztGNm6SVworP9BsT1A/eBCfjSP
++P6s6crsOQm3ztjGs13hd/JgUTv3HmeeGSJGTLqkx6uZKfq4atislAcbpvbVgu7h4dCRQq
+Ea6NvLkUoDZ97lUjHtaQIoXasJWegmg8Hzf9/mhKg08/3vxONQCiYw8ew2gjumpSm5J9lf
+A9mpbYY5we2bSjbGH5IkOlfarvZRLYHhUHhGSZJVj26vgmC3L6+xcrPDOegADagc2uSnPG
+uwC2WTRG6225rAsvmr0vz7X7ey1zYw3zU1F0PjUQzR7b3PVJhzsfXHaJIFOeIcQH8b/Ctr
+HL2lngUCRwLu+qDTK5xsSiDHTQR9GWzbnUoC5R1fWfzyGGFze18R3CbiIPYY6Nq8lHT3UQ
+OChmnmTfa1569PPKiVLQyY9DAWkUgmbauc1miclJAAAFiG6RBSlukQUpAAAAB3NzaC1yc2
+EAAAGBALRcxH2vw02vnz7wGZsP4LJNB32JCqIhiNjjmBWISqXT5HmtqFYdAHG5IDGQls8w
+u53KbV991Lf44O4FU7yccAFnt4Zo9klBBM7RjZuklcKKz/QbE9QP3gQn40j/j+rOnK7DkJ
+t87YxrNd4XfyYFE79x5nnhkiRky6pMermSn6uGrYrJQHG6b21YLu4eHQkUKhGujby5FKA2
+fe5VIx7WkCKF2rCVnoJoPB83/f5oSoNPP978TjUAomMPHsNoI7pqUpuSfZXwPZqW2GOcHt
+m0o2xh+SJDpX2q72US2B4VB4RkmSVY9ur4Jgty+vsXKzwznoAA2oHNrkpzxrsAtlk0Rutt
+uawLL5q9L8+1+3stc2MN81NRdD41EM0e29z1SYc7H1x2iSBTniHEB/G/wraxy9pZ4FAkcC
+7vqg0yucbEogx00EfRls251KAuUdX1n88hhhc3tfEdwm4iD2GOjavJR091EDgoZp5k32te
+evTzyolS0MmPQwFpFIJm2rnNZonJSQAAAAMBAAEAAAGBAKhduOcDPjO079kW1TBVABIxqf
+5cAVscJt0giIYBNn3acXvMykmoxRNkF1Ntf/plqZ5AqxzrH7mlUIOg4Ww+NKh7I20Lam0z
+jsNqBuD2IP78Cef7puTc8wm6Goe4WaZ9vPG/iaw8UJw2MJDkKkNZlfeu4dGA6qWimiSdRC
+sbXoYGMNZPzCLeQMo3+Yc7ASvKcQMUiSdVNpXgiGoFe8V70g0IGv+gi9l8aDNUV3w36ubt
+Adisem0r7GrAYJ1VB5UrTeOtMB0jfUfhTWpzskPBIj1no6k0iv+3/xX1Q/A33zgo62qNlY
+8ufw1E45dH/e/V2EXrNt/muP5l12Jm/oUggLepkPfXvDOmjO6HUn0MrSIRQc+h/jHbW8oM
+uB/9w84blDtAxPBFlWBwqwFMiwBrcb69wX+hSSk4lt1fgb0cmVdZ/g6/LUZ+rhDJBoF8tt
+hLQNwc/spI2jyVWQA6xI0QCyXnAZkhDl7SG4l1+bNSbdVOycTwJIwxtFY83c/TOOGFiQAA
+AMEAvcP/w/VVhC9dUeolArTs+G+NLIhRAmAtF1buYqfpyKw+XFKo3ZCDV8L/YeApQRiggW
+UN3fRdFmduW6y7gGQFhmjZsPDzjBGnSAYHX7LP5JaykaV/kMzXKPLPQf5JvAMPw6mokTd8
+yHuwPczjlzAkAXeXNk/dJ3kk5y0CL3lGC5KTLLlSSrhXlZai82SH1QNuudZLKsHUZ8du+f
+Qjh/pwD6+DDT2mg2kxKA12oPlmTOOUnI7cQxT7HQEYjybK9CHXAAAAwQDnvXWMmZKgWfnc
+4LZlxCYQvr5ZXQUksxgACW9WWoBR/7e9SjQs1th8NmEbX5JQsgxuXjXLhalr30UZzTbO82
+u0lwyCraVgAfr2YL8PuhCkSimi6NI9CrvetfbgHPsDAR45bMmLDbU3kGFKN47T2v6oYSYX
+KY6dS805LzaQH2+RnHR+xxZjd305lAZXkxZT54MOV80L3YSk7HyfCdY0WUS01UBD6uAQbw
+cvmWDxCp8gUkKrFL/ASyV9yK+IYy4ZJAcAAADBAMc+aBhA+T9Jwq7/x6lCzrG4zO3w+l0X
+AztXQAAHH64nkiECQ+pTn/qHH6TEfSkeqj97o/RDlGbf3s0NogUZEhSxGMxMhoqPatMa93
+UajDxU+4Xchxtt4S6MPHMIYRRcRi+pqa91Iz8wYYsN3PHVoRKsbRI2H0Nh5cqjjHeN1DhD
+lbzZvl0rkSQSotKBVWnX/1aU5Pk0RX8HKzYyLZiTjXJAX8RKnem5gsmeVv6yRbcQ2Fp5+I
+t3XODgiOxVK190LwAAAApyb290QHJpdmVyAQIDBAUGBw==
+-----END OPENSSH PRIVATE KEY-----
+EOF
+chmod 600 /root/.ssh/id_rsa
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' > /root/.ssh/id_rsa.pub
+
+cat >> /root/.ssh/config << EOF
+StrictHostKeyChecking no
+HostKeyAlgorithms ssh-rsa
+PreferredAuthentications publickey
+#ControlMaster auto
+#ControlPersist 86400
+#ControlPath ~/.ssh/ssh_%r_%h_%p
+EOF
+cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys /root/.ssh/config
 ]]>
         </source>
       </script>
@@ -293,6 +348,15 @@ EOF
         <filename>disable_dom0_balloon.sh</filename>
         <source><![CDATA[
 if [ -e /etc/xen/xl.conf ]; then sed -i '/autoballoon=/ s/.*/autoballoon="off"/' /etc/xen/xl.conf; fi
+]]>
+        </source>
+      </script>
+   % } 
+    % if ($check_var->('VERSION', '15-SP4') && $check_var->('IPMI_HW', 'AMD') && $check_var->('SYSTEM_ROLE', 'xen')) {
+      <script>
+        <filename>workround_ip_forward_amd.sh</filename>
+        <source><![CDATA[
+		echo 'net.ipv4.ip_forward = 1' >> /etc/sysctl.conf
 ]]>
         </source>
       </script>

--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -128,7 +128,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles15sp3PV => {
             name => 'sles15sp3PV',
             autoyast => 'autoyast_xen/sles15sp3PV_PRG.xml',
-            extra_params => '--os-variant sles12',
+            extra_params => '--os-variant sle15-unknown',
             macaddress => '52:54:00:78:73:b1',
             ip => '192.168.122.117',
             distro => 'SLE_15',
@@ -138,7 +138,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles15sp3HVM => {
             name => 'sles15sp3HVM',
             autoyast => 'autoyast_xen/sles15sp3HVM_PRG.xml',
-            extra_params => '--os-variant sles12',
+            extra_params => '--os-variant sle15-unknown',
             macaddress => '52:54:00:78:73:b2',
             ip => '192.168.122.118',
             distro => 'SLE_15',
@@ -165,6 +165,24 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             location => 'http://mirror.suse.cz/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/',
             linuxrc => 'ifcfg="eth0=192.168.122.114/24,192.168.122.1,192.168.122.1"',
         },
+        sles15sp4PV => {
+            name => 'sles15sp4PV',
+            extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
+            macaddress => '52:54:00:78:73:a5',
+            ip => '192.168.122.110',
+            distro => 'SLE_15_SP4',
+            location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP4-Full-LATEST/x86_64/DVD1/',
+            linuxrc => 'ifcfg="eth0=192.168.122.110/24,192.168.122.1,192.168.122.1"'
+        },
+        sles15sp4HVM => {
+            name => 'sles15sp4HVM',
+            extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
+            macaddress => '52:54:00:78:73:a6',
+            ip => '192.168.122.108',
+            distro => 'SLE_15_SP4',
+            location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP4-Full-LATEST/x86_64/DVD1/',
+            linuxrc => 'ifcfg="eth0=192.168.122.108/24,192.168.122.1,192.168.122.1"'
+        }
     );
 
     delete($guests{sles12sp3HVM}) if (!is_sle('=12-SP3'));
@@ -207,7 +225,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles15sp1 => {
             name => 'sles15sp1',
             autoyast => 'autoyast_kvm/sles15sp1_PRG.xml',
-            extra_params => '--os-variant sles12',    # problems after kernel upgrade
+            extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
             macaddress => '52:54:00:78:73:ab',
             ip => '192.168.122.111',
             distro => 'SLE_15',
@@ -217,7 +235,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles15sp2 => {
             name => 'sles15sp2',
             autoyast => 'autoyast_kvm/sles15sp2_PRG.xml',
-            extra_params => '--os-variant sles12',    # problems after kernel upgrade (originally sle15sp2)
+            extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade (originally sle15sp2)
             macaddress => '52:54:00:78:73:af',
             ip => '192.168.122.115',
             distro => 'SLE_15',
@@ -227,7 +245,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles15sp3 => {
             name => 'sles15sp3',
             autoyast => 'autoyast_kvm/sles15sp3_PRG.xml',
-            extra_params => '--os-variant sles12',
+            extra_params => '--os-variant sle15-unknown',
             macaddress => '52:54:00:78:73:b1',
             ip => '192.168.122.117',
             distro => 'SLE_15',
@@ -244,6 +262,15 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             location => 'http://mirror.suse.cz/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/',
             linuxrc => 'ifcfg="eth0=192.168.122.113/24,192.168.122.1,192.168.122.1"',
         },
+        sles15sp4 => {
+            name => 'sles15sp4',
+            extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
+            macaddress => '52:54:00:78:73:a6',
+            ip => '192.168.122.108',
+            distro => 'SLE_15',
+            location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP4-Full-LATEST/x86_64/DVD1/',
+            linuxrc => 'ifcfg="eth0=192.168.122.108/24,192.168.122.1,192.168.122.1"'
+        }
     );
 } elsif (get_var("REGRESSION", '') =~ /vmware/) {
     %guests = (

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -199,7 +199,7 @@ sub create_guest {
 
         # Run unattended installation for selected guest
         my ($autoyastURL, $diskformat, $virtinstall);
-        $autoyastURL = data_url($autoyast);
+        $autoyastURL = $autoyast;
         $diskformat = get_var("VIRT_QEMU_DISK_FORMAT") // "qcow2";
 
         assert_script_run "qemu-img create -f $diskformat /var/lib/libvirt/images/xen/$name.$diskformat 20G", 180;
@@ -267,7 +267,7 @@ sub ensure_online {
     my ($guest, %args) = @_;
 
     my $hypervisor = $args{HYPERVISOR} // "192.168.122.1";
-    my $dns_host = $args{DNS_TEST_HOST} // "suse.de";
+    my $dns_host = $args{DNS_TEST_HOST} // "www.suse.com";
     my $skip_ssh = $args{skip_ssh} // 0;
     my $skip_network = $args{skip_network} // 0;
     my $skip_ping = $args{skip_ping} // 0;

--- a/schedule/qam/common/virt/qam_virt_install_guest.yaml
+++ b/schedule/qam/common/virt/qam_virt_install_guest.yaml
@@ -5,14 +5,6 @@ description:    >
 schedule:
   - virt_autotest/login_console
   - virtualization/universal/prepare_guests
-  - virtualization/universal/ssh_hypervisor_init
   - virtualization/universal/waitfor_guests
-  - virtualization/universal/ssh_guests_init
-  - virtualization/universal/register_guests
-  - virtualization/universal/upgrade_guests
-  - virtualization/universal/patch_guests
-  - virtualization/universal/patch_and_reboot
-  - virt_autotest/login_console
-  - virtualization/universal/list_guests
   - virtualization/universal/kernel
   - virtualization/universal/finish

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -15,29 +15,55 @@ use warnings;
 use testapi;
 use utils;
 use version_utils 'is_sle';
+use File::Copy 'copy';
+use File::Path 'make_path';
+
+sub create_profile {
+    my ($vm_name, $arch, $mac, $ip) = @_;
+    my $version = $vm_name =~ /sp/ ? $vm_name =~ s/\D*(\d+)sp(\d)\D*/$1.$2/r : $vm_name =~ s/\D*(\d+)\D*/$1/r;
+    my $path = $version >= 15 ? "virtualization/autoyast/guest_15.xml.ep" : "virtualization/autoyast/guest_12.xml.ep";
+    my $scc_code = get_required_var("SCC_REGCODE");
+    my %ltss_products = @{get_var_array("LTSS_REGCODES_SECRET")};
+    my $ca_str = "SLE_" . $version =~ s/\./_SP/r;
+    record_info("$ca_str");
+    my $profile = get_test_data($path);
+    $profile =~ s/\{\{GUEST\}\}/$vm_name/g;
+    $profile =~ s/\{\{SCC_REGCODE\}\}/$scc_code/g;
+    $profile =~ s/\{\{ARCH\}\}/$arch/g;
+    $profile =~ s/\{\{MAC\}\}/$mac/g;
+    $profile =~ s/\{\{IP\}\}/$ip/g;
+    $profile =~ s/\{\{VERSION\}\}/$version/g;
+    $profile =~ s/\{\{CA_STR\}\}/$ca_str/g;
+    my $host_os_version = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
+    my $incident_repos = "";
+    $incident_repos = get_var('INCIDENT_REPO', '') if ($vm_name eq $host_os_version || $vm_name eq "${host_os_version}PV" || $vm_name eq "${host_os_version}HVM");
+    my $vars = {
+        vm_name => $vm_name,
+        ltss_code => $ltss_products{$version},
+        repos => [split(/,/, $incident_repos)]
+    };
+    my $output = Mojo::Template->new(vars => 1)->render($profile, $vars);
+    save_tmp_file("$vm_name.xml", $output);
+    # Copy profile to ulogs directory, so profile is available in job logs
+    make_path('ulogs');
+    copy(hashed_string("$vm_name.xml"), "ulogs/$vm_name.xml");
+    return autoinst_url . "/files/$vm_name.xml";
+}
 
 sub run {
     my $self = shift;
     # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
-    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
-    # Clean up VMs if any. This makes it possable to reinstall VMs.
+    #    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
+    select_console('root-console');
     systemctl("restart libvirtd");
     assert_script_run('for i in $(virsh list --name|grep sles);do virsh destroy $i;done');
     assert_script_run('for i in $(virsh list --name --inactive); do virsh undefine $i --remove-all-storage;done');
 
+
     # Ensure additional package is installed
-    zypper_call '-t in libvirt-client iputils nmap supportutils xmlstarlet';
+    zypper_call '-t in libvirt-client iputils nmap supportutils';
 
     assert_script_run "mkdir -p /var/lib/libvirt/images/xen/";
-
-    if (is_sle('<=12-SP1')) {
-        script_run "umount /home";
-        assert_script_run qq(sed -i 's/\\/home/\\/var\\/lib\\/libvirt\\/images\\/xen/g' /etc/fstab);
-        script_run "mount /var/lib/libvirt/images/xen/";
-    }
-
-    assert_script_run "curl -f -v " . data_url("virt_autotest/libvirtd.conf") . " >> /etc/libvirt/libvirtd.conf";
-    systemctl 'restart libvirtd';
 
     if (script_run("virsh net-list --all | grep default") != 0) {
         assert_script_run "curl " . data_url("virt_autotest/default_network.xml") . " -o ~/default_network.xml";
@@ -57,6 +83,8 @@ sub run {
     foreach my $guest (values %virt_autotest::common::guests) {
         my $method = $guest->{method} // 'virt-install'; # by default install guest using virt-install. SLES11 gets installed via importing a pre-installed guest however
         if ($method eq "virt-install") {
+            $guest->{autoyast} = create_profile($guest->{name}, "x86_64", $guest->{macaddress}, $guest->{ip});
+            record_info("$guest->{autoyast}");
             create_guest($guest, $method);
         } elsif ($method eq "import") {
             # Download the diskimage. Note: this could be merged with download_image.pm at some point
@@ -72,7 +100,6 @@ sub run {
     script_run 'history -a';
     assert_script_run('cat ~/virt-install*', 30);
     script_run('xl dmesg |grep -i "fail\|error" |grep -vi Loglevel') if (is_xen_host());
-    collect_virt_system_logs();
 }
 
 sub post_fail_hook {

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -107,8 +107,9 @@ sub run {
     # script_retry("! ps x | grep -v 'grep' | grep 'virt-install'", retry => 120, delay => 10);
     # Unfortunately this doesn't cover the second step of the installation, where ssh is available
     my $sleep_delay = 1200;
-    $sleep_delay = 1800 if (is_xen_host);    # XEN has more guests
+    $sleep_delay = 2400 if (is_xen_host);    # XEN has more guests
     sleep($sleep_delay);    # XXX Get rid of this sleep!
+    wait_guest_online($_, 120) foreach (keys %virt_autotest::common::guests);
     record_info("guests installed", "Guest installation completed");
 
     # Adding the PCI bridges requires the guests to be shutdown


### PR DESCRIPTION
1.  Guest profile will be generated automatically on the fly.  Manually creating and maintaining profiles will be no longer needed.
2. Guest will be directly installed the latest packages in scc instead of installing lower version from mirror server, then upgrading from scc
3. Guest and host will set up to satisfy "virtualization best practice"  in SUSE virtualization document by autoyast
4. Extend test to cover 15sp4 test

- Related ticket: https://progress.opensuse.org/issues/109963
- Needles: no
- Verification run: 
- sle15sp4 xen: http://openqa.qam.suse.cz/tests/overview?groupid=163&version=15-SP4&build=%3Ainara%3Afont&distri=sle
- sles15sp4 kvm: http://openqa.qam.suse.cz/tests/overview?version=15-SP4&groupid=164&build=%3Ariver%3Afont&distri=sle
- sles12sp3 xen: http://openqa.qam.suse.cz/tests/overview?version=12-SP3&groupid=162&distri=sle&build=%3Axen%3Akaylee%3A12sp3
- sles12sp4 kvm: http://openqa.qam.suse.cz/tests/overview?build=%3Akvm%3Ariver%3A12sp3&distri=sle&version=12-SP4&groupid=142 