### PR TITLE
Setup the network connection of postgresql_ssl on s390x

### DIFF
--- a/tests/security/postgresql_ssl/postgresql_ssl_client.pm
+++ b/tests/security/postgresql_ssl/postgresql_ssl_client.pm
@@ -5,7 +5,7 @@
 #
 # Summary: The client side of postgresql ssl connection test.
 # Maintainer: Starry Wang <starry.wang@suse.com> Ben Chou <bchou@suse.com>
-# Tags: poo#110233, tc#1769967
+# Tags: poo#110233, tc#1769967, poo#112094
 
 use base 'consoletest';
 use strict;
@@ -25,7 +25,7 @@ sub run {
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV
     my $netdev = get_var('NETDEV', 'eth0');
-    assert_script_run("ip addr add $server_ip/24 dev $netdev") if (is_s390x);
+    assert_script_run("ip addr add $client_ip/24 dev $netdev") if (is_s390x);
     systemctl("stop firewalld");
 
     zypper_call('in postgresql');

--- a/tests/security/postgresql_ssl/postgresql_ssl_server.pm
+++ b/tests/security/postgresql_ssl/postgresql_ssl_server.pm
@@ -5,7 +5,7 @@
 #
 # Summary: The server side of postgresql ssl connection test.
 # Maintainer: Starry Wang <starry.wang@suse.com> Ben Chou <bchou@suse.com>
-# Tags: poo#110233, tc#1769967
+# Tags: poo#110233, tc#1769967, poo#112094
 
 use base 'consoletest';
 use strict;
@@ -62,8 +62,9 @@ sub run {
     save_screenshot;
 
     # Setup configuration
-    assert_script_run "echo \"hostssl all all $client_ip/32 trust\" >> $pg_hba_config";
+    assert_script_run "echo \"hostssl all all $client_ip/24 trust\" >> $pg_hba_config";
     assert_script_run "echo \"ssl = on\nlisten_addresses = '*'\" >> $pg_config";
+    assert_script_run "echo \"ssl_cert_file = 'server.crt'\" >> $pg_config";
     systemctl('restart postgresql');
 
     # Check the server status


### PR DESCRIPTION
Setup the network connection of postgresql_ssl on s390x
POO: https://progress.opensuse.org/issues/112094

- Related ticket: https://progress.opensuse.org/issues/112094
- Needles: None
- Verification run: 
      - fips kernel mode:
            aarch64: http://openqa.suse.de/tests/8922348
            x86_64: https://openqa.suse.de/tests/8922440
            s390:http://openqa.suse.de/tests/8922368
      - fips env mode:
            aarch64: https://openqa.suse.de/tests/8922447
            x86_64: https://openqa.suse.de/tests/8922455
            s390:https://openqa.suse.de/tests/8922367

