### PR TITLE
Disable root ssh login on s390x for cc testing

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -172,11 +172,7 @@ sub compare_run_log {
 #
 sub _parse_results_with_diff_baseline {
     my ($name, $result, $msg, $flag) = @_;
-    my $softfail_tests = {
-        s390x => {
-            ssh04 => 'Test case ssh04 fails in s390x is a known issue, see poo#99096'
-        }
-    };
+    my $softfail_tests = {};
     if ($result eq 'PASS') {
         record_soft_failure($msg);
         $flag = 'softfail' if ($flag ne 'fail');

--- a/schedule/security/atsec_tests.yaml
+++ b/schedule/security/atsec_tests.yaml
@@ -5,6 +5,7 @@ schedule:
     - '{{bootloader_zkvm}}'
     - boot/boot_to_desktop
     - security/atsec/setup_atsec_env
+    - '{{disable_root_ssh}}'
     - security/atsec/kvm_check
     - security/atsec/drng_test_preparation
     - security/atsec/dbus_services_exposure
@@ -26,3 +27,7 @@ conditional_schedule:
                 - security/atsec/check_processor_vulnerability_mitigations
             aarch64:
                 - security/atsec/check_processor_vulnerability_mitigations
+    disable_root_ssh:
+        ARCH:
+            s390x:
+                - security/cc/disable_root_ssh

--- a/schedule/security/cc_audit_remote.yaml
+++ b/schedule/security/cc_audit_remote.yaml
@@ -8,6 +8,7 @@ schedule:
     - '{{cc_audit_test_setup}}'
     - security/selinux/selinux_setup
     - security/cc/cc_selinux_setup
+    - '{{disable_root_ssh}}'
     - security/cc/audit_remote
 conditional_schedule:
     bootloader_zkvm:
@@ -24,3 +25,7 @@ conditional_schedule:
         ARCH:
             s390x:
                 - security/cc/cc_audit_test_setup
+    disable_root_ssh:
+        ARCH:
+            s390x:
+                - security/cc/disable_root_ssh

--- a/schedule/security/cc_audit_tests.yaml
+++ b/schedule/security/cc_audit_tests.yaml
@@ -5,11 +5,12 @@ schedule:
     - '{{bootloader_zkvm}}'
     - boot/boot_to_desktop
     - security/cc/cc_audit_test_setup
+    - security/cc/trustedprograms
+    - '{{disable_root_ssh}}'
     - security/cc/filter
     - security/cc/syscalls
     - security/cc/polkit_tests
     - security/cc/audit_trail_protection
-    - security/cc/trustedprograms
     - security/selinux/selinux_setup
     - security/cc/libpam
 conditional_schedule:
@@ -17,3 +18,7 @@ conditional_schedule:
         ARCH:
             s390x:
                 - installation/bootloader_zkvm
+    disable_root_ssh:
+        ARCH:
+            s390x:
+                - security/cc/disable_root_ssh

--- a/schedule/security/cc_ipsec.yaml
+++ b/schedule/security/cc_ipsec.yaml
@@ -8,6 +8,7 @@ schedule:
     - '{{setup_multimachine}}'
     - security/cc/cc_audit_test_setup
     - security/atsec/setup_atsec_env
+    - '{{disable_root_ssh}}'
     - '{{cc_ipsec}}'
 conditional_schedule:
     bootloader_zkvm:
@@ -36,3 +37,7 @@ conditional_schedule:
                 - security/cc/ipsec/weak_ipsec_ciphers
                 - security/cc/ipsec/ipsec_ciphers
                 - security/cc/ipsec/ipsec_certificate
+    disable_root_ssh:
+        ARCH:
+            s390x:
+                - security/cc/disable_root_ssh

--- a/schedule/security/cc_netfilter_netfilebt.yaml
+++ b/schedule/security/cc_netfilter_netfilebt.yaml
@@ -8,6 +8,7 @@ schedule:
     - '{{cc_audit_test_setup}}'
     - security/selinux/selinux_setup
     - security/cc/cc_selinux_setup
+    - '{{disable_root_ssh}}'
     - security/cc/setup_net_test_env
 conditional_schedule:
     bootloader_zkvm:
@@ -24,6 +25,10 @@ conditional_schedule:
         ARCH:
             s390x:
                 - security/cc/cc_audit_test_setup
+    disable_root_ssh:
+        ARCH:
+            s390x:
+                - security/cc/disable_root_ssh
 test_data:
     server:
         first_interface:

--- a/tests/security/cc/disable_root_ssh.pm
+++ b/tests/security/cc/disable_root_ssh.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Disable or enable root ssh login due to CC hard requirement.
+#          Only for s390x platform CC automation.
+# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Tags: poo#105564
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self, $run_args) = @_;
+
+    select_console 'root-console';
+
+    my $switch = $run_args ? $run_args->{option} : 'no';
+    assert_script_run("sed -i 's/^PermitRootLogin.*/PermitRootLogin $switch/' /etc/ssh/sshd_config");
+    systemctl('restart sshd');
+}
+
+1;

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -16,7 +16,9 @@ use Utils::Architectures;
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
+
+    # In CC testing, the root login will be disabled, so we need to use select_console
+    is_s390x() ? select_console 'root-console' : $self->select_serial_terminal;
 
     # Using packages from gitlab
     my $repo_link = 'https://gitlab.suse.de/QA-APAC-I/testing/-/raw/master/data/selinux';


### PR DESCRIPTION
We enable root ssh login when installing system on s390x, otherwise the
automation test will fail due to root can't login with ssh. But for CC
testing, disable root ssh login is a requirement. So we need to disable
it before running cc test cases.

Related: https://progress.opensuse.org/issues/105564
Verify run:
       https://openqa.suse.de/tests/8921615#   (audit_test)
       https://openqa.suse.de/tests/8921614#  (audit_test2)
       https://openqa.suse.de/tests/8921616#  (audit_remote)
       https://openqa.suse.de/tests/8921631#  (ipsec)
       https://openqa.suse.de/tests/8921621# (netfilter and netfilebt)
       https://openqa.suse.de/tests/8921962# (cc_atsec)