### PR TITLE
Ignore load firefox test on leap(< 15.2) upgrade test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1325,7 +1325,8 @@ sub load_x11tests {
         loadtest "x11/gnome_terminal";
         loadtest "x11/gedit";
     }
-    loadtest "x11/firefox";
+    # Need remove firefox tests in our migration tests from old Leap releases, keep them only in 15.2 and newer.
+    loadtest "x11/firefox" unless (is_leap && check_version('<15.2', get_var('ORIGINAL_VERSION'), qr/\d{2,}\.\d/) && is_upgrade());
     if (is_opensuse && !get_var("OFW") && is_qemu && !check_var('FLAVOR', 'Rescue-CD') && !is_kde_live) {
         loadtest "x11/firefox_audio";
     }


### PR DESCRIPTION
As the requirement of opensuse release team, remove firefox tests in our migration tests from old Leap releases, keep them only in 15.2 and newer.

- Related ticket: https://progress.opensuse.org/issues/109926
- Needles: N/A
- Verification run: 
  https://openqa.opensuse.org/tests/2377678#details // leap 15.0 upgrade, no firefox loaded
  https://openqa.opensuse.org/tests/2377691#details // leap 15.2 upgrade, firefox loaded
  https://openqa.opensuse.org/tests/2377743#details // leap 15.4 installation but not upgrade test, firefox loaded