### PR TITLE
sles4sap: Fix missing Exporter import

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -24,6 +24,7 @@ use registration qw(add_suseconnect_product);
 use version_utils qw(is_sle);
 use utils qw(zypper_call);
 use Utils::Systemd qw(systemctl);
+use Exporter 'import';
 
 our @EXPORT = qw(
   $instance_password


### PR DESCRIPTION
Functions should be exported, but they are not without Exporter module