### PR TITLE
Public Cloud: use URL variable as a base url and hardcode the suffix

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -74,7 +74,7 @@ sub init {
     $self->service("EC2") unless (defined($self->service));
 
     if (get_var('PUBLIC_CLOUD_CREDENTIALS_URL')) {
-        my $data = get_credentials();
+        my $data = get_credentials('aws.json');
         $self->key_id($data->{access_key_id});
         $self->key_secret($data->{secret_access_key});
     } elsif (!defined($self->key_id) || !defined($self->key_secret)) {

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -27,7 +27,7 @@ has container_registry => sub { get_required_var('PUBLIC_CLOUD_CONTAINER_IMAGES_
 sub init {
     my ($self) = @_;
     if (get_var('PUBLIC_CLOUD_CREDENTIALS_URL')) {
-        my $data = get_credentials();
+        my $data = get_credentials('azure.json');
         $self->subscription($data->{subscription_id});
         $self->key_id($data->{client_id});
         $self->key_secret($data->{client_secret});

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -37,7 +37,7 @@ sub init {
     my ($self) = @_;
     # For now we support Vault and the credentials-microservice. Vault will be removed after a certain transition period
     if (get_var('PUBLIC_CLOUD_CREDENTIALS_URL')) {
-        my $data = get_credentials(CREDENTIALS_FILE);
+        my $data = get_credentials('gce.json', CREDENTIALS_FILE);
         $self->project_id($data->{project_id});
         $self->account($data->{client_id});
     } else {

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -217,8 +217,8 @@ sub define_secret_variable {
 # Get credentials from the Public Cloud micro service, which requires user
 # and password. The resulting json will be stored in a file.
 sub get_credentials {
-    my ($output_json) = @_;
-    my $url = get_required_var('PUBLIC_CLOUD_CREDENTIALS_URL');
+    my ($url_sufix, $output_json) = @_;
+    my $url = get_required_var('PUBLIC_CLOUD_CREDENTIALS_URL') . '/' . $url_sufix;
     my $user = get_required_var('_SECRET_PUBLIC_CLOUD_CREDENTIALS_USER');
     my $pwd = get_required_var('_SECRET_PUBLIC_CLOUD_CREDENTIALS_PWD');
     my $url_auth = Mojo::URL->new($url)->userinfo("$user:$pwd");


### PR DESCRIPTION
To allow flexibility when we want to run modules using different
providers in the same job, this approach makes this possible by
hardcoding the sufix of the URL in the provider and use the var
PUBLIC_CLOUD_CREDENTIALS_URL for the base url only.
