### PR TITLE
Support Infiniband testing for tumbleweed

### DIFF
--- a/schedule/kernel/ibtest-master-autoyast.yaml
+++ b/schedule/kernel/ibtest-master-autoyast.yaml
@@ -24,4 +24,5 @@ schedule:
     - installation/ipxe_install
     - console/suseconnect_scc
     - toolchain/install
+    - kernel/ibtests_prepare
     - kernel/ibtests

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -44,4 +44,5 @@ schedule:
     - installation/handle_reboot
     - installation/first_boot
     - kernel/build_git_kernel
+    - kernel/ibtests_prepare
     - kernel/ibtests

--- a/schedule/kernel/ibtest-master-tumbleweed.yaml
+++ b/schedule/kernel/ibtest-master-tumbleweed.yaml
@@ -1,0 +1,40 @@
+name:           ibtest-master-tumbleweed
+description:    >
+    The master node for the infiniband testsuite (hpc-testing)
+vars:
+    DESKTOP: textmode
+    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/openSUSE_Tumbleweed/devel:tools.repo
+    IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
+    IBTEST_IP1: 10.162.2.93
+    IBTEST_IP2: 10.162.2.94
+    IBTEST_ROLE: IBTEST_MASTER
+    PATTERNS: base,minimal
+    ROOTONLY: 1
+    SCC_ADDONS: sdk
+schedule:
+    - kernel/ibtests_barriers
+    - installation/ipxe_install
+    - installation/welcome
+    - installation/online_repos
+    - installation/installation_mode
+    - installation/logpackages
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/handle_reboot
+    - installation/first_boot
+    - kernel/ibtests_prepare
+    - installation/handle_reboot
+    - kernel/ibtests

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -41,4 +41,5 @@ schedule:
     - installation/reboot_after_installation
     - installation/handle_reboot
     - installation/first_boot
+    - kernel/ibtests_prepare
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave-autoyast.yaml
+++ b/schedule/kernel/ibtest-slave-autoyast.yaml
@@ -24,4 +24,5 @@ schedule:
     - installation/ipxe_install
     - console/suseconnect_scc
     - toolchain/install
+    - kernel/ibtests_prepare
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -44,4 +44,5 @@ schedule:
     - installation/handle_reboot
     - installation/first_boot
     - kernel/build_git_kernel
+    - kernel/ibtests_prepare
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave-tumbleweed.yaml
+++ b/schedule/kernel/ibtest-slave-tumbleweed.yaml
@@ -1,0 +1,38 @@
+name:           ibtest-slave-tumbleweed
+description:    >
+    The slave node for the infiniband testsuite (hpc-testing)
+vars:
+    DESKTOP: textmode
+    EVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/openSUSE_Tumbleweed/devel:tools.repo
+    IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
+    IBTEST_IP1: 10.162.2.93
+    IBTEST_IP2: 10.162.2.94
+    IBTEST_ROLE: IBTEST_SLAVE
+    ROOTONLY: 1
+    SCC_ADDONS: sdk
+schedule:
+    - installation/ipxe_install
+    - installation/welcome
+    - installation/online_repos
+    - installation/installation_mode
+    - installation/logpackages
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/handle_reboot
+    - installation/first_boot
+    - kernel/ibtests_prepare
+    - installation/handle_reboot
+    - kernel/ibtests

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -41,4 +41,5 @@ schedule:
     - installation/reboot_after_installation
     - installation/handle_reboot
     - installation/first_boot
+    - kernel/ibtests_prepare
     - kernel/ibtests

--- a/tests/kernel/ibtests_prepare.pm
+++ b/tests/kernel/ibtests_prepare.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright 2018-2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: git-core twopence-shell-client bc iputils python
+# Summary: run InfiniBand test suite hpc-testing
+#
+# Maintainer: Michael Moese <mmoese@suse.de>, Nick Singer <nsinger@suse.de>, ybonatakis <ybonatakis@suse.com>
+
+use Mojo::Base qw(opensusebasetest);
+use Utils::Backends;
+use testapi;
+use utils;
+use power_action_utils 'power_action';
+use lockapi;
+use version_utils;
+use mmapi;
+
+
+sub permit_root_login {
+    my $self = shift;
+
+    select_console('sol', await_console => 1);
+    type_string "root";
+    wait_screen_change { type_string "\n" };
+    type_password;
+    wait_screen_change { type_string "\n" };
+    permit_root_ssh_in_sol;
+    wait_screen_change { type_string "\n" };
+}
+
+sub run {
+    my $self = shift;
+    my $master = get_required_var('IBTEST_IP1');
+    my $slave = get_required_var('IBTEST_IP2');
+
+    my $role = get_required_var('IBTEST_ROLE');
+    my $packages = "rdma-core rdma-ndd iputils python";
+    my $packages_master = $packages . " git-core twopence-shell-client bc";
+
+
+    $self->permit_root_login if is_ipmi;
+
+    $self->select_serial_terminal;
+    # unload firewall. MPI- and libfabric-tests require too many open ports
+    systemctl("disable --now " . opensusebasetest::firewall);
+
+    # create a ssh key if we don't have one
+    script_run('[ ! -f /root/.ssh/id_rsa ] && ssh-keygen -b 2048 -t rsa -q -N "" -f /root/.ssh/id_rsa');
+
+
+    if ($role eq 'IBTEST_MASTER') {
+        zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);
+        zypper_ar(get_required_var('SCIENCE_HPC_REPO'), no_gpg_check => 1, priority => 50) if get_var('SCIENCE_HPC_REPO', '');
+        $packages = $packages_master;
+    }
+
+    zypper_call("in $packages", exitcode => [0, 65, 107]);
+
+
+    power_action('reboot', textmode => 1, keepconsole => 1);
+
+
+}
+
+1;


### PR DESCRIPTION
Add support for running InfiniBand tests on openSUSE Tumbleweed
Do some cleanups and add schedules for Tumbleweed.

Related ticket: [https://progress.opensuse.org/issues/104871](https://progress.opensuse.org/issues/104871)

Verification run: http://baremetal-support.qa.suse.de/tests/2194 and http://baremetal-support.qa.suse.de/tests/2195