### PR TITLE
Fix broken localhost registries

### DIFF
--- a/data/containers/registries.conf
+++ b/data/containers/registries.conf
@@ -10,7 +10,6 @@ location = "registry.opensuse.org"
 location = "docker.io"
 
 [[registry]]
-prefix = "localhost"
 location = "localhost:5000"
 insecure = true
 


### PR DESCRIPTION
Fix a broken podman pull against the localhost registry due to a wrong
prefix configuration.

- Related ticket: https://progress.opensuse.org/issues/112154
- Verification run: [Tumbleweed](https://duck-norris.qam.suse.de/tests/8924) and [SLES 15-SP3](https://duck-norris.qam.suse.de/t8925)
