### PR TITLE
Fix mpi_slave dependency on 15sp3 aarch64

### DIFF
--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -10,6 +10,7 @@ use Mojo::Base qw(hpcbase hpc::utils), -signatures;
 use lockapi;
 use utils;
 use version_utils 'is_sle';
+use Utils::Architectures;
 
 sub run ($self) {
     my $mpi = $self->get_mpi();
@@ -19,6 +20,7 @@ sub run ($self) {
     if (is_sle('>=15-SP3')) {
         push @hpc_deps, 'libhwloc15' if $mpi =~ m/mpich/;
         push @hpc_deps, ('libfabric1', 'libpsm2') if $mpi =~ m/openmpi/;
+        pop @hpc_deps if (is_aarch64 && $mpi =~ m/openmpi/);
     } else {
         push @hpc_deps, 'libpciaccess0' if $mpi =~ m/mpich/;
         push @hpc_deps, 'libfabric1' if $mpi =~ m/openmpi/;


### PR DESCRIPTION
`libpsm2` is not required on 15sp3 and 15sp4 for aarch64. And it breaks the 15sp3 jobs as the
package is not provided.
the solution i chose is to include initially for all the verions >=15sp3 but take it out
when aarch64 is set.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: 
https://openqa.suse.de/tests/8815987
https://openqa.suse.de/tests/8815989
