### PR TITLE
Integrate 'Check undocumented security programs' into openQA

### DIFF
--- a/schedule/security/atsec_tests.yaml
+++ b/schedule/security/atsec_tests.yaml
@@ -8,6 +8,7 @@ schedule:
     - security/atsec/kvm_check
     - security/atsec/drng_test_preparation
     - security/atsec/dbus_services_exposure
+    - security/atsec/check_undocumented_security_programs
     - security/atsec/dbus_fuzzer
     - security/atsec/syscall_thrasher
     - security/atsec/netlink_message

--- a/tests/security/atsec/check_undocumented_security_programs.pm
+++ b/tests/security/atsec/check_undocumented_security_programs.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run 'Check for undocumented security-relevant programs' test case of ATSec test suite
+# Maintainer: xiaojing.liu <xiaojing.liu@suse.com>
+# Tags: poo#111671
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # The programs are defined by the FSP and corresponding man pages
+    my $known_programs = {
+        '/usr/bin/passwd' => 1,
+        '/usr/bin/crontab' => 1,
+        '/usr/bin/su' => 1,
+        '/usr/bin/sudo' => 1,
+        '/sbin/unix_chkpwd' => 1
+    };
+
+    # Search for setuid programs
+    my $output = script_output('find / -user root -perm -4000 -exec ls -ls {} \; | grep -v ".snapshots"', proceed_on_failure => 1);
+
+    # Add step results for each setuid program to show if it is known
+    foreach my $info (split(/\n/, $output)) {
+        my $program = (split(/\s+/, $info))[-1];
+        if ($program !~ /^\//) {
+            next;
+        }
+        unless ($known_programs->{$program}) {
+            record_info($program, "This program is not in known list\n$info", result => 'fail');
+            $self->result('fail');
+            next;
+        }
+        record_info($program, "This is a known safe program\n$info");
+    }
+}
+
+1;


### PR DESCRIPTION
This is the test case '4.6 Check for undocumented security-relevant programs'
of atsec. We plan to automate all test cases.

Related: https://progress.opensuse.org/issues/111671

Verify run:
https://openqa.suse.de/tests/8842364#  (s390x)
https://openqa.suse.de/tests/8842383# (64bit)
https://openqa.suse.de/tests/8842382# (aarch64)