### PR TITLE
Display status of rollback service

### DIFF
--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -7,13 +7,12 @@
 # Summary: Snapshot creation and rollback on JeOS
 # Maintainer: Ciprian Cret <ccret@suse.com>
 
-use base 'consoletest';
+use Mojo::Base qw(consoletest);
 use testapi;
 use Utils::Architectures;
 use utils;
-use strict;
-use warnings;
 use power_action_utils qw(power_action);
+use Utils::Systemd qw(systemctl);
 
 sub check_package
 {
@@ -52,7 +51,8 @@ sub rollback_and_reboot {
             return 1;
         }
         record_info('ps', script_output('ps -ef'));
-        bmwqemu::diag("SUSEConnect --rollback is still running [$runs/10]");
+        systemctl 'status rollback.service';
+        bmwqemu::diag("SUSEConnect --rollback is still running, or failing [$runs/10]");
         sleep 60;
     }
     die "SUSEConnect --rollback is running longer than expected";


### PR DESCRIPTION
`SUSEConnect --rollback` might failed and the error is display in the
status of oneshot `rollback` service. If the `SUSEConnect` call fails in
`/usr/sbin/rollback-reset-registration`, `/var/lib/rollback/check-registration`
file is not removed.

- Related ticket: https://progress.opensuse.org/issues/111635
- Verification run: 
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220525-1-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/17229#)
  * [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20220525-1-jeos-filesystem@64bit-virtio-vga](http://kepler.suse.cz/tests/17227#)
