### PR TITLE
Podman pods: use curl instead of wget

### DIFF
--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -20,7 +20,7 @@ sub run {
     my $podman = $self->containers_factory('podman');
 
     record_info('Prep', 'Get kube yaml');
-    assert_script_run("wget " . data_url("containers/hello-kubic.yaml") . " -O hello-kubic.yaml");
+    assert_script_run('curl ' . data_url('containers/hello-kubic.yaml') . ' -o hello-kubic.yaml');
 
     record_info('Test', 'Create hello-kubic pod');
     assert_script_run('podman play kube hello-kubic.yaml');


### PR DESCRIPTION
Some products don't have wget pre-installed


SLE JeOS http://openqa.suse.de/t8844153
SLE PC: https://openqa.suse.de/tests/8844158
SLE Micro: https://openqa.suse.de/tests/8844159