### PR TITLE
Stabilize lan device settings test

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -421,7 +421,12 @@ Close yast2 lan configuration and check that it is closed successfully
 
 =cut
 sub close_yast2_lan {
-    send_key "alt-o";    # OK=>Save&Exit
+    my ($tag) = @_;
+    if ($tag eq '') {
+        send_key 'alt-o';
+    } else {
+        send_key_until_needlematch($tag, 'alt-o', 5, 5);
+    }
     wait_serial("$module_name-0", 180) || die "'yast2 lan' didn't finish";
 }
 

--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -73,7 +73,7 @@ sub run {
             send_key "alt-y";    # select dynamic address option
             send_key "alt-n";    # next
             assert_screen 'dynamic-ip-address-set';
-            close_yast2_lan();
+            close_yast2_lan('yast2-ncurses-closed');
 
             # verify that dynamic IP address has been set
             assert_script_run "ip r s | grep dhcp";


### PR DESCRIPTION
The keybinding shortcut pressed for OK button is sometimes not registering in close_yast2_lan function, resulting in sporadic
fails. 
In order to stabilize the test, the keybind is pressed until the screen has changed and we have moved to the next page.

- Related ticket: https://progress.opensuse.org/issues/111524
- Needles: None
- Verification runs: [12SP2](https://openqa.suse.de/tests/8913442#step/yast2_lan_device_settings/36) | [12SP3](https://openqa.suse.de/tests/8913597#step/yast2_lan_device_settings/41) | [12SP4](https://openqa.suse.de/tests/8913598#step/yast2_lan_device_settings/43) | [12SP5](https://openqa.suse.de/tests/8913599#step/yast2_lan_device_settings/41) | [15](https://openqa.suse.de/tests/8913600#step/yast2_lan_device_settings/42) | [15SP1](https://openqa.suse.de/tests/8913601#step/yast2_lan_device_settings/42) | [15SP2](https://openqa.suse.de/tests/8913602#step/yast2_lan_device_settings/42) | [15SP3](https://openqa.suse.de/tests/8913603#step/yast2_lan_device_settings/43)