### PR TITLE
Remove yast_users from mau_extratest_yast_cmd for now

### DIFF
--- a/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12.yaml
+++ b/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12.yaml
@@ -9,7 +9,6 @@ schedule:
   - yast2_cmd/yast_timezone
   - yast2_cmd/yast_tftp_server
   - yast2_cmd/yast_ftp_server
-  - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
   - yast2_cmd/yast_keyboard
   - yast2_cmd/yast_nfs_server

--- a/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12_SP2.yaml
+++ b/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12_SP2.yaml
@@ -9,7 +9,6 @@ schedule:
   - yast2_cmd/yast_timezone
   - yast2_cmd/yast_tftp_server
   - yast2_cmd/yast_ftp_server
-  - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
   - yast2_cmd/yast_nfs_server
   - yast2_cmd/yast_nfs_client

--- a/schedule/yast/maintenance/mau_extratests_yast_cmd.yaml
+++ b/schedule/yast/maintenance/mau_extratests_yast_cmd.yaml
@@ -10,7 +10,6 @@ schedule:
   - yast2_cmd/yast_tftp_server
   - yast2_cmd/yast_ftp_server
   - yast2_cmd/yast_rdp
-  - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
   - yast2_cmd/yast_keyboard
   - yast2_cmd/yast_nfs_server


### PR DESCRIPTION
Currently the test is broken and spams us, this change will remove it
until we figure out what happens, then we can revert this change.

See https://progress.opensuse.org/issues/112271
