### PR TITLE
sles4sap: get rid of copy_media() and install directly from NFS

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Functions for SAP tests
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 ## no critic (RequireFilenameMatchesPackage);
 package sles4sap;
@@ -35,7 +36,7 @@ our @EXPORT = qw(
   reset_user_change
   get_total_mem
   prepare_profile
-  copy_media
+  mount_media
   add_hostname_to_hosts
   test_pids_max
   test_forkbomb
@@ -321,52 +322,27 @@ sub prepare_profile {
     }
 }
 
-=head2 copy_media
+=head2 mount_media
 
- $self->copy_media( $proto, $path, $timeout, $target );
+ $self->mount_media( $proto, $path, $target );
 
-Copies installation media in SUT from the share identified by B<$proto> and
-B<$path> into the target directory B<$target>. B<$timeout> specifies how long
-to wait for the copy to complete.
-
-After installation files are copied, this method will also verify the existence
-of a F<checksum.md5sum> file in the target directory and use it to check for the
-integrity of the copied files. This test can be skipped by setting to a
-true value the B<DISABLE_CHECKSUM> setting in the test.
-
-The method will croak if any of the commands sent to SUT fail.
+Mount installation media in SUT from the share identified by B<$proto> and
+B<$path> into the target directory B<$target>.
 
 =cut
 
-sub copy_media {
-    my ($self, $proto, $path, $nettout, $target) = @_;
-
-    # First copy media
+sub mount_media {
+    my ($self, $proto, $path, $target) = @_;
     my $mnt_path = '/mnt';
     my $media_path = "$mnt_path/" . get_required_var('ARCH');
+
     assert_script_run "mkdir $target";
     assert_script_run "mount -t $proto -o ro $path $mnt_path";
     $media_path = $mnt_path if script_run "[[ -d $media_path ]]";    # Check if specific ARCH subdir exists
-    assert_script_run "cp -ax $media_path/. $target/", $nettout;
 
-    # Go back to target directory and umount the share, as we don't need it anymore
-    assert_script_run "umount $mnt_path";
-
-    return 1 if get_var('DISABLE_CHECKSUM');
-
-    # Save current directory and go to target path for checking the files
-    my $current_dir = script_output 'pwd';
-    type_string "cd $target\n";
-
-    # Then verify everything was copied correctly
-    # NOTE: checksum is generated with this command: "find . -type f -exec md5sum {} \; > checksums.md5sum"
-    my $chksum_file = 'checksum.md5sum';
-    # We can't check the checksum file itself as well as the clustered NFS share part
-    assert_script_run "sed -i -e '/$chksum_file\$/d' -e '/\\/nfs_share/d' $chksum_file";
-    assert_script_run "md5sum -c --quiet $chksum_file", $nettout;
-
-    # Back to previous directory
-    type_string "cd $current_dir\n";
+    # Create a overlay to "allow" writes to the readonly filesystem
+    assert_script_run "mkdir /.workdir /.upperdir";
+    assert_script_run "mount -t overlay overlay -o lowerdir=$media_path,upperdir=/.upperdir,workdir=/.workdir $target";
 }
 
 =head2 add_hostname_to_hosts

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -6,7 +6,7 @@
 # Package: lvm2 util-linux parted device-mapper
 # Summary: Install HANA via command line. Verify installation with
 # sles4sap/hana_test
-# Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use base 'sles4sap';
 use strict;
@@ -88,6 +88,7 @@ sub run {
     my ($proto, $path) = $self->fix_path(get_required_var('HANA'));
     my $sid = get_required_var('INSTANCE_SID');
     my $instid = get_required_var('INSTANCE_ID');
+    my $tout = get_var('HANA_INSTALLATION_TIMEOUT', 3600);    # Timeout for HANA installation commands.
 
     $self->select_serial_terminal;
     my $RAM = $self->get_total_mem();
@@ -104,9 +105,8 @@ sub run {
     # This installs HANA. Start by configuring the appropiate SAP profile
     $self->prepare_profile('HANA');
 
-    # Copy media
-    my $tout = get_var('HANA_INSTALLATION_TIMEOUT', 3600);    # Timeout for HANA installation commands.
-    $self->copy_media($proto, $path, $tout, '/sapinst');
+    # Mount media
+    $self->mount_media($proto, $path, '/sapinst');
 
     # Mount points information: use the same paths and minimum sizes as the wizard (based on RAM size)
     my $full_size = ceil($RAM / 1024);    # Use the ceil value of RAM in GB

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -5,7 +5,7 @@
 
 # Summary: Perform an unattended installation of SAP NetWeaver
 # Requires: ENV variable NW pointing to installation media
-# Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.de> / Loic Devulder <ldevulder@suse.de>
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use base "sles4sap";
 use testapi;
@@ -44,8 +44,8 @@ sub run {
     # SAP profile and solution are configured in the system
     $self->prepare_profile('NETWEAVER');
 
-    # Copy media
-    $self->copy_media($proto, $path, $timeout, '/sapinst');
+    # Mount media
+    $self->mount_media($proto, $path, '/sapinst');
 
     # Define a valid hostname/IP address in /etc/hosts, but not in HA
     $self->add_hostname_to_hosts if (!get_var('HA_CLUSTER'));


### PR DESCRIPTION
Install directly from NFS instead of copying media.

Notes:
- The overlayfs hack is because `netweaver_install` needs to do some funky stuff on the media directory. We mount the share read-only and the overlay mount allows us to "write" onto it.
- I see no need to unmount later.

Verification runs:
- HANA: https://openqa.suse.de/tests/8822629
- NW: https://openqa.suse.de/tests/8822628
- NW (12-SP3): https://openqa.suse.de/tests/8823246