### PR TITLE
Add AutoConfig for Firefox to disable pop-ups on start

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -21,6 +21,7 @@ use version_utils 'is_tumbleweed';
 sub run() {
     my ($self) = shift;
 
+    $self->prepare_firefox_autoconfig;
     $self->start_firefox;
     wait_still_screen;
     send_key('alt');


### PR DESCRIPTION
I adapted the code from https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/87 to create the AutoConfig file before the first Firefox launch.

For now, it is only used in the _x11/firefox_ test. Other can easily reuse the code by adding `$self->prepare_firefox_autoconfig;
` before launching the Firefox for the first time.

- Related ticket: https://progress.opensuse.org/issues/111416
- Verification run: http://polaris.suse.cz/tests/2546#step/firefox/9