### PR TITLE
Record soft failure when executing usr_sbin_smbd on 15-SP3

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -108,6 +108,8 @@ sub samba_client_access {
         type_string("$testdir");
         assert_screen("nautilus-sharedir-selected");
         send_key "ret";
+    } else {
+        record_soft_failure("bsc#1199860 for 15-SP3: Unable to mount Windows share: Invalid argument.");
     }
 
     # Input password for samb user


### PR DESCRIPTION
Add a soft failure when executing the workaround on 15-SP3, so when the fix from upstream is backported we won't forget to remove it.

poo: https://progress.opensuse.org/issues/111659
