### PR TITLE
Public Cloud: bugfix for cleanup introduced by 068d7dd

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -131,7 +131,7 @@ sub configure_podman {
 
 sub cleanup {
     my ($self) = @_;
-    $self->vault->revoke();
+    $self->vault->revoke() unless (get_var('PUBLIC_CLOUD_CREDENTIALS_URL'));
 }
 
 1;


### PR DESCRIPTION
We need to skip the vault call in the cleanup if we are using the new
credentials system

- Related ticket: https://progress.opensuse.org/issues/108509
Failure: https://openqa.suse.de/tests/8867283#step/ssh_interactive_end/12

