### PR TITLE
Replace systemctl with script_run

### DIFF
--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -51,7 +51,7 @@ sub rollback_and_reboot {
             return 1;
         }
         record_info('ps', script_output('ps -ef'));
-        systemctl 'status rollback.service';
+        script_run('systemctl --no-pager --full status rollback.service');
         bmwqemu::diag("SUSEConnect --rollback is still running, or failing [$runs/10]");
         sleep 60;
     }


### PR DESCRIPTION
systemctl status fails if the process is not running.
bug introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14971 

Failure: https://openqa.suse.de/tests/8828359#step/snapper_jeos_cli/98
VR: http://openqa.suse.de/t8830691

