### PR TITLE
Quotes added in tox for BCI_IMAGE_MARKER expression

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -67,7 +67,7 @@ sub run_tox_cmd {
     my $bci_reruns = get_var('BCI_RERUNS', 3);
     my $bci_reruns_delay = get_var('BCI_RERUNS_DELAY', 10);
     my $cmd = "tox -e $env -- -n auto";
-    $cmd .= " -k $bci_marker" if $bci_marker;
+    $cmd .= " -k \"$bci_marker\"" if $bci_marker;
     $cmd .= " --reruns $bci_reruns --reruns-delay $bci_reruns_delay";
     record_info("tox", "Running command: $cmd");
     my $ret = script_run("timeout $bci_timeout $cmd", timeout => ($bci_timeout + 3));


### PR DESCRIPTION
In the **tox** command the -k options for **pytest** allows to select specific test based on a string stored in BCI_IMAGE_MARKER, 

`tox -e <test> -- -k $BCI_IMAGE_MARKER`

But also boolean expressions with and/or/not, enclosed in quotes, can be used for more specific selections, as BCI_IMAGE_MARKER="<test_group> and <test_name> or <string>", so that when expanded the command becomes:

`tox -e <test> -- -k "<test_group> and <test_name> or <string>"`

This PR is to add quotes around that parameter, otherwise the boolean term are not aggregated for the -k option.

- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
