### PR TITLE
Modify spack modules to use nfs sharing

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -268,6 +268,7 @@ sub setup_nfs_server {
     zypper_call 'in nfs-kernel-server';
     assert_script_run "echo $exports *(rw,no_root_squash,sync,no_subtree_check) >> /etc/exports";
     assert_script_run "echo /usr/lib/hpc *(ro,no_root_squash,sync,no_subtree_check) >> /etc/exports";
+    assert_script_run "echo /opt/spack *(ro,no_root_squash,sync,no_subtree_check) >> /etc/exports" if get_var('SPACK');
     assert_script_run 'exportfs -a';
     systemctl 'enable --now nfs-server';
 }
@@ -285,6 +286,7 @@ sub mount_nfs_exports {
     assert_script_run "mount master-node00:$exports $exports";
     assert_script_run 'mkdir /usr/lib/hpc';
     assert_script_run 'mount master-node00:/usr/lib/hpc /usr/lib/hpc';
+    assert_script_run 'mount master-node00:/opt/spack /opt/spack' if get_var('SPACK');
 }
 
 1;

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -9,23 +9,12 @@
 use Mojo::Base qw(hpcbase hpc::utils), -signatures;
 use lockapi;
 use utils;
-use version_utils 'is_sle';
-use Utils::Architectures;
 
 sub run ($self) {
     my $mpi = $self->get_mpi();
     my $exports_path = '/home/bernhard/bin';
     # Install required HPC dependencies on the nodes act as compute nodes
-    my @hpc_deps = ('libucp0');
-    if (is_sle('>=15-SP3')) {
-        push @hpc_deps, 'libhwloc15' if $mpi =~ m/mpich/;
-        push @hpc_deps, ('libfabric1', 'libpsm2') if $mpi =~ m/openmpi/;
-        pop @hpc_deps if (is_aarch64 && $mpi =~ m/openmpi/);
-    } else {
-        push @hpc_deps, 'libpciaccess0' if $mpi =~ m/mpich/;
-        push @hpc_deps, 'libfabric1' if $mpi =~ m/openmpi/;
-    }
-    push @hpc_deps, ('libibmad5') if $mpi =~ m/mvapich2/;
+    my @hpc_deps = $self->get_compute_nodes_deps($mpi);
     zypper_call("in @hpc_deps");
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -70,7 +70,7 @@ sub post_fail_hook ($self) {
     my $compiler_ver = script_output("gcc --version | grep -E '\\b[0-9]+\.[0-9]+\.[0-9]+\$' | awk '{print \$4}'");
     my $arch = get_var('ARCH');
     my $node = script_output('hostname');
-    $self->tar_and_upload_log("/opt/spack/linux-sle_hpc15-$arch/gcc-$compiler_ver", "/tmp/spack_$node.tar.bz2");
+    $self->tar_and_upload_log("/opt/spack/linux-sle_hpc15-$arch/gcc-$compiler_ver", "/tmp/spack_$node.tar.bz2", timeout => 360);
     upload_logs('/tmp/make.out');
     $self->export_logs();
 }

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -9,16 +9,36 @@ use Mojo::Base qw(hpcbase hpc::utils), -signatures;
 use testapi;
 use lockapi;
 use utils;
+use Utils::Architectures;
+use version_utils 'is_sle';
 
 sub run ($self) {
     my $mpi = $self->get_mpi();
-    $self->prepare_spack_env($mpi);
-    assert_script_run "spack install boost+mpi^$mpi", timeout => 12000;
-    assert_script_run 'spack load boost';
+    my $exports_path = '/home/bernhard/bin';
+    set_var('SPACK', '1');
+    zypper_call "in spack";
+    $self->relogin_root;
+    #$self->prepare_spack_env($mpi);
+    my @hpc_deps = ('libucp0');
+    if (is_sle('>=15-SP3')) {
+        push @hpc_deps, 'libhwloc15' if $mpi =~ m/mpich/;
+        push @hpc_deps, ('libfabric1', 'libpsm2') if $mpi =~ m/openmpi/;
+        pop @hpc_deps if (is_aarch64 && $mpi =~ m/openmpi/);
+    } else {
+        push @hpc_deps, 'libpciaccess0' if $mpi =~ m/mpich/;
+        push @hpc_deps, 'libfabric1' if $mpi =~ m/openmpi/;
+    }
+    push @hpc_deps, ('libibmad5') if $mpi =~ m/mvapich2/;
+    zypper_call("in @hpc_deps");
 
-    record_info 'boost info', script_output 'spack info boost';
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
+
+    $self->mount_nfs_exports($exports_path);
+    assert_script_run "source /usr/share/spack/setup-env.sh";
+    # Once the /opt/spack is mounted `boost` should be available
+    script_run "module av";
+    record_info 'boost info', script_output 'spack info boost';
     barrier_wait('MPI_BINARIES_READY');
     barrier_wait('MPI_RUN_TEST');
 }
@@ -27,9 +47,7 @@ sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_run_hook ($self) {
-    $self->uninstall_spack_module('boost');
-}
+sub post_run_hook ($self) { }
 
 sub post_fail_hook ($self) {
     # Upload all the modules.


### PR DESCRIPTION
Same as the other mpi modules. Try to simulate a HPC setup as close to the
reality. The so-called modules should be able to run mpi code without
installing HPC specific modules. Although with spack this is a bit tricky and
we have actual to install the spack package itself. But later we can avoid to
run the compilation of the spack module we need, as we share them from the
management node(spack_master).

I set a job variable in the beginning of the execution which helps to avoid
edit the job variables manual and is used to distinguish when the regular
mpi modules or the spack is used. When is set the common funtions between
those two will choose what to share. Which, in spack case, is the /opt/spack
directory

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/109584
- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP4&build=b10n1k%2Fos-autoinst-distri-opensuse%2314990&distri=sle