### PR TITLE
Use Public AWS ECR registry

### DIFF
--- a/data/containers/registries.conf
+++ b/data/containers/registries.conf
@@ -16,8 +16,3 @@ insecure = true
 [[registry]]
 location = "registry.suse.de"
 insecure = true
-
-# Note: REGISTRY will be replaced by the registry URL of the according test run.
-[[registry]]
-location = "REGISTRY"
-insecure = true

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -26,9 +26,7 @@ sub configure_insecure_registries {
     my $registry = registry_url();
     # The debug output is messing with terminal in migration tests
     my $debug = (get_var('UPGRADE')) ? 'false' : 'true';
-    # Allow our internal 'insecure' registry
-    assert_script_run(
-'echo "{ \"debug\": ' . $debug . ', \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\", \"' . $registry . '\"] }" > /etc/docker/daemon.json');
+    assert_script_run('echo "{ \"debug\": ' . $debug . ', \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\"] }" > /etc/docker/daemon.json');
     assert_script_run('cat /etc/docker/daemon.json');
     systemctl('restart docker');
     record_info "setup $self->runtime", "deamon.json ready";

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -27,7 +27,6 @@ sub configure_insecure_registries {
 
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
-    file_content_replace("/etc/containers/registries.conf", REGISTRY => $registry);
 }
 
 1;

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -136,14 +136,14 @@ sub basic_container_tests {
 
     #   - pull minimalistic alpine image of declared version using tag
     #   - https://store.docker.com/images/alpine
-    assert_script_run("$runtime image pull $alpine", timeout => 300);
+    script_retry("$runtime image pull $alpine", timeout => 300);
     #   - pull typical docker demo image without tag. Should be latest.
     #   - https://store.docker.com/images/hello-world
-    assert_script_run("$runtime image pull $hello_world", timeout => 300);
+    script_retry("$runtime image pull $hello_world", timeout => 300);
     #   - pull image of last released version of openSUSE Leap
-    assert_script_run("$runtime image pull $leap", timeout => 600);
+    script_retry("$runtime image pull $leap", timeout => 600);
     #   - pull image of openSUSE Tumbleweed
-    assert_script_run("$runtime image pull $tumbleweed", timeout => 600);
+    script_retry("$runtime image pull $tumbleweed", timeout => 600);
 
     # All images can be listed
     assert_script_run("$runtime image ls");

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -83,7 +83,7 @@ sub registry_url {
 sub runtime_smoke_tests {
     my %args = @_;
     my $runtime = $args{runtime};
-    my $image = $args{image} // registry_url('alpine', '3.6');
+    my $image = $args{image} // registry_url('alpine', 'latest');
 
     record_info('Smoke', "Smoke test running image: $image on runtime: $runtime.");
 
@@ -125,7 +125,7 @@ sub basic_container_tests {
     my %args = @_;
     my $runtime = $args{runtime};
     die "You must define the runtime!" unless $runtime;
-    my $alpine_image_version = '3.6';
+    my $alpine_image_version = 'latest';
     my $alpine = registry_url('alpine', $alpine_image_version);
     my $hello_world = registry_url('hello-world');
     my $leap = "registry.opensuse.org/opensuse/leap";

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -60,7 +60,11 @@ sub run {
     assert_script_run("curl -O " . data_url("containers/docker-compose.yml"));
     assert_script_run("curl -O " . data_url("containers/haproxy.cfg"));
 
-    file_content_replace("docker-compose.yml", REGISTRY => get_var('REGISTRY', 'docker.io'));
+    my $registry = get_var('REGISTRY', 'docker.io');
+    file_content_replace("docker-compose.yml", REGISTRY => $registry);
+    # Pull images in advance to avoid Rate exceeded issues
+    script_retry("docker pull $registry/library/nginx", retry => 3, timeout => 300);
+    script_retry("docker pull $registry/library/haproxy", retry => 3, timeout => 300);
     assert_script_run 'docker-compose pull', 600;
 
     # Start all containers in background

--- a/tests/containers/docker_firewall.pm
+++ b/tests/containers/docker_firewall.pm
@@ -50,6 +50,7 @@ sub run {
     validate_script_output "iptables -L DOCKER-USER -nvx --line-numbers", sub { /1.+all.+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0/ };
 
     # Run container in the background
+    script_retry "docker pull " . registry_url('alpine'), retry => 3, delay => 120;
     assert_script_run "docker run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
     my $container_ip = container_ip($container_name, 'docker');
 

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -36,6 +36,7 @@ sub run {
     # export alpine via Docker into the rootfs directory (see bsc#1152508)
     my $registry = get_var('REGISTRY', 'docker.io');
     my $alpine = "$registry/library/alpine:3.6";
+    script_retry("docker pull $alpine", retry => 3, timeout => 120);
     assert_script_run('docker export $(docker create ' . $alpine . ') | tar -C rootfs -xvf -');
 
     foreach my $runc (@runtimes) {

--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -35,7 +35,7 @@ sub run {
 
     # export alpine via Docker into the rootfs directory (see bsc#1152508)
     my $registry = get_var('REGISTRY', 'docker.io');
-    my $alpine = "$registry/library/alpine:3.6";
+    my $alpine = "$registry/library/alpine:latest";
     script_retry("docker pull $alpine", retry => 3, timeout => 120);
     assert_script_run('docker export $(docker create ' . $alpine . ') | tar -C rootfs -xvf -');
 

--- a/tests/containers/podman_firewall.pm
+++ b/tests/containers/podman_firewall.pm
@@ -33,12 +33,11 @@ sub run {
     }
 
     # cni-podman0 interface is created when running the first container
-    assert_script_run "podman pull " . registry_url('alpine');
+    script_retry "podman pull " . registry_url('alpine'), retry => 3, delay => 120;
     assert_script_run "podman run --rm " . registry_url('alpine');
     validate_script_output('ip a s cni-podman0', sub { /,UP/ });
 
     # Run container in the background
-    assert_script_run "podman pull " . registry_url('alpine');
     assert_script_run "podman run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
 
     # Cheking rules of specific running container


### PR DESCRIPTION
The VM where the current registry service is running today will be
decommissioned soon as we are migrating the Public Cloud accounts.

There is solution using the public ECR Gallery which basically contains
the same images of DockerHub.
https://gallery.ecr.aws

There are some limitations when pulling images with docker, like
toomanyrequests: Rate exceeded
but with using retries, we can workaround the problem.

This solution is desired as we don't need to maintain any registry
ourselves which has caused some issues in the past.

https://progress.opensuse.org/issues/98415


[Tumbleweed](https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_new_registry2)
[SLE](https://openqa.suse.de/tests/overview?version=15-SP4&distri=sle&build=jlausuch%2Fos-autoinst-distri-opensuse%23containers_new_registry2)


