### PR TITLE
BCI tests --reruns value parametrized

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -65,9 +65,10 @@ sub run_tox_cmd {
     my $bci_marker = get_var('BCI_IMAGE_MARKER');
     my $bci_timeout = get_var('BCI_TIMEOUT', 1200);
     my $bci_reruns = get_var('BCI_RERUNS', 3);
+    my $bci_reruns_delay = get_var('BCI_RERUNS_DELAY', 10);
     my $cmd = "tox -e $env -- -n auto";
     $cmd .= " -k $bci_marker" if $bci_marker;
-    $cmd .= " --reruns  $bci_reruns --reruns-delay 10";
+    $cmd .= " --reruns $bci_reruns --reruns-delay $bci_reruns_delay";
     record_info("tox", "Running command: $cmd");
     my $ret = script_run("timeout $bci_timeout $cmd", timeout => ($bci_timeout + 3));
     if ($ret == 124) {

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -64,9 +64,10 @@ sub run_tox_cmd {
     my ($self, $env) = @_;
     my $bci_marker = get_var('BCI_IMAGE_MARKER');
     my $bci_timeout = get_var('BCI_TIMEOUT', 1200);
+    my $bci_reruns = get_var('BCI_RERUNS', 3);
     my $cmd = "tox -e $env -- -n auto";
     $cmd .= " -k $bci_marker" if $bci_marker;
-    $cmd .= " --reruns 3 --reruns-delay 10";
+    $cmd .= " --reruns  $bci_reruns --reruns-delay 10";
     record_info("tox", "Running command: $cmd");
     my $ret = script_run("timeout $bci_timeout $cmd", timeout => ($bci_timeout + 3));
     if ($ret == 124) {


### PR DESCRIPTION
BCI test reruns parameter

Requirement discussed:
add in the openQa BCI tests job settings a test parameter BCI_RERUNS for the tox --reruns ... command, in order to customize that value during debugging sessions. See [discussion.]( https://suse.slack.com/archives/C02CGKBCGT1/p1653386464794009) 

Test Proofs, (used expected failing test of [PR 128](https://github.com/SUSE/BCI-tests/pull/128)):

1) Failing test report with BCI_RERUNS=1 (t=16'.17''): http://pasta.qam.suse.de/f0bI9JZs
- command: clone_job.pl --from openqa.suse.de --skip-chained-deps --skip-download 8770672 BCI_TESTS_REPO=https://github.com/m-dati/bci-tests.git BCI_TESTS_BRANCH=python_ws1_err QEMUCPU=host BCI_TEST_ENVS=python BCI_RERUNS=1

2) Failing test report with BCI_RERUNS=0 (t=13'.27''): http://pasta.qam.suse.de/aswFxZRp
- command: clone_job.pl --from openqa.suse.de --skip-chained-deps --skip-download 8770672 BCI_TESTS_REPO=https://github.com/m-dati/bci-tests.git BCI_TESTS_BRANCH=python_ws1_err QEMUCPU=host BCI_TEST_ENVS=python BCI_RERUNS=0

3) Failing test report without param --> default BCI_RERUNS=3 (t=20'.33''): http://pasta.qam.suse.de/v2flYtpB
- command: clone_job.pl --from openqa.suse.de --skip-chained-deps --skip-download 8770672 BCI_TESTS_REPO=https://github.com/m-dati/bci-tests.git BCI_TESTS_BRANCH=python_ws1_err QEMUCPU=host BCI_TEST_ENVS=python
