### PR TITLE
Containers: Run ubi9 images depending on CPU flags

### DIFF
--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -13,7 +13,7 @@ use warnings;
 
 use base 'Exporter';
 use Exporter;
-use testapi qw(check_var get_var);
+use testapi qw(check_var get_var script_output);
 
 use constant {
     ARCH => [
@@ -22,6 +22,7 @@ use constant {
           is_i586
           is_i686
           is_x86_64
+          is_x86_64_v2
           is_aarch64
           is_arm
           is_ppc64le
@@ -82,6 +83,22 @@ Returns C<check_var('x86_64')>.
 =cut
 sub is_x86_64 {
     return check_var('ARCH', 'x86_64');
+}
+
+=head2 is_x86_64_v2
+
+ is_x86_64_v2();
+
+Returns C<check_var('is_x86_64_v2')>.
+
+=cut
+sub is_x86_64_v2 {
+    return 0 unless is_x86_64;
+    my $cpu_flags = script_output('lscpu | grep -i flags');
+    foreach my $flag (qw(cx16 lahf popcnt sse4_1 sse4_2 ssse3)) {
+        return 0 if ($cpu_flags !~ /$flag/);
+    }
+    return 1;
 }
 
 =head2 is_aarch64

--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -289,14 +289,16 @@ sub get_3rd_party_images {
     #     on z13: "Fatal glibc error: CPU lacks VXE support (z14 or later required)".
     # - ubi9 images require power9+ machine.
     #     on Power8: "Fatal glibc error: CPU lacks ISA 3.00 support (POWER9 or later required)"
-    # - poo#72124 Ubuntu image (occasionally) fails on s390x.
-    # - CentOS image not available on s390x.
+    # - ubi9 images require x86_64-v2, which needs certain cpu flags
     push @images, (
         "registry.access.redhat.com/ubi9/ubi",
         "registry.access.redhat.com/ubi9/ubi-minimal",
         "registry.access.redhat.com/ubi9/ubi-micro",
         "registry.access.redhat.com/ubi9/ubi-init"
-    ) unless (is_s390x || is_ppc64le || is_opensuse);    # XXX Quick fix: On openSUSE workers we don't have support for x86-64-v2 and we should fix this soon
+    ) unless (is_s390x || is_ppc64le || !is_x86_64_v2);
+
+    # - poo#72124 Ubuntu image (occasionally) fails on s390x.
+    # - CentOS image not available on s390x.
     push @images, (
         "$ex_reg/library/ubuntu",
         "$ex_reg/library/centos"


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/111359

VRs:
[SLE Public Cloud](https://openqa.suse.de/tests/8806632#step/podman_3rd_party_images/446) (no skip)
[15-SP3 podman](https://openqa.suse.de/tests/8806634) (skip)
[15-SP3 docker](https://openqa.suse.de/tests/8806633#) (skip)
[Staging Kubic](https://openqa.opensuse.org/tests/2364568#) (skip)
[MicroOS](https://openqa.opensuse.org/tests/2364569#) (skip)
[TW docker](https://openqa.opensuse.org/tests/2364566#) (skip)
[TW podman](https://openqa.opensuse.org/tests/2364567#) (skip)

VRs with `QEMUCPU=host`:
[TW](https://openqa.opensuse.org/tests/2364567#step/podman_3rd_party_images/449)
[SLE](https://openqa.suse.de/tests/8806631#step/podman_3rd_party_images/446)

