### PR TITLE
Support to add optional kernel parameters under textmode installer

### DIFF
--- a/tests/installation/edit_optional_kernel_cmd_parameters.pm
+++ b/tests/installation/edit_optional_kernel_cmd_parameters.pm
@@ -19,29 +19,45 @@ use version_utils qw(is_sle is_leap is_upgrade);
 sub run {
     my ($self) = shift;
 
-    # Verify Installation Settings overview is displayed as starting point
-    assert_screen "installation-settings-overview-loaded";
+    if (check_var('VIDEOMODE', 'text')) {
+        send_key 'alt-c';
+        assert_screen 'inst-overview-options';
+        send_key 'alt-b';
+        assert_screen 'installation-bootloader-config';
+        send_key 'alt-k';
+        assert_screen 'installation-kernel-parameters';
+        send_key 'alt-p';
+        wait_still_screen(1);
+    }
+    else {
+        # Verify Installation Settings overview is displayed as starting point
+        assert_screen "installation-settings-overview-loaded";
 
-    # Select section booting on Installation Settings overview (video mode)
-    send_key_until_needlematch 'booting-section-selected', 'tab';
-    send_key 'ret';
+        # Select section booting on Installation Settings overview (video mode)
+        send_key_until_needlematch 'booting-section-selected', 'tab';
+        send_key 'ret';
 
-    assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
-    # Depending on an optional button "release notes" we need to press "tab"
-    # to go to the first tab
-    send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
-    send_key_until_needlematch 'inst-kernel-parameters-highlighted', 'right';
-    assert_screen 'installation-kernel-parameters';
-    # Select Timeout dropdown box and disable
-    send_key 'alt-p';
-    wait_still_screen(1);
-    # clean up the field
-    send_key "backspace";
-    wait_still_screen(1);
+        assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
+        # Depending on an optional button "release notes" we need to press "tab"
+        # to go to the first tab
+        send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
+        send_key_until_needlematch 'inst-kernel-parameters-highlighted', 'right';
+        assert_screen 'installation-kernel-parameters';
+        # Select Timeout dropdown box and disable
+        send_key 'alt-p';
+        wait_still_screen(1);
+        # clean up the field
+        send_key "backspace";
+        wait_still_screen(1);
+    }
     # type default parameters
     type_string_slow(get_var('OPT_KERNEL_PARAMS'));
     save_screenshot;
-    send_key $cmd{ok};
+    if (check_var('VIDEOMODE', 'text')) {
+        send_key 'alt-o';
+    } else {
+        send_key $cmd{ok};
+    }
     # Adapting system setting needs longer time in case of installing/upgrading with multi-addons
     assert_screen 'installation-settings-overview-loaded', 220;
 }


### PR DESCRIPTION
Below kernel parameters need to be set during installation in textmode, it will take effect when the param "VIDEOMODE=text" is passed to job.
OPT_KERNEL_PARAMS=hugepagesz=2M hugepages=64

- Related ticket: https://progress.opensuse.org/issues/76735
- Needles: https://gitlab.suse.de/qa-testsuites/os-autoinst-needles-sles/-/merge_requests/3
- Verification run: http://10.67.129.66/tests/1255#step/edit_optional_kernel_cmd_parameters/4
