### PR TITLE
Add apparmor log check for apache2_changehat

### DIFF
--- a/tests/security/apparmor_profile/apache2_changehat.pm
+++ b/tests/security/apparmor_profile/apache2_changehat.pm
@@ -36,7 +36,7 @@
 #   $audit_log" and fail test.
 # - upload /var/log/apache2/error_log and audit.log
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#48773, tc#1695946
+# Tags: poo#48773, tc#1695946, poo#111036
 
 
 use base apparmortest;
@@ -148,6 +148,14 @@ sub run {
     if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* operation=.*profile_replace.* profile=.*httpd-prefork.*adminer.*/sx) {
         record_info("ERROR", "There are denied profile_replace records found in $audit_log", result => 'fail');
         $self->result('fail');
+    }
+    # Due to bsc#1191684, add following check points as well
+    my @check_list = ('file_receive', 'open', 'signal', 'mknod');
+    foreach my $check_point (@check_list) {
+        if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* operation=.*$check_point.* profile=.*httpd-prefork.*/sx) {
+            record_info("ERROR", "There are denied $check_point records found in $audit_log", result => 'fail');
+            $self->result('fail');
+        }
     }
 
     # Upload logs for reference


### PR DESCRIPTION
Due to bsc#1191684, we need add more check points
to make sure no expected error messages

- Related ticket: https://progress.opensuse.org/issues/111036
- Verification run:
https://openqa.suse.de/tests/8825942 - OSD
https://openqa.opensuse.org/tests/2379943 -O3

The failed cases are expected results