### PR TITLE
Move all common code about Trento tests to a lib

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -4,8 +4,27 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Functions for Trento tests
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 ## no critic (RequireFilenameMatchesPackage);
+
+=encoding utf8
+
+=head1 NAME
+
+Trento test lib
+
+=head1 COPYRIGHT
+
+Copyright 2017-2020 SUSE LLC
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE SAP <qe-sap@suse.de>
+
+=cut
+
 package trento;
 
 use strict;
@@ -13,11 +32,10 @@ use warnings;
 use testapi;
 use mmapi 'get_current_job_id';
 use utils qw(script_retry);
-use Carp qw(croak);
+use File::Basename qw(basename);
 use Exporter 'import';
 
 our @EXPORT = qw(
-  TRENTO_AZ_PREFIX
   get_resource_group
   get_vm_name
   get_acr_name
@@ -25,58 +43,65 @@ our @EXPORT = qw(
   VM_USER
   SSH_KEY
   cypress_install_container
-  PODMAN_PULL_LOG
   CYPRESS_LOG_DIR
+  PODMAN_PULL_LOG
   cypress_exec
   cypress_test_exec
   cypress_log_upload
 );
 
-=head1 SYNOPSIS
-Package with common methods and default values for Trento tests
+# Exported constants
+use constant VM_USER => 'cloudadmin';
+use constant SSH_KEY => '/root/.ssh/id_rsa';
+use constant CYPRESS_LOG_DIR => '/root/result';
+use constant PODMAN_PULL_LOG => '/tmp/podman_pull.log';
 
-=cut
-
+# Lib internal constants
 use constant TRENTO_AZ_PREFIX => 'openqa-trento';
-# Parameter 'registry_name' must conform to the following pattern: '^[a-zA-Z0-9]*$'.
+# Parameter 'registry_name' must conform to
+# the following pattern: '^[a-zA-Z0-9]*$'.
+# Azure does not support dash or underscore in ACR name
 use constant TRENTO_AZ_ACR_PREFIX => 'openqatrentoacr';
+use constant CYPRESS_IMAGE_TAG => 'goofy';
 
+=head1 DESCRIPTION 
 
-=head2 get_resource_group
+Package with common methods and default or constant  values for Trento tests
+
+=head2 Methods
+
+=head3 get_resource_group
+
 Return a string to be used as cloud resource group.
 It contains the JobId
-
 =cut
 sub get_resource_group {
     my $job_id = get_current_job_id();
     return TRENTO_AZ_PREFIX . "-rg-$job_id";
 }
 
+=head3 get_vm_name
 
-=head2 get_vm_name
 Return a string to be used as cloud VM name.
 It contains the JobId
-
 =cut
 sub get_vm_name {
     my $job_id = get_current_job_id();
     return TRENTO_AZ_PREFIX . "-vm-$job_id";
 }
 
+=head3 get_acr_name
 
-=head2 get_acr_name
 Return a string to be used as cloud ACR name.
 It contains the JobId
-
 =cut
 sub get_acr_name {
     return TRENTO_AZ_ACR_PREFIX . get_current_job_id();
 }
 
+=head3 az_get_vm_ip
 
-=head2 az_get_vm_ip
-Return the running VM IP
-
+Return the running VM public IP
 =cut
 sub az_get_vm_ip {
     my $az_cmd = 'az vm show -d ' .
@@ -87,10 +112,9 @@ sub az_get_vm_ip {
     return script_output($az_cmd, 180);
 }
 
+=head3 az_delete_group
 
-=head2 az_delete_group
-Delere resource group and so all its content
-
+Delete the resource group associated to this JobID and all its content
 =cut
 sub az_delete_group {
     script_run('echo "Delete all resources"');
@@ -100,27 +124,27 @@ sub az_delete_group {
     script_retry($az_cmd, timeout => 600, retry => 5, delay => 60);
 }
 
+=head3 az_vm_ssh_cmd
 
-use constant VM_USER => 'cloudadmin';
-use constant SSH_KEY => '/root/.ssh/id_rsa';
+Compose I<ssh> command for remote execution on the VM machine.
+The function optionally accept the VM public IP.
+If not provided, the IP is calculated on the fly with an I<az> query,
+take care that is a time consuming I<az> query.
 
+=over 2
 
-=head2 az_vm_ssh_cmd
-Compose ssh command for remote ssh execution on the VM machine
-The function optionally accept the vm ip.
-If it is not provided it is calculated on the fly with an az query,
-take care that is a time consuming az query.
+=item B<CMD_ARG> - String of the command to be executed remotely
+
+=item B<VM_IP_ARG> - Public IP of the remote machine where to execute the command
+
+=back
 =cut
 sub az_vm_ssh_cmd {
     my ($self, $cmd_arg, $vm_ip_arg) = @_;
-    my $vm_ip;
     record_info('REMOTE', "cmd:$cmd_arg");
-    if (defined $vm_ip_arg) {
-        $vm_ip = $vm_ip_arg;
-    }
-    else {
-        $vm_ip = az_get_vm_ip();
-    }
+
+    # undef comparision operator
+    my $vm_ip = $vm_ip_arg // az_get_vm_ip();
     return 'ssh' .
       ' -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR' .
       ' -i ' . SSH_KEY . ' ' .
@@ -128,50 +152,57 @@ sub az_vm_ssh_cmd {
       ' -- ' . $cmd_arg;
 }
 
+=head3 k8s_logs
 
-=head2 k8s_logs
-Get all relevan tinfo out from the cluster
+Get all relevant info out from the cluster
+
+=over 2
+
+=item B<CMD_ARG> - String of the command to be executed remotely
+
+=item B<VM_IP_ARG> - Public IP of the remote machine where to execute the command
+
+=back
 =cut
 sub k8s_logs {
     my $self = shift;
     my (@pods_list) = @_;
     my $machine_ip = az_get_vm_ip;
 
-    if ($machine_ip ne "") {
-        my $kubectl_pods = script_output($self->az_vm_ssh_cmd('kubectl get pods', $machine_ip), 180);
-        # for each pod that I'm interested to inspect
-        for my $s (@pods_list) {
-            # for each running pod from 'kubectl get pods'
-            foreach my $row (split(/\n/, $kubectl_pods)) {
-                # name of the file where we will eventually dump the log
-                my $describe_txt = "pod_describe_$s.txt";
-                my $log_txt = "pod_log_$s.txt";
-                # if the running pod is one of them that I'm interested about...
-                if ($row =~ m/trento-server-$s/) {
-                    # extract this pod name
-                    my $pod_name = (split /\s/, $row)[0];
+    return unless ($machine_ip);
 
-                    # get the description
-                    my $kubectl_describe_cmd = $self->az_vm_ssh_cmd("kubectl describe pods/$pod_name > $describe_txt", $machine_ip);
-                    script_run($kubectl_describe_cmd, 180);
-                    upload_logs($describe_txt);
+    my $kubectl_pods = script_output($self->az_vm_ssh_cmd('kubectl get pods', $machine_ip), 180);
+    # for each pod that I'm interested to inspect
+    for my $s (@pods_list) {
+        # for each running pod from 'kubectl get pods'
+        foreach my $row (split(/\n/, $kubectl_pods)) {
+            # name of the file where we will eventually dump the log
+            my $describe_txt = "pod_describe_$s.txt";
+            my $log_txt = "pod_log_$s.txt";
+            # if the running pod is one of the ones I'm interested in...
+            if ($row =~ m/trento-server-$s/) {
+                # extract this pod name
+                my $pod_name = (split /\s/, $row)[0];
 
-                    # get the log
-                    my $kubectl_logs_cmd = $self->az_vm_ssh_cmd("kubectl logs $pod_name > $log_txt", $machine_ip);
-                    script_run($kubectl_logs_cmd, 180);
-                    upload_logs($log_txt);
-                }
+                # get the description
+                my $kubectl_describe_cmd = $self->az_vm_ssh_cmd("kubectl describe pods/$pod_name > $describe_txt", $machine_ip);
+                script_run($kubectl_describe_cmd, 180);
+                upload_logs($describe_txt);
+
+                # get the log
+                my $kubectl_logs_cmd = $self->az_vm_ssh_cmd("kubectl logs $pod_name > $log_txt", $machine_ip);
+                script_run($kubectl_logs_cmd, 180);
+                upload_logs($log_txt);
             }
         }
-        script_run('ls -lai *.txt', 180);
     }
+    script_run('ls -lai *.txt', 180);
 }
 
+=head3 podman_self_check
 
-=head2 podman_self_check
-Perform some generic checks realted to the podman installation itself
-and the relevant paramenters of the current machine environment.
-
+Perform some generic checks related to the podman installation itself
+and the relevant parameters of the current machine environment.
 =cut
 sub podman_self_check {
     record_info('PODMAN', 'Check podman');
@@ -183,16 +214,18 @@ sub podman_self_check {
     assert_script_run('df -h');
 }
 
+=head3 cypress_install_container
 
-use constant PODMAN_PULL_LOG => '/tmp/podman_pull.log';
-
-
-=head2 crypress_install_container
 Prepare whatever is needed to run cypress tests using container
 
+=over 1
+
+=item B<CYPRESS_VER> - String used as tag for the cypress/included image.
+
+=back
 =cut
 sub cypress_install_container {
-    my ($cypress_ver) = @_;
+    my ($self, $cypress_ver) = @_;
     podman_self_check();
 
     # list all the available cypress images
@@ -211,89 +244,122 @@ sub cypress_install_container {
     assert_script_run('podman images');
 }
 
+=head3 cypress_log_upload
 
-use constant CYPRESS_LOG_DIR => '/root/result';
-
-
-=head2 cypress_log_upload
 Upload to openQA the relevant logs
-Optional argument array of strings with relevant file extensions
-(dot needed)
 
+=over 1
+
+=item B<LOG_FILTER> - List of strings. List of file extensions (dot needed) 
+
+=back
 =cut
 sub cypress_log_upload {
-    my $self = shift;
-    my @log_filter = @_;
+    my ($self, @log_filter) = @_;
     my $find_cmd = 'find ' . CYPRESS_LOG_DIR . ' -type f \( -iname \*' . join(' -o -iname \*', @log_filter) . ' \)';
 
     upload_logs("$_") for split(/\n/, script_output($find_cmd));
 }
 
+=head3 cypress_exec
 
-=head2 cypress_exec
 Execute a cypress command within the container 
 
+=over 5
 
+=item B<CYPRESS_TEST_DIR> - String of the path where the cypress Trento code is available.
+It is the I<test> folder within the path used by L<setup_jumphost>
+
+=item B<CMD> - String of cmd to be used as main argument for the cypress
+executable call. 
+
+=item B<TIMEOUT> - Integer used as timeout for the cypress command execution
+
+=item B<LOG_PREFIX> - String of the command to be executed remotely
+
+=item B<FAILOK> - Integer boolean value. 0:test marked as failure if the podman/cypress
+return not 0 exit code. 1:all not 0 podman/cypress exit code are ignored. SoftFail reported.
+
+=back
 =cut
 sub cypress_exec {
     my ($self, $cypress_test_dir, $cmd, $timeout, $log_prefix, $failok) = @_;
     my $ret = 0;
 
     record_info('CY EXEC', 'Cypress exec:' . $cmd);
-    my $cypress_ver = get_var('TRENTO_CYPRESS_VERSION', '4.4.0');
-    my $container_name = "docker.io/cypress/included:$cypress_ver";
-    # container is executed with --name to easy the log retrieve
-    # to do so we need to rm eventually present container with that name
-    script_run('podman rm goofy || echo "No Goofy to delete"');
+    my $cypress_ver = get_var(TRENTO_CYPRESS_VERSION => '4.4.0');
+    my $image_name = "docker.io/cypress/included:$cypress_ver";
+    # container is executed with --name to simplify the log retrieve.
+    # To do so, we need to rm present container with the same name
+    script_run('podman rm ' . CYPRESS_IMAGE_TAG . ' || echo "No ' . CYPRESS_IMAGE_TAG . ' to delete"');
     my $cypress_run_cmd = 'podman run ' .
-      '-it --name goofy ' .
-      "-v " . CYPRESS_LOG_DIR . ":/results " .
+      '-it --name ' . CYPRESS_IMAGE_TAG . ' ' .
+      '-v ' . CYPRESS_LOG_DIR . ':/results ' .
       "-v $cypress_test_dir:/e2e -w /e2e " .
       '-e "DEBUG=cypress:*" ' .
       '--entrypoint=\'[' .
       '"/bin/sh", "-c", ' .
-      ' "/usr/local/bin/cypress ' . $cmd .
+      '"/usr/local/bin/cypress ' . $cmd .
       ' 2>/results/cypress_' . $log_prefix . '_log.txt"' .
-      ']\' ' . $container_name .
+      ']\' ' . $image_name .
       ' | tee cypress_' . $log_prefix . '_result.txt';
     $ret = script_run($cypress_run_cmd, $timeout);
     if ($ret != 0) {
-        record_soft_failure("Cypress exit code:$ret at $log_prefix");
         # look for SIGTERM
-        script_run('podman logs -t goofy');
+        script_run('podman logs -t ' . CYPRESS_IMAGE_TAG);
         $self->result("fail");
     }
     if ($failok) {
+        record_soft_failure("Cypress exit code:$ret at $log_prefix");
         $ret = 0;
     }
-    croak "Cypress exec error at '$cmd'" unless ($ret == 0);
+    die "Cypress exec error at '$cmd'" unless ($ret == 0);
 }
 
-=head2 cypress_test_exec
-Execute a cypress test 
+=head3 cypress_test_exec
 
+Execute a set of cypress tests.
+Execute, one by one, all tests in all .js files in the provided folder. 
+
+=over 3 
+
+=item B<CYPRESS_TEST_DIR> - String of the path where the cypress Trento code is available.
+It is the I<test> folder within the path used by L<setup_jumphost>
+
+=item B<TEST_TAG> - String of the test subfolder within I<$cypress_test_dir/cypress/integration>
+Also used as tag for each test result file
+
+=item B<TIMEOUT> - Integer used as timeout for the internal L<cypress_exec> call
+
+=back
 =cut
 sub cypress_test_exec {
-    my ($self, $cypress_test_dir, $test_tag, $timeout, $failok) = @_;
+    my ($self, $cypress_test_dir, $test_tag, $timeout) = @_;
     my $ret = 0;
 
     my $test_file_list = script_output("find $cypress_test_dir/cypress/integration/$test_tag -type f -iname \"*.js\"");
 
-    my @arr;
     for (split(/\n/, $test_file_list)) {
-        my $test_filename = +(split /\//, $_)[-1];
+        # compose the JUnit .xml file name, starting from the .js filename
+        my $test_filename = basename($_);
         my $test_result = 'test_result_' . $test_tag . '_' . $test_filename;
         $test_result =~ s/js$/xml/;
         my $test_cmd = 'run' .
           ' --spec \"cypress/integration/' . $test_tag . '/' . $test_filename . '\"' .
           ' --reporter junit' .
           ' --reporter-options \"mochaFile=/results/' . $test_result . ',toConsole=true\"';
-        record_info('DEBUG', "test_filename:$test_filename test_result:$test_result test_cmd:$test_cmd");
-        $self->cypress_exec($cypress_test_dir, $test_cmd, 900, $test_tag, 1);
-        parse_extra_log("XUnit", $_) for split(/\n/, script_output('find ' . $self->CYPRESS_LOG_DIR . ' -type f -iname "' . $test_result . '"'));
+        record_info('CY INFO', "test_filename:$test_filename test_result:$test_result test_cmd:$test_cmd");
 
-        # look for and upload all logs at once
-        $self->cypress_log_upload(('.txt', '.mp4'));
+        # execute the test: force $failok=1 to keep the execution going.
+        # Any cypress test failure will be reported during the XUnit parsing
+        $self->cypress_exec($cypress_test_dir, $test_cmd, $timeout, $test_tag, 1);
+
+        # parsing the results
+        my $find_cmd = 'find ' . $self->CYPRESS_LOG_DIR . ' -type f -iname "' . $test_result . '"';
+        parse_extra_log("XUnit", $_) for split(/\n/, script_output($find_cmd));
+
+        # upload all logs at once
+        $self->cypress_log_upload(qw(.txt .mp4));
     }
 }
 

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -1,0 +1,300 @@
+# SUSE's openQA tests
+#
+# Copyright 2017-2020 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Functions for Trento tests
+
+## no critic (RequireFilenameMatchesPackage);
+package trento;
+
+use strict;
+use warnings;
+use testapi;
+use mmapi 'get_current_job_id';
+use utils qw(script_retry);
+use Carp qw(croak);
+use Exporter 'import';
+
+our @EXPORT = qw(
+  TRENTO_AZ_PREFIX
+  get_resource_group
+  get_vm_name
+  get_acr_name
+  az_get_vm_ip
+  VM_USER
+  SSH_KEY
+  cypress_install_container
+  PODMAN_PULL_LOG
+  CYPRESS_LOG_DIR
+  cypress_exec
+  cypress_test_exec
+  cypress_log_upload
+);
+
+=head1 SYNOPSIS
+Package with common methods and default values for Trento tests
+
+=cut
+
+use constant TRENTO_AZ_PREFIX => 'openqa-trento';
+# Parameter 'registry_name' must conform to the following pattern: '^[a-zA-Z0-9]*$'.
+use constant TRENTO_AZ_ACR_PREFIX => 'openqatrentoacr';
+
+
+=head2 get_resource_group
+Return a string to be used as cloud resource group.
+It contains the JobId
+
+=cut
+sub get_resource_group {
+    my $job_id = get_current_job_id();
+    return TRENTO_AZ_PREFIX . "-rg-$job_id";
+}
+
+
+=head2 get_vm_name
+Return a string to be used as cloud VM name.
+It contains the JobId
+
+=cut
+sub get_vm_name {
+    my $job_id = get_current_job_id();
+    return TRENTO_AZ_PREFIX . "-vm-$job_id";
+}
+
+
+=head2 get_acr_name
+Return a string to be used as cloud ACR name.
+It contains the JobId
+
+=cut
+sub get_acr_name {
+    return TRENTO_AZ_ACR_PREFIX . get_current_job_id();
+}
+
+
+=head2 az_get_vm_ip
+Return the running VM IP
+
+=cut
+sub az_get_vm_ip {
+    my $az_cmd = 'az vm show -d ' .
+      '-g ' . get_resource_group() . ' ' .
+      '-n ' . get_vm_name() . ' ' .
+      '--query "publicIps" ' .
+      '-o tsv';
+    return script_output($az_cmd, 180);
+}
+
+
+=head2 az_delete_group
+Delere resource group and so all its content
+
+=cut
+sub az_delete_group {
+    script_run('echo "Delete all resources"');
+    my $az_cmd = 'az group delete ' .
+      '--resource-group ' . get_resource_group() .
+      ' --yes';
+    script_retry($az_cmd, timeout => 600, retry => 5, delay => 60);
+}
+
+
+use constant VM_USER => 'cloudadmin';
+use constant SSH_KEY => '/root/.ssh/id_rsa';
+
+
+=head2 az_vm_ssh_cmd
+Compose ssh command for remote ssh execution on the VM machine
+The function optionally accept the vm ip.
+If it is not provided it is calculated on the fly with an az query,
+take care that is a time consuming az query.
+=cut
+sub az_vm_ssh_cmd {
+    my ($self, $cmd_arg, $vm_ip_arg) = @_;
+    my $vm_ip;
+    record_info('REMOTE', "cmd:$cmd_arg");
+    if (defined $vm_ip_arg) {
+        $vm_ip = $vm_ip_arg;
+    }
+    else {
+        $vm_ip = az_get_vm_ip();
+    }
+    return 'ssh' .
+      ' -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR' .
+      ' -i ' . SSH_KEY . ' ' .
+      VM_USER . '@' . $vm_ip .
+      ' -- ' . $cmd_arg;
+}
+
+
+=head2 k8s_logs
+Get all relevan tinfo out from the cluster
+=cut
+sub k8s_logs {
+    my $self = shift;
+    my (@pods_list) = @_;
+    my $machine_ip = az_get_vm_ip;
+
+    if ($machine_ip ne "") {
+        my $kubectl_pods = script_output($self->az_vm_ssh_cmd('kubectl get pods', $machine_ip), 180);
+        # for each pod that I'm interested to inspect
+        for my $s (@pods_list) {
+            # for each running pod from 'kubectl get pods'
+            foreach my $row (split(/\n/, $kubectl_pods)) {
+                # name of the file where we will eventually dump the log
+                my $describe_txt = "pod_describe_$s.txt";
+                my $log_txt = "pod_log_$s.txt";
+                # if the running pod is one of them that I'm interested about...
+                if ($row =~ m/trento-server-$s/) {
+                    # extract this pod name
+                    my $pod_name = (split /\s/, $row)[0];
+
+                    # get the description
+                    my $kubectl_describe_cmd = $self->az_vm_ssh_cmd("kubectl describe pods/$pod_name > $describe_txt", $machine_ip);
+                    script_run($kubectl_describe_cmd, 180);
+                    upload_logs($describe_txt);
+
+                    # get the log
+                    my $kubectl_logs_cmd = $self->az_vm_ssh_cmd("kubectl logs $pod_name > $log_txt", $machine_ip);
+                    script_run($kubectl_logs_cmd, 180);
+                    upload_logs($log_txt);
+                }
+            }
+        }
+        script_run('ls -lai *.txt', 180);
+    }
+}
+
+
+=head2 podman_self_check
+Perform some generic checks realted to the podman installation itself
+and the relevant paramenters of the current machine environment.
+
+=cut
+sub podman_self_check {
+    record_info('PODMAN', 'Check podman');
+    assert_script_run('which podman');
+    assert_script_run('podman --version');
+    assert_script_run('podman info --debug');
+    assert_script_run('podman ps');
+    assert_script_run('podman images');
+    assert_script_run('df -h');
+}
+
+
+use constant PODMAN_PULL_LOG => '/tmp/podman_pull.log';
+
+
+=head2 crypress_install_container
+Prepare whatever is needed to run cypress tests using container
+
+=cut
+sub cypress_install_container {
+    my ($cypress_ver) = @_;
+    podman_self_check();
+
+    # list all the available cypress images
+    my $cypress_image = 'docker.io/cypress/included';
+    assert_script_run('podman search --list-tags ' . $cypress_image);
+
+    # Pull in advance the cypress container
+    my $podman_pull_cmd = 'time podman ' .
+      '--log-level trace ' .
+      'pull ' .
+      '--quiet ' .
+      $cypress_image . ':' . $cypress_ver .
+      ' | tee ' . PODMAN_PULL_LOG;
+    assert_script_run($podman_pull_cmd, 1800);
+    assert_script_run('df -h');
+    assert_script_run('podman images');
+}
+
+
+use constant CYPRESS_LOG_DIR => '/root/result';
+
+
+=head2 cypress_log_upload
+Upload to openQA the relevant logs
+Optional argument array of strings with relevant file extensions
+(dot needed)
+
+=cut
+sub cypress_log_upload {
+    my $self = shift;
+    my @log_filter = @_;
+    my $find_cmd = 'find ' . CYPRESS_LOG_DIR . ' -type f \( -iname \*' . join(' -o -iname \*', @log_filter) . ' \)';
+
+    upload_logs("$_") for split(/\n/, script_output($find_cmd));
+}
+
+
+=head2 cypress_exec
+Execute a cypress command within the container 
+
+
+=cut
+sub cypress_exec {
+    my ($self, $cypress_test_dir, $cmd, $timeout, $log_prefix, $failok) = @_;
+    my $ret = 0;
+
+    record_info('CY EXEC', 'Cypress exec:' . $cmd);
+    my $cypress_ver = get_var('TRENTO_CYPRESS_VERSION', '4.4.0');
+    my $container_name = "docker.io/cypress/included:$cypress_ver";
+    # container is executed with --name to easy the log retrieve
+    # to do so we need to rm eventually present container with that name
+    script_run('podman rm goofy || echo "No Goofy to delete"');
+    my $cypress_run_cmd = 'podman run ' .
+      '-it --name goofy ' .
+      "-v " . CYPRESS_LOG_DIR . ":/results " .
+      "-v $cypress_test_dir:/e2e -w /e2e " .
+      '-e "DEBUG=cypress:*" ' .
+      '--entrypoint=\'[' .
+      '"/bin/sh", "-c", ' .
+      ' "/usr/local/bin/cypress ' . $cmd .
+      ' 2>/results/cypress_' . $log_prefix . '_log.txt"' .
+      ']\' ' . $container_name .
+      ' | tee cypress_' . $log_prefix . '_result.txt';
+    $ret = script_run($cypress_run_cmd, $timeout);
+    if ($ret != 0) {
+        record_soft_failure("Cypress exit code:$ret at $log_prefix");
+        # look for SIGTERM
+        script_run('podman logs -t goofy');
+        $self->result("fail");
+    }
+    if ($failok) {
+        $ret = 0;
+    }
+    croak "Cypress exec error at '$cmd'" unless ($ret == 0);
+}
+
+=head2 cypress_test_exec
+Execute a cypress test 
+
+=cut
+sub cypress_test_exec {
+    my ($self, $cypress_test_dir, $test_tag, $timeout, $failok) = @_;
+    my $ret = 0;
+
+    my $test_file_list = script_output("find $cypress_test_dir/cypress/integration/$test_tag -type f -iname \"*.js\"");
+
+    my @arr;
+    for (split(/\n/, $test_file_list)) {
+        my $test_filename = +(split /\//, $_)[-1];
+        my $test_result = 'test_result_' . $test_tag . '_' . $test_filename;
+        $test_result =~ s/js$/xml/;
+        my $test_cmd = 'run' .
+          ' --spec \"cypress/integration/' . $test_tag . '/' . $test_filename . '\"' .
+          ' --reporter junit' .
+          ' --reporter-options \"mochaFile=/results/' . $test_result . ',toConsole=true\"';
+        record_info('DEBUG', "test_filename:$test_filename test_result:$test_result test_cmd:$test_cmd");
+        $self->cypress_exec($cypress_test_dir, $test_cmd, 900, $test_tag, 1);
+        parse_extra_log("XUnit", $_) for split(/\n/, script_output('find ' . $self->CYPRESS_LOG_DIR . ' -type f -iname "' . $test_result . '"'));
+
+        # look for and upload all logs at once
+        $self->cypress_log_upload(('.txt', '.mp4'));
+    }
+}
+
+1;

--- a/schedule/sles4sap/trento/trento.yml
+++ b/schedule/sles4sap/trento/trento.yml
@@ -7,10 +7,11 @@ description: |
     - Test interacting with the web interface using Cypress
     - Destroy all Azure resources related to the Trento app and other utility like ACR
 vars:
-    TRENTO_TEST_REGISTRY: 'registry.suse.com/trento/trento-runner'
+    TRENTO_REGISTRY_CHART: 'registry.suse.com/trento/trento-runner'
+    TRENTO_REGISTRY_CHART_VERSION: '1.0.0'
     TRENTO_DEPLOY_SCRIPTS_REPO: 'gitlab.suse.de/qa-css/trento'
     TRENTO_VM_IMAGE: 'SUSE:sles-sap-15-sp3-byos:gen2:latest'
-    TRENTO_CYPRESS_VERSION: '3.4.0'
+    TRENTO_CYPRESS_VERSION: '4.4.0'
     PUBLIC_CLOUD_PROVIDER: 'AZURE'
     TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:

--- a/schedule/sles4sap/trento/trento_jumphost.yml
+++ b/schedule/sles4sap/trento/trento_jumphost.yml
@@ -8,7 +8,7 @@ description: |
 vars:
     TRENTO_DEPLOY_SCRIPTS_REPO: 'gitlab.suse.de/qa-css/trento'
     TRENTO_HELM_VERSION: '3.8.2'
-    TRENTO_CYPRESS_VERSION: '3.4.0'
+    TRENTO_CYPRESS_VERSION: '4.4.0'
     TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
     - boot/boot_to_desktop

--- a/tests/sles4sap/trento/deploy_trento.pm
+++ b/tests/sles4sap/trento/deploy_trento.pm
@@ -4,9 +4,10 @@
 # Summary: Trento test
 # Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
 
+use strict;
+use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
-use strict;
 use testapi;
 use base 'trento';
 
@@ -22,7 +23,7 @@ sub run {
     enter_cmd "cd /root/test";
 
     # Run the Trento deployment
-    my $vm_image = get_var('TRENTO_VM_IMAGE', 'SUSE:sles-sap-15-sp3-byos:gen2:latest');
+    my $vm_image = get_var(TRENTO_VM_IMAGE => 'SUSE:sles-sap-15-sp3-byos:gen2:latest');
     my $deploy_script_log = 'script_00.040.txt';
     my $deploy_script_run = './';
     my $cmd_00_040 = 'set -o pipefail ; ' . $deploy_script_run . "00.040-trento_vm_server_deploy_azure.sh " .
@@ -35,7 +36,7 @@ sub run {
     assert_script_run($cmd_00_040, 360);
     upload_logs($deploy_script_log);
 
-    my $trento_registry_chart = get_var('TRENTO_REGISTRY_CHART', 'registry.suse.com/trento/trento-server');
+    my $trento_registry_chart = get_var(TRENTO_REGISTRY_CHART => 'registry.suse.com/trento/trento-server');
     $deploy_script_log = 'script_trento_acr_azure.log.txt';
     my $trento_acr_azure_cmd = 'set -o pipefail ; ' . $deploy_script_run . "trento_acr_azure.sh " .
       "-g $resource_group " .
@@ -73,7 +74,7 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
 
-    $self->k8s_logs(('web', 'runner'));
+    $self->k8s_logs(qw(web runner));
     $self->az_delete_group;
 
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/trento/deploy_trento.pm
+++ b/tests/sles4sap/trento/deploy_trento.pm
@@ -8,42 +8,44 @@ use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
 use strict;
 use testapi;
-use mmapi 'get_current_job_id';
-
-use constant TRENTO_AZ_PREFIX => 'openqa-trento';
-use constant TRENTO_AZ_ACR_PREFIX => 'openqatrentoacr';
+use base 'trento';
 
 sub run {
     my ($self) = @_;
     die "Only AZURE deployment supported for the moment" unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
     $self->select_serial_terminal;
-    my $job_id = get_current_job_id();
 
-    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
-    my $machine_name = TRENTO_AZ_PREFIX . "-vm-$job_id";
-    # Parameter 'registry_name' must conform to the following pattern: '^[a-zA-Z0-9]*$'.
-    my $acr_name = TRENTO_AZ_ACR_PREFIX . "$job_id";
+    my $resource_group = $self->get_resource_group;
+    my $machine_name = $self->get_vm_name;
+    my $acr_name = $self->get_acr_name;
 
     enter_cmd "cd /root/test";
 
     # Run the Trento deployment
     my $vm_image = get_var('TRENTO_VM_IMAGE', 'SUSE:sles-sap-15-sp3-byos:gen2:latest');
-    my $cmd_00_040 = "./00.040-trento_vm_server_deploy_azure.sh " .
-      "-g $resource_group " .
-      "-s $machine_name " .
-      "-i $vm_image " .
-      "-a cloudadmin " .
-      "-k /root/.ssh/id_rsa.pub " .
-      "-v";
+    my $deploy_script_log = 'script_00.040.txt';
+    my $deploy_script_run = './';
+    my $cmd_00_040 = 'set -o pipefail ; ' . $deploy_script_run . "00.040-trento_vm_server_deploy_azure.sh " .
+      " -g $resource_group" .
+      " -s $machine_name" .
+      " -i $vm_image" .
+      ' -a ' . $self->VM_USER .
+      ' -k ' . $self->SSH_KEY . '.pub' .
+      " -v 2>&1|tee $deploy_script_log";
     assert_script_run($cmd_00_040, 360);
+    upload_logs($deploy_script_log);
 
-    my $trento_acr_azure_cmd = "./trento_acr_azure.sh " .
+    my $trento_registry_chart = get_var('TRENTO_REGISTRY_CHART', 'registry.suse.com/trento/trento-server');
+    $deploy_script_log = 'script_trento_acr_azure.log.txt';
+    my $trento_acr_azure_cmd = 'set -o pipefail ; ' . $deploy_script_run . "trento_acr_azure.sh " .
       "-g $resource_group " .
       "-n $acr_name " .
-      "-r registry.suse.com/trento/trento-server " .
-      "-v";
+      "-r $trento_registry_chart " .
+      "-v 2>&1|tee $deploy_script_log";
     assert_script_run($trento_acr_azure_cmd, 360);
-    my $machine_ip = script_output("az vm show -d -g $resource_group -n $machine_name --query \"publicIps\" -o tsv");
+    upload_logs($deploy_script_log);
+
+    my $machine_ip = $self->az_get_vm_ip;
     my $acr_server = script_output("az acr list -g $resource_group --query \"[0].loginServer\" -o tsv");
     my $acr_username = script_output("az acr credential show -n $acr_name --query username -o tsv");
     my $acr_secret = script_output("az acr credential show -n $acr_name --query 'passwords[0].value' -o tsv");
@@ -51,25 +53,29 @@ sub run {
     # Check what registry has been created by  trento_acr_azure_cmd
     assert_script_run("az acr repository list -n $acr_name");
 
-    my $cmd_01_010 = "./01.010-trento_server_installation_premium_v.sh " .
-      "-i $machine_ip " .
-      "-k /root/.ssh/id_rsa " .
-      "-u cloudadmin " .
-      "-c 3.8.2 " .
-      '-p $(pwd) ' .
-      "-r $acr_server/trento/trento-server " .
+    $deploy_script_log = 'script_1.010.log.txt';
+    my $cmd_01_010 = 'set -o pipefail ; ' . $deploy_script_run . '01.010-trento_server_installation_premium_v.sh ' .
+      " -i $machine_ip " .
+      ' -k ' . $self->SSH_KEY .
+      ' -u ' . $self->VM_USER;
+    if (get_var('TRENTO_REGISTRY_CHART_VERSION')) {
+        $cmd_01_010 .= ' -c ' . get_var('TRENTO_REGISTRY_CHART_VERSION');
+    }
+    $cmd_01_010 .= ' -p $(pwd) ' .
+      " -r $acr_server/trento/trento-server " .
       "-s $acr_username " .
       '-w $(az acr credential show -n ' . $acr_name . " --query 'passwords[0].value' -o tsv) " .
-      "-v";
+      "-v 2>&1|tee $deploy_script_log";
     assert_script_run($cmd_01_010, 600);
+    upload_logs($deploy_script_log);
 }
 
 sub post_fail_hook {
     my ($self) = @_;
-    my $job_id = get_current_job_id();
-    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
 
-    assert_script_run("az group delete --resource-group $resource_group --yes", 180);
+    $self->k8s_logs(('web', 'runner'));
+    $self->az_delete_group;
+
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/trento/setup_jumphost.pm
+++ b/tests/sles4sap/trento/setup_jumphost.pm
@@ -78,7 +78,7 @@ sub run {
     assert_script_run("git clone $gitlab_clone_cmd . | tee " . GITLAB_CLONE_LOG);
 
     # Cypress.io installation
-    my $cypress_ver = get_var('TRENTO_CYPRESS_VERSION', '3.4.0');
+    my $cypress_ver = get_var('TRENTO_CYPRESS_VERSION', '4.4.0');
     cypress_install_container($cypress_ver);
 }
 

--- a/tests/sles4sap/trento/setup_jumphost.pm
+++ b/tests/sles4sap/trento/setup_jumphost.pm
@@ -4,53 +4,22 @@
 # Summary: Trento test
 # Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
 
+use strict;
+use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
-use strict;
 use testapi;
 use utils 'zypper_call';
-use version_utils 'is_sle';
-use registration qw(add_suseconnect_product get_addon_fullname);
+use base 'trento';
 
 use constant GITLAB_CLONE_LOG => '/tmp/gitlab_clone.log';
-use constant PODMAN_PULL_LOG => '/tmp/podman_pull.log';
-
-=head2 crypress_install_container
-
-Prepare whatever is needed to run cypress tests using container
-
-=cut
-sub cypress_install_container {
-    my ($cypress_ver) = @_;
-
-    record_info('INFO', 'Check podman');
-    zypper_call('in podman') if (script_run 'which podman');
-    assert_script_run('podman --version');
-    assert_script_run('podman info --debug');
-    assert_script_run('podman ps');
-    assert_script_run('podman images');
-
-    # Pull in advance the cypress container
-    my $cypress_image = 'docker.io/cypress/included';
-    assert_script_run('podman search --list-tags ' . $cypress_image);
-    assert_script_run('df -h');
-    my $podman_pull_cmd = 'time podman ' .
-      '--log-level trace ' .
-      'pull ' .
-      '--quiet ' .
-      $cypress_image . ':' . $cypress_ver .
-      ' | tee ' . PODMAN_PULL_LOG;
-    assert_script_run($podman_pull_cmd, 1800);
-    assert_script_run('df -h');
-    assert_script_run('podman images');
-}
 
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
     # Install needed tools
-    my $helm_ver = get_var('TRENTO_HELM_VERSION', '3.8.2');
+    my $helm_ver = get_var(TRENTO_HELM_VERSION => '3.8.2');
 
     if (script_run('which helm')) {
         assert_script_run('curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3');
@@ -63,7 +32,7 @@ sub run {
     assert_script_run('az --version');
 
     # Get the code for the Trento deployment
-    my $gitlab_repo = get_var('TRENTO_GITLAB_REPO', 'gitlab.suse.de/qa-css/trento');
+    my $gitlab_repo = get_var(TRENTO_GITLAB_REPO => 'gitlab.suse.de/qa-css/trento');
 
     # The usage of a variable with a different name is to
     # be able to overwrite the token when triggering manually.
@@ -71,22 +40,22 @@ sub run {
     # Note: this test is mostly used to create a HDD image; part of it is this cloned repo.
     # The key is part of the cloned repo itself so TRENTO_GITLAB_TOKEN for the moment
     # cannot be changed as running init_jumphost
-    my $gitlab_token = get_var('TRENTO_GITLAB_TOKEN', get_required_var('_SECRET_TRENTO_GITLAB_TOKEN'));
+    my $gitlab_token = get_var(TRENTO_GITLAB_TOKEN => get_required_var('_SECRET_TRENTO_GITLAB_TOKEN'));
 
     my $gitlab_clone_cmd = 'https://git:' . $gitlab_token . '@' . $gitlab_repo;
     enter_cmd 'mkdir ${HOME}/test && cd ${HOME}/test';
     assert_script_run("git clone $gitlab_clone_cmd . | tee " . GITLAB_CLONE_LOG);
 
     # Cypress.io installation
-    my $cypress_ver = get_var('TRENTO_CYPRESS_VERSION', '4.4.0');
-    cypress_install_container($cypress_ver);
+    my $cypress_ver = get_var(TRENTO_CYPRESS_VERSION => '4.4.0');
+    $self->cypress_install_container($cypress_ver);
 }
 
 sub post_fail_hook {
     my ($self) = shift;
     # $self->select_serial_terminal;
     upload_logs(GITLAB_CLONE_LOG);
-    upload_logs(PODMAN_PULL_LOG);
+    upload_logs($self->PODMAN_PULL_LOG);
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/trento/test_trento_deploy.pm
+++ b/tests/sles4sap/trento/test_trento_deploy.pm
@@ -4,9 +4,10 @@
 # Summary: Trento test
 # Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
 
+use strict;
+use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
-use strict;
 use testapi;
 use utils qw(script_retry);
 use base 'trento';
@@ -34,7 +35,7 @@ sub run {
     }
 
     # test if the web page is reachable on http
-    my $trento_url = 'http://' . $machine_ip . '/';
+    my $trento_url = "http://$machine_ip/";
     script_run('curl --version');
     assert_script_run('curl -k  ' . $trento_url);
     # HEAD request
@@ -48,7 +49,7 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->k8s_logs(('web', 'runner'));
+    $self->k8s_logs(qw(web runner));
 
     $self->az_delete_group;
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/trento/test_trento_deploy.pm
+++ b/tests/sles4sap/trento/test_trento_deploy.pm
@@ -8,33 +8,49 @@ use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
 use strict;
 use testapi;
-use mmapi 'get_current_job_id';
+use utils qw(script_retry);
+use base 'trento';
 
-use constant TRENTO_AZ_PREFIX => 'openqa-trento';
 
 sub run {
     my ($self) = @_;
     die "Only AZURE deployment supported for the moment" unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
     $self->select_serial_terminal;
-    my $job_id = get_current_job_id();
 
-    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
-    my $machine_name = TRENTO_AZ_PREFIX . "-vm-$job_id";
+    my $resource_group = $self->get_resource_group;
 
     # check if VM is still there :-)
     assert_script_run("az vm list -g $resource_group --query \"[].name\"  -o tsv", 180);
 
-    my $machine_ip = script_output("az vm show -d -g $resource_group -n $machine_name --query \"publicIps\" -o tsv", 180);
+    # get deployed version from the cluster
+    my $machine_ip = $self->az_get_vm_ip;
+    my $kubectl_pods = script_output($self->az_vm_ssh_cmd('kubectl get pods', $machine_ip), 180);
+    foreach my $row (split(/\n/, $kubectl_pods)) {
+        if ($row =~ m/trento-server-web/) {
+            my $pod_name = (split /\s/, $row)[0];
+            my $trento_ver_cmd = $self->az_vm_ssh_cmd("kubectl exec --stdin $pod_name -- /app/bin/trento version", $machine_ip);
+            script_run($trento_ver_cmd, 180);
+        }
+    }
 
     # test if the web page is reachable on http
-    assert_script_run("curl -k  http://" . $machine_ip . "/");
+    my $trento_url = 'http://' . $machine_ip . '/';
+    script_run('curl --version');
+    assert_script_run('curl -k  ' . $trento_url);
+    # HEAD request
+    my $trento_http_code = script_output('curl -I --silent --output /dev/null --write-out "%{http_code}" ' . $trento_url);
+    # HEAD request and follow redirection
+    my $curl_cmd_test = 'test $(' .
+      'curl -I -L --silent --output /dev/null --write-out "%{http_code}" ' . $trento_url .
+      ') -eq 200 ';
+    script_retry($curl_cmd_test, retry => 5, delay => 60);
 }
 
 sub post_fail_hook {
     my ($self) = @_;
-    my $job_id = get_current_job_id();
-    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
-    assert_script_run("az group delete --resource-group $resource_group --yes", 180);
+    $self->k8s_logs(('web', 'runner'));
+
+    $self->az_delete_group;
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -4,9 +4,10 @@
 # Summary: Trento test
 # Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
 
+use strict;
+use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
-use strict;
 use testapi;
 use base 'trento';
 
@@ -36,10 +37,10 @@ sub run {
     $self->cypress_log_upload(('.txt'));
 
     # test about first visit: login and eula
-    $self->cypress_test_exec($cypress_test_dir, 'first_visit', 900, 0);
+    $self->cypress_test_exec($cypress_test_dir, 'first_visit', 900);
 
     # all other cypress tests
-    $self->cypress_test_exec($cypress_test_dir, 'all', 900, 0);
+    $self->cypress_test_exec($cypress_test_dir, 'all', 900);
 }
 
 sub post_fail_hook {

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -8,52 +8,20 @@ use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
 use strict;
 use testapi;
-use mmapi 'get_current_job_id';
+use base 'trento';
 
-use constant CYPRESS_LOG_DIR => '/root/result';
-use constant TRENTO_AZ_PREFIX => 'openqa-trento';
-use constant TRENTO_AZ_ACR_PREFIX => 'openqatrentoacr';
-
-=head2 cypress_exec
-Execute a cypress command
-
-=cut
-sub cypress_exec {
-    my ($cypress_ver, $cypress_test_dir, $cmd, $timeout) = @_;
-    record_info('INFO', 'Cypress exec:' . $cmd);
-    my $cypress_run_cmd = "podman run -it " .
-      "-v " . CYPRESS_LOG_DIR . ":/results " .
-      "-v $cypress_test_dir:/e2e -w /e2e " .
-      '-e "DEBUG=cypress:*" ' .
-      '--entrypoint=\'[' .
-      '"/bin/sh", "-c", ' .
-      ' "/usr/local/bin/cypress ' . $cmd .
-      ' 2>/results/log.txt"' .
-      ']\' ' .
-      'docker.io/cypress/included:' . $cypress_ver;
-    assert_script_run($cypress_run_cmd, $timeout);
-}
 
 sub run {
     my ($self) = @_;
     die "Only AZURE deployment supported for the moment" unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
     $self->select_serial_terminal;
-    my $job_id = get_current_job_id();
 
-    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
-    my $machine_name = TRENTO_AZ_PREFIX . "-vm-$job_id";
+    my $machine_ip = $self->az_get_vm_ip;
 
-    my $machine_ip = script_output("az vm show -d -g $resource_group -n $machine_name --query \"publicIps\" -o tsv", 180);
-
-    my $ssh_remote_cmd = "ssh" .
-      " -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR" .
-      " -i /root/.ssh/id_rsa" .
-      " cloudadmin@" . $machine_ip .
-      " -- ";
-    my $trento_web_password_cmd = $ssh_remote_cmd .
-      " kubectl get secret trento-server-web-secret" .
-      " -o jsonpath='{.data.ADMIN_PASSWORD}'" .
-      "|base64 --decode";
+    my $trento_web_password_cmd = $self->az_vm_ssh_cmd(
+        'kubectl get secret trento-server-web-secret' .
+          " -o jsonpath='{.data.ADMIN_PASSWORD}'" .
+          '|base64 --decode', $machine_ip);
     my $trento_web_password = script_output($trento_web_password_cmd);
 
     my $cypress_test_dir = "/root/test/test";
@@ -61,29 +29,26 @@ sub run {
     assert_script_run("./cypress.env.py -u http://" . $machine_ip . " -p " . $trento_web_password . " -f Premium");
     assert_script_run('cat cypress.env.json');
 
-    assert_script_run "mkdir " . CYPRESS_LOG_DIR;
-    my $cypress_ver = get_var('TRENTO_CYPRESS_VERSION', '3.4.0');
-    cypress_exec($cypress_ver, $cypress_test_dir, 'verify', 120);
+    assert_script_run "mkdir " . $self->CYPRESS_LOG_DIR;
 
-    cypress_exec($cypress_ver, $cypress_test_dir, 'run', 600);
-    script_run('find ' . CYPRESS_LOG_DIR . ' -type f');    # all files listed in the test log
-    my $cypress_output = script_output 'find ' . CYPRESS_LOG_DIR . ' -type f -print';
-    upload_logs($_) for grep(/(.txt|.xml)$/, split(/\n/, $cypress_output));
+    #  Cypress verify: cypress.io self check about the framework installation
+    $self->cypress_exec($cypress_test_dir, 'verify', 120, 'verify', 1);
+    $self->cypress_log_upload(('.txt'));
+
+    # test about first visit: login and eula
+    $self->cypress_test_exec($cypress_test_dir, 'first_visit', 900, 0);
+
+    # all other cypress tests
+    $self->cypress_test_exec($cypress_test_dir, 'all', 900, 0);
 }
 
 sub post_fail_hook {
     my ($self) = @_;
-    my $job_id = get_current_job_id();
-    my $resource_group = TRENTO_AZ_PREFIX . "-rg-$job_id";
-    assert_script_run('az group list --query "[].name" -o tsv');
-    assert_script_run("az group delete --resource-group $resource_group --yes", 1200);
+    $self->az_delete_group;
 
-    # the sleep is to give to the cypress test app
-    # the time to complete the log write
-    sleep 60;
-    script_output('find ' . CYPRESS_LOG_DIR . ' -type f');
-    my $cypress_output = script_output 'find ' . CYPRESS_LOG_DIR . ' -type f -print';
-    upload_logs($_) for grep(/(.txt|.xml|.mp4)$/, split(/\n/, $cypress_output));
+    $self->cypress_log_upload(('.txt', '.mp4'));
+    parse_extra_log("XUnit", $_) for split(/\n/, script_output('find ' . $self->CYPRESS_LOG_DIR . ' -type f -iname "*.xml"'));
+
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Better cypress.io integration by starting tests one by one
fail hook of the deploy_trento takes care to record all cluster logs

- Verification run: 
--- trento_jumphost http://1c242.qa.suse.de/tests/399  -  http://1c242.qa.suse.de/tests/439
--- trento http://1c242.qa.suse.de/tests/400  -  http://1c242.qa.suse.de/tests/441
