### PR TITLE
Trento test first implementation.

### DIFF
--- a/schedule/sles4sap/trento/trento.yml
+++ b/schedule/sles4sap/trento/trento.yml
@@ -1,0 +1,21 @@
+---
+name: trento
+description: |
+  Run Trento tests on public cloud instances:
+    - Test to deploy and test a Trento app
+    - Deploy on Azure: Trento and a SAP landscape and bond them together
+    - Test interacting with the web interface using Cypress
+    - Destroy all Azure resources related to the Trento app and other utility like ACR
+vars:
+    TRENTO_TEST_REGISTRY: 'registry.suse.com/trento/trento-runner'
+    TRENTO_DEPLOY_SCRIPTS_REPO: 'gitlab.suse.de/qa-css/trento'
+    TRENTO_VM_IMAGE: 'SUSE:sles-sap-15-sp3-byos:gen2:latest'
+    TRENTO_CYPRESS_VERSION: '3.4.0'
+    PUBLIC_CLOUD_PROVIDER: 'AZURE'
+    TEST_CONTEXT: 'OpenQA::Test::RunArgs'
+schedule:
+    - boot/boot_to_desktop
+    - sles4sap/trento/init_jumphost
+    - sles4sap/trento/deploy_trento
+    - sles4sap/trento/test_trento_deploy
+    - sles4sap/trento/test_trento_web

--- a/schedule/sles4sap/trento/trento_jumphost.yml
+++ b/schedule/sles4sap/trento/trento_jumphost.yml
@@ -1,0 +1,17 @@
+---
+name: trento
+description: |
+  Run Trento test sequence to generate a JumpHost image:
+    - Install all needed test resources needed to the JumpHost during the test
+    - Install all tools like az cli, helm
+    - Pull all needed conteiners like Cypress/include
+vars:
+    TRENTO_DEPLOY_SCRIPTS_REPO: 'gitlab.suse.de/qa-css/trento'
+    TRENTO_HELM_VERSION: '3.8.2'
+    TRENTO_CYPRESS_VERSION: '3.4.0'
+    TEST_CONTEXT: 'OpenQA::Test::RunArgs'
+schedule:
+    - boot/boot_to_desktop
+    - sles4sap/trento/setup_jumphost
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/tests/sles4sap/trento/deploy_trento.pm
+++ b/tests/sles4sap/trento/deploy_trento.pm
@@ -1,0 +1,76 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Trento test
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use Mojo::Base 'publiccloud::basetest';
+use base 'consoletest';
+use strict;
+use testapi;
+use mmapi 'get_current_job_id';
+
+use constant TRENTO_AZ_PREFIX => 'openqa-trento';
+use constant TRENTO_AZ_ACR_PREFIX => 'openqatrentoacr';
+
+sub run {
+    my ($self) = @_;
+    die "Only AZURE deployment supported for the moment" unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    $self->select_serial_terminal;
+    my $job_id = get_current_job_id();
+
+    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
+    my $machine_name = TRENTO_AZ_PREFIX . "-vm-$job_id";
+    # Parameter 'registry_name' must conform to the following pattern: '^[a-zA-Z0-9]*$'.
+    my $acr_name = TRENTO_AZ_ACR_PREFIX . "$job_id";
+
+    enter_cmd "cd /root/test";
+
+    # Run the Trento deployment
+    my $vm_image = get_var('TRENTO_VM_IMAGE', 'SUSE:sles-sap-15-sp3-byos:gen2:latest');
+    my $cmd_00_040 = "./00.040-trento_vm_server_deploy_azure.sh " .
+      "-g $resource_group " .
+      "-s $machine_name " .
+      "-i $vm_image " .
+      "-a cloudadmin " .
+      "-k /root/.ssh/id_rsa.pub " .
+      "-v";
+    assert_script_run($cmd_00_040, 360);
+
+    my $trento_acr_azure_cmd = "./trento_acr_azure.sh " .
+      "-g $resource_group " .
+      "-n $acr_name " .
+      "-r registry.suse.com/trento/trento-server " .
+      "-v";
+    assert_script_run($trento_acr_azure_cmd, 360);
+    my $machine_ip = script_output("az vm show -d -g $resource_group -n $machine_name --query \"publicIps\" -o tsv");
+    my $acr_server = script_output("az acr list -g $resource_group --query \"[0].loginServer\" -o tsv");
+    my $acr_username = script_output("az acr credential show -n $acr_name --query username -o tsv");
+    my $acr_secret = script_output("az acr credential show -n $acr_name --query 'passwords[0].value' -o tsv");
+
+    # Check what registry has been created by  trento_acr_azure_cmd
+    assert_script_run("az acr repository list -n $acr_name");
+
+    my $cmd_01_010 = "./01.010-trento_server_installation_premium_v.sh " .
+      "-i $machine_ip " .
+      "-k /root/.ssh/id_rsa " .
+      "-u cloudadmin " .
+      "-c 3.8.2 " .
+      '-p $(pwd) ' .
+      "-r $acr_server/trento/trento-server " .
+      "-s $acr_username " .
+      '-w $(az acr credential show -n ' . $acr_name . " --query 'passwords[0].value' -o tsv) " .
+      "-v";
+    assert_script_run($cmd_01_010, 600);
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    my $job_id = get_current_job_id();
+    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
+
+    assert_script_run("az group delete --resource-group $resource_group --yes", 180);
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/trento/init_jumphost.pm
+++ b/tests/sles4sap/trento/init_jumphost.pm
@@ -1,0 +1,27 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Trento test
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use Mojo::Base 'publiccloud::basetest';
+use base 'consoletest';
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    # Get the code for the Trento deployment
+    enter_cmd 'cd ${HOME}/test';
+    my $git_branch = get_var('TRENTO_GITLAB_BRANCH', 'master');
+    assert_script_run("git checkout " . $git_branch);
+    assert_script_run("git pull origin " . $git_branch);
+
+    # az login
+    die "Only AZURE deployment supported for the moment" unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    my $provider = $self->provider_factory();
+}
+
+1;

--- a/tests/sles4sap/trento/setup_jumphost.pm
+++ b/tests/sles4sap/trento/setup_jumphost.pm
@@ -1,0 +1,93 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Trento test
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use Mojo::Base 'publiccloud::basetest';
+use base 'consoletest';
+use strict;
+use testapi;
+use utils 'zypper_call';
+use version_utils 'is_sle';
+use registration qw(add_suseconnect_product get_addon_fullname);
+
+use constant GITLAB_CLONE_LOG => '/tmp/gitlab_clone.log';
+use constant PODMAN_PULL_LOG => '/tmp/podman_pull.log';
+
+=head2 crypress_install_container
+
+Prepare whatever is needed to run cypress tests using container
+
+=cut
+sub cypress_install_container {
+    my ($cypress_ver) = @_;
+
+    record_info('INFO', 'Check podman');
+    zypper_call('in podman') if (script_run 'which podman');
+    assert_script_run('podman --version');
+    assert_script_run('podman info --debug');
+    assert_script_run('podman ps');
+    assert_script_run('podman images');
+
+    # Pull in advance the cypress container
+    my $cypress_image = 'docker.io/cypress/included';
+    assert_script_run('podman search --list-tags ' . $cypress_image);
+    assert_script_run('df -h');
+    my $podman_pull_cmd = 'time podman ' .
+      '--log-level trace ' .
+      'pull ' .
+      '--quiet ' .
+      $cypress_image . ':' . $cypress_ver .
+      ' | tee ' . PODMAN_PULL_LOG;
+    assert_script_run($podman_pull_cmd, 1800);
+    assert_script_run('df -h');
+    assert_script_run('podman images');
+}
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    # Install needed tools
+    my $helm_ver = get_var('TRENTO_HELM_VERSION', '3.8.2');
+
+    if (script_run('which helm')) {
+        assert_script_run('curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3');
+        assert_script_run('chmod 700 get_helm.sh');
+        assert_script_run('DESIRED_VERSION="v' . $helm_ver . '" ./get_helm.sh');
+    }
+    assert_script_run("helm version");
+
+    # If 'az' is preinstalled, we test that version
+    assert_script_run('az --version');
+
+    # Get the code for the Trento deployment
+    my $gitlab_repo = get_var('TRENTO_GITLAB_REPO', 'gitlab.suse.de/qa-css/trento');
+
+    # The usage of a variable with a different name is to
+    # be able to overwrite the token when triggering manually.
+    #
+    # Note: this test is mostly used to create a HDD image; part of it is this cloned repo.
+    # The key is part of the cloned repo itself so TRENTO_GITLAB_TOKEN for the moment
+    # cannot be changed as running init_jumphost
+    my $gitlab_token = get_var('TRENTO_GITLAB_TOKEN', get_required_var('_SECRET_TRENTO_GITLAB_TOKEN'));
+
+    my $gitlab_clone_cmd = 'https://git:' . $gitlab_token . '@' . $gitlab_repo;
+    enter_cmd 'mkdir ${HOME}/test && cd ${HOME}/test';
+    assert_script_run("git clone $gitlab_clone_cmd . | tee " . GITLAB_CLONE_LOG);
+
+    # Cypress.io installation
+    my $cypress_ver = get_var('TRENTO_CYPRESS_VERSION', '3.4.0');
+    cypress_install_container($cypress_ver);
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    # $self->select_serial_terminal;
+    upload_logs(GITLAB_CLONE_LOG);
+    upload_logs(PODMAN_PULL_LOG);
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/trento/test_trento_deploy.pm
+++ b/tests/sles4sap/trento/test_trento_deploy.pm
@@ -1,0 +1,41 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Trento test
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use Mojo::Base 'publiccloud::basetest';
+use base 'consoletest';
+use strict;
+use testapi;
+use mmapi 'get_current_job_id';
+
+use constant TRENTO_AZ_PREFIX => 'openqa-trento';
+
+sub run {
+    my ($self) = @_;
+    die "Only AZURE deployment supported for the moment" unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    $self->select_serial_terminal;
+    my $job_id = get_current_job_id();
+
+    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
+    my $machine_name = TRENTO_AZ_PREFIX . "-vm-$job_id";
+
+    # check if VM is still there :-)
+    assert_script_run("az vm list -g $resource_group --query \"[].name\"  -o tsv", 180);
+
+    my $machine_ip = script_output("az vm show -d -g $resource_group -n $machine_name --query \"publicIps\" -o tsv", 180);
+
+    # test if the web page is reachable on http
+    assert_script_run("curl -k  http://" . $machine_ip . "/");
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    my $job_id = get_current_job_id();
+    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
+    assert_script_run("az group delete --resource-group $resource_group --yes", 180);
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -1,0 +1,90 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Trento test
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use Mojo::Base 'publiccloud::basetest';
+use base 'consoletest';
+use strict;
+use testapi;
+use mmapi 'get_current_job_id';
+
+use constant CYPRESS_LOG_DIR => '/root/result';
+use constant TRENTO_AZ_PREFIX => 'openqa-trento';
+use constant TRENTO_AZ_ACR_PREFIX => 'openqatrentoacr';
+
+=head2 cypress_exec
+Execute a cypress command
+
+=cut
+sub cypress_exec {
+    my ($cypress_ver, $cypress_test_dir, $cmd, $timeout) = @_;
+    record_info('INFO', 'Cypress exec:' . $cmd);
+    my $cypress_run_cmd = "podman run -it " .
+      "-v " . CYPRESS_LOG_DIR . ":/results " .
+      "-v $cypress_test_dir:/e2e -w /e2e " .
+      '-e "DEBUG=cypress:*" ' .
+      '--entrypoint=\'[' .
+      '"/bin/sh", "-c", ' .
+      ' "/usr/local/bin/cypress ' . $cmd .
+      ' 2>/results/log.txt"' .
+      ']\' ' .
+      'docker.io/cypress/included:' . $cypress_ver;
+    assert_script_run($cypress_run_cmd, $timeout);
+}
+
+sub run {
+    my ($self) = @_;
+    die "Only AZURE deployment supported for the moment" unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    $self->select_serial_terminal;
+    my $job_id = get_current_job_id();
+
+    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
+    my $machine_name = TRENTO_AZ_PREFIX . "-vm-$job_id";
+
+    my $machine_ip = script_output("az vm show -d -g $resource_group -n $machine_name --query \"publicIps\" -o tsv", 180);
+
+    my $ssh_remote_cmd = "ssh" .
+      " -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR" .
+      " -i /root/.ssh/id_rsa" .
+      " cloudadmin@" . $machine_ip .
+      " -- ";
+    my $trento_web_password_cmd = $ssh_remote_cmd .
+      " kubectl get secret trento-server-web-secret" .
+      " -o jsonpath='{.data.ADMIN_PASSWORD}'" .
+      "|base64 --decode";
+    my $trento_web_password = script_output($trento_web_password_cmd);
+
+    my $cypress_test_dir = "/root/test/test";
+    enter_cmd "cd " . $cypress_test_dir;
+    assert_script_run("./cypress.env.py -u http://" . $machine_ip . " -p " . $trento_web_password . " -f Premium");
+    assert_script_run('cat cypress.env.json');
+
+    assert_script_run "mkdir " . CYPRESS_LOG_DIR;
+    my $cypress_ver = get_var('TRENTO_CYPRESS_VERSION', '3.4.0');
+    cypress_exec($cypress_ver, $cypress_test_dir, 'verify', 120);
+
+    cypress_exec($cypress_ver, $cypress_test_dir, 'run', 600);
+    script_run('find ' . CYPRESS_LOG_DIR . ' -type f');    # all files listed in the test log
+    my $cypress_output = script_output 'find ' . CYPRESS_LOG_DIR . ' -type f -print';
+    upload_logs($_) for grep(/(.txt|.xml)$/, split(/\n/, $cypress_output));
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    my $job_id = get_current_job_id();
+    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
+    assert_script_run('az group list --query "[].name" -o tsv');
+    assert_script_run("az group delete --resource-group $resource_group --yes", 1200);
+
+    # the sleep is to give to the cypress test app
+    # the time to complete the log write
+    sleep 60;
+    script_output('find ' . CYPRESS_LOG_DIR . ' -type f');
+    my $cypress_output = script_output 'find ' . CYPRESS_LOG_DIR . ' -type f -print';
+    upload_logs($_) for grep(/(.txt|.xml|.mp4)$/, split(/\n/, $cypress_output));
+    $self->SUPER::post_fail_hook;
+}
+
+1;


### PR DESCRIPTION
Two schedule provided:

- **trento_jumphost** : designed to create the Jumphost qcow2 file.
   The test will check the presence of all needed tools and eventually
   add them (az, helm, podman). The cypress image is pulled to be ready
   available. For the moment the test is expected to run against publiccloud_tools_xxx.qcow2

```
openqa-clone-job --from https://openqa.suse.de/tests/8736011 --skip-chained-deps  YAML_SCHEDULE=schedule/sles4sap/trento/trento_jumphost.yml HDD_1=publiccloud_tools_0034.qcow2  PUBLISH_HDD_1=trento_tools.qcow2
```
Execution example http://1c242.qa.suse.de/tests/167  and http://1c242.qa.suse.de/tests/292#

 - **trento** : test main scheduling. Test take care to deploy Trento on
   Azure and perform some basic test on the web front-end.

Execution example: http://1c242.qa.suse.de/tests/192