### PR TITLE
Containers: use new registry from Amazon ECR

### DIFF
--- a/data/containers/docker-compose.yml
+++ b/data/containers/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   nginx:
     # The REGISTRY is variable and will be replaced
-    image: REGISTRY/library/nginx
+    image: REGISTRY/nginx
     networks:
       - backend
     volumes:
@@ -12,7 +12,7 @@ services:
 
   haproxy:
     # The REGISTRY is variable and will be replaced
-    image: REGISTRY/library/haproxy
+    image: REGISTRY/haproxy
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     ports:

--- a/data/containers/registries.conf
+++ b/data/containers/registries.conf
@@ -16,8 +16,3 @@ insecure = true
 [[registry]]
 location = "registry.suse.de"
 insecure = true
-
-# Note: REGISTRY will be replaced by the registry URL of the according test run.
-[[registry]]
-location = "REGISTRY"
-insecure = true

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -250,10 +250,6 @@ sub test_container_image {
     die 'Argument $image not provided!' unless $image;
     die 'Argument $runtime not provided!' unless $runtime;
 
-    # Images from docker.io registry are listed without the 'docker.io/library/'
-    # Images from custom registry are listed with the '$registry/library/'
-    $image =~ s/^docker\.io\/library\///;
-
     my $smoketest = qq[/bin/sh -c '/bin/uname -r; /bin/echo "Heartbeat from $image"; ps'];
 
     $runtime->pull($image, timeout => 420);

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -27,8 +27,7 @@ sub configure_insecure_registries {
     # The debug output is messing with terminal in migration tests
     my $debug = (get_var('UPGRADE')) ? 'false' : 'true';
     # Allow our internal 'insecure' registry
-    assert_script_run(
-'echo "{ \"debug\": ' . $debug . ', \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\", \"' . $registry . '\"] }" > /etc/docker/daemon.json');
+    assert_script_run('echo "{ \"debug\": ' . $debug . ', \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\"] }" > /etc/docker/daemon.json');
     assert_script_run('cat /etc/docker/daemon.json');
     systemctl('restart docker');
     record_info "setup $self->runtime", "deamon.json ready";

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -27,7 +27,6 @@ sub configure_insecure_registries {
 
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
-    file_content_replace("/etc/containers/registries.conf", REGISTRY => $registry);
 }
 
 1;

--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -277,9 +277,9 @@ sub get_3rd_party_images {
     my @images = (
         "registry.opensuse.org/opensuse/leap",
         "registry.opensuse.org/opensuse/tumbleweed",
-        "$ex_reg/library/alpine",
-        "$ex_reg/library/debian",
-        "$ex_reg/library/fedora",
+        "$ex_reg/alpine",
+        "$ex_reg/debian",
+        "$ex_reg/fedora",
         "registry.access.redhat.com/ubi8/ubi",
         "registry.access.redhat.com/ubi8/ubi-minimal",
         "registry.access.redhat.com/ubi8/ubi-micro",
@@ -300,8 +300,8 @@ sub get_3rd_party_images {
     # - poo#72124 Ubuntu image (occasionally) fails on s390x.
     # - CentOS image not available on s390x.
     push @images, (
-        "$ex_reg/library/ubuntu",
-        "$ex_reg/library/centos"
+        "$ex_reg/ubuntu",
+        "$ex_reg/centos"
     ) unless (is_s390x || is_ppc64le);
 
     # RedHat UBI7 images are not built for aarch64

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -73,7 +73,7 @@ sub registry_url {
     # Images from docker.io registry are listed without the 'docker.io/library/'
     # Images from custom registry are listed with the 'server/library/'
     # We also filter images the same way they are listed.
-    my $repo = ($registry =~ /docker\.io/) ? "" : "$registry/library";
+    my $repo = ($registry =~ /docker\.io/) ? "" : $registry;
     return $registry unless $container_name;
     return sprintf("%s/%s", $repo, $container_name) unless $version_tag;
     return sprintf("%s/%s:%s", $repo, $container_name, $version_tag);

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -60,7 +60,7 @@ sub run {
     assert_script_run("curl -O " . data_url("containers/docker-compose.yml"));
     assert_script_run("curl -O " . data_url("containers/haproxy.cfg"));
 
-    file_content_replace("docker-compose.yml", REGISTRY => get_var('REGISTRY', 'docker.io'));
+    file_content_replace("docker-compose.yml", REGISTRY => get_var('REGISTRY', 'docker.io/library'));
     assert_script_run 'docker-compose pull', 600;
 
     # Start all containers in background

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -35,7 +35,7 @@ sub run {
 
     # export alpine via Docker into the rootfs directory (see bsc#1152508)
     my $registry = get_var('REGISTRY', 'docker.io');
-    my $alpine = "$registry/library/alpine:3.6";
+    my $alpine = "$registry/alpine:3.6";
     assert_script_run('docker export $(docker create ' . $alpine . ') | tar -C rootfs -xvf -');
 
     foreach my $runc (@runtimes) {


### PR DESCRIPTION
The VM where the current registry service is running today will be
decommissioned soon as we are migrating the Public Cloud accounts.
I found a solution using directly the ECR service instead of creating
a VM which is prone to failure and requires maintenance.
ECR provides a public registry for our openQA tests.

Related ticket: https://progress.opensuse.org/issues/98415
VRS:
  - [15-SP4 all arch](https://openqa.suse.de/tests/overview?build=CONTAINER_NEW_REGISTRY&distri=sle&version=15-SP4)
  - [TW x86_64 and arm](https://openqa.opensuse.org/tests/overview?version=Tumbleweed&distri=opensuse&build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_new_registry)


These need to be merged together: 
- https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/831
- https://github.com/os-autoinst/opensuse-jobgroups/pull/156
- a bunch of test suites in https://openqa.opensuse.org/admin/test_suites using this variable need to be updated