### PR TITLE
Use cli for kdump check

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -346,7 +346,7 @@ sub check_function {
         reconnect_mgmt_console if is_pvm;
     }
     else {
-        power_action('reboot', observe => 1, keepconsole => 1);
+        power_action('reboot', textmode => 1, observe => 1, keepconsole => 1);
     }
     unlock_if_encrypted;
     # Wait for system's reboot; more time for Hyper-V as it's slow.
@@ -415,7 +415,7 @@ sub full_kdump_check {
     select_console 'root-console';
 
     if ($stage eq 'before') {
-        configure_service(test_type => $stage);
+        configure_service(test_type => $stage, yast_interface => 'cli');
     }
     check_function();
 


### PR DESCRIPTION
We need to change kdump test from yast to cli, which will avoid
many unexpect yast2 needle matching errors.

And we can specify CRASH_MEMORY variable in your job group schedule
per architecture

- Related ticket:  https://progress.opensuse.org/issues/111938 
- Needles: N/A
- Verification run: 
  http://openqa.nue.suse.com/t8897362
  http://openqa.nue.suse.com/t8897363