### PR TITLE
Public Cloud: use different variables for credentials URL

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -73,8 +73,8 @@ sub init {
 
     $self->service("EC2") unless (defined($self->service));
 
-    if (get_var('PUBLIC_CLOUD_CREDENTIALS_URL')) {
-        my $data = get_credentials();
+    if (my $url = get_var('PUBLIC_CLOUD_CREDENTIALS_URL_AWS')) {
+        my $data = get_credentials($url);
         $self->key_id($data->{access_key_id});
         $self->key_secret($data->{secret_access_key});
     } elsif (!defined($self->key_id) || !defined($self->key_secret)) {

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -26,8 +26,8 @@ has container_registry => sub { get_required_var('PUBLIC_CLOUD_CONTAINER_IMAGES_
 
 sub init {
     my ($self) = @_;
-    if (get_var('PUBLIC_CLOUD_CREDENTIALS_URL')) {
-        my $data = get_credentials();
+    if (my $url = get_var('PUBLIC_CLOUD_CREDENTIALS_URL_AZURE')) {
+        my $data = get_credentials($url);
         $self->subscription($data->{subscription_id});
         $self->key_id($data->{client_id});
         $self->key_secret($data->{client_secret});

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -36,8 +36,8 @@ has vault => undef;
 sub init {
     my ($self) = @_;
     # For now we support Vault and the credentials-microservice. Vault will be removed after a certain transition period
-    if (get_var('PUBLIC_CLOUD_CREDENTIALS_URL')) {
-        my $data = get_credentials(CREDENTIALS_FILE);
+    if (my $url = get_var('PUBLIC_CLOUD_CREDENTIALS_URL_GCP')) {
+        my $data = get_credentials($url, CREDENTIALS_FILE);
         $self->project_id($data->{project_id});
         $self->account($data->{client_id});
     } else {

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -217,8 +217,7 @@ sub define_secret_variable {
 # Get credentials from the Public Cloud micro service, which requires user
 # and password. The resulting json will be stored in a file.
 sub get_credentials {
-    my ($output_json) = @_;
-    my $url = get_required_var('PUBLIC_CLOUD_CREDENTIALS_URL');
+    my ($url, $output_json) = @_;
     my $user = get_required_var('_SECRET_PUBLIC_CLOUD_CREDENTIALS_USER');
     my $pwd = get_required_var('_SECRET_PUBLIC_CLOUD_CREDENTIALS_PWD');
     my $url_auth = Mojo::URL->new($url)->userinfo("$user:$pwd");


### PR DESCRIPTION
This way, we can use more than one provider in a single job.

There is another proposal here: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15044
It uses single variable but hardcodes the suffix for each provider, but I think hardcoding the url suffix makes things more complicated, as we will need different suffixes for each account. So, I vote for the approach presented here where we have 3 different variables, one per provider.
