### PR TITLE
Remove obsoleted test runs from img_proof

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -30,12 +30,12 @@ our $azure_on_demand_updates = 'test_sles,test_sles_on_demand,test_sles_azure';
 our $azure_byos = $test_sles_for_dev . ',test_sles_azure';
 our $azure_on_demand = $test_sles_for_dev . ',' . $test_sles_on_demand_for_dev . ',test_sles_azure';
 
-our $ec2_byos_updates = 'test_sles,test_sles_ec2,test_sles_ec2_byos';
-our $ec2_on_demand_updates = 'test_sles,test_sles_ec2,test_sles_on_demand,test_sles_ec2_on_demand';
+our $ec2_byos_updates = 'test_sles,test_sles_ec2';
+our $ec2_on_demand_updates = 'test_sles,test_sles_ec2,test_sles_on_demand';
 
-our $ec2_byos = $test_sles_for_dev . ',test_sles_ec2,test_sles_ec2_byos';
+our $ec2_byos = $test_sles_for_dev . ',test_sles_ec2';
 our $ec2_byos_chost = $test_sles_for_dev . ',test_sles_ec2';
-our $ec2_on_demand = $test_sles_for_dev . ',test_sles_ec2,' . $test_sles_on_demand_for_dev . ',test_sles_ec2_on_demand';
+our $ec2_on_demand = $test_sles_for_dev . ',test_sles_ec2,' . $test_sles_on_demand_for_dev;
 
 our $gce_byos_updates = 'test_sles,test_sles_gce';
 our $gce_on_demand_updates = 'test_sles,test_update,test_sles_smt_reg,test_sles_guestregister,test_sles_on_demand,test_sles_gce';


### PR DESCRIPTION
Remove no longer existing test runs from our img_proof template after
https://github.com/SUSE-Enceladus/img-proof/pull/338.

Related ticket: https://progress.opensuse.org/issues/111284 
Verification run: https://duck-norris.qam.suse.de/tests/8906
