### PR TITLE
Stabilize yast2 keyboard

### DIFF
--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -60,7 +60,7 @@ sub run {
 
     # 4. simulate german keystrokes to switch back us keymap
     send_key "alt-f2";
-    type_string "xdg/su /c |&sbin&zast2 kezboard|";
+    wait_screen_change { type_string "xdg/su /c |&sbin&zast2 kezboard|" };
     send_key_until_needlematch('root-auth-dialog', 'ret', 3, 3);
     wait_still_screen 2;
     type_password;


### PR DESCRIPTION
Sometimes we type test before the prompt appears, the change seem to fix
it as confirmed by 50 VRs.

poo# : https://progress.opensuse.org/issues/111276

VR http://waaa-amazing.suse.cz/tests/16957
