### PR TITLE
Stabilize network/firewalld_policy_objects test module

### DIFF
--- a/data/firewalld_policy_objectsmysite.conf
+++ b/data/firewalld_policy_objectsmysite.conf
@@ -1,0 +1,4 @@
+<VirtualHost *:80>
+  DocumentRoot /srv/www/htdocs/mysite
+</VirtualHost>
+

--- a/schedule/functional/firewalld_policy_objects.yaml
+++ b/schedule/functional/firewalld_policy_objects.yaml
@@ -6,3 +6,4 @@ schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
     - network/firewalld_policy_objects
+    - shutdown/shutdown


### PR DESCRIPTION
 * Try to google.com until we're sure the network is working
 * Move the apache vhost config to data/ to mitigate typing issues
 * Use `Utils::Systemd::systemd` as that is the prefered way
 * Make sure the parent job waits for children jobs.

- Related ticket: [poo#110737](https://progress.opensuse.org/issues/110737)
- Verification run: [pdostal-server](http://pdostal-server.suse.cz/tests/14855#live)