### PR TITLE
Enhance function: curve25519 is not FIPS approved

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -73,7 +73,11 @@ sub init {
 
     $self->service("EC2") unless (defined($self->service));
 
-    if (!defined($self->key_id) || !defined($self->key_secret)) {
+    if (get_var('PUBLIC_CLOUD_CREDENTIALS_URL')) {
+        my $data = get_credentials();
+        $self->key_id($data->{access_key_id});
+        $self->key_secret($data->{secret_access_key});
+    } elsif (!defined($self->key_id) || !defined($self->key_secret)) {
         $self->vault(publiccloud::vault->new());
         $self->vault_create_credentials();
     }

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -47,7 +47,7 @@ sub run {
         systemctl('stop ' . $self->firewall);
     }
 
-    # Restart sshd and check it's status
+    #  Restart sshd and check it's status
     my $ret = systemctl('restart sshd', ignore_failure => 1);
     my $fips_enabled = script_output('cat /proc/sys/crypto/fips_enabled', proceed_on_failure => 1) eq '1';
 


### PR DESCRIPTION
Curve is not supported in FIPS mode
POO: https://progress.opensuse.org/issues/111488


- Related ticket:https://progress.opensuse.org/issues/111488
- Needles: NA
- Verification run: 
kernel mode:https://openqa.suse.de/tests/8847299#step/sshd/114
ENV mode:https://openqa.suse.de/tests/8847298#step/sshd/105