### PR TITLE
Select UEFI item only on 15-SP3+

### DIFF
--- a/tests/security/grub_auth/grub_authorization.pm
+++ b/tests/security/grub_auth/grub_authorization.pm
@@ -31,7 +31,8 @@ my $test_passwd = 'pw_test';
 sub switch_boot_menu {
     my $switch = shift;
 
-    if (get_var('UEFI')) {
+    # UEFI item is available only from 15-SP4
+    if (get_var('UEFI') && (!is_sle('<15-SP4'))) {
         assert_screen("grub_uefi_firmware_menu_entry", timeout => 90);
         send_key_until_needlematch("grub_auth_boot_menu_entry", "down", 5, 2) if $switch;
     }


### PR DESCRIPTION
On SLE <= 15-SP3, the test `grub_authorization` fails because the "UEFI firmware settings" item is not available. This PR fixes this issue by checking for this menu item only on SLE >= 15-SP4.

Verification runs:
- 15-SP3: https://openqa.suse.de/tests/8787566 and https://openqa.suse.de/tests/8787672
- 15-SP2: https://openqa.suse.de/tests/8787573 and https://openqa.suse.de/tests/8787671