### PR TITLE
Switch to version 2 of registries.conf

### DIFF
--- a/data/containers/registries.conf
+++ b/data/containers/registries.conf
@@ -1,20 +1,24 @@
 # For more information on this configuration file, see containers-registries.conf(5).
-#
+
 # Registries to search for images that are not fully-qualified.
-# i.e. foobar.com/my_image:latest vs my_image:latest
-[registries.search]
-registries = ["registry.opensuse.org", "docker.io"]
+unqualified-search-registries = ["registry.opensuse.org", "registry.suse.com", "docker.io"]
 
-# Registries that do not use TLS when pulling images or uses self-signed
-# certificates.
-[registries.insecure]
-registries = ["localhost:5000", "registry.suse.de", "REGISTRY"]
+[[registry]]
+location = "registry.opensuse.org"
 
-# Blocked Registries, blocks the `docker daemon` from pulling from the blocked registry.  If you specify
-# "*", then the docker daemon will only be allowed to pull from registries listed above in the search
-# registries.  Blocked Registries is deprecated because other container runtimes and tools will not use it.
-# It is recommended that you use the trust policy file /etc/containers/policy.json to control which
-# registries you want to allow users to pull and push from.  policy.json gives greater flexibility, and
-# supports all container runtimes and tools including the docker daemon, cri-o, buildah ...
-[registries.block]
-registries = []
+[[registry]]
+location = "docker.io"
+
+[[registry]]
+prefix = "localhost"
+location = "localhost:5000"
+insecure = true
+
+[[registry]]
+location = "registry.suse.de"
+insecure = true
+
+# Note: REGISTRY will be replaced by the registry URL of the according test run.
+[[registry]]
+location = "REGISTRY"
+insecure = true


### PR DESCRIPTION
Use the new TOML version of `registries.conf` for our podman test runs.

- Related ticket: https://progress.opensuse.org/issues/111299
- Verification run: [Tumbleweed](https://duck-norris.qam.suse.de/tests/8912) | [SLES15-SP3](https://duck-norris.qam.suse.de/tests/8915) | [SLES15-SP2](https://duck-norris.qam.suse.de/tests/8914) | [SLES15-SP1](https://duck-norris.qam.suse.de/tests/89143)