### PR TITLE
Prevent timeout on aarch64 when mpirun invoke with mapich2

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -61,7 +61,7 @@ sub run ($self) {
     record_info('INFO', 'Run MPI over several nodes');
     if ($mpi eq 'mvapich2') {
         # we do not support ethernet with mvapich2
-        my $return = script_run("set -o pipefail;" . $mpirun_s->all_nodes("$exports_path/$mpi_bin |& tee /tmp/mpi_bin.log"));
+        my $return = script_run("set -o pipefail;" . $mpirun_s->all_nodes("$exports_path/$mpi_bin |& tee /tmp/mpi_bin.log"), timeout => 120);
         if ($return == 143) {
             record_info("mvapich2 info", "echo $return - No IB device found");
         } elsif ($return == 139 || $return == 255) {


### PR DESCRIPTION
For some reason mapich2 takes longer time in the latest builds and timeouts on
aarch64. mapich2 encounter a known issue with a segmentation fault and the
test should check and raise a soft fail tho. Increase the timeout of
script_run to avoid the test to fail.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: https://openqa.suse.de/tests/8776570#
