### PR TITLE
Fix unstable firefox download test

### DIFF
--- a/tests/x11/firefox/firefox_downloading.pm
+++ b/tests/x11/firefox/firefox_downloading.pm
@@ -19,8 +19,8 @@
 # - Cancel download and remove from history
 # - Open firefox preferences, change download to save files by default
 # - Open
-# url "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-NET-aarch64-Media.iso"
-# and "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-NET-x86_64-Media.iso"
+# url "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-DVD-aarch64-Media.iso"
+# and "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-DVD-x86_64-Media.iso"
 # - Open download library and check both downloads running
 # - Cancel both downloads
 # - Exit firefox
@@ -33,8 +33,8 @@ use base "x11test";
 use testapi;
 use version_utils 'is_sle';
 
-my $dl_link_01 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-NET-aarch64-Media.iso";
-my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-NET-x86_64-Media.iso";
+my $dl_link_01 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-DVD-aarch64-Media.iso";
+my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-DVD-x86_64-Media.iso";
 
 sub dl_location_switch {
     my ($self, $tg) = @_;

--- a/tests/x11/firefox/firefox_downloading.pm
+++ b/tests/x11/firefox/firefox_downloading.pm
@@ -19,8 +19,8 @@
 # - Cancel download and remove from history
 # - Open firefox preferences, change download to save files by default
 # - Open
-# url"http://mirrors.kernel.org/opensuse/distribution/leap/15.4/iso/openSUSE-Leap-15.4-DVD-x86_64-Media.iso"
-# and "http://mirrors.kernel.org/opensuse/distribution/leap/15.4/iso/openSUSE-Leap-15.4-DVD-aarch64-Media.iso"
+# url "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-NET-aarch64-Media.iso"
+# and "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-NET-x86_64-Media.iso"
 # - Open download library and check both downloads running
 # - Cancel both downloads
 # - Exit firefox
@@ -33,8 +33,8 @@ use base "x11test";
 use testapi;
 use version_utils 'is_sle';
 
-my $dl_link_01 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.4/iso/openSUSE-Leap-15.4-DVD-x86_64-Media.iso";
-my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.4/iso/openSUSE-Leap-15.4-DVD-aarch64-Media.iso";
+my $dl_link_01 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-NET-aarch64-Media.iso";
+my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-NET-x86_64-Media.iso";
 
 sub dl_location_switch {
     my ($self, $tg) = @_;


### PR DESCRIPTION
Use leap 15.3 images instead of 15.4 beacause the latter is updated
often and during the update the file is not available for download

- Related ticket: https://progress.opensuse.org/issues/111207
- Needles: no needles
- Verification run: https://openqa.suse.de/tests/8816235
