### PR TITLE
check_default_network_manager: Only JeOS based on SLE and Leap still use wicked

### DIFF
--- a/tests/console/check_default_network_manager.pm
+++ b/tests/console/check_default_network_manager.pm
@@ -37,7 +37,7 @@ sub run {
     my $unexpected = 'wicked';
     my $reason = 'networking';
 
-    if (is_jeos) {
+    if (is_jeos && (is_sle || is_leap)) {
         $expected = 'wicked';
         $unexpected = 'NetworkManager';
         $reason = 'JeOS';


### PR DESCRIPTION
JeOS based on Tumbleweed has been switched to use NetworkManager

- Related ticket: https://progress.opensuse.org/issues/110211
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2398327
