### PR TITLE
Remove the softfail in ip_eb_tables

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -174,8 +174,7 @@ sub _parse_results_with_diff_baseline {
     my ($name, $result, $msg, $flag) = @_;
     my $softfail_tests = {
         s390x => {
-            ssh04 => 'Test case ssh04 fails in s390x is a known issue, see poo#99096',
-            iptables_SETSOCKOPT => 'bsc#1192324'
+            ssh04 => 'Test case ssh04 fails in s390x is a known issue, see poo#99096'
         }
     };
     if ($result eq 'PASS') {


### PR DESCRIPTION
Related: https://progress.opensuse.org/issues/111222

Verify run:
       https://openqa.suse.de/tests/8864200# (s390x)
       https://openqa.suse.de/tests/8864201# (x86_64)