### PR TITLE
sles4sap: Move upload of NW installation logs to another module

### DIFF
--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -92,6 +92,8 @@ sub run {
         assert_script_run "grep -q 'Cannot stop instance.*ASCS' /sapinst/unattended/sapinst.log";
     }
 
+    $self->upload_nw_install_log;
+
     # Synchronize with other nodes
     if (get_var('HA_CLUSTER') && is_node(1)) {
         my $cluster_name = get_cluster_name;

--- a/tests/sles4sap/netweaver_test_instance.pm
+++ b/tests/sles4sap/netweaver_test_instance.pm
@@ -5,7 +5,7 @@
 
 # Summary: Checks NetWeaver installation as performed by sles4sap/netweaver_install
 # Requires: sles4sap/netweaver_install, ENV variables INSTANCE_SID, INSTANCE_TYPE and INSTANCE_ID
-# Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.de>
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use base "sles4sap";
 use testapi;
@@ -18,10 +18,6 @@ sub run {
     my $pscmd = $self->set_ps_cmd(get_required_var('INSTANCE_TYPE'));
 
     $self->select_serial_terminal;
-
-    # First, upload the installation logs
-    # NOTE: done here because there are multiple installation paths
-    $self->upload_nw_install_log;
 
     # On upgrade scenarios, hostname and IP address could have changed from the original
     # installation of NetWeaver. This ensures the current hostname can be resolved


### PR DESCRIPTION
Fix problem described at:
https://suse.slack.com/archives/C02CU8X53RC/p1654161641697329

Verification runs:
- https://openqa.suse.de/tests/8875936 (create_hdd_sles4sap_gnome_netweaver_sle12_sp5)
- https://openqa.suse.de/tests/8878370 (migration_offline_scc_sles4sap12sp5)