### PR TITLE
Use normal user to run HPC relative tasks on mpi jobs

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -143,11 +143,17 @@ sub distribute_slurm_conf {
 
 =head2 generate_and_distribute_ssh
 
-Generates and distributes ssh keys across all cluster nodes
+     generate_and_distribute_ssh($user)
+
+Generates and distributes ssh keys across compute nodes. C<user> by default is set
+to B<root> user unless another value is passed to the parameters.
+C<user> is used to determine the user on the remote machine where the ssh_id will
+be copied.
 
 =cut
 sub generate_and_distribute_ssh {
     my ($self, $user) = @_;
+    $user //= 'root';
     my @slave_nodes = slave_node_names();
     assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ~/.ssh/id_rsa');
     foreach (@slave_nodes) {
@@ -236,9 +242,14 @@ sub prepare_spack_env {
     my ($self, $mpi) = @_;
     $mpi //= 'mpich';
     zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel";
-    $self->relogin_root;
-    assert_script_run 'module load gnu $mpi';
+    type_string('pkill -u root');    # this kills sshd
+    $self->select_serial_terminal(0);
+    assert_script_run 'module load gnu $mpi';    ## TODO
     assert_script_run 'source /usr/share/spack/setup-env.sh';
+    record_info 'spack', script_output 'zypper -q info spack';
+    record_info 'boost spec', script_output('spack spec boost', timeout => 360);
+    assert_script_run "spack install boost+mpi^$mpi", timeout => 12000;
+    assert_script_run 'spack load boost';
 }
 
 =head2 uninstall_spack_module
@@ -283,18 +294,18 @@ sub get_compute_nodes_deps {
 =head2 setup_nfs_server
 
 Prepare a nfs server on the so called management node of the HPC setup.
-Exports the path of the *-gnu-hpc installed libraries
-and the directory with the binaries, which compute nodes will share.
-C<exports> points to the location in the filesystem where the source code
-and the binaries are located.
+The management node in a minimal setup should provide the directories
+of *-gnu-hpc installed libraries and the directory with the binaries.
 
+C<exports> takes a hash reference with the paths which NFS should make
+available to the compute nodes in order to run MPI software.
 =cut
 sub setup_nfs_server {
     my ($self, $exports) = @_;
     zypper_call 'in nfs-kernel-server';
-    assert_script_run "echo $exports *(rw,no_root_squash,sync,no_subtree_check) >> /etc/exports";
-    assert_script_run "echo /usr/lib/hpc *(ro,no_root_squash,sync,no_subtree_check) >> /etc/exports";
-    assert_script_run "echo /opt/spack *(ro,no_root_squash,sync,no_subtree_check) >> /etc/exports" if get_var('SPACK');
+    foreach my $dir (values %$exports) {
+        assert_script_run "echo $dir *(rw,no_root_squash,sync,no_subtree_check) >> /etc/exports";
+    }
     assert_script_run 'exportfs -a';
     systemctl 'enable --now nfs-server';
 }
@@ -303,16 +314,16 @@ sub setup_nfs_server {
 
 Make the HPC libraries and the location of the binaries available to the so called
 compute nodes, from the management one.
-C<exports> should be the location which nfs server exports the source code and the binaries.
-
+C<exports> takes a hash reference with the paths which the management node share in order to
+run the MPI binaries
 =cut
 sub mount_nfs_exports {
     my ($self, $exports) = @_;
     zypper_call 'in nfs-client';
-    assert_script_run "mount master-node00:$exports $exports", timeout => 120;
-    assert_script_run 'mkdir /usr/lib/hpc';
-    assert_script_run 'mount master-node00:/usr/lib/hpc /usr/lib/hpc', timeout => 120;
-    assert_script_run 'mount master-node00:/opt/spack /opt/spack', timeout => 120 if get_var('SPACK');
+    foreach my $dir (values %$exports) {
+        assert_script_run "mkdir -p $dir" unless script_run("test -f $dir", quiet => 1) == 0;
+        assert_script_run "mount master-node00:$dir $dir", timeout => 120;
+    }
 }
 
 1;

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -147,11 +147,11 @@ Generates and distributes ssh keys across all cluster nodes
 
 =cut
 sub generate_and_distribute_ssh {
-    my ($self) = @_;
-    my @cluster_nodes = cluster_names();
+    my ($self, $user) = @_;
+    my @slave_nodes = slave_node_names();
     assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ~/.ssh/id_rsa');
-    foreach (@cluster_nodes) {
-        exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$_");
+    foreach (@slave_nodes) {
+        exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no $user\@$_");
     }
 }
 
@@ -309,10 +309,10 @@ C<exports> should be the location which nfs server exports the source code and t
 sub mount_nfs_exports {
     my ($self, $exports) = @_;
     zypper_call 'in nfs-client';
-    assert_script_run "mount master-node00:$exports $exports";
+    assert_script_run "mount master-node00:$exports $exports", timeout => 120;
     assert_script_run 'mkdir /usr/lib/hpc';
-    assert_script_run 'mount master-node00:/usr/lib/hpc /usr/lib/hpc';
-    assert_script_run 'mount master-node00:/opt/spack /opt/spack' if get_var('SPACK');
+    assert_script_run 'mount master-node00:/usr/lib/hpc /usr/lib/hpc', timeout => 120;
+    assert_script_run 'mount master-node00:/opt/spack /opt/spack', timeout => 120 if get_var('SPACK');
 }
 
 1;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -22,12 +22,14 @@ sub run ($self) {
     my $mpi_bin = 'mpi_bin';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);
-    my $exports_path = '/home/bernhard/bin';
-
+    my %exports_path = (
+        bin => '/home/bernhard/bin',
+        hpc_lib => '/usr/lib/hpc',
+    );
     zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel python3-devel");
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
-    $self->setup_nfs_server($exports_path);
+    $self->setup_nfs_server(\%exports_path);
 
     type_string('pkill -u root');
     $self->select_serial_terminal(0);
@@ -43,7 +45,7 @@ sub run ($self) {
     my $hostname = get_var('HOSTNAME', 'susetest');
     record_info "hostname", "$hostname";
     assert_script_run "hostnamectl status | grep $hostname";
-    assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O $exports_path/$mpi_c");
+    assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O $exports_path{'bin'}/$mpi_c");
 
     # I need to restart the nfs-server for some reason otherwise the compute nodes
     # cannot mount directories
@@ -57,7 +59,7 @@ sub run ($self) {
     script_run "module av";
 
     barrier_wait('MPI_SETUP_READY');
-    assert_script_run("$mpi_compiler $exports_path/$mpi_c -o $exports_path/$mpi_bin") if $mpi_compiler;
+    assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin") if $mpi_compiler;
 
     # python code is not compiled. *mpi_bin* is expected as a compiled binary. if compilation was not
     # invoked return source code (ex: sample_scipy.py).
@@ -70,19 +72,19 @@ sub run ($self) {
         record_info('INFO', 'Run MPI over single machine');
         if ($mpi eq 'mvapich2') {
             # mvapich2/2.2 known issue
-            my $return = script_run("set -o pipefail;" . $mpirun_s->single_node("$exports_path/$mpi_bin |& tee /tmp/mpi_bin.log"), timeout => 120);
+            my $return = script_run("set -o pipefail;" . $mpirun_s->single_node("$exports_path{'bin'}/$mpi_bin |& tee /tmp/mpi_bin.log"), timeout => 120);
             if (script_run('grep \'invalid error code ffffffff\' /tmp/mpi_bin.log') == 0) {
                 record_soft_failure('bsc#1199811 known problem on single core on mvapich2/2.2');
             }
         } else {
-            assert_script_run($mpirun_s->single_node("$exports_path/$mpi_bin"), timeout => 120);
+            assert_script_run($mpirun_s->single_node("$exports_path{'bin'}/$mpi_bin"), timeout => 120);
         }
     }
 
     record_info('INFO', 'Run MPI over several nodes');
     if ($mpi eq 'mvapich2') {
         # we do not support ethernet with mvapich2
-        my $return = script_run("set -o pipefail;" . $mpirun_s->all_nodes("$exports_path/$mpi_bin |& tee /tmp/mpi_bin.log"), timeout => 120);
+        my $return = script_run("set -o pipefail;" . $mpirun_s->all_nodes("$exports_path{'bin'}/$mpi_bin |& tee /tmp/mpi_bin.log"), timeout => 120);
         if ($return == 143) {
             record_info("mvapich2 info", "echo $return - No IB device found", result => 'softfail');
         } elsif ($return == 139 || $return == 255) {
@@ -99,7 +101,7 @@ sub run ($self) {
             die("echo $return - not expected errorcode");
         }
     } else {
-        assert_script_run($mpirun_s->all_nodes("$exports_path/$mpi_bin"), timeout => 120);
+        assert_script_run($mpirun_s->all_nodes("$exports_path{'bin'}/$mpi_bin"), timeout => 120);
     }
 
     barrier_wait('MPI_RUN_TEST');

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -12,13 +12,16 @@ use utils;
 
 sub run ($self) {
     my $mpi = $self->get_mpi();
-    my $exports_path = '/home/bernhard/bin';
+    my %exports_path = (
+        bin => '/home/bernhard/bin',
+        hpc_lib => '/usr/lib/hpc',
+    );
     # Install required HPC dependencies on the nodes act as compute nodes
     my @hpc_deps = $self->get_compute_nodes_deps($mpi);
     zypper_call("in @hpc_deps");
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
-    $self->mount_nfs_exports($exports_path);
+    $self->mount_nfs_exports(\%exports_path);
 
     barrier_wait('MPI_BINARIES_READY');
     barrier_wait('MPI_RUN_TEST');

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -14,44 +14,57 @@ use utils;
 use lockapi;
 
 sub run ($self) {
-    set_var('SPACK', '1');
     my $mpi = $self->get_mpi();
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
     my $mpi_bin = 'mpi_bin';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);
     $self->prepare_spack_env($mpi);
-    record_info 'spack', script_output 'zypper -q info spack';
-    record_info 'boost spec', script_output('spack spec boost', timeout => 360);
-    assert_script_run "spack install boost+mpi^$mpi", timeout => 12000;
-    assert_script_run 'spack load boost';
+    my %exports_path = (
+        bin => '/home/bernhard/bin',
+        spack => '/home/bernhard/spack',
+        hpc_lib => '/usr/lib/hpc',
+        spack_lib => '/opt/spack'
+    );
+
     record_info 'boost info', script_output 'spack info boost';
     barrier_wait('CLUSTER_PROVISIONED');
-    ## all nodes should be able to ssh to each other, as MPIs requires so
-    $self->generate_and_distribute_ssh();
-    $self->check_nodes_availability();
+    script_run "pkill -u $testapi::username";
+    select_console('root-console');
+    $self->setup_nfs_server(\%exports_path);
 
+    # And login as normal user to run the tests
+    type_string('pkill -u root');
+    $self->select_serial_terminal(0);
+
+    ## all nodes should be able to ssh to each other, as MPIs requires so
+    $self->generate_and_distribute_ssh($testapi::username);
+    $self->check_nodes_availability();
     record_info('INFO', script_output('cat /proc/cpuinfo'));
 
     my $hostname = get_var('HOSTNAME', 'susetest');
     record_info "hostname", "$hostname";
     assert_script_run "hostnamectl status|grep $hostname";
 
-    my $exports_path = '/home/bernhard/bin';
-    assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O $exports_path/$mpi_c");
-    $self->setup_nfs_server($exports_path);
+    assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O $exports_path{'bin'}/$mpi_c");
+
     barrier_wait('MPI_SETUP_READY');
 
-    assert_script_run("$mpi_compiler $exports_path/$mpi_c -o $exports_path/$mpi_bin -l boost_mpi -I \${BOOST_ROOT}/include/ -L \${BOOST_ROOT}/lib 2>&1 > /tmp/make.out");
+    assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin -l boost_mpi -I \${BOOST_ROOT}/include/ -L \${BOOST_ROOT}/lib 2>&1 > /tmp/make.out");
     barrier_wait('MPI_BINARIES_READY');
 
+    type_string "sudo systemctl restart sshd\n";
+    sleep 3;
+    type_string("$testapi::password\n");
+    record_info('ssh', 'check sshd service before continue');
+    systemctl 'status sshd';
     # Testing compiled code
     record_info('INFO', 'Run MPI over single machine');
-    assert_script_run("mpirun $exports_path/$mpi_bin");
+    assert_script_run("mpirun $exports_path{'bin'}/$mpi_bin");
 
     record_info('INFO', 'Run MPI over several nodes');
     my $nodes = join(',', @cluster_nodes);
-    assert_script_run("mpirun -n 2 --host $nodes $exports_path/$mpi_bin");
+    assert_script_run("mpirun -n 2 --host $nodes $exports_path{'bin'}/$mpi_bin", timeout => 120);
     barrier_wait('MPI_RUN_TEST');
 }
 

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -12,8 +12,11 @@ use utils;
 
 sub run ($self) {
     my $mpi = $self->get_mpi();
-    my $exports_path = '/home/bernhard/bin';
-    set_var('SPACK', '1');
+    my %exports_path = (
+        bin => '/home/bernhard/bin',
+        spack => '/home/bernhard/spack',
+        hpc_lib => '/usr/lib/hpc',
+        spack_lib => '/opt/spack');
     zypper_call "in spack";
     $self->relogin_root;
     my @hpc_deps = $self->get_compute_nodes_deps($mpi);
@@ -21,12 +24,23 @@ sub run ($self) {
 
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
+    $self->mount_nfs_exports(\%exports_path);
+    type_string('pkill -u root');
+    $self->select_serial_terminal(0);
 
-    $self->mount_nfs_exports($exports_path);
     assert_script_run "source /usr/share/spack/setup-env.sh";
     # Once the /opt/spack is mounted `boost` should be available
-    #script_run "module av";
     record_info 'boost info', script_output 'spack info boost';
+    assert_script_run 'spack load boost';
+    script_run "module av";
+
+    ## TODO: Restart only when is needed, otherwise include a softfail
+    record_info('ssh restart', 'Ensure sshd service is running before mpirun');
+    type_string "sudo systemctl restart sshd\n";
+    sleep 3;
+    type_string("$testapi::password\n");
+    record_info('ssh check', 'Validate sshd service status before mpirun');
+    systemctl 'status sshd';
     barrier_wait('MPI_BINARIES_READY');
     barrier_wait('MPI_RUN_TEST');
 }


### PR DESCRIPTION
Once the `user-virtio-console` resolved we can now switch easily to the normal
user for all the mpi implementations. As per `select_serial_terminal` was
called earlier to get a root console, we have to kill that session, because
the implementation doesnt taking care of this scenario and fails in a login
check.
During the implementation i encounter some timeouts and such i bump up the
particular parameter in specific invocations. However not sure whether it was
a sporadic issue on my local OpenQA or something else.
Finally i modified the `generate_and_distribute_ssh` to make copies only on
the compute nodes.

To run MPI binaries on the compute nodes as a regular user the management node
has to export the `/opt/spack` and `$HOME/spack` in additional of the HPC
libraries.

Initialy i thought that sharing the whole `$HOME` could work but during the
testing that failed. Likely because it is override previous steps that we have
performed, for instance the ssh key configuration. Anyhow, the functions which
setup the NFS were slightly modified to accept a hash ref with the absolute
paths to export. That impacted also the *mpi_master* ans *mpi_slave* modules.

Due to the need to run some commands as root, there are several switches
between the root and the regural user, which look ungly and need to improve in the future.

- Related ticket: https://progress.opensuse.org/issues/111206

- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP4&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2315023