### PR TITLE
chromium: Use pre-commit input instead of waiting

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -12,13 +12,9 @@ use Mojo::Base 'x11test', -signatures;
 use testapi;
 use utils;
 
-# Prevent lost characters due to temporary unresponsiveness of chromium address bar.
-# It looks like chromium becomes unresponsive after typing about 3
-# characters, likely due to some auto-completion feature.
-# See https://progress.opensuse.org/issues/109737 for details
 sub type_address ($string) {
-    type_string substr($string, 0, 10), @_, max_interval => utils::SLOW_TYPING_SPEED;
-    enter_cmd substr($string, 10), @_;
+    send_key 'ctrl-l';    # select text in address bar
+    enter_cmd($string);
 }
 
 sub run {
@@ -27,25 +23,16 @@ sub run {
     ensure_installed 'chromium';
 
     # avoid async keyring popups
-    x11_start_program('chromium --password-store=basic', target_match => 'chromium-main-window', match_timeout => 50);
+    # allow key input before rendering is done, see poo#109737 for details
+    x11_start_program('chromium --password-store=basic --allow-pre-commit-input', target_match => 'chromium-main-window', match_timeout => 50);
 
-    wait_screen_change { send_key 'esc' };    # get rid of popup (or abort loading)
-    send_key 'ctrl-l';    # select text in address bar
-
-    # Additional waiting to prevent unready address bar
-    # https://progress.opensuse.org/issues/36304
-    assert_screen 'chromium-highlighted-urlbar';
-    type_address('chrome://version ');
+    type_address('chrome://version');
     assert_screen 'chromium-about';
 
-    send_key 'ctrl-l';
-    assert_screen 'chromium-highlighted-urlbar';
     type_address('https://html5test.opensuse.org');
     assert_screen 'chromium-html-test', 90;
 
     # check a site with different ssl configuration (boo#1144625)
-    send_key 'ctrl-l';
-    assert_screen 'chromium-highlighted-urlbar';
     type_address('https://upload.wikimedia.org/wikipedia/commons/d/d0/OpenSUSE_Logo.svg');
     assert_screen 'chromium-opensuse-logo', 90;
     send_key 'alt-f4';


### PR DESCRIPTION
- Use --allow-pre-commit-input to ensure key input is processed even
if rendering is still on-going, see
https://bugs.chromium.org/p/chromium/issues/detail?id=987626 for details
This means we don't need to check for needles to see if the urlbar is
active. We just type blind and wait for when the website is loaded.
- Use default typing speed because of the previous point.

See: https://progress.opensuse.org/issues/109737
