### PR TITLE
Fix samba access on 15-SP3

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -97,24 +97,29 @@ sub samba_client_access {
     # Connect to samba server
     assert_and_click("nautilus-other-locations");
     send_key_until_needlematch("nautilus-connect-to-server", 'tab', 20, 2);
-    type_string("smb://$ip");
+    my $smb_str = is_sle('=15-SP3') ? "smb://$testuser:$pw\@$ip/$testdir" : "smb://$ip";
+    type_string("$smb_str");
     send_key "ret";
     wait_still_screen(2);
 
-    # Search the shared dir
-    send_key_until_needlematch("nautilus-sharedir-search", 'ctrl-f', 5, 2);
-    type_string("$testdir");
-    assert_screen("nautilus-sharedir-selected");
-    send_key "ret";
+    if (!is_sle('=15-SP3')) {
+        # Search the shared dir
+        send_key_until_needlematch("nautilus-sharedir-search", 'ctrl-f', 5, 2);
+        type_string("$testdir");
+        assert_screen("nautilus-sharedir-selected");
+        send_key "ret";
+    }
 
     # Input password for samb user
     assert_screen("nautilus-selected-sharedir-access-passwd");
-    send_key_until_needlematch("nautilus-registered-user-login", 'down', 5, 2);
-    send_key "tab";
-    send_key "ctrl-a";
-    send_key "delete";
-    type_string("$testuser");
-    send_key "ret";
+    if (!is_sle('=15-SP3')) {
+        send_key_until_needlematch("nautilus-registered-user-login", 'down', 5, 2);
+        send_key "tab";
+        send_key "ctrl-a";
+        send_key "delete";
+        type_string("$testuser");
+        send_key "ret";
+    }
     send_key "ctrl-a";
     send_key "delete";
     type_string("WORKGROUP");


### PR DESCRIPTION
On SLE 15-SP3, Nautilus/gvfs has a bug that doesn't allow samba access directly from the UI. This workaround the issue.

https://bugzilla.suse.com/show_bug.cgi?id=1199860
https://gitlab.gnome.org/GNOME/gvfs/-/issues/611

Verification runs:
- 15-SP3: https://openqa.suse.de/tests/8827435
- 15-SP2: https://openqa.suse.de/tests/8827384