### PR TITLE
Select serial console to get full CLI cmd output for debug

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -258,6 +258,7 @@ Check service before migration, zypper install service package, enable, start an
 =cut
 sub install_services {
     my ($service) = @_;
+    opensusebasetest::select_serial_terminal() if (get_var('SEL_SERIAL_CONSOLE'));
     # turn off lmod shell debug information
     assert_script_run('echo export LMOD_SH_DBG_ON=1 >> /etc/bash.bashrc.local');
     # turn off screen saver

--- a/lib/services/hpcpackage_remain.pm
+++ b/lib/services/hpcpackage_remain.pm
@@ -38,7 +38,8 @@ sub install_pkg {
     my $version = get_var('HDDVERSION');
     # Install all 'library wrappers' (packages matching -hpc, not having a version number with '_' after their name)
     record_soft_failure('bsc#1194917', "openQA test fails : nothing provides 'gcc9' needed by the to be installed gnu9-compilers-hpc-devel-1.4-3.14.3.noarch");
-    my @pkginstall = split('\n', script_output q[zypper search -r SLE-Module-HPC] . $version . q[-Pool -r SLE-Module-HPC] . $version . q[-Updates | cut -d '|' -f 2 | sed -e 's/ *//g' | grep -E '.*-hpc.*' | grep -vE 'system|module|suse' | grep -vE 'gnu9|gnu10|gnu11' |  grep -vE '.*_[[:digit:]]+_[[:digit:]]+.*gnu|.*_[[:digit:]]+_[[:digit:]]+.*-hpc' | grep -vE '.*-static$' | grep -vE '.*hpc-macros.*'], proceed_on_failure => 1, timeout => 180);
+    my $module_list_p = script_output q[zypper search -r SLE-Module-HPC] . $version . q[-Pool -r SLE-Module-HPC] . $version . q[-Updates | cut -d '|' -f 2 | sed -e 's/ *//g' | grep -E '.*-hpc.*' | grep -vE 'system|module|suse' | grep -vE 'gnu9|gnu10|gnu11' | grep -vE '.*_[[:digit:]]+_[[:digit:]]+.*gnu|.*_[[:digit:]]+_[[:digit:]]+.*-hpc' | grep -vE '.*-static$' | grep -vE '.*hpc-macros.*'], proceed_on_failure => 1, timeout => 180;
+    my @pkginstall = split('\n', $module_list_p);
     # on x86 zypper will print out the Shell debug information, we need exclude it.
     @pkginstall = grep { !/LMOD_SH_DBG_ON/ } @pkginstall;
     zypper_call("in " . join(' ', @pkginstall), timeout => 1800);

--- a/tests/installation/install_service.pm
+++ b/tests/installation/install_service.pm
@@ -16,7 +16,12 @@ use main_common 'is_desktop';
 
 sub run {
 
-    select_console 'root-console';
+    if (get_var('SEL_SERIAL_CONSOLE')) {
+        opensusebasetest::select_serial_terminal();
+    }
+    else {
+        select_console 'root-console';
+    }
 
     install_services($default_services)
       if is_sle


### PR DESCRIPTION
Select serial console to get full CLI cmd output for debug for service check, and update complicated script on SUT to simple perl script. The purpose is 'the entire command line and the output to stdout and stderr should be made available for debugging purposes'.

- Related ticket: https://progress.opensuse.org/issues/105388
- Needles: N/A
- Verification run:  http://openqa.suse.de/tests/8793403#step/install_service/38
