### PR TITLE
xfstests: Fix incorrect 'power_action' call

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -471,7 +471,7 @@ sub run {
         };
         # If SUT didn't reboot for some reason, force reset
         if ($@) {
-            power('reset', keepconsole => is_pvm);
+            power_action('reset', keepconsole => is_pvm);
             reconnect_mgmt_console if is_pvm;
             $self->wait_boot;
         }


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/99663