### PR TITLE
Add schedules for mau-extratests-yast and split textmode in two modules.

### DIFF
--- a/schedule/yast/maintenance/mau_extratest_yast-cmd_SLE12.yaml
+++ b/schedule/yast/maintenance/mau_extratest_yast-cmd_SLE12.yaml
@@ -1,0 +1,20 @@
+---
+name: mau_extratests_yast_cmd
+description:    >
+  Testsuite maintained at https://gitlab.suse.de/qa-maintenance/qam-openqa-yml. Run
+  yast command-line tests against aggregated test repo.
+schedule:
+  - boot/boot_to_desktop
+  - yast2_cmd/yast_lan
+  - yast2_cmd/yast_timezone
+  - yast2_cmd/yast_tftp_server
+  - yast2_cmd/yast_ftp_server
+  - yast2_cmd/yast_users
+  - yast2_cmd/yast_sysconfig
+  - yast2_cmd/yast_keyboard
+  - yast2_cmd/yast_nfs_server
+  - yast2_cmd/yast_nfs_client
+  - yast2_cmd/yast_dns_server
+  - yast2_cmd/yast_lang
+  - yast2_cmd/yast_storage
+  - console/coredump_collect

--- a/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12_SP2.yaml
+++ b/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12_SP2.yaml
@@ -1,0 +1,19 @@
+---
+name: mau_extratests_yast_cmd
+description:    >
+  Testsuite maintained at https://gitlab.suse.de/qa-maintenance/qam-openqa-yml. Run
+  yast command-line tests against aggregated test repo.
+schedule:
+  - boot/boot_to_desktop
+  - yast2_cmd/yast_lan
+  - yast2_cmd/yast_timezone
+  - yast2_cmd/yast_tftp_server
+  - yast2_cmd/yast_ftp_server
+  - yast2_cmd/yast_users
+  - yast2_cmd/yast_sysconfig
+  - yast2_cmd/yast_nfs_server
+  - yast2_cmd/yast_nfs_client
+  - yast2_cmd/yast_dns_server
+  - yast2_cmd/yast_lang
+  - yast2_cmd/yast_storage
+  - console/coredump_collect

--- a/schedule/yast/maintenance/mau_extratests_yast2_ncurses.yaml
+++ b/schedule/yast/maintenance/mau_extratests_yast2_ncurses.yaml
@@ -1,0 +1,14 @@
+---
+name: mau_extratests_yast2_ncurses
+description:    >
+  Testsuite maintained at https://gitlab.suse.de/qa-maintenance/qam-openqa-yml. Run
+  yast ncurses tests against aggregated test repo.
+schedule:
+  - boot/boot_to_desktop
+  - console/yast2_apparmor
+  - console/yast2_http
+  - console/yast2_nis
+  - console/yast2_ftp
+  - console/yast2_tftp
+  - console/yast2_lan_device_settings
+  - console/coredump_collect

--- a/schedule/yast/maintenance/mau_extratests_yast_cmd.yaml
+++ b/schedule/yast/maintenance/mau_extratests_yast_cmd.yaml
@@ -1,0 +1,20 @@
+---
+name: mau_extratests_yast_cmd
+description:    >
+  Testsuite maintained at https://gitlab.suse.de/qa-maintenance/qam-openqa-yml. Run
+  yast command-line tests against aggregated test repo.
+schedule:
+  - boot/boot_to_desktop
+  - yast2_cmd/yast_lan
+  - yast2_cmd/yast_timezone
+  - yast2_cmd/yast_tftp_server
+  - yast2_cmd/yast_ftp_server
+  - yast2_cmd/yast_rdp
+  - yast2_cmd/yast_users
+  - yast2_cmd/yast_sysconfig
+  - yast2_cmd/yast_keyboard
+  - yast2_cmd/yast_nfs_server
+  - yast2_cmd/yast_nfs_client
+  - yast2_cmd/yast_dns_server
+  - yast2_cmd/yast_lang
+  - console/coredump_collect


### PR DESCRIPTION
See https://progress.opensuse.org/issues/111025
We want to split mau-extratests-yast2ui-textmode in two test suites.
Currently this test suite includes both ncurses modules with yast command-line tools.
We would like to differentiate those.
See https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/258