### PR TITLE
Provide user-virtio-terminal console option

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1229,8 +1229,11 @@ sub remount_tmp_if_ro {
 
  select_serial_terminal($root);
 
-Select most suitable text console with root user. The choice is made by
-BACKEND and other variables.
+Select most suitable text console. The optional parameter C<root> controls
+whether the console will have root privileges or not. Passing any value that
+evaluates to true will select a root console (default). Passing any value that
+evaluates to false will select unprivileged user console.
+The choice is made by BACKEND and other variables.
 
 Purpose of this wrapper is to avoid if/else conditions when selecting console.
 
@@ -1239,7 +1242,7 @@ default when parameter not specified) or prefer non-root user if available.
 
 Variables affecting behavior:
 C<VIRTIO_CONSOLE>=0 disables virtio console (use {root,user}-console instead
-of the default {root-,}virtio-terminal)
+of the default {root-,user-}virtio-terminal)
 NOTE: virtio console is enabled by default (C<VIRTIO_CONSOLE>=1).
 For ppc64le it requires to call prepare_serial_console() to before first use
 (used in console/system_prepare and shutdown/cleanup_before_shutdown modules)
@@ -1269,7 +1272,7 @@ sub select_serial_terminal {
         if (check_var('VIRTIO_CONSOLE', 0)) {
             $console = $root ? 'root-console' : 'user-console';
         } else {
-            $console = $root ? 'root-virtio-terminal' : 'virtio-terminal';
+            $console = $root ? 'root-virtio-terminal' : 'user-virtio-terminal';
         }
     } elsif (get_var('SUT_IP')) {
         $console = $root ? 'root-serial-ssh' : 'user-serial-ssh';

--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -142,11 +142,11 @@ sub login {
         type_password;
         send_key 'ret';
     }
-    die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
+    die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \s*$/x);
 
     # Some (older) versions of bash don't take changes to the terminal during runtime into account. Re-exec it.
     enter_cmd('export TERM=dumb; stty cols 2048; exec $SHELL');
-    die 'Failed to confirm that shell re-exec was successful' unless wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
+    die 'Failed to confirm that shell re-exec was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \s*$/x);
     set_serial_prompt($prompt);
     # TODO: Send 'tput rmam' instead/also
     assert_script_run('export TERM=dumb');

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -410,6 +410,7 @@ sub init_consoles {
 
     if (is_qemu) {
         $self->add_console('root-virtio-terminal', 'virtio-terminal', {});
+        $self->add_console('user-virtio-terminal', 'virtio-terminal', {});
         for (my $num = 1; $num < get_var('VIRTIO_CONSOLE_NUM', 1); $num++) {
             $self->add_console('root-virtio-terminal' . $num, 'virtio-terminal', {socked_path => cwd() . '/virtio_console' . $num});
         }
@@ -796,6 +797,7 @@ sub activate_console {
         }
     }
     elsif ($type =~ /^(virtio-terminal|sut-serial)$/) {
+        $self->{serial_term_prompt} = $user eq 'root' ? '# ' : '> ';
         serial_terminal::login($user, $self->{serial_term_prompt});
     }
     elsif ($console eq 'novalink-ssh') {
@@ -890,7 +892,7 @@ sub console_selected {
     }
     $args{await_console} //= 1;
     $args{tags} //= $console;
-    $args{ignore} //= qr{sut|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary|serial-ssh};
+    $args{ignore} //= qr{sut|user-virtio-terminal|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary|serial-ssh};
     $args{timeout} //= 30;
 
     if ($args{tags} =~ $args{ignore} || !$args{await_console} || (get_var('FLAVOR') eq 'WSL')) {


### PR DESCRIPTION
The `select_serial_terminal` picks by default `root-virtio-terminal` but the
subroutine provides parameter to select a console as normal user.

Somehow this found misconfigured. The condition was like that
`$console = $root ? 'root-virtio-terminal' : 'virtio-terminal';`. There was
two main issues. One was that the propor console was not added during the
`init_consoles` and the second was that the variable was not a valid option.

The first is solved easily by adding another line to call `add_console`.
In the second case the correct name is `user-virtio-terminal` instead
`virtio-terminal`. the underline variable is evaluated later against a regex
to assign some other variables, one of them is *$user* and another is *type*
which each are required for the user _login_ and the console _initialization_.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/88193
- Verification run: http://aquarius.suse.cz/tests/10113
