### PR TITLE
Update scheduling of 15-SP2-Server-DVD-HPC-Incidents

### DIFF
--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -20,6 +20,8 @@ conditional_schedule:
     VERSION:
       15-SP4:
         - installation/user_settings_root
+      15-SP2:
+        - installation/user_settings_root
   systemrole_dev:
     HPC:
       installation_dev:


### PR DESCRIPTION
After enabling and running tests in the HPC incidents against sle15sp2 two
jobs found with wrong scheduling which do not let the test go on. The reason
is that the module which handles the root user_settings was missing.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: http://aquarius.suse.cz/tests/10052
