### PR TITLE
Update yaml to load check_upgraded_service

### DIFF
--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -33,7 +33,7 @@ conditional_schedule:
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
-        - '{{check_upgraded_service}}'
+        - console/check_upgraded_service
         - '{{openldap_to_389ds}}'
         - '{{regression_tests}}'
         - boot/grub_test_snapshot
@@ -42,10 +42,6 @@ conditional_schedule:
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
-  check_upgraded_service:
-    REGRESSION_SERVICE:
-      1:
-        - console/check_upgraded_service
   install_service:
     REGRESSION_SERVICE:
       1:

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -24,6 +24,7 @@ conditional_schedule:
   qcow_generation:
     QCOW_GENERATION:
       0:
+        - console/check_upgraded_service
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
@@ -61,7 +62,6 @@ conditional_schedule:
   regression_tests:
     REGRESSION_TEST:
       1:
-        - console/check_upgraded_service
         - locale/keymap_or_locale
         - console/supportutils
         - console/force_scheduled_tasks


### PR DESCRIPTION
In yaml file schedule/migration/x86_regression_test_online.yaml missed check_upgraded_service when REGRESSION_SERVICE=2, we need update yaml to load check_upgraded_service.

- Related ticket: https://progress.opensuse.org/issues/112040
- Needles: N/A
- Verification run: 
  http://openqa.nue.suse.com/tests/8897372#  x86 online with REGRESSION_TEST=2
  http://openqa.nue.suse.com/tests/8897373#  ppc64le online without REGRESSION_SERVICE=1