### PR TITLE
qcatool: checkpoint to make sure keystore monitor is running

### DIFF
--- a/tests/console/libqca2.pm
+++ b/tests/console/libqca2.pm
@@ -58,6 +58,7 @@ sub run {
     assert_script_run "$qca_cmd keybundle make rsapriv.pem cert.pem --pass=suse --newpass=suse";
     assert_script_run "$qca_cmd keystore list-stores";
     enter_cmd "$qca_cmd keystore monitor";
+    assert_screen "qctool2_keystore_monitor";
     enter_cmd "q";
     assert_script_run "$qca_cmd show kb cert.p12 --pass=suse";
 


### PR DESCRIPTION
qcatool keystore monitor runs and needs a moment to initialize
We need to wait sufficiently long to send 'q' to quit again

Verifying that the screen is actually ready for us is the best way

- Related ticket: https://progress.opensuse.org/issues/111069
- Needles: Already done on o3
- Verification run: https://openqa.opensuse.org/tests/2357107#step/libqca2/18
