### PR TITLE
schedule: only run yast2_rmt on SLE/Leap >= 15.1

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1458,7 +1458,7 @@ sub load_extra_tests_y2uitest_ncurses {
         return;
     }
     # start extra yast console tests (self-contained only) from here
-    loadtest "console/yast2_rmt" unless (is_sle('<15-sp1') || is_leap('<15.0'));
+    loadtest "console/yast2_rmt" if (is_sle('>=15-sp1') || is_leap('>=15.0'));
     loadtest "console/yast2_ntpclient";
     loadtest "console/yast2_tftp";
     # We don't schedule some tests on s390x as they are unstable, see poo#42692


### PR DESCRIPTION
yast2_rmt no longer exists on Tumbleweed

- Related ticket: https://progress.opensuse.org/issues/111479
- Needles: N/A
- Verification run: NONE
