### PR TITLE
Podman pods: cleanup system host

### DIFF
--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -40,6 +40,7 @@ sub run {
         record_info('Cleanup', 'Stop pods');
         assert_script_run('podman play kube --down hello-kubic.yaml');
     }
+    $podman->cleanup_system_host();
 }
 
 1;


### PR DESCRIPTION
When we don't run podman play kube --down the next test module,
podman_firewall complains that there are containers running:
https://openqa.suse.de/tests/8850484#step/podman_firewall/115
