### PR TITLE
Public Cloud: don't dump instance information

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -257,7 +257,7 @@ sub create_instances {
 
     my @vms = $self->terraform_apply(%args);
     foreach my $instance (@vms) {
-        record_info("INSTANCE $instance->{instance_id}", Dumper($instance));
+        record_info("INSTANCE", $instance->{instance_id});
         if ($args{check_connectivity}) {
             $instance->wait_for_ssh();
             # Install server's ssh publicckeys to prevent authenticity interactions


### PR DESCRIPTION
When dumping the $instance object, we are also dumping secrets in plan text
e.g.
```
'provider_client' => bless( {
  'key_id' => 'xyz',
  'tenantid' => 'xyz',
  'subscription' => 'xyz',
  'key_secret' => 'xyz',
  'region' => 'southeastasia',
```