### PR TITLE
Connect iscsi target manually

### DIFF
--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -68,8 +68,17 @@ sub run {
         assert_screen 'iscsi-client-overview-service-tab', $default_timeout;
         send_key 'alt-v';
         wait_still_screen 3;
-        assert_screen 'iscsi-client-target-connected', $default_timeout;
-        send_key 'alt-c';
+        assert_screen 'iscsi-client-target-list', $default_timeout;
+
+        if (!check_screen('iscsi-client-target-connected')) {
+            # Connects target manually if not automatic
+            send_key 'alt-e';
+            assert_screen 'iscsi-client-target-startup';
+            send_key 'alt-n';
+            assert_screen 'iscsi-client-target-connected', $default_timeout;
+        }
+
+        send_key 'alt-o';
         wait_still_screen 3;
         wait_serial('yast2-iscsi-client-status-0', 90) || die "'yast2 iscsi-client' didn't finish";
         assert_screen 'root-console', $default_timeout;


### PR DESCRIPTION
On HA migration tests iscsi sometimes does not connect automatically 
during verification runs. This PR checks for such situation and does 
the manual connection via yast2 iscsi module.

- Related ticket: https://jira.suse.com/browse/TEAM-6067
- Needles: N/A
- Verification run: 
- FAILED: https://openqa.suse.de/tests/8753154#step/check_after_reboot/21
- PASSED:
  http://openqaworker15.qa.suse.cz/tests/169#
  http://openqaworker15.qa.suse.cz/tests/163#
  http://openqaworker15.qa.suse.cz/tests/160#
  
Additional VR without default timeou - took 2min less to complete:
http://openqaworker15.qa.suse.cz/tests/196#
http://openqaworker15.qa.suse.cz/tests/194
http://openqaworker15.qa.suse.cz/tests/190