### PR TITLE
Enable SEV in kernel on host

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -16,8 +16,10 @@ use testapi;
 use version_utils qw(is_storage_ng is_sle);
 use utils;
 use power_action_utils 'prepare_system_shutdown';
+use Utils::Architectures;
+use Carp;
 
-our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot ipmitool);
+our @EXPORT = qw(set_grub_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot ipmitool enable_sev_in_kernel add_kernel_options);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
@@ -337,11 +339,11 @@ sub set_pxe_efiboot {
 }
 
 #Usage:
-#For post installation, use set_serial_console_on_vh(,...) directly
-#For during installation, use set_serial_console_on_vh("/mnt",...)
-#For custom usage, use set_serial_console_on_vh($mount_point, $installation_disk, $virt_type)
+#For post installation, use set_grub_on_vh(,...) directly
+#For during installation, use set_grub_on_vh("/mnt",...)
+#For custom usage, use set_grub_vh($mount_point, $installation_disk, $virt_type)
 #Please pass desired hypervisor type to this function explicitly. There is no default value for $virt_type
-sub set_serial_console_on_vh {
+sub set_grub_on_vh {
     my ($mount_point, $installation_disk, $virt_type) = @_;
 
     #prepare accessible grub
@@ -366,6 +368,9 @@ sub set_serial_console_on_vh {
     if (${virt_type} eq "xen" || ${virt_type} eq "kvm") { setup_console_in_grub($ipmi_console, $root_dir, $virt_type); }
     else { die "Host Hypervisor is not xen or kvm"; }
 
+    #Enabling SEV on the machine if it is running SEV/SEV-ES test
+    enable_sev_in_kernel(root_dir => $root_dir) if (get_var('VIRT_SEV_ES_GUEST_INSTALL') and is_x86_64 and ${virt_type} eq "kvm");
+
     #cleanup mount
     if ($mount_point ne "") {
         assert_script_run("cd /");
@@ -388,6 +393,100 @@ sub ipmitool {
 
     bmwqemu::diag("IPMI: $stdout");
     return $stdout;
+}
+
+=head2 enable_sev_in_kernel
+
+  enable_sev_in_kernel(dst_machine => $dst_machine, root_dir => $root_dir)
+
+Enable SEV in the kernel, because it is disabled by default. This is done by putting
+the following onto the kernel command line: mem_encrypt=on kvm_amd.sev=1. To make the 
+changes persistent, append the above to the variable holding parameters of the kernel
+command line in /etc/default/grub to preserve SEV settings across reboots:
+$ cat /etc/default/grub
+...
+GRUB_CMDLINE_LINUX="... mem_encrypt=on kvm_amd.sev=1"
+...
+mem_encrypt=on turns on the SME memory encryption feature on the host which protects 
+against the physical attack on the hypervisor memory. The kvm_amd.sev parameter 
+actually enables SEV in the kvm module. This subroutine receives only two arguments,
+the dst_machine is the host on which operations will be performed, the root_dir is 
+the partition on which grub files reside. If these two arguments are not given any
+values, operations will be performed on localhost and '/' partition. This subroutine
+calls add_kernel_options to do the actual kernel options adding work.
+
+=cut
+
+sub enable_sev_in_kernel {
+    my (%args) = @_;
+
+    $args{dst_machine} //= 'localhost';
+    $args{root_dir} //= '';
+    $args{root_dir} .= '/' unless $args{root_dir} =~ /\/$/;
+    croak("No AMD EPYC cpu on $args{dst_machine}, so sev can not be enabled in kernel.") unless (script_run("lscpu | grep -i \'AMD EPYC\'") == 0);
+    add_kernel_options(dst_machine => $args{dst_machine}, root_dir => $args{root_dir}, kernel_opts => 'mem_encrypt=on kvm_amd.sev=1');
+}
+
+=head2 add_kernel_options
+
+  add_kernel_options(dst_machine => $dst_machine, root_dir => $root_dir, kernel_opts => $options)
+
+Adding additional kernel options onto kernel command line in grub config file and 
+also GRUB_CMDLINE_LINUX_DEFAULT line in default grub config file. This subroutine 
+receives only four arguments, dst_machine is the host on which operations will be 
+performed, root_dir is the partition on which grub files reside, kernel_opts holds 
+a single text string this is composed of kernel options separated by spaces, and
+the grub_to_change indicates whether grub.cfg or default grub will be changed to 
+have the kernel_opts, including 1(Default value. Both grub.cfg and default grub 
+will be changed), 2(Only the grub.cfg will be changed, 3(Only the default grub will 
+be changed), and all the other values are invalid. If there are no values passed in 
+to dst_machine and root_dir, operations will be performed on localhost and root '/' 
+partition by default.  Almost all regular kernel options can be passed in directly 
+without modification except for very extreme cases in which very special characters 
+should be treated specially and even escaped before being used.
+
+=cut
+
+sub add_kernel_options {
+    my (%args) = @_;
+
+    $args{dst_machine} //= 'localhost';
+    $args{root_dir} //= '';
+    $args{root_dir} .= '/' unless $args{root_dir} =~ /\/$/;
+    $args{kernel_opts} //= '';
+    $args{grub_to_change} //= 1;
+    croak("Nothing to be added onto kernel command line. Argument kernel_opts should not be empty.") if ($args{kernel_opts} eq '');
+    if (($args{grub_to_change} != 1) and ($args{grub_to_change} != 2) and ($args{grub_to_change} != 3)) {
+        croak("Nothing to be changed. Argument grub_to_change indicates neither grub.cfg nor default grub will be changed.");
+    }
+
+    my @options = split(/ /, $args{kernel_opts});
+    my $cmd = '';
+    if (($args{grub_to_change} == 1) or ($args{grub_to_change} == 2)) {
+        my $grub_cfg_file = "$args{root_dir}boot/grub2/grub.cfg";
+        foreach (@options) {
+            $cmd = "sed -i -r \'s/$_//g; /^\\s{1,}linux\\s{1,}\\\/boot\\\// s/\$/ $_/g\' $grub_cfg_file";
+            $cmd = "ssh root\@$args{dst_machine} " . "\"$cmd\"" if ($args{dst_machine} ne 'localhost');
+            assert_script_run($cmd);
+            save_screenshot;
+        }
+        $cmd = "cat $grub_cfg_file";
+        $cmd = "ssh root\@$args{dst_machine} " . "\"$cmd\"" if ($args{dst_machine} ne 'localhost');
+        record_info("Content of $grub_cfg_file on $args{dst_machine}", script_output($cmd, proceed_on_failure => 1));
+    }
+
+    if (($args{grub_to_change} == 1) or ($args{grub_to_change} == 3)) {
+        my $grub_default_file = "$args{root_dir}etc/default/grub";
+        foreach (@options) {
+            $cmd = "sed -i -r \'s/$_//g; /GRUB_CMDLINE_LINUX_DEFAULT/ s/\\\"\$/ $_\\\"/g\' $grub_default_file";
+            $cmd = "ssh root\@$args{dst_machine} " . "\"$cmd\"" if ($args{dst_machine} ne 'localhost');
+            assert_script_run($cmd);
+            save_screenshot;
+        }
+        $cmd = "cat $grub_default_file";
+        $cmd = "ssh root\@$args{dst_machine} " . "\"$cmd\"" if ($args{dst_machine} ne 'localhost');
+        record_info("Content of $grub_default_file on $args{dst_machine}", script_output($cmd, proceed_on_failure => 1));
+    }
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -893,10 +893,10 @@ elsif (get_var("VIRT_AUTOTEST")) {
         }
         loadtest "virt_autotest/reboot_and_wait_up_upgrade";
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
-            loadtest "virt_autotest/setup_xen_serial_console";
+            loadtest "virt_autotest/setup_xen_grub";
         }
         else {
-            loadtest "virt_autotest/setup_kvm_serial_console";
+            loadtest "virt_autotest/setup_kvm_grub";
         }
         loadtest "virt_autotest/reboot_and_wait_up_normal";
         loadtest "virt_autotest/host_upgrade_step3_run";

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -68,8 +68,8 @@ sub run {
         # set serial console for xen and kvm of SLE hosts
         # for openSUSE TW, it is set in other place where after kvm/xen patterns are installed
         if (is_sle) {
-            set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));
-            set_serial_console_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE', 'kvm'));
+            set_grub_on_vh('/mnt', '', 'xen') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));
+            set_grub_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE', 'kvm'));
             adjust_for_ipmi_xen('/mnt') if (get_var('REGRESSION') && (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')));
             set_pxe_efiboot('/mnt') if is_aarch64;
         }

--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -30,7 +30,7 @@ sub post_execute_script_configuration {
 
     #online upgrade actually
     if (is_remote_backend && is_aarch64 && is_installed_equal_upgrade_major_release) {
-        set_serial_console_on_vh('', '', 'kvm');
+        set_grub_on_vh('', '', 'kvm');
         set_pxe_efiboot('');
     }
 }

--- a/tests/virt_autotest/setup_kvm_grub.pm
+++ b/tests/virt_autotest/setup_kvm_grub.pm
@@ -21,7 +21,7 @@ sub run {
         return;
     }
     else {
-        set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));
+        set_grub_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));
         set_pxe_efiboot('') if is_aarch64;
     }
 }

--- a/tests/virt_autotest/setup_xen_grub.pm
+++ b/tests/virt_autotest/setup_xen_grub.pm
@@ -13,7 +13,7 @@ use base "virt_autotest_base";
 use ipmi_backend_utils;
 
 sub run {
-    set_serial_console_on_vh('', '', 'xen') if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
+    set_grub_on_vh('', '', 'xen') if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
 }
 
 sub test_flags {

--- a/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
+++ b/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
@@ -50,7 +50,7 @@ sub run {
     my $hypervisor = is_kvm_host ? 'kvm' : 'xen';
     zypper_call('--gpg-auto-import-keys ref');
     zypper_call("in -t pattern ${hypervisor}_server ${hypervisor}_tools", 1800);
-    set_serial_console_on_vh('', '', $hypervisor);
+    set_grub_on_vh('', '', $hypervisor);
     systemctl 'enable libvirtd', ignore_failure => 1;
 
     virt_autotest::utils::install_default_packages();

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -50,8 +50,8 @@ sub run {
     #workaroud: skip update package for registered aarch64 tests and because there are conflicts on sles15sp2 XEN
     $self->update_package() unless (is_registered_sles && is_aarch64);
     unless ((is_registered_sles && is_aarch64) || is_s390x) {
-        set_serial_console_on_vh('', '', 'xen') if is_xen_host;
-        set_serial_console_on_vh('', '', 'kvm') if is_kvm_host;
+        set_grub_on_vh('', '', 'xen') if is_xen_host;
+        set_grub_on_vh('', '', 'kvm') if is_kvm_host;
     }
     update_guest_configurations_with_daily_build();
 


### PR DESCRIPTION
* **Inroduce** new subroutine enable_sev_in_kernel to enable SEV in the kernel because it is disabled by default. This is done by putting the following onto the kernel command line: mem_encrypt=on kvm_amd.sev=1.

* **To** make the changes persistent, append the above to the variable holding parameters of the kernel command line in /etc/default/grub to preserve SEV settings across reboots.

* **The** actual work is done by calling new subroutine add_kernel_options which supports adding almost any options onto kernel command line. But in some extreme cases, user should pay attention to special characters that need to be treated differently and even escaped before being used.

* **Rename** setup_kvm(xen)_serial_console.pm to setup_kvm(xen)_grub.pm, setup_serial_console_on_vh to setup_grub_on_vh to reflect their real purposes.

* **This** pull request is only about adding sev parameters onto kernel command line and verification runs as below has already demonstrated what is required to be added in, namely 'mem_encrypt=on kvm_amd.sev=1', can be successfully added in as required and expected. SEV functionality verification will be done together with SEV feature verification.

* **Verification runs:**
  * [kvm - success example](https://openqa.suse.de/tests/9016027)
  * [xen - no effect example](https://openqa.suse.de/tests/8950707)
  * [kvm - fail example](https://openqa.suse.de/tests/8983502)
  * [kvm - success and repeated run example](http://10.67.131.12/tests/300)
  * [kvm upgrade - success example](https://openqa.suse.de/tests/9016025)
  * [xen upgrade - no effect example](https://openqa.suse.de/tests/8972053)
  * [Both grub2.cfg and default grub changed](https://openqa.suse.de/tests/9016025)
  * [Only grub2.cfg changed](https://openqa.suse.de/tests/9064958)
  * [Only default grub changed](https://openqa.suse.de/tests/9064968)
  * [Nothing to be changed](https://openqa.suse.de/tests/9065065)
  * [Renamed setup_kvm_grub module](https://openqa.suse.de/tests/9016026)
  * [Renamed setup_xen_grub module](https://openqa.suse.de/tests/9065725)