### PR TITLE
Remove Python2 module from 15sp4

### DIFF
--- a/data/autoyast_qam/15-SP4_installtest.xml.ep
+++ b/data/autoyast_qam/15-SP4_installtest.xml.ep
@@ -64,7 +64,7 @@
         <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Updates/SLE-Module-Web-Scripting/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
       </listentry>
       % }
-      % unless ($check_var->('VERSION', '15')) {
+      % unless ($check_var->('VERSION', '15-SP4')) {
       <listentry>
         <name>sle-module-python2:<%= $get_var->('VERSION') %>::pool</name>
         <alias>sle-module-python2:<%= $get_var->('VERSION') %>::pool</alias>


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/112202
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
