### PR TITLE
Support subscribe extensions or modules on running system

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -47,6 +47,7 @@ use constant {
           get_os_release
           check_os_release
           package_version_cmp
+          get_version_id
         )
     ],
     BACKEND => [
@@ -760,4 +761,24 @@ Returns true if called in quaterly iso testing
 =cut
 sub is_quarterly_iso {
     return 1 if get_var('FLAVOR', '') =~ /QR/;
+}
+
+=head2 get_version_id
+
+  get_version_id(dst_machine => 'machine')
+
+Get SLES version from VERSION_ID in /etc/os-release. This subroutine also supports
+performing query on remote machine if dst_machine is given specific ip address or
+fqdn text of the remote machine. The default location that contains VERSION_ID is
+file /etc/os-release if nothing else is passed in to argument verid_file.
+
+=cut
+sub get_version_id {
+    my (%args) = @_;
+    $args{dst_machine} //= 'localhost';
+    $args{verid_file} //= '/etc/os-release';
+
+    my $cmd = "cat $args{verid_file} | grep VERSION_ID | grep -Eo \"[[:digit:]]{1,}\\.[[:digit:]]{1,}\"";
+    $cmd = "ssh root\@$args{dst_machine} " . "$cmd" if ($args{dst_machine} ne 'localhost');
+    return script_output($cmd);
 }

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -16,7 +16,7 @@ use version_utils qw(is_sle);
 use virt_utils;
 use utils;
 use Utils::Backends 'is_remote_backend';
-use virt_autotest::utils qw(is_xen_host);
+use virt_autotest::utils qw(is_xen_host subscribe_extensions_and_modules);
 
 sub install_package {
 
@@ -102,6 +102,8 @@ sub install_package {
     ###Install required package for window guest installation on xen host
     if (get_var('GUEST_LIST') =~ /^win-.*/ && (is_xen_host)) { zypper_call '--no-refresh --no-gpg-checks in mkisofs' }
 
+    #Subscribing packagehub from SLE 15-SP4 onwards that enables access to many useful software tools
+    virt_autotest::utils::subscribe_extensions_and_modules(reg_exts => 'PackageHub') if (is_sle('>=15-sp4') and !is_s390x);
 }
 
 sub run {


### PR DESCRIPTION
* **On** registered SLES, any available extensions and modules listed out by SUSEConnect --list-extensions that do not require additional regcode can be subscribed directly by using SUSEConnect -p command.

* **So** user can choose to activate certain extension or module even on up and running system, for example, PackageHub and etc, which offer convenience and access to many more software tools that do not exist on default installation, for example, sshpass and etc.

* **Subroutine** subscribe_extensions_and_modules implements this functionality in lib/virt_autotest/utils.pm.

* **Verification runs:**
  * [15sp4 kvm host](https://openqa.suse.de/tests/8951143)
  * [15sp4 xen host](https://openqa.suse.de/tests/8966244)
  * [12sp5 host](https://openqa.suse.de/tests/8945813)
  * [15sp3 host](https://openqa.suse.de/tests/8945816)
  * [15sp4 kvm host aarch64](http://10.67.131.12/tests/290)
  * [15sp4 kvm host s390x](https://openqa.suse.de/tests/8950704)
  * [Unsubscribe example](http://10.67.131.12/tests/344)
  * [Not registered example](http://10.67.131.12/tests/302)
  * [Multiple extensions subscription example](http://10.67.131.12/tests/343)