### PR TITLE
Fix test failed in yast2_apparmor

### DIFF
--- a/tests/security/yast2_apparmor/manually_add_profile.pm
+++ b/tests/security/yast2_apparmor/manually_add_profile.pm
@@ -5,7 +5,7 @@
 #          also verify Bug 1172040 - YaST2 apparmor profile creation:
 #          "View profile" does nothing
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#70537, tc#1741266
+# Tags: poo#70537, tc#1741266, poo#103341
 
 use base 'apparmortest';
 use strict;
@@ -43,6 +43,7 @@ sub run {
     send_key_until_needlematch("AppArmor-Chose-a-program-to-generate-a-profile", "alt-n", 30, 3);
     type_string("$test_file");
     assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
+    wait_still_screen(5);
     if (!check_screen("AppArmor-generate-a-profile-Error")) {
         assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
         record_soft_failure("bsc#1190295, add workaround to click 'Open' again");
@@ -63,6 +64,7 @@ sub run {
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_bk");
     assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
+    wait_still_screen(5);
     if (!check_screen("AppArmor-Scan-system-log")) {
         assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
         record_soft_failure("bsc#1190295, add workaround to click 'Open' again");
@@ -87,12 +89,12 @@ sub run {
     assert_screen("AppArmor-Chose-a-program-to-generate-a-profile");
     type_string("$test_file_vsftpd");
     assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
+    wait_still_screen(5);
     if (!check_screen("AppArmor-Inactive-local-profile")) {
         assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
         record_soft_failure("bsc#1190295, add workaround to click 'Open' again");
         send_key "tab";
     }
-    mouse_click("right");
     send_key_until_needlematch("AppArmor-Inactive-local-profile", "tab", 2, 2);
     send_key "tab";
 
@@ -103,13 +105,20 @@ sub run {
     send_key_until_needlematch("AppArmor-Inactive-local-profile", "tab", 2, 2);
     # Check "Use Profile"
     send_key "alt-u";
-    mouse_click("right");
     assert_screen("AppArmor-Scan-system-log");
     # Exit "yast2 apparmor"
     wait_screen_change { send_key "alt-f" };
 
     # Exit x11 and turn to console
+    # Close the yast2 apparmor window
+    save_screenshot;
     send_key "alt-f4";
+    wait_still_screen(5);
+
+    # Close the second xterm window
+    save_screenshot;
+    send_key "alt-f4";
+
     assert_screen("generic-desktop");
     select_console("root-console");
     send_key "ctrl-c";

--- a/tests/security/yast2_apparmor/scan_audit_logs.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs.pm
@@ -3,7 +3,7 @@
 #
 # Summary: Test "# yast2 apparmor" can scan audit logs
 # Maintainer: llzhao <llzhao@suse.com>
-# Tags: poo#67933, tc#1741266
+# Tags: poo#67933, tc#1741266, poo#103341
 
 use base 'apparmortest';
 use strict;
@@ -34,6 +34,7 @@ sub run {
     # Enter "Scan Audit logs" and check there should no records
     assert_and_click("AppArmor-Scan-Audit-logs", timeout => 120);
     assert_and_click("AppArmor-Launch", timeout => 60);
+    wait_still_screen(5);
     if (!check_screen("AppArmor-Scan-Audit-logs-no-records")) {
         assert_and_click("AppArmor-Launch", timeout => 60);
         record_soft_failure("bsc#1190292, add workaround to click 'Launch' again");
@@ -66,6 +67,7 @@ sub run {
     # Enter "Scan Audit logs" and check there should have records
     assert_and_click("AppArmor-Scan-Audit-logs", timeout => 120);
     assert_and_click("AppArmor-Launch", timeout => 60);
+    wait_still_screen(5);
     if (!check_screen("AppArmor-Scan-Audit-logs-scan-records")) {
         assert_and_click("AppArmor-Launch", timeout => 60);
         record_soft_failure("bsc#1190292, add workaround to click 'Launch' again");
@@ -96,13 +98,10 @@ sub run {
     send_key "alt-a";
     send_key_until_needlematch("AppArmor-Scan-Audit-logs-abort", "tab", 2, 2);
     send_key "alt-n";
-    mouse_click("right");
     assert_screen("AppArmor-Scan-Audit-logs-allow");
 
     # Save changes
     send_key "alt-s";
-    mouse_click("right");
-    assert_and_click("AppArmor-Scan-Audit-logs-save");
     assert_screen("AppArmor-Scan-Audit-logs-saved");
     send_key "alt-o";
 


### PR DESCRIPTION
1. Added `wait_still_screen` before `check_screen` since `check_screen`
use the lowest possible timeout to prevent needless waiting time in case
no match is expected behavior.
2. Removed `mouse_click("right");` in the test code.
3. Updated the test code of 'exit x11 and turn back to console'.

- Related ticket: [poo#103341](https://progress.opensuse.org/issues/103341)
- Needles: 
    - [AppArmor-generate-a-profile-Error](https://openqa.opensuse.org/tests/2407850#step/manually_add_profile/37)
    - [AppArmor-Scan-system-log](https://openqa.opensuse.org/tests/2407850#step/manually_add_profile/46)
    - [AppArmor-generate-a-profile-Ok](https://openqa.opensuse.org/tests/2407850#step/manually_add_profile/48)
    - [AppArmor-Inactive-local-profile](https://openqa.opensuse.org/tests/2407850#step/manually_add_profile/57)
    - [AppArmor-View-Profile-clickview](https://openqa.opensuse.org/tests/2407850#step/manually_add_profile/58)
    - [AppArmor-View-Profile](https://openqa.opensuse.org/tests/2407850#step/manually_add_profile/59)
- Verification run: https://openqa.opensuse.org/tests/2407850

After discussing with @rfan1 and @lilyeyes offline, this PR is for TW only.