### PR TITLE
Fix suppotconfig log file name to upload

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -598,7 +598,7 @@ sub ha_export_logs {
 
     # supportconfig
     script_run "supportconfig -g -B $clustername", 300;
-    upload_logs("/var/log/nts_$clustername.tgz", failok => 1);
+    upload_logs("/var/log/scc_$clustername.tgz", failok => 1);
 
     # pacemaker cts log
     upload_logs($cts_log, failok => 1) if (get_var('PACEMAKER_CTS_TEST_ROLE'));


### PR DESCRIPTION
- Related ticket:
https://openqa.suse.de/tests/8785494#step/check_cluster_integrity/40
https://openqa.suse.de/tests/8787182#step/filesystem#1/91
https://openqa.suse.de/tests/8787142#step/cluster_md/71
- Verification run: not needed