### PR TITLE
[WIP]Fix apache2_changehat on SLE15<SP4

### DIFF
--- a/tests/security/apparmor_profile/apache2_changehat.pm
+++ b/tests/security/apparmor_profile/apache2_changehat.pm
@@ -153,8 +153,13 @@ sub run {
     my @check_list = ('file_receive', 'open', 'signal', 'mknod');
     foreach my $check_point (@check_list) {
         if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* operation=.*$check_point.* profile=.*httpd-prefork.*/sx) {
-            record_info("ERROR", "There are denied $check_point records found in $audit_log", result => 'fail');
-            $self->result('fail');
+            if (!is_sle('<=15-SP3')) {
+                record_info("ERROR", "There are denied $check_point records found in $audit_log", result => 'fail');
+                $self->result('fail');
+            }
+            else {
+                record_soft_failure('bsc#1191684', 'Apparmor profile test case "apache2_changehat" found some "DENIED" audit records');
+            }
         }
     }
 


### PR DESCRIPTION
Due to bsc#1191684, the case apache2_changehat may fail
on sles15sp4- version as well, so we need add some workaround
here for QEM tests. will remove the workaround once the issue
is fixed.

- Related ticket: https://progress.opensuse.org/issues/111680
- Verification run：
SLE15SP3:http://openqa.suse.de/tests/8842238#
SLE15SP4:http://openqa.suse.de/tests/8842237# [The failed case is expected]
TW: https://openqa.opensuse.org/tests/2393045# [The failed case is expected]
