### PR TITLE
revert:Support for pv vms of RSB

### DIFF
--- a/tests/cpu_bugs/xen_mitigations.pm
+++ b/tests/cpu_bugs/xen_mitigations.pm
@@ -141,14 +141,14 @@ my $spec_ctrl_hvm_0 = {"hvm=0" => {
 };
 my $spec_ctrl_msr_sc_on = {"msr-sc=on" => {
         default => {
-            expected => {'xl dmesg' => ['Support for HVM VMs: MSR_SPEC_CTRL RSB EAGER_FPU MD_CLEAR', 'Support for PV VMs: MSR_SPEC_CTRL EAGER_FPU MD_CLEAR']},
+            expected => {'xl dmesg' => ['Support for HVM VMs: MSR_SPEC_CTRL RSB EAGER_FPU MD_CLEAR', 'Support for PV VMs: MSR_SPEC_CTRL RSB EAGER_FPU MD_CLEAR']},
             unexpected => {'xl dmesg' => ['']}
         }
     }
 };
 my $spec_ctrl_msr_sc_off = {"msr-sc=off" => {
         default => {
-            expected => {'xl dmesg' => ['Support for HVM VMs: RSB EAGER_FPU MD_CLEAR', 'Support for PV VMs: EAGER_FPU MD_CLEAR']},
+            expected => {'xl dmesg' => ['Support for HVM VMs: RSB EAGER_FPU MD_CLEAR', 'Support for PV VMs: RSB EAGER_FPU MD_CLEAR']},
             unexpected => {'xl dmesg' => ['']}
         }
     }


### PR DESCRIPTION
Revert “Modify the xen_mitigation.pm of support_for_vm",remove the RSB flag.

Verification run: http://openqa.qa2.suse.asia/group_overview/39
